### PR TITLE
Fix qt4 axes parameter dialog when '%' appears in plot titles

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -447,15 +447,17 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
                     title = axes.get_title()
                     ylabel = axes.get_ylabel()
                     if title:
-                        text = title
+                        fmt = "%(title)s"
                         if ylabel:
-                            text += ": "+ylabel
-                        text += " (%s)"
+                            fmt += ": %(ylabel)s"
+                        fmt += " (%(axes_repr)s)"
                     elif ylabel:
-                        text = "%%s (%s)" % ylabel
+                        fmt = "%(axes_repr)s (%(ylabel)s)" % ylabel
                     else:
-                        text = "%s"
-                    titles.append(text % repr(axes))
+                        fmt = "%(axes_repr)s"
+                    titles.append(fmt % dict(title = title,
+                                         ylabel = ylabel,
+                                         axes_repr = repr(axes)))
                 item, ok = QtGui.QInputDialog.getItem(self, 'Customize',
                                                       'Select axes:', titles,
                                                       0, False)


### PR DESCRIPTION
I got an exception when pressing the "edit curves line and axes parameter" button on a plot with '%' in a subplot title:

```
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/matplotlib/backends/backend_qt4.py", line 456, in edit_parameters
    titles.append(text % repr(axes))
ValueError: unsupported format character ')' (0x29) at index 38
```

I had used sth. like:
`pylab.title("differences (in %)")`
