### PR TITLE
Write out the results of tests that don't yet have baseline images.

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -88,7 +88,7 @@ def image_comparison(baseline_images=None,extensions=None,tol=1e-3):
                 orig_expected_fnames = [os.path.join(baseline_dir,fname) + '.' + extension for fname in baseline_images]
                 expected_fnames = [os.path.join(result_dir,'expected-'+fname) + '.' + extension for fname in baseline_images]
                 actual_fnames = [os.path.join(result_dir, fname) + '.' + extension for fname in baseline_images]
-                have_baseline_images = [os.path.exists(expected) for expected in expected_fnames]
+                have_baseline_images = [os.path.exists(expected) for expected in orig_expected_fnames]
                 have_baseline_image = np.all(have_baseline_images)
                 is_comparable = extension in comparable_formats()
                 if not is_comparable:


### PR DESCRIPTION
A new test that did not yet have baseline images would fail before the results of the test were generated.  This commit changes things so it writes out the results, then fails, thereby creating new files that can be copied to the source directory as new baseline images.
