### PR TITLE
Small issue with hist (probably in mac os x backend)

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -7792,6 +7792,8 @@ class Axes(martist.Artist):
                 p.update(kwargs)
                 if lbl is not None: p.set_label(lbl)
 
+                p.set_snap(False)
+
                 for p in patch[1:]:
                     p.update(kwargs)
                     p.set_label('_nolegend_')


### PR DESCRIPTION
(Firstly, this is the kind of bugreport that gets the reporter run out of town with pitch-forks, because it is so trivial. But it scared me a little when I first saw it, so I will report it anyway).
## Issue:

When hist is used to plot a histogram with the align='mid' option, the drawing of the histogram on screen is just slightly displaced. A pdf produced with the same plot turns out exactly as expected.
## To replicate

``` python
import pylab

pylab.figure(figsize=(3,3))
r = pylab.randn(1000000)
pylab.hist(r,bins=100,range=[-3,3],normed=True, align='mid',histtype='stepfilled',color='gray')
x = pylab.linspace(-3,3,100)
y = (1./(2*pylab.pi)**.5)*pylab.exp(-x**2/2)
pylab.plot(x,y,'k')
pylab.setp(pylab.gca(), xlim=[-3,3])
```
## system specs

matplotlib 1.0.1
Mac OS X 

This might be an issue with the mac os x backend since pdfs come out fine.

The reason I post this is because I had an analytic derivation for a distribution I was working with and some simulations I was doing. I kept noticing a slight systematic discrepancy between my analytic formula and the monte carlo simulation histogram and started to worry I had missed something in the  derivation. But when I printed to pdf, my problem went away, much to my relief.
