### PR TITLE
Fix a possible infinite loop by incrementing one of the variables used in the loop conditional.

### DIFF
--- a/src/_image.cpp
+++ b/src/_image.cpp
@@ -1066,8 +1066,7 @@ _image_module::fromarray2(const Py::Tuple& args)
         int rgba = A->dimensions[2] == 4;
         double r, g, b, alpha;
         const size_t N = imo->rowsIn * imo->colsIn;
-        size_t i = 0;
-        while (i < N)
+        for (size_t i = 0; i < N; ++i)
         {
             r = *(double *)(A->data++);
             g = *(double *)(A->data++);


### PR DESCRIPTION
Fix a possible infinite loop by incrementing one of the variables used in the loop conditional.

This was detected by Richard Trieu when compiling with clang.
