### PR TITLE
recursive import : bug in cbook.unicode_safe

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -28,15 +28,18 @@ major, minor1, minor2, s, tmp = sys.version_info
 # On some systems, getpreferredencoding sets the locale, which has
 # side effects.  Passing False eliminates those side effects.
 
-try:
-    preferredencoding = locale.getpreferredencoding(
-        matplotlib.rcParams['axes.formatter.use_locale']).strip()
-    if not preferredencoding:
-        preferredencoding = None
-except (ValueError, ImportError, AttributeError):
-    preferredencoding = None
 
 def unicode_safe(s):
+    import matplotlib
+
+    try:
+        preferredencoding = locale.getpreferredencoding(
+            matplotlib.rcParams['axes.formatter.use_locale']).strip()
+        if not preferredencoding:
+            preferredencoding = None
+    except (ValueError, ImportError, AttributeError):
+        preferredencoding = None
+
     if preferredencoding is None: return unicode(s)
     else: return unicode(s, preferredencoding)
 


### PR DESCRIPTION
I find the following recursive import :
matplotlib.**init**  --> matplotlib.rcsetup --> matplotlib.colors --> matplotlib.cbook --> matplotlib.**init**
with :
    - matplotlib.rcsetup imported line 133
    - matplotlib.rcParams defined much later
    - and cbook asking for rcParams["axes.formatter.use_local"]
