### PR TITLE
Cleanup after the gca test. 

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -40,7 +40,7 @@ def test_figure():
     plt.close('tomorrow')
     
     
-#@cleanup
+@cleanup
 def test_gca():
     fig = plt.figure()
 


### PR DESCRIPTION
This causes the next test to fail otherwise I.e test_image.test_figimage-0 for me.
Not sure why this was disabled to begin with.
