### PR TITLE
Set axis limits in test_stackplot

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -822,6 +822,8 @@ def test_stackplot():
     y3 = 3.0 * x + 2
     ax = fig.add_subplot(1, 1, 1)
     ax.stackplot(x, y1, y2, y3)
+    ax.set_xlim((0, 10))
+    ax.set_ylim((0, 70))
 
 @image_comparison(baseline_images=['boxplot'])
 def test_boxplot():


### PR DESCRIPTION
On Travis, the autoscaling was choosing a y limit of -10 instead of 0
because some data values came out at -2.3e-18 instead of zero.

Some discussion at https://github.com/matplotlib/matplotlib/issues/1248
