### PR TITLE
Fix radar chart example

### DIFF
--- a/examples/api/radar_chart.py
+++ b/examples/api/radar_chart.py
@@ -1,6 +1,12 @@
 """
 Example of creating a radar chart (a.k.a. a spider or star chart) [1]_.
 
+Although this example allows a frame of either 'circle' or 'polygon', polygon
+frames don't have proper gridlines (the lines are circles instead of polygons).
+It's possible to get a polygon grid by setting GRIDLINE_INTERPOLATION_STEPS in
+matplotlib.axis to the desired number of vertices, but the orientation of the
+polygon is not aligned with the radial axes.
+
 .. [1] http://en.wikipedia.org/wiki/Radar_chart
 """
 import numpy as np


### PR DESCRIPTION
Partial fix of radar chart example for polygon frame.

This example was broken after drawing of frames changed from patches to spines.

This fix makes a polygon frame, but leaves grid lines circular.
