### PR TITLE
Fix USE_FONTCONFIG=True mode

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -997,7 +997,10 @@ class FontManager:
         self.afmfiles = findSystemFonts(paths, fontext='afm') + \
             findSystemFonts(fontext='afm')
         self.afmlist = createFontList(self.afmfiles, fontext='afm')
-        self.defaultFont['afm'] = self.afmfiles[0]
+        if len(self.afmfiles):
+            self.defaultFont['afm'] = self.afmfiles[0]
+        else:
+            self.defaultFont['afm'] = None
 
         self.ttf_lookup_cache = {}
         self.afm_lookup_cache = {}


### PR DESCRIPTION
A simple bugfix for a problem found when switching on USE_FONTCONFIG.  Reported by Paulo César Pereira de Andrade on matplotlib-devel
