### PR TITLE
FIX nose.tools.assert_is is only supported with python2.7

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,11 +1,12 @@
-from nose.tools import assert_equal, assert_is, assert_is_not
+from nose.tools import assert_equal, assert_true
 from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 
 
 @cleanup
 def test_figure_label():
-    # pyplot figure creation, selection and closing with figure label and number
+    # pyplot figure creation, selection and closing with figure label and
+    # number
     plt.close('all')
     plt.figure('today')
     plt.figure(3)
@@ -33,34 +34,37 @@ def test_figure():
     ax.plot(range(5))
     # plot red line in a different figure.
     plt.figure('tomorrow')
-    plt.plot([0, 1], [1,0], 'r')
+    plt.plot([0, 1], [1, 0], 'r')
     # Return to the original; make sure the red line is not there.
     plt.figure('today')
     plt.close('tomorrow')
-    
-    
+
+
 @cleanup
 def test_gca():
     fig = plt.figure()
 
     ax1 = fig.add_axes([0, 0, 1, 1])
-    assert_is(fig.gca(projection='rectilinear'), ax1)
-    assert_is(fig.gca(), ax1)
-    
+    assert_true(fig.gca(projection='rectilinear') is ax1)
+    assert_true(fig.gca() is ax1)
+
     ax2 = fig.add_subplot(121, projection='polar')
-    assert_is(fig.gca(), ax2)
-    assert_is(fig.gca(polar=True), ax2)
-    
+    assert_true(fig.gca() is ax2)
+    assert_true(fig.gca(polar=True)is ax2)
+
     ax3 = fig.add_subplot(122)
-    assert_is(fig.gca(), ax3)
+    assert_true(fig.gca() is ax3)
 
     # the final request for a polar axes will end up creating one
     # with a spec of 111.
-    assert_is_not(fig.gca(polar=True), ax3)
-    assert_is_not(fig.gca(polar=True), ax2)
+    assert_true(fig.gca(polar=True) is not ax3)
+    assert_true(fig.gca(polar=True) is not ax2)
     assert_equal(fig.gca().get_geometry(), (1, 1, 1))
-    
+
     fig.sca(ax1)
-    assert_is(fig.gca(projection='rectilinear'), ax1)
-    assert_is(fig.gca(), ax1)
-    
+    assert_true(fig.gca(projection='rectilinear') is ax1)
+    assert_true(fig.gca() is ax1)
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
`assert_is` is only supported in python2.7.

I've got other tests failing on my box, but I don't know how to fix them: http://bpaste.net/show/unemAaLZCxFixslh2FBi/

Thanks,
Nelle
