### PR TITLE
0.99.x documentation build failure fix (plot_directive formats can be unicode)

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -238,7 +238,7 @@ def plot_directive(name, arguments, options, content, lineno,
     Handle the plot directive.
     """
     formats = setup.config.plot_formats
-    if type(formats) == str:
+    if isinstance(formats, basestring):
         formats = eval(formats)
 
     # The user may provide a filename *or* Python code content, but not both


### PR DESCRIPTION
A build failure appeared in Debian sid (which still has 0.99.3) 
http://bugs.debian.org/625150

It appears that "formats" may be unicode. Not quite sure why this happens. This code has completely changed in 1.x, so I don't expect it to be an issue in master.

```
(sid-amd64)sbuild@dvorak:/build/matplotlib-jD7Xkb/matplotlib-0.99.3/doc$ MATPLOTLIBDATA=../lib/matplotlib/mpl-data/ PYTHONPATH=../build/lib.linux-x86_64-2.6 ./make.py --small all
Running Sphinx v1.0.7
WARNING: extension 'math_symbol_table' has no setup() function; is it really a Sphinx extension module?
loading pickled environment... done
animation, api, axes_grid, event_handling, misc, mplot3d, pngsuite, pylab_examples, tests, units, user_interfaces, widgets,
building [html]: targets for 286 source files that are out of date
updating environment: [config changed] 467 added, 0 changed, 0 removed
reading sources... [  0%] api/afm_api
reading sources... [  0%] api/api_changes
reading sources... [  0%] api/artist_api
/build/matplotlib-jD7Xkb/matplotlib-0.99.3/doc/sphinxext/inheritance_diagram.py:312: DeprecationWarning: xfileref_role is deprecated, use XRefRole
  'class', ':class:`%s`' % name, name, 0, state)
...Exception occurred while building, starting debugger:
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/sphinx/cmdline.py", line 188, in main
    app.build(force_all, filenames)
  File "/usr/lib/pymodules/python2.6/sphinx/application.py", line 207, in build
    self.builder.build_update()
  File "/usr/lib/pymodules/python2.6/sphinx/builders/__init__.py", line 198, in build_update
    'out of date' % len(to_build))
  File "/usr/lib/pymodules/python2.6/sphinx/builders/__init__.py", line 218, in build
    purple, length):
  File "/usr/lib/pymodules/python2.6/sphinx/builders/__init__.py", line 120, in status_iterator
    for item in iterable:
  File "/usr/lib/pymodules/python2.6/sphinx/environment.py", line 519, in update_generator
    self.read_doc(docname, app=app)
  File "/usr/lib/pymodules/python2.6/sphinx/environment.py", line 664, in read_doc
    pub.publish()
  File "/usr/lib/pymodules/python2.6/docutils/core.py", line 203, in publish
    self.settings)
  File "/usr/lib/pymodules/python2.6/docutils/readers/__init__.py", line 69, in read
    self.parse()
  File "/usr/lib/pymodules/python2.6/docutils/readers/__init__.py", line 75, in parse
    self.parser.parse(self.input, document)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/__init__.py", line 157, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 170, in run
    input_source=document['source'])
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2940, in text
    self.section(title.lstrip(), source, style, lineno + 1, messages)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 329, in section
    self.new_subsection(title, lineno, messages)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 398, in new_subsection
    node=section_node, match_titles=1)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 284, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2706, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 329, in section
    self.new_subsection(title, lineno, messages)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 398, in new_subsection
    node=section_node, match_titles=1)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 284, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2281, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2293, in explicit_construct
    return method(self, expmatch)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2035, in directive
    directive_class, match, type_name, option_presets)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2086, in run_directive
    result = directive_instance.run()
  File "/usr/lib/pymodules/python2.6/sphinx/ext/autodoc.py", line 1194, in run
    nested_parse_with_titles(self.state, self.result, node)
  File "/usr/lib/pymodules/python2.6/sphinx/util/nodes.py", line 32, in nested_parse_with_titles
    return state.nested_parse(content, 0, node, match_titles=1)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 284, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2283, in explicit_markup
    self.explicit_list(blank_finish)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2314, in explicit_list
    match_titles=self.state_machine.match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 321, in nested_list_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2587, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2293, in explicit_construct
    return method(self, expmatch)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2035, in directive
    directive_class, match, type_name, option_presets)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2086, in run_directive
    result = directive_instance.run()
  File "/usr/lib/pymodules/python2.6/sphinx/domains/__init__.py", line 193, in run
    return BaseDirective.run(self)
  File "/usr/lib/pymodules/python2.6/sphinx/directives/__init__.py", line 164, in run
    self.state.nested_parse(self.content, self.content_offset, contentnode)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 284, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2283, in explicit_markup
    self.explicit_list(blank_finish)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2314, in explicit_list
    match_titles=self.state_machine.match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 321, in nested_list_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2587, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2293, in explicit_construct
    return method(self, expmatch)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2035, in directive
    directive_class, match, type_name, option_presets)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2086, in run_directive
    result = directive_instance.run()
  File "/usr/lib/pymodules/python2.6/sphinx/domains/__init__.py", line 193, in run
    return BaseDirective.run(self)
  File "/usr/lib/pymodules/python2.6/sphinx/directives/__init__.py", line 164, in run
    self.state.nested_parse(self.content, self.content_offset, contentnode)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 284, in nested_parse
    node=node, match_titles=match_titles)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 233, in run
    context, state, transitions)
  File "/usr/lib/pymodules/python2.6/docutils/statemachine.py", line 454, in check_line
    return method(match, context, next_state)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2281, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2293, in explicit_construct
    return method(self, expmatch)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2035, in directive
    directive_class, match, type_name, option_presets)
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/states.py", line 2086, in run_directive
    result = directive_instance.run()
  File "/usr/lib/pymodules/python2.6/docutils/parsers/rst/__init__.py", line 370, in run
    self.state, self.state_machine)
  File "/build/matplotlib-jD7Xkb/matplotlib-0.99.3/build/lib.linux-x86_64-2.6/matplotlib/sphinxext/plot_directive.py", line 331, in plot_directive
    os.path.join(destdir, outname + "." + format))
  File "/usr/lib/python2.6/shutil.py", line 50, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: u'/build/matplotlib-jD7Xkb/matplotlib-0.99.3/doc/build/plot_directive/mpl_examples/pylab_examples/findobj_demo.('
> /usr/lib/python2.6/shutil.py(50)copyfile()
-> with open(src, 'rb') as fsrc:
(Pdb) u
> /build/matplotlib-jD7Xkb/matplotlib-0.99.3/build/lib.linux-x86_64-2.6/matplotlib/sphinxext/plot_directive.py(331)plot_directive()
-> os.path.join(destdir, outname + "." + format))
(Pdb) p formats
u"[('png', 80)]"
```
