### PR TITLE
six inclusion for dateutil on py3 doesn't work

### DIFF
--- a/lib/dateutil_py2/__init__.py
+++ b/lib/dateutil_py2/__init__.py
@@ -6,4 +6,4 @@ datetime module.
 """
 __author__ = "Gustavo Niemeyer <gustavo@niemeyer.net>"
 __license__ = "PSF License"
-__version__ = "1.5"
+__version__ = "1.5-mpl"

--- a/lib/dateutil_py3/__init__.py
+++ b/lib/dateutil_py3/__init__.py
@@ -7,4 +7,4 @@ datetime module.
 """
 __author__ = "Tomi Pieviläinen <tomi.pievilainen@iki.fi>"
 __license__ = "Simplified BSD"
-__version__ = "2.1"
+__version__ = "2.1-mpl"

--- a/lib/pytz/__init__.py
+++ b/lib/pytz/__init__.py
@@ -13,7 +13,7 @@ OLSON_VERSION = '2012d'
 VERSION = OLSON_VERSION
 # Version format for a patch release - only one so far.
 #VERSION = OLSON_VERSION + '.2'
-__version__ = OLSON_VERSION
+__version__ = OLSON_VERSION + "-mpl"
 
 OLSEN_VERSION = OLSON_VERSION # Old releases had this misspelling
 
@@ -115,7 +115,7 @@ def resource_exists(name):
 # module, as well as the Zope3 i18n package. Perhaps we should just provide
 # the POT file and translations, and leave it up to callers to make use
 # of them.
-# 
+#
 # t = gettext.translation(
 #         'pytz', os.path.join(os.path.dirname(__file__), 'locales'),
 #         fallback=True
@@ -128,7 +128,7 @@ def resource_exists(name):
 _tzinfo_cache = {}
 
 def timezone(zone):
-    r''' Return a datetime.tzinfo implementation for the given timezone 
+    r''' Return a datetime.tzinfo implementation for the given timezone
 
     >>> from datetime import datetime, timedelta
     >>> utc = timezone('UTC')
