### PR TITLE
DOC: 'inout' option for tick_params direction

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -2334,8 +2334,8 @@ class Axes(martist.Artist):
         *which* : ['major' | 'minor' | 'both']
             Default is 'major'; apply arguments to *which* ticks.
 
-        *direction* : ['in' | 'out']
-            Puts ticks inside or outside the axes.
+        *direction* : ['in' | 'out' | 'inout']
+            Puts ticks inside the axes, outside the axes, or both.
 
         *length*
             Tick length in points.


### PR DESCRIPTION
Thanks to Mike Kaufman for reporting it to mpl-devel list.

I would have just pushed this to the branch myself, but as I'm still not totally clear in my head about the dev cycle, I decided to make a PR instead.
