### PR TITLE
cbook._putmask added to handle putmask deprecation in numpy > 1.6.x

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1827,6 +1827,23 @@ def is_math_text(s):
 
     return even_dollars
 
+# Numpy > 1.6.x deprecates putmask in favor of the new copyto.
+# So long as we support versions 1.6.x and less, we need the
+# following local version of putmask.  We choose to make a
+# local version of putmask rather than of copyto because the
+# latter includes more functionality than the former. Therefore
+# it is easy to make a local version that gives full putmask
+# behavior, but duplicating the full copyto behavior would be
+# more difficult.
+
+try:
+    np.copyto
+except AttributeError:
+    _putmask = np.putmask
+else:
+    def _putmask(a, mask, values):
+        return np.copyto(a, values, where=mask)
+
 
 if __name__=='__main__':
     assert( allequal([1,1,1]) )

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -516,7 +516,7 @@ class Colormap:
             # masked values are substituted below; no need to fill them here
 
         if xa.dtype.char in np.typecodes['Float']:
-            np.putmask(xa, xa==1.0, 0.9999999) #Treat 1.0 as slightly less than 1.
+            cbook._putmask(xa, xa==1.0, 0.9999999) #Treat 1.0 as slightly less than 1.
             # The following clip is fast, and prevents possible
             # conversion of large positive values to negative integers.
 
@@ -528,15 +528,15 @@ class Colormap:
 
             # ensure that all 'under' values will still have negative
             # value after casting to int
-            np.putmask(xa, xa<0.0, -1)
+            cbook._putmask(xa, xa<0.0, -1)
             xa = xa.astype(int)
         # Set the over-range indices before the under-range;
         # otherwise the under-range values get converted to over-range.
-        np.putmask(xa, xa>self.N-1, self._i_over)
-        np.putmask(xa, xa<0, self._i_under)
+        cbook._putmask(xa, xa>self.N-1, self._i_over)
+        cbook._putmask(xa, xa<0, self._i_under)
         if mask_bad is not None:
             if mask_bad.shape == xa.shape:
-                np.putmask(xa, mask_bad, self._i_bad)
+                cbook._putmask(xa, mask_bad, self._i_bad)
             elif mask_bad:
                 xa.fill(self._i_bad)
         if bytes:
@@ -927,7 +927,7 @@ class LogNorm(Normalize):
                 mask = (resdat <= 0)
             else:
                 mask |= resdat <= 0
-            np.putmask(resdat, mask, 1)
+            cbook._putmask(resdat, mask, 1)
             np.log(resdat, resdat)
             resdat -= np.log(vmin)
             resdat /= (np.log(vmax) - np.log(vmin))

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -24,6 +24,7 @@ import matplotlib.artist as martist
 from matplotlib.artist import allow_rasterization
 from matplotlib import docstring
 import matplotlib.font_manager as font_manager
+import matplotlib.cbook as cbook
 from matplotlib.cbook import delete_masked_points
 from matplotlib.patches import CirclePolygon
 import math
@@ -624,8 +625,8 @@ class Quiver(collections.PolyCollection):
         Y0 = shrink * Y0[np.newaxis,:]
         short = np.repeat(length < minsh, 8, axis=1)
         # Now select X0, Y0 if short, otherwise X, Y
-        np.putmask(X, short, X0)
-        np.putmask(Y, short, Y0)
+        cbook._putmask(X, short, X0)
+        cbook._putmask(Y, short, Y0)
         if self.pivot[:3] == 'mid':
             X -= 0.5 * X[:,3, np.newaxis]
         elif self.pivot[:3] == 'tip':
@@ -641,8 +642,8 @@ class Quiver(collections.PolyCollection):
             X1 = np.repeat(x1[np.newaxis, :], N, axis=0)
             Y1 = np.repeat(y1[np.newaxis, :], N, axis=0)
             tooshort = np.repeat(tooshort, 8, 1)
-            np.putmask(X, tooshort, X1)
-            np.putmask(Y, tooshort, Y1)
+            cbook._putmask(X, tooshort, X1)
+            cbook._putmask(Y, tooshort, Y1)
         # Mask handling is deferred to the caller, _make_verts.
         return X, Y
 


### PR DESCRIPTION
putmask is deprecated in favor of the new and more powerful copyto.

I decided to make a compatibility version of putmask using copyto instead of the reverse because that easily yields an exact equivalence, whereas simulating a full copyto with numpy <=1.6.x would be more difficult.  In the present scheme, cbook._putmask is an exact substitute for np.putmask that uses copyto internally when available, thereby suppressing the deprecation warning from numpy.
