### PR TITLE
Fix svg writer for StringIO objects

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1095,6 +1095,8 @@ class FigureCanvasSVG(FigureCanvasBase):
                     svgwriter = io.TextIOWrapper(filename, 'utf-8')
                 else:
                     svgwriter = codecs.getwriter('utf-8')(filename)
+            else:
+                svgwriter = filename
             fh_to_close = None
         else:
             raise ValueError("filename must be a path or a file-like object")


### PR DESCRIPTION
Fix #1373.

This seems like a really simple fix. I'm a little concerned that it may now be possible to pass something to `print_svg` that doesn't make sense. Hopefully someone will correct me if this is the case.

Also, I kind of feel like the write should be in a `try`/`finally` block, like `print_png` in the `agg` backend.
