### PR TITLE
Include username in tempdir

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -471,9 +471,11 @@ def _create_tmp_config_dir():
     If the config directory can not be created, create a temporary
     directory.
     """
+    import getpass
     import tempfile
 
-    tempdir = os.path.join(tempfile.gettempdir(), 'matplotlib')
+    tempdir = os.path.join(
+        tempfile.gettempdir(), 'matplotlib-%s' % getpass.getuser())
     os.environ['MPLCONFIGDIR'] = tempdir
 
     return tempdir


### PR DESCRIPTION
Fixes an issue introduced by #832.  If multiple users on the same machine have non-writable home directories, the /tmp/matplotlib directory created may be shared.  This includes the user's login name in the directory name to prevent that.

Discovered by Matt Anderson.
