### PR TITLE
Clang fixes

### DIFF
--- a/agg24/include/agg_renderer_outline_aa.h
+++ b/agg24/include/agg_renderer_outline_aa.h
@@ -1365,7 +1365,7 @@ namespace agg
         //---------------------------------------------------------------------
         void profile(const line_profile_aa& prof) { m_profile = &prof; }
         const line_profile_aa& profile() const { return *m_profile; }
-        line_profile_aa& profile() { return *m_profile; }
+        const line_profile_aa& profile() { return *m_profile; }
 
         //---------------------------------------------------------------------
         int subpixel_width() const { return m_profile->subpixel_width(); }


### PR DESCRIPTION
This makes compilation finish when using OS-X Lion's clang compiler.