@@ -252,7 +252,7 @@ UTC = utc = UTC() # UTC is a singleton
 def _UTC():
     """Factory function for utc unpickling.
 
-    Makes sure that unpickling a utc instance always returns the same 
+    Makes sure that unpickling a utc instance always returns the same
     module global.
 
     These examples belong in the UTC class above, but it is obscured; or in
@@ -1098,7 +1098,7 @@ all_timezones = \
  'Zulu']
 all_timezones = [
         tz for tz in all_timezones if resource_exists(tz)]
-        
+
 all_timezones_set = set(all_timezones)
 common_timezones = \
 ['Africa/Abidjan',
@@ -1533,5 +1533,5 @@ common_timezones = \
  'UTC']
 common_timezones = [
         tz for tz in common_timezones if tz in all_timezones]
-        
+
 common_timezones_set = set(common_timezones)

--- a/lib/six.py
+++ b/lib/six.py
@@ -5,7 +5,7 @@ import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.1.0"
+__version__ = "1.1.0-mpl"
 
 
 # True if we are running on Python 3.

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -28,6 +28,7 @@
 ## Date/timezone support:
 #pytz = False
 #dateutil = False
+#six = False
 
 [gui_support]
 # Matplotlib supports multiple GUI toolkits, including Cocoa,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ from setupext import build_agg, build_gtkagg, build_tkagg,\
      check_for_qt, check_for_qt4, check_for_pyside, check_for_cairo, \
      check_provide_pytz, check_provide_dateutil,\
      check_for_dvipng, check_for_ghostscript, check_for_latex, \
-     check_for_pdftops, options, build_png, build_tri
+     check_for_pdftops, options, build_png, build_tri, check_provide_six
 
 # jdh
 packages = [
@@ -190,6 +190,7 @@ print_raw("OPTIONAL DATE/TIMEZONE DEPENDENCIES")
 
 provide_dateutil = check_provide_dateutil()
 provide_pytz = check_provide_pytz()
+provide_six = check_provide_six()
 
 def add_pytz():
     packages.append('pytz')
@@ -217,10 +218,14 @@ def add_dateutil():
     else:
         package_dir['dateutil'] = 'lib/dateutil_py2'
 
+def add_six():
+    py_modules.append('six')
+
 if sys.platform=='win32':
     # always add these to the win32 installer
     add_pytz()
     add_dateutil()
+    add_six()
 else:
     # only add them if we need them
     if provide_pytz:
@@ -228,6 +233,8 @@ else:
         print_raw("adding pytz")
     if provide_dateutil:
         add_dateutil()
+    if provide_six:
+        add_six()
 
 print_raw("")
 print_raw("OPTIONAL USETEX DEPENDENCIES")
@@ -257,7 +264,8 @@ if sys.version_info[0] >= 3:
         file = os.path.abspath(file)[len(os.path.abspath(root)):]
         if ('py3' in file or
             file.startswith('pytz') or
-            file.startswith('dateutil')):
+            file.startswith('dateutil') or
+            file.startswith('six')):
             return False
         return True
 

--- a/setupext.py
+++ b/setupext.py
@@ -107,6 +107,7 @@ options = {'display_status': True,
            'verbose': False,
            'provide_pytz': 'auto',
            'provide_dateutil': 'auto',
+           'provide_six': 'auto',
            'build_agg': True,
            'build_gtk': 'auto',
            'build_gtkagg': 'auto',
@@ -142,6 +143,10 @@ if os.path.exists(setup_cfg):
     try: options['provide_dateutil'] = config.getboolean("provide_packages",
                                                          "dateutil")
     except: options['provide_dateutil'] = 'auto'
+
+    try: options['provide_six'] = config.getboolean("provide_packages",
+                                                    "six")
+    except: options['provide_six'] = 'auto'
 
     try: options['build_gtk'] = config.getboolean("gui_support", "gtk")
     except: options['build_gtk'] = 'auto'
@@ -476,6 +481,36 @@ def check_provide_dateutil():
         except AttributeError:
             print_status("dateutil", "present, version unknown")
             return False
+
+def check_provide_six():
+    # We don't need six on Python 2.x
+    if sys.version_info[0] < 3:
+        return
+
+    if options['provide_six'] is True:
+        print_status("six", "matplotlib will provide")
+        return True
+    try:
+        import six
+    except ImportError:
+        if options['provide_six']:
+            print_status("six", "matplotlib will provide")
+            return True
+        else:
+            print_status("six", "no")
+            return False
+    else:
+        try:
+            if six.__version__.endswith('mpl'):
+                print_status("six", "matplotlib will provide")
+                return True
+            else:
+                print_status("six", six.__version__)
+                return False
+        except AttributeError:
+            print_status("six", "present, version unknown")
+            return False
+
 
 def check_for_dvipng():
     try:


### PR DESCRIPTION
I just installed the current HEAD to a fresh python3 install. It all installs fine, but if I try to do `ipython --pylab`, I get this `ImportError`:

```
/usr/local/Cellar/python3/3.2.3/Frameworks/Python.framework/Versions/3.2/lib/python3.2/site-packages/dateutil/rrule.py in <module>()
     16 import sys
     17 
---> 18 from six import advance_iterator, integer_types
     19 
     20 __all__ = ["rrule", "rruleset", "rrulestr",

ImportError: No module named six
```

The `six.py` introduced in `lib/dateutil_py3` in 07d8416b9 is included in my `site-packages/dateutil` folder, but the attempted relative import doesn't work (thanks to [PEP 328](http://www.python.org/dev/peps/pep-0328/)).

To solve this, matplotlib should install `six` directly into `site-packages` when on python 3 if not already present, or alternatively change all `six` imports in dateutil to `from .six import ...`.

(An easy workaround for users is of course to `pip install six` or `pip install python-dateutil`, which includes `six` as a dependency.)
