### PR TITLE
add interp_at_native keyword to BboxImage

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1137,7 +1137,6 @@ class BboxImage(_AxesImageBase):
         numrows, numcols = self._A.shape[:2]
 
         if not self.interp_at_native and widthDisplay==numcols and heightDisplay==numrows:
-           print "setting interpolation to zero"
            im.set_interpolation(0)
 
         # resize viewport to display


### PR DESCRIPTION
Tells BboxImage whether or not to always apply interpolation (as is the desire when doing data analysis)
or to apply interpolation only when the image is at a non-native resolution (as is the desire when using an image to annotate something).

The new interp_at_native is set to True by default, in order to retain the old behavior of matplotlib, which always uses interpolation on the image.

Along with the addition of the keyword, there is also a bugfix to the calculation of the display width and height, which was off by one pixel always.

The test script is below to demonstrate the difference, but the images must be picked up at the matplotlib dev list under the topic "blurry images at native resolution with images.BboxImage: patch to fix"

``` python

#!/usr/bin/env python
import matplotlib
from matplotlib import pyplot as plt
import matplotlib.image
import matplotlib.transforms
import Image # PIL required.

fig = plt.figure()
ax = fig.gca()
ax.grid(True)
ax.set_title('blurry image demo')
fig.patch.set_facecolor('white')

# read in and store the image
im = Image.open("screen.png")


bbox = matplotlib.transforms.Bbox([0,0,im.size[0],im.size[1]])
#original
#bboxim = matplotlib.image.BboxImage(bbox,origin='lower',interpolation='bicubic',zorder=100)
#new keyword: interp_at_native
bboxim = matplotlib.image.BboxImage(bbox,origin='lower',interpolation='bicubic',zorder=100,interp_at_native=True)
bboxim.set_data(im)
ax.artists.append(bboxim)

plt.show()
```
