### PR TITLE
Fix BoundaryNorm interpolation with numpy 1.7rc.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1056,8 +1056,8 @@ class BoundaryNorm(Normalize):
         for i, b in enumerate(self.boundaries):
             iret[xx >= b] = i
         if self._interp:
-            iret *= float(self.Ncmap - 1) / (self.N - 2)
-            iret = iret.astype(np.int16)
+            scalefac = float(self.Ncmap - 1) / (self.N - 2)
+            iret = (iret * scalefac).astype(np.int16)
         iret[xx < self.vmin] = -1
         iret[xx >= self.vmax] = self.Ncmap
         ret = ma.array(iret, mask=mask)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -23,4 +23,17 @@ def test_colormap_endian():
         #print(anative.dtype.isnative, aforeign.dtype.isnative)
         assert_array_equal(cmap(anative), cmap(aforeign))
 
+def test_BoundaryNorm():
+    """
+    Github issue #1258: interpolation was failing with numpy
+    1.7 pre-release.
+    """
+    # TODO: expand this into a more general test of BoundaryNorm.
+    boundaries = [0, 1.1, 2.2]
+    vals = [-1, 0, 2, 2.2, 4]
+    expected = [-1, 0, 2, 3, 3]
+    # ncolors != len(boundaries) - 1 triggers interpolation
+    ncolors = len(boundaries)
+    bn = mcolors.BoundaryNorm(boundaries, ncolors)
+    assert_array_equal(bn(vals), expected)
 


### PR DESCRIPTION
Closes github issue #1258.
