### PR TITLE
Fix bug in _AnnotationBase

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1544,7 +1544,7 @@ class _AnnotationBase(object):
             from matplotlib.transforms import Affine2D
             if unit == "points":
                 # dots per points
-                dpp = self.figure.get_dpi() / 12.
+                dpp = self.figure.get_dpi() / 72.
                 tr = Affine2D().scale(dpp, dpp)
             elif unit == "pixels":
                 tr = Affine2D()


### PR DESCRIPTION
Value of "72" switched to "12" in d5a1a3dd36f7daaf8b7e2ec5a73fa5fd4df3e026 (EDIT: here's a better link: https://github.com/matplotlib/matplotlib/commit/d5a1a3dd36f7daaf8b7e2ec5a73fa5fd4df3e026#L0R1547). As a result, one of  the annotation demos looks like this:

![annotate_bug](https://f.cloud.github.com/assets/133031/28646/782d9dda-4c6b-11e2-8b1b-5d75d5257b22.png)

instead of this:

![annotate_correct](https://f.cloud.github.com/assets/133031/28647/83463fe2-4c6b-11e2-83ac-db4078dd9109.png)
