### PR TITLE
Fix Objective-C 2.0 error with gcc-4.0

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5760,11 +5760,12 @@ show(PyObject* self)
     if(nwin > 0)
     {
         [NSApp activateIgnoringOtherApps: YES];
-        NSArray *windowsArray = [[NSApp windows] retain];
-        for (int i = 0; i < [windowsArray count]; i++) {
-            [[windowsArray objectAtIndex:i] orderFront:nil];
+        NSArray *windowsArray = [NSApp windows];
+        NSEnumerator *enumerator = [windowsArray objectEnumerator];
+        NSWindow *window;
+        while ((window = [enumerator nextObject])) {
+            [window orderFront:nil];
         }
-        [windowsArray release];
         [NSApp run];
     }
     Py_INCREF(Py_None);


### PR DESCRIPTION
Fixes #1270.

I'm not sure I have gcc-4.0 any more. @r-owen Could you try this?
