### PR TITLE
Do not modify dict while iterating over it

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1491,10 +1491,10 @@ class Grouper(object):
         Clean dead weak references from the dictionary
         """
         mapping = self._mapping
-        for key, val in mapping.iteritems():
-            if key() is None:
-                del mapping[key]
-                val.remove(key)
+        to_drop = [key for key in mapping if key() is None]
+        for key in to_drop:
+            val = mapping.pop(key)
+            val.remove(key)
 
     def join(self, a, *args):
         """


### PR DESCRIPTION
Modifying a dictionary while iterating over it is forbidden since at least Python 2.7, and (from a quick search) probably earlier. This simply builds a list of keys to remove, then iterates over that list to remove them.
