### PR TITLE
ERROR: matplotlib.tests.test_axes.test_contour_colorbar.test fails on Python 3

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -208,8 +208,15 @@ def pdfRepr(obj):
         return fill([pdfRepr(val) for val in obj.bounds])
 
     else:
-        raise TypeError("Don't know a PDF representation for %s objects." \
-            % type(obj))
+        # Handle float-like objects
+        try:
+            f = float(obj)
+        except:
+            raise TypeError("Don't know a PDF representation for %s objects." \
+                            % type(obj))
+        else:
+            return pdfRepr(f)
+
 
 class Reference(object):
     """PDF reference object.


### PR DESCRIPTION
I'm getting this on Python 3.x only on Fedora 17 with Numpy 1.7dev.

```
======================================================================
ERROR: matplotlib.tests.test_axes.test_contour_colorbar.test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mdboom/python3/lib/python3.2/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/testing/decorators.py", line 39, in failer
    result = f(*args, **kwargs)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/testing/decorators.py", line 145, in do_test
    figure.savefig(actual_fname)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/figure.py", line 1229, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/backend_bases.py", line 2089, in print_figure
    **kwargs)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/backend_bases.py", line 1843, in print_pdf
    return pdf.print_pdf(*args, **kwargs)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/backends/backend_pdf.py", line 2276, in print_pdf
    self.figure.draw(renderer)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/artist.py", line 57, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/figure.py", line 930, in draw
    func(*args)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/artist.py", line 57, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/axes.py", line 2002, in draw
    a.draw(renderer)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/artist.py", line 57, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/collections.py", line 260, in draw
    self._offset_position)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/backends/backend_pdf.py", line 1533, in draw_path_collection
    self.check_gc(gc0, rgbFace)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/backends/backend_pdf.py", line 1436, in check_gc
    if delta: self.file.output(*delta)
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/backends/backend_pdf.py", line 537, in output
    self.write(fill(list(map(pdfRepr, data))))
  File "/home/mdboom/python3/lib/python3.2/site-packages/matplotlib/backends/backend_pdf.py", line 212, in pdfRepr
    % type(obj))
TypeError: Don't know a PDF representation for <class 'numpy.int64'> objects.
```
