### PR TITLE
Fix use() so that it is possible to reset the rcParam.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -117,8 +117,7 @@ def switch_backend(newbackend):
     """
     close('all')
     global new_figure_manager, draw_if_interactive, _show
-    matplotlib.use(newbackend, warn=False)
-    reload(matplotlib.backends)
+    matplotlib.use(newbackend, warn=False, force=True)
     from matplotlib.backends import pylab_setup
     new_figure_manager, draw_if_interactive, _show = pylab_setup()
 


### PR DESCRIPTION
With this change, the warn argument acts as a way to ignore the warning
and force the rcParam change. This allows switch_backend() to actually
function again.
