### PR TITLE
Fix a syntax error in examples (movie_demo.py)

### DIFF
--- a/examples/animation/old_animation/movie_demo.py
+++ b/examples/animation/old_animation/movie_demo.py
@@ -49,7 +49,7 @@ except subprocess.CalledProcessError:
     # This is a quick and dirty check; it leaves some spurious output
     # for the user to puzzle over.
 except OSError:
-    print not_found_msg
+    print(not_found_msg)
     sys.exit("quitting\n")
 
 


### PR DESCRIPTION
This code no longer works in Python 2 or 3 due to the use of old-style print statement, with "`from __future__ import print_function`".
