### PR TITLE
Fix overwriting suptitle

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -493,10 +493,8 @@ class Figure(Artist):
             kwargs['verticalalignment'] = 'top'
 
         if self._suptitle is not None:
-            self._suptitle.set_text(t)
-            self._suptitle.set_position((x, y))
-        else:
-            self._suptitle = self.text(x, y, t, **kwargs)
+            self._suptitle.set_text('')
+        self._suptitle = self.text(x, y, t, **kwargs)
         return self._suptitle
 
     def set_canvas(self, canvas):


### PR DESCRIPTION
Fixes #1262.

Note, once the position is set, it can't be changed on a new call to `suptitle`. I think it might be a better idea to allow the user to change the position on subsequent calls to `suptitle`.
