### PR TITLE
add "|-|" to annnotation_guide table with options widthA,widthB

### DIFF
--- a/doc/users/annotations_guide.rst
+++ b/doc/users/annotations_guide.rst
@@ -150,6 +150,7 @@ an arrow patch, according to the given ``arrowstyle``.
     ``-``        None
     ``->``       head_length=0.4,head_width=0.2
     ``-[``       widthB=1.0,lengthB=0.2,angleB=None
+    ``|-|``      widthA=1.0,widthB=1.0
     ``-|>``      head_length=0.4,head_width=0.2
     ``<-``       head_length=0.4,head_width=0.2
     ``<->``      head_length=0.4,head_width=0.2

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3314,7 +3314,7 @@ class ArrowStyle(_Style):
 
     class BarAB(_Bracket):
         """
-        An arrow with a bracket(])  at both ends.
+        An arrow with a bar(|) at both ends.
         """
 
         def __init__(self,


### PR DESCRIPTION
this patch adds a bit of documentation for the barAB arrowstyle to the annotations_guide + a small comment fix. 
