### PR TITLE
Improve "Report a problem" to "Getting help"

### DIFF
--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -62,14 +62,22 @@ environment variable -- see
 
 .. _reporting-problems:
 
-Report a problem
-================
+Getting help
+============
 
-If you are having a problem with matplotlib, search the mailing
-lists first: there's a good chance someone else has already run into
-your problem.
+There are a number of good resources for getting help with matplotlib.
+There is a good chance your question has already been asked:
 
-If not, please provide the following information in your e-mail to the
+  - The `mailing list
+    <http://sourceforge.net/search/?group_id=80706&type_of_search=mlists>`_.
+
+  - `Github issues <https://github.com/matplotlib/matplotlib/issues>`_.
+
+  - Stackoverflow questions tagged `matplotlib
+<http://stackoverflow.com/questions/tagged/matplotlib>`_.
+
+If you are unable to find an answer to your question through search,
+please provide the following information in your e-mail to the
 `mailing list
 <http://lists.sourceforge.net/mailman/listinfo/matplotlib-users>`_:
 


### PR DESCRIPTION
This is a follow-on to #1344 contributed by @yarikoptic, which I've just superceded here since that pull request was against master etc. anyway.

This adds stackoverflow as a resource and changes the header from "Report a problem" to "Getting help".
