### PR TITLE
Alway pass unicode string to io buffer

### DIFF
--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -298,7 +298,7 @@ class Type1Font(object):
             for value in self._transformer(tokenizer,
                                            slant=effects.get('slant', 0.0),
                                            extend=effects.get('extend', 1.0)):
-                buffer.write(value)
+                buffer.write(unicode(value))
             result = buffer.getvalue()
         finally:
             buffer.close()


### PR DESCRIPTION
I came across crash in savefig, with Times font, and uselatex, and lots more options,  complaining here that `value` was `str` and that it was expecting `string`... 

This seem to do the trick for me in this case, even if I'm not really sure if it's the right thing to do.

I can try to get a minimal working/crashing example if you want.

Thank you.
