### PR TITLE
Image being snapped erroneously

### DIFF
--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -442,9 +442,9 @@ RendererAgg::set_clipbox(const Py::Object& cliprect, R& rasterizer)
     if (py_convert_bbox(cliprect.ptr(), l, b, r, t))
     {
         rasterizer.clip_box(std::max(int(floor(l - 0.5)), 0),
-                            std::max(int(floor(height - b - 0.5)), 0),
-                            std::min(int(floor(r - 0.5)), int(width)),
-                            std::min(int(floor(height - t - 0.5)), int(height)));
+                            std::max(int(height - floor(b - 0.5)), 0),
+                            std::min(int(ceil(r + 0.5)), int(width)),
+                            std::min(int(height - ceil(t + 0.5)), int(height)));
     }
     else
     {


### PR DESCRIPTION
Since 1262326c00074fb497816242c9aa0e7787bd5cda implemented by @mdboom the following example results in a figure which has a 1 pixel border around left and bottom edges in the resultant image:

```
import matplotlib.pyplot as plt
import matplotlib

import numpy


if __name__ == '__main__':
    print matplotlib.__version__

    f = plt.figure(figsize=[1, 1])
    ax = plt.axes([0, 0, 1, 1],
                  frameon=False,
                  )

    data = numpy.tile(numpy.arange(12), 15).reshape(20, 9)

    im = ax.imshow(data, origin='upper',
                   extent=[-10, 10, -10, 10], interpolation='none',
                   cmap='gray'
                   )

    x = y = 2
    ax.set_xlim([-x, x])
    ax.set_ylim([-y, y])

    ax.set_xticks([])
    ax.set_yticks([])

    fname = 'test.png'
    plt.savefig(fname, facecolor=(0, 1, 0))
    plt.close()

    im = plt.imread(fname)
    r, g, b, a = sum(im[:, 0])
    print 'Left edge: ', r, g, b, a
    r, g, b, a = sum(im[:, -1])

    print 'Right edge:' , r, g, b, a
    assert g != 100, 'Expected a non-green edge - but sadly, it was.'
```

![output](https://f.cloud.github.com/assets/810663/7907/0df5563e-444f-11e2-9128-5d91ace95c33.png)

Notice the green 1px border on the bottom and right of the output.

The problem is limited to the Agg backend and the "none" image interpolation scheme.

With a bit of refinement, this example should be turned into a test once we have a fix for this.
