### PR TITLE
Figure.show: clarify docstring and error message

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -340,12 +340,23 @@ class Figure(Artist):
 
     def show(self, warn=True):
         """
-        If using a GUI backend, display the figure window.
+        If using a GUI backend with pyplot, display the figure window.
+
+        If the figure was not created using
+        :func:`~matplotlib.pyplot.figure`, it will lack a
+        :class:`~matplotlib.backend_bases.FigureManagerBase`, and
+        will raise an AttributeError.
 
         For non-GUI backends, this does nothing, in which case
-        a warning will be issued if *warn* is True.
+        a warning will be issued if *warn* is True (default).
         """
-        manager = getattr(self.canvas, 'manager')
+        try:
+            manager = getattr(self.canvas, 'manager')
+        except AttributeError as err:
+            raise AttributeError("%s\n    Figure.show works only "
+                        "for figures managed by pyplot,\n    normally "
+                        "created by pyplot.figure()." % err)
+
         if manager is not None:
             try:
                 manager.show()


### PR DESCRIPTION
Figure.show is only for use with the pyplot figure management
framework.  The error of trying to use it in a pure OO context,
with a directly-instantiated Figure instance, now generates an
error message explaining this.  This closes #1219.
