### PR TITLE
Tests don't display progress

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -992,7 +992,7 @@ default_test_modules = [
     'matplotlib.tests.test_legend'
     ]
 
-def test(verbosity=0):
+def test(verbosity=1):
     """run the matplotlib test suite"""
     old_backend = rcParams['backend']
     try:


### PR DESCRIPTION
I installed matplotlib a6f17f9 on Mac OS X Lion (XCode 4.3).
Then I ran the tests and all pass, which is very nice.
But the usual progress report of one dot "." per test is not there, after five minutes I was actually inclined to abort because I wasn't sure it was working ok.

Can you show the usual  nosetests progress info by default?

Also note the one warning that occurs when running the tests.

```
christoph-deils-macbook:tmp deil$ python -c 'import matplotlib; matplotlib.test()'
----------------------------------------------------------------------
Ran 1086 tests in 534.355s

OK (KNOWNFAIL=274)
/Users/deil/Library/Python/2.7/lib/python/site-packages/matplotlib/__init__.py:936: UserWarning:  This call to matplotlib.use() has no effect
because the the backend has already been chosen;
matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
or matplotlib.backends is imported for the first time.

  if warn: warnings.warn(_use_error_msg)
```
