### PR TITLE
Add a *simple* arrow example

### DIFF
--- a/examples/pylab_examples/arrow_simple_demo.py
+++ b/examples/pylab_examples/arrow_simple_demo.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 
-fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1)
+ax = plt.axes()
 ax.arrow(0, 0, 0.5, 0.5, head_width=0.05, head_length=0.1, fc='k', ec='k')
 plt.show()


### PR DESCRIPTION
The current `arrow` example is rather long. As requested in a comment in #1096, this provides a much simpler arrow example for users to look at.
