### PR TITLE
Test framework cleanups

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -283,10 +283,6 @@ def compare_images( expected, actual, tol, in_decorator=False ):
 
    actualImage, expectedImage = crop_to_same(actual, actualImage, expected, expectedImage)
 
-   # normalize the images
-   # expectedImage = image_util.autocontrast( expectedImage, 2 )
-   # actualImage = image_util.autocontrast( actualImage, 2 )
-
    # compare the resulting image histogram functions
    expected_version = version.LooseVersion("1.6")
    found_version = version.LooseVersion(np.__version__)


### PR DESCRIPTION
This addresses a couple of the comments in #778 made before it was merged.
1. The caching functionality of the convert function is documented.
2. Some dead code that was commented out has been removed.
