### PR TITLE
broken links in the gallery

### DIFF
--- a/doc/sphinxext/gen_gallery.py
+++ b/doc/sphinxext/gen_gallery.py
@@ -16,7 +16,7 @@ template = """\
 import os, glob, re, sys, warnings
 import matplotlib.image as image
 
-multiimage = re.compile('(.*)_\d\d')
+multiimage = re.compile('(.*?)(_\d\d){1,2}')
 
 def make_thumbnail(args):
     image.thumbnail(args[0], args[1], 0.3)
@@ -68,11 +68,8 @@ def gen_gallery(app, doctree):
                 thumbnails[orig_path] = thumb_path
 
             m = multiimage.match(basename)
-            if m is None:
-                pyfile = '%s.py'%basename
-            else:
+            if m is not None:
                 basename = m.group(1)
-                pyfile = '%s.py'%basename
 
             data.append((subdir, basename,
                          os.path.join(rootdir, subdir, 'thumbnails', filename)))


### PR DESCRIPTION
the following links in the gallery
http://matplotlib.sourceforge.net/examples/pylab_examples/demo_tight_layout_00.html
http://matplotlib.sourceforge.net/examples/pylab_examples/demo_tight_layout_01.html
http://matplotlib.sourceforge.net/examples/axes_grid/demo_axes_divider_01.html
(and maybe others) do not work

error:
1. Server: matplotlib.sourceforge.net
2. URL path: /examples/pylab_examples/demo_tight_layout_00.html
3. Error notes: NONE
4. Error type: 404
5. Request method: GET
6. Request query string: NONE
7. Time: 2012-07-19 09:12:32 UTC (1342689152)

The corresponding links in the examples (e.g. http://matplotlib.sourceforge.net/examples/pylab_examples/demo_tight_layout.html) are fine
