### PR TITLE
Make make.py build docs under python 3

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -102,7 +102,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
         else:
             errors.extend((src, dst, str(why)))
     if errors:
-        raise Error, errors
+        raise Error(errors)
 
 ### End compatibility block for pre-v2.6 ###
 


### PR DESCRIPTION
Fixes #1356.

@cjmayo Could you confirm this works as intended?
