### PR TITLE
fix issue #1572 caused by PR #1081

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -585,8 +585,7 @@ class Text(Artist):
                 if self.get_path_effects():
                     for path_effect in self.get_path_effects():
                         path_effect.draw_tex(renderer, gc, x, y, clean_line,
-                                             self._fontproperties, angle,
-                                             mtext=self)
+                                             self._fontproperties, angle)
                 else:
                     renderer.draw_tex(gc, x, y, clean_line,
                                       self._fontproperties, angle, mtext=self)
@@ -605,7 +604,7 @@ class Text(Artist):
                     for path_effect in self.get_path_effects():
                         path_effect.draw_text(renderer, gc, x, y, clean_line,
                                               self._fontproperties, angle,
-                                              ismath=ismath, mtext=self)
+                                              ismath=ismath)
                 else:
                     renderer.draw_text(gc, x, y, clean_line,
                                        self._fontproperties, angle,


### PR DESCRIPTION
Addressing issue #1572. The new mtext parameter introduced by #1081 should be applied to a draw_text method of a backend, not to a PathEffect (yet?).

@dopplershift Does this fix the error you are seeing? Seems to work for me now.
