### PR TITLE
Add dpi kwarg to PIL image.save method for TIFF file.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1910,7 +1910,9 @@ class FigureCanvasBase(object):
             buf, size = agg.print_to_buffer()
             if kwargs.pop("dryrun", False): return
             image = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
-            return image.save(filename_or_obj, format='tiff')
+            dpi = (self.figure.dpi, self.figure.dpi)
+            return image.save(filename_or_obj, format='tiff',
+                              dpi=dpi)
         print_tiff = print_tif
 
     def get_supported_filetypes(self):


### PR DESCRIPTION
This corrects a bug in which the tiff image metadata was set to a
default dpi of 72 regardless of the actual dpi.  At least some
image viewers, including Preview on the Mac, do not use this
dpi metadata, even though they can display it, so fixing this
bug does not correct the erroneous display of the image on such
viewers.
