### PR TITLE
matshow: behave well with origin kwarg

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -5770,7 +5770,7 @@ class Axes(martist.Artist):
             marker_obj.get_transform())
         if not marker_obj.is_filled():
             edgecolors = 'face'
-        
+
         collection = mcoll.PathCollection(
                 (path,), scales,
                 facecolors = colors,
@@ -8214,19 +8214,16 @@ class Axes(martist.Artist):
             *Z*   anything that can be interpreted as a 2-D array
 
         kwargs all are passed to :meth:`~matplotlib.axes.Axes.imshow`.
-        :meth:`matshow` sets defaults for *extent*, *origin*,
-        *interpolation*, and *aspect*; use care in overriding the
-        *extent* and *origin* kwargs, because they interact.  (Also,
-        if you want to change them, you probably should be using
-        imshow directly in your own version of matshow.)
+        :meth:`matshow` sets defaults for *origin*,
+        *interpolation*, and *aspect*; if you want row zero to
+        be at the bottom instead of the top, you can set the *origin*
+        kwarg to "lower".
 
         Returns: an :class:`matplotlib.image.AxesImage` instance.
         '''
-        Z = np.asarray(Z)
+        Z = np.asanyarray(Z)
         nr, nc = Z.shape
-        extent = [-0.5, nc-0.5, nr-0.5, -0.5]
-        kw = {'extent': extent,
-              'origin': 'upper',
+        kw = {'origin': 'upper',
               'interpolation': 'nearest',
               'aspect': 'equal'}          # (already the imshow default)
         kw.update(kwargs)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1710,8 +1710,10 @@ def matshow(A, fignum=None, **kw):
 
     Tick labels for the xaxis are placed on top.
 
-    With the exception of fignum, keyword arguments are passed to
-    :func:`~matplotlib.pyplot.imshow`.
+    With the exception of *fignum*, keyword arguments are passed to
+    :func:`~matplotlib.pyplot.imshow`.  You may set the *origin*
+    kwarg to "lower" if you want the first row in the array to be
+    at the bottom instead of the top.
 
 
     *fignum*: [ None | integer | False ]
@@ -1724,6 +1726,7 @@ def matshow(A, fignum=None, **kw):
 
       If *fignum* is *False* or 0, a new figure window will **NOT** be created.
     """
+    A = np.asanyarray(A)
     if fignum is False or fignum is 0:
         ax = gca()
     else:


### PR DESCRIPTION
http://www.mail-archive.com/matplotlib-devel@lists.sourceforge.net/msg08412.html

This change solves the problem noted in the above message by Eike von Seggern. It also allows pyplot.matshow to work with more general input; formerly it required an ndarray or subclass.
