### PR TITLE
Fix 2to3 and packaging of dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,7 @@ def add_pytz():
 def add_dateutil():
     packages.append('dateutil')
     packages.append('dateutil.zoneinfo')
-    package_data['dateutil'] = ['zoneinfo/zoneinfo*.tar.*']
+    package_data['dateutil'] = ['zoneinfo/*.tar.gz']
     if sys.version_info[0] >= 3:
         package_dir['dateutil'] = 'lib/dateutil_py3'
     else:
@@ -263,7 +263,7 @@ for mod in ext_modules:
 
 if sys.version_info[0] >= 3:
     def should_2to3(file, root):
-        file = os.path.abspath(file)[len(os.path.abspath(root)):]
+        file = os.path.abspath(file)[len(os.path.abspath(root))+1:]
         if ('py3' in file or
             file.startswith('pytz') or
             file.startswith('dateutil') or


### PR DESCRIPTION
In mpl 1.2.0rc1,on Windows, the zoneinfo-2011d.tar.gz file is not packaged, and 2to3 is run on the dateutil_py3 package, which leads to test failures and stackoverflow crashes.
