### PR TITLE
tuples don't have a pop() method. The same change has been made upstream...

### DIFF
--- a/lib/matplotlib/backends/qt4_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt4_editor/formlayout.py
@@ -273,6 +273,7 @@ class FormWidget(QWidget):
             elif isinstance(value, (str, unicode)):
                 field = QLineEdit(value, self)
             elif isinstance(value, (list, tuple)):
+                value = list(value)  # in case this is a tuple
                 selindex = value.pop(0)
                 field = QComboBox(self)
                 if isinstance(value[0], (list, tuple)):


### PR DESCRIPTION
... too: http://code.google.com/p/formlayout/source/browse/formlayout.py
