### PR TITLE
backends: fix alpha handling for cairo and macosx

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -774,6 +774,8 @@ class GraphicsContextBase:
         if alpha is not None:
             self._alpha = alpha
             self._forced_alpha = True
+        else:
+            self._forced_alpha = False
 
     def set_antialiased(self, b):
         """
@@ -834,7 +836,10 @@ class GraphicsContextBase:
         else:
             self._rgb = colors.colorConverter.to_rgba(fg)
         if len(self._rgb) == 4 and not self._forced_alpha:
-            self._alpha = self._rgb[3]
+            self.set_alpha(self._rgb[3])
+            # Use set_alpha method here so that subclasses will
+            # be calling their own version, which may set their
+            # own attributes.
 
     def set_graylevel(self, frac):
         """

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -283,6 +283,8 @@ class RendererCairo(RendererBase):
     def new_gc(self):
         if _debug: print '%s.%s()' % (self.__class__.__name__, _fn_name())
         self.gc.ctx.save()
+        self.gc._alpha = 1.0
+        self.gc._forced_alpha = False # if True, _alpha overrides A from RGBA
         return self.gc
 
 

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -101,6 +101,8 @@ class RendererMac(RendererBase):
     def new_gc(self):
         self.gc.save()
         self.gc.set_hatch(None)
+        self.gc._alpha = 1.0
+        self.gc._forced_alpha = False # if True, _alpha overrides A from RGBA
         return self.gc
 
     def draw_gouraud_triangle(self, gc, points, colors, transform):


### PR DESCRIPTION
There are two parts to this change.  First, the cairo
and macosx backends recycle the graphics context instead
of making a new one with the new_gc() method, so the _alpha
attribute must be reset to 1 at that point.  Second, the
GraphicsContextBase.set_foreground() method needs to call
the set_alpha method instead of setting the _alpha attribute,
so that the subclass method is called.
