### PR TITLE
Fix: make TaggedValue iterable on Python 3. Use consistent indentation

### DIFF
--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -158,12 +158,10 @@ class TaggedValue (object):
             def __init__(self, iter, unit):
                 self.iter = iter
                 self.unit = unit
-            def next(self):
-                value = self.iter.next()
-                return TaggedValue(value, self.unit)
             def __next__(self):
                 value = next(self.iter)
                 return TaggedValue(value, self.unit)
+            next = __next__  # for Python 2
         return IteratorProxy(iter(self.value), self.unit)
 
     def get_compressed_copy(self, mask):


### PR DESCRIPTION
This fixes failing bar_demo2.py on Python 3
