### PR TITLE
Added fontsize= keyword argument to legend

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -4410,6 +4410,12 @@ class Axes(martist.Artist):
             instance. If *prop* is a dictionary, a new instance will be
             created with *prop*. If *None*, use rc settings.
 
+          *fontsize*: [ size in points | 'xx-small' | 'x-small' | 'small' |
+                        'medium' | 'large' | 'x-large' | 'xx-large' ]
+            Set the font size.  May be either a size string, relative to
+            the default font size, or an absolute font size in points. This
+            argument is only used if prop is not specified.
+
           *numpoints*: integer
             The number of points in the legend for line
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -134,6 +134,7 @@ class Legend(Artist):
                  scatterpoints = 3,    # TODO: may be an rcParam
                  scatteryoffsets=None,
                  prop = None,          # properties for the legend texts
+                 fontsize = None,        # keyword to set font size directly
 
                  # the following dimensions are in axes coords
                  pad = None,           # deprecated; use borderpad
@@ -174,6 +175,7 @@ class Legend(Artist):
         ================   ==================================================================
         loc                a location code
         prop               the font property
+        fontsize           the font size (used only if prop is not specified)
         markerscale        the relative size of legend markers vs. original
         numpoints          the number of points in the legend for line
         scatterpoints      the number of points in the legend for scatter plot
@@ -214,7 +216,10 @@ in the normalized axes coordinate.
         Artist.__init__(self)
 
         if prop is None:
-            self.prop=FontProperties(size=rcParams["legend.fontsize"])
+            if fontsize is not None:
+                self.prop=FontProperties(size=fontsize)
+            else:
+                self.prop=FontProperties(size=rcParams["legend.fontsize"])
         elif isinstance(prop, dict):
             self.prop=FontProperties(**prop)
             if "size" not in prop:


### PR DESCRIPTION
This is just a minor addition to add a `fontsize=` keyword argument to the legend plotting. The lack of `fontsize` argument in the legend is often confusing to beginners, since other functions/methods provide this (xlabel/ylabel, title, clabel, etc.). This option is overridden if `prop=` is specified.
