### PR TITLE
A disconnected callback cannot be reconnected

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -323,9 +323,10 @@ class CallbackRegistry:
             except KeyError:
                 continue
             else:
-                for key, value in self._func_cid_map.items():
-                    if value == cid:
-                        del self._func_cid_map[key]
+                for category, functions in self._func_cid_map.items():
+                    for function, value in functions.items():
+                        if value == cid:
+                            del functions[function]
                 return
 
     def process(self, s, *args, **kwargs):


### PR DESCRIPTION
Consider the following example:

```
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
p = lambda event: print(event)
cid = fig.canvas.mpl_connect("button_press_event", p)
print("connection", cid)
if __debug__:
    print("disconnect, reconnect")
    fig.canvas.mpl_disconnect(cid)
    cid = fig.canvas.mpl_connect("button_press_event", p)
    print("connection", cid)
plt.show()
```

One would expect the callback to be connected whether `__debug__` is True or False, but in fact after the disconnection and reconnection, nothing happens anymore on button press.
