### PR TITLE
Include test_text in default_test_modules

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -968,7 +968,8 @@ default_test_modules = [
     'matplotlib.tests.test_spines',
     'matplotlib.tests.test_image',
     'matplotlib.tests.test_simplification',
-    'matplotlib.tests.test_mathtext'
+    'matplotlib.tests.test_mathtext',
+    'matplotlib.tests.test_text'
     ]
 
 def test(verbosity=0):


### PR DESCRIPTION
I added a pull request for this two line change just in case there was a specific reason to _exclude_ test_text from the test modules. 

For instance, right now, I get one failure in the test suite if I include it. The failure is in test_text:test_font_styles, but this has been the case for a while, it's just that these tests weren't running before.

Any developers want to chime in on this?

By the way, this was the source of discrepancy between running via nosetests and matplotlib.test() as was described [here] [1]

[1]: http://old.nabble.com/matplotlib.test%28%29-no-errors%2C-but-%24nosetest-matplotlib.tests--%3E-errors-%09and-failure--td29257062.html#a29257062 "here".
