### PR TITLE
backend_qt4: avoid a crash at exit with PySide

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -382,6 +382,8 @@ class FigureManagerQT( FigureManagerBase ):
         self.window.show()
 
     def destroy( self, *args ):
+        # check for qApp first, as PySide deletes it in its atexit handler
+        if QtGui.QApplication.instance() is None: return
         if self.window._destroying: return
         self.window._destroying = True
         QtCore.QObject.disconnect( self.window, QtCore.SIGNAL( 'destroyed()' ),


### PR DESCRIPTION
When testing ipython's pylab mode with the latest matplotlib and PySide, we get the following crash when exiting the interpreter:

```
In [6]:
Do you really want to exit ([y]/n)?
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "C:\Dev\Python27-EPD-7.1\lib\atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "c:\workspace\src\git\matplotlib\lib\matplotlib\_pylab_helpers.py", line 82, in destroy_all
    manager.destroy()
  File "c:\workspace\src\git\matplotlib\lib\matplotlib\backends\backend_qt4.py", line 388, in destroy
    self._widgetclosed )
RuntimeError: Internal C++ object (PySide.QtGui.QMainWindow) already deleted.
Error in sys.exitfunc:
Traceback (most recent call last):
  File "C:\Dev\Python27-EPD-7.1\lib\atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "c:\workspace\src\git\matplotlib\lib\matplotlib\_pylab_helpers.py", line 82, in destroy_all
    manager.destroy()
  File "c:\workspace\src\git\matplotlib\lib\matplotlib\backends\backend_qt4.py", line 388, in destroy
    self._widgetclosed )
RuntimeError: Internal C++ object (PySide.QtGui.QMainWindow) already deleted.
```

(full details in https://github.com/ipython/ipython/pull/815#issuecomment-2498106)

The present patch fixes this issue. 
