### PR TITLE
Only call dirname on string-like directory names

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -223,6 +223,8 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
             for j in range(_winreg.QueryInfoKey(local)[1]):
                 try:
                     key, direc, any = _winreg.EnumValue( local, j)
+                    if not is_string_like(direc):
+                        continue
                     if not os.path.dirname(direc):
                         direc = os.path.join(directory, direc)
                     direc = os.path.abspath(direc).lower()


### PR DESCRIPTION
In [issue 672](https://github.com/matplotlib/matplotlib/issues/672) @gujax reports that the registry includes an entry where the value is numeric, not a string, and os.path.dirname crashes. This should avoid that problem, but I don't have a Windows system to test on.
