### PR TITLE
Add dateutil kwargs to csv2rec

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2129,6 +2129,14 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
 
     - *use_mrecords*: if True, return an mrecords.fromrecords record array if any of the data are missing
 
+    - *dayfirst*: default is False so that MM-DD-YY has precedence over
+      DD-MM-YY.  See http://labix.org/python-dateutil#head-b95ce2094d189a89f80f5ae52a05b4ab7b41af47
+      for further information.
+
+    - *yearfirst*: default is False so that MM-DD-YY has precedence over
+      YY-MM-DD.  See http://labix.org/python-dateutil#head-b95ce2094d189a89f80f5ae52a05b4ab7b41af47
+      for further information.
+
       If no rows are found, *None* is returned -- see :file:`examples/loadrec.py`
     """
 


### PR DESCRIPTION
Fixes ambiguous date problems between US/UK date conventions.

My attempt at resolving #208.

I'm not sure this is the best way to resolve this issue. Another option is to keep the `dateutil` stuff separate from the specific `csv2rec` kwargs by having only one `dateutil_properties` kwarg, say. This kwarg would take a dictionary of keyword arguments that are passed directly to the dateutil parser. The functionality would be the same, with the only difference being an aesthetic one.

Another method is suggested by @efiring in the comments in #208.

Edit: @efiring's suggestion is to have one kwarg specifying the exact date in strptime format, rather than having `dateutil` do it.
