### PR TITLE
Rebase of #1418 on v1.2.x

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -279,7 +279,9 @@ class Table(Artist):
 
     def get_window_extent(self, renderer):
         'Return the bounding box of the table in window coords'
-        boxes = [c.get_window_extent(renderer) for c in self._cells]
+        boxes = [cell.get_window_extent(renderer)
+                 for cell in self._cells.values()]
+
         return Bbox.union(boxes)
 
     def _do_cell_alignment(self):


### PR DESCRIPTION
#1420 is not needed on v1.2.x. This is a bug only present on master introduced in 2f11dee795e935000738dd33f62d8e8d61ee14f3
