### PR TITLE
Animation fixes

### DIFF
--- a/examples/animation/basic_example_writer.py
+++ b/examples/animation/basic_example_writer.py
@@ -41,3 +41,13 @@ for add in np.arange(15):
 
 im_ani = animation.ArtistAnimation(fig2, ims, interval=50, repeat_delay=3000)
 im_ani.save('im.mp4', writer=writer)
+
+# Set up formatting for the movie files
+Writer = animation.writers['ffmpeg_file']
+
+# we can force ffmpeg to make webm movies if we use -f webm and no
+# codec.  webm works by default on chrome and firefox; these will
+# display inline in the ipython notebook
+
+#writer = Writer(fps=15, codec='None', extra_args=['-f', 'webm'])
+# im_ani.save('movies/im2.webm', writer=writer)

--- a/examples/animation/basic_example_writer.py
+++ b/examples/animation/basic_example_writer.py
@@ -28,15 +28,16 @@ line_ani = animation.FuncAnimation(fig1, update_line, 25, fargs=(data, l),
     interval=50, blit=True)
 line_ani.save('lines.mp4', writer=writer)
 
-fig2 = plt.figure()
+fig2, ax = plt.subplots()
 
 x = np.arange(-9, 10)
 y = np.arange(-9, 10).reshape(-1, 1)
 base = np.hypot(x, y)
 ims = []
 for add in np.arange(15):
-    ims.append((plt.pcolor(x, y, base + add, norm=plt.Normalize(0, 30)),))
+    ax.cla() # clear the last frame
+    im = ax.pcolor(x, y, base + add, norm=plt.Normalize(0, 30))
+    ims.append([im])
 
-im_ani = animation.ArtistAnimation(fig2, ims, interval=50, repeat_delay=3000,
-    blit=True)
+im_ani = animation.ArtistAnimation(fig2, ims, interval=50, repeat_delay=3000)
 im_ani.save('im.mp4', writer=writer)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -242,7 +242,7 @@ class MovieWriter(object):
 class FileMovieWriter(MovieWriter):
     '`MovieWriter` subclass that handles writing to a file.'
     def __init__(self, *args, **kwargs):
-        MovieWriter.__init__(self, *args)
+        MovieWriter.__init__(self, *args, **kwargs)
         self.frame_format = rcParams['animation.frame_format']
 
     def setup(self, fig, outfile, dpi, frame_prefix='_tmp', clear_temp=True):
@@ -354,6 +354,11 @@ class FFMpegBase:
 # Combine FFMpeg options with pipe-based writing
 @writers.register('ffmpeg')
 class FFMpegWriter(MovieWriter, FFMpegBase):
+    def __init__(self, *args, **kwargs):
+        # FFMpegBase doesn't have an init method so we need to make
+        # sure the MovieWriter gets called with our args and kwargs
+        MovieWriter.__init__(self, *args, **kwargs)
+
     def _args(self):
         # Returns the command line parameters for subprocess to use
         # ffmpeg to create a movie using a pipe
@@ -366,6 +371,11 @@ class FFMpegWriter(MovieWriter, FFMpegBase):
 @writers.register('ffmpeg_file')
 class FFMpegFileWriter(FileMovieWriter, FFMpegBase):
     supported_formats = ['png', 'jpeg', 'ppm', 'tiff', 'sgi', 'bmp', 'pbm', 'raw', 'rgba']
+    def __init__(self, *args, **kwargs):
+        # FFMpegBase doesn't have an init method so we need to make
+        # sure the FileMovieWriter gets called with our args and kwargs
+        FileMovieWriter.__init__(self, *args, **kwargs)
+
     def _args(self):
         # Returns the command line parameters for subprocess to use
         # ffmpeg to create a movie using a collection of temp images
@@ -406,6 +416,11 @@ class MencoderBase:
 # Combine Mencoder options with pipe-based writing
 @writers.register('mencoder')
 class MencoderWriter(MovieWriter, MencoderBase):
+    def __init__(self, *args, **kwargs):
+        # MencoderBase doesn't have an init method so we need to make
+        # sure the MovieWriter gets called with our args and kwargs
+        MovieWriter.__init__(self, *args, **kwargs)
+
     def _args(self):
         # Returns the command line parameters for subprocess to use
         # mencoder to create a movie
