### PR TITLE
use an imagemap for the "fork me on github" ribbon

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -35,8 +35,6 @@ var req = false;
 }
 </script>
 
-  <!-- The "Fork me on github" ribbon -->
-  <a href="https://github.com/matplotlib/matplotlib"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
 
   <h1>John Hunter (1968-2012)</h1>
 

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -36,6 +36,13 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
 <a href="{{ pathto('index') }}"><img src="{{
 pathto("_static/logo2.png", 1) }}" border="0" alt="matplotlib"/></a>
 </div>
+
+<!-- The "Fork me on github" ribbon -->
+<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" usemap="#ribbonmap"/>
+<map name="ribbonmap">
+    <area shape="poly" coords="20,2,148,-1,148,135" href="https://github.com/matplotlib/matplotlib" alt="Fork me on GitHub" />
+</map>
+
 {{ super() }}
 {% endblock %}
 


### PR DESCRIPTION
Right now, the ribbon on the front page blocks out the possiblity of clicking
on the "Index" link, because the "Fork me on Github" link is on top of it.

I've rectified this by providing an imagemap, which only makes part of the
image clickable as a link. I've verified that it works under Firefox, Chromium,
and w3m.

I have also moved the ribbon from being only on the front page, to
appearing on all pages, since that has the potential of inviting
contributors more actively, as most people won't spend much time on the
index page, once they are actually using matplotlib, whereas they will
be peaking at the gallery, as well as the api docs, etc.

I got the numbers for the ribbon from here: susestudio/studio-help#20, but then
adjusted them so that the full upper left triangle would be clickable, and not
just the ribbon.

Also, can someone tell me if I should be filing this only against master, only against 1.2.x, or both?
