### PR TITLE
Enhance font_table_ttf.py

### DIFF
--- a/examples/pylab_examples/font_table_ttf.py
+++ b/examples/pylab_examples/font_table_ttf.py
@@ -7,10 +7,20 @@ by character code.
 
 Usage python font_table_ttf.py somefile.ttf
 """
-import sys, os
+
+import sys
+import os
+
+import matplotlib
 from matplotlib.ft2font import FT2Font
-from pylab import figure, table, show, axis, title
 from matplotlib.font_manager import FontProperties
+from pylab import figure, table, show, axis, title
+
+try:
+    unichr
+except NameError:
+    # Python 3
+    unichr = chr
 
 # the font table grid
 
@@ -19,25 +29,29 @@ labelc = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
 labelr = ['00', '10', '20', '30', '40', '50', '60', '70', '80', '90',
           'A0', 'B0', 'C0', 'D0', 'E0', 'F0']
 
-fontname = sys.argv[1]
+if len(sys.argv) > 1:
+    fontname = sys.argv[1]
+else:
+    fontname = os.path.join(matplotlib.get_data_path(),
+                            'fonts', 'ttf', 'Vera.ttf')
+
 font = FT2Font(fontname)
-codes = font.get_charmap().items()
+codes = list(font.get_charmap().items())
 codes.sort()
 
 # a 16,16 array of character strings
-chars = [ ['' for c in range(16)] for r in range(16)]
-colors = [ [(0.95,0.95,0.95) for c in range(16)] for r in range(16)]
+chars = [['' for c in range(16)] for r in range(16)]
+colors = [[(0.95, 0.95, 0.95) for c in range(16)] for r in range(16)]
 
-figure(figsize=(8,4),dpi=120)
+figure(figsize=(8, 4), dpi=120)
 for ccode, glyphind in codes:
-    if ccode>=256: continue
-    r,c = divmod(ccode,16)
+    if ccode >= 256:
+        continue
+    r, c = divmod(ccode, 16)
     s = unichr(ccode)
     chars[r][c] = s
 
-
-
-lightgrn = (0.5,0.8,0.5)
+lightgrn = (0.5, 0.8, 0.5)
 title(fontname)
 tab = table(cellText=chars,
             rowLabels=labelr,
@@ -50,7 +64,7 @@ tab = table(cellText=chars,
 
 for key, cell in tab.get_celld().items():
     row, col = key
-    if row>0 and col>0:
-        cell.set_text_props(fontproperties=FontProperties(fname=sys.argv[1]))
+    if row > 0 and col > 0:
+        cell.set_text_props(fontproperties=FontProperties(fname=fontname))
 axis('off')
 show()


### PR DESCRIPTION
Load `mpl-data/fonts/ttf/Vera.ttf` by default. 
Fix Python 3 compatibility.
