### PR TITLE
Patched pyplot.subplots for squeeze==False

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -801,8 +801,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
             ret = fig, axarr.squeeze()
     else:
         # returned axis array will be always 2-d, even if nrows=ncols=1
-        return fig, axarr.reshape(nrows, ncols)
-
+        ret = fig, axarr.reshape(nrows, ncols)
 
     return ret
 


### PR DESCRIPTION
If squeeze == False, ret was never defined. I just copied over the code from 1.0.1 release.
