### PR TITLE
Fix 'Path lacks initial MOVETO'

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -127,6 +127,8 @@ class RendererCairo(RendererBase):
         for points, code in path.iter_segments(transform):
             if code == Path.MOVETO:
                 ctx.move_to(*points)
+            elif code == Path.CLOSEPOLY:
+                ctx.close_path()
             elif code == Path.LINETO:
                 ctx.line_to(*points)
             elif code == Path.CURVE3:
@@ -135,8 +137,6 @@ class RendererCairo(RendererBase):
                              points[2], points[3])
             elif code == Path.CURVE4:
                 ctx.curve_to(*points)
-            elif code == Path.CLOSEPOLY:
-                ctx.close_path()
 
 
     def draw_path(self, gc, path, transform, rgbFace=None):

--- a/lib/matplotlib/backends/backend_emf.py
+++ b/lib/matplotlib/backends/backend_emf.py
@@ -234,6 +234,8 @@ class RendererEMF(RendererBase):
         for points, code in tpath.iter_segments():
             if code == Path.MOVETO:
                 self.emf.MoveTo(*points)
+            elif code == Path.CLOSEPOLY:
+                self.emf.CloseFigure()
             elif code == Path.LINETO:
                 self.emf.LineTo(*points)
             elif code == Path.CURVE3:
@@ -241,8 +243,6 @@ class RendererEMF(RendererBase):
                 self.emf.PolyBezierTo(zip(points[2::2], points[3::2]))
             elif code == Path.CURVE4:
                 self.emf.PolyBezierTo(zip(points[::2], points[1::2]))
-            elif code == Path.CLOSEPOLY:
-                self.emf.CloseFigure()
             last_points = points
         self.emf.EndPath()
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1227,6 +1227,8 @@ end"""
                 # This is allowed anywhere in the path
                 cmds.extend(points)
                 cmds.append(Op.moveto)
+            elif code == Path.CLOSEPOLY:
+                cmds.append(Op.closepath)
             elif last_points is None:
                 # The other operations require a previous point
                 raise ValueError, 'Path lacks initial MOVETO'
@@ -1240,8 +1242,6 @@ end"""
             elif code == Path.CURVE4:
                 cmds.extend(points)
                 cmds.append(Op.curveto)
-            elif code == Path.CLOSEPOLY:
-                cmds.append(Op.closepath)
             last_points = points
         return cmds
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -524,6 +524,11 @@ grestore
                                                simplify=simplify):
             if code == Path.MOVETO:
                 ps.append("%g %g m" % tuple(points))
+            elif code == Path.CLOSEPOLY:
+                ps.append("cl")
+            elif last_points is None:
+                # The other operations require a previous point
+                raise ValueError('Path lacks initial MOVETO')
             elif code == Path.LINETO:
                 ps.append("%g %g l" % tuple(points))
             elif code == Path.CURVE3:
@@ -532,8 +537,6 @@ grestore
                           tuple(points[2:]))
             elif code == Path.CURVE4:
                 ps.append("%g %g %g %g %g %g c" % tuple(points))
-            elif code == Path.CLOSEPOLY:
-                ps.append("cl")
             last_points = points
 
         ps = "\n".join(ps)


### PR DESCRIPTION
Paths that get compressed down to nothing by the path simplification algorithms have a single "CLOSEPOLY" command.  These changes allow those paths to work (and effectively do nothing) without raise an exception.
