### PR TITLE
Geo divide zero

### DIFF
--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -271,16 +271,16 @@ class AitoffAxes(GeoAxes):
             cos_latitude = np.cos(latitude)
 
             alpha = np.arccos(cos_latitude * np.cos(half_long))
-            # Mask this array, or we'll get divide-by-zero errors
+            # Mask this array or we'll get divide-by-zero errors
             alpha = ma.masked_where(alpha == 0.0, alpha)
+            # The numerators also need to be masked so that masked
+            # division will be invoked.
             # We want unnormalized sinc.  numpy.sinc gives us normalized
             sinc_alpha = ma.sin(alpha) / alpha
 
-            x = (cos_latitude * np.sin(half_long)) / sinc_alpha
-            y = (np.sin(latitude) / sinc_alpha)
-            x.set_fill_value(0.0)
-            y.set_fill_value(0.0)
-            return np.concatenate((x.filled(), y.filled()), 1)
+            x = (cos_latitude * ma.sin(half_long)) / sinc_alpha
+            y = (ma.sin(latitude) / sinc_alpha)
+            return np.concatenate((x.filled(0), y.filled(0)), 1)
         transform.__doc__ = Transform.transform.__doc__
 
         transform_non_affine = transform


### PR DESCRIPTION
The Newton-Raphson iteration converges more slowly near
the poles, and triggers a divide-by-zero at the poles.
Although the previous transform was handling this correctly
in the sense that it was still giving the right answer,
the divide-by-zero warning was non-optimal.

The present version switches to a Taylor-series approximation
for latitudes within 5 degrees of the poles.  This avoids
the divide-by-zero, and also runs faster on arrays with a
full range of latitudes.
