### PR TITLE
Work around a huge memory leak in PySide on Python 3

### DIFF
--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -114,9 +114,12 @@ class FigureCanvasQTAgg( FigureCanvasQT, FigureCanvasAgg ):
                 p.drawRect( self.rect[0], self.rect[1], self.rect[2], self.rect[3] )
             p.end()
 
+            # This works around a bug in PySide 1.1.2 on Python 3.x,
+            # where the reference count of stringBuffer is incremented
+            # but never decremented by QImage.
+            # TODO: revert PR #1323 once the issue is fixed in PySide.
             del qImage
             if refcnt != sys.getrefcount(stringBuffer):
-                # Fix a huge memory leak in PySide on Python 3
                 _decref(stringBuffer)
         else:
             bbox = self.blitbox


### PR DESCRIPTION
As reported by David Honcik on the [matplotlib-users](http://www.mail-archive.com/matplotlib-users@lists.sourceforge.net/msg25371.html) mailing list, there is a huge memory leak on Python 3 when using the Qt4Agg backend with PySide versions 1.1.1 and 1.1.2 (confirmed on Windows).

To reproduce, run the following script on Python 3.2 or 3.3 and observe the allocated process memory increase while resizing the main window:

```
import matplotlib
matplotlib.use('Qt4Agg')
matplotlib.rcParams['backend.qt4']='PySide'
from matplotlib import pyplot
pyplot.plot()
pyplot.show()
```

The problem is that QImage increases, but never decreases, the reference count of the string buffer passed to QImage.

This PR forcibly decreases the reference count of the string buffer after use, if necessary.  Tested on Windows only. Is there a policy for including (or not) this kind of temporary workaround in matplotlib?

There are other reported problems creating QImage from string buffers at https://bugreports.qt-project.org/browse/PYSIDE-52 .
