### PR TITLE
fixed lognorm clip behavior

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -953,7 +953,7 @@ class LogNorm(Normalize):
         else:
             if clip:
                 mask = ma.getmask(result)
-                val = ma.array(np.clip(result.filled(vmax), vmin, vmax),
+                result = ma.array(np.clip(result.filled(vmax), vmin, vmax),
                                 mask=mask)
             # in-place equivalent of above can be much faster
             resdat = result.data

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -36,4 +36,13 @@ def test_BoundaryNorm():
     ncolors = len(boundaries)
     bn = mcolors.BoundaryNorm(boundaries, ncolors)
     assert_array_equal(bn(vals), expected)
+    
+def test_LogNorm():
+    """
+    LogNorm igornoed clip, now it has the same
+    behavior as Normalize, e.g. values > vmax are bigger than 1
+    without clip, with clip they are 1.
+    """
+    ln = mcolors.LogNorm(clip=True, vmax=5)
+    assert_array_equal(ln([1, 6]), [0, 1.0])
 


### PR DESCRIPTION
LogNorm did not clip, this PR fixes that. The behavior is now the same as normalize. A test is 
also added.
