### PR TITLE
Fix for issue #955

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -99,6 +99,9 @@ class AxesY(_Base):
         self._aspect = aspect
 
     def get_size(self, renderer):
+        #Reset the aspect. The grid aspect may have been changed.
+        self._aspect = self._axes.get_aspect()
+
         l1, l2 = self._axes.get_ylim()
         rel_size = abs(l2-l1)*self._aspect
         abs_size = 0.


### PR DESCRIPTION
The Y axis will reset its aspect ratio to the aspect of its parent axes when get_size is called.
