### PR TITLE
Added a contains() method to matplotlib.legend.Legend().

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -50,7 +50,7 @@ class DraggableLegend(DraggableOffsetBox):
                                     use_blit=use_blit)
 
     def artist_picker(self, legend, evt):
-        return self.legend.legendPatch.contains(evt)
+        return self.legend.contains(evt)
 
     def finalize_offset(self):
         loc_in_canvas = self.get_loc_in_canvas()
@@ -924,6 +924,8 @@ in the normalized axes coordinate.
 
         return ox, oy
 
+    def contains(self, event):
+        return self.legendPatch.contains(event)
 
     def draggable(self, state=None, use_blit=False, update="loc"):
         """


### PR DESCRIPTION
If contains() was called on a legend, the following message is printed:

> C:\Python26\lib\site-packages\matplotlib\artist.py:272: UserWarning: 'Legend' needs 'contains' method
> warnings.warn("'%s' needs 'contains' method" % self.class.name)

This small patch gives the Legend() a legitimate contains() method.

The following is a small test script:

``` python
#!/usr/bin/env python
import matplotlib.pyplot as plt
import numpy as np

fig = plt.gcf()
t = np.arange(0.0,3.0,0.01)
s = np.sin(2*np.pi*t)
c = np.cos(2*np.pi*t)
plt.plot(t,s,label="sine")
plt.plot(t,c,label="cosine")

leg = plt.gca().legend()
leg.draggable()

def OnMotion(event):
   global leg
   print leg.contains(event)

cid = fig.canvas.mpl_connect('motion_notify_event',OnMotion)
plt.show()
```
