### PR TITLE
Fix error when multiple densities passed to streamplot.

### DIFF
--- a/examples/pylab_examples/streamplot_demo.py
+++ b/examples/pylab_examples/streamplot_demo.py
@@ -10,7 +10,7 @@ plt.streamplot(X, Y, U, V, color=U, linewidth=2, cmap=plt.cm.autumn)
 plt.colorbar()
 
 f, (ax1, ax2) = plt.subplots(ncols=2)
-ax1.streamplot(X, Y, U, V)
+ax1.streamplot(X, Y, U, V, density=[0.5, 1])
 
 lw = 5*speed/speed.max()
 ax2.streamplot(X, Y, U, V, density=0.6, color='k', linewidth=lw)

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -259,11 +259,11 @@ class StreamMask(object):
     """
 
     def __init__(self, density):
-        if cbook.is_numlike(density):
+        if np.isscalar(density):
             assert density > 0
             self.nx = self.ny = int(30 * density)
         else:
-            assert len(density) > 0
+            assert len(density) == 2
             self.nx = int(25 * density[0])
             self.ny = int(25 * density[1])
         self._mask = np.zeros((self.ny, self.nx))


### PR DESCRIPTION
Right before the `streamplot` PR was accepted, I made a last-minute change that broke `streamplot` when separate x- and y- densities are specified.

Also, added demo of unequal densities for `streamplot` as a test.
