### PR TITLE
Fix traceback for vlines/hlines, when an empty list or array passed in for x/y.

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -3626,7 +3626,7 @@ class Axes(martist.Artist):
         self.add_collection(coll)
         coll.update(kwargs)
 
-        if len(x) > 0:
+        if len(y) > 0:
             minx = min(xmin.min(), xmax.min())
             maxx = max(xmin.max(), xmax.max())
             miny = y.min()


### PR DESCRIPTION
Handle the edge case in matplotlib.axes.vlines and matplotlib.axes.hlines where an empty list or array is passed in as x (or y).  Previously, the vlines/hlines routines would raise an exception when min() was called, if x (or y) was an empty list.