@@ -418,6 +433,11 @@ class MencoderWriter(MovieWriter, MencoderBase):
 @writers.register('mencoder_file')
 class MencoderFileWriter(FileMovieWriter, MencoderBase):
     supported_formats = ['png', 'jpeg', 'tga', 'sgi']
+    def __init__(self, *args, **kwargs):
+        # MencoderBase doesn't have an init method so we need to make
+        # sure the MovieWriter gets called with our args and kwargs
+        MovieWriter.__init__(self, *args, **kwargs)
+
     def _args(self):
         # Returns the command line parameters for subprocess to use
         # mencoder to create a movie

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -17,6 +17,7 @@
 # * Movies
 #   * Can blit be enabled for movies?
 # * Need to consider event sources to allow clicking through multiple figures
+import os
 import itertools
 import contextlib
 import subprocess
@@ -631,6 +632,26 @@ class Animation(object):
                 self._start)
 
 
+        # if fname is a relative path, return a custom object that
+        # supports the ipython display hook for embedding the video
+        # directly into an ipynb.  The wrapper inherits from string so
+        # for normal users the class will just look like the filename
+        # when returned.  But we define the custom ipython html
+        # display hook to embed HTML5 video for others, but only if
+        # webm is requested because the browsers do not currently
+        # support mp4, etc; the '/files/' prefix is an ipython
+        # notebook convention meaning the root of the notebook tree
+        # (where the nb lives)
+        class EmbedHTML(str):
+
+            def _repr_html_(self):
+                fname = os.path.join('/files/', filename)
+                return '<video controls src="%s" />'%fname
+
+        if os.path.isabs(filename):
+            return filename
+        else:
+            return EmbedHTML(filename)
 
 
     def _step(self, *args):

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -88,9 +88,10 @@ class MovieWriter(object):
         ----------
         fps: int
             Framerate for movie.
-        codec: string or None, optional
-            The codec to use. If None (the default) the setting in the
-            rcParam `animation.codec` is used.
+        codec: string or None, optional The codec to use. If None (the
+            default) the setting in the rcParam `animation.codec` is
+            used.  If codec is the special sentinel string 'None',
+            then no codec argument will be passed through.
         bitrate: int or None, optional
             The bitrate for the saved movie file, which is one way to control
             the output file size and quality. The default value is None,
@@ -340,7 +341,9 @@ class FFMpegBase:
     def output_args(self):
         # The %dk adds 'k' as a suffix so that ffmpeg treats our bitrate as in
         # kbps
-        args = ['-vcodec', self.codec]
+        args = []
+        if self.codec!='None':
+            args.extend(['-vcodec', self.codec])
         if self.bitrate > 0:
             args.extend(['-b', '%dk' % self.bitrate])
         if self.extra_args:
@@ -403,7 +406,9 @@ class MencoderBase:
     @property
     def output_args(self):
         self._remap_metadata()
-        args = ['-o', self.outfile, '-ovc', 'lavc', 'vcodec=%s' % self.codec]
+        args = ['-o', self.outfile, '-ovc', 'lavc']
+        if self.codec!='None':
+            args.append('vcodec=%s' % self.codec)
         if self.bitrate > 0:
             args.append('vbitrate=%d' % self.bitrate)
         if self.extra_args:
@@ -520,21 +525,27 @@ class Animation(object):
         used.
 
         *fps* is the frames per second in the movie. Defaults to None,
-        which will use the animation's specified interval to set the frames
-        per second.
+        which will use the animation's specified interval to set the
+        frames per second.  This is only respected if *writer* is a
+        string; if using a class instance just set the *fps* in the
+        writer.
 
         *dpi* controls the dots per inch for the movie frames. This combined
         with the figure's size in inches controls the size of the movie.
 
         *codec* is the video codec to be used. Not all codecs are supported
         by a given :class:`MovieWriter`. If none is given, this defaults to the
