### PR TITLE
Make matplotlib.delaunay give a valid triangulation for duplicate points

### DIFF
--- a/lib/matplotlib/delaunay/triangulate.py
+++ b/lib/matplotlib/delaunay/triangulate.py
@@ -89,6 +89,7 @@ class Triangulation(object):
         self.circumcenters, self.edge_db, self.triangle_nodes, \
             self.triangle_neighbors = delaunay(self.x, self.y)
 
+        self._map_to_duplicates()
         self.hull = self._compute_convex_hull()
 
     def _collapse_duplicate_points(self):
@@ -103,7 +104,18 @@ class Triangulation(object):
             True,
             (np.diff(self.x[j_sorted]) != 0) | (np.diff(self.y[j_sorted]) != 0),
         ])
+        self._dupes = np.where(mask_unique==False)[0]
         return j_sorted[mask_unique]
+
+    def _map_to_duplicates(self):
+        for k in xrange(len(self._dupes)):
+            r, c = np.where(self.triangle_nodes >= self._dupes[k])
+            for i in xrange(len(r)):
+                self.triangle_nodes[r[i]][c[i]] += 1
+
+            r, c = np.where(self.edge_db >= self._dupes[k])
+            for i in xrange(len(r)):
+                self.edge_db[r[i]][c[i]] += 1
 
     def _compute_convex_hull(self):
         """Extract the convex hull from the triangulation information.


### PR DESCRIPTION
This is a bugfix for issue #838. The `matplotlib.delaunay` code now provides a valid triangulation for lists containing duplicate points.

This code works on the test case provided in issue #838.

I have added an array of nonunique points to the `matplotlib.delaunay.Triangulate()` class and also added a function to fudge all of the triangle indices to their correct values when duplicate points are involved.
