### PR TITLE
add documentation for figure show method in backend_bases and backend_template

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1034,6 +1034,24 @@ def get_backend():
     "Returns the current backend."
     return rcParams['backend']
 
+
+class NonGUIBackendWarning(Warning):
+    pass
+
+
+def _warn_non_gui_show():
+    warnings.warn(
+        "matplotlib is currently using a non-GUI backend, "
+        "so the figure can not be shown.  Call "
+        "matplotlib.hide_show_warnings() to suppress "
+        "these warnings.",
+        NonGUIBackendWarning)
+
+
+def hide_show_warnings():
+    warnings.simplefilter('ignore', NonGUIBackendWarning)
+
+
 def interactive(b):
     """
     Set interactive mode to boolean b.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -39,6 +39,7 @@ import matplotlib.widgets as widgets
 from matplotlib import rcParams
 from matplotlib import is_interactive
 from matplotlib._pylab_helpers import Gcf
+from matplotlib import _warn_non_gui_show
 
 from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
 import cStringIO
@@ -2435,7 +2436,7 @@ class FigureManagerBase:
         """
         For GUI backends, show the figure window and redraw.
         """
-        pass
+        _warn_non_gui_show()
 
     def destroy(self):
         pass

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -39,6 +39,7 @@ from matplotlib.projections import (get_projection_names,
 from matplotlib.text import Text, _process_text_args
 from matplotlib.transforms import (Affine2D, Bbox, BboxTransformTo,
                                     TransformedBbox)
+from matplotlib import _warn_non_gui_show
 
 
 docstring.interpd.update(projection_names = get_projection_names())
@@ -334,13 +335,12 @@ class Figure(Artist):
 
         For non-GUI backends, this does nothing.
         """
-        manager = getattr(self.canvas, 'manager')
-        if manager is not None:
-            manager.show()
-        import warnings
-        warnings.warn(
-            "matplotlib is currently using a non-GUI backend, "
-            "so can not show the figure")
+        if hasattr(self, 'canvas'):
+            manager = getattr(self.canvas, 'manager', None)
+            if manager is not None:
+                manager.show()
+                return
+        _warn_non_gui_show()
 
     def _get_axes(self):
         return self._axstack.as_list()


### PR DESCRIPTION
We have support for a figure show method that was added in this commit https://github.com/matplotlib/matplotlib/commit/884a5665367e24c52ce3d2635304926af02667ff

but it was never properly documented in backend_bases and backend_template.  This bit the ipython notebook author's inline backend, as described in this issue https://github.com/ipython/ipython/issues/1612
