### PR TITLE
mathtext \left and \right delimiters not working

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -2122,9 +2122,9 @@ class Parser(object):
       | \| / \backslash \uparrow \downarrow \updownarrow \Uparrow
       \Downarrow \Updownarrow .""".split())
 
-    _left_delim = set(r"( \[ \{ < \lfloor \langle \lceil".split())
+    _left_delim = set(r"( [ \{ < \lfloor \langle \lceil".split())
 
-    _right_delim = set(r") \] \} > \rfloor \rangle \rceil".split())
+    _right_delim = set(r") ] \} > \rfloor \rangle \rceil".split())
 
     def __init__(self):
         # All forward declarations are here


### PR DESCRIPTION
Mathtext doesn't seem to understand all delimiters when using \left and \right.  For example, I can do

```
import matplotlib.pyplot as plt
plt.plot([0,1,4,9])
plt.ylabel(r'$\left\{ \frac{a}{b} \right\}$')
plt.show()
```

The result is a big ugly traceback ending in 

```
matplotlib.pyparsing.ParseFatalException: Expected a delimiter
$\left\{ \frac{a}{b} \right\}$ (at char 0), (line:1, col:1)
```

Using \left{ does work (but that's incorrect TeX), while \left[ doesn't work either.  When I set 

```
matplotlib.rcParams['text.usetex'] = True
```

Everything works as expected.  But I'd prefer to be able to use mathtext.

I am using matplotlib version 1.1.0 with python 2.7.2 on Mac OS X 10.6.8.  I tried this on a new user account with no matplotlibrc or pythonrc.  My default backend is MacOSX, but I get the same thing with Agg.
