### PR TITLE
Fix tripcolor with shading='faceted'

### DIFF
--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -93,7 +93,7 @@ def tripcolor(ax, *args, **kwargs):
     kwargs.setdefault('linewidths', linewidths)
 
     if shading == 'faceted':   # Deprecated.
-        edgecolors = 'k',
+        edgecolors = 'k'
     else:
         edgecolors = 'none'
     if 'edgecolor' in kwargs:


### PR DESCRIPTION
In this case `edgecolors` is mistakenly set to a tuple `'k',` such that the following `ec.lower()` statement will fail with an `AttributeError`.
