### PR TITLE
Fixing OSX makefile

### DIFF
--- a/README.osx
+++ b/README.osx
@@ -9,11 +9,22 @@ lib, png or freetype on your system
 
 Example usage::
 
-  make -f make.osx PREFIX=/Users/jdhunter/dev PYVERSION=2.6 fetch deps mpl_install
+  make -f make.osx PREFIX=/Users/jdhunter/dev PYVERSION=2.6 \
+    fetch deps mpl_install_std
 
 Variables:
     PREFIX (required): where to install the dependencies
-    PYVERSION (optional): which python version to use (default=python, e.g.=python2.6)
+    PYVERSION (optional): which python version to use
+       (default=python, e.g. PYVERSION=2.6 uses python2.6)
 
-The Python libraries will be installed in the relevant site-packages, instead of under PREFIX.
+Targets:
 
+  clean: remove compiled files
+  fetch: download dependencies
+  deps: build all dependencies (zlib, png, freetype)
+  mpl_build: compile matplotlib
+  mpl_install: install matplotlib in $PREFIX/lib/pythonX.Y/site-packages
+  mpl_install_std: install matplotlib in standard site-packages directory
+  mpl_install_egg: install matplotlib as an egg
+  mpl_install_develop: set up egg link to working directory (for developers)
+  binaries: create the dmg file for distribution

--- a/make.osx
+++ b/make.osx
@@ -1,3 +1,4 @@
+# -*- makefile -*-
 # build mpl into a local install dir with
 # make -f make.osx PREFIX=/Users/jdhunter/dev PYVERSION=2.6 fetch deps mpl_install
 # (see README.osx for more details)
@@ -8,18 +9,18 @@ PNGVERSION=1.2.39
 FREETYPEVERSION=2.3.11
 MACOSX_DEPLOYMENT_TARGET=10.6
 OSX_SDK_VER=10.6
-ARCH_FLAGS="-arch i386-arch x86_64"
+ARCH_FLAGS=-arch i386 -arch x86_64
 
 ## You shouldn't need to configure past this point
 
-#PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
-#CFLAGS="${ARCH_FLAGS} -I${PREFIX}/include -I${PREFIX}/include/freetype2 -isysroot /Developer/SDKs/MacOSX${OSX_SDK_VER}.sdk"
-#LDFLAGS="${ARCH_FLAGS} -L${PREFIX}/lib -syslibroot,/Developer/SDKs/MacOSX${OSX_SDK_VER}.sdk"
+export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+export CFLAGS=${ARCH_FLAGS} -I${PREFIX}/include -I${PREFIX}/include/freetype2 -isysroot /Developer/SDKs/MacOSX${OSX_SDK_VER}.sdk
+export LDFLAGS=${ARCH_FLAGS} -L${PREFIX}/lib -syslibroot,/Developer/SDKs/MacOSX${OSX_SDK_VER}.sdk
+export MACOSX_DEPLOYMENT_TARGET
 
-PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
-CFLAGS="-arch i386 -arch x86_64 -I${PREFIX}/include -I${PREFIX}/include/freetype2 -isysroot /Developer/SDKs/MacOSX${OSX_SDK_VER}.sdk"
-LDFLAGS="-arch i386 -arch x86_64 -L${PREFIX}/lib -syslibroot,/Developer/SDKs/MacOSX${OSX_SDK_VER}.sdk"
-FFLAGS="-arch i386 -arch x86_64"
+help:
+	@echo "Interesting targets: clean, fetch, deps, mpl_build, mpl_install_std"
+	@echo "See README.osx for details"
 
 clean:
 	rm -rf zlib-${ZLIBVERSION}.tar.gz libpng-${PNGVERSION}.tar.gz \
@@ -36,72 +37,61 @@ fetch:
 	${PYTHON} -c 'import urllib; urllib.urlretrieve("http://sourceforge.net/projects/libpng/files/libpng12/older-releases/${PNGVERSION}/libpng-${PNGVERSION}.tar.gz/download", "libpng-${PNGVERSION}.tar.gz")' &&\
 	${PYTHON} -c 'import urllib; urllib.urlretrieve("http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPEVERSION}.tar.bz2", "freetype-${FREETYPEVERSION}.tar.bz2")'
 
+check-prefix:
+	@if [ ! -d "$(PREFIX)" ]; then echo Set PREFIX to a directory - see README.osx; exit 1; fi
 
-
-
-zlib:
-	export PKG_CONFIG_PATH=${PKG_CONFIG_PATH} &&\
+zlib: check-prefix
 	rm -rf zlib-${ZLIBVERSION} &&\
 	tar xvfz zlib-${ZLIBVERSION}.tar.gz &&\
 	cd zlib-${ZLIBVERSION} &&\
