### PR TITLE
Make Figure.legend not to flatten the input handle list

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -991,7 +991,6 @@ class Figure(Artist):
 
         .. plot:: mpl_examples/pylab_examples/figlegend_demo.py
         """
-        handles = flatten(handles)
         l = Legend(self, handles, labels, *args, **kwargs)
         self.legends.append(l)
         return l


### PR DESCRIPTION
Currently, Figure.legend flattens the given handle list.
Is this necessary?
Because of this, Figure.legend cannot be used for complex plots (e.g., errorbar).

-JJ
