### PR TITLE
backend_pgf: handle OSError when testing for xelatex/pdflatex

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -22,10 +22,13 @@ def check_for(texsystem):
     \makeatletter
     \@@end
     """
-    latex = subprocess.Popen(["xelatex", "-halt-on-error"],
-                             stdin=subprocess.PIPE,
-                             stdout=subprocess.PIPE)
-    stdout, stderr = latex.communicate(header.encode("utf8"))
+    try:
+        latex = subprocess.Popen(["xelatex", "-halt-on-error"],
+                                 stdin=subprocess.PIPE,
+                                 stdout=subprocess.PIPE)
+        stdout, stderr = latex.communicate(header.encode("utf8"))
+    except OSError:
+        return False
 
     return latex.returncode == 0
 


### PR DESCRIPTION
Fixed an OSError showing up on the travis-ci platform that originates from a missing try-except block when testing for xelatex/pdflatex in test_backend_pgf.
