### PR TITLE
Fixed pre-transform limit calculation bug for contour sets.

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -946,6 +946,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                     min = seg.min(axis=0)
                     max = seg.max(axis=0)
                     havelimits = True
+        
         if havelimits:
             self.ax.update_datalim([min, max])
             self.ax.autoscale_view(tight=True)
@@ -1291,17 +1292,31 @@ class QuadContourSet(ContourSet):
             self.zmax = args[0].zmax
         else:
             x, y, z = self._contour_args(args, kwargs)
-
+            
+            _mask = ma.getmask(z)
+            if _mask is ma.nomask:
+                _mask = None
+            C = _cntr.Cntr(x, y, z.filled(), _mask)
+            
+            t = self.ax.transData if self.transform is None else self.transform
+            
+            # if the transform is not trans data, and some part of it
+            # contains transData, transform the xs and ys to data coordinates
+            if (t != self.ax.transData and
+                        any(t.contains_branch_seperately(self.ax.transData))):
+                trans_to_data = self.transform - self.ax.transData
+                pts = (np.vstack([x.flat, y.flat]).T)
+                transformed_pts = trans_to_data.transform(pts)
+                x = transformed_pts[..., 0]
+                y = transformed_pts[..., 1]
+            
             x0 = ma.minimum(x)
             x1 = ma.maximum(x)
             y0 = ma.minimum(y)
             y1 = ma.maximum(y)
             self.ax.update_datalim([(x0,y0), (x1,y1)])
             self.ax.autoscale_view(tight=True)
-            _mask = ma.getmask(z)
-            if _mask is ma.nomask:
-                _mask = None
-            C = _cntr.Cntr(x, y, z.filled(), _mask)
+
         self.Cntr = C
 
     def _get_allsegs_and_allkinds(self):

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -16,7 +16,6 @@ import matplotlib.path as mpath
 import matplotlib.patches as mpatches
 
 
-
 @cleanup
 def test_non_affine_caching():
     class AssertingNonAffineTransform(mtrans.Transform):
@@ -108,6 +107,17 @@ def test_pre_transform_plotting():
     ax.quiver(x, y + 5, u, v, transform=times10 + ax.transData)
     
     ax.barbs(x - 3, y + 5, u**2, v**2, transform=times10 + ax.transData)
+
+
+@cleanup
+def test_contour_pre_transform_limits():
+    ax = plt.axes()
+    xs, ys = np.meshgrid(np.linspace(15, 20, 15), np.linspace(12.4, 12.5, 20))
+    ax.contourf(xs, ys, np.log(xs * ys), transform=mtrans.Affine2D().scale(0.1) + ax.transData)
+    
+    expected = np.array([[ 1.5 ,  1.24],
+                         [ 2.  ,  1.25]])
+    assert_almost_equal(expected, ax.dataLim.get_points())
     
 
 def test_Affine2D_from_values():


### PR DESCRIPTION
This is a bug fix to calculate the limits of a ContourSets using pre-transforms appropriately (see test) which I missed in #1090.

As well as this, I intend to write a MEP to unify and simplify the limit/view calculations for all artists on an axes for future mpl versions.
