### PR TITLE
transforms: bugfix: examples/api/custom_projection_example.py was failing

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -518,9 +518,9 @@ class BboxBase(TransformNode):
         if container is None:
             container = self
         l, b, w, h = container.bounds
-        if isinstance(c, str):
+        try:
             cx, cy = self.coefs[c]
-        else:
+        except KeyError:
             cx, cy = c
         L, B, W, H = self.bounds
         return Bbox(self._points +


### PR DESCRIPTION
An anchor u'C' was being passed in and was failing the test of
being a string.  The proposed solution is to use try/except to
see if the value passed in is a dictionary key.  This seems to
work regardless of whether the value is a string or unicode.
