### PR TITLE
Alternative to #1404. Sets the cursor without refering to a FigureManage...

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -603,7 +603,7 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
 
     def set_cursor( self, cursor ):
         if DEBUG: print('Set cursor' , cursor)
-        self.canvas.manager.window.setCursor(cursord[cursor])
+        self.canvas.window().setCursor(cursord[cursor])
 
     def draw_rubberband( self, event, x0, y0, x1, y1 ):
         height = self.canvas.figure.bbox.height


### PR DESCRIPTION
This is a suggested alternative to the fix in #1404, and works outside of pyplot. It hasn't been tested to verify that it fixes the main issue in #1404.
