### PR TITLE
Crash with text.usetex=True and plt.annotate

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -524,7 +524,7 @@ class Text(Artist):
         if renderer is not None:
             self._renderer = renderer
         if not self.get_visible(): return
-        if self.get_text()=='': return
+        if self.get_text().strip() == '': return
 
         renderer.open_group('text', self.get_gid())
 
@@ -1898,7 +1898,7 @@ class Annotation(Text, _AnnotationBase):
                         props = props.copy() # don't want to alter the pad externally
                         pad = props.pop('pad', 4)
                         pad = renderer.points_to_pixels(pad)
-                        if self.get_text() == "":
+                        if self.get_text().strip() == "":
                             self.arrow_patch.set_patchA(None)
                             return
 


### PR DESCRIPTION
The following minimal example causes a crash on the current master:

``` python
import matplotlib
import matplotlib.pyplot as plt

matplotlib.rcParams['text.usetex'] = True
plt.annotate(" ", (0, 0), (1, 0), arrowprops=dict(arrowstyle='->'))

plt.show()
```

If `" "` is changed to `""` (an empty string) or if the `arrowprops` argument is removed, then the crash doesn't happen.  Here is the traceback:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1413, in __call__
    return self.func(*args)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/backends/backend_tkagg.py", line 276, in resize
    self.show()
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/backends/backend_tkagg.py", line 348, in draw
    FigureCanvasAgg.draw(self)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/backends/backend_agg.py", line 439, in draw
    self.figure.draw(self.renderer)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/figure.py", line 999, in draw
    func(*args)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/axes.py", line 2093, in draw
    a.draw(renderer)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/text.py", line 2031, in draw
    self.arrow_patch.draw(renderer)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/patches.py", line 4001, in draw
    path, fillable = self.get_path_in_displaycoord()
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/patches.py", line 3949, in get_path_in_displaycoord
    shrinkB=self.shrinkB * dpi_cor
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/patches.py", line 2507, in __call__
    clipped_path = self._clip(path, patchA, patchB)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/patches.py", line 2452, in _clip
    left, right = split_path_inout(path, insideA)
  File "/home/vanderplas/PythonEnv/pydev/local/lib/python2.7/site-packages/matplotlib/bezier.py", line 242, in split_path_inout
    ctl_points, command = next(path_iter)
StopIteration
```

I'm running ubuntu with python 2.7.3, and the following:

```
>>> matplotlib.__version__
'1.3.x'
>>> matplotlib.rcParams['backend']
'TkAgg'
```

I've seen the crash also using Agg.
