### PR TITLE
Hatching gap on agg backend

### DIFF
--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -43,37 +43,28 @@ class VerticalHatch(HatchPatternBase):
 class NorthEastHatch(HatchPatternBase):
     def __init__(self, hatch, density):
         self.num_lines = (hatch.count('/') + hatch.count('x') + hatch.count('X')) * density
-        self.num_vertices = self.num_lines * 4
+        self.num_vertices = (self.num_lines + 1) * 2
 
     def set_vertices_and_codes(self, vertices, codes):
-        steps = np.linspace(0.0, 1.0, self.num_lines, False)
-        rev_steps = 1.0 - steps
-        vertices[0::4, 0] = 0.0
-        vertices[0::4, 1] = steps
-        vertices[1::4, 0] = rev_steps
-        vertices[1::4, 1] = 1.0
-        vertices[2::4, 0] = rev_steps
-        vertices[2::4, 1] = 0.0
-        vertices[3::4, 0] = 1.0
-        vertices[3::4, 1] = steps
+        steps = np.linspace(-0.5, 0.5, self.num_lines + 1, True)
+        vertices[0::2, 0] = 0.0 + steps
+        vertices[0::2, 1] = 0.0 - steps
+        vertices[1::2, 0] = 1.0 + steps
+        vertices[1::2, 1] = 1.0 - steps
         codes[0::2] = Path.MOVETO
         codes[1::2] = Path.LINETO
 
 class SouthEastHatch(HatchPatternBase):
     def __init__(self, hatch, density):
         self.num_lines = (hatch.count('\\') + hatch.count('x') + hatch.count('X')) * density
-        self.num_vertices = self.num_lines * 4
+        self.num_vertices = (self.num_lines + 1) * 2
 
     def set_vertices_and_codes(self, vertices, codes):
-        steps = np.linspace(0.0, 1.0, self.num_lines, False)
-        vertices[0::4, 0] = 1.0
-        vertices[0::4, 1] = steps
-        vertices[1::4, 0] = steps
-        vertices[1::4, 1] = 1.0
-        vertices[2::4, 0] = steps
-        vertices[2::4, 1] = 0.0
-        vertices[3::4, 0] = 0.0
-        vertices[3::4, 1] = steps
+        steps = np.linspace(-0.5, 0.5, self.num_lines + 1, True)
+        vertices[0::2, 0] = 0.0 + steps
+        vertices[0::2, 1] = 1.0 + steps
+        vertices[1::2, 0] = 1.0 + steps
+        vertices[1::2, 1] = 0.0 + steps
         codes[0::2] = Path.MOVETO
         codes[1::2] = Path.LINETO
 


### PR DESCRIPTION
Every 72 pixels, with some hatch patterns, the hatch line is interrupted in the agg backend.

```
ax = plt.axes()
patch = mpatches.Rectangle([0, 0], 1, 1, transform=ax.transAxes, hatch='/', facecolor='none')
ax.add_patch(patch)

# put boxes where there are gaps (in device pixel coordinates)
fig = plt.gcf()
w, h = fig.transFigure.transform([1, 1])

box_height = 11 
box1_x, box1_y = 144 - box_height/2, h - 145 + box_height/2

for i in xrange(3):
    for j in xrange(3):
        patch = mpatches.Rectangle([box1_x + i*72, box1_y - j*72], box_height, box_height, transform=None, facecolor='none')
        fig.patches.append(patch)

plt.show()
```

An interesting observation is that when using the hatch "x" the artefact doesn't exist, which suggests there may be an anti-aliasing influence at the edge of the tile before it is passed through as an `agg::span_pattern_rgba`.

I have tried changing the agg renderer in `src/_backend_agg.cpp` to renderer_bin for hatch pattern rendering, in the hope that it would be a simple anti-aliasing problem, but the problem persists. Unfortunately that is as far as I have been able to take it.
