### PR TITLE
savefig with bbox_inches='tight' takes account of all text artists

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8250,7 +8250,7 @@ class Axes(martist.Artist):
                                                  integer=True))
         return im
 
-    def get_default_bbox_extra_artists(self, renderer):
+    def get_default_bbox_extra_artists(self):
         bbox_extra_artists = [t for t in self.texts if t.get_visible()]
         if self.legend_:
             bbox_extra_artists.append(self.legend_)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1996,7 +1996,7 @@ class FigureCanvasBase(object):
 
                 bbox_extra_artists = kwargs.pop("bbox_extra_artists", None)
                 if bbox_extra_artists is None:
-                    bbox_extra_artists = self.figure.get_default_bbox_extra_artists(renderer)
+                    bbox_extra_artists = self.figure.get_default_bbox_extra_artists()
 
                 bb = [a.get_window_extent(renderer) for a in bbox_extra_artists]
                 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1288,11 +1288,11 @@ class Figure(Artist):
         return blocking_input(timeout=timeout)
 
 
-    def get_default_bbox_extra_artists(self, renderer):
+    def get_default_bbox_extra_artists(self):
         bbox_extra_artists = [t for t in self.texts if t.get_visible()]
         for ax in self.axes:
             if ax.get_visible():
-                bbox_extra_artists.extend(ax.get_default_bbox_extra_artists(renderer))
+                bbox_extra_artists.extend(ax.get_default_bbox_extra_artists())
         return bbox_extra_artists
 
 


### PR DESCRIPTION
I have added  _Figure.get_default_bbox_extra_artists_ and  _Axes.get_default_bbox_extra_artists_ methods. And if _bbox_extra_artists_ is not set for the savefig command, the return value of _Figure.get_default_bbox_extra_artists_ will be used instead.
By default, Figure.get_default_bbox_extra_artists adds all the visible text artists.
I think the default behavior will resolve the issues raised in #688 (although I have not tested this with Basemap).

Note, that the default behavior may result in an incorrect bbox if texts are clipped.
Any feedback will be welcomed.
