### PR TITLE
very high negative zorder breaks vector graphic rendering

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -14,6 +14,12 @@ For new features that were added to matplotlib, please see
 Changes in 1.2.x
 ================
 
+* The `rasterization_zorder` property on `~matplotlib.axes.Axes` a
+  zorder below which artists are rasterized.  This has defaulted to
+  -30000.0, but it now defaults to `None`, meaning no artists will be
+  rasterized.  In order to rasterize artists below a given zorder
+  value, `set_rasterization_zorder` must be explicitly called.
+
 * In :meth:`~matplotlib.axes.Axes.scatter`, and `~pyplot.scatter`,
   when specifying a marker using a tuple, the angle is now specified
   in degrees, not radians.
@@ -90,14 +96,14 @@ Changes in 1.2.x
          def transform(self, xy):
              ...
          transform_non_affine = transform
-  
-  
+
+
   This approach will no longer function correctly and should be changed to::
 
      class MyTransform(mtrans.Transform):
          def transform_non_affine(self, xy):
              ...
-  
+
 
 * Artists no longer have ``x_isdata`` or ``y_isdata`` attributes; instead
   any artist's transform can be interrogated with
@@ -115,7 +121,7 @@ Changes in 1.2.x
       Bbox('array([[  0.,   0.],\n       [ 90.,  90.]])')
 
 * One can now easily get a transform which goes from one transform's coordinate
-  system to another, in an optimized way, using the new subtract method on a 
+  system to another, in an optimized way, using the new subtract method on a
   transform. For instance, to go from data coordinates to axes coordinates::
 
       >>> import matplotlib.pyplot as plt
@@ -126,8 +132,8 @@ Changes in 1.2.x
       >>> print(data2ax.depth)
       2
 
-  for versions before 1.2 this could only be achieved in a sub-optimal way, 
-  using ``ax.transData + ax.transAxes.inverted()`` (depth is a new concept, 
+  for versions before 1.2 this could only be achieved in a sub-optimal way,
+  using ``ax.transData + ax.transAxes.inverted()`` (depth is a new concept,
   but had it existed it would return 4 for this example).
 
 * ``twinx`` and ``twiny`` now returns an instance of SubplotBase if
@@ -141,8 +147,8 @@ Changes in 1.2.x
 * :class:`~matplotlib.colors.ColorConverter`,
   :class:`~matplotlib.colors.Colormap` and
   :class:`~matplotlib.colors.Normalize` now subclasses ``object``
-  
-* ContourSet instances no longer have a ``transform`` attribute. Instead, 
+
+* ContourSet instances no longer have a ``transform`` attribute. Instead,
   access the transform with the ``get_transform`` method.
 
 Changes in 1.1.x

--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -16,7 +16,7 @@ import matplotlib.cbook as cbook
 import matplotlib.collections as mcoll
 import matplotlib.colors as mcolors
 import matplotlib.contour as mcontour
-import matplotlib.dates as _ # <-registers a date unit converter 
+import matplotlib.dates as _ # <-registers a date unit converter
 from matplotlib import docstring
 import matplotlib.font_manager as font_manager
 import matplotlib.image as mimage
@@ -465,7 +465,7 @@ class Axes(martist.Artist):
         self._frameon = frameon
         self._axisbelow = rcParams['axes.axisbelow']
 
-        self._rasterization_zorder = -30000
+        self._rasterization_zorder = None
 
         self._hold = rcParams['axes.hold']
         self._connected = {} # a dict from events to (id, func)
@@ -1852,7 +1852,9 @@ class Axes(martist.Artist):
 
     def set_rasterization_zorder(self, z):
         """
-        Set zorder value below which artists will be rasterized
+        Set zorder value below which artists will be rasterized.  Set
+        to `None` to disable rasterizing of artists below a particular
+        zorder.
         """
         self._rasterization_zorder = z
 
@@ -2029,7 +2031,8 @@ class Axes(martist.Artist):
         # rasterize artists with negative zorder
         # if the minimum zorder is negative, start rasterization
         rasterization_zorder = self._rasterization_zorder
-        if len(dsu) > 0 and dsu[0][0] < rasterization_zorder:
+        if (rasterization_zorder is not None and
+            len(dsu) > 0 and dsu[0][0] < rasterization_zorder):
             renderer.start_rasterizing()
             dsu_rasterized = [l for l in dsu if l[0] < rasterization_zorder]
             dsu = [l for l in dsu if l[0] >= rasterization_zorder]
@@ -3972,7 +3975,7 @@ class Axes(martist.Artist):
 
             plot(x, y, color='green', linestyle='dashed', marker='o',
                  markerfacecolor='blue', markersize=12).
-                 
+
         See :class:`~matplotlib.lines.Line2D` for details.
 
         The kwargs are :class:`~matplotlib.lines.Line2D` properties:
@@ -7073,7 +7076,7 @@ class Axes(martist.Artist):
         **Example:**
 
         .. plot:: mpl_examples/pylab_examples/image_demo.py
-        
+
         """
 
         if not self._hold: self.cla()
@@ -7418,7 +7421,7 @@ class Axes(martist.Artist):
 
             If ``'None'``, edges will not be visible.
 
-            If ``'face'``, edges will have the same color as the faces. 
+            If ``'face'``, edges will have the same color as the faces.
 
             An mpl color or sequence of colors will set the edge color
 


### PR DESCRIPTION
I have stumbled over a problem in vector graphic output with the pdf backend in combination with very high negative zorders (high positive values seem to be ok). Using the following example you see that for very high, negative zorder values the object gets visualized as bitmap.
I have verified this on matplotlib compiled from current master (Debian Squeeze, Python 2.6.6, with additional numpy 1.6.2).

``` python
import matplotlib
matplotlib.use("pdf")
import matplotlib.pyplot as plt
plt.plot([0, 1], [0, 1], zorder=-10000000)
plt.savefig("/tmp/zorder_bad.pdf")
plt.figure()
plt.plot([0, 1], [0, 1], zorder=-100)
plt.savefig("/tmp/zorder_ok.pdf")
plt.figure()
plt.plot([0, 1], [0, 1], zorder=1000000000000000)
plt.savefig("/tmp/zorder_ok2.pdf")
```

While this is obviously easy to circumvent (use reasonable zorder values ;)), I nevertheless think this should be fixed.
