### PR TITLE
set_linestyle can take custom dash styles

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -887,12 +887,22 @@ class GraphicsContextBase:
     def set_linestyle(self, style):
         """
         Set the linestyle to be one of ('solid', 'dashed', 'dashdot',
-        'dotted').
+        'dotted'). One may specify customized dash styles by providing
+        a tuple of (offset, dash pairs). For example, the predefiend
+        linestyles have following values.:
+
+         'dashed'  : (0, (6.0, 6.0)),
+         'dashdot' : (0, (3.0, 5.0, 1.0, 5.0)),
+         'dotted'  : (0, (1.0, 3.0)),
         """
-        try:
+
+        if style in self.dashd.keys():
             offset, dashes = self.dashd[style]
-        except:
-            raise ValueError('Unrecognized linestyle: %s' % style)
+        elif isinstance(style, tuple):
+            offset, dashes = style
+        else:
+            raise ValueError('Unrecognized linestyle: %s' % str(style))
+
         self._linestyle = style
         self.set_dashes(offset, dashes)
 


### PR DESCRIPTION
This patch lets a user to specify custom dash styles in the form of (offset, dash pairs). For example,

 p = Circle((0.5, 0.5), 0.5, linestyle=(0, (2, 4)))

The predefined styles are defined as follows.

```
    'dashed'  : (0, (6.0, 6.0)),
    'dashdot' : (0, (3.0, 5.0, 1.0, 5.0)),
    'dotted'  : (0, (1.0, 3.0)),
```
