### PR TITLE
Fix issue 34: set_rubberband: integer argument expected, got float

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -453,7 +453,7 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
         _macosx.NavigationToolbar2.__init__(self, basedir)
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
-        self.canvas.set_rubberband(x0, y0, x1, y1)
+        self.canvas.set_rubberband(int(x0), int(y0), int(x1), int(y1))
 
     def release(self, event):
         self.canvas.remove_rubberband()


### PR DESCRIPTION
Like a few others, the MacOSX backend is responsible for casting it's arguments to int .  See the backtrace in

  https://github.com/matplotlib/matplotlib/issues/34
