### PR TITLE
fixed conversion from pt to inch in tight_layout

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1361,7 +1361,7 @@ class Figure(Artist):
 
         return bbox_inches
 
-    def tight_layout(self, renderer=None, pad=1.2, h_pad=None, w_pad=None, rect=None):
+    def tight_layout(self, renderer=None, pad=1.08, h_pad=None, w_pad=None, rect=None):
         """
         Adjust subplot parameters to give specified padding.
 

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -270,7 +270,7 @@ class GridSpec(GridSpecBase):
         return [k for k in self._AllowedKeys if getattr(self, k)]
 
 
-    def tight_layout(self, fig, renderer=None, pad=1.2, h_pad=None, w_pad=None, rect=None):
+    def tight_layout(self, fig, renderer=None, pad=1.08, h_pad=None, w_pad=None, rect=None):
         """
         Adjust subplot parameters to give specified padding.
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1114,7 +1114,7 @@ def subplot_tool(targetfig=None):
 
 
 
-def tight_layout(pad=1.2, h_pad=None, w_pad=None, rect=None):
+def tight_layout(pad=1.08, h_pad=None, w_pad=None, rect=None):
     """
     Adjust subplot parameters to give specified padding.
 

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -110,7 +110,7 @@ def test_tight_layout6():
 
     ax.set_xlabel("x-label", fontsize=12)
 
-    gs2.tight_layout(fig, rect=[0.5, 0, 1, 1], h_pad=0.5)
+    gs2.tight_layout(fig, rect=[0.5, 0, 1, 1], h_pad=0.45)
 
     top = min(gs1.top, gs2.top)
     bottom = max(gs1.bottom, gs2.bottom)
@@ -119,5 +119,5 @@ def test_tight_layout6():
                                 0.5, 1 - (gs1.top-top)])
     gs2.tight_layout(fig, rect=[0.5, 0 + (bottom-gs2.bottom),
                                 None, 1 - (gs2.top-top)],
-                     h_pad=0.5)
+                     h_pad=0.45)
 

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -38,7 +38,7 @@ def auto_adjust_subplotpars(fig, renderer,
                             num1num2_list,
                             subplot_list,
                             ax_bbox_list=None,
-                            pad=1.2, h_pad=None, w_pad=None,
+                            pad=1.08, h_pad=None, w_pad=None,
                             rect=None):
     """
     Return a dictionary of subplot parameters so that spacing between
@@ -210,7 +210,7 @@ def get_renderer(fig):
 
 
 def get_tight_layout_figure(fig, axes_list, renderer,
-                            pad=1.2, h_pad=None, w_pad=None, rect=None):
+                            pad=1.08, h_pad=None, w_pad=None, rect=None):
     """
     return subplot parameters for tigh-layouted- figure with
     specified padding.


### PR DESCRIPTION
When using tight_layout the figure padding changes for different figure.dpi settings. This is caused by an error in when converting from points to inches. A point is always 1/72 inch and does not depend on the dots per inches.
