### PR TITLE
New 'gridon' keyword in plotfile

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2092,7 +2092,7 @@ def polar(*args, **kwargs):
 
 def plotfile(fname, cols=(0,), plotfuncs=None,
              comments='#', skiprows=0, checkrows=5, delimiter=',', names=None,
-             subplots=True, newfig=True, gridon=rcParams['axis.grid'],
+             subplots=True, newfig=True, gridon=rcParams['axes.grid'],
              **kwargs):
     """
     Plot the data in in a file.


### PR DESCRIPTION
bool 'gridon' keyword added in pyplot.plotfile: it makes easier to turn on or off the axes grid. The default is True to agree with the author of the function.
