### PR TITLE
is_string_like existed both in matplotlib and matplotlib.cbook

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -195,7 +195,7 @@ del version
 
 def is_string_like(obj):
     """Return True if *obj* looks like a string"""
-    if isinstance(obj, (str, unicode)):
+    if isinstance(obj, basestring):
         return True
     # numpy strings are subclass of str, ma strings are not
     if ma.isMaskedArray(obj):

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -23,6 +23,8 @@ from weakref import ref, WeakKeyDictionary
 
 import matplotlib
 from matplotlib import MatplotlibDeprecationWarning as mplDeprecation
+
+# is_string_like has to be imported here for backward compatibility
 from matplotlib import is_string_like
 
 import numpy as np


### PR DESCRIPTION
This closes #1019.

`is_string_like` existed both in `matplotlib` and in `matplotlib.cbook`. The proposed fix was to remove  `is_string_like` from `cbook` and import the one from `matplotlib` in `cbook`. I'm somewhat unsatisfied with this solution, but backward compatibility is completely maintained, and it is better than what existed before (code duplication).
