### PR TITLE
Fix 3187521 - crash due to unescaped fontpaths

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2011-03-25 Fixed bug #3187521, crash due to unescaped fontpaths -PI
+
 2011-03-10 Update pytz version to 2011c, thanks to Simon Cross. - JKS
 
 2011-03-06 Add standalone tests.py test runner script. - JKS

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -349,8 +349,8 @@ def findSystemFonts(fontpaths=None, fontext='ttf'):
     for path in fontpaths:
         files = []
         for ext in fontexts:
-            files.extend(glob.glob(os.path.join(path, '*.'+ext)))
-            files.extend(glob.glob(os.path.join(path, '*.'+ext.upper())))
+            files.extend(glob.glob(os.path.join(repr(path), '*.'+ext)))
+            files.extend(glob.glob(os.path.join(repr(path), '*.'+ext.upper())))
         for fname in files:
             fontfiles[os.path.abspath(fname)] = 1
 


### PR DESCRIPTION
Some paths were improperly being interpreted as a regular expression, leading to errors.
