### PR TITLE
make hist return value for 'step' and 'bar' consistent with each other

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -7862,11 +7862,11 @@ class Axes(martist.Artist):
                     x,y = y,x
 
                 if fill:
-                    patches.append( self.fill(x, y,
-                        closed=False, facecolor=c)[0] )
+                    patches.append( Container(self.fill(x, y,
+                        closed=False, facecolor=c)) )
                 else:
-                    patches.append( self.fill(x, y,
-                        closed=False, edgecolor=c, fill=False)[0] )
+                    patches.append( Container(self.fill(x, y,
+                        closed=False, edgecolor=c, fill=False)) )
 
             # adopted from adjust_x/ylim part of the bar method
             if orientation == 'horizontal':
@@ -7899,20 +7899,16 @@ class Axes(martist.Artist):
             labels += [None] * (nx - len(labels))
 
         for (patch, lbl) in zip(patches, labels):
-            if isinstance(patch,Container):
-                p = patch[0]
+            p = patch[0]
+            p.update(kwargs)
+            if lbl is not None: p.set_label(lbl)
+
+            p.set_snap(False)
+
+            for p in patch[1:]:
                 p.update(kwargs)
-                if lbl is not None: p.set_label(lbl)
+                p.set_label('_nolegend_')
 
-                p.set_snap(False)
-
-                for p in patch[1:]:
-                    p.update(kwargs)
-                    p.set_label('_nolegend_')
-            else:
-                patch.set_label(lbl)
-                patch.update(kwargs)
-                patch.set_snap(False)
                 
         if binsgiven:
             if orientation == 'vertical':
@@ -7928,6 +7924,65 @@ class Axes(martist.Artist):
             return n[0], bins, cbook.silent_list('Patch', patches[0])
         else:
             return n, bins, cbook.silent_list('Lists of Patches', patches)
+            
+    @docstring.dedent_interpd
+    def hist2d(self, x, y, bins = 10, range=None, weights=None, cmin=None, cmax=None, **kwargs):
+        """
+        Call signature::
+
+           hist2d(x, y, bins = None, range=None, weights=None, cmin=None, cmax=None **kwargs)
+        Make a 2d histogram plot of *x* versus *y*, where *x*,
+        *y* are 1-D sequences of the same length
+        
+        The return value is (counts,xedges,yedges,im)
+        
+        Optional keyword arguments:
+        *bins*: [None | int | [int, int] | array_like | [array, array]]
+            The bin specification:
+                If int, the number of bins for the two dimensions (nx=ny=bins).
+                If [int, int], the number of bins in each dimension (nx, ny = bins).
+                If array_like, the bin edges for the two dimensions (x_edges=y_edges=bins).
+                If [array, array], the bin edges in each dimension (x_edges, y_edges = bins).
+            The default value is 10.
+
+        *range*: [*None* | array_like shape(2,2)]
+            The leftmost and rightmost edges of the bins along each dimension (if not specified 
+            explicitly in the bins parameters): [[xmin, xmax], [ymin, ymax]]. All values outside of 
+            this range will be considered outliers and not tallied in the histogram.
+
+        *weights*: [*None* | array]
+            An array of values w_i weighing each sample (x_i, y_i).
+
+        *cmin* : [None| scalar]
+            All bins that has count less than cmin will not be displayed 
+            and these count values in the return value count histogram will also be set to nan upon return
+ 
+        *cmax* : [None| scalar]
+            All bins that has count more than cmax will not be displayed (set to none before passing to imshow)
+            and these count values in the return value count histogram will also be set to nan upon return
+        
+        Remaining keyword arguments are passed directly to :meth:imshow
+        
+        **Example:**
+
+        .. plot:: mpl_examples/pylab_examples/hist2d_demo.py
+        """
+
+        # xrange becomes range after 2to3
+        bin_range = range
+        range = __builtins__["range"]
+        h,xedges,yedges = np.histogram2d(x, y, bins=bins, range=bin_range, normed=False, weights=weights)
+
+        if 'origin' not in kwargs: kwargs['origin']='lower'
+        if 'extent' not in kwargs: kwargs['extent']=[xedges[0], xedges[-1], yedges[0], yedges[-1]]
+        if 'interpolation' not in kwargs: kwargs['interpolation']='nearest'
+        if 'aspect' not in kwargs: kwargs['aspect']='auto'
+        if cmin is not None: h[h<cmin]=None
+        if cmax is not None: h[h>cmax]=None
+        
+        im = self.imshow(h.T,**kwargs)
+
+        return h,xedges,yedges,im
 
     @docstring.dedent_interpd
     def psd(self, x, NFFT=256, Fs=2, Fc=0, detrend=mlab.detrend_none,


### PR DESCRIPTION
'step' now return Poly or list of Poly of list of Poly and list of list of Poly for single and multiple hist request. And it's more consistent with what is written in the documentation of hist:

> Compute and draw the histogram of x. The return value is a tuple (n, bins, patches) or ([n0, n1, ...], bins, [patches0, patches1,...]) if the input contains multiple data

This gives a trouble when people are trying to create legend ex:

``` python
from matplotlib import pyplot as P
import numpy as np
arrs = []
arrs.append( np.random.randn(100) )
arrs.append( np.random.randn(100) )
n, bins, patches = P.hist( arrs, 10, histtype='step')
print patches
print patches[0]
P.title('test legend')
P.legend(patches, ('a','b') )
```

This doesn't work while

``` python
from matplotlib import pyplot as P
import numpy as np
arrs = []
arrs.append( np.random.randn(100) )
arrs.append( np.random.randn(100) )
n, bins, patches = P.hist( arrs, 10, histtype='bar')
print patches
print patches[0]
P.title('test legend')
P.legend(patches, ('a','b') )
```

works
