### PR TITLE
fix some python2.4 compliance issues

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -108,7 +108,7 @@ class Line2D(Artist):
     markers = MarkerStyle.markers
     filled_markers = MarkerStyle.filled_markers
     fillStyles = MarkerStyle.fillstyles
-    
+
     zorder = 2
     validCap = ('butt', 'round', 'projecting')
     validJoin =   ('miter', 'round', 'bevel')
@@ -551,7 +551,7 @@ class Line2D(Artist):
                     renderer.draw_markers(
                         gc, alt_marker_path, alt_marker_trans, subsampled,
                         affine.frozen(), rgbFace)
-                    
+
             gc.restore()
 
         gc.restore()
@@ -747,9 +747,9 @@ class Line2D(Artist):
         """
         try:
             self._marker.set_marker(marker)
-        except ValueError as e:
+        except ValueError,e:
             verbose.report(str(e))
-        
+
     def set_markeredgecolor(self, ec):
         """
         Set the marker edge color

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -578,7 +578,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
             for format, dpi in formats:
                 try:
                     figman.canvas.figure.savefig(img.filename(format), dpi=dpi)
-                except exceptions.BaseException as err:
+                except Exception,err:
                     raise PlotError(traceback.format_exc())
                 img.formats.append(format)
 


### PR DESCRIPTION
There are a couple of cases where we have code::

  except SomeException as e:

and this pull request rewrites them as::

  except SomeException, e:

to maintain python2.4 compliance.

When fixing this, I also noticed this code::

```
    try:
        self._marker.set_marker(marker)
    except ValueError as e:
        verbose.report(str(e))
```

which fails silently for unknown markers since the default verbose.report is silent.  This isn't a great concept -- can the original author of this pipe in and comment why we wouldn't want to raise here?
