### PR TITLE
Bugfix: enable picking of AsteriskCollection instances

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2011-04-03 Fixed broken pick interface to AsteriskCollection objects
+           used by scatter. - EF
+
 2011-03-29 Wrapped ViewVCCachedServer definition in a factory function.
            This class now inherits from urllib2.HTTPSHandler in order
            to fetch data from github, but HTTPSHandler is not defined


### PR DESCRIPTION
A primary use of these is in scatter, where they provide + and x
symbols.

This fixes the problem reported here:
http://article.gmane.org/gmane.comp.python.matplotlib.devel/10069

The present commit is a fairly minimal solution to the problem; it makes the symbols pickable without breaking anything that I know of.  It does change default behavior in that filled symbols from scatter (i.e., collections) now obey the pickradius--the cursor can be outside the symbol if self._pickradius or self._picker is non-zero.  This could be addressed by setting different default _pickradius falues for different types of symbol; the filled types could default to zero, or at least to a smaller value than the default for unfilled types, and this can then be overridden by the picker kwarg if the user so chooses.  I would be willing to add this change to the present branch, if others think it a good idea; I am neutral on doing it here and now.

Note that all this leaves an inconsistency between collections and Line2D objects.  In the former, picking is based on the object path after stroking with a line of pickradius thickness; in the latter picking is based on datapoint locations and pickradius alone, with no account taken of the marker size.  If any of this is to be smoothed out, I am inclined to do it in master, not v1.0.x.  
