### PR TITLE
Make setupegg symlink correct dateutil library

### DIFF
--- a/setupegg.py
+++ b/setupegg.py
@@ -9,13 +9,11 @@ from setuptools import setup
 # Setupegg assumes the install tree and source tree are exactly the same. Since
 # this is not the case, symlink the correct dateutil dir depending on which
 # version of python is used
-os.chdir('lib')
-if not os.path.isdir('dateutil'):
+if not os.path.isdir('lib/dateutil'):
     if sys.version_info[0] >= 3:
-        os.symlink('dateutil_py3', 'dateutil')
+        os.symlink('dateutil_py3', 'lib/dateutil')
     else:
-        os.symlink('dateutil_py2', 'dateutil')
-os.chdir('..')
+        os.symlink('dateutil_py2', 'lib/dateutil')
 
 execfile('setup.py',
          {'additional_params' :


### PR DESCRIPTION
Setupegg assumes the install tree is the same as the source tree. This
is not the case, since a different version of the dateutil library is
used depending on whether python version 2 or 3 is used. This fix
symlinks the correct version at run-time.

Fixes #1354.
