### PR TITLE
CXX/Python2/cxx_extensions.cxx:1320: Assertion `ob_refcnt == 0'

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -852,28 +852,24 @@ FT2Font::FT2Font(Py::PythonClassInstance *self, Py::Tuple &args, Py::Dict &kwds)
     {
         std::ostringstream s;
         s << "Could not load facefile " << facefile << "; Unknown_File_Format" << std::endl;
-        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
     else if (error == FT_Err_Cannot_Open_Resource)
     {
         std::ostringstream s;
         s << "Could not open facefile " << facefile << "; Cannot_Open_Resource" << std::endl;
-        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
     else if (error == FT_Err_Invalid_File_Format)
     {
         std::ostringstream s;
         s << "Could not open facefile " << facefile << "; Invalid_File_Format" << std::endl;
-        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
     else if (error)
     {
         std::ostringstream s;
         s << "Could not open facefile " << facefile << "; freetype error code " << error << std::endl;
-        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
 
@@ -891,7 +887,6 @@ FT2Font::FT2Font(Py::PythonClassInstance *self, Py::Tuple &args, Py::Dict &kwds)
     {
         std::ostringstream s;
         s << "Could not set the fontsize for facefile  " << facefile << std::endl;
-        ob_refcnt--;
         throw Py::RuntimeError(s.str());
     }
 


### PR DESCRIPTION
In your recent version matplotlib-1.2.0, you appear to have an issue with the file CXX/Python2/cxx_extensions.cxx.  The testsuite is massive and it's currently stopped in its tracks by the above.  Comment out the line make_set('mathfont', 'cm', font_tests, ['png']) in matplotlib/tests/test_mathtext.py and the massive testsuite completes fine.

python2.7: CXX/Python2/cxx_extensions.cxx:1320: virtual Py::PythonExtensionBase::~PythonExtensionBase(): Assertion `ob_refcnt == 0' failed.  
Building HTML failed.

See here it's called in the building of the docs and it also fails.  Why you have an in source version of CXX for pycxx rather than use a system installed version I don't know,. but the one you have has this deficit. 

CXX/Python2/cxx_extensions.cxx:1320:

You even have the line number

libpng         version  1.2.50
stix-fonts    version    1.0.0
ipython       version     0.13
Python       version     2.7.3, 3.2.3
