### PR TITLE
savefig with bbox_inches='tight' takes account of all text artists (against v1.1.x)

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8267,7 +8267,7 @@ class Axes(martist.Artist):
                                                  integer=True))
         return im
 
-    def get_default_bbox_extra_artists(self, renderer):
+    def get_default_bbox_extra_artists(self):
         bbox_extra_artists = [t for t in self.texts if t.get_visible()]
         if self.legend_:
             bbox_extra_artists.append(self.legend_)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1986,7 +1986,7 @@ class FigureCanvasBase(object):
 
                 bbox_extra_artists = kwargs.pop("bbox_extra_artists", None)
                 if bbox_extra_artists is None:
-                    bbox_extra_artists = self.figure.get_default_bbox_extra_artists(renderer)
+                    bbox_extra_artists = self.figure.get_default_bbox_extra_artists()
 
                 bb = [a.get_window_extent(renderer) for a in bbox_extra_artists]
                 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1287,11 +1287,11 @@ class Figure(Artist):
         return blocking_input(timeout=timeout)
 
 
-    def get_default_bbox_extra_artists(self, renderer):
+    def get_default_bbox_extra_artists(self):
         bbox_extra_artists = [t for t in self.texts if t.get_visible()]
         for ax in self.axes:
             if ax.get_visible():
-                bbox_extra_artists.extend(ax.get_default_bbox_extra_artists(renderer))
+                bbox_extra_artists.extend(ax.get_default_bbox_extra_artists())
         return bbox_extra_artists
 
 


### PR DESCRIPTION
This is same as PR #689, but against v1.1.x branch.
