### PR TITLE
colorbar: update to work with #901 (41fcab53)

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -423,8 +423,10 @@ class ColorbarBase(cm.ScalarMappable):
             args = (X, Y, C)
         else:
             args = (np.transpose(Y), np.transpose(X), np.transpose(C))
-        kw = {'cmap':self.cmap, 'norm':self.norm,
-                    'alpha':self.alpha,}
+        kw = dict(cmap=self.cmap,
+                  norm=self.norm,
+                  alpha=self.alpha,
+                  edgecolors='None')
         # Save, set, and restore hold state to keep pcolor from
         # clearing the axes. Ordinarily this will not be needed,
         # since the axes object should already have hold set.


### PR DESCRIPTION
edgecolors='None' now must be included explicitly.  Even if
this change in the default is reverted, it makes sense for
colorbar to be explicit about it.
