### PR TITLE
tight_layout: fix regression for figures with non SubplotBase Axes

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1424,16 +1424,15 @@ class Figure(Artist):
 
         from tight_layout import get_renderer, get_tight_layout_figure
 
-        no_go = [ax for ax in self.axes if not isinstance(ax, SubplotBase)]
-        if no_go:
-            warnings.Warn("Cannot use tight_layout;"
-                          " all Axes must descend from SubplotBase")
-            return
+        subplot_axes = [ax for ax in self.axes if isinstance(ax, SubplotBase)]
+        if len(subplot_axes) < len(self.axes):
+            warnings.warn("tight_layout can only process Axes that descend "
+                          "from SubplotBase; results might be incorrect.")
 
         if renderer is None:
             renderer = get_renderer(self)
 
-        kwargs = get_tight_layout_figure(self, self.axes, renderer,
+        kwargs = get_tight_layout_figure(self, subplot_axes, renderer,
                                          pad=pad, h_pad=h_pad, w_pad=w_pad,
                                          rect=rect)
 


### PR DESCRIPTION
When encountering axes instances that do not descent from SubplotBase, tight_layout tries to print a warning, but there is a typo in that code block causing an exception and thus stopping the whole process.

Also, in my thesis I have a figure that uses an inset (`mpl_toolkits.axes_grid1.inset_locator.inset_axes`). I usually remove the figure borders using `tight_layout(0.0)`. This worked fine in matplotlib 1.1.1, but the current master just bails out from tight_layout when encountering the inset axes. I think showing the warning to the user is enough, the result might turn out to be just fine...
