### PR TITLE
let Qt4 backend ignore extra mouse buttons (fixes exceptions)

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -122,8 +122,13 @@ class FigureCanvasQT( QtGui.QWidget, FigureCanvasBase ):
                 QtCore.Qt.Key_Alt : 'alt',
                 QtCore.Qt.Key_Return : 'enter'
                }
-    # left 1, middle 2, right 3
-    buttond = {1:1, 2:3, 4:2}
+    # map Qt button codes to MouseEvent's ones:
+    buttond = {QtCore.Qt.LeftButton  : 1,
+               QtCore.Qt.MidButton   : 2,
+               QtCore.Qt.RightButton : 3,
+               # QtCore.Qt.XButton1 : None,
+               # QtCore.Qt.XButton2 : None,
+               }
     def __init__( self, figure ):
         if DEBUG: print 'FigureCanvasQt: ', figure
         _create_qApp()


### PR DESCRIPTION
My mouse has more than three buttons, so I noticed by accident that the current qt4 backend does not cope with mouse events on the canvas for these buttons (but throws exceptions). Apart from fixing the exception, I introduced the use of Qt constants for readability, and added the two missing constants for the extra buttons in case someone wants to pick this up later and introduce support for these buttons.

This was discussed in pull request #890 and now rebased onto the v1.1.x branch as requested. (Note that during the rebase, the fix of the double-click handler got removed, because that one’s not present in 1.1.x yet.)
