### PR TITLE
FIX assert_raises cannot be called with ``with\\

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,4 +1,3 @@
-import matplotlib
 from nose.tools import assert_equal, assert_is, assert_is_not
 from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -96,9 +96,8 @@ def test_shared():
 
 def test_exceptions():
     # TODO should this test more options?
-    with assert_raises(ValueError):
-        plt.subplots(2, 2, sharex='blah')
-        plt.subplots(2, 2, sharey='blah')
+    assert_raises(ValueError, plt.subplots, 2, 2, sharex='blah')
+    assert_raises(ValueError, plt.subplots, 2, 2, sharey='blah')
 
 
 def test_subplots():
@@ -108,3 +107,8 @@ def test_subplots():
     test_shared()
     # - are exceptions thrown correctly
     test_exceptions()
+
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_raises
 from numpy.testing import assert_almost_equal
 import numpy as np
 
@@ -8,10 +8,10 @@ import matplotlib.ticker as mticker
 
 def test_MaxNLocator():
     loc = mticker.MaxNLocator(nbins=5)
-    test_value = np.array([  20.,   40.,   60.,   80.,  100.])
+    test_value = np.array([20., 40., 60., 80., 100.])
     assert_almost_equal(loc.tick_values(20, 100), test_value)
 
-    test_value = np.array([ 0., 0.0002, 0.0004, 0.0006, 0.0008, 0.001])
+    test_value = np.array([0., 0.0002, 0.0004, 0.0006, 0.0008, 0.001])
     assert_almost_equal(loc.tick_values(0.001, 0.0001), test_value)
 
     test_value = np.array([-1.0e+15, -5.0e+14, 0e+00, 5e+14, 1.0e+15])
@@ -33,9 +33,7 @@ def test_MultipleLocator():
 def test_LogLocator():
     loc = mticker.LogLocator(numticks=5)
 
-    # make sure the 0 case is covered with an exception
-    with assert_raises(ValueError):
-        loc.tick_values(0, 1000)
+    assert_raises(ValueError, loc.tick_values, 0, 1000)
 
     test_value = np.array([1.00000000e-03, 1.00000000e-01, 1.00000000e+01,
                            1.00000000e+03, 1.00000000e+05, 1.00000000e+07])
@@ -46,6 +44,6 @@ def test_LogLocator():
     assert_almost_equal(loc.tick_values(1, 100), test_value)
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     import nose
-    nose.runmodule(argv=['-s','--with-doctest'], exit=False)
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
with assert_raises(ValueError):
   something

does not work with nose 1.1.2 (raises a TypeError: TypeError: failUnlessRaises() takes at least 3 arguments (2 given))

This PR fixes some of the remaining failing tests on my machine (I still have some, but they seem more tricky to fix)
