### PR TITLE
Using a stricter check to see if Python was installed as a framework.

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -231,13 +231,6 @@ def new_figure_manager(num, *args, **kwargs):
     """
     Create a new figure manager instance
     """
-    if not _macosx.verify_main_display():
-        import warnings
-        warnings.warn("Python is not installed as a framework. The MacOSX "
-                      "backend may not work correctly if Python is not "
-                      "installed as a framework. Please see the Python "
-                      "documentation for more information on installing "
-                      "Python as a framework on Mac OS X")
     FigureClass = kwargs.pop('FigureClass', Figure)
     figure = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, figure)


### PR DESCRIPTION
Using a stricter check to see if Python was installed as a framework. Also, because of the recurring problems with non-framework Pythons, importing the Mac OS X backend will now fail (instead of just issuing a warning) if Python is not installed as a framework. This patch uses the WITH_NEXT_FRAMEWORK macro in pyconfig.h to determine if Python is installed as a framework. This is safer than the previous approach using CGMainDisplayID().

This is a bug fix for issue 665 (https://github.com/matplotlib/matplotlib/issues/665).
