### PR TITLE
set_cmap should not require an active image

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2012-11-16 plt.set_cmap no longer throws errors if there is not already
+           an active colorable artist, such as an image, and just sets
+           up the colormap to use from that point forward. - PI
+
 2012-11-13 Add a symmetric log normalization class to colors.py.
            Also added some tests for the normalization class.
            Till Stensitzki

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2027,8 +2027,6 @@ def set_cmap(cmap):
 
     if im is not None:
         im.set_cmap(cmap)
-    else:
-        raise RuntimeError('You must first define an image, eg with imshow')
 
     draw_if_interactive()
 


### PR DESCRIPTION
Before this commit, it was not possible to change the default colormap if there
wasn't an active colorable artist, i.e. if plt.gci() returned None.

There's no reason why we should force this, though, since part of what
plt.set_cmap does is setting the default colormap for all FUTURE colorable
artists which will be created.

Colormaps which are currently exposed as their own functions in pyplot, such as
plt.gray(), plt.hsv(), plt.hot() and plt.jet() make no such restriction, they
do not complain if plt.gci() happens to return None.

Prior to this commit

```
In [2]: plt.set_cmap('bwr')
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-fa42f8679abe> in <module>()
----> 1 plt.set_cmap('bwr')

/home/pi/.local/lib/python2.7/site-packages/matplotlib/pyplot.pyc in set_cmap(cmap)
   2029         im.set_cmap(cmap)
   2030     else:
-> 2031         raise RuntimeError('You must first define an image, eg with imshow')
   2032
   2033     draw_if_interactive()

RuntimeError: You must first define an image, eg with imshow

In [3]:
```

After this commit, no error is thrown, and the appropriate colormap is activated.

```
In [2]: plt.set_cmap('bwr')

In [3]:
```
