### PR TITLE
Remove -Wstrict-prototypes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ from setupext import build_agg, build_gtkagg, build_tkagg, build_wxagg,\
      check_provide_pytz, check_provide_dateutil,\
      check_for_dvipng, check_for_ghostscript, check_for_latex, \
      check_for_pdftops, check_for_datetime, options, build_png, build_tri
-#import distutils.sysconfig
 
 # jdh
 packages = [

--- a/setupext.py
+++ b/setupext.py
@@ -46,6 +46,7 @@ WIN32 - VISUAL STUDIO 7.1 (2003)
 import os
 import re
 import subprocess
+from distutils import sysconfig
 
 basedir = {
     'win32'  : ['win32_static',],
@@ -199,6 +200,20 @@ else:
     def print_line(*args, **kwargs):
         pass
     print_status = print_message = print_raw = print_line
+
+# Remove the -Wstrict-prototypesoption, is it's not valid for C++
+customize_compiler = sysconfig.customize_compiler
+def my_customize_compiler(compiler):
+    retval = customize_compiler(compiler)
+    try:
+        compiler.compiler_so.remove('-Wstrict-prototypes')
+    except (ValueError, AttributeError):
+        pass
+    return retval
+
+sysconfig.customize_compiler = my_customize_compiler
+
+
 
 def run_child_process(cmd):
     p = subprocess.Popen(cmd, shell=True,


### PR DESCRIPTION
The strict-prototypes warning is pointless for C++ code, and adds needless noise to the compilation. Remove this option before building matplotlib.

(a fix from the CTPUG matplotlib porting sprint that is also relevant to matplotlib trunk).
