### PR TITLE
Fix invalid transformation in InvertedSymmetricalLogTransform.

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -347,17 +347,19 @@ class SymmetricalLogScale(ScaleBase):
 
         def __init__(self, base, linthresh, linscale):
             Transform.__init__(self)
+            symlog = SymmetricalLogScale.SymmetricalLogTransform(base, linthresh, linscale)
             self.base = base
             self.linthresh = linthresh
+            self.invlinthresh = symlog.transform(linthresh)
             self.linscale = linscale
             self._linscale_adj = (linscale / (1.0 - self.base ** -1))
 
         def transform(self, a):
             sign = np.sign(a)
-            masked = ma.masked_inside(a, -self.linthresh, self.linthresh, copy=False)
+            masked = ma.masked_inside(a, -self.invlinthresh, self.invlinthresh, copy=False)
             exp = sign * self.linthresh * (
-                ma.power(self.base, sign * (masked / self.linthresh))
-                - self._linscale_adj)
+                ma.power(self.base, (sign * (masked / self.linthresh))
+                - self._linscale_adj))
             if masked.mask.any():
                 return ma.where(masked.mask, a / self._linscale_adj, exp)
             else:


### PR DESCRIPTION
The InvertedSymmetricalLogTransform was incorrect (used for "symlog" plots).  There are two problems with the existing code: first, linthresh must be transformed to the target space.  It is linear, but not equal to +/- linthresh in the original space.  I introduced a new class member invlinthresh for the inverted linear threshold.  Second, there is a parenthesis missing in the inverted formula.

This transform is likely unused by anyone, I needed it so I could add an image (imshow) to a symlog plot.  Since imshow only works with linear axes, I added a second axes with twiny() but needed to be able to create a new image, appropriately scaled logarithmically.  Thus, the correct inverse transform was needed so I could compute coordinates for the new linear axis.

I hope the problem and the fix are sufficiently obvious.  If not I can provide a worksheet that demonstrates the problem.  
