### PR TITLE
Fix matplotlib.testing.util.MiniExpect.expect hangs on Windows

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -151,7 +151,7 @@ if matplotlib.checkdep_ghostscript() is not None:
 
         def do_convert(old, new):
             process.expect("GS>")
-            process.sendline("(%s) run" % old)
+            process.sendline("(%s) run" % old.replace('\\', '/'))
             with open(new, 'wb') as fd:
                 process.expect(">>showpage, press <return> to continue<<", fd)
             process.sendline('')


### PR DESCRIPTION
gswin32c expects forward slashes in file paths.

Fixes issues #1238

Btw, the compare.py file has inconsistent indentation. Is that considered a bug?
