### PR TITLE
Make qt4 backend more consistent with tk and gtk.

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -314,10 +314,6 @@ class FigureManagerQT( FigureManagerBase ):
         image = os.path.join( matplotlib.rcParams['datapath'],'images','matplotlib.png' )
         self.window.setWindowIcon(QtGui.QIcon( image ))
 
-        # Give the keyboard focus to the figure instead of the manager
-        self.canvas.setFocusPolicy( QtCore.Qt.ClickFocus )
-        self.canvas.setFocus()
-
         QtCore.QObject.connect( self.window, QtCore.SIGNAL( 'destroyed()' ),
                             self._widgetclosed )
         self.window._destroying = False


### PR DESCRIPTION
This pull request fixes the following in the qt4 backend:
- #299 (arrow keys not triggering a key press event)
- Focus now set properly without the user needing to click on the canvas to activate keyboard events
- Fixed a consistency such that unmapped keys still come through as None (as tk and gtk do)

Code to test these (by hand):

```
import matplotlib

matplotlib.use('qt4agg')
#matplotlib.use('tkagg')
#matplotlib.use('gtkagg')

import matplotlib.pyplot as plt

plt.plot(range(10))

def onclick(event):
    print event.key

cid = plt.gcf().canvas.mpl_connect('key_press_event', onclick)

plt.show()
```

I've based this off master, but it might be that we would prefer to put this on the 1.1.x line?
