### PR TITLE
make ScalarFormatter use of mathtext configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2011-12-01 Make use of mathtext in tick labels configurable - DSD
+
 2011-10-25 added support for \operatorname to mathtext,
            including the ability to insert spaces, such as
            $\operatorname{arg\,max}$ - PI

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -450,7 +450,9 @@ defaultParams = {
                                # use scientific notation if log10
                                # of the axis range is smaller than the
                                # first or larger than the second
-    'axes.formatter.use_locale' : [False, validate_bool], # Use the current locale to format ticks
+    'axes.formatter.use_locale' : [False, validate_bool],
+                               # Use the current locale to format ticks
+    'axes.formatter.use_mathtext' : [False, validate_bool],
     'axes.unicode_minus'        : [True, validate_bool],
     'axes.color_cycle'      : [['b','g','r','c','m','y','k'],
                                     validate_colorlist], # cycle of plot

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -330,21 +330,22 @@ class ScalarFormatter(Formatter):
 
     """
 
-    def __init__(self, useOffset=True, useMathText=False, useLocale=None):
+    def __init__(self, useOffset=True, useMathText=None, useLocale=None):
         # useOffset allows plotting small data ranges with large offsets:
         # for example: [1+1e-9,1+2e-9,1+3e-9]
         # useMathText will render the offset and scientific notation in mathtext
         self.set_useOffset(useOffset)
         self._usetex = rcParams['text.usetex']
+        if useMathText is None:
+            useMathText = rcParams['axes.formatter.use_mathtext']
         self._useMathText = useMathText
         self.orderOfMagnitude = 0
         self.format = ''
         self._scientific = True
         self._powerlimits = rcParams['axes.formatter.limits']
         if useLocale is None:
-            self._useLocale = rcParams['axes.formatter.use_locale']
-        else:
-            self._useLocale = useLocale
+            useLocale = rcParams['axes.formatter.use_locale']
+        self._useLocale = useLocale
 
     def get_useOffset(self):
         return self._useOffset

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -216,6 +216,8 @@ backend      : %(backend)s
                                    # according to the user's locale.
                                    # For example, use ',' as a decimal
                                    # separator in the fr_FR locale.
+#axes.formatter.use_mathtext : False # When True, use mathtext for scientific
+                                     # notation.
 #axes.unicode_minus  : True    # use unicode for the minus symbol
                                # rather than hypen.  See
                                # http://en.wikipedia.org/wiki/Plus_sign


### PR DESCRIPTION
Adds an rc parameter allowing the user to enable mathtext rendering of scientific notation. Disabled by default, for consistent behavior.
