### PR TITLE
Fix typo in transforms.py

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -474,10 +474,9 @@ class BboxBase(TransformNode):
         :attr:`y1`.
         """
         y0, y1 = self.intervaly
-        # FIXME x is not define. This method probably doesn't work.
         return ((y0 < y1
-                 and (x > y0 and x < y1))
-                or (x > y1 and x < y0))
+                 and (y > y0 and y < y1))
+                or (y > y1 and y < y0))
 
     def fully_contains(self, x, y):
         """


### PR DESCRIPTION
Fix #1364.

All the tests had been passing before this change, so I guess it doesn't look like it's being used.
