### PR TITLE
Tables: Fix get_window_extent for table 

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -279,7 +279,8 @@ class Table(Artist):
 
     def get_window_extent(self, renderer):
         'Return the bounding box of the table in window coords'
-        boxes = [c.get_window_extent(renderer) for c in self._cells]
+        boxes = [self._cells[c].get_window_extent(renderer)
+                 for c in self._cells.keys()]
         return Bbox.union(boxes)
 
     def _do_cell_alignment(self):


### PR DESCRIPTION
This allows a table to be added to bbox_extra_artists. 
See https://github.com/ipython/ipython/issues/2508

Got rid of bbox_all and replaced it with Bbox.union.
Furthermore the get_window_extent is a method on the cells not the key of the cell 
so change that to avoid an attribute error. 
