### PR TITLE
DOC: github ribbon does not cover up index link

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -32,16 +32,16 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
 <!-- End Piwik Tag -->
 <link rel="shortcut icon" href="_static/favicon.ico">
 
+<!-- The "Fork me on github" ribbon -->
+<img style="float: right; margin-bottom: -40px; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" usemap="#ribbonmap"/>
+<map name="ribbonmap">
+    <area shape="poly" coords="15,0,148,-1,148,135" href="https://github.com/matplotlib/matplotlib" title="Fork me on GitHub" />
+</map>
+
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">
 <a href="{{ pathto('index') }}"><img src="{{
 pathto("_static/logo2.png", 1) }}" border="0" alt="matplotlib"/></a>
 </div>
-
-<!-- The "Fork me on github" ribbon -->
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" usemap="#ribbonmap"/>
-<map name="ribbonmap">
-    <area shape="poly" coords="20,2,148,-1,148,135" href="https://github.com/matplotlib/matplotlib" alt="Fork me on GitHub" />
-</map>
 
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
thanks to @jenshnielsen for spotting the fact that the previous "solution"
didn't actually work as intended in #1474. This PR fixes the issue of the ribbon covering up links under it.

Before this commit, hovering over the word "index" did not activate the link, and the ribbon looked like this:
![](http://i.imgur.com/8W4X5.png)

Now, the ribbon has moved, and hovering over "index" works as intended.
![](http://i.imgur.com/R7Vi3.png)

Also, I've given a title to the GitHub ribbon link, so hovering over it also displays a little tooltip, like so
![](http://i.imgur.com/GzUSw.png)
