### PR TITLE
BUG: Fix streamplot when velocity component is exactly zero.

### DIFF
--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -325,7 +325,7 @@ def get_integrator(u, v, dmap, minlength):
     # speed (path length) will be in axes-coordinates
     u_ax = u / dmap.grid.nx
     v_ax = v / dmap.grid.ny
-    speed = np.sqrt(u_ax**2 + v_ax**2)
+    speed = np.ma.sqrt(u_ax**2 + v_ax**2)
 
     def forward_time(xi, yi):
         ds_dt = interpgrid(speed, xi, yi)


### PR DESCRIPTION
When one component of the velocity field is zero, streamplot fails to draw streamlines. Here's a short example of the issue:

``` python
import matplotlib.pyplot as plt
import numpy as np

N = 10
Y, X = np.mgrid[:N, :N]
U = np.ones((N, N))
V = np.zeros((N, N))

plt.streamplot(X, Y, U, V)
plt.show()
```

Explanation of fix:
Negative and positive steps are treated differently by the code. Before, a zero gradient (`cx`, `cy`) was getting treated as a negative step. This resulted in a step size of `-inf`; treating zero as a positive step results in a step size of (positive) `inf`. This `inf` value gets filtered out since the integration routine chooses the smaller of the two (`dsx`, `dsy`) step sizes.
