### PR TITLE
Fix for issue #841

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8127,7 +8127,7 @@ class Axes(martist.Artist):
 
             x[0::2], x[1::2] = bins, bins
 
-            minimum = min( min(m) for m in n ) # Issue #841
+            minimum = np.min( n )
 
             if align == 'left' or align == 'center':
                 x -= 0.5*(bins[1]-bins[0])


### PR DESCRIPTION
As I mentioned in Issue #841, there's a bug in hist autoscaling when histtype.startswith('step). An easy test is:

``` python
import pylab as P
P.hist([3000,3010,3012], histtype='step')
P.show()
```
