### PR TITLE
Fix download path for libpng 1.5.1 in make.osx

### DIFF
--- a/make.osx
+++ b/make.osx
@@ -25,7 +25,7 @@ ZLIBURL=http://sourceforge.net/projects/libpng/files/zlib/${ZLIBVERSION}/${ZLIBF
 
 PNGFILE=libpng-${PNGVERSION}.tar.gz
 PNGDIR=$(basename $(basename ${PNGFILE}))
-PNGURL=http://sourceforge.net/projects/libpng/files/libpng15/${PNGVERSION}/${PNGFILE}/download
+PNGURL=http://sourceforge.net/projects/libpng/files/libpng15/older-releases/${PNGVERSION}/${PNGFILE}/download
 
 FREETYPEFILE=freetype-${FREETYPEVERSION}.tar.bz2
 FREETYPEDIR=$(basename $(basename ${FREETYPEFILE}))


### PR DESCRIPTION
The download path for libpng 1.5.1 in make.osx is incorrect; this includes the new download path for libpng 1.5.1. I tested this on my own system, running Mac OS 10.7 and Python 2.7; this delta retains the defaults of Mac OS 10.6 and Python 2.6.
