### PR TITLE
Fix Qt canvas resize_event

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -289,15 +289,17 @@ class FigureCanvasQT( QtGui.QWidget, FigureCanvasBase ):
         FigureCanvasBase.key_release_event( self, key )
         if DEBUG: print('key release', key)
 
-    def resizeEvent( self, event ):
-        if DEBUG: print('resize (%d x %d)' % (event.size().width(), event.size().height()))
+    def resizeEvent(self, event):
         w = event.size().width()
         h = event.size().height()
-        if DEBUG: print("FigureCanvasQtAgg.resizeEvent(", w, ",", h, ")")
+        if DEBUG:
+            print('resize (%d x %d)' % (w, h))
+            print("FigureCanvasQt.resizeEvent(%d, %d)" % (w, h))
         dpival = self.figure.dpi
         winch = w/dpival
         hinch = h/dpival
         self.figure.set_size_inches( winch, hinch )
+        FigureCanvasBase.resize_event(self)
         self.draw()
         self.update()
         QtGui.QWidget.resizeEvent(self, event)


### PR DESCRIPTION
The Qt backend doesn't fire `resize_event` when resizing so callbacks connected to the event never get called. The following example should print when the figure is resized:

``` python
import matplotlib as mpl
mpl.use('Qt4Agg')
import matplotlib.pyplot as plt

def printer(event):
    print('callback')

fig = plt.figure()
fig.canvas.mpl_connect('resize_event', printer)
plt.show()
```

This PR just adds a call to `resize_event`.  (Some slight refactoring also wandered into the commit.)
