### PR TITLE
SVG output broken

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -532,14 +532,14 @@ class RendererSVG(RendererBase):
             return
 
         writer = self.writer
-        dictkey = (id(marker_path), marker_trans)
+        path_data = self._convert_path(
+            marker_path,
+            marker_trans + Affine2D().scale(1.0, -1.0),
+            simplify=False)
+        dictkey = (path_data)
         oid = self._markers.get(dictkey)
         if oid is None:
             oid = self._make_id('m', dictkey)
-            path_data = self._convert_path(
-                marker_path,
-                marker_trans + Affine2D().scale(1.0, -1.0),
-                simplify=False)
             writer.start('defs')
             writer.element('path', id=oid, d=path_data)
             writer.end('defs')
@@ -573,7 +573,7 @@ class RendererSVG(RendererBase):
             transform = Affine2D(transform.get_matrix()).scale(1.0, -1.0)
             d = self._convert_path(path, transform, simplify=False)
             oid = 'C%x_%x_%s' % (self._path_collection_id, i,
-                                    self._make_id('', d))
+                                 self._make_id('', d))
             writer.element('path', id=oid, d=d)
             path_codes.append(oid)
         writer.end('defs')


### PR DESCRIPTION
SVG output is broken, as validated through http://validator.w3.org/#validate_by_upload
e.g. run the following and upload the output, and the id's on elements are used multiple times:

``` python
from matplotlib.figure import Figure
from matplotlib.backends.backend_svg import FigureCanvasSVG

def get_series():
    yield [2.5, 1.5, 0.5], [1.1, 2.1, 3.1], dict(color='b', hatch='|')
    yield [2.6, 1.6, 0.6], [1.2, 2.2, 3.2], dict(color='r', hatch='|')

def do_chart(file):
    fig = Figure(facecolor='#FFFFFF')
    canvas = FigureCanvasSVG(fig)
    ax = fig.add_subplot(1, 1, 1)
    for xs, ys, attributes in get_series():
        ax.barh(xs, ys, 0.1, **attributes)
    canvas.print_figure(from_file)

if __name__ == '__main__':
    from_file = r"C:\temp\prob.svg"
    do_chart(from_file)
```
