### PR TITLE
Backend qt4 bugs

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -446,7 +446,7 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
                             fmt += ": %(ylabel)s"
                         fmt += " (%(axes_repr)s)"
                     elif ylabel:
-                        fmt = "%(axes_repr)s (%(ylabel)s)" % ylabel
+                        fmt = "%(axes_repr)s (%(ylabel)s)"
                     else:
                         fmt = "%(axes_repr)s"
                     titles.append(fmt % dict(title = title,

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -563,7 +563,7 @@ class Line2D(Artist):
     def get_linestyle(self): return self._linestyle
 
     def get_linewidth(self): return self._linewidth
-    def get_marker(self): return self._marker
+    def get_marker(self): return self._marker.get_marker()
 
     def get_markeredgecolor(self):
         if (is_string_like(self._markeredgecolor) and
@@ -746,7 +746,7 @@ class Line2D(Artist):
         %(MarkerAccepts)s
         """
         self._marker.set_marker(marker)
-        
+
     def set_markeredgecolor(self, ec):
         """
         Set the marker edge color


### PR DESCRIPTION
As reported by Marko Luther in the e-mail "[matplotlib-devel] Typo in backend_qt4.py    (matplotlib-1.1.0-rc1-py2.7-python.org-macosx10.3.dmg)?", opening the Qt4 figure editor was crashing.  This appears to fix that.
