### PR TITLE
Backport sliderfix

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -768,7 +768,12 @@ class Polygon(Patch):
         Patch.__init__(self, **kwargs)
         xy = np.asarray(xy, np.float_)
         self._path = Path(xy)
-        self.set_closed(closed)
+
+        self._closed = closed
+        if closed and len(xy):
+            xy = np.concatenate([xy, [xy[0]]])
+
+        self._set_xy(xy)
 
     def get_path(self):
         return self._path
@@ -777,6 +782,10 @@ class Polygon(Patch):
         return self._closed
 
     def set_closed(self, closed):
+
+        if self._closed == bool(closed):
+            return
+
         self._closed = closed
         xy = self._get_xy()
         if closed:


### PR DESCRIPTION
Finish backporting https://github.com/matplotlib/matplotlib/pull/576 to v1.1.x which fixes triangle rendering glitch for sliders with initial val set to valmin
