### PR TITLE
Legend: Also calc the bbox of the legend when the frame is not drawn. (1.2.x)

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -460,14 +460,14 @@ class Legend(Artist):
             pad = 2 * (self.borderaxespad + self.borderpad) * fontsize
             self._legend_box.set_width(self.get_bbox_to_anchor().width - pad)
 
+        # update the location and size of the legend. This needs to
+        # be done in any case to clip the figure right.
+        bbox = self._legend_box.get_window_extent(renderer)
+        self.legendPatch.set_bounds(bbox.x0, bbox.y0,
+                                    bbox.width, bbox.height)
+        self.legendPatch.set_mutation_scale(fontsize)
+
         if self._drawFrame:
-            # update the location and size of the legend
-            bbox = self._legend_box.get_window_extent(renderer)
-            self.legendPatch.set_bounds(bbox.x0, bbox.y0,
-                                        bbox.width, bbox.height)
-
-            self.legendPatch.set_mutation_scale(fontsize)
-
             if self.shadow:
                 shadow = Shadow(self.legendPatch, 2, -2)
                 shadow.draw(renderer)


### PR DESCRIPTION
This should fix #1586
