### PR TITLE
Hide Tk root window until later

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -85,6 +85,7 @@ def new_figure_manager_given_figure(num, figure):
     """
     _focus = windowing.FocusManager()
     window = Tk.Tk()
+    window.withdraw()
 
     if Tk.TkVersion >= 8.5:
         # put a mpl icon on the window rather than the default tk icon. Tkinter


### PR DESCRIPTION
On Windows, when using the tkagg backend with mpl 1.2.0rc2, before a figure window is displayed, a small, empty window is shown for a short amount of time.
This becomes annoying. 
I'm not sure this is the correct fix, but it works for me on Python 2.6 to 3.3.
