### PR TITLE
backend_pgf. Enable custom dashstyles in the pgf backend 

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -497,18 +497,16 @@ class RendererPgf(RendererBase):
             writeln(self.fh, r"\pgfsetstrokeopacity{%f}" % gc.get_alpha())
 
         # line style
+        dash_offset, dash_list = gc.get_dashes()
         ls = gc.get_linestyle(None)
         if ls == "solid":
             writeln(self.fh, r"\pgfsetdash{}{0pt}")
-        elif ls == "dashed":
-            dashargs = (2.5 * lw, 2.5 * lw)
-            writeln(self.fh, r"\pgfsetdash{{%fpt}{%fpt}}{0pt}" % dashargs)
-        elif ls == "dashdot":
-            dashargs = (3 * lw, 3 * lw, 1 * lw, 3 * lw)
-            writeln(self.fh, r"\pgfsetdash{{%fpt}{%fpt}{%fpt}{%fpt}}{0pt}" % dashargs)
-        elif "dotted":
-            dashargs = (lw, 3 * lw)
-            writeln(self.fh, r"\pgfsetdash{{%fpt}{%fpt}}{0pt}" % dashargs)
+        elif (ls == "dashed" or ls == "dashdot" or ls == "dotted"):
+            dash_str = r"\pgfsetdash{"
+            for dash in dash_list:
+                dash_str += r"{%fpt}" % dash
+            dash_str += r"}{%fpt}" % dash_offset
+            writeln(self.fh, dash_str)
 
     def _print_pgf_path(self, path, transform):
         f = 1. / self.dpi


### PR DESCRIPTION
The following code produces lines with identical standard dashes using the pgf backend. 

``` python
import matplotlib
matplotlib.use('pgf')
import matplotlib.pyplot as plt
import numpy as np
y = np.arange(10)

plt.plot(y,dashes=(5,1))
plt.plot(y*1.5,dashes=(2,2))
plt.plot(y*2,dashes=(1,5))
plt.legend(['line1','line2','line3'])
plt.savefig('test.pdf')
plt.savefig('test.pgf')
```

This happens because the pgf backend only takes the linestyle argument into account but ignores the dashes. In addition the dash length is scaled with the linewidth in the pgf backend. This is inconsistent with other backends (I tested pdf and agg) where it is independent of the linewidth.  This pull request fixes both these issues. 
