### PR TITLE
Numpy loose version

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -154,8 +154,8 @@ if not _python24:
 
 import numpy
 from distutils import version
-expected_version = version.StrictVersion(__version__numpy__)
-found_version = version.StrictVersion(numpy.__version__)
+expected_version = version.LooseVersion(__version__numpy__)
+found_version = version.LooseVersion(numpy.__version__)
 if not found_version >= expected_version:
     raise ImportError(
         'numpy %s or later is required; you have %s' % (

--- a/setupext.py
+++ b/setupext.py
@@ -46,7 +46,7 @@ WIN32 - VISUAL STUDIO 7.1 (2003)
 import os
 import re
 import subprocess
-from distutils import sysconfig
+from distutils import sysconfig, version
 
 basedir = {
     'win32'  : ['win32_static',],
@@ -550,8 +550,8 @@ def check_for_numpy(min_version):
                       min_version)
         return False
 
-    expected_version = min_version.split('.')
-    found_version = numpy.__version__.split('.')
+    expected_version = version.LooseVersion(min_version)
+    found_version = version.LooseVersion(numpy.__version__)
     if not found_version >= expected_version:
         print_message(
             'numpy %s or later is required; you have %s' %


### PR DESCRIPTION
There are two places where the version check is done, and my
last changeset fixed only one of them.  This time I am restoring
the use of distutils.version, and using LooseVersion in
both locations.  It looks like it should work as well as "split"
for the forseeable future.
