### PR TITLE
Fixes a memory leak where each spines' path was a view of the spine path 

### DIFF
--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -247,7 +247,7 @@ class Spine(mpatches.Patch):
         else:
             low,high = self._bounds
 
-        v1 = self._path.vertices.copy()
+        v1 = self._path.vertices
         assert v1.shape == (2,2), 'unexpected vertices shape'
         if self.spine_type in ['left','right']:
             v1[0,1] = low
@@ -257,7 +257,6 @@ class Spine(mpatches.Patch):
             v1[1,0] = high
         else:
             raise ValueError('unable to set bounds for spine "%s"'%spine_type)
-        self._path.vertices = v1 # replace
 
     @allow_rasterization
     def draw(self, renderer):


### PR DESCRIPTION
Fixes a memory leak where each spines' path was a view of the spine path of the previous run.

The following code (simplified to its essence from an example by Caleb Constantine) leaks memory very slowly -- detectable only using valgrind.  It turns out that if the axes are cleared and reused rather than deleted, each spine's path is created as a view based on the spine's path in the previous draw.  This creates a long reference chain rather than freeing the previous draw's path view.  

This pull request fixes the leak, but @astraw may want to have a look at the fix...  I'm not entirely sure why the copy is needed at all -- it hasn't actually been creating a copy all this time any way.  Perhaps an alternative solution is just to remove the copy and the assignment (marked with the comment "# replace") altogether?

<pre>
import numpy
import matplotlib
matplotlib.use("Agg")
from matplotlib.figure import Figure
from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas

figure = Figure(dpi=None)
canvas = FigureCanvas(figure)
axes = figure.add_subplot(1,1,1)

def draw(channel, seconds):
    axes.clear()
    axes.plot(channel, seconds)
    canvas.print_figure('test.png')

channel = numpy.sin(numpy.arange(1000))
seconds = numpy.arange(len(channel))

for i in range(10):
    draw(channel, seconds)
</pre>
