### PR TITLE
doc/implementation mismatch for path.get_path_collection_extents()

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -713,21 +713,22 @@ _get_path_collection_extents = get_path_collection_extents
 def get_path_collection_extents(
         master_transform, paths, transforms, offsets, offset_transform):
     """
-    Given a sequence of :class:`Path` objects, :class:`Transform`
-    objects and offsets, as found in a
-    :class:`collections.PathCollection`, returns the bounding box that
-    encapsulates all of them.
+    Given a sequence of :class:`Path` objects,
+    :class:`~matplotlib.transforms.Transform` objects and offsets, as
+    found in a :class:`~matplotlib.collections.PathCollection`,
+    returns the bounding box that encapsulates all of them.
 
     *master_transform* is a global transformation to apply to all paths
 
     *paths* is a sequence of :class:`Path` instances.
 
-    *transforms* is a sequence of :class:`Affine2D` instances.
+    *transforms* is a sequence of
+    :class:`~matplotlib.transforms.Affine2D` instances.
 
     *offsets* is a sequence of (x, y) offsets (or an Nx2 array)
 
-    *offset_transform* is a :class:`Affine2D` to apply to the offsets
-    before applying the offset to the path.
+    *offset_transform* is a :class:`~matplotlib.transforms.Affine2D`
+    to apply to the offsets before applying the offset to the path.
 
     The way that *paths*, *transforms* and *offsets* are combined
     follows the same method as for collections.  Each is iterated over
@@ -745,17 +746,17 @@ def get_path_collection_extents(
 def get_paths_extents(paths, transforms=[]):
     """
     Given a sequence of :class:`Path` objects and optional
-    :class:`Transform` objects, returns the bounding box that
-    encapsulates all of them.
+    :class:`~matplotlib.transforms.Transform` objects, returns the
+    bounding box that encapsulates all of them.
 
     *paths* is a sequence of :class:`Path` instances.
 
-    *transforms* is an optional sequence of :class:`Affine2D`
-    instances to apply to each path.
+    *transforms* is an optional sequence of
+    :class:`~matplotlib.transforms.Affine2D` instances to apply to
+    each path.
     """
     from transforms import Bbox, Affine2D
     if len(paths) == 0:
         raise ValueError("No paths provided")
     return Bbox.from_extents(*_get_path_collection_extents(
         Affine2D(), paths, transforms, [], Affine2D()))
-


### PR DESCRIPTION
Docstring for matplotlib.path.get_path_collection_extents() states "Given a sequence of :class:`Path` objects, returns the bounding box that encapsulates all of them." and the subsequent code passes *args to the CXX wrapper to the function in _path.cpp.  However, the call signature and documentation for the CXX wrapped function is entirely different:

```
        add_varargs_method("get_path_collection_extents", &_path_module::get_path_collection_extents,
                           "get_path_collection_extents(trans, paths, transforms, offsets, offsetTrans)");
```

And the implementation does a check for 5 arguments and expects more than just a list of Path objects:

```
    args.verify_length(5);

    //segments, trans, clipbox, colors, linewidths, antialiaseds
    agg::trans_affine       master_transform = py_to_agg_transformation_matrix(args[0].ptr());
    Py::SeqBase<Py::Object> paths            = args[1];
    Py::SeqBase<Py::Object> transforms_obj   = args[2];
    Py::Object              offsets_obj      = args[3];
    agg::trans_affine       offset_trans     = py_to_agg_transformation_matrix(args[4].ptr(), false);
```

Since it is the python function that is borked and is probably not being used right anywhere, I think it is that part that should be changed.
