### PR TITLE
Numpy version 1.4

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -45,10 +45,10 @@ progress::
     >>> import numpy
     >>> print numpy.__version__
 
-matplotlib requires numpy version 1.4 or later.  Although it is not a
-requirement to use matplotlib, we strongly encourage you to install
-`ipython <http://ipython.org>`_, which is an interactive
-shell for python that is matplotlib-aware.
+matplotlib requires numpy version |minimum_numpy_version| or later.
+Although it is not a requirement to use matplotlib, we strongly
+encourage you to install `ipython <http://ipython.org>`_, which is an
+interactive shell for python that is matplotlib-aware.
 
 Next, we need to get matplotlib installed.  We provide prebuilt
 binaries for OS X and Windows on the matplotlib `download
@@ -182,7 +182,7 @@ libraries themselves.
 :term:`python` 2.4 (or later but not python3)
     matplotlib requires python 2.4 or later (`download <http://www.python.org/download/>`__)
 
-:term:`numpy` 1.4 (or later)
+:term:`numpy` |minimum_numpy_version| (or later)
     array support for python (`download
     <http://sourceforge.net/project/showfiles.php?group_id=1369&package_id=175103>`__)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -182,3 +182,7 @@ latex_use_parts = True
 # Show both class-level docstring and __init__ docstring in class
 # documentation
 autoclass_content = 'both'
+
+rst_epilog = """
+.. |minimum_numpy_version| replace:: %s
+""" % matplotlib.__version__numpy__

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -100,6 +100,7 @@ to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
 from __future__ import generators
 
 __version__  = '1.1.0'
+__version__numpy__ = '1.4' # minimum required numpy version
 
 import os, re, shutil, subprocess, sys, warnings
 import distutils.sysconfig
@@ -150,11 +151,17 @@ _havedate = True
 if not _python24:
     raise ImportError('matplotlib requires Python 2.4 or later')
 
+
 import numpy
-nmajor, nminor = [int(n) for n in numpy.__version__.split('.')[:2]]
-if not (nmajor > 1 or (nmajor == 1 and nminor >= 4)):
+from distutils import version
+expected_version = version.StrictVersion(__version__numpy__)
+found_version = version.StrictVersion(numpy.__version__)
+if not found_version >= expected_version:
     raise ImportError(
-            'numpy 1.4 or later is required; you have %s' % numpy.__version__)
+        'numpy %s or later is required; you have %s' % (
+            __version__numpy__, numpy.__version__))
+del version
+
 
 def is_string_like(obj):
     if hasattr(obj, 'shape'): return 0

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if 1:
     baseline_images = [chop_package(f) for f in baseline_images]
     package_data['matplotlib'].extend(baseline_images)
 
-if not check_for_numpy():
+if not check_for_numpy(__version__numpy__):
     sys.exit(1)
 
 if not check_for_freetype():

--- a/setupext.py
+++ b/setupext.py
@@ -46,7 +46,7 @@ WIN32 - VISUAL STUDIO 7.1 (2003)
 import os
 import re
 import subprocess
-from distutils import sysconfig
+from distutils import sysconfig, version
 
 basedir = {
     'win32'  : ['win32_static',],
@@ -541,20 +541,22 @@ def check_for_pdftops():
         print_status("pdftops", "no")
         return False
 
-def check_for_numpy():
+def check_for_numpy(min_version):
     try:
         import numpy
     except ImportError:
         print_status("numpy", "no")
-        print_message("You must install numpy 1.4 or later to build matplotlib.")
+        print_message("You must install numpy %s or later to build matplotlib." %
+                      min_version)
         return False
-    nn = numpy.__version__.split('.')
-    if not (int(nn[0]) >= 1 and int(nn[1]) >= 1):
-        if not (int(nn[0]) >= 4):
-            print_message(
-               'numpy 1.4 or later is required; you have %s' %
-               numpy.__version__)
-            return False
+
+    expected_version = version.StrictVersion(min_version)
+    found_version = version.StrictVersion(numpy.__version__)
+    if not found_version >= expected_version:
+        print_message(
+            'numpy %s or later is required; you have %s' %
+            (min_version, numpy.__version__))
+        return False
     module = Extension('test', [])
     add_numpy_flags(module)
     add_base_flags(module)


### PR DESCRIPTION
Update documentation and checks to refer to Numpy 1.4 as the minimum Numpy version.  See thread "Fwd:  Upgraded to 1.1.0, now only line graphs work!" on matplotlib-users.