-        value specified by the rcparam `animation.codec`.
+        value specified by the rcparam `animation.codec`.  This is only
+        respected if *writer* is a string; if using a class instance just set
+        the *codec* in the writer.
 
         *bitrate* specifies the amount of bits used per second in the
         compressed movie, in kilobits per second. A higher number means a
         higher quality movie, but at the cost of increased file size. If no
         value is given, this defaults to the value given by the rcparam
-        `animation.bitrate`.
+        `animation.bitrate`.  This is only respected if *writer* is a
+        string; if using a class instance just set the *bitrate* in the
+        writer.
 
         *extra_args* is a list of extra string arguments to be passed to the
         underlying movie utiltiy. The default is None, which passes the
@@ -618,6 +629,8 @@ class Animation(object):
         if reconnect_first_draw:
             self._first_draw_id = self._fig.canvas.mpl_connect('draw_event',
                 self._start)
+
+
 
 
     def _step(self, *args):


### PR DESCRIPTION
This PR fixes a few problems with the new animation write functionality.

The first commit addresses the problem that there was no way to get
the args to setup that you may want to customize.  The
MovieWriter.setup method only gets called Animation.save in the "with
writer.saving" call, but there is no way to pass extra args through to
setup like "clear_temp=False" to the FileMovieWriter.

To fix this, I added an optional dictionary argument to Animation.save
called "writer_setup_kwargs" that get passed through to "saving" and
ultimately "setup", so you can use it like:

```
im_ani.save('movies/im1.mp4', writer=writer,
  writer_setup_kwargs=dict(clear_temp=False))
```

The second commit fixes a serious problem in the that the args and
kwargs passed to the writer were being dropped on the floor.  This
ultimately is another example of why multiple inheritance is
dangerous.  Effectively, what we have in master is:

```
class MovieWriter:
    def __init__(self, name='jdh'):
        self.name = 'jdh'

class FFMpegBase:
    # no init method
    def getx(self):
        return 1

class FFMpegWriter(MovieWriter, FFMpegBase):
    pass

mixin = FFMpegWriter(name='tom')
print mixin.name
```

which when you test this you will see that "mixin.name" still gets the
default value for name="jdh" because the FFMpegWriter did not define
an init method and pass the args to the proper base class Moviewriter.
The second commit fixes this.  However, I strongly advise @dopplershift to
reconsider the design and get rid of multiple inheritance.  There is
just not enough advantage to overweigh the dangers, as we see here.

Here is a real-world example using the existing animation code that shows the problem:

```
writer = animation.FFMpegFileWriter(fps=15, codec='webm', bitrate=1800)
print 'CODEC', writer.codec
print 'FPS', writer.fps
```

The third commit adds information to the docstrings for Animation.save to
point out that the fps, bitrate and codec args are only utilized if
the writer is a string; if the writer is a class instance they are
ignored in the current code.  We may want to change this to set them
on the writer unconditionally (I actually favor this) but in this
commit I just clarify the current behavior.  I also added support for
the special codec 'None'.  We use None to mean "use the default codec"
but there is at least one case when you want to force the codec to not
be included on the command line, and that is when you are using a
special -f arg to ffmpeg.  Eg, in order to get webm movies, I need a
line like:

```
ffmpeg -r 15 -i _tmp%04d.png -f webm  -y im1.webm
```

which I could do if I could get the writer to drop the 'vcodec' arg and add the -f arg using:

```
writer = Writer(fps=15, codec='None', extra_args=['-f', 'webm'])
```

In the fourth commit, I added support for the ipython display protocol so animations made in the notebook would display a movie window in the browser.

In the fifth commit, I fixed the basic_animation_writer.py example so
that we woud not be creatig a huge list of ax.colleciotns with every
call to pcolor.  The new loop looks like:

```
for add in np.arange(15):
    ax.cla() # clear the last frame
    im = ax.pcolor(x, y, base + add, norm=plt.Normalize(0, 30))
    ims.append([im])
```

and the cla call prevents pcolor from creating 15 different
collections.

The final commit adds a commented out example to the basic_animation_writer.py example that shows how to create webm movies using ffmpeg.  These are supported by chrome and firefox by default, so work using the embedded html ipython display protocol with most stock browsers.
