### PR TITLE
Fix TypeError: set_autoscalez_on() takes exactly 2 arguments (3 given)

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -251,7 +251,7 @@ class Axes3D(Axes):
             This function was added, but not tested. Please report any bugs.
         """
         Axes.set_autoscale_on(self, b)
-        self.set_autoscalez_on(self, b)
+        self.set_autoscalez_on(b)
 
     def set_autoscalez_on(self, b) :
         """


### PR DESCRIPTION
Reported on the matplotlib-users ML http://sourceforge.net/mailarchive/message.php?msg_id=28365447
