### PR TITLE
Initial rework of gen_gallery.py

### DIFF
--- a/doc/sphinxext/gen_gallery.py
+++ b/doc/sphinxext/gen_gallery.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 # generate a thumbnail gallery of examples
 template = """\
 {%% extends "layout.html" %%}
@@ -8,6 +10,11 @@ template = """\
 
 <h3>Click on any image to see full size image and source code</h3>
 <br/>
+
+<li><a class="reference internal" href="#">Gallery</a><ul>
+%s
+</ul>
+</li>
 
 %s
 {%% endblock %%}
@@ -42,14 +49,32 @@ def gen_gallery(app, doctree):
         'matplotlib_icon',
         ])
 
-    data = []
     thumbnails = {}
+    rows = []
+    toc_rows = []
 
-    for subdir in ('api', 'pylab_examples', 'mplot3d', 'widgets', 'axes_grid' ):
+    link_template = """\
+    <a href="%s"><img src="%s" border="0" alt="%s"/></a>
+    """
+
+    header_template = """<div class="section" id="%s">\
+    <h4>%s<a class="headerlink" href="#%s" title="Permalink to this headline">¶</a></h4>"""
+
+    toc_template = """\
+    <li><a class="reference internal" href="#%s">%s</a></li>"""
+
+    dirs = ('api', 'pylab_examples', 'mplot3d', 'widgets', 'axes_grid' )
+
+    for subdir in dirs :
+        rows.append(header_template % (subdir, subdir, subdir))
+        toc_rows.append(toc_template % (subdir, subdir))
+
         origdir = os.path.join('build', rootdir, subdir)
         thumbdir = os.path.join(outdir, rootdir, subdir, 'thumbnails')
         if not os.path.exists(thumbdir):
             os.makedirs(thumbdir)
+
+        data = []
 
         for filename in sorted(glob.glob(os.path.join(origdir, '*.png'))):
             if filename.endswith("hires.png"):
@@ -77,22 +102,26 @@ def gen_gallery(app, doctree):
             data.append((subdir, basename,
                          os.path.join(rootdir, subdir, 'thumbnails', filename)))
 
-    link_template = """\
-    <a href="%s"><img src="%s" border="0" alt="%s"/></a>
-    """
 
-    if len(data) == 0:
-        warnings.warn("No thumbnails were found")
 
-    rows = []
-    for (subdir, basename, thumbfile) in data:
-        if thumbfile is not None:
-            link = 'examples/%s/%s.html'%(subdir, basename)
-            rows.append(link_template%(link, thumbfile, basename))
+
+        for (subdir, basename, thumbfile) in data:
+            if thumbfile is not None:
+                link = 'examples/%s/%s.html'%(subdir, basename)
+                rows.append(link_template%(link, thumbfile, basename))
+
+        if len(data) == 0:
+            warnings.warn("No thumbnails were found in %s" % subdir)
+
+        # Close out the <div> opened up at the top of this loop
+        rows.append("</div>")
+
+    content = template % ('\n'.join(toc_rows),
+                          '\n'.join(rows))
 
     # Only write out the file if the contents have actually changed.
     # Otherwise, this triggers a full rebuild of the docs
-    content = template%'\n'.join(rows)
+
     gallery_path = os.path.join(app.builder.srcdir, '_templates', 'gallery.html')
     if os.path.exists(gallery_path):
         fh = file(gallery_path, 'r')


### PR DESCRIPTION
- Creates a toc at the top of the gallery page
- entries are created by a list of sub-directories
- examples from each sub-dir is sectioned

After this change, we could then focus on re-organizing the examples directory. Comments welcome!
