### PR TITLE
Nuke Travis python 3.1 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.1
   - 3.2
 
 install:
@@ -11,7 +10,7 @@ install:
   # This is a workaround to install numpy with the version of
   # virtualenv in Travis.  If that is updated in the future, this can
   # be simplified to 'pip install numpy'
-  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ] || [ $TRAVIS_PYTHON_VERSION == "3.1" ]; then pip install https://github.com/y-p/numpy/archive/1.6.2_with_travis_fix.tar.gz; fi'
+  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then pip install https://github.com/y-p/numpy/archive/1.6.2_with_travis_fix.tar.gz; fi'
   - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install numpy; fi' # should be nop if pre-installed
   - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then pip install --use-mirrors PIL; fi
   - python setup.py install


### PR DESCRIPTION
Python 3.1 is unsuported by Travis-ci [1](http://about.travis-ci.org/docs/user/ci-environment/#Python-VM-images), so this change removes it.
