### PR TITLE
Non string projection definitions in matplotlib

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8378,10 +8378,12 @@ class SubplotBase:
 
         self.update_params()
 
+        # initialise the axes_class
+        self._init_axes(fig, **kwargs)
+
+    def _init_axes(self, fig, **kwargs):
         # _axes_class is set in the subplot_class_factory
         self._axes_class.__init__(self, fig, self.figbox, **kwargs)
-
-
 
     def get_geometry(self):
         'get the subplot geometry, eg 2,2,3'
@@ -8443,7 +8445,7 @@ class SubplotBase:
 
 _subplot_classes = {}
 def subplot_class_factory(axes_class=None):
-    # This makes a new class that inherits from SubclassBase and the
+    # This makes a new class that inherits from SubplotBase and the
     # given axes_class (which is assumed to be a subclass of Axes).
     # This is perhaps a little bit roundabout to make a new class on
     # the fly like this, but it means that a new Subplot class does

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -757,24 +757,33 @@ class Figure(Artist):
                         projection)
                 projection = 'polar'
 
-            projection_class = get_projection_class(projection)
-
             # Remake the key without projection kwargs:
             key = self._make_key(*args, **kwargs)
             ax = self._axstack.get(key)
             if ax is not None:
-                if isinstance(ax, projection_class):
+                if projection is None or isinstance(projection, basestring):
+                    projection_class = get_projection_class(projection)
+                    if isinstance(ax, projection_class):
+                        self.sca(ax)
+                        return ax
+
+                elif hasattr(projection, 'axes_isinstance') and projection.axes_isinstance(ax):
                     self.sca(ax)
                     return ax
-                else:
-                    self._axstack.remove(ax)
-                    # Undocumented convenience behavior:
-                    # subplot(111); subplot(111, projection='polar')
-                    # will replace the first with the second.
-                    # Without this, add_subplot would be simpler and
-                    # more similar to add_axes.
+                        
+                self._axstack.remove(ax)
+                # Undocumented convenience behavior:
+                # subplot(111); subplot(111, projection='polar')
+                # will replace the first with the second.
+                # Without this, add_subplot would be simpler and
+                # more similar to add_axes.
 
-            a = subplot_class_factory(projection_class)(self, *args, **kwargs)
+            if projection is None or isinstance(projection, basestring):
+                projection_class = get_projection_class(projection)
+                a = subplot_class_factory(projection_class)(self, *args, **kwargs)
+            else:
+                a = projection.subplot(self, *args, **kwargs)
+
         self._axstack.add(key, a)
         self.sca(a)
         return a
@@ -1047,9 +1056,13 @@ class Figure(Artist):
                         projection)
                 projection = 'polar'
 
-            projection_class = get_projection_class(projection)
-            if isinstance(ax, projection_class):
+            if projection is None or isinstance(projection, basestring):
+                projection_class = get_projection_class(projection)
+                if isinstance(ax, projection_class):
+                    return ax
+            elif hasattr(projection, 'axes_isinstance') and projection.axes_isinstance(ax):
                 return ax
+
         return self.add_subplot(111, **kwargs)
 
     def sca(self, a):


### PR DESCRIPTION
As per the devel mailing list:

I would like the ability to setup a plot projection in MPL that can be defined by various parameters and does not need to be serialised as a string and registered with matplotlib.projections.register_projection.  For example, an extension of /examples/api/custom_projection_example.py might be to add the ability to define the central meridian to an arbitrary value rather than the current value of 0 - in this case I would expect to define the projection by creating an object which can then be turned into a matplotlib axes:

```
hammer_proj = Hammer(central_meridian=45)
ax = plt.subplot(111, projection=hammer_proj)
```

I have made a change to matplotlib which would enable this capability. Any feedback and thoughts would be really appreciated with the ultimate goal of getting this functionality into MPL.
