### PR TITLE
regression on v1.1.x branch, doc build deadlocks

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -58,7 +58,7 @@ class RendererAgg(RendererBase):
     # draw at at time and so the font cache is used by only one
     # renderer at a time
 
-    lock = threading.Lock()
+    lock = threading.RLock()
     _fontd = maxdict(50)
     def __init__(self, width, height, dpi):
         if __debug__: verbose.report('RendererAgg.__init__', 'debug-annoying')


### PR DESCRIPTION
since commit a00e510e7f3bcb113a55b47469a68f35b6b7c16b (use threading Lock to protect class level font cache) the doc build deadlocks on 91% faq/how_to on an ubuntu 12.04 system

reverting only that commit fixes the issue 
Using a recursive lock fixes it too.
