### PR TITLE
Gtk no toolbar

### DIFF
--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -547,14 +547,14 @@ class FigureManagerGTK(FigureManagerBase):
 
     def destroy(self, *args):
         if _debug: print 'FigureManagerGTK.%s' % fn_name()
+        if hasattr(self, 'toolbar') and self.toolbar is not None:
+            self.toolbar.destroy()
         if hasattr(self, 'vbox'):
             self.vbox.destroy()
         if hasattr(self, 'window'):
             self.window.destroy()
         if hasattr(self, 'canvas'):
             self.canvas.destroy()
-        if hasattr(self, 'toolbar'):
-            self.toolbar.destroy()
         self.__dict__.clear()   #Is this needed? Other backends don't have it.
 
         if Gcf.get_num_fig_managers()==0 and \


### PR DESCRIPTION
When rcParams['toolbar'] is "none", the figure manager toolbar
attribute becomes None.  Only the gtk backend seems not to have
been taking this into account.
