### PR TITLE
fix limit calculation of step* histogram

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -7848,7 +7848,7 @@ class Axes(martist.Artist):
                 _barfunc = self.barh
             else:  # orientation == 'vertical'
                 _barfunc = self.bar
-
+            
             for m, c in zip(n, color):
                 patch = _barfunc(bins[:-1]+boffset, m, width, bottom,
                                   align='center', log=log,
@@ -7897,7 +7897,7 @@ class Axes(martist.Artist):
                         closed=False, edgecolor=c, fill=False) )
 
             # adopted from adjust_x/ylim part of the bar method
-            if orientation == 'horizontal':
+            if orientation == 'vertical':
                 xmin0 = max(_saved_bounds[0]*0.9, minimum)
                 xmax = self.dataLim.intervalx[1]
                 for m in n:
@@ -7905,7 +7905,7 @@ class Axes(martist.Artist):
                 xmin = max(xmin*0.9, minimum)
                 xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
-            elif orientation == 'vertical':
+            elif orientation == 'horizontal':
                 ymin0 = max(_saved_bounds[1]*0.9, minimum)
                 ymax = self.dataLim.intervaly[1]
                 for m in n:


### PR DESCRIPTION
The limit calculation for histogram was switched for horizontal and vertical orientation.

Bar defines the vertical one as the one that x axis represents bin interval and y axis represent bin count.
The former one try to set y axis limit to bin interval for step\* with vertical orientation which is wrong.

This PR fixed it.
