### PR TITLE
show: fix behavior when running in ipython --pylab

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -21,7 +21,7 @@ except ImportError:
     figureoptions = None
 
 from qt4_compat import QtCore, QtGui, _getSaveFileName, __version__
-    
+
 backend_version = __version__
 def fn_name(): return sys._getframe(1).f_code.co_name
 
@@ -55,18 +55,12 @@ def _create_qApp():
             qApp = QtGui.QApplication( [" "] )
             QtCore.QObject.connect( qApp, QtCore.SIGNAL( "lastWindowClosed()" ),
                                 qApp, QtCore.SLOT( "quit()" ) )
-            #remember that matplotlib created the qApp - will be used by show()
-            _create_qApp.qAppCreatedHere = True
         else:
             qApp = app
-            _create_qApp.qAppCreatedHere = False
-
-_create_qApp.qAppCreatedHere = False
 
 class Show(ShowBase):
     def mainloop(self):
-        if _create_qApp.qAppCreatedHere:
-            QtGui.qApp.exec_()
+        QtGui.qApp.exec_()
 
 show = Show()
 
@@ -287,7 +281,7 @@ class FigureManagerQT( FigureManagerBase ):
         if DEBUG: print 'FigureManagerQT.%s' % fn_name()
         FigureManagerBase.__init__( self, canvas, num )
         self.canvas = canvas
-        self.window = QtGui.QMainWindow() 
+        self.window = QtGui.QMainWindow()
         self.window.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         self.window.setWindowTitle("Figure %d" % num)
@@ -335,7 +329,7 @@ class FigureManagerQT( FigureManagerBase ):
     def _show_message(self,s):
         # Fixes a PySide segfault.
         self.window.statusBar().showMessage(s)
-        
+
     def _widgetclosed( self ):
         if self.window._destroying: return
         self.window._destroying = True

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -120,16 +120,23 @@ def switch_backend(newbackend):
     new_figure_manager, draw_if_interactive, _show = pylab_setup()
 
 
-def show():
+def show(*args, **kw):
     """
+    When running in ipython with its pylab mode, display all
+    figures and return to the ipython prompt.
+
     In non-interactive mode, display all figures and block until
     the figures have been closed; in interactive mode it has no
     effect unless figures were created prior to a change from
     non-interactive to interactive mode (not recommended).  In
     that case it displays the figures but does not block.
+
+    A single experimental keyword argument, *block*, may be
+    set to True or False to override the blocking behavior
+    described above.
     """
     global _show
-    _show()
+    _show(*args, **kw)
 
 
 def isinteractive():
@@ -159,6 +166,9 @@ def pause(interval):
     This can be used for crude animation. For more complex
     animation, see :mod:`matplotlib.animation`.
 
+    This function is experimental; its behavior may be changed
+    or extended in a future release.
+
     """
     backend = rcParams['backend']
     if backend in _interactive_bk:
@@ -166,13 +176,8 @@ def pause(interval):
         if figManager is not None:
             canvas = figManager.canvas
             canvas.draw()
-            was_interactive = isinteractive()
-            if not was_interactive:
-                ion()
-                show()
+            show(block=False)
             canvas.start_event_loop(interval)
-            if not was_interactive:
-                ioff()
             return
 
     # No on-screen figure is active, so sleep() is all we need.


### PR DESCRIPTION
There were implementation bugs, and inconsistencies in behavior
among ipython versions and backends.  Furthermore, the change in
show behavior introduced in mpl 1.0, in which it would block in
non-interactive mode regardless of whether the environment was
"ipython --pylab", has now been reverted.

A kwarg has been added to show to override all other blocking
determinants; it simplifies the experimental pyplot.pause(), but
whether it should stay is open to discussion.
