### PR TITLE
Remove wxversion import errors. Closes #885.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -47,21 +47,22 @@ if not hasattr(sys, 'frozen'): # i.e., not py2exe
     try:
         import wxversion
     except ImportError:
-        raise ImportError(missingwx)
-
-    # Some early versions of wxversion lack AlreadyImportedError.
-    # It was added around 2.8.4?
-    try:
-        _wx_ensure_failed = wxversion.AlreadyImportedError
-    except AttributeError:
-        _wx_ensure_failed = wxversion.VersionError
-
-    try:
-        wxversion.ensureMinimal('2.8')
-    except _wx_ensure_failed:
         pass
-    # We don't really want to pass in case of VersionError, but when
-    # AlreadyImportedError is not available, we have to.
+    else:
+
+        # Some early versions of wxversion lack AlreadyImportedError.
+        # It was added around 2.8.4?
+        try:
+            _wx_ensure_failed = wxversion.AlreadyImportedError
+        except AttributeError:
+            _wx_ensure_failed = wxversion.VersionError
+
+        try:
+            wxversion.ensureMinimal('2.8')
+        except _wx_ensure_failed:
+            pass
+        # We don't really want to pass in case of VersionError, but when
+        # AlreadyImportedError is not available, we have to.
 
 try:
     import wx


### PR DESCRIPTION
It seems silly to me to have wxversion as a hard dependency when it's not a requirement for a proper installation of wx.  Especially so since backend_wx.py still checks the `VERSION_STRING` after using going through all the hoops with wxversion.  This is simply an alternative.
