### PR TITLE
For a text artist, if it has a _bbox_patch associated with it, the contains test should reflect this.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -218,7 +218,7 @@ class Text(Artist):
         if self._bbox_patch:
             patch_inside, patch_cattr =  self._bbox_patch.contains(mouseevent)
             inside = inside or patch_inside
-            cattr.update(patch_cattr) 
+            cattr["bbox_patch"] = patch_cattr
 
         return inside, cattr 
 


### PR DESCRIPTION
For a text artist, if it has a _bbox_patch associated with it, the contains test should reflect this.
