### PR TITLE
Fixed transoffset example from failing.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2080,12 +2080,8 @@ def polar(*args, **kwargs):
     Make a polar plot.  Multiple *theta*, *r* arguments are supported,
     with format strings, as in :func:`~matplotlib.pyplot.plot`.
 
-    An optional kwarg *resolution* sets the number of vertices to
-    interpolate between each pair of points.  The default is 1,
-    which disables interpolation.
     """
-    resolution = kwargs.pop('resolution', 1)
-    ax = gca(polar=True, resolution=resolution)
+    ax = gca(polar=True)
     ret = ax.plot(*args, **kwargs)
     draw_if_interactive()
     return ret

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy import ma
 import matplotlib
-from matplotlib.testing.decorators import image_comparison, knownfailureif
+from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 
 
@@ -733,6 +733,7 @@ def test_scatter_plot():
     ax = plt.axes()
     ax.scatter([3, 4, 2, 6], [2, 5, 2, 3], c=['r', 'y', 'b', 'lime'], s=[24, 15, 19, 29])
 
+@cleanup
 def test_as_mpl_axes_api():
     # tests the _as_mpl_axes api
     from matplotlib.projections.polar import PolarAxes
@@ -755,9 +756,7 @@ def test_as_mpl_axes_api():
     assert type(ax) == PolarAxes, \
            'Expected a PolarAxes, got %s' % type(ax)
     ax_via_gca = plt.gca(projection=prj)
-    # ideally, ax_via_gca is ax should be true. However, gca isn't
-    # plummed like that. (even with projection='polar').
-    assert ax_via_gca is not ax
+    assert ax_via_gca is ax
     plt.close()
 
     # testing axes creation with gca

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,6 +1,6 @@
 import matplotlib
-from nose.tools import assert_equal
-from matplotlib.testing.decorators import image_comparison, knownfailureif, cleanup
+from nose.tools import assert_equal, assert_is, assert_is_not
+from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 
 
@@ -38,3 +38,30 @@ def test_figure():
     # Return to the original; make sure the red line is not there.
     plt.figure('today')
     plt.close('tomorrow')
+    
+    
+#@cleanup
+def test_gca():
+    fig = plt.figure()
+
+    ax1 = fig.add_axes([0, 0, 1, 1])
+    assert_is(fig.gca(projection='rectilinear'), ax1)
+    assert_is(fig.gca(), ax1)
+    
+    ax2 = fig.add_subplot(121, projection='polar')
+    assert_is(fig.gca(), ax2)
+    assert_is(fig.gca(polar=True), ax2)
+    
+    ax3 = fig.add_subplot(122)
+    assert_is(fig.gca(), ax3)
+
+    # the final request for a polar axes will end up creating one
+    # with a spec of 111.
+    assert_is_not(fig.gca(polar=True), ax3)
+    assert_is_not(fig.gca(polar=True), ax2)
+    assert_equal(fig.gca().get_geometry(), (1, 1, 1))
+    
+    fig.sca(ax1)
+    assert_is(fig.gca(projection='rectilinear'), ax1)
+    assert_is(fig.gca(), ax1)
+    


### PR DESCRIPTION
This issue came about because the polar axes which had already been created via `plt.subplot` wasn't getting picked up with a simple `plt.gca(projection='polar')` due to different gridspecs. I have removed the use of the gridspec in the key comparison of gca, and added a few tests which cover these changes.

Fixes #1084.
