### PR TITLE
Set artist colors in one fell swoop

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -940,6 +940,18 @@ class Axes(martist.Artist):
         self._get_patches_for_fill.set_color_cycle(clist)
 
     def set_artists_color(self, color):
+        """
+        Set the colour of several artists to *color* in one move. The argument
+        *color* is any mpl colour.
+
+        The default artists to colour are:
+
+        Tick labels
+        Tick marks
+        Axes grid lines (if they are on)
+        The axes frame
+        """
+
         self.tick_params(colors=color)
         [lx.set_color(color) for lx in self.get_xgridlines()]
         [ly.set_color(color) for ly in self.get_ygridlines()]


### PR DESCRIPTION
Currently only sets axes frame, tickmarks, ticklabels and gridlines (if they are on). This addresses issue #326.

I've thought a little bit about where this should live and considered putting it in `figure.py`, however I decided against this because the figure's colour (using `show`) and the colour that's used when executing `savefig` are _different_. I wanted to give the user the option to choose this without touching it using the `set_artists_color` method.

Feedback welcome.
