### PR TITLE
Slider polyfix

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -316,8 +316,8 @@ class Slider(Widget):
 
     def set_val(self, val):
         xy = self.poly.xy
-        xy[-1] = val, 0
-        xy[-2] = val, 1
+        xy[2] = val, 1
+        xy[3] = val, 0
         self.poly.xy = xy
         self.valtext.set_text(self.valfmt%val)
         if self.drawon: self.ax.figure.canvas.draw()


### PR DESCRIPTION
When you use the figure subplots_adjust tool, and set the slider value,, the rectangle of the slider widget gets screwed up.  This is fixed in master already, and the PR fixes it in v1.1.x
