### PR TITLE
Mac OS X 10.5 needs an autoreleasepool here to avoid memory leaks. Newer...

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5693,12 +5693,14 @@ show(PyObject* self)
     if(nwin > 0)
     {
         [NSApp activateIgnoringOtherApps: YES];
+        NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
         NSArray *windowsArray = [NSApp windows];
         NSEnumerator *enumerator = [windowsArray objectEnumerator];
         NSWindow *window;
         while ((window = [enumerator nextObject])) {
             [window orderFront:nil];
         }
+        [pool release];
         [NSApp run];
     }
     Py_INCREF(Py_None);


### PR DESCRIPTION
... versions of Mac OS X do not, but it doesn't hurt to have one anyway. Without the autorelease pool, on Mac OS X 10.5 show() leaks memory and the OS prints error messages.
