### PR TITLE
agg_buffer_to_array.py crashes

### DIFF
--- a/examples/pylab_examples/agg_buffer_to_array.py
+++ b/examples/pylab_examples/agg_buffer_to_array.py
@@ -12,7 +12,9 @@ fig.canvas.draw()
 # grab the pixel buffer and dump it into a numpy array
 buf = fig.canvas.buffer_rgba()
 l, b, w, h = fig.bbox.bounds
-X = np.fromstring(buf, np.uint8)
+# The array needs to be copied, because the underlying buffer
+# may be reallocated when the window is resized.
+X = np.frombuffer(buf, np.uint8).copy()
 X.shape = h,w,4
 
 # now display the array X as an Axes in a new figure


### PR DESCRIPTION
On Python 2.x for Windows, using matplotlib 1.2.0 (any rc build) with the TkAgg backend, the [agg_buffer_to_array.py](https://github.com/matplotlib/matplotlib/blob/v1.2.x/examples/pylab_examples/agg_buffer_to_array.py) crashes reproducibly. Python 3.x and other backends (Qt4Agg, FltkAgg, wxAgg) _seem_ to work OK.

The faulthandler traceback is:

```
Fatal Python error: Segmentation fault

Current thread 0x00001078:
  File "X:\Python27\lib\site-packages\matplotlib\image.py", line 198 in _get_unsampled_image
  File "X:\Python27\lib\site-packages\matplotlib\image.py", line 580 in make_image
  File "X:\Python27\lib\site-packages\matplotlib\image.py", line 360 in draw
  File "X:\Python27\lib\site-packages\matplotlib\artist.py", line 54 in draw_wrapper
  File "X:\Python27\lib\site-packages\matplotlib\axes.py", line 2086 in draw
  File "X:\Python27\lib\site-packages\matplotlib\artist.py", line 54 in draw_wrapper
  File "X:\Python27\lib\site-packages\matplotlib\figure.py", line 999 in draw
  File "X:\Python27\lib\site-packages\matplotlib\artist.py", line 54 in draw_wrapper
  File "X:\Python27\lib\site-packages\matplotlib\backends\backend_agg.py", line 439 in draw
  File "X:\Python27\lib\site-packages\matplotlib\backends\backend_tkagg.py", line 348 in draw
  File "X:\Python27\lib\site-packages\matplotlib\backends\backend_tkagg.py", line 276 in resize
  File "X:\Python27\lib\lib-tk\Tkinter.py", line 1410 in __call__
  File "X:\Python27\lib\lib-tk\Tkinter.py", line 911 in update
  File "X:\Python27\lib\site-packages\matplotlib\backends\backend_tkagg.py", line 574 in show
  File "X:\Python27\lib\site-packages\matplotlib\backend_bases.py", line 82 in __call__
  File "X:\Python27\lib\site-packages\matplotlib\pyplot.py", line 143 in show
  File "matplotlib-1.2.0rc3\examples\pylab_examples\agg_buffer_to_array.py", line 24 in <module>
```

The crash happens at [line 198 of image.py](https://github.com/matplotlib/matplotlib/blob/v1.2.x/lib/matplotlib/image.py#L198):

```
im = _image.frombyte(self._A[yslice,xslice,:], 0)
```

Any access to the data of `self._A`, such as `self._A[0,0,0]`, triggers a crash. The shape and dtype of `self._A` are correct.

Changing [line 15 of agg_buffer_to_array.py](https://github.com/matplotlib/matplotlib/blob/v1.2.x/examples/pylab_examples/agg_buffer_to_array.py#L15) from

```
X = np.frombuffer(buf, np.uint8)
```

to

```
X = np.fromstring(buf, np.uint8)
```

seems to fix this crash. 
