### PR TITLE
workaround for fixed dpi assumption in adjust_bbox_pdf

### DIFF
--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -88,7 +88,12 @@ def adjust_bbox_pdf(fig, bbox_inches):
     adjust_bbox for pdf & eps format
     """
 
-    tr = Affine2D().scale(72)
+    if fig._cachedRenderer.__class__.__name__ == "RendererPgf":
+        tr = Affine2D().scale(fig.dpi)
+        f = 1.
+    else:
+        tr = Affine2D().scale(72)
+        f = 72. / fig.dpi
 
     _bbox = TransformedBbox(bbox_inches, tr)
 
@@ -96,7 +101,6 @@ def adjust_bbox_pdf(fig, bbox_inches):
                                        bbox_inches.width,
                                        bbox_inches.height)
     x0, y0 = _bbox.x0, _bbox.y0
-    f = 72. / fig.dpi
     w1, h1 = fig.bbox.width*f, fig.bbox.height*f
     fig.transFigure._boxout = Bbox.from_bounds(-x0, -y0,
                                                        w1, h1)


### PR DESCRIPTION
When saving figures with `bbox_inches='tight'`, the function `adjust_bbox_pdf` which is used for rescaling and repositioning the figure assumes a fixed dpi of 72. The pgf backend leaves figure.dpi up to the user for defining the resolution of images. This PR is a workaround for PGF figures being handled incorrectly in `adjust_bbox_pdf` until we find out why the 72 dpi assumption was necessary (fixes #1135).
