### PR TITLE
Fixed traceback importing font_manager.py on japanese windows xp

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -232,7 +232,8 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
                     continue
                 except WindowsError:
                     continue
-
+                except MemoryError:
+                    continue
             return items.keys()
         finally:
             _winreg.CloseKey(local)


### PR DESCRIPTION
Japanese Windows XP with python-2.7 will produce a MemoryError from a failed Registry query - 

so I added a continue statement for a MemoryError in addition to a WindowsError. Since we already caught this exception and continue, just added another type of exception to continue on.
