### PR TITLE
fix fancy-style annotation causing an exception when the connecting path 

### DIFF
--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -12,6 +12,9 @@ from operator import xor
 import warnings
 
 
+class NonIntersectingPathException(ValueError):
+    pass
+
 # some functions
 
 def get_intersection(cx1, cy1, cos_t1, sin_t1,
@@ -126,7 +129,7 @@ def find_bezier_t_intersecting_with_closedpath(bezier_point_at_t, inside_closedp
     end_inside = inside_closedpath(end)
 
     if not xor(start_inside, end_inside):
-        raise ValueError("the segment does not seemed to intersect with the path")
+        raise NonIntersectingPathException("the segment does not seemed to intersect with the path")
 
     while 1:
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3459,13 +3459,24 @@ class ArrowStyle(_Style):
             head_length  = self.head_length * mutation_size
             arrow_path = [(x0, y0), (x1, y1), (x2, y2)]
 
+            from bezier import NonIntersectingPathException
+
             # path for head
             in_f = inside_circle(x2, y2, head_length)
-            path_out, path_in = \
-                       split_bezier_intersecting_with_closedpath(arrow_path,
-                                                                 in_f,
-                                                                 tolerence=0.01)
-            path_head = path_in
+            try:
+                path_out, path_in = \
+                          split_bezier_intersecting_with_closedpath(arrow_path,
+                                                                    in_f,
+                                                                    tolerence=0.01)
+            except NonIntersectingPathException:
+                # if this happens, make a straight line of the head_length long.
+                dx, dy = x2 - x1, y2 - y1
+                ff = head_length/(dx*dx+dy*dy)**.5
+                x0, y0 = x2 - ff*dx, y2 - ff*dy
+                arrow_path = [(x0, y0), (x1, y1), (x2, y2)]
+                path_head = arrow_path
+            else:
+                path_head = path_in
 
             # path for head
             in_f = inside_circle(x2, y2, head_length*.8)
@@ -3510,21 +3521,6 @@ class ArrowStyle(_Style):
                           (Path.CURVE3, tail_left[0]),
                           (Path.LINETO, tail_start),
                           (Path.CLOSEPOLY, tail_start),
-                          ]
-            patch_path2 = [(Path.MOVETO, tail_right[0]),
-                          (Path.CURVE3, tail_right[1]),
-                          (Path.CURVE3, tail_right[2]),
-                          (Path.LINETO, head_right[0]),
-                          (Path.CURVE3, head_right[1]),
-                          (Path.CURVE3, head_right[2]),
-                          (Path.CURVE3, head_left[1]),
-                          (Path.CURVE3, head_left[0]),
-                          (Path.LINETO, tail_left[2]),
-                          (Path.CURVE3, tail_left[1]),
-                          (Path.CURVE3, tail_left[0]),
-                          (Path.CURVE3, tail_start),
-                          (Path.CURVE3, tail_right[0]),
-                          (Path.CLOSEPOLY, tail_right[0]),
                           ]
             path = Path([p for c, p in patch_path], [c for c, p in patch_path])
 


### PR DESCRIPTION
This issue is originally reported by brenbarn@brenbarn.net on the user mailing list.

http://www.mail-archive.com/matplotlib-users@lists.sourceforge.net/msg22443.html

This happens when the connecting path is too short compared to the arrow head length.
The patch fixes this problem.
