### PR TITLE
Close fd temp file following rec2csv_bad_shape test

### DIFF
--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -27,11 +27,14 @@ def test_recarray_csv_roundtrip():
 
 @raises(ValueError)
 def test_rec2csv_bad_shape():
-    bad = np.recarray((99,4),[('x',np.float),('y',np.float)])
-    fd = tempfile.TemporaryFile(suffix='csv')
-
-    # the bad recarray should trigger a ValueError for having ndim > 1.
-    mlab.rec2csv(bad,fd)
+    try:
+        bad = np.recarray((99,4),[('x',np.float),('y',np.float)])
+        fd = tempfile.TemporaryFile(suffix='csv')
+    
+        # the bad recarray should trigger a ValueError for having ndim > 1.
+        mlab.rec2csv(bad,fd)
+    finally:
+        fd.close()
 
 def test_prctile():
     # test odd lengths


### PR DESCRIPTION
This avoids a warning in python3 about the unclosed file
and potential side effects of the open file. 
