### PR TITLE
Fix bug when resizing qt4 figure window.

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -318,7 +318,9 @@ class FigureManagerQT( FigureManagerBase ):
         # requested size:
         cs = canvas.sizeHint()
         sbs = self.window.statusBar().sizeHint()
-        self.window.resize(cs.width(), cs.height()+tbs_height+sbs.height())
+        self._status_and_tool_height = tbs_height+sbs.height()
+        height = cs.height() + self._status_and_tool_height
+        self.window.resize(cs.width(), height)
 
         self.window.setCentralWidget(self.canvas)
 
@@ -364,7 +366,7 @@ class FigureManagerQT( FigureManagerBase ):
 
     def resize(self, width, height):
         'set the canvas size in pixels'
-        self.window.resize(width, height)
+        self.window.resize(width, height + self._status_and_tool_height)
 
     def show(self):
         self.window.show()


### PR DESCRIPTION
Resizing window didn't account for toolbar and status bar heights.

This PR duplicates #748, but is based off of v1.1.x instead of master.
