### PR TITLE
added explicit 'zorder' kwarg to `Colection` and `LineCollection`.

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -965,7 +965,7 @@ class LineCollection(Collection):
         The default is 5 pt.
 
         *zorder*
-           2 the zorder of the LineCollection
+           The zorder of the LineCollection.  Default is 2
 
         The use of :class:`~matplotlib.cm.ScalarMappable` is optional.
         If the :class:`~matplotlib.cm.ScalarMappable` array


### PR DESCRIPTION
Vaguely related to issue  #1622.  Changed the location of the default zorder of Collection and LineCollection from a class level-member, to explicitly being a keyword argument. 

I think this makes it clearer, but isn't strictly necessary, because if zorder is included as a kwarg, it will get set by the `self.update` anyway.
