### PR TITLE
Move all figures to the front with a non-interactive show() in macosx backend.

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5743,8 +5743,8 @@ show(PyObject* self)
     if(nwin > 0)
     {
         [NSApp activateIgnoringOtherApps: YES];
-        for (NSWindow *aWindow in [NSApp windows]) {
-            [aWindow orderFront:nil];
+        for (NSWindow *window in [NSApp windows]) {
+            [window orderFront:nil];
         }
         [NSApp run];
     }


### PR DESCRIPTION
Previously, only the last Figure window would be moved to the front, and all other windows would stay behind the interpreter.
