### PR TITLE
BUG: check for closed path in Polygon.set_xy()

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -770,8 +770,6 @@ class Polygon(Patch):
         xy = np.asarray(xy, np.float_)
         self._path = Path(xy)
         self._closed = closed
-        if closed and len(xy):
-            xy = np.concatenate([xy, [xy[0]]])
         self._set_xy(xy)
 
     def get_path(self):
@@ -796,7 +794,7 @@ class Polygon(Patch):
     def get_xy(self):
         return self._path.vertices
     def set_xy(self, vertices):
-        if self._closed:
+        if self._closed and len(vertices):
             vertices = np.concatenate([vertices, [vertices[0]]])
         self._path = Path(vertices, closed=self._closed)
     _get_xy = get_xy


### PR DESCRIPTION
This was something unexpected I came across: I had to dig through the code to see why it didn't behave as I thought it should. I'm not sure whether it should be changed (I can see arguments both ways) but I thought I'd bring it up just in case.

Former behavior:

```
>>> xy = [[0,0], [0,1], [1,1]]
>>> p = Polygon(xy, closed=True)
>>> p.get_xy()
array([[ 0.,  0.],
       [ 0.,  1.],
       [ 1.,  1.],
       [ 0.,  0.]])
>>> p.set_xy(xy)
>>> p.get_xy()
array([[ 0.,  0.],
       [ 0.,  1.],
       [ 1.,  1.]])
```

This PR changes things so the second output is the same as the first, for both `closed = True` and `closed = False`.
