### PR TITLE
hexbin_demo.py crashes with gtk backend

### DIFF
--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -142,7 +142,7 @@ class RendererGDK(RendererBase):
     def draw_text(self, gc, x, y, s, prop, angle, ismath):
         x, y = int(x), int(y)
 
-        if x <0 or y <0: # window has shrunk and text is off the edge
+        if x < 0 or y < 0: # window has shrunk and text is off the edge
             return
 
         if angle not in (0,90):
@@ -157,6 +157,9 @@ class RendererGDK(RendererBase):
         else:
             layout, inkRect, logicalRect = self._get_pango_layout(s, prop)
             l, b, w, h = inkRect
+            if (x + w > self.width or y + h > self.height):
+                return
+
             self.gdkDrawable.draw_layout(gc.gdkGC, x, y-h-b, layout)
 
 
@@ -225,10 +228,8 @@ class RendererGDK(RendererBase):
         x = int(x-h)
         y = int(y-w)
 
-        if x < 0 or y < 0: # window has shrunk and text is off the edge
-            return
-
-        if x + w > self.width or y + h > self.height:
+        if (x < 0 or y < 0 or: # window has shrunk and text is off the edge
+            x + w > self.width or y + h > self.height):
             return
 
         key = (x,y,s,angle,hash(prop))


### PR DESCRIPTION
the demo:
http://matplotlib.sourceforge.net/examples/pylab_examples/hexbin_demo.html
crashes in matplotlib 1.0.1 when using the gtk backend:

```
$ python hexbin.py -dgtk
The program 'hexbin.py' received an X Window System error.
This probably reflects a bug in the program.
The error was 'BadMatch (invalid parameter attributes)'.
  (Details: serial 56509 error_code 8 request_code 73 minor_code 0)
  (Note to programmers: normally, X errors are reported asynchronously;
   that is, you will receive the error a while after causing it.
   To debug your program, run it with the --sync command line
   option to change this behavior. You can then get a meaningful
   backtrace from your debugger if you break on the gdk_x_error() function.)
```

other backends including gtkagg work fine.
downstream bug, verified with 1.0.1ubuntu1:
https://bugs.launchpad.net/ubuntu/+source/matplotlib/+bug/782812
