### PR TITLE
Plot Colorbar in axes_grid1 with pcolormesh

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -544,9 +544,8 @@ class ColorbarBase(cm.ScalarMappable):
         del self.solids
         del self.dividers
 
-        col = self.ax.pcolor(*args, **kw)
-        col.set_antialiased(False) # This is to suppress artifacts. We
-                                   # may use pcolormesh instead.
+        col = self.ax.pcolormesh(*args, **kw)
+
         self.solids = col
         if self.drawedges:
             self.dividers = collections.LineCollection(self._edges(X,Y),


### PR DESCRIPTION
This is identical to the standard colorbar and removes artifacts (white stripes)
in the pdf version of the ImageGrid plot.

The following example should illustrate the difference.

``` python
from __future__ import division
import numpy as np
import matplotlib.pyplot as plt
from mpl_toolkits.axes_grid1 import ImageGrid,make_axes_locatable

F = plt.figure()
grid = ImageGrid(F, 111, # similar to subplot(111)
                 nrows_ncols = (2, 2),
                 axes_pad = 0.1,
                 add_all=True,
                 label_mode = "L",
                 share_all = True,
                 cbar_mode = "single",
                  )
data = np.arange(100).reshape(10,10)
for a in range(4):
    ax = grid[a]
    im = ax.imshow(data,interpolation='none',origin='lower')
v = grid.cbar_axes[0].colorbar(im)

plt.savefig('test_imagegrid.pdf')
```

Examples of the figures using current v1.1.x branch without and with the pcolormesh. 

Before:
http://ubuntuone.com/5p9IYAFbFj9bbmN4A1dfo9
After:
http://ubuntuone.com/18vD21xtiQuVTFy96QVNOS
