### PR TITLE
Fix BboxBase.anchored for unicode literals

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -518,7 +518,7 @@ class BboxBase(TransformNode):
         if container is None:
             container = self
         l, b, w, h = container.bounds
-        if isinstance(c, str):
+        if isinstance(c, basestring):
             cx, cy = self.coefs[c]
         else:
             cx, cy = c


### PR DESCRIPTION
When 'c' argument was unicode, it was not detected as a string.

For example, "examples/api/custom_projection_example.py" fails because it uses unicode literals.
