### PR TITLE
BUG: in qt4 backend, ignore auto-repeat keyboard events.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2011-04-17 Disable keyboard auto-repeat in qt4 backend by ignoring
+           key events resulting from auto-repeat.  This makes
+           constrained zoom/pan work. - EF
+
 2011-04-03 Fixed broken pick interface to AsteriskCollection objects
            used by scatter. - EF
 

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -207,11 +207,15 @@ class FigureCanvasQT( QtGui.QWidget, FigureCanvasBase ):
 
     def keyPressEvent( self, event ):
         key = self._get_key( event )
+        if key is None:
+            return
         FigureCanvasBase.key_press_event( self, key )
         if DEBUG: print 'key press', key
 
     def keyReleaseEvent( self, event ):
         key = self._get_key(event)
+        if key is None:
+            return
         FigureCanvasBase.key_release_event( self, key )
         if DEBUG: print 'key release', key
 
@@ -236,6 +240,8 @@ class FigureCanvasQT( QtGui.QWidget, FigureCanvasBase ):
         return QtCore.QSize( 10, 10 )
 
     def _get_key( self, event ):
+        if event.isAutoRepeat():
+            return None
         if event.key() < 256:
             key = str(event.text())
         elif event.key() in self.keyvald:


### PR DESCRIPTION
This makes constrained zoom/pan work. I don't see any need
to support keyboard auto-repeat in mpl.

The bug was reported here: 
http://thread.gmane.org/gmane.comp.python.matplotlib.devel/10134
