### PR TITLE
Fixed bug in MaxNLocator.bin_boundaries

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1237,8 +1237,8 @@ class MaxNLocator(Locator):
         scale, offset = scale_range(vmin, vmax, nbins)
         if self._integer:
             scale = max(1, scale)
-        vmin -= offset
-        vmax -= offset
+        vmin = vmin - offset
+        vmax = vmax - offset
         raw_step = (vmax-vmin)/nbins
         scaled_raw_step = raw_step/scale
         best_vmax = vmax


### PR DESCRIPTION
```
import numpy.random
import numpy.ma as ma
import matplotlib.pyplot as plt
a = numpy.random.uniform(size=(10,10)) + 280
a2 = ma.MaskedArray(a)
plt.contour(a2)  # Fails
```

```
ValueError: zero-size array to minimum.reduce without identity
```

Fixed a bug where `MaxNLocator.bin_boundaries()` was changing `QuadContourSet.zmin` and `zmax` in place, causing an empty levels list, and therefore the above exception.
