### PR TITLE
Yafli

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -15,7 +15,13 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.figure import Figure
 from matplotlib.mathtext import MathTextParser
 from matplotlib.widgets import SubplotTool
-import matplotlib.backends.qt4_editor.figureoptions as figureoptions
+try:
+    import matplotlib.backends.qt4_editor.figureoptions as figureoptions
+except ImportError:
+    figureoptions = None
+figureoptions = None
+
+print figureoptions
 
 try:
     from PyQt4 import QtCore, QtGui, Qt
@@ -424,9 +430,10 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
                 self.configure_subplots)
         a.setToolTip('Configure subplots')
 
-        a = self.addAction(self._icon("qt4_editor_options.svg"),
-                           'Customize', self.edit_parameters)
-        a.setToolTip('Edit curves line and axes parameters')
+        if figureoptions is not None:
+            a = self.addAction(self._icon("qt4_editor_options.svg"),
+                               'Customize', self.edit_parameters)
+            a.setToolTip('Edit curves line and axes parameters')
 
         a = self.addAction(self._icon('filesave.svg'), 'Save',
                 self.save_figure)
@@ -451,34 +458,35 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
         # reference holder for subplots_adjust window
         self.adj_window = None
 
-    def edit_parameters(self):
-        allaxes = self.canvas.figure.get_axes()
-        if len(allaxes) == 1:
-            axes = allaxes[0]
-        else:
-            titles = []
-            for axes in allaxes:
-                title = axes.get_title()
-                ylabel = axes.get_ylabel()
-                if title:
-                    text = title
-                    if ylabel:
-                        text += ": "+ylabel
-                    text += " (%s)"
-                elif ylabel:
-                    text = "%%s (%s)" % ylabel
-                else:
-                    text = "%s"
-                titles.append(text % repr(axes))
-            item, ok = QtGui.QInputDialog.getItem(self, 'Customize',
-                                                  'Select axes:', titles,
-                                                  0, False)
-            if ok:
-                axes = allaxes[titles.index(unicode(item))]
+    if figureoptions is not None:
+        def edit_parameters(self):
+            allaxes = self.canvas.figure.get_axes()
+            if len(allaxes) == 1:
+                axes = allaxes[0]
             else:
-                return
+                titles = []
+                for axes in allaxes:
+                    title = axes.get_title()
+                    ylabel = axes.get_ylabel()
+                    if title:
+                        text = title
+                        if ylabel:
+                            text += ": "+ylabel
+                        text += " (%s)"
+                    elif ylabel:
+                        text = "%%s (%s)" % ylabel
+                    else:
+                        text = "%s"
+                    titles.append(text % repr(axes))
+                item, ok = QtGui.QInputDialog.getItem(self, 'Customize',
+                                                      'Select axes:', titles,
+                                                      0, False)
+                if ok:
+                    axes = allaxes[titles.index(unicode(item))]
+                else:
+                    return
 
-        figureoptions.figure_edit(axes, self)
+            figureoptions.figure_edit(axes, self)
 
 
     def dynamic_update( self ):


### PR DESCRIPTION
The qt4 plot options editor uses some PyQt features that were not available in <PyQt4-4.3. This patch prevents this constraint from rendering the entire Qt4 backend unusable on older platforms (like RHEL5). It should be merged into both v1.0.x and master.
