### PR TITLE
Tk build improvements

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -914,9 +914,11 @@ def query_tcltk():
 def parse_tcl_config(tcl_lib_dir, tk_lib_dir):
     import Tkinter
     tcl_poss = [tcl_lib_dir,
+                os.path.normpath(os.path.join(tcl_lib_dir, '..')),
                 "/usr/lib/tcl"+str(Tkinter.TclVersion),
                 "/usr/lib"]
     tk_poss = [tk_lib_dir,
+                os.path.normpath(os.path.join(tk_lib_dir, '..')),
                "/usr/lib/tk"+str(Tkinter.TkVersion),
                "/usr/lib"]
     for ptcl, ptk in zip(tcl_poss, tk_poss):
@@ -927,52 +929,29 @@ def parse_tcl_config(tcl_lib_dir, tk_lib_dir):
     if not (os.path.exists(tcl_config) and os.path.exists(tk_config)):
         return None
 
-    # These files are shell scripts that set a bunch of
-    # environment variables.  To actually get at the
-    # values, we use ConfigParser, which supports almost
-    # the same format, but requires at least one section.
-    # So, we push a "[default]" section to a copy of the
-    # file in a StringIO object.
-    try:
-        tcl_vars_str = cStringIO.StringIO(
-            "[default]\n" + open(tcl_config, "r").read())
-        tk_vars_str = cStringIO.StringIO(
-            "[default]\n" + open(tk_config, "r").read())
-    except IOError:
-        # if we can't read the file, that's ok, we'll try
-        # to guess instead
+    def get_var(file, varname):
+        p = subprocess.Popen(
+            'source %s ; eval echo ${%s}' % (file, varname),
+            shell=True, stdout=subprocess.PIPE)
+        result = p.communicate()[0]
+        return result
+
+    tcl_lib_dir = get_var(tcl_config, 'TCL_LIB_SPEC').split()[0][2:]
+    tcl_inc_dir = get_var(tcl_config, 'TCL_INCLUDE_SPEC')[2:]
+    tcl_lib = get_var(tcl_config, 'TCL_LIB_FLAG')[2:].strip()
+
+    tk_lib_dir = get_var(tk_config, 'TK_LIB_SPEC').split()[0][2:]
+    tk_inc_dir = get_var(tk_config, 'TK_INCLUDE_SPEC').strip()
+    if tk_inc_dir == '':
+        tk_inc_dir = tcl_inc_dir
+    else:
+        tk_inc_dir = tk_inc_dir[2:]
+    tk_lib = get_var(tk_config, 'TK_LIB_FLAG')[2:].strip()
+
+    if not os.path.exists(os.path.join(tk_inc_dir, 'tk.h')):
         return None
 
-    tcl_vars_str.seek(0)
-    tcl_vars = ConfigParser.RawConfigParser()
-    tk_vars_str.seek(0)
-    tk_vars = ConfigParser.RawConfigParser()
-    try:
-        tcl_vars.readfp(tcl_vars_str)
-        tk_vars.readfp(tk_vars_str)
-    except ConfigParser.ParsingError:
-        # if we can't read the file, that's ok, we'll try
-        # to guess instead
-        return None
-
-    try:
-        tcl_lib = tcl_vars.get("default", "TCL_LIB_SPEC")[1:-1].split()[0][2:]
-        tcl_inc = tcl_vars.get("default", "TCL_INCLUDE_SPEC")[3:-1]
-
-        tk_lib = tk_vars.get("default", "TK_LIB_SPEC")[1:-1].split()[0][2:]
-        if tk_vars.has_option("default", "TK_INCLUDE_SPEC"):
-            # On Ubuntu 8.04
-            tk_inc = tk_vars.get("default", "TK_INCLUDE_SPEC")[3:-1]
-        else:
-            # On RHEL4
-            tk_inc = tcl_inc
-    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
-        return None
-
-    if not os.path.exists(os.path.join(tk_inc, 'tk.h')):
-        return None
-
-    return tcl_lib, tcl_inc, tk_lib, tk_inc
+    return tcl_lib_dir, tcl_inc_dir, tcl_lib, tk_lib_dir, tk_inc_dir, tk_lib
 
 def guess_tcl_config(tcl_lib_dir, tk_lib_dir, tk_ver):
     if not (os.path.exists(tcl_lib_dir) and os.path.exists(tk_lib_dir)):
@@ -1007,14 +986,14 @@ def guess_tcl_config(tcl_lib_dir, tk_lib_dir, tk_ver):
     if not os.path.exists(os.path.join(tk_inc, 'tk.h')):
         return None
 
-    return tcl_lib, tcl_inc, tk_lib, tk_inc
+    return tcl_lib, tcl_inc, 'tcl' + tk_ver, tk_lib, tk_inc, 'tk' + tk_ver
 
 def hardcoded_tcl_config():
     tcl_inc = "/usr/local/include"
     tk_inc = "/usr/local/include"
     tcl_lib = "/usr/local/lib"
     tk_lib = "/usr/local/lib"
-    return tcl_lib, tcl_inc, tk_lib, tk_inc
+    return tcl_lib, tcl_inc, 'tcl', tk_lib, tk_inc, 'tk'
 
 def add_tk_flags(module):
     'Add the module flags to build extensions which use tk'
@@ -1115,10 +1094,10 @@ so that setup can determine where your libraries are located."""
                     result = hardcoded_tcl_config()
 
         # Add final versions of directories and libraries to module lists
-        tcl_lib, tcl_inc, tk_lib, tk_inc = result
-        module.include_dirs.extend([tcl_inc, tk_inc])
-        module.library_dirs.extend([tcl_lib, tk_lib])
-        module.libraries.extend(['tk' + tk_ver, 'tcl' + tk_ver])
+        tcl_lib_dir, tcl_inc_dir, tcl_lib, tk_lib_dir, tk_inc_dir, tk_lib = result
+        module.include_dirs.extend([tcl_inc_dir, tk_inc_dir])
+        module.library_dirs.extend([tcl_lib_dir, tk_lib_dir])
+        module.libraries.extend([tcl_lib, tk_lib])
 
     return message
 


### PR DESCRIPTION
Yet more improvments to finding Tcl/Tk.  Recent versions of Tcl/Tk put "real" bash code in tclConfig.sh and tkConfig.sh so the hackish "treat this as an ini file" approach no longer works.  The new way is to actually source the file with bash and "eval echo" environment variables to get the results back.  This should work fine on Unices -- it doesn't have to work on Windows since we use a more hard-coded config there.

This needs some testing in other environments to make sure it doesn't break things that already work.
