### PR TITLE
Fix leak of gc's in gtkagg backend

### DIFF
--- a/src/_gtkagg.cpp
+++ b/src/_gtkagg.cpp
@@ -1,3 +1,4 @@
+
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
 #include <pygobject.h>
@@ -121,6 +122,7 @@ private:
                               destbuffer,
                               deststride);
 
+        gdk_gc_destroy(gc);
         if (needfree)
         {
             delete [] destbuffer;


### PR DESCRIPTION
The gtkagg backend creates gc's with gdk_gc_new, but never destroyed them. This commit adds a matching gdk_gc_destroy to fix the memory leak.
