### PR TITLE
_init() was not accessible because expected _init(self)

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -602,7 +602,7 @@ class Colormap:
             self._lut[self._i_over] = self._lut[self.N-1]
         self._lut[self._i_bad] = self._rgba_bad
 
-    def _init():
+    def _init(self):
         '''Generate the lookup table, self._lut'''
         raise NotImplementedError("Abstract class only")
 


### PR DESCRIPTION
Found a minor bug with the Colormap abstract base class. If you try to instantiate it, self._init() should be called, and a NotImplementedError is raised. This does not happen because the definition of _init() was lacking the 'self' parameter. 

Note: this my first attempt at a pull request and contribution, so any advice, suggestions are much appreciated. 
