### PR TITLE
Added sphinx documentation for Triangulation

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -40,5 +40,6 @@
    spines_api.rst
    ticker_api.rst
    tight_layout_api.rst
+   tri_api.rst
    units_api.rst
    widgets_api.rst

--- a/doc/api/tri_api.rst
+++ b/doc/api/tri_api.rst
@@ -1,0 +1,10 @@
+****************
+triangular grids
+****************
+
+:mod:`matplotlib.tri`
+=====================
+
+.. automodule:: matplotlib.tri
+   :members: Triangulation
+

--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -37,27 +37,6 @@ class Triangulation(object):
         triangles[i,(j+1)%3].
     """
     def __init__(self, x, y, triangles=None, mask=None):
-        """
-        Create a Triangulation object.
-
-        The first two arguments must be:
-
-        *x*, *y*: arrays of shape (npoints).
-          Point coordinates.
-
-        Optional arguments (args or keyword args):
-
-        *triangles*: integer array of shape (ntri,3).
-          For each triangle, the indices of the three points that make
-          up the triangle.  If the points are ordered in a clockwise
-          manner, they are converted to anticlockwise.
-
-          If not specified, matplotlib.delaunay is used to create a
-          Delaunay triangulation of the points.
-
-        *mask*: optional boolean array of shape (ntri).
-          Which triangles are masked out.
-        """
         self.x = np.asarray(x, dtype=np.float64)
         self.y = np.asarray(y, dtype=np.float64)
         if self.x.shape != self.y.shape or len(self.x.shape) != 1:
@@ -106,10 +85,8 @@ class Triangulation(object):
         return self._edges
 
     def get_cpp_triangulation(self):
-        """
-        Return the underlying C++ Triangulation object, creating it
-        if necessary.
-        """
+        # Return the underlying C++ Triangulation object, creating it
+        # if necessary.
         if self._cpp_triangulation is None:
             self._cpp_triangulation = _tri.Triangulation(
                 self.x, self.y, self.triangles, self.mask, self._edges,

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -102,7 +102,7 @@ class TriContourSet(ContourSet):
 
           tricontour(triangulation, ...)
 
-        where triangulation is a :class:`~matplotlib.tri.Triangulation`
+        where triangulation is a :class:`matplotlib.tri.Triangulation`
         object, or
 
         ::

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -12,7 +12,7 @@ def tripcolor(ax, *args, **kwargs):
 
       tripcolor(triangulation, ...)
 
-    where triangulation is a :class:`~matplotlib.tri.Triangulation`
+    where triangulation is a :class:`matplotlib.tri.Triangulation`
     object, or
 
     ::

--- a/lib/matplotlib/tri/triplot.py
+++ b/lib/matplotlib/tri/triplot.py
@@ -14,7 +14,7 @@ def triplot(ax, *args, **kwargs):
 
       triplot(triangulation, ...)
 
-    where triangulation is a :class:`~matplotlib.tri.Triangulation`
+    where triangulation is a :class:`matplotlib.tri.Triangulation`
     object, or
 
     ::


### PR DESCRIPTION
Class matplotlib.tri.Triangulation was not in the sphinx documentation.  This PR adds a page to the API documentation containing the class.
