### PR TITLE
Geo projections getting clobbered by 2to3 when used when python3

### DIFF
--- a/examples/api/custom_projection_example.py
+++ b/examples/api/custom_projection_example.py
@@ -262,25 +262,25 @@ class HammerAxes(Axes):
         Axes.set_ylim(self, -np.pi / 2.0, np.pi / 2.0)
     set_ylim = set_xlim
 
-    def format_coord(self, long, lat):
+    def format_coord(self, lon, lat):
         """
         Override this method to change how the values are displayed in
         the status bar.
 
         In this case, we want them to be displayed in degrees N/S/E/W.
         """
-        long = long * (180.0 / np.pi)
+        lon = lon * (180.0 / np.pi)
         lat = lat * (180.0 / np.pi)
         if lat >= 0.0:
             ns = 'N'
         else:
             ns = 'S'
-        if long >= 0.0:
+        if lon >= 0.0:
             ew = 'E'
         else:
             ew = 'W'
         # \u00b0 : degree symbol
-        return '%f\u00b0%s, %f\u00b0%s' % (abs(lat), ns, abs(long), ew)
+        return '%f\u00b0%s, %f\u00b0%s' % (abs(lat), ns, abs(lon), ew)
 
     class DegreeFormatter(Formatter):
         """

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -163,19 +163,19 @@ class GeoAxes(Axes):
 
     set_ylim = set_xlim
 
-    def format_coord(self, long, lat):
+    def format_coord(self, lon, lat):
         'return a format string formatting the coordinate'
-        long = long * (180.0 / np.pi)
+        lon = lon * (180.0 / np.pi)
         lat = lat * (180.0 / np.pi)
         if lat >= 0.0:
             ns = 'N'
         else:
             ns = 'S'
-        if long >= 0.0:
+        if lon >= 0.0:
             ew = 'E'
         else:
             ew = 'W'
-        return u'%f\u00b0%s, %f\u00b0%s' % (abs(lat), ns, abs(long), ew)
+        return u'%f\u00b0%s, %f\u00b0%s' % (abs(lat), ns, abs(lon), ew)
 
     def set_longitude_grid(self, degrees):
         """
@@ -576,10 +576,10 @@ class LambertAxes(GeoAxes):
 
             lat = np.arcsin(cos_c*np.sin(clat) +
                              ((y*sin_c*np.cos(clat)) / p))
-            long = clong + np.arctan(
+            lon = clong + np.arctan(
                 (x*sin_c) / (p*np.cos(clat)*cos_c - y*np.sin(clat)*sin_c))
 
-            return np.concatenate((long, lat), 1)
+            return np.concatenate((lon, lat), 1)
         transform_non_affine.__doc__ = Transform.transform_non_affine.__doc__
 
         def inverted(self):


### PR DESCRIPTION
`projections/geo.py` uses `long` as a variable name in many places.  This is replaced with `int` by 2to3, which leads to problems (e.g. `foo = int * bar` instead of `foo = long * bar`).

Steps to reproduce:
1. Install matplotlib with python3.x
2. Run `examples/api/custom_projection_example.py`
3. Mouse over the plot (or anything else that will call an inverse geo projection)
