### PR TITLE
FIX undefined elements were used at several places in the mlab module

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2772,8 +2772,6 @@ def griddata(x,y,z,xi,yi,interp='nn'):
         if xi.ndim == 1:
             xi,yi = np.meshgrid(xi,yi)
         # triangulate data
-        # FIXME delaunay is not imported here, and depends on the
-        # scipy.spatial packages; Scipy is not a dependency of matplotlib.
         tri = delaunay.Triangulation(x,y)
         # interpolate data
         if interp == 'nn':


### PR DESCRIPTION
There were undefined elements in the mlab module. it seems like this module is quite old and not very well tested in terms of coverage; It's also probably not widely used. I've fixed some of the problems but it might be worth it to do a huge clean up in the near future.
