### PR TITLE
Set slider to min/max constraint when value exceeds constraint.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -307,11 +307,15 @@ class Slider(Widget):
                 return
             val = self.valmax
 
-        if self.slidermin is not None:
-            if val<=self.slidermin.val: return
+        if self.slidermin is not None and val <= self.slidermin.val:
+            if not self.closedmin:
+                return
+            val = self.slidermin.val
 
-        if self.slidermax is not None:
-            if val>=self.slidermax.val: return
+        if self.slidermax is not None and val >= self.slidermax.val:
+            if not self.closedmax:
+                return
+            val = self.slidermax.val
 
         self.set_val(val)
 


### PR DESCRIPTION
Currently, when a slider's limits are constrained by another slider (using `slidermin/slidermax`), the slider will simply return unchanged when you move the slider beyond the limits.

Instead, the slider should update to the min/max value when `closedmin/closedmax` attributes are True. This would match the behavior of the `valmin/valmax` limits.
