### PR TITLE
Fix clipping in PDF backend

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -7,6 +7,7 @@ Author: Jouni K Seppänen <jks@iki.fi>
 from __future__ import division, print_function
 
 import codecs
+import copy
 import os
 import re
 import sys
@@ -1534,7 +1535,7 @@ class RendererPdf(RendererBase):
             path_codes.append(name)
 
         output = self.file.output
-        output(Op.gsave)
+        output(*self.gc.push())
         lastx, lasty = 0, 0
         for xo, yo, path_id, gc0, rgbFace in self._iter_collection(
             gc, master_transform, all_transforms, path_codes, offsets,
@@ -1545,7 +1546,7 @@ class RendererPdf(RendererBase):
             dx, dy = xo - lastx, yo - lasty
             output(1, 0, 0, 1, dx, dy, Op.concat_matrix, path_id, Op.use_xobject)
             lastx, lasty = xo, yo
-        output(Op.grestore)
+        output(*self.gc.pop())
 
     def draw_markers(self, gc, marker_path, marker_trans, path, trans, rgbFace=None):
         # For simple paths or small numbers of markers, don't bother


### PR DESCRIPTION
This fixes a bug introduced in #1444, where the clipping information would be lost when using a path collection.  I think this fixes things once and for all, but if not it's probably safest to just revert #1444 which was solving a much less serious bug than this one.
