### PR TITLE
Bugfix/qt4 savefile

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -22,6 +22,22 @@ try:
 except ImportError:
     raise ImportError("Qt4 backend requires that PyQt4 is installed.")
 
+import sip
+
+try :
+    if sip.getapi("QString") > 1 :
+        # Use new getSaveFileNameAndFilter()
+        _getSaveFileName = lambda self, msg, start, filters, selectedFilter : \
+                            QtGui.QFileDialog.getSaveFileNameAndFilter(self,  \
+                                msg, start, filters, selectedFilter)[0]
+    else :
+        # Use old getSaveFileName()
+        _getSaveFileName = QtGui.QFileDialog.getSaveFileName
+except (AttributeError, KeyError) :
+    # call to getapi() can fail in older versions of sip
+    # Use the old getSaveFileName()
+    _getSaveFileName = QtGui.QFileDialog.getSaveFileName
+
 backend_version = "0.9.1"
 def fn_name(): return sys._getframe(1).f_code.co_name
 
@@ -524,8 +540,8 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
             filters.append(filter)
         filters = ';;'.join(filters)
 
-        fname = QtGui.QFileDialog.getSaveFileName(
-            self, "Choose a filename to save to", start, filters, selectedFilter)
+        fname = _getSaveFileName(self, "Choose a filename to save to",
+                                        start, filters, selectedFilter)
         if fname:
             try:
                 self.canvas.print_figure( unicode(fname) )


### PR DESCRIPTION
This is an attempt to support the change in the PyQt4 API of getSaveFileName().  There is now a _getSaveFileName variable that gets conditionally assigned either the old getSaveFileName method or a lambda function that wraps a call to the new getSaveFileNameAndFilter().  The lambda function was necessary so that only the filename part of the tuple returned by getSaveFileNameAndFilter() gets returned by the call to _getSaveFileName().

I have only tested the case where sip.getapi("QString") returns 1.  I would greatly appreciate if others with different versions of PyQt4 test to make sure this works.
