### PR TITLE
Fix pcolormesh edgecolors default

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -7202,6 +7202,7 @@ class Axes(martist.Artist):
         vmax = kwargs.pop('vmax', None)
         shading = kwargs.pop('shading', 'flat').lower()
         antialiased = kwargs.pop('antialiased', False)
+        kwargs.setdefault('edgecolors', 'None')
 
         X, Y, C = self._pcolorargs('pcolormesh', *args)
         Ny, Nx = X.shape


### PR DESCRIPTION
Fix bug introduced in #901 and mentioned later in #929.  The default behavior of pcolormesh should be to draw no edges if no `edgecolors` kwarg is provided.
