### PR TITLE
ENH: allow animations to be saved as animated GIFs

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -456,18 +456,33 @@ class ImageMagickBase:
     args_key = 'animation.convert_args'
 
     @property
+    def delay(self):
+        return 100. / self.fps
+
+    @property
     def output_args(self):
         return [self.outfile]
 
 
+@writers.register('imagemagick')
+class ImageMagickWriter(MovieWriter, ImageMagickBase):
+    def _args(self):
+        return ([self.bin_path(),
+                 '-size', '%ix%i' % self.frame_size, '-depth', '8',
+                 '-delay', str(self.delay), '-loop', '0',
+                 '%s:-' % self.frame_format]
+                + self.output_args)
+
+
 @writers.register('imagemagick_file')
 class ImageMagickFileWriter(FileMovieWriter, ImageMagickBase):
-    supported_formats = ['png']
+    supported_formats = ['png', 'jpeg', 'ppm', 'tiff', 'sgi', 'bmp',
+                         'pbm', 'raw', 'rgba']
 
     def _args(self):
-        delay = 100. / self.fps
-        return [self.bin_path(), '-delay', str(delay), '-loop', '0',
-                '%s*.%s' % (self.temp_prefix, self.frame_format)] + self.output_args
+        return ([self.bin_path(), '-delay', str(self.delay), '-loop', '0',
+                 '%s*.%s' % (self.temp_prefix, self.frame_format)]
+                + self.output_args)
 
 
 class Animation(object):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -323,7 +323,8 @@ validate_pgf_texsystem = ValidateInStrings('pgf.texsystem',
                                            ['xelatex', 'lualatex', 'pdflatex'])
 
 validate_movie_writer = ValidateInStrings('animation.writer',
-    ['ffmpeg', 'ffmpeg_file', 'mencoder', 'mencoder_file', 'imagemagick_file'])
+    ['ffmpeg', 'ffmpeg_file', 'mencoder', 'mencoder_file',
+     'imagemagick', 'imagemagick_file'])
 
 validate_movie_frame_fmt = ValidateInStrings('animation.frame_format',
     ['png', 'jpeg', 'tiff', 'raw', 'rgba'])


### PR DESCRIPTION
This is a basic enhancement that allows animations to be saved as animated GIFs, using the ImageMagick `convert` utility.  It works with either temporary files or piping.

A deficiency currently is that extra arguments and options are not passed through: the only option used currently is setting the correct frame rate.  Extra options are tough, because they are position dependent.  I'm not sure where they should be inserted in the command by default.

A test script can be found here: https://gist.github.com/3843162
