### PR TITLE
Py3k: reload->imp.reload

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -55,6 +55,11 @@ from ticker import TickHelper, Formatter, FixedFormatter, NullFormatter,\
            LinearLocator, LogLocator, AutoLocator, MultipleLocator,\
            MaxNLocator
 
+try:
+    reload
+except NameError:
+    # Python 3
+    from imp import reload
 
 ## Backend detection ##
 def _backend_selection():


### PR DESCRIPTION
In Python 3, `plt.switch_backend()` breaks because [2to3 does not correct "reload"](http://bugs.python.org/issue11797):

```
/home/bfroehle/.local/lib/python3.2/site-packages/matplotlib/pyplot.py in switch_backend(newbackend)
    117     global new_figure_manager, draw_if_interactive, _show
    118     matplotlib.use(newbackend, warn=False)
--> 119     reload(matplotlib.backends)
    120     from matplotlib.backends import pylab_setup
    121     new_figure_manager, draw_if_interactive, _show = pylab_setup()
NameError: global name 'reload' is not defined
```

It'd be relatively easy to work around this with a simple, but somewhat ugly fix:

``` python
try: reload
except: from imp import reload
```
