### PR TITLE
Workaround for QT cursor bug in dock areas

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -603,7 +603,7 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
 
     def set_cursor( self, cursor ):
         if DEBUG: print('Set cursor' , cursor)
-        self.canvas.window().setCursor(cursord[cursor])
+        self.canvas.setCursor(cursord[cursor])
 
     def draw_rubberband( self, event, x0, y0, x1, y1 ):
         height = self.canvas.figure.bbox.height


### PR DESCRIPTION
Someone pointed out to me that the change in https://github.com/matplotlib/matplotlib/issues/1433 doesn't work when plots are embedded within QDockAreas (the cursor never changes). This is probably related to the Qt bug discussed [here](https://bugreports.qt-project.org/browse/QTBUG-4190). 

To reproduce the issue, under MPL 1.2.0: https://gist.github.com/4208745

This PR sets the cursor at a different level in the widget hierarchy, and seems to sidestep the problem.  

Note that I haven't checked whether this change breaks the original problem addressed by https://github.com/matplotlib/matplotlib/pull/1404
