### PR TITLE
Marker not round with markersize=3

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -276,7 +276,7 @@ that define the shape.
 
     def _set_circle(self, reduction = 1.0):
         self._transform = Affine2D().scale(0.5 * reduction)
-        self._snap_threshold = None
+        self._snap_threshold = 6.0
         fs = self.get_fillstyle()
         if not self._half_fill():
             self._path = Path.unit_circle()


### PR DESCRIPTION
On `1.2.0rc2` the following example produces one round marker, and one diamond marker:

```
import matplotlib.pyplot as plt
import numpy as np

plt.xlim([1, 2])
plt.ylim([1, 2])
plt.plot(1.1, 1.1, 'ro', markersize=2.5)
plt.plot(1.5, 1.5, 'bo', markersize=3)
plt.plot(1.9, 1.9, 'ko', markersize=3.5)

plt.show()
```

Git bisect will be useful here, but I'm not sure this was even working in 1.1.0.
