### PR TITLE
tight_labels

### DIFF
--- a/examples/pylab_examples/demo_tight_labels.py
+++ b/examples/pylab_examples/demo_tight_labels.py
@@ -1,0 +1,8 @@
+import matplotlib.pyplot as plt
+
+for n in [1, 2, 3, 5]:
+    fig, axes_list = plt.subplots(n, n)
+    plt.tight_labels(0.5, 0.3)
+    plt.tight_layout()
+
+plt.show()

--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8435,6 +8435,14 @@ class Axes(martist.Artist):
         mtri.triplot(self, *args, **kwargs)
     triplot.__doc__ = mtri.triplot.__doc__
 
+    def optimize_ticker_nbin(self,
+                             max_label_fraction_x, max_label_fraction_y,
+                             renderer):
+        if max_label_fraction_x:
+            self.xaxis.optimize_ticker_nbin(max_label_fraction_x, renderer)
+        if max_label_fraction_y:
+            self.yaxis.optimize_ticker_nbin(max_label_fraction_y, renderer)
+
 
 from matplotlib.gridspec import GridSpec, SubplotSpec
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1417,6 +1417,18 @@ class Figure(Artist):
         self.subplots_adjust(**kwargs)
 
 
+    def tight_labels(self, renderer=None, label_fraction_x=0.5, label_fraction_y=0.3):
+        """
+        """
+
+        from tight_layout import get_renderer
+
+        if renderer is None:
+            renderer = get_renderer(self)
+
+        for ax in self.axes:
+            ax.optimize_ticker_nbin( label_fraction_x, label_fraction_y, renderer)
+
 
 def figaspect(arg):
     """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1057,6 +1057,15 @@ def tight_layout(pad=1.2, h_pad=None, w_pad=None):
     draw_if_interactive()
 
 
+def tight_labels(label_fraction_x=0.5, label_fraction_y=0.3):
+    """
+    """
+
+    fig = gcf()
+    fig.tight_labels(None, label_fraction_x, label_fraction_y)
+    draw_if_interactive()
+
+
 
 def box(on=None):
     """


### PR DESCRIPTION
This is my attempt to improve the situation of axis with too many ticks with overlapping ticklabels.
The overall idea is similar to tight_layout.
It calculates the fraction of the sum of ticklabel lengths (or heights) along the x-axis (or y-axis) over the axis length,  and adjust the nbin value of tick locator until it satisfies some criteria.

Here is a simple usage.

``` python
fig, axes_list = plt.subplots(4, 4)
plt.tight_labels()
plt.tight_layout()
```

This PR is just to toss around ideas. It may have some problems with shared axes.
Also, I'm not quite happy with the current heuristics, and want to play with other heuristics.
