### PR TITLE
Changed mailinglist archive link.

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -138,7 +138,7 @@ var req = false;
 
 <p>Check the <a href="{{ pathto('faq/index') }}">faq</a>,
 the <a href="{{ pathto('api/index') }}">api</a> docs,
-<a href="http://sourceforge.net/mailarchive/forum.php?forum_name=matplotlib-users">mailing
+<a href="http://matplotlib.1069221.n5.nabble.com/matplotlib-users-f3.html">mailing
 list archives</a>, and join the matplotlib
 mailing <a href="http://sourceforge.net/mail/?group_id=80706">lists</a>.
 Check out the matplotlib questions

--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -68,8 +68,7 @@ Getting help
 There are a number of good resources for getting help with matplotlib.
 There is a good chance your question has already been asked:
 
-  - The `mailing list archive
-    <http://sourceforge.net/search/?group_id=80706&type_of_search=mlists>`_.
+  - The `mailing list archive <http://matplotlib.1069221.n5.nabble.com/>`_.
 
   - `Github issues <https://github.com/matplotlib/matplotlib/issues>`_.
 


### PR DESCRIPTION
Not a like for like change, but allows users to see the recent mailing list archive rather than pointing to the (seemingly) broken sourceforge one.
