### PR TITLE
lines.py: fix bugs in marker alpha and edge colors

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -508,8 +508,15 @@ class Line2D(Artist):
         if self._marker:
             gc = renderer.new_gc()
             self._set_gc_clip(gc)
-            gc.set_foreground(self.get_markeredgecolor())
-            gc.set_linewidth(self._markeredgewidth)
+            rgbFace = self._get_rgb_face()
+            rgbFaceAlt = self._get_rgb_face(alt=True)
+            edgecolor = self.get_markeredgecolor()
+            if is_string_like(edgecolor) and edgecolor.lower() == 'none':
+                gc.set_linewidth(0)
+                gc.set_foreground(rgbFace)
+            else:
+                gc.set_foreground(edgecolor)
+                gc.set_linewidth(self._markeredgewidth)
             gc.set_alpha(self._alpha)
             marker = self._marker
             tpath, affine = self._transformed_path.get_transformed_points_and_affine()
@@ -539,7 +546,6 @@ class Line2D(Artist):
                 w = renderer.points_to_pixels(self._markersize)
                 if marker.get_marker() != ',': # Don't scale for pixels
                     marker_trans = marker_trans.scale(w)
-                rgbFace = self._get_rgb_face()
                 renderer.draw_markers(
                     gc, marker_path, marker_trans, subsampled, affine.frozen(),
                     rgbFace)
@@ -547,10 +553,9 @@ class Line2D(Artist):
                 if alt_marker_path:
                     alt_marker_trans = marker.get_alt_transform()
                     alt_marker_trans = alt_marker_trans.scale(w)
-                    rgbFace = self._get_rgb_face(alt=True)
                     renderer.draw_markers(
                         gc, alt_marker_path, alt_marker_trans, subsampled,
-                        affine.frozen(), rgbFace)
+                        affine.frozen(), rgbFaceAlt)
 
             gc.restore()
 
@@ -567,16 +572,15 @@ class Line2D(Artist):
 
     def get_markeredgecolor(self):
         if (is_string_like(self._markeredgecolor) and
-            self._markeredgecolor == 'auto'):
+                                    self._markeredgecolor == 'auto'):
+            if self._marker.get_marker() in ('.', ','):
+                return self._color
             if self._marker.is_filled():
-                return 'k'
+                return 'k'  # Bad hard-wired default...
             else:
                 return self._color
-        else:
-            return self._markeredgecolor
-
-
         return self._markeredgecolor
+
     def get_markeredgewidth(self): return self._markeredgewidth
 
     def _get_markerfacecolor(self, alt=False):


### PR DESCRIPTION
Two bugs are fixed:

1) plt.plot(np.arange(3),'ro', mec='none')
was not plotting anything because 'none' was setting the
edgecolor alpha to 0, and that alpha was being propagated
to gc, overriding the face color. The 'none' case needs to
be trapped, not passed on to the GraphicsContext.

2) plt.plot(np.arange(3), 'r.')
was drawing a black edge around the point; same for 'r,';
the markers.py refactoring turned the point and pixel markers
into filled markers, with their default black borders.  The
solution here was to special-case them in Line2D.  They do
need to be filled, with edges of the same color; otherwise
the pixel can end up nearly invisible, and the point could
end up as a donut.
