### PR TITLE
Faster "direct" interpolation

### DIFF
--- a/src/_image.cpp
+++ b/src/_image.cpp
@@ -439,11 +439,15 @@ Image::resize(const Py::Tuple& args, const Py::Dict& kwargs)
 
     case NEAREST:
     {
-        typedef agg::span_image_filter_rgba_nn<img_accessor_type, interpolator_type> span_gen_type;
-        typedef agg::renderer_scanline_aa<renderer_base, span_alloc_type, span_gen_type> renderer_type;
-        span_gen_type sg(ia, interpolator);
-        renderer_type ri(rb, sa, sg);
-        agg::render_scanlines(ras, sl, ri);
+        if (colsIn == numcols && rowsIn == numrows) {
+            memcpy(bufferOut, bufferIn, colsIn * rowsIn * 4);
+        } else {
+            typedef agg::span_image_filter_rgba_nn<img_accessor_type, interpolator_type> span_gen_type;
+            typedef agg::renderer_scanline_aa<renderer_base, span_alloc_type, span_gen_type> renderer_type;
+            span_gen_type sg(ia, interpolator);
+            renderer_type ri(rb, sa, sg);
+            agg::render_scanlines(ras, sl, ri);
+        }
     }
     break;
 


### PR DESCRIPTION
When using nearest neighbor interpolation and not actually scaling, just copy the data verbatim.  (Note we don't do this for other kinds of interpolation, because the filtering on those interpolations could have an effect even when not actually scaling.)
