### PR TITLE
Doc tidy up.

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -84,18 +84,20 @@ Changes in 1.2.x
   implements a non-affine transformation, then it should override the
   ``transform_non_affine`` method, rather than the generic ``transform`` method.
   Previously transforms would define ``transform`` and then copy the
-  method into ``transform_non_affine``:
+  method into ``transform_non_affine``::
 
      class MyTransform(mtrans.Transform):
          def transform(self, xy):
              ...
          transform_non_affine = transform
-
-  This approach will no longer function correctly and should be changed to:
+  
+  
+  This approach will no longer function correctly and should be changed to::
 
      class MyTransform(mtrans.Transform):
          def transform_non_affine(self, xy):
              ...
+  
 
 * Artists no longer have ``x_isdata`` or ``y_isdata`` attributes; instead
   any artist's transform can be interrogated with
@@ -103,7 +105,7 @@ Changes in 1.2.x
 
 * Lines added to an axes now take into account their transform when updating the
   data and view limits. This means transforms can now be used as a pre-transform.
-  For instance:
+  For instance::
 
       >>> import matplotlib.pyplot as plt
       >>> import matplotlib.transforms as mtrans

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,6 +25,7 @@ sys.path.append(os.path.abspath('sphinxext'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['matplotlib.sphinxext.mathmpl', 'math_symbol_table',
               'sphinx.ext.autodoc', 'matplotlib.sphinxext.only_directives',
+              'sphinx.ext.doctest',
               'matplotlib.sphinxext.plot_directive', 'sphinx.ext.inheritance_diagram',
               'gen_gallery', 'gen_rst',
               'matplotlib.sphinxext.ipython_console_highlighting', 'github']

--- a/doc/make.py
+++ b/doc/make.py
@@ -130,8 +130,11 @@ def sfpdf():
     'push a copy to the sf site'
     os.system('cd build/latex; scp Matplotlib.pdf jdh2358,matplotlib@web.sf.net:/home/groups/m/ma/matplotlib/htdocs/')
 
-def figs():
-    os.system('cd users/figures/ && python make.py')
+def doctest():
+    os.system('sphinx-build -b doctest -d build/doctrees . build/doctest')
+
+def linkcheck():
+    os.system('sphinx-build -b linkcheck -d build/doctrees . build/linkcheck')
 
 def html():
     check_build()
@@ -215,7 +218,6 @@ def all():
 
 
 funcd = {
-    'figs'     : figs,
     'html'     : html,
     'latex'    : latex,
     'texinfo'  : texinfo,
@@ -223,6 +225,8 @@ funcd = {
     'sf'       : sf,
     'sfpdf'    : sfpdf,
     'all'      : all,
+    'doctest'  : doctest,
+    'linkcheck': linkcheck,
     }
 
 

--- a/doc/mpl_toolkits/index.rst
+++ b/doc/mpl_toolkits/index.rst
@@ -1,5 +1,12 @@
 .. _toolkits-index:
 
+.. toctree::
+   :hidden:
+
+   axes_grid/index.rst
+   mplot3d/index.rst
+   
+
 ########
 Toolkits
 ########

--- a/doc/users/github_stats.rst
+++ b/doc/users/github_stats.rst
@@ -120,7 +120,7 @@ Pull Requests (123):
 * :ghpull:`1164`: doc: note contourf hatching in whats_new.rst
 * :ghpull:`1153`: PEP8 on artist
 * :ghpull:`1163`: tight_layout: fix regression for figures with non SubplotBase Axes
-* :ghpull:`1159`: FIX assert_raises cannot be called with ``with\\
+* :ghpull:`1159`: FIX assert_raises cannot be called with ``with``
 * :ghpull:`1160`: backend_pgf: clarifications and fixes in documentation
 * :ghpull:`1154`: six inclusion for dateutil on py3 doesn't work
 * :ghpull:`1149`: Add Phil Elson's percentage histogram example
@@ -268,7 +268,7 @@ Issues (226):
 * :ghissue:`1153`: PEP8 on artist
 * :ghissue:`1163`: tight_layout: fix regression for figures with non SubplotBase Axes
 * :ghissue:`1117`: ERROR: matplotlib.tests.test_axes.test_contour_colorbar.test fails on Python 3
-* :ghissue:`1159`: FIX assert_raises cannot be called with ``with\\
+* :ghissue:`1159`: FIX assert_raises cannot be called with ``with``
 * :ghissue:`206`: hist normed=True problem?
 * :ghissue:`1160`: backend_pgf: clarifications and fixes in documentation
 * :ghissue:`1154`: six inclusion for dateutil on py3 doesn't work

--- a/doc/users/index.rst
+++ b/doc/users/index.rst
@@ -31,6 +31,7 @@ User's Guide
     recipes.rst
     screenshots.rst
     whats_new.rst
+    github_stats.rst
     license.rst
     credits.rst
 

--- a/examples/pylab_examples/mri_demo.py
+++ b/examples/pylab_examples/mri_demo.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from pylab import *
 import matplotlib.cbook as cbook
 # data are 256x256 16 bit integers
-dfile = cbook.get_sample_data('s1045.ima')
+dfile = cbook.get_sample_data('s1045.ima.gz')
 im = np.fromstring(dfile.read(), np.uint16).astype(float)
 im.shape = 256, 256
 

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -17,14 +17,14 @@ class ProxyDelegate(object):
         return self.proxy_type(self.fn_name, obj)
 
 
-class TaggedValueMeta (type):
-    def __init__(cls, name, bases, dict):
-        for fn_name in cls._proxies.keys():
+class TaggedValueMeta(type):
+    def __init__(self, name, bases):
+        for fn_name in self._proxies.keys():
             try:
-                dummy = getattr(cls, fn_name)
+                dummy = getattr(self, fn_name)
             except AttributeError:
-                setattr(cls, fn_name,
-                        ProxyDelegate(fn_name, cls._proxies[fn_name]))
+                setattr(self, fn_name,
+                        ProxyDelegate(fn_name, self._proxies[fn_name]))
 
 
 class PassThroughProxy(object):
@@ -189,7 +189,7 @@ class _TaggedValue(object):
         return self.unit
 
 
-TaggedValue = TaggedValueMeta('TaggedValue', (_TaggedValue, ), {})
+TaggedValue = TaggedValueMeta('TaggedValue', (_TaggedValue, ))
 
 
 class BasicUnit(object):

--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -4433,7 +4433,7 @@ class Axes(martist.Artist):
 
         Call signature::
 
-          legend(*args, **kwargs)
+           legend(*args, **kwargs)
 
         Places legend at location *loc*.  Labels are a sequence of
         strings and *loc* can be a string or an integer specifying the
@@ -4441,36 +4441,36 @@ class Axes(martist.Artist):
 
         To make a legend with existing lines::
 
-          legend()
+           legend()
 
         :meth:`legend` by itself will try and build a legend using the label
         property of the lines/patches/collections.  You can set the label of
         a line by doing::
 
-          plot(x, y, label='my data')
+           plot(x, y, label='my data')
 
         or::
 
-          line.set_label('my data').
+           line.set_label('my data').
 
         If label is set to '_nolegend_', the item will not be shown in
         legend.
 
         To automatically generate the legend from labels::
 
-          legend( ('label1', 'label2', 'label3') )
+           legend( ('label1', 'label2', 'label3') )
 
         To make a legend for a list of lines and labels::
 
-          legend( (line1, line2, line3), ('label1', 'label2', 'label3') )
+           legend( (line1, line2, line3), ('label1', 'label2', 'label3') )
 
         To make a legend at a given location, using a location argument::
 
-          legend( ('label1', 'label2', 'label3'), loc='upper left')
+           legend( ('label1', 'label2', 'label3'), loc='upper left')
 
         or::
 
-          legend( (line1, line2, line3),  ('label1', 'label2', 'label3'), loc=2)
+           legend( (line1, line2, line3),  ('label1', 'label2', 'label3'), loc=2)
 
         The location codes are
 
@@ -4496,7 +4496,7 @@ class Axes(martist.Artist):
         of BboxBase(or its derivatives) or a tuple of 2 or 4 floats.
         For example,
 
-          loc = 'upper right', bbox_to_anchor = (0.5, 0.5)
+           loc = 'upper right', bbox_to_anchor = (0.5, 0.5)
 
         will place the legend so that the upper right corner of the legend at
         the center of the axes.
@@ -7072,6 +7072,7 @@ class Axes(martist.Artist):
         **Example:**
 
         .. plot:: mpl_examples/pylab_examples/image_demo.py
+        
         """
 
         if not self._hold: self.cla()

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -107,8 +107,6 @@ class Legend(Artist):
     respect its parent.
 
     """
-
-
     codes = {'best'         : 0, # only implemented for axis legends
              'upper right'  : 1,
              'upper left'   : 2,
@@ -121,7 +119,6 @@ class Legend(Artist):
              'upper center' : 9,
              'center'       : 10,
              }
-
 
     zorder = 5
     def __str__(self):
@@ -195,20 +192,20 @@ class Legend(Artist):
         bbox_to_anchor     the bbox that the legend will be anchored.
         bbox_transform     the transform for the bbox. transAxes if None.
         ================   ==================================================================
-
-
-The pad and spacing parameters are measured in font-size units.  E.g.,
-a fontsize of 10 points and a handlelength=5 implies a handlelength of
-50 points.  Values from rcParams will be used if None.
-
-Users can specify any arbitrary location for the legend using the
-*bbox_to_anchor* keyword argument. bbox_to_anchor can be an instance
-of BboxBase(or its derivatives) or a tuple of 2 or 4 floats.
-See :meth:`set_bbox_to_anchor` for more detail.
-
-The legend location can be specified by setting *loc* with a tuple of
-2 floats, which is interpreted as the lower-left corner of the legend
-in the normalized axes coordinate.
+    
+    
+        The pad and spacing parameters are measured in font-size units.  E.g.,
+        a fontsize of 10 points and a handlelength=5 implies a handlelength of
+        50 points.  Values from rcParams will be used if None.
+        
+        Users can specify any arbitrary location for the legend using the
+        *bbox_to_anchor* keyword argument. bbox_to_anchor can be an instance
+        of BboxBase(or its derivatives) or a tuple of 2 or 4 floats.
+        See :meth:`set_bbox_to_anchor` for more detail.
+        
+        The legend location can be specified by setting *loc* with a tuple of
+        2 floats, which is interpreted as the lower-left corner of the legend
+        in the normalized axes coordinate.
         """
         from matplotlib.axes import Axes     # local import only to avoid circularity
         from matplotlib.figure import Figure # local import only to avoid circularity
@@ -916,7 +913,7 @@ in the normalized axes coordinate.
         for candidate in candidates:
             if candidate[0] < minCandidate[0]:
                 minCandidate = candidate
-
+        
         ox, oy = minCandidate[1]
 
         return ox, oy

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3192,10 +3192,10 @@ def offset_line(y, yerr):
 
     The error term can be:
 
-    o A scalar. In this case, the returned tuple is obvious.
-    o A vector of the same length as *y*. The quantities y +/- err are computed
+    * A scalar. In this case, the returned tuple is obvious.
+    * A vector of the same length as *y*. The quantities y +/- err are computed
       component-wise.
-    o A tuple of length 2. In this case, yerr[0] is the error below *y* and
+    * A tuple of length 2. In this case, yerr[0] is the error below *y* and
       yerr[1] is error above *y*. For example::
 
         from pylab import *

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1183,45 +1183,45 @@ def title(s, *args, **kwargs):
 
 def axis(*v, **kwargs):
     """
-    Set or get the axis properties.
+    Set or get the axis properties.::
 
       >>> axis()
 
-    returns the current axes limits ``[xmin, xmax, ymin, ymax]``.
+    returns the current axes limits ``[xmin, xmax, ymin, ymax]``.::
 
       >>> axis(v)
 
     sets the min and max of the x and y axes, with
-    ``v = [xmin, xmax, ymin, ymax]``.
+    ``v = [xmin, xmax, ymin, ymax]``.::
 
       >>> axis('off')
 
-    turns off the axis lines and labels.
+    turns off the axis lines and labels.::
 
       >>> axis('equal')
 
     changes limits of *x* or *y* axis so that equal increments of *x*
-    and *y* have the same length; a circle is circular.
+    and *y* have the same length; a circle is circular.::
 
       >>> axis('scaled')
 
     achieves the same result by changing the dimensions of the plot box instead
-    of the axis data limits.
+    of the axis data limits.::
 
       >>> axis('tight')
 
     changes *x* and *y* axis limits such that all data is shown. If
     all data is already shown, it will move it to the center of the
     figure without modifying (*xmax* - *xmin*) or (*ymax* -
-    *ymin*). Note this is slightly different than in MATLAB.
+    *ymin*). Note this is slightly different than in MATLAB.::
 
       >>> axis('image')
 
-    is 'scaled' with the axis limits equal to the data limits.
+    is 'scaled' with the axis limits equal to the data limits.::
 
       >>> axis('auto')
 
-    and
+    and::
 
       >>> axis('normal')
 

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -48,16 +48,17 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     *minlength* : float
         Minimum length of streamline in axes coordinates.
 
-    Returns
-    -------
-    *stream_container* : StreamplotSet
-        Container object with attributes
-            lines : `matplotlib.collections.LineCollection` of streamlines
-            arrows : collection of `matplotlib.patches.FancyArrowPatch` objects
-                repesenting arrows half-way along stream lines.
-        This container will probably change in the future to allow changes to
-        the colormap, alpha, etc. for both lines and arrows, but these changes
-        should be backward compatible.
+    Returns:
+    
+        *stream_container* : StreamplotSet
+            Container object with attributes
+                lines : `matplotlib.collections.LineCollection` of streamlines
+                arrows : collection of `matplotlib.patches.FancyArrowPatch` objects
+                    repesenting arrows half-way along stream lines.
+            This container will probably change in the future to allow changes to
+            the colormap, alpha, etc. for both lines and arrows, but these changes
+            should be backward compatible.
+    
     """
     grid = Grid(x, y)
     mask = StreamMask(density)

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -187,6 +187,7 @@ class MaxHeight(_Base):
 class Fraction(_Base):
     """
     An instance whose size is a *fraction* of the *ref_size*.
+    ::
 
       >>> s = Fraction(0.3, AxesX(ax))
 
@@ -223,7 +224,7 @@ def from_any(size, fraction_ref=None):
     """
     Creates Fixed unit when the first argument is a float, or a
     Fraction unit if that is a string that ends with %. The second
-    argument is only meaningful when Fraction unit is created.
+    argument is only meaningful when Fraction unit is created.::
 
       >>> a = Size.from_any(1.2) # => Size.Fixed(1.2)
       >>> Size.from_any("50%", a) # => Size.Fraction(0.5, a)


### PR DESCRIPTION
Fixes some warnings/errors in the sphinx build (but not all, as they are **really** hard to track down).

Adds the ability to do a `python make.py linkcheck` to find dead links (of which there are still some, but I will make a separate issue for that).

Adds the new capability of running `python make.py doctest` to test that our documentation examples make sense/still function. These are not unit tests, merely a chance to make certain that our documentation isn't giving erroneous examples (currently there are only a limited number of doctests, and I do not propose we make a concerted effort to grow the number).
