### PR TITLE
Enable dynamic updating for the OS X backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -487,6 +487,9 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
     def set_message(self, message):
         _macosx.NavigationToolbar2.set_message(self, message.encode('utf-8'))
 
+    def dynamic_update(self):
+        self.canvas.draw_idle()
+
 ########################################################################
 #
 # Now just provide the standard names that backend.__init__ is expecting


### PR DESCRIPTION
Before, on panning the figure in the OS X backend, the figure didn't update. This change updates the figure on a pan event.
