### PR TITLE
collections: fix bug in scatter with log scale; handle masked offsets

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -101,7 +101,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         # Force _offsets to be Nx2
         self._offsets.shape = (0, 2)
         if offsets is not None:
-            offsets = np.asarray(offsets)
+            offsets = np.asanyarray(offsets)
             offsets.shape = (-1, 2)             # Make it Nx2
             if transOffset is not None:
                 self._offsets = offsets
@@ -160,7 +160,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
             offsets = transOffset.transform_non_affine(offsets)
             transOffset = transOffset.get_affine()
 
-        offsets = np.asarray(offsets, np.float_)
+        offsets = np.asanyarray(offsets, np.float_)
+        if np.ma.isMaskedArray(offsets):
+            offsets = offsets.filled(np.nan)
+            # get_path_collection_extents handles nan but not masked arrays
         offsets.shape = (-1, 2)                     # Make it Nx2
 
         result = mpath.get_path_collection_extents(
@@ -198,7 +201,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 ys = self.convert_yunits(offsets[:,1])
                 offsets = zip(xs, ys)
 
-        offsets = np.asarray(offsets, np.float_)
+        offsets = np.asanyarray(offsets, np.float_)
         offsets.shape = (-1, 2)             # Make it Nx2
 
         if not transform.is_affine:
@@ -206,7 +209,13 @@ class Collection(artist.Artist, cm.ScalarMappable):
             transform = transform.get_affine()
         if not transOffset.is_affine :
             offsets = transOffset.transform_non_affine(offsets)
+            # This might have changed an ndarray into a masked array.
             transOffset = transOffset.get_affine()
+
+        if np.ma.isMaskedArray(offsets):
+            offsets = offsets.filled(np.nan)
+            # Changing from a masked array to nan-filled ndarray
+            # is probably most efficient at this point.
 
         return transform, transOffset, offsets, paths
 
@@ -289,7 +298,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         ACCEPTS: float or sequence of floats
         """
-        offsets = np.asarray(offsets, np.float_)
+        offsets = np.asanyarray(offsets, np.float_)
         offsets.shape = (-1, 2)             # Make it Nx2
         #This decision is based on how they are initialized above
         if self._uniform_offsets is None:
@@ -588,13 +597,13 @@ class PathCollection(Collection):
 
     def set_paths(self, paths):
         self._paths = paths
-        
+
     def get_paths(self):
         return self._paths
-        
+
     def get_sizes(self):
         return self._sizes
-        
+
     @allow_rasterization
     def draw(self, renderer):
         if self._sizes is not None:


### PR DESCRIPTION
This was prompted by the following email:
http://www.mail-archive.com/matplotlib-users@lists.sourceforge.net/msg21760.html
