### PR TITLE
pyplot: add pause() function for crude animation

### DIFF
--- a/examples/pylab_examples/animation_demo.py
+++ b/examples/pylab_examples/animation_demo.py
@@ -1,0 +1,30 @@
+"""
+Pyplot animation example.
+
+The method shown here is only for very simple, low-performance
+use.  For more demanding applications, look at the animation
+module and the examples that use it.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+x = np.arange(6)
+y = np.arange(5)
+z = x * y[:,np.newaxis]
+
+for i in xrange(5):
+    if i==0:
+        p = plt.imshow(z)
+        fig = plt.gcf()
+        plt.clim()   # clamp the color limits
+        plt.title("Boring slide show")
+    else:
+        z = z + 2
+        p.set_data(z)
+
+    print "step", i
+    plt.pause(0.5)
+
+
+

--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -61,6 +61,7 @@ _Plotting commands
   loglog   - a log log plot
   matshow  - display a matrix in a new figure preserving aspect
   margins  - set margins used in autoscaling
+  pause    - pause for a specified interval
   pcolor   - make a pseudocolor plot
   pcolormesh - make a pseudocolor plot using a quadrilateral mesh
   pie      - make a pie chart

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -146,6 +146,41 @@ def ion():
     'Turn interactive mode on.'
     matplotlib.interactive(True)
 
+def pause(interval):
+    """
+    Pause for *interval* seconds.
+
+    If there is an active figure it will be updated and displayed,
+    and the gui event loop will run during the pause.
+
+    If there is no active figure, or if a non-interactive backend
+    is in use, this executes time.sleep(interval).
+
+    This can be used for crude animation. For more complex
+    animation, see :mod:`matplotlib.animation`.
+
+    """
+    backend = rcParams['backend']
+    if backend in _interactive_bk:
+        figManager = _pylab_helpers.Gcf.get_active()
+        if figManager is not None:
+            canvas = figManager.canvas
+            canvas.draw()
+            was_interactive = isinteractive()
+            if not was_interactive:
+                ion()
+                show()
+            canvas.start_event_loop(interval)
+            if not was_interactive:
+                ioff()
+            return
+
+    # No on-screen figure is active, so sleep() is all we need.
+    import time
+    time.sleep(interval)
+
+
+
 @docstring.copy_dedent(matplotlib.rc)
 def rc(*args, **kwargs):
     matplotlib.rc(*args, **kwargs)
@@ -958,7 +993,7 @@ def subplot_tool(targetfig=None):
 
 def tight_layout(pad=1.2, h_pad=None, w_pad=None):
     """Adjust subplot parameters to give specified padding.
-    
+
     Parameters
     ----------
     pad : float


### PR DESCRIPTION
New users often want to be able to do simple animation
using pyplot functions, but run into trouble trying to
use time.sleep() or show().  pause() eliminates the need
for either for this application.

This was prompted by Sourceforge bug ID 3114540.  A
modified version of the example given there is included
in this changeset.
