### PR TITLE
Raises the Figures windows when issuing a blocking show() on the macosx backend.

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5552,7 +5552,10 @@ set_cursor(PyObject* unused, PyObject* args)
 static PyObject*
 show(PyObject* self)
 {
-    if(nwin > 0) [NSApp run];
+    if(nwin > 0) {
+        [NSApp activateIgnoringOtherApps:YES];
+        [NSApp run];
+    }
     Py_INCREF(Py_None);
     return Py_None;
 }


### PR DESCRIPTION
Currently when issuing a blocking show() on the macosx backend, the figures appear in the background, and the shell (or application) that holds the python interpreter stays active. The user has to make the figures active by clicking on them, interact with them, and then close them to keep going. Why not directly make the figure active, since the only way to keep going is to close the windows?
