### PR TITLE
Added method 'add_signal' to CallbackRegistry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2011-06-24 Added 'add_signal' to the CallbackRegistry. - BVR
+
 2011-06-16 Added *bottom* keyword parameter for the stem command. 
            Also, implemented a legend handler for the stem plot. 
            - JJL

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -221,6 +221,16 @@ class CallbackRegistry:
             signals.sort()
             raise ValueError('Unknown signal "%s"; valid signals are %s'%(s, signals))
 
+    def add_signal(self, s) :
+        """
+        Add another valid signal *s* to the registry.
+        If the signal already exists, no change is made.
+        """
+        if s not in self.signals :
+            self.signals.add(s)
+            self.callbacks[s] = dict()
+        
+
     def connect(self, s, func):
         """
         register *func* to be called when a signal *s* is generated


### PR DESCRIPTION
Added method 'add_signal' to CallbackRegistry to allow for the adding of additional valid signals after the creation of the CallbackRegistry object.
