### PR TITLE
wx resize bug

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1473,6 +1473,8 @@ class FigureFrameWx(wx.Frame):
         self.SetSizer(self.sizer)
         self.Fit()
 
+        self.canvas.SetMinSize((2, 2))
+
         self.figmgr = FigureManagerWx(self.canvas, num, self)
 
         bind(self, wx.EVT_CLOSE, self._onClose)


### PR DESCRIPTION
On ubuntu 11.04 using the wxagg backend 2.8.11.0, if you continually resize the image smaller, you hit some limit where the image stops resizing smaller and the toolbar gets rendered oddly.

![wxagg resize bug](http://i.imgur.com/ZDhoc.png)
