### PR TITLE
check `ret == False` in Timer._on_timer

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1118,14 +1118,14 @@ class TimerBase(object):
     def _on_timer(self):
         '''
         Runs all function that have been registered as callbacks. Functions
-        can return False if they should not be called any more. If there
+        can return False (or 0) if they should not be called any more. If there
         are no callbacks, the timer is automatically stopped.
         '''
         for func, args, kwargs in self.callbacks:
             ret = func(*args, **kwargs)
-            # docstring above explains why we use `if ret is False` here,
+            # docstring above explains why we use `if ret == False` here,
             # instead of `if not ret`.
-            if ret is False:
+            if ret == False:
                 self.callbacks.remove((func, args, kwargs))
 
         if len(self.callbacks) == 0:


### PR DESCRIPTION
The docstring states:

> Functions can return False if they should not be called any more.

Cleanup commit 2f11dee changed this logic so any return value whose boolean interpretation is False (e.g. None) would be unregistered.

This restores the logic to check only for explicit False (not None, not 0, etc.).

fixes #1492
