### PR TITLE
ENH: raise a more informative error

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -660,7 +660,7 @@ class Animation(object):
 
                 try:
                     writer = writers.list()[0]
-                except:
+                except IndexError:
                     raise ValueError("Cannot save animation: no writers are "
                                      "available. Please install mencoder or "
                                      "ffmpeg to save animations.")


### PR DESCRIPTION
Raise a more informative error when `save` is called and no animation writers are available on the system.  Previously this situation would lead to an `IndexError` at the line `writer = writers.list()[0]`
