### PR TITLE
Clean up code in cbook

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -28,7 +28,6 @@ import numpy as np
 import numpy.ma as ma
 
 
-
 import types
 
 
@@ -77,7 +76,7 @@ else:
             return unicode(s, preferredencoding)
 
 
-class converter:
+class converter(object):
     """
     Base class for handling string -> python type with support for
     missing values
@@ -580,7 +579,8 @@ def get_sample_data(fname, asfileobj=True):
     if matplotlib.rcParams['examples.directory']:
         root = matplotlib.rcParams['examples.directory']
     else:
-        root = os.path.join(os.path.dirname(__file__), "mpl-data", "sample_data")
+        root = os.path.join(os.path.dirname(__file__),
+                            "mpl-data", "sample_data")
     path = os.path.join(root, fname)
 
     if asfileobj:
@@ -830,7 +830,6 @@ class RingBuffer:
         if len(self.data) == self.max:
             self.cur = 0
             # Permanently change self's class from non-full to full
-            # FIXME __Full is not defined
             self.__class__ = __Full
 
     def get(self):
@@ -1820,11 +1819,3 @@ if hasattr(subprocess, 'check_output'):
     check_output = subprocess.check_output
 else:
     check_output = _check_output
-
-
-if __name__ == '__main__':
-    assert(allequal([1, 1, 1]))
-    assert(not allequal([1, 1, 0]))
-    assert(allequal([]))
-    assert(allequal(('a', 'a')))
-    assert(not allequal(('a', 'b')))

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -78,3 +78,9 @@ class Test_delete_masked_points:
         assert_array_equal(actual[1], expected[1])
 
 
+def test_allequal():
+    assert(cbook.allequal([1, 1, 1]))
+    assert(not cbook.allequal([1, 1, 0]))
+    assert(cbook.allequal([]))
+    assert(cbook.allequal(('a', 'a')))
+    assert(not cbook.allequal(('a', 'b')))


### PR DESCRIPTION
In this PR, I removed deprecated methods from 0.98.x - I moved some code to the tests, and I properly deprecated some methods (with a deprecation warning, and the release of removal).

This is a first PR before deprecating the module from the public interface.
