### PR TITLE
fix GridSpec.update to update axes position only for axes assocaited with the gridspec instance.

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -233,14 +233,17 @@ class GridSpec(GridSpecBase):
                 if not isinstance(ax, SubplotBase):
                     # Check if sharing a subplots axis
                     if ax._sharex is not None and isinstance(ax._sharex, SubplotBase):
-                        ax._sharex.update_params()
-                        ax.set_position(ax._sharex.figbox)
+                        if ax._sharex.get_subplotspec().get_gridspec() == self:
+                            ax._sharex.update_params()
+                            ax.set_position(ax._sharex.figbox)
                     elif ax._sharey is not None and isinstance(ax._sharey,SubplotBase):
-                        ax._sharey.update_params()
-                        ax.set_position(ax._sharey.figbox)
+                        if ax._sharey.get_subplotspec().get_gridspec() == self:
+                            ax._sharey.update_params()
+                            ax.set_position(ax._sharey.figbox)
                 else:
-                    ax.update_params()
-                    ax.set_position(ax.figbox)
+                    if ax.get_subplotspec().get_gridspec() == self:
+                        ax.update_params()
+                        ax.set_position(ax.figbox)
 
 
 
@@ -287,7 +290,7 @@ class GridSpec(GridSpecBase):
         subplot_list = []
         num1num2_list = []
         subplot_dict = {}
-        
+
         for ax in fig.axes:
             locator = ax.get_axes_locator()
             if hasattr(locator, "get_subplotspec"):
@@ -340,7 +343,7 @@ class GridSpec(GridSpecBase):
                                              pad=pad, h_pad=h_pad, w_pad=w_pad,
                                              rect=(left, bottom, right, top))
 
-            
+
         self.update(**kwargs)
 
 


### PR DESCRIPTION
This problem is reported by Kurt Mueller in the mailing-list. For example,

``` python
gs1 = GridSpec(3,3)
ax1 = fig.add_subplot( gs1[ 0:1, 0:1 ] )

gs2 = GridSpec(3,3)
ax2 = fig.add_subplot( gs2[ 1:3, 1:3 ] )

gs2.update( left=0.55, right=0.95 )
```

Currently, gs2.update not only update the position of ax2, but positions of all the subplots in the figure, e.g., ax1 which is not associated with gs2.

This pull request fixes it so that only subplots associated with given gridspec  are updated.

-JJ
