### PR TITLE
backend_cairo.py -- added print_surface method

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -435,6 +435,16 @@ class FigureCanvasCairo (FigureCanvasBase):
 
     def print_svgz(self, fobj, *args, **kwargs):
         return self._save(fobj, 'svgz', *args, **kwargs)
+        
+    def print_surface(self, fobj, *args, **kwargs):
+        dpi = 72
+        self.figure.dpi = dpi
+        w_in, h_in = self.figure.get_size_inches()
+        width_pt, height_pt = w_in * dpi, h_in * dpi
+        renderer = RendererCairo(self.figure.dpi)
+        renderer.set_width_height(width_pt, height_pt)
+        renderer.set_ctx_from_surface(fobj)
+        self.figure.draw(renderer)
 
     def _save (self, fo, format, **kwargs):
         # save PDF/PS/SVG


### PR DESCRIPTION
Added ability to print to a supplied cairo surface. It was the least hackish way I could interface matplotlib and mapnik.
