### PR TITLE
added QtGui.QMainWindow.closeEvent() to make sure the close event

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -370,7 +370,7 @@ class FigureCanvasQT( QtGui.QWidget, FigureCanvasBase ):
 class MainWindow(QtGui.QMainWindow):
     def closeEvent(self, event):
         self.emit(QtCore.SIGNAL('closing()'))
-        QtGui.QMainWindow.closeEvent(self,event)
+        QtGui.QMainWindow.closeEvent(self, event)
 
 class FigureManagerQT( FigureManagerBase ):
     """


### PR DESCRIPTION
cascades closeEvents up properly.

issue #1676

I am not sure if there is a testable issue that shows up with out this patch, but this my understanding of good practice when over-riding functions in sub-classed QT classes.  

I will look for any issues that show up without this.
