### PR TITLE
Quiver crashes if given matrices

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -459,8 +459,8 @@ class Quiver(collections.PolyCollection):
         collections.PolyCollection.draw(self, renderer)
 
     def set_UVC(self, U, V, C=None):
-        U = ma.masked_invalid(U, copy=False).ravel()
-        V = ma.masked_invalid(V, copy=False).ravel()
+        U = ma.masked_invalid(np.asarray(U), copy=False).ravel()
+        V = ma.masked_invalid(np.asarray(V), copy=False).ravel()
         mask = ma.mask_or(U.mask, V.mask, copy=False, shrink=True)
         if C is not None:
             C = ma.masked_invalid(C, copy=False).ravel()


### PR DESCRIPTION
As it is now, quiver() fails if you give it numpy.matrix objects, as this simple example shows:

```
>>> quiver(np.matrix(np.ones((32, 32))), np.matrix(np.ones((32, 32))))
```

It does so because it runs ravel() on the input, which if the input is a matrix gives a row matrix of shape (N, 1), instead of an array of shape (N,), which is what quiver expects in further calculations.

This pull request fixes this problem by running the input through np.asarray() before ravel() is called.
