### PR TITLE
MPLCONFIGDIR tries to be created in read-only home

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -469,7 +469,7 @@ def _get_home():
 def _create_tmp_config_dir():
     """
     If the config directory can not be created, create a temporary
-    directory that is destroyed atexit.
+    directory.
     """
     import tempfile
 


### PR DESCRIPTION
Hi,

I just ran into an issue after upgrading matplotlib on a server that generates graphs. The stacktrace I'm getting is:

```
Traceback (most recent call last):
  File "/srv/wiki/env/scripts/gen_open_tickets.py", line 5, in <module>
    import matplotlib
  File "/usr/lib/pymodules/python2.6/matplotlib/__init__.py", line 711, in <module>
    rcParams = rc_params()
  File "/usr/lib/pymodules/python2.6/matplotlib/__init__.py", line 629, in rc_params
    fname = matplotlib_fname()
  File "/usr/lib/pymodules/python2.6/matplotlib/__init__.py", line 567, in matplotlib_fname
    fname = os.path.join(get_configdir(), 'matplotlibrc')
  File "/usr/lib/pymodules/python2.6/matplotlib/__init__.py", line 240, in wrapper
    ret = func(*args, **kwargs)
  File "/usr/lib/pymodules/python2.6/matplotlib/__init__.py", line 439, in _get_configdir
    raise RuntimeError("Failed to create %s/.matplotlib; consider setting MPLCONFIGDIR to a writable directory for matplotlib configuration data"%h)
RuntimeError: Failed to create /var/www/.matplotlib; consider setting MPLCONFIGDIR to a writable directory for matplotlib configuration data
```

Obviously, I am getting this because my user has no write permission in its home folder. I've seen other people having this issue, too: http://www.mail-archive.com/matplotlib-users@lists.sourceforge.net/msg08089.html and while setting MPLCONFIGDIR to `/tmp` certainly would fix this issue, I wonder why it needs to be created in the first place? Like almost all other *NIX systems I think matplotlib should not fail if a resource doesn't exist. Possibly warn. It'll work anyway, right?

What do you think? Can we make it a warning? I could probably come up with a pull request if noone else has time.
