### PR TITLE
DOC: make example cursor show up in the docs

### DIFF
--- a/examples/widgets/cursor.py
+++ b/examples/widgets/cursor.py
@@ -16,4 +16,9 @@ ax.set_ylim(-2, 2)
 # set useblit = True on gtkagg for enhanced performance
 cursor = Cursor(ax, useblit=True, color='red', linewidth=2 )
 
+# The next two lines are here just to "simulate" for what the cursor will look
+# like for the gallery, because the documentation is generated without a GUI
+ax.axvline(.3, 0, 1, color='red', linewidth=2)
+ax.axhline(.14, 0, 1, color='red', linewidth=2)
+
 plt.show()


### PR DESCRIPTION
As can be seen over in [our gallery](http://matplotlib.org/gallery.html#widgets), the cursor widget does not get displayed in the generated image, since documentation images get generated without a GUI backend. 

I've modified that example so that the image the gets generated actually will have a red cursor, by "injecting" a fake GUI event.

This is a documentation only update, but wanted to get feedback if people think this is ok. I just think that visually, it makes it much easier to find this example or see what it might be doing with my proposed change.

_edit_ hang on, I'm not sure this actually works for the generated examples...
