### PR TITLE
Added deprecation notices for Qt3-based backends.

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -131,6 +131,11 @@ Changes in 1.2.x
 * ``twinx`` and ``twiny`` now returns an instance of SubplotBase if
   parent axes is an instance of SubplotBase.
 
+* All Qt3-based backends are now deprecated due to the lack of py3k bindings.
+  Qt and QtAgg backends will continue to work in v1.2.x for py2.6
+  and py2.7. It is anticipated that the Qt3 support will be completely
+  removed for the next release.
+
 
 Changes in 1.1.x
 ================

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -34,7 +34,8 @@ project.
 The following GUI backends work under Python 3.x: Gtk3Agg, Gtk3Cairo,
 Qt4Agg, TkAgg and MacOSX.  The other GUI backends do not yet have
 adequate bindings for Python 3.x, but continue to work on Python 2.6
-and 2.7.  The non-GUI backends, such as PDF, PS and SVG, work on both
+and 2.7, particularly the Qt and QtAgg backends (which have been
+deprecated). The non-GUI backends, such as PDF, PS and SVG, work on both
 Python 2.x and 3.x.
 
 Features that depend on the Python Imaging Library, such as JPEG

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -2,6 +2,11 @@ from __future__ import division, print_function
 import math
 import os
 import sys
+import warnings
+
+warnings.warn("QT3-based backends are deprecated and will be removed after"
+              " the v1.2.x release. Use the equivalent QT4 backend instead.",
+              DeprecationWarning)
 
 import matplotlib
 from matplotlib import verbose
@@ -18,7 +23,9 @@ from matplotlib.widgets import SubplotTool
 try:
     import qt
 except ImportError:
-    raise ImportError("Qt backend requires pyqt to be installed.")
+    raise ImportError("Qt backend requires pyqt to be installed."
+                      " NOTE: QT3-based backends will not work in"
+                      " Python 3.")
 
 backend_version = "0.9.1"
 def fn_name(): return sys._getframe(1).f_code.co_name


### PR DESCRIPTION
Added deprecation notice for Qt3-based backends.  Note, due to the way python2.7 auto-matically filters the DeprecationWarning, maybe we should raise this warning differently?
