### PR TITLE
fix drawing error of fancyarrow of simple style

### DIFF
--- a/examples/pylab_examples/arrow_test.py
+++ b/examples/pylab_examples/arrow_test.py
@@ -1,0 +1,28 @@
+import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import image_comparison
+
+def draw_arrow(ax, t, r):
+    ax.annotate('', xy=(0.5, 0.5+r), xytext=(0.5, 0.5), size=30,
+                arrowprops=dict(arrowstyle=t,
+                                fc="b", ec='k'))
+
+def test_fancyarrow():
+    r = [0.4, 0.3, 0.2, 0.1]
+    t = ["fancy", "simple"]
+
+    fig, axes = plt.subplots(len(t), len(r), squeeze=False,
+                             subplot_kw=dict(aspect=True),
+                         figsize=(8, 4.5))
+
+    for i_r, r1 in enumerate(r):
+        for i_t, t1 in enumerate(t):
+            ax = axes[i_t, i_r]
+            draw_arrow(ax, t1, r1)
+            ax.tick_params(labelleft=False, labelbottom=False)
+
+
+    plt.show()
+
+if __name__ == '__main__':
+    test_fancyarrow()
+


### PR DESCRIPTION
fix drawing error of fancyarrow of simple style when two points are too close. 
This addresses #566. And the initial patch was submitted by Rolf Barinka.

Current PR includes a file "examples/pylab_examples/arrow_test.py". I am planning to make it as a test before merge if others find this patch work okay.
