### PR TITLE
Colorbar edges are different in PDF backend

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1534,7 +1534,7 @@ class RendererPdf(RendererBase):
             path_codes.append(name)
 
         output = self.file.output
-        output(Op.gsave)
+        output(*self.gc.push())
         lastx, lasty = 0, 0
         for xo, yo, path_id, gc0, rgbFace in self._iter_collection(
             gc, master_transform, all_transforms, path_codes, offsets,
@@ -1545,7 +1545,7 @@ class RendererPdf(RendererBase):
             dx, dy = xo - lastx, yo - lasty
             output(1, 0, 0, 1, dx, dy, Op.concat_matrix, path_id, Op.use_xobject)
             lastx, lasty = xo, yo
-        output(Op.grestore)
+        output(*self.gc.pop())
 
     def draw_markers(self, gc, marker_path, marker_trans, path, trans, rgbFace=None):
         # For simple paths or small numbers of markers, don't bother


### PR DESCRIPTION
This is a reopening of #1444, since it still hasn't found a satisfactory solution.

In a message on matplotlib-users from Andrew Dawson:

Hi all,

I just noticed that colorbar edges are drawn in white when output in PDF and black when output in PNG. A small test script is attached along with the output to show the difference.

I'd be interested in knowing if others can reproduce this? I'm using mpl-1.3.x (updated 5 minutes ago) on 64-bit Ubuntu 12.04.

Cheers,
Andrew

```
import matplotlib.pyplot as plt
import numpy as np

# dummy data
x = y = np.linspace(-np.pi, np.pi, 50)
X, Y = np.meshgrid(x, y)
Z = np.sin(X) * np.cos(2.*Y)

# draw a filled contour plot and add a colorbar with drawedges turned on
contours = plt.contourf(x, y, Z)
cb = plt.colorbar(orientation='horizontal', drawedges=True)

# turn off tick marks so the edges can be seen
for tick in cb.ax.get_xticklines() + cb.ax.get_yticklines():
    tick.set_visible(False)

# save as a PDF and a PNG
plt.savefig('test.pdf')
plt.savefig('test.png')
```
