### PR TITLE
let Qt4 backend ignore extra mouse buttons (fixes exceptions)

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -143,8 +143,13 @@ class FigureCanvasQT( QtGui.QWidget, FigureCanvasBase ):
                 QtCore.Qt.Key_PageUp : 'pageup',
                 QtCore.Qt.Key_PageDown : 'pagedown',
                }
-    # left 1, middle 2, right 3
-    buttond = {1:1, 2:3, 4:2}
+    # map Qt button codes to MouseEvent's ones:
+    buttond = {QtCore.Qt.LeftButton  : 1,
+               QtCore.Qt.MidButton   : 2,
+               QtCore.Qt.RightButton : 3,
+               # QtCore.Qt.XButton1 : None,
+               # QtCore.Qt.XButton2 : None,
+               }
     def __init__( self, figure ):
         if DEBUG: print('FigureCanvasQt: ', figure)
         _create_qApp()


### PR DESCRIPTION
My mouse has more than three buttons; the current qt4 backend does not cope with mouse events on the canvas for these buttons.
