### PR TITLE
Update documentation regarding lines.color

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -3854,6 +3854,11 @@ class Axes(martist.Artist):
 
         Return value is a list of lines that were added.
 
+        By default, each line is assigned a different color specified by a
+        'color cycle'.  To change this behavior, you can edit the
+        axes.color_cycle rcParam. Alternatively, you can use
+        :meth:`~matplotlib.axes.Axes.set_default_color_cycle`.
+
         The following format string characters are accepted to control
         the line style or marker:
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -60,7 +60,7 @@ backend      : %(backend)s
 # information on line properties.
 #lines.linewidth   : 1.0     # line width in points
 #lines.linestyle   : -       # solid line
-#lines.color       : blue
+#lines.color       : blue    # has no affect on plot(); see axes.color_cycle
 #lines.marker      : None    # the default marker
 #lines.markeredgewidth  : 0.5     # the line width around the marker symbol
 #lines.markersize  : 6            # markersize, in points


### PR DESCRIPTION
Add a comment to the matplotlibrc template file to alleviate confusion
regarding the use of lines.color for plots. axes.color_cycle should be
used to change the colour of plotted lines.

The Axes.plot docstring has also been update to include this
information.

This addresses #822.
