### PR TITLE
Remove python2.5 support from texmanager.py

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -43,10 +43,7 @@ import shutil
 import sys
 from subprocess import Popen, PIPE, STDOUT
 
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5  # Deprecated in 2.5
+from hashlib import md5
 
 import distutils.version
 import numpy as np


### PR DESCRIPTION
closes #1552

Very small PR to remove python2.5 support from texmanager.
