### PR TITLE
change cbook to relative import

### DIFF
--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -216,7 +216,7 @@ __end
 from __future__ import print_function
 import sys, warnings
 
-from .cbook import flatten, is_string_like, exception_to_str, \
+from matplotlib.cbook import flatten, is_string_like, exception_to_str, \
      silent_list, iterable, dedent
 
 from matplotlib import mpl  # pulls in most modules


### PR DESCRIPTION
In the current master, the following bug is present in python 3

```
 $ python3
Python 3.2.3 (default, Oct 19 2012, 20:10:41) 
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pylab
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.2/dist-packages/pylab.py", line 1, in <module>
    from matplotlib.pylab import *
  File "/usr/local/lib/python3.2/dist-packages/matplotlib/pylab.py", line 219, in <module>
    from cbook import flatten, is_string_like, exception_to_str, \
ImportError: No module named cbook
```

This PR changes `cbook` to a relative import, which works in both python 2.6+ and python 3+.
