### PR TITLE
Remove unused autolayout_validator() from rcsetup

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -114,10 +114,6 @@ validate_toolbar = ValidateInStrings('toolbar',[
     'None','classic','toolbar2',
     ], ignorecase=True)
 
-def validate_autolayout(v):
-    if v:
-        warnings.warn("figure.autolayout is not currently supported")
-
 def validate_maskedarray(v):
     # 2008/12/12: start warning; later, remove all traces of maskedarray
     try:


### PR DESCRIPTION
figure.autolayout is now being handled by validate_bool, so the original autolayout_validator, which warned that figure.autolayout had no function, is unused.  
