### PR TITLE
Fix show command for Qt backend to raise window to top

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -250,9 +250,10 @@ class FigureManagerQT( FigureManagerBase ):
 
         if matplotlib.is_interactive():
             self.window.show()
+            self.window.raise_()
 
         # attach a show method to the figure for pylab ease of use
-        self.canvas.figure.show = lambda *args: self.window.show()
+        self.canvas.figure.show = lambda *args: self.window.show() and self.window.raise_()
 
         def notify_axes_change( fig ):
            # This will be called whenever the current axes is changed
@@ -285,6 +286,7 @@ class FigureManagerQT( FigureManagerBase ):
 
     def show(self):
         self.window.show()
+        self.window.raise_()
 
     def destroy( self, *args ):
         if self.window._destroying: return

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -425,9 +425,10 @@ class FigureManagerQT( FigureManagerBase ):
 
         if matplotlib.is_interactive():
             self.window.show()
+            self.window.raise_()
 
         # attach a show method to the figure for pylab ease of use
-        self.canvas.figure.show = lambda *args: self.window.show()
+        self.canvas.figure.show = lambda *args: self.window.show() and self.window.raise_()
 
         def notify_axes_change( fig ):
             # This will be called whenever the current axes is changed
@@ -474,6 +475,7 @@ class FigureManagerQT( FigureManagerBase ):
 
     def show(self):
         self.window.show()
+        self.window.raise_()
 
     def destroy( self, *args ):
         # check for qApp first, as PySide deletes it in its atexit handler


### PR DESCRIPTION
When running ipython in pylab mode using the Qt4 backend (either from qtconsole or the ipython notebook), calling show() does not raise the window to the front.
