### PR TITLE
add get_segments method to collections.LineCollection

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1008,6 +1008,16 @@ class LineCollection(Collection):
     set_verts = set_segments  # for compatibility with PolyCollection
     set_paths = set_segments
 
+    def get_segments(self):
+        segments = []
+
+        for path in self._paths:
+            vertices = [vertex for vertex, _ in path.iter_segments()]
+            vertices = np.asarray(vertices)
+            segments.append(vertices)
+
+        return segments
+
     def _add_offsets(self, segs):
         offsets = self._uniform_offsets
         Nsegs = len(segs)


### PR DESCRIPTION
collections.LineCollection has a set_segments method that lets you set the vertices of the line segments in the collection. However, it has no corresponding get_segments method. This adds the method.

This version implements the suggestions from pelson on the last version of this pull request.
