### PR TITLE
savefig to StringIO crashes

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1068,7 +1068,7 @@ class FigureCanvasSVG(FigureCanvasBase):
                 if sys.version_info[0] >= 3:
                     svgwriter = io.TextIOWrapper(filename, 'utf-8')
                 else:
-                    svgwriter = codecs.EncodedFile(filename, 'utf-8')
+                    svgwriter = codecs.getwriter('utf-8')(filename)
             fh_to_close = None
         else:
             raise ValueError("filename must be a path or a file-like object")


### PR DESCRIPTION
Example code:

``` python
import pylab, StringIO

out = StringIO.StringIO()
pylab.plot([1, 2, 3])
pylab.savefig(out, format = "svg")
```

Crashes here:
https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/backends/backend_svg.py#L1067
`AttributeError: readable` (apparently, it expects an `io.StringIO` file object)

... but using `io.StringIO` crashes as well, with an unicode issue:
`TypeError: string argument expected, got 'str'`

The only workaround I have found so far consists in subclassing StringIO:

``` python
class MyStringIO(StringIO):
    def readable(self):
        return True

    def writable(self):
        return True

    def seekable(self):
        return True
```
