### PR TITLE
BUG: plot_directive: look for plot script files relative to the .rst file

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -88,7 +88,7 @@ The plot directive has the following configuration options:
     plot_basedir
         Base directory, to which ``plot::`` file names are relative
         to.  (If None or empty, file names are relative to the
-        directoly where the file containing the directive is.)
+        directory where the file containing the directive is.)
 
     plot_formats
         File formats to generate. List of tuples or strings::
@@ -601,7 +601,7 @@ def run(arguments, content, options, state_machine, state, lineno):
 
     if len(arguments):
         if not config.plot_basedir:
-            source_file_name = os.path.join(setup.app.builder.srcdir,
+            source_file_name = os.path.join(rst_dir,
                                             directives.uri(arguments[0]))
         else:
             source_file_name = os.path.join(setup.confdir, config.plot_basedir,


### PR DESCRIPTION
BUG: plot_directive: look for plot script files relative to the .rst file directory (rather than doc source root), when plot_basedir is not given

A tiny fix to the plot directive -- it should look for the plot scripts relative to the current .rst file and not the source root specified on the command line.
