### PR TITLE
Add table to default_bbox_extra_artists

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8806,6 +8806,9 @@ class Axes(martist.Artist):
         bbox_extra_artists = [t for t in self.texts if t.get_visible()]
         if self.legend_:
             bbox_extra_artists.append(self.legend_)
+        if self.tables:
+            for t in self.tables:
+                bbox_extra_artists.append(t)
         return bbox_extra_artists
 
 


### PR DESCRIPTION
If tables exists add them to default_bbox_extra_artists. This avoids clipping the
table if bbox_inches='tight' is used. Thus a table is shown correctly in the IPython notebook.

To work correctly this needs both #1420 and #1418 to be merged. 

It resolves https://github.com/ipython/ipython/issues/2508
