### PR TITLE
add get_segments method to collections.LineCollection - updated

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1008,6 +1008,19 @@ class LineCollection(Collection):
     set_verts = set_segments  # for compatibility with PolyCollection
     set_paths = set_segments
 
+    def get_segments(self):
+        _segments = []
+
+        for path in self._paths:
+            _vertices = [vertex for vertex, _ in path.iter_segments()]
+            _vertices = np.asarray(_vertices)
+            _segments.append(_vertices)
+
+        return _segments
+
+    get_verts = get_segments
+    get_paths = get_segments
+
     def _add_offsets(self, segs):
         offsets = self._uniform_offsets
         Nsegs = len(segs)


### PR DESCRIPTION
collections.LineCollection has a set_segments method that lets you set the vertices of the line segments in the collection.  However, it has no corresponding get_segments method.  This adds the method.
