### PR TITLE
Issues compiling with clang + Python 3.x

### DIFF
--- a/CXX/Python3/Objects.hxx
+++ b/CXX/Python3/Objects.hxx
@@ -413,7 +413,7 @@ namespace Py
         {
         }
 
-        bool accepts( PyObject *pyob )
+        virtual bool accepts( PyObject *pyob ) const
         {
             return pyob == NULL;
         }
@@ -1520,7 +1520,7 @@ namespace Py
 
             int operator-( const iterator &other ) const
             {
-                if( seq.ptr() != other.seq.ptr() )
+              if( seq->ptr() != other.seq->ptr() )
                     throw RuntimeError( "SeqBase<T>::iterator comparison error" );
 
                 return count - other.count;


### PR DESCRIPTION
When trying to compile matplotlib with Python 3.x on MacOS 10.7, the compilation fails:

```
clang -fno-common -dynamic -DNDEBUG -g -O3 -Wall -pipe -O2 -DPY_ARRAY_UNIQUE_SYMBOL=MPL_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/Users/Shared/Jenkins/Home/virtualenvs/python3.2-numpy1.5.0/lib/python3.2/site-packages/numpy/core/include -I/opt/local/include/freetype2 -I/opt/local/include -I. -I/opt/local/Library/Frameworks/Python.framework/Versions/3.2/include/python3.2m -c src/ft2font.cpp -o build/temp.macosx-10.7-x86_64-3.2/src/ft2font.o
In file included from src/ft2font.cpp:3:
In file included from src/ft2font.h:6:
In file included from ./CXX/Extensions.hxx:42:
In file included from ./CXX/Python3/Extensions.hxx:52:
./CXX/Python3/Objects.hxx:416:14: warning: 'Py::Null::accepts' hides overloaded virtual function [-Woverloaded-virtual]
        bool accepts( PyObject *pyob )
             ^
./CXX/Python3/Objects.hxx:239:22: note: hidden overloaded virtual function 'Py::Object::accepts' declared here
        virtual bool accepts( PyObject *pyob ) const
                     ^
./CXX/Python3/Objects.hxx:1523:25: error: member reference base type 'SeqBase<T> *const' is not a structure or union
                if( seq.ptr() != other.seq.ptr() )
                    ~~~ ^
1 warning and 1 error generated.
error: command 'clang' failed with exit status 1
```

The same compilation works with gcc (but this is not the default compiler on 10.7). I found this after setting up a Jenkins instance to test matplotlib with different Python and Numpy versions, and C compilers.

@mdboom - maybe you have some ideas since you fixed the clang errors with Python 2.x?
