### PR TITLE
backend_pgf: fix parsing of CR+LF newlines

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -340,7 +340,7 @@ class LatexManager:
 
         # parse metrics from the answer string
         try:
-            width, height, offset = answer.split("\n")[0].split(",")
+            width, height, offset = answer.splitlines()[0].split(",")
         except:
             msg = "Error processing '%s'\nLaTeX Output:\n%s" % (text, answer)
             raise ValueError(msg)


### PR DESCRIPTION
This fixes a parsing error of newlines on windows systems. The commit is already in master and should be applied to the 1.2 branch too.
