### PR TITLE
YAArrow.figure gets overwritten during superclass construction

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1037,6 +1037,7 @@ class YAArrow(Patch):
         self.frac = frac
         self.headwidth = headwidth
         Patch.__init__(self, **kwargs)
+        # Set self.figure after Patch.__init__, since it sets self.figure to None
         self.figure = figure
 
     def get_path(self):
@@ -4240,6 +4241,3 @@ class ConnectionPatch(FancyArrowPatch):
             return
 
         FancyArrowPatch.draw(self, renderer)
-
-
-


### PR DESCRIPTION
SVN revision 4909 seems to have broken the YAArrow constructor by changing its **dpi** parameter to be **figure** instead, while Artist's constructor sets **self.figure** to None.  Since `YAArrow.__init__` calls the Patch constructor after setting **self.figure**, and the Patch constructor calls the Artist constructor, the constructed YAArrow object ends up with self.figure == None.

This causes YAArrow patches to not be usable in a PatchCollection because that constructor calls **get_path**, which attempts to access the YAArrow's dpi from the figure member:

``` Python
    p = PatchCollection(patches, match_original=True)
  File "/usr/local/lib/python2.7/site-packages/matplotlib/collections.py", line 1125, in __init__
    self.set_paths(patches)
  File "/usr/local/lib/python2.7/site-packages/matplotlib/collections.py", line 1129, in set_paths
    for p in patches]
  File "/usr/local/lib/python2.7/site-packages/matplotlib/patches.py", line 1039, in get_path
    k1 = self.width*self.figure.dpi/72./2.
AttributeError: 'NoneType' object has no attribute 'dpi'
```

To work around the issue, it suffices to simply set the figure manually after constructing the YAArrow:

```
arrow = YAArrow(figure, (x,y), (x+dx, y+dy))
arrow.figure = figure
```

(For a diff of SVN revision 4909, see http://www.mail-archive.com/matplotlib-checkins@lists.sourceforge.net/msg01214.html )

I'm using version 1.1.1~rc1+git20120423-0ubuntu1, but from scanning the source on github it looks as though the bug is still present.
