### PR TITLE
search in more paths for tcl/tkConfig.sh

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -827,15 +827,20 @@ def query_tcltk():
     return TCL_TK_CACHE
 
 def parse_tcl_config(tcl_lib_dir, tk_lib_dir):
-    # This is where they live on Ubuntu Hardy (at least)
-    tcl_config = os.path.join(tcl_lib_dir, "tclConfig.sh")
-    tk_config = os.path.join(tk_lib_dir, "tkConfig.sh")
+    import Tkinter
+    tcl_poss = [tcl_lib_dir,
+                "/usr/lib/tcl"+str(Tkinter.TclVersion),
+                "/usr/lib"]
+    tk_poss = [tk_lib_dir,
+               "/usr/lib/tk"+str(Tkinter.TkVersion),
+               "/usr/lib"]
+    for ptcl, ptk in zip(tcl_poss, tk_poss):
+        tcl_config = os.path.join(ptcl, "tclConfig.sh")
+        tk_config = os.path.join(ptk, "tkConfig.sh")
+        if (os.path.exists(tcl_config) and os.path.exists(tk_config)):
+            break
     if not (os.path.exists(tcl_config) and os.path.exists(tk_config)):
-        # This is where they live on RHEL4 (at least)
-        tcl_config = "/usr/lib/tclConfig.sh"
-        tk_config = "/usr/lib/tkConfig.sh"
-        if not (os.path.exists(tcl_config) and os.path.exists(tk_config)):
-            return None
+        return None
 
     # These files are shell scripts that set a bunch of
     # environment variables.  To actually get at the


### PR DESCRIPTION
The location of tcl/tkConfig.sh has changed in debian testing and ubuntu natty.
https://launchpad.net/ubuntu/+source/tcl8.5/8.5.9-2
the new locations are:
/usr/lib/tcl8.5/
/usr/lib/tk8.5/

this means setupext.py does not find the files anymore and fails to build the _tkagg.so extension in some circumstances.

This is the same patch as posted in the sourceforge tracker:
https://sourceforge.net/tracker/?func=detail&aid=3279844&group_id=80706&atid=560720