-	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} &&\
-	export CFLAGS=${CFLAGS} &&\
-	export LDFLAGS=${LDFLAGS} &&\
 	./configure --prefix=${PREFIX}&&\
-	MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} make -j3 install&& \
-	unset MACOSX_DEPLOYMENT_TARGET
+	${MAKE} -j3 install
 
-png: zlib
-	export PKG_CONFIG_PATH=${PKG_CONFIG_PATH} &&\
+png: check-prefix zlib
 	rm -rf libpng-${PNGVERSION} &&\
 	tar xvfz libpng-${PNGVERSION}.tar.gz && \
 	cd libpng-${PNGVERSION} &&\
-	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} &&\
-	export CFLAGS=${CFLAGS} &&\
-	export LDFLAGS=${LDFLAGS} &&\
 	./configure  --disable-dependency-tracking  --prefix=${PREFIX} &&\
-	make -j3 install&&\
-	cp .libs/libpng.a . &&\
-	unset MACOSX_DEPLOYMENT_TARGET
+	${MAKE} -j3 install&&\
+	cp .libs/libpng.a .
 
-
-freetype: zlib
-	export PKG_CONFIG_PATH=${PKG_CONFIG_PATH} &&\
+freetype: check-prefix zlib
 	rm -rf ${FREETYPEVERSION} &&\
 	tar xvfj freetype-${FREETYPEVERSION}.tar.bz2 &&\
 	cd freetype-${FREETYPEVERSION} &&\
-	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} &&\
-	export CFLAGS=${CFLAGS} &&\
-	export LDFLAGS=${LDFLAGS} &&\
 	./configure  --prefix=${PREFIX} &&\
-	make -j3 install &&\
-	cp objs/.libs/libfreetype.a .  &&\
-	unset MACOSX_DEPLOYMENT_TARGET
-
+	${MAKE} -j3 install &&\
+	cp objs/.libs/libfreetype.a .
 
 deps: zlib png freetype
 	echo 'all done'
 
-mpl_build:
-	export PKG_CONFIG_PATH=${PKG_CONFIG_PATH} &&\
-	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} &&\
-	export CFLAGS=${CFLAGS} &&\
-	export LDFLAGS=${LDFLAGS} &&\
+# Various build and install targets
+#
+# The values of PKG_CONFIG_PATH, MACOSX_DEPLOYMENT_TARGET, CFLAGS,
+# LDFLAGS affect the compilation; note that variables are
+# automatically put into the environment by make.
+
+mpl_build: check-prefix
 	${PYTHON} setup.py build
 
-mpl_install:
-	export PKG_CONFIG_PATH=${PKG_CONFIG_PATH} &&\
-	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} &&\
-	export CFLAGS=${CFLAGS} &&\
-	export LDFLAGS=${LDFLAGS} &&\
+mpl_install: check-prefix
+	${PYTHON} setup.py install --prefix=${PREFIX}
+
+mpl_install_std: check-prefix
 	${PYTHON} setup.py install
 
+mpl_install_egg: check-prefix
+	${PYTHON} setupegg.py install
 
-binaries:
+mpl_install_develop: check-prefix
+	${PYTHON} setupegg.py develop
+
+
+binaries: check-prefix
+	@if [ -z "$(PYVERSION)" ]; then echo Must set PYVERSION; exit 1; fi
 	unset PKG_CONFIG_PATH &&\
 	cp release/osx/data/setup.cfg release/osx/data/ReadMe.txt . &&\
-	export CFLAGS=${CFLAGS} &&\
-	export LDFLAGS=${LDFLAGS} &&\
 	rm -f ${PREFIX}/lib/*.dylib &&\
 	/Library/Frameworks/Python.framework/Versions/${PYVERSION}/bin/bdist_mpkg --readme=ReadMe.txt &&\
 	hdiutil create -srcdir dist/matplotlib-${MPLVERSION}-py${PYVERSION}-macosx10.5.mpkg  dist/matplotlib-${MPLVERSION}-py${PYVERSION}-macosx10.5.dmg &&\


### PR DESCRIPTION
I updated a couple of links for fetch and added some stray files to clean. I'm also making a couple of suggestions regarding requiring PYVERSION in the command line and dropping the PREFIX from mpl_install. For this last one, I'm assuming that the dependencies are compile-time and matplotlib will work correctly from the relevant site-packages (I haven't seen any problems yet, although I've kept the dependencies in the PREFIX), but I welcome any comments or corrections.
