### PR TITLE
Pcolormesh and colorbar documentation. 

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -7413,10 +7413,12 @@ class Axes(martist.Artist):
             'gouraud', each quad will be Gouraud shaded.  When gouraud
             shading, edgecolors is ignored.
 
-          *edgecolors*: [ *None* | ``'None'`` | color | color sequence]
+          *edgecolors*: [ *None* | ``'None'`` | ``'face'`` | color | color sequence]
             If *None*, the rc setting is used by default.
 
             If ``'None'``, edges will not be visible.
+
+            If ``'face'``, edges will have the same color as the faces. 
 
             An mpl color or sequence of colors will set the edge color
 

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -518,7 +518,7 @@ class ColorbarBase(cm.ScalarMappable):
 
     def _add_solids(self, X, Y, C):
         '''
-        Draw the colors using :meth:`~matplotlib.axes.Axes.pcolor`;
+        Draw the colors using :meth:`~matplotlib.axes.Axes.pcolormesh`;
         optionally add separators.
         '''
         ## Change to pcolorfast after fixing bugs in some backends...


### PR DESCRIPTION
This lifts the documentation updates from #1178 which will not be merged. However I believe that
these documentation updates should go into the 1.2.x branch. 

The changes are 

Document that pcolormesh takes a face argument to the edgecolor.
And clarify that the colorbar in axesgrid1 is also drawn with pcolormesh (like the regular colorbar)
