### PR TITLE
BF - Fix maximum colorbar extension.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -598,7 +598,7 @@ class ColorbarBase(cm.ScalarMappable):
         nb = len(self._boundaries)
         if self.extend == 'both':
             nb -= 2
-        elif self._extend_lower():
+        elif self.extend in ('min', 'max'):
             nb -= 1
         return nb
 


### PR DESCRIPTION
The maximum extension for colorbars was broken. This resulted in the maximum extension being the wrong color. This was introduced in commit b2f2ab944b0c1f45dbb6fcef1385a9f566fec9ed.

I traced this to a simple error when setting the number of boundaries. A check for `'min'` or `'both'` was used instead of a check for `'min'` or `'max'`.
