### PR TITLE
Chdir import path fixes

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -105,6 +105,10 @@ import os, re, shutil, subprocess, sys, warnings
 import distutils.sysconfig
 import distutils.version
 
+# This is to make sure we're using an absolute module path instead of
+# a relative one to load submodules.
+__path__[0] = os.path.abspath(__path__[0])
+
 # Needed for toolkit setuptools support
 if 0:
     try:


### PR DESCRIPTION
In some situations, the matplotlib package seems to be imported for a relative module path. Since much of the backend wrangling involves importing submodules in functions, this means that a chdir() before calling one of these functions can raise confusing ImportErrors. The test framework performs such a chdir() in the image_comparison() decorator that many of the tests use, which causes spurious test errors.
