### PR TITLE
pyplot.set_cmap broken 

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1737,9 +1737,11 @@ def set_cmap(cmap):
     '''
     cmap = cm.get_cmap(cmap)
 
+    # set the default colormap
     rc('image', cmap=cmap.name)
+    
+    # apply to current image if any
     im = gci()
-
     if im is not None:
         im.set_cmap(cmap)
 


### PR DESCRIPTION
With at least matplotlib 1.1.1rc and above (the one in Ubuntu 12.04 LTS), the following code does not work, while it worked in at least matplotlib 0.99.1.1 and below (the one in Ubuntu 10.04 LTS):

``` python
import pylab
pylab.set_cmap('hot')
pylab.imsave('test.png', pylab.array([[0,1],[1,0]]))
```

The following code works in both versions of matplotlib:

``` python
import pylab
pylab.hot()
pylab.imsave('test.png', pylab.array([[0,1],[1,0]]))
```

The attached pull request restores the behavior of earlier matplotlib versions, consistent with the docstring of pyplot.set_cmap.

_Background information:_ In the current version of matplotlib, pyplot.set_cmap throws a RuntimeError('You must first define an image, eg with imshow') when pyplot.gci() returns None. This is wrong, as the documentation explicitly states that it sets "the default colormap" and only applies it "to current image if any".
Of course, set_cmap is not needed in the example above, but it's terribly useful for colormaps that do not have a shortcut method (such as 'binary').
