### PR TITLE
Documentation Errors for specgram

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8218,6 +8218,10 @@ class Axes(martist.Artist):
 
         %(PSD)s
 
+          *noverlap*: integer
+            The number of points of overlap between blocks.  The default value
+            is 0 (no overlap).
+
           *Fc*: integer
             The center frequency of *x* (defaults to 0), which offsets
             the x extents of the plot to reflect the frequency range used
@@ -8295,6 +8299,10 @@ class Axes(martist.Artist):
 
         %(PSD)s
 
+          *noverlap*: integer
+            The number of points of overlap between blocks.  The
+            default value is 0 (no overlap).
+
           *Fc*: integer
             The center frequency of *x* (defaults to 0), which offsets
             the x extents of the plot to reflect the frequency range used
@@ -8361,6 +8369,10 @@ class Axes(martist.Artist):
 
         %(PSD)s
 
+          *noverlap*: integer
+            The number of points of overlap between blocks.  The
+            default value is 0 (no overlap).
+
           *Fc*: integer
             The center frequency of *x* (defaults to 0), which offsets
             the x extents of the plot to reflect the frequency range used
@@ -8421,6 +8433,10 @@ class Axes(martist.Artist):
 
         %(PSD)s
 
+          *noverlap*: integer
+            The number of points of overlap between blocks.  The
+            default value is 128.
+
           *Fc*: integer
             The center frequency of *x* (defaults to 0), which offsets
             the y extents of the plot to reflect the frequency range used
@@ -8445,7 +8461,7 @@ class Axes(martist.Artist):
 
           - *bins* are the time points the spectrogram is calculated over
           - *freqs* is an array of frequencies
-          - *Pxx* is a len(times) x len(freqs) array of power
+          - *Pxx* is an array of shape `(len(times), len(freqs))` of power
           - *im* is a :class:`~matplotlib.image.AxesImage` instance
 
         Note: If *x* is real (i.e. non-complex), only the positive

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -332,10 +332,6 @@ docstring.interpd.update(PSD=cbook.dedent("""
           argument, it must take a data segment as an argument and
           return the windowed version of the segment.
 
-      *noverlap*: integer
-          The number of points of overlap between blocks.  The default value
-          is 0 (no overlap).
-
       *pad_to*: integer
           The number of points to which the data segment is padded when
           performing the FFT.  This can be different from *NFFT*, which
@@ -377,6 +373,10 @@ def psd(x, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
 
     %(PSD)s
 
+      *noverlap*: integer
+          The number of points of overlap between blocks.  The default value
+          is 0 (no overlap).
+
     Returns the tuple (*Pxx*, *freqs*).
 
     Refs:
@@ -409,6 +409,10 @@ def csd(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
 
     %(PSD)s
 
+      *noverlap*: integer
+          The number of points of overlap between blocks.  The default value
+          is 0 (no overlap).
+
     Returns the tuple (*Pxy*, *freqs*).
 
     Refs:
@@ -436,6 +440,10 @@ def specgram(x, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
     spectrum is returned.
 
     %(PSD)s
+
+      *noverlap*: integer
+          The number of points of overlap between blocks.  The default value
+          is 128.
 
     Returns a tuple (*Pxx*, *freqs*, *t*):
 
@@ -481,6 +489,10 @@ def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
         Array or sequence containing the data
 
     %(PSD)s
+
+      *noverlap*: integer
+          The number of points of overlap between blocks.  The default value
+          is 0 (no overlap).
 
     The return value is the tuple (*Cxy*, *f*), where *f* are the
     frequencies of the coherence vector. For cohere, scaling the


### PR DESCRIPTION
Im sorry if im breaking some standard of communication with these issues. 

Im using matplotlib version 1.2.x in MacOs Lion

The documentation errors are located in http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.specgram

1.
The function prototype states that the default parameter for overlap - noverlap is 128 while in the description it is stated that is 0. I think the correct is 128.
1. The description for the return value at the end states that Pxx is a len(times) x len(freqs) array of powe,r while in reality Pxx is an array with len(freqs) and each subarray is len(bins)
