### PR TITLE
Pass bbox_to_anchor and bbox_transform from zoomed_inset_axes to AnchoredZoomLocator

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -309,7 +309,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc=1,
                               **axes_kwargs)
 
    axes_locator = AnchoredZoomLocator(parent_axes, zoom=zoom, loc=loc,
-                                      bbox_to_anchor=None, bbox_transform=None,
+                                      bbox_to_anchor=bbox_to_anchor, bbox_transform=bbox_transform,
                                       **kwargs)
    inset_axes.set_axes_locator(axes_locator)
 


### PR DESCRIPTION
This commit changes zoomed_inset_axes to pass bbox_to_anchor and bbox_transform to AnchoredZoomLocator. That makes it possible to control the position of zoomed inset as expected. 
