### PR TITLE
PySide segfaults immediately on Linux

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -603,8 +603,7 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
 
     def set_cursor( self, cursor ):
         if DEBUG: print('Set cursor' , cursor)
-        QtGui.QApplication.restoreOverrideCursor()
-        QtGui.QApplication.setOverrideCursor( QtGui.QCursor( cursord[cursor] ) )
+        self.canvas.manager.window.setCursor(cursord[cursor])
 
     def draw_rubberband( self, event, x0, y0, x1, y1 ):
         height = self.canvas.figure.bbox.height


### PR DESCRIPTION
PySide 1.1.0 crashes upon startup with this script

```
import matplotlib
matplotlib.use('Qt4Agg')
matplotlib.rcParams['backend.qt4']='PySide'
from matplotlib import pyplot
pyplot.plot()
pyplot.show()
```

It may or may not be related to #1323.  (It happens whether or not that patch is applied).
