### PR TITLE
Fix Image Tutorial: plt.imshow instead of mpimg.imshow.

### DIFF
--- a/doc/users/image_tutorial.rst
+++ b/doc/users/image_tutorial.rst
@@ -337,7 +337,7 @@ and the computer has to draw in pixels to fill that space.
     In [9]: img = Image.open('stinkbug.png')    # Open image as PIL image object
     In [10]: rsize = img.resize((img.size[0]/10,img.size[1]/10)) # Use PIL to resize
     In [11]: rsizeArr = np.asarray(rsize)  # Get array back
-    In [12]: imgplot = mpimg.imshow(rsizeArr)
+    In [12]: imgplot = plt.imshow(rsizeArr)
 
 .. plot::
 


### PR DESCRIPTION
I found a small typo in the documentation.
