### PR TITLE
Remove unnecessary clip cairo

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -163,11 +163,9 @@ class RendererCairo(RendererBase):
         surface = cairo.ImageSurface.create_for_data (
                       buf, cairo.FORMAT_ARGB32, cols, rows, cols*4)
         ctx = gc.ctx
-        ctx.save()
         y = self.height - y - rows
         ctx.set_source_surface (surface, x, y)
         ctx.paint()
-        ctx.restore()
 
         im.flipud_out()
 


### PR DESCRIPTION
When the draw_image function was simplified, the cairo backend was not updated.
Specifically, it's not necessary to perform clipping separately -- this has already been done when draw_image is being called.
