### PR TITLE
Add AxesWidget base class to handle event activation and clean up.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -64,15 +64,16 @@ class Widget(object):
 
 
 class AxesWidget(Widget):
-    """
-    Widget that is connected to a single :class:`Axes`.
+    """Widget that is connected to a single :class:`~matplotlib.axes.Axes`.
 
-    Attributes
-    ----------
-    *ax*
-        The parent :class:`matplotlib.axes.Axes` for the widget
-    *canvas*
-        The parent FigureCanvas for the widget
+    Attributes:
+
+    *ax* : :class:`~matplotlib.axes.Axes`
+        The parent axes for the widget
+    *canvas* : :class:`~matplotlib.backend_bases.FigureCanvasBase` subclass
+        The parent figure canvs for the widget.
+    *active* : bool
+        If False, the widget does not respond to events.
     """
     def __init__(self, ax):
         self.ax = ax
@@ -81,10 +82,16 @@ class AxesWidget(Widget):
         self.active = True
 
     def connect_event(self, event, callback):
+        """Connect callback with an event.
+
+        This should be used in lieu of `figure.canvas.mpl_connect` since this
+        function stores call back ids for later clean up.
+        """
         cid = self.canvas.mpl_connect(event, callback)
         self.cids.append(cid)
 
     def disconnect_events(self):
+        """Disconnect all events created by this widget."""
         for c in self.cids:
             self.canvas.mpl_disconnect(c)
 


### PR DESCRIPTION
- Adds `connect_event` method to connect event _and store a reference_. Additional `disconnect_events` method allows user to clean up widget. Some widgets did their own cleanup, but this makes behavior more consistent.
- Adds default `ignore` method and call it in event callbacks. Some widgets had their own `ignore` methods, but this makes behavior more consistent.

Todo:
- I think `SpanSelector.new_axes` should be removed, but may be some user's code depends on it. Right now I duplicate most of the `new_axes` code in `__init__`: If `new_axis` isn't removed, then duplication should be removed.
- `update_background` in `SpanSelector` and `RectangleSelector` don't ignore events when deactivated.
