### PR TITLE
DOC: provide convenience url for seachling MLs + mentioned github issues

### DIFF
--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -65,9 +65,11 @@ environment variable -- see
 Report a problem
 ================
 
-If you are having a problem with matplotlib, search the mailing
-lists first: there's a good chance someone else has already run into
-your problem.
+If you are having a problem with matplotlib, search the `mailing lists
+<http://sourceforge.net/search/?group_id=80706&type_of_search=mlists>`_
+and `github issues <https://github.com/matplotlib/matplotlib/issues>`_
+first: there's a good chance someone else has already run into your
+problem.
 
 If not, please provide the following information in your e-mail to the
 `mailing list


### PR DESCRIPTION
otherwise whoever wants to report an issue needs to research first where exactly to
search.  also github issues page was not mentioned at all

N.B. I haven't tried rebuilding docs so not 100% if I haven't screwed up
