### PR TITLE
Fix empty wedge vertices

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -630,7 +630,7 @@ class Path(object):
 
         if is_wedge:
             length = n * 3 + 4
-            vertices = np.empty((length, 2), np.float_)
+            vertices = np.zeros((length, 2), np.float_)
             codes = cls.CURVE4 * np.ones((length, ), cls.code_type)
             vertices[1] = [xA[0], yA[0]]
             codes[0:2] = [cls.MOVETO, cls.LINETO]


### PR DESCRIPTION
_This is a follow-up to a patch I sent to matplotlib-devel back in July 2011._

Using `matplotlib.path.Path.arc()` to create a wedge (e.g. via `matplotlib.path.Path.wedge()`) creates a Path with three uninitialized vertex positions. (The first one and the last two.)

As you would expect - sometimes this leads to nasty drawing artifacts!

I've tried zeroing the entire array, and a couple of ways to just zero the offending vertices, but they all have equal performance, so I've gone with zeroing the entire array. It has the simplest, cleanest code, and will be more robust to future changes.
