### PR TITLE
Simplify import statement

### DIFF
--- a/examples/mplot3d/scatter3d_demo.py
+++ b/examples/mplot3d/scatter3d_demo.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
+import mpl_toolkits.mplot3d
 import matplotlib.pyplot as plt
 
 def randrange(n, vmin, vmax):


### PR DESCRIPTION
While doing the mplot3D tutorial, I found this import statement confusing.  `Axes3D` is not needed specifically for the script to work.
