### PR TITLE
Fix shifted ylabels (Issue #1571)

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1887,10 +1887,12 @@ class YAxis(Axis):
         ACCEPTS: [ 'left' | 'right' ]
         """
         assert position == 'left' or position == 'right'
-        if position == 'right':
-            self.label.set_horizontalalignment('left')
+        self.label.set_rotation_mode('anchor')
+        self.label.set_horizontalalignment('center')
+        if position == 'left':
+            self.label.set_verticalalignment('bottom')
         else:
-            self.label.set_horizontalalignment('right')
+            self.label.set_verticalalignment('top')
         self.label_position = position
 
     def _update_label_position(self, bboxes, bboxes2):


### PR DESCRIPTION
Account for rotation mode when setting axis label position. This is used, for instance, when setting labels on colorbars.
