### PR TITLE
ylim=0.0 is not well handled in polar plots

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -57,14 +57,10 @@ class PolarTransform(Transform):
         t *= theta_direction
         t += theta_offset
 
-        if rmin != 0:
-            r = r - rmin
-            mask = r < 0
-            x[:] = np.where(mask, np.nan, r * np.cos(t))
-            y[:] = np.where(mask, np.nan, r * np.sin(t))
-        else:
-            x[:] = r * np.cos(t)
-            y[:] = r * np.sin(t)
+        r = r - rmin
+        mask = r < 0
+        x[:] = np.where(mask, np.nan, r * np.cos(t))
+        y[:] = np.where(mask, np.nan, r * np.sin(t))
 
         return xy
     transform_non_affine.__doc__ = Transform.transform_non_affine.__doc__
@@ -779,4 +775,3 @@ PolarAxes.RadialLocator = RadialLocator
 #             result = self.transform(result)
 #             return mpath.Path(result, codes)
 #         transform_path_non_affine = transform_path
-


### PR DESCRIPTION
As you can see in the following source example, when set_xlim(0.0,5) is called, negatives values are still plotted in the polar plot. Whereas if set_xlim(0.01,5) or set_xlim(-0.01,5) are called, the drawing are as expected.

![ylim 0 issue](https://f.cloud.github.com/assets/3061902/16417/4fe8325c-4830-11e2-9cc5-f6686d63639a.png)

from matplotlib.pyplot import figure, show
import numpy as np

x = np.arange(0,1,0.001)
y = np.arange(-2.0,0.0, 0.002)
fig = figure()

ax = fig.add_subplot(131, polar=True)
ax.plot(x, y)
ax.set_ylim(bottom= 0.0, top=5)

ax = fig.add_subplot(132, polar=True)
ax.plot(x, y)
ax.set_ylim(bottom= 0.01, top=5)

ax = fig.add_subplot(133, polar=True)
ax.plot(x, y)
ax.set_ylim(bottom= -0.01, top=5)

fig.show()
raw_input()
