### PR TITLE
Fixed warning message relating to interpolation='none' setting

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -620,7 +620,7 @@ class AxesImage(_AxesImageBase):
             if renderer.option_scale_image():
                 return True
             else:
-                warnings.warn("The backend (%s) does not support interpolation='none'. The image will be interpolated with 'nearest` mode." % (str(type(renderer))))
+                warnings.warn("The backend (%s) does not support interpolation='none'. The image will be interpolated with 'nearest` mode." % renderer.__class__)
 
         return False
 


### PR DESCRIPTION
Before this patch, if using `interpolation='none'` and a backend that doesn't support it, the warning was:

```
The backend (<type 'instance'>) does not support interpolation='none'. The image will be interpolated with 'nearest` mode.
```

With the current patch, it is:

```
The backend (matplotlib.backends.backend_macosx.RendererMac) does not support interpolation='none'. The image will be interpolated with 'nearest` mode.
```
