### PR TITLE
Check before opening clipboard in wx

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -772,10 +772,13 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         "copy bitmap of canvas to system clipboard"
         bmp_obj = wx.BitmapDataObject()
         bmp_obj.SetBitmap(self.bitmap)
-        wx.TheClipboard.Open()
-        wx.TheClipboard.SetData(bmp_obj)
-        wx.TheClipboard.Close()
-        wx.TheClipboard.Flush()
+        
+        if not wx.TheClipboard.IsOpened(): 
+           open_success = wx.TheClipboard.Open()
+           if open_success:
+              wx.TheClipboard.SetData(bmp_obj)
+              wx.TheClipboard.Close()
+              wx.TheClipboard.Flush()
 
     def Printer_Init(self):
         """


### PR DESCRIPTION
This one is a little nitpicky, but there was no checking before the clipboard was opened in the wx backend.  Added appropriate checking.
