### PR TITLE
Move Python 3 import of reload() to the module that uses it

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -106,6 +106,12 @@ import os, re, shutil, subprocess, sys, warnings
 import distutils.sysconfig
 import distutils.version
 
+try:
+    reload
+except NameError:
+    # Python 3
+    from imp import reload
+
 # Needed for toolkit setuptools support
 if 0:
     try:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -55,12 +55,6 @@ from ticker import TickHelper, Formatter, FixedFormatter, NullFormatter,\
            LinearLocator, LogLocator, AutoLocator, MultipleLocator,\
            MaxNLocator
 
-try:
-    reload
-except NameError:
-    # Python 3
-    from imp import reload
-
 ## Backend detection ##
 def _backend_selection():
     """ If rcParams['backend_fallback'] is true, check to see if the


### PR DESCRIPTION
This was added by PR #1033, but the call to `reload()` was moved in commit 865f1c05ee116645e6620fba5f2b54baa46923d5. This puts it back in the file that needs it.
