### PR TITLE
Initialize memory in csv roundtrip test

### DIFF
--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -13,9 +13,9 @@ def test_colinear_pca():
 def test_recarray_csv_roundtrip():
     expected = np.recarray((99,),
                           [('x',np.float),('y',np.float),('t',np.float)])
-    expected['x'][0] = 1
-    expected['y'][1] = 2
-    expected['t'][2] = 3
+    expected['x'][:] = np.linspace(-1e9, -1, 99)
+    expected['y'][:] = np.linspace(1, 1e9, 99)
+    expected['t'][:] = np.linspace(0, 0.01, 99)
     fd = tempfile.TemporaryFile(suffix='csv')
     mlab.rec2csv(expected,fd)
     fd.seek(0)


### PR DESCRIPTION
This fixes test_recarray_csv_roundtrip, which was failing on some systems (but not everywhere). The data being written and read was mostly not initialized, and therefore sometimes contained a NaN, and while it was correctly read back, np.allclose does not consider NaN to be "allclose" to NaN.
