### PR TITLE
Symlog plotting is broken for anything other than base 10

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1373,12 +1373,15 @@ class SymmetricalLogLocator(Locator):
     Determine the tick locations for log axes
     """
 
-    def __init__(self, transform, subs=[1.0]):
+    def __init__(self, transform, subs=None):
         """
         place ticks on the location= base**i*subs[j]
         """
         self._transform = transform
-        self._subs = subs
+        if subs is None:
+            self._subs = [1.0]
+        else:
+            self._subs = subs
         self.numticks = 15
 
     def __call__(self):


### PR DESCRIPTION
Symlog plotting raises an `IndexError` if `basex` or `basey` is anything other than `10`.

As an example:

```
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
ax.set_xscale('symlog', basex=2)

x = range(1024)
ax.plot(x)

plt.show()
```

This is caused by a mutable default argument in `ticker.SymmetricalLogLocator`.  
