### PR TITLE
Remove nonfunctioning cbook.isvector

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -14,6 +14,9 @@ For new features that were added to matplotlib, please see
 Changes in 1.2.x
 ================
 
+* The :meth:`~matplotlib.cbook.isvector` method has been removed since it
+  is no longer functional.
+
 * The `rasterization_zorder` property on `~matplotlib.axes.Axes` a
   zorder below which artists are rasterized.  This has defaulted to
   -30000.0, but it now defaults to `None`, meaning no artists will be

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1672,18 +1672,6 @@ def less_simple_linear_interpolation(x, y, xi, extrap=False):
     return mlab.less_simple_linear_interpolation(x, y, xi, extrap=extrap)
 
 
-def isvector(X):
-    """
-    This function has been moved to matplotlib.mlab -- please import
-    it from there
-    """
-    # deprecated from cbook in 0.98.4
-    warnings.warn('isvector has been moved to matplotlib.mlab -- please '
-                  'import it from there', DeprecationWarning)
-    import matplotlib.mlab as mlab
-    return mlab.isvector(x, y, xi, extrap=extrap)
-
-
 def vector_lengths(X, P=2.0, axis=None):
     """
     This function has been moved to matplotlib.mlab -- please import


### PR DESCRIPTION
A note has also been added to api_changes.rst to reflect the removal.

This is a follow-up from the discussion in #1335.
