### PR TITLE
BUG: fix mistake in calling from_list

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -64,7 +64,7 @@ def _generate_cmap(name, lutsize):
     if 'red' in spec:
         return colors.LinearSegmentedColormap(name, spec, lutsize)
     else:
-        return colors.LinearSegmentedColormap.from_list(spec, spec, lutsize)
+        return colors.LinearSegmentedColormap.from_list(name, spec, lutsize)
 
 LUTSIZE = mpl.rcParams['image.lut']
 


### PR DESCRIPTION
example:

```
In [6]: cm.cmap_d['winter'].name
Out[6]: 'winter'

In [7]: cm.cmap_d['gist_rainbow'].name
Out[7]: 
((0.0, (1.0, 0.0, 0.16)),
 (0.03, (1.0, 0.0, 0.0)),
 (0.215, (1.0, 1.0, 0.0)),
 (0.4, (0.0, 1.0, 0.0)),
 (0.586, (0.0, 1.0, 1.0)),
 (0.77, (0.0, 0.0, 1.0)),
 (0.954, (1.0, 0.0, 1.0)),
 (1.0, (1.0, 0.0, 0.75)))
```
