### PR TITLE
Fixed to contour to support the _as_mpl_transform api.

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -114,9 +114,9 @@ Changes in 1.2.x
       >>> print(ax.viewLim)
       Bbox('array([[  0.,   0.],\n       [ 90.,  90.]])')
 
-* One can now easily get a transform which goes from one transform's coordinate system
-  to another, in an optimized way, using the new subtract method on a transform. For instance,
-  to go from data coordinates to axes coordinates::
+* One can now easily get a transform which goes from one transform's coordinate
+  system to another, in an optimized way, using the new subtract method on a 
+  transform. For instance, to go from data coordinates to axes coordinates::
 
       >>> import matplotlib.pyplot as plt
       >>> ax = plt.axes()
@@ -126,9 +126,9 @@ Changes in 1.2.x
       >>> print(data2ax.depth)
       2
 
-  for versions before 1.2 this could only be achieved in a sub-optimal way, using
-  ``ax.transData + ax.transAxes.inverted()`` (depth is a new concept, but had it existed
-  it would return 4 for this example).
+  for versions before 1.2 this could only be achieved in a sub-optimal way, 
+  using ``ax.transData + ax.transAxes.inverted()`` (depth is a new concept, 
+  but had it existed it would return 4 for this example).
 
 * ``twinx`` and ``twiny`` now returns an instance of SubplotBase if
   parent axes is an instance of SubplotBase.
@@ -141,6 +141,9 @@ Changes in 1.2.x
 * :class:`~matplotlib.colors.ColorConverter`,
   :class:`~matplotlib.colors.Colormap` and
   :class:`~matplotlib.colors.Normalize` now subclasses ``object``
+  
+* ContourSet instances no longer have a ``transform`` attribute. Instead, 
+  access the transform with the ``get_transform`` method.
 
 Changes in 1.1.x
 ================

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -775,7 +775,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             raise ValueError('Either colors or cmap must be None')
         if self.origin == 'image': self.origin = mpl.rcParams['image.origin']
 
-        self.transform = kwargs.get('transform', None)
+        self._transform = kwargs.get('transform', None)
 
         self._process_args(*args, **kwargs)
         self._process_levels()
@@ -857,12 +857,12 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         Return the :class:`~matplotlib.transforms.Transform`
         instance used by this ContourSet.
         """
-        if self.transform is None:
-            self.transform = self.ax.transData
-        elif (not isinstance(self.transform, mtrans.Transform)
-              and hasattr(self.transform, '_as_mpl_transform')):
-            self.transform = self.transform._as_mpl_transform(self.ax)
-        return self.transform
+        if self._transform is None:
+            self._transform = self.ax.transData
+        elif (not isinstance(self._transform, mtrans.Transform)
+              and hasattr(self._transform, '_as_mpl_transform')):
+            self._transform = self._transform._as_mpl_transform(self.ax)
+        return self._transform
 
     def __getstate__(self):
         state = self.__dict__.copy()


### PR DESCRIPTION
It turns out a bug fix PR (#1265) broke my own feature PR (#1090) of having an external `_as_mpl_transform` api.

Even if this doesn't make it in the final 1.2 cut (i.e. we don't find any issues with RC2), I think it is worth merging into the 1.2 branch.

Because we are so close to a release, I have tried to minimize any changes, hence have not changed the ContourSet's `transform` attribute to be private (i.e. `_transform`).
