### PR TITLE
Fix tests following test_non_affine_caching, which was leaving a figure behind

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_almost_equal
 from matplotlib.transforms import Affine2D, BlendedGenericTransform
 from matplotlib.path import Path
 from matplotlib.scale import LogScale
+from matplotlib.testing.decorators import cleanup
 import numpy as np
 
 import matplotlib.transforms as mtrans
@@ -11,7 +12,7 @@ import matplotlib.pyplot as plt
 
 
 
-
+@cleanup
 def test_non_affine_caching():
     class AssertingNonAffineTransform(mtrans.Transform):
         """


### PR DESCRIPTION
Bug introduced by #723.
