### PR TITLE
Do not assume < 8-bit images are 8-bit.

### DIFF
--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -429,7 +429,7 @@ _png_module::read_png(const Py::Tuple& args)
     int num_dims  = (png_get_color_type(png_ptr, info_ptr)
                                 & PNG_COLOR_MASK_COLOR) ? 3 : 2;
 
-    double max_value = (1 << ((bit_depth < 8) ? 8 : bit_depth)) - 1;
+    double max_value = (1 << bit_depth) - 1;
     PyArrayObject *A = (PyArrayObject *) PyArray_SimpleNew(
         num_dims, dimensions, PyArray_FLOAT);
 


### PR DESCRIPTION
When loading PNGs with bit-depth < 8, matplotlib assumes the bit depth is 8.  This causes black and white images to be returned in the range [0, 1/255] instead of [0, 1].

This PR is about indicating where the problem occurs, more than trying to be a complete fix.

A sample image for testing may be found here:

http://mentat.za.net/refer/circles.png
