### PR TITLE
svg engine broken: fails with default tick labels on colorbar 

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1682,6 +1682,8 @@ import matplotlib.colorbar
 def colorbar(mappable=None, cax=None, ax=None, **kw):
     if mappable is None:
         mappable = gci()
+        if mappable is None:
+            raise RuntimeError('You must first define an image, eg with imshow')
     if ax is None:
         ax = gca()
 
@@ -1732,6 +1734,9 @@ def set_cmap(cmap):
 
     if im is not None:
         im.set_cmap(cmap)
+    else:
+        raise RuntimeError('You must first define an image, eg with imshow')
+
     draw_if_interactive()
 
 


### PR DESCRIPTION
From Launchpad bug #877519.

``` python
from pylab import *
figimage([1])
jet()
h=colorbar()
h.set_label('$wer$')
savefig('tmpbug.svg',format='svg')
```

```
  File "lp877519.py", line 4, in <module>
    h=colorbar()
  File "/home/mdroe/ports/lib/python2.7/site-packages/matplotlib/pyplot.py", line 1688, in colorbar
    ret = gcf().colorbar(mappable, cax = cax, ax=ax, **kw)
  File "/home/mdroe/ports/lib/python2.7/site-packages/matplotlib/figure.py", line 1197, in colorbar
    cb = cbar.Colorbar(cax, mappable, **kw)
  File "/home/mdroe/ports/lib/python2.7/site-packages/matplotlib/colorbar.py", line 718, in __init__
    mappable.autoscale_None() # Ensure mappable.norm.vmin, vmax
AttributeError: 'NoneType' object has no attribute 'autoscale_None'
```
