### PR TITLE
Fix incorrect conversion in PEP8 fixes.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2091,7 +2091,8 @@ class FigureCanvasBase(object):
                 if bbox_filtered:
                     _bbox = Bbox.union(bbox_filtered)
                     trans = Affine2D().scale(1.0 / self.figure.dpi)
-                    bbox_inches = TransformedBbox(_bbox, trans)
+                    bbox_inches = Bbox.union([bbox_inches,
+                                              TransformedBbox(_bbox, trans)])
 
                 pad = kwargs.pop("pad_inches", None)
                 if pad is None:


### PR DESCRIPTION
This code wasn't quite correctly translated when making PEP8 fixes, commit 2f11dee795e935000738dd33f62d8e8d61ee14f3.

This breaks inline graphics in the ipython notebook.
