### PR TITLE
Ignore kdevelop4 project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *~
 *$
 *.bak
+*.kdev4
 .project
 .pydevproject
 


### PR DESCRIPTION
The kdevelop4 IDE now has pretty complete support for python files and python-based projects.  Add those files to the .gitignore list so they are not pushed to upstream.
