### PR TITLE
Broken doc links

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -8,7 +8,7 @@ Overview
     :Release: |version|
     :Date: |today|
 
-    Download `PDF <http://matplotlib.sf.net/Matplotlib.pdf>`_
+    Download `PDF <Matplotlib.pdf>`_
 
 
 .. toctree::

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -88,8 +88,7 @@ Packaging
 
 * We have a Makefile for the win32 mingw builds in the mpl source dir
   :file:`release/win32` which you can use this to prepare the windows
-  releases, but this is currently broken for python2.6 as described at
-  http://www.nabble.com/binary-installers-for-python2.6--libpng-segfault%2C-MSVCR90.DLL-and-%09mingw-td23971661.html
+  releases.
 
 .. _release-candidate-testing:
 

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -756,8 +756,10 @@ Cite Matplotlib
 ===============
 
 If you want to refer to matplotlib in a publication, you can use
-"Matplotlib: A 2D Graphics Environment" by J. D. Hunter In Computing in Science &
-Engineering, Vol. 9, No. 3. (2007), pp. 90-95 (see `citeulike <http://www.citeulike.org/user/jabl/article/2878517>`_)::
+"Matplotlib: A 2D Graphics Environment" by J. D. Hunter In Computing
+in Science & Engineering, Vol. 9, No. 3. (2007), pp. 90-95 (see `IEEE
+Xplore
+<http://ieeexplore.ieee.org/xpl/login.jsp?tp=&arnumber=4160265&url=http%3A%2F%2Fieeexplore.ieee.org%2Fxpls%2Fabs_all.jsp%3Farnumber%3D4160265>`_)::
 
   @article{Hunter:2007,
 	  Address = {10662 LOS VAQUEROS CIRCLE, PO BOX 3014, LOS ALAMITOS, CA 90720-1314 USA},

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -71,7 +71,7 @@ class ContourLabeler:
         Optional keyword arguments:
 
           *fontsize*:
-            See http://matplotlib.sf.net/fonts.html
+            size in points or relative size eg 'smaller', 'x-large'
 
           *colors*:
             - if *None*, the color of each label matches the color of

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -86,7 +86,7 @@ Here are all the date tickers:
       :class:`matplotlib.dates.rrulewrapper`.  The
       :class:`rrulewrapper` is a simple wrapper around a
       :class:`dateutils.rrule` (`dateutil
-      <https://moin.conectiva.com.br/DateUtil>`_) which allow almost
+      <http://labix.org/python-dateutil>`_) which allow almost
       arbitrary date tick specifications.  See `rrule example
       <../examples/pylab_examples/date_demo_rrule.html>`_.
 
@@ -302,13 +302,13 @@ def drange(dstart, dend, delta):
             delta.microseconds/MUSECONDS_PER_DAY)
     f1 = _to_ordinalf(dstart)
     f2 = _to_ordinalf(dend)
-    
+
     num = int(np.ceil((f2-f1)/step))        #calculate the difference between dend and dstart in times of delta
     dinterval_end = dstart + num*delta      #calculate end of the interval which will be generated
     if dinterval_end >= dend:               #ensure, that an half open interval will be generated [dstart, dend)
         dinterval_end -= delta              #if the endpoint is greated than dend, just subtract one delta
         num -= 1
-        
+
     f2 = _to_ordinalf(dinterval_end) #new float-endpoint
     return np.linspace(f1, f2, num+1)
 


### PR DESCRIPTION
Using changes from #1242:

```
$> python make.py linkcheck
$> grep broken build/linkcheck/output.txt 
api/axes_api.rst:20: [broken] http://matplotlib.sf.net/fonts.html: HTTP Error 404: Not Found
api/dates_api.rst:83: [broken] https://moin.conectiva.com.br/DateUtil: <urlopen error Tunnel connection failed: 503 Service Unavailable>
api/pyplot_api.rst:20: [broken] http://matplotlib.sf.net/fonts.html: HTTP Error 404: Not Found
contents.rst:11: [broken] http://matplotlib.sf.net/Matplotlib.pdf: HTTP Error 404: Not Found
devel/gitwash/git_resources.rst:33: [broken] http://kerneltrap.org/Linux/Git_Management: <urlopen error timed out>
devel/release_guide.rst:89: [broken] http://www.nabble.com/binary-installers-for-python2.6--libpng-segfault%2C-MSVCR90.DLL-and-%09mingw-td23971661.html: HTTP Error 404: Not Found
faq/howto_faq.rst:758: [broken] http://www.citeulike.org/user/jabl/article/2878517: HTTP Error 404: Not Found
glossary/index.rst:26: [broken] http://www.fltk.org/: <urlopen error timed out>
```
