### PR TITLE
Fix test_text and test_tightlayout.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -970,7 +970,7 @@ default_test_modules = [
     'matplotlib.tests.test_image',
     'matplotlib.tests.test_simplification',
     'matplotlib.tests.test_mathtext',
-    'matplotlib.tests.test_text'
+    'matplotlib.tests.test_text',
     'matplotlib.tests.test_tightlayout'
     ]
 


### PR DESCRIPTION
test_text and test_tightlayout' don't run property in the default test suite because a , is missing between them in the list in /lib/**init**.py  
Add that to make them run.
