### PR TITLE
Crash and test failure during test_font_styles on win-amd64-py2.7

### DIFF
--- a/ttconv/pprdrv_tt2.cpp
+++ b/ttconv/pprdrv_tt2.cpp
@@ -226,6 +226,22 @@ void GlyphToType3::PSConvert(TTStreamWriter& stream)
 
         // For any two consecutive off-path points, insert the implied
         // on-path point.
+
+        if (points.size() == 0) {
+            k=nextinctr(i,k);
+
+            if (k==NOMOREINCTR)
+            {
+                i=k=nextoutctr(i);
+            }
+
+            if (i==NOMOREOUTCTR)
+            {
+                break;
+            }
+            continue;
+        }
+
         FlaggedPoint prev = points.back();
         for (std::list<FlaggedPoint>::iterator it = points.begin();
              it != points.end();


### PR DESCRIPTION
This issue was first reported on the matplotlib-devel mailing list at http://www.mail-archive.com/matplotlib-devel@lists.sourceforge.net/msg09076.html.

The latest github v1.1.x (and probably also the master) branch segfaults during the `matplotlib.tests.test_text.test_font_styles.test` on win-amd64-py2.7 when using the PDF backend: 

```
Python 2.7.3 (default, Apr 10 2012, 23:24:47) [MSC v.1500 64 bit 
(AMD64)] on win32
>>> import matplotlib as mpl
>>> mpl.use("agg")
>>> mpl.test(verbosity=2)
<snip>
matplotlib.tests.test_mathtext.mathtext_stixsans_65_test.test ... ok
matplotlib.tests.test_mathtext.mathtext_stixsans_65_test.test ... ok
matplotlib.tests.test_mathtext.mathtext_stixsans_65_test.test ... 
KNOWNFAIL: Cannot compare svg files on this system
matplotlib.tests.test_mathtext.test_fontinfo ... ok
matplotlib.tests.test_text.test_antialiasing.test ... ok
matplotlib.tests.test_text.test_font_styles.test ... ok
matplotlib.tests.test_text.test_font_styles.test ... <crash>
```

The crash is in line 229 of ttconv/pprdrv_tt2.cpp during a back() call on an empty std::list. https://github.com/matplotlib/matplotlib/blob/v1.1.x/ttconv/pprdrv_tt2.cpp#L229

On win32-py2.7 the test fails but doesn't crash. The failure is that bold font styles are not rendered bold:

```
Python 2.7.3 (default, Apr 10 2012, 23:31:26) [MSC v.1500 32 bit (Intel)] on win32
<snip>
======================================================================
FAIL: matplotlib.tests.test_text.test_font_styles.test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27\lib\site-packages\matplotlib\testing\decorators.py", line 36, in failer
    result = f(*args, **kwargs)
  File "X:\Python27\lib\site-packages\matplotlib\testing\decorators.py", line 140, in do_test
    '(RMS %(rms).3f)'%err)
ImageComparisonFailure: images not close: test\result_images\test_text\font_styles.png vs.
 test\result_images\test_text\expected-font_styles.png (RMS 47.138)

======================================================================
FAIL: matplotlib.tests.test_text.test_font_styles.test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27\lib\site-packages\matplotlib\testing\decorators.py", line 36, in failer
    result = f(*args, **kwargs)
  File "X:\Python27\lib\site-packages\matplotlib\testing\decorators.py", line 140, in do_test
    '(RMS %(rms).3f)'%err)
ImageComparisonFailure: images not close: test\result_images\test_text\font_styles_pdf.png vs.
 test\result_images\test_text\expected-font_styles_pdf.png (RMS 23.409)

----------------------------------------------------------------------
Ran 1068 tests in 231.978s

FAILED (KNOWNFAIL=268, failures=2) 
```

PR #905 is probably related.
