### PR TITLE
Fix bug where there was a thin semitransparent line on the upper and left

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -226,7 +226,7 @@ class Figure(Artist):
                  dpi       = None,  # defaults to rc figure.dpi
                  facecolor = None,  # defaults to rc figure.facecolor
                  edgecolor = None,  # defaults to rc figure.edgecolor
-                 linewidth = 1.0,   # the default linewidth of the frame
+                 linewidth = 0.0,   # the default linewidth of the frame
                  frameon = True,    # whether or not to draw the figure frame
                  subplotpars = None, # default to rc
                  ):
@@ -271,6 +271,7 @@ class Figure(Artist):
             linewidth=linewidth,
             )
         self._set_artist_props(self.patch)
+        self.patch.set_aa(False)
 
         self._hold = rcParams['axes.hold']
         self.canvas = None

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -1317,11 +1317,15 @@ RendererAgg::draw_path(const Py::Tuple& args)
     trans *= agg::trans_affine_translation(0.0, (double)height);
     bool clip = !face.first && gc.hatchpath.isNone() && !path.has_curves();
     bool simplify = path.should_simplify() && clip;
+    double snapping_linewidth = gc.linewidth;
+    if (gc.color.a == 1.0) {
+        snapping_linewidth = 0.0;
+    }
 
     transformed_path_t tpath(path, trans);
     nan_removed_t      nan_removed(tpath, true, path.has_curves());
     clipped_t          clipped(nan_removed, clip, width, height);
-    snapped_t          snapped(clipped, gc.snap_mode, path.total_vertices(), gc.linewidth);
+    snapped_t          snapped(clipped, gc.snap_mode, path.total_vertices(), snapping_linewidth);
     simplify_t         simplified(snapped, simplify, path.simplify_threshold());
     curve_t            curve(simplified);
 


### PR DESCRIPTION
Fix bug where there was a thin semitransparent line on the upper and left edge of the image in the Agg backend.  Closes #117.
