### PR TITLE
update URLs for basemap docs in matplotlb docs

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -43,7 +43,7 @@ at <a href="http://chipy.org">ChiPy</a>.
 <p>There are several matplotlib add-on <a href="{{
 pathto('users/toolkits') }}">toolkits</a>, including the projection
 and mapping toolkit
-<a href="http://matplotlib.sf.net/basemap/doc/html">basemap</a>, 3d plotting with <a href="{{
+<a href="http://matplotlib.githumb.com/basemap">basemap</a>, 3d plotting with <a href="{{
 pathto('mpl_toolkits/mplot3d/index') }}">mplot3d</a>, axes and axis helpers in <a href="{{
 pathto('mpl_toolkits/axes_grid/index') }}">axes_grid</a> and more.
  </p>

--- a/doc/mpl_toolkits/index.rst
+++ b/doc/mpl_toolkits/index.rst
@@ -19,7 +19,7 @@ Basemap
 =======
 
 Plots data on map projections, with continental and political
-boundaries, see `basemap <http://matplotlib.sf.net/basemap/doc/html>`_
+boundaries, see `basemap <http://matplotlib.github.com/basemap>`_
 docs.
 
 .. _toolkit_gtk:


### PR DESCRIPTION
changed URLs to point to github instead of sourceforge.
