### PR TITLE
fix doc typo

### DIFF
--- a/doc/users/recipes.rst
+++ b/doc/users/recipes.rst
@@ -307,7 +307,7 @@ Transparent, fancy legends
 ==========================
 
 Sometimes you know what your data looks like before you plot it, and
-mak know for instance that there won't be much data in the upper right
+may know for instance that there won't be much data in the upper right
 hand corner.  Then you can safely create a legend that doesn't overlay
 your data::
 
@@ -316,7 +316,7 @@ your data::
 Other times you don't know where your data is, and loc='best' will try
 and place the legend::
 
-  ax.legend(loc='upper right')
+  ax.legend(loc='best')
 
 but still, your legend may overlap your data, and in these cases it's
 nice to make the legend frame transparent.


### PR DESCRIPTION
While reading ["Our Favorite Recipes"](http://matplotlib.sourceforge.net/users/recipes.html) i noticed a little typo. This pull request corrects it.
