### PR TITLE
Updated setupext.py that allows building on Mac OS X

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -58,12 +58,6 @@ basedir = {
     'linux3' : ['/usr/local', '/usr'],
     'linux'  : ['/usr/local', '/usr',],
     'cygwin' : ['/usr/local', '/usr',],
-    
-    # darwin is Mac OS X.
-    # The default configuration works for Apple's built-in python, python.org python and Homebrew python
-    # If you use Fink python then prepend '/sw'
-    # If you use MacPorts python then prepend '/opt/local'
-
     'darwin' : ['/usr/local/', '/usr', '/usr/X11'],
     'freebsd4' : ['/usr/local', '/usr'],
     'freebsd5' : ['/usr/local', '/usr'],


### PR DESCRIPTION
Fix build on Mac OS X so that:
- It "just builds" against Apple's Python using Apple's library, with no special configuration required.
- It also looks in /usr/local. This should support HomeBrew and is used on all other platforms, so I think most users expect it.

This new setupext.py will not work with MacPorts or fink, but the old one would not either. I think it is dangerous to try to support both by default, since old or incomplete setups could lead to including unexpected libraries.
