### PR TITLE
BUG: Fix fill_between when NaN values are present

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -6718,9 +6718,9 @@ class Axes(martist.Artist):
         self._process_unit_info(ydata=y2)
 
         # Convert the arrays so we can work with them
-        x = np.asanyarray(self.convert_xunits(x))
-        y1 = np.asanyarray(self.convert_yunits(y1))
-        y2 = np.asanyarray(self.convert_yunits(y2))
+        x = ma.masked_invalid(self.convert_xunits(x))
+        y1 = ma.masked_invalid(self.convert_yunits(y1))
+        y2 = ma.masked_invalid(self.convert_yunits(y2))
 
         if y1.ndim == 0:
             y1 = np.ones_like(x)*y1
@@ -6735,8 +6735,7 @@ class Axes(martist.Artist):
         if not (x.shape == y1.shape == y2.shape == where.shape):
             raise ValueError("Argument dimensions are incompatible")
 
-        mask = reduce(ma.mask_or, [f(a) for f in (ma.getmask, np.isnan)
-                                        for a in (x, y1, y2)])
+        mask = reduce(ma.mask_or, [ma.getmask(a) for a in (x, y1, y2)])
         if mask is not ma.nomask:
             where &= ~mask
 
@@ -6851,9 +6850,9 @@ class Axes(martist.Artist):
         self._process_unit_info(xdata=x2)
 
         # Convert the arrays so we can work with them
-        y = np.asanyarray(self.convert_yunits(y))
-        x1 = np.asanyarray(self.convert_xunits(x1))
-        x2 = np.asanyarray(self.convert_xunits(x2))
+        y = ma.masked_invalid(self.convert_yunits(y))
+        x1 = ma.masked_invalid(self.convert_xunits(x1))
+        x2 = ma.masked_invalid(self.convert_xunits(x2))
 
         if x1.ndim == 0:
             x1 = np.ones_like(y)*x1
@@ -6868,8 +6867,7 @@ class Axes(martist.Artist):
         if not (y.shape == x1.shape == x2.shape == where.shape):
             raise ValueError("Argument dimensions are incompatible")
 
-        mask = reduce(ma.mask_or, [f(a) for f in (ma.getmask, np.isnan)
-                                        for a in (y, x1, x2)])
+        mask = reduce(ma.mask_or, [ma.getmask(a) for a in (y, x1, x2)])
         if mask is not ma.nomask:
             where &= ~mask
 


### PR DESCRIPTION
When NaN values are passed to `fill_between`, the nan value gets replaced by a value at the origin. This PR reuses the function's mask handling to produce a more user-friendly result.

Here's an example demonstrating the issue.

``` python
import numpy as np
import matplotlib.pyplot as plt

x = np.linspace(0, 2*np.pi, 50)
y = np.sin(x)
y[10] = np.nan
y[30] = np.nan
plt.fill_between(x, y)
plt.show()
```
