### PR TITLE
fix rendering slowdown with big invisible lines (issue #1256)

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1097,6 +1097,7 @@ default_test_modules = [
     'matplotlib.tests.test_figure',
     'matplotlib.tests.test_image',
     'matplotlib.tests.test_legend',
+    'matplotlib.tests.test_lines',
     'matplotlib.tests.test_mathtext',
     'matplotlib.tests.test_mlab',
     'matplotlib.tests.test_patches',

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -484,6 +484,9 @@ class Line2D(Artist):
 
     @allow_rasterization
     def draw(self, renderer):
+        """draw the Line with `renderer` unless visiblity is False"""
+        if not self.get_visible(): return
+
         if self._invalidy or self._invalidx:
             self.recache()
         self.ind_offset = 0  # Needed for contains() method.
@@ -497,8 +500,6 @@ class Line2D(Artist):
             self._transform_path(subslice)
 
         transformed_path = self._get_transformed_path()
-
-        if not self.get_visible(): return
 
         renderer.open_group('line2d', self.get_gid())
         gc = renderer.new_gc()

--- a/lib/matplotlib/tests/README
+++ b/lib/matplotlib/tests/README
@@ -1,0 +1,9 @@
+About Matplotlib Testing Infrastructure
+---------------------------------------
+
+Information on the testing infrastructure is provided in
+the Testing section of the Matplotlib Developers’ Guide:
+
+* http://matplotlib.org/devel/testing.html
+* <mpl_source_dir>/doc/devel/coding_guide.rst (equivalent, but in reST format)
+

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -1,0 +1,53 @@
+"""
+Tests specific to the lines module.
+"""
+
+from nose.tools import assert_true
+from timeit import repeat
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import cleanup
+
+@cleanup
+def test_invisible_Line_rendering():
+    """
+    Github issue #1256 identified a bug in Line.draw method
+    
+    Despite visibility attribute set to False, the draw method was not
+    returning early enough and some pre-rendering code was executed
+    though not necessary.
+
+    Consequence was an excessive draw time for invisible Line instances
+    holding a large number of points (Npts> 10**6)
+    """
+    # Creates big x and y data:
+    N = 10**7
+    x = np.linspace(0,1,N)
+    y = np.random.normal(size=N)
+
+    # Create a plot figure:
+    fig = plt.figure()
+    ax = plt.subplot(111)
+
+    # Create a "big" Line instance:
+    l = mpl.lines.Line2D(x,y)
+    l.set_visible(False)
+    # but don't add it to the Axis instance `ax`
+
+    # [here Interactive panning and zooming is pretty responsive]
+    # Time the canvas drawing:
+    t_no_line = min(repeat(fig.canvas.draw, number=1, repeat=3))
+    # (gives about 25 ms)
+
+    # Add the big invisible Line:
+    ax.add_line(l)
+
+    # [Now interactive panning and zooming is very slow]
+    # Time the canvas drawing:
+    t_unvisible_line = min(repeat(fig.canvas.draw, number=1, repeat=3))
+    # gives about 290 ms for N = 10**7 pts
+
+    slowdown_factor = (t_unvisible_line/t_no_line)
+    slowdown_threshold = 2 # trying to avoid false positive failures
+    assert_true(slowdown_factor < slowdown_threshold)


### PR DESCRIPTION
tiny change in `Line2D.draw` to return immediately if the line is not visible.
This avoids annoying rendering slowdown with _big_ Line2D objects (say  lines holding about 10**7 points)
