### PR TITLE
restore 'None' (a string) as a valid marker style (draw nothing)

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -90,6 +90,7 @@ that define the shape.
         CARETRIGHT : 'caretright',
         CARETUP    : 'caretup',
         CARETDOWN  : 'caretdown',
+        "None"       : 'nothing',
         None       : 'nothing',
         ' '        : 'nothing',
         ''         : 'nothing'


### PR DESCRIPTION
With the recent refactoring of marker style, set_marker("None") stopped working, and this simple patch fixes this.

For a reference, here is a documentation of Line2D.set_marker method in v1.0.x-maint branch, which says that "None" is a valid marker style.

https://github.com/matplotlib/matplotlib/blob/v1.0.x-maint/lib/matplotlib/lines.py#L755
