### PR TITLE
pyplot.plotfile. gridon option added with default from rcParam.

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -15,6 +15,11 @@ For new features that were added to matplotlib, please see
 Changes in 1.3.x
 ================
 
+* Removed call of :meth:`~matplotlib.axes.Axes.grid` in
+  :meth:`~matplotlib.pyplot.plotfile`. To draw the axes grid, set to *True*
+  matplotlib.rcParams['axes.grid'] or ``axes.grid`` in ``.matplotlibrc`` or
+  explicitly call :meth:`~matplotlib.axes.Axes.grid`
+
 * A new keyword *extendrect* in :meth:`~matplotlib.pyplot.colorbar` and
   :class:`~matplotlib.colorbar.ColorbarBase` allows one to control the shape
   of colorbar extensions.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2101,8 +2101,7 @@ def polar(*args, **kwargs):
 
 def plotfile(fname, cols=(0,), plotfuncs=None,
              comments='#', skiprows=0, checkrows=5, delimiter=',', names=None,
-             subplots=True, newfig=True,
-             **kwargs):
+             subplots=True, newfig=True, **kwargs):
     """
     Plot the data in in a file.
 
@@ -2197,9 +2196,6 @@ def plotfile(fname, cols=(0,), plotfuncs=None,
                     ax = fig.add_subplot(N-1,1,i, sharex=ax1)
             elif i==1:
                 ax = fig.add_subplot(1,1,1)
-
-            ax.grid(True)
-
 
             yname, y = getname_val(cols[i])
             ynamelist.append(yname)


### PR DESCRIPTION
This should be a clean pull request of issue: https://github.com/matplotlib/matplotlib/pull/1205

Recap: the original plotfile function draw the axes grids at each call. This pull request implements a 
keywords to enable or disable the grid. The default is taken from rc.Params['axes.gris'].
This keyword is deprecated and will be deleted from future releases
