### PR TITLE
Add a convenience method to rotate a patch

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3197,7 +3197,7 @@ def quad2cubic(q0x, q0y, q1x, q1y, q2x, q2y):
 
 def rotate_patch(p, ax, theta, pivot=None):
     """
-    Rotates a simple closed polygon *p* of type :class:`Patch` *rad* radians
+    Rotates a simple closed polygon *p* of type :class:`Patch` *theta* radians
     about the point *pivot*. If pivot is *None* then rotate about the
     polygon's centre of mass.
 


### PR DESCRIPTION
The default behaviour is to rotate the patch about it's centre of mass, otherwise rotate about a specified pivot.

This is to address #987.

I think it'd be better to have this is a convenience method in `mlab` rather than a new `kwarg` in the `Patch` constructor because the patch's `transform` can't be decided until an `Axes` object is created.
