### PR TITLE
Problem with images and alpha in pdf when viewed in adobe

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -448,7 +448,11 @@ class PdfFile(object):
                     'Parent': self.pagesObject,
                     'Resources': self.resourceObject,
                     'MediaBox': [ 0, 0, 72*width, 72*height ],
-                    'Contents': contentObject }
+                    'Contents': contentObject,
+                    'Group': {'Type': Name('Group'),
+                              'S': Name('Transparency'),
+                              'CS': Name('DeviceRGB')}
+                    }
         pageObject = self.reserveObject('page')
         self.writeObject(pageObject, thePage)
         self.pageList.append(pageObject)


### PR DESCRIPTION
I have noticed a strange bug when viewing some pdf figures generated with the mpl
pdf backend in adobe reader (tested in acrobat 8 and reader X). Using the Cairo pdf 
backend no problems are seen and using Okular or evince the plots look fine. In addition any
latex document with the same images embedded, created using pdflatex from texlive 2011,
has the same problem. The colours on images and plots with a transparent object are dimmed on all lines 
even the ones that have an alpha value of 1 and and the images are dimmed compared to other backends. 

Attached are some examples of png screenshots from adobe reader X in a winxp virtualbox 
on Ubuntu 11.10, they are generated from the script below. For some reason it seems like my Firefox on Ubuntu 11.10 renders all the attached pngs colours wrong (Downloading and / or viewing in chrome seems OK)

Alpha cairo backend:
http://ubuntuone.com/0VllIZfqC5VcC45Bf2PbPy

Alpha matplotlib pdf backend:
http://ubuntuone.com/0z9DeKo0ZIY9bnYUsSejqu

Image cairo backend:
http://ubuntuone.com/29e0lLI3O4NIf2gtKLjIZY

Image mpl backend:
http://ubuntuone.com/3TM6uLgZuT8zV43q8Agd1z

``` python
#import matplotlib
#matplotlib.use('GTKCairo')
import numpy as np
import matplotlib.pyplot as plt

x = np.arange(100)
y = x**2
F1 = plt.figure()
plt.plot(x,y,'b',zorder=1)
plt.plot(x,-y,'g',alpha=0.3,zorder=2)
F1.savefig('alphatest1.pdf')

F2 = plt.figure()
x = np.arange(100)
x = x.reshape(10,10)
G = plt.figure()
plt.imshow(x)
G.savefig('alphaimtest.pdf')
```
