### PR TITLE
Travis: suppress logs for installing numpy, nose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ python:
   - 3.2
 
 install:
-  - pip install --use-mirrors nose numpy
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then pip install --use-mirrors PIL; fi
+  - pip install -q --use-mirrors nose numpy
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then
+        pip install -q --use-mirrors PIL;
+    fi
   - python setup.py install
 
 script:


### PR DESCRIPTION
Previously one had to go through the logs and try to figure out where the log
for matplotlib starts. Since we are not testing that numpy builds here, it's ok
to simply use the "-q" option, that way the logs will not be cluttered by the
numpy build.
