### PR TITLE
formlayout: TypeError: QComboBox.addItems(QStringList): argument 1 has unexpected type 'list'

### DIFF
--- a/lib/matplotlib/backends/qt4_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt4_editor/formlayout.py
@@ -271,7 +271,9 @@ class FormWidget(QWidget):
             elif isinstance(value, (str, unicode)):
                 field = QLineEdit(value, self)
             elif isinstance(value, (list, tuple)):
-                selindex = list(value).pop(0)
+                if isinstance(value, tuple):
+                    value = list(value)
+                selindex = value.pop(0)
                 field = QComboBox(self)
                 if isinstance(value[0], (list, tuple)):
                     keys = [ key for key, _val in value ]


### PR DESCRIPTION
Clicking on the "edit curves [sic] line and axes parameters" button on a figure generated by the `plot()` command in the qt4 backend raises this error:

```
In [1]: plot(np.arange(10))
Out[1]: [<matplotlib.lines.Line2D at 0x3199b50>]

In [2]: Traceback (most recent call last):
  File "/home/mspacek/src/matplotlib/lib/matplotlib/backends/backend_qt4.py", line 519, in edit_parameters
    figureoptions.figure_edit(axes, self)
  File "/home/mspacek/src/matplotlib/lib/matplotlib/backends/qt4_editor/figureoptions.py", line 134, in figure_edit
    icon=get_icon('qt4_editor_options.svg'), apply=apply_callback)
  File "/home/mspacek/src/matplotlib/lib/matplotlib/backends/qt4_editor/formlayout.py", line 512, in fedit
    dialog = FormDialog(data, title, comment, icon, parent, apply)
  File "/home/mspacek/src/matplotlib/lib/matplotlib/backends/qt4_editor/formlayout.py", line 429, in __init__
    self.formwidget.setup()
  File "/home/mspacek/src/matplotlib/lib/matplotlib/backends/qt4_editor/formlayout.py", line 401, in setup
    widget.setup()
  File "/home/mspacek/src/matplotlib/lib/matplotlib/backends/qt4_editor/formlayout.py", line 376, in setup
    widget.setup()
  File "/home/mspacek/src/matplotlib/lib/matplotlib/backends/qt4_editor/formlayout.py", line 283, in setup
    field.addItems(value)
TypeError: QComboBox.addItems(QStringList): argument 1 has unexpected type 'list'
```

Histogram plots don't seem to have this problem. Editing the figure generated by `hist(np.arange(10))` works fine.

This may have been triggered by 97c58d2 in #693. On second thought, that seems unlikely.

Sounds like something similar was previously reported here:

http://code.google.com/p/formlayout/issues/detail?id=4

This is with git master mpl, Qt 4.7.2, and PyQt4 4.8.3-2 on Ubuntu 11.04.
