### PR TITLE
Three more plot_directive configuration options

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -466,7 +466,16 @@ def run_code(code, code_path, ns=None, function_name=None):
     pwd = os.getcwd()
     old_sys_path = list(sys.path)
     if setup.config.plot_working_directory is not None:
-        os.chdir(setup.config.plot_working_directory)
+        try:
+            os.chdir(setup.config.plot_working_directory)
+        except OSError as err:
+            raise OSError(str(err) + '\n`plot_working_directory` option in'
+                          'Sphinx configuration file must be a valid '
+                          'directory path')
+        except TypeError as err:
+            raise TypeError(str(err) + '\n`plot_working_directory` option in '
+                            'Sphinx configuration file must be a string or '
+                            'None')
         sys.path.insert(0, setup.config.plot_working_directory)
     elif code_path is not None:
         dirname = os.path.abspath(os.path.dirname(code_path))


### PR DESCRIPTION
Hello,

I have added three new configuration options to Sphinx extension `plot_directive`. The added code must not change any behaviour of the extension, but will add more flexibility. 
- _plot_apply_rcparams_ : allows appyling rcParams when context is used
- _plot_working_directory_ : allows running plot directive codes in any directory
- _plot_template_ : allows customization of template used for generating restructured text

This is how I use these new options to customize `plot_directive` when documenting a project of mine.

``` python
plot_formats = [('png', 80), ('pdf', 80)]
plot_pre_code = """import numpy as np
from prody import *
from matplotlib import pyplot as plt
"""
plot_working_directory = os.path.join(os.getcwd(), 'doctest')
plot_template = """
{{ source_code }}

{{ only_html }}


   {% for img in images %}
   .. figure:: {{ build_dir }}/{{ img.basename }}.png
      {%- for option in options %}
      {{ option }}
      {% endfor %}

      {{ caption }}
   {% endfor %}

{{ only_latex }}

   {% for img in images %}
   .. image:: {{ build_dir }}/{{ img.basename }}.pdf
   {% endfor %}

"""
plot_rcparams = {'font.size': 10,
                 'xtick.labelsize': 'small',
                 'ytick.labelsize': 'small',
                 'figure.figsize': [5., 4.],}
plot_apply_rcparams = True
```
