### PR TITLE
 stix_fonts_demo.py fails with bad refcount

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -870,24 +870,28 @@ FT2Font::FT2Font(std::string facefile) :
     {
         std::ostringstream s;
         s << "Could not load facefile " << facefile << "; Unknown_File_Format" << std::endl;
+        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
     else if (error == FT_Err_Cannot_Open_Resource)
     {
         std::ostringstream s;
         s << "Could not open facefile " << facefile << "; Cannot_Open_Resource" << std::endl;
+        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
     else if (error == FT_Err_Invalid_File_Format)
     {
         std::ostringstream s;
         s << "Could not open facefile " << facefile << "; Invalid_File_Format" << std::endl;
+        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
     else if (error)
     {
         std::ostringstream s;
         s << "Could not open facefile " << facefile << "; freetype error code " << error << std::endl;
+        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
 
@@ -904,6 +908,7 @@ FT2Font::FT2Font(std::string facefile) :
     {
         std::ostringstream s;
         s << "Could not set the fontsize for facefile  " << facefile << std::endl;
+        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
 


### PR DESCRIPTION
with the Agg backend, trying to build docs, I get:

 python stix_fonts_demo.py 

python2.7: CXX/Python2/cxx_extensions.cxx:1320: virtual Py::PythonExtensionBase::~PythonExtensionBase(): Assertion `ob_refcnt == 0' failed.
Aborted (core dumped)

looks like commit https://github.com/matplotlib/matplotlib/commit/85af0c02bf9a8ecdd0fd18eab8c9662c6b9f4302#src/ft2font.cpp is the culprit
