### PR TITLE
Ignore lib/dateutil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ doc/examples
 doc/_templates/gallery.html
 doc/users/installing.rst
 doc/_static/matplotlibrc
+lib/dateutil


### PR DESCRIPTION
A symlink lib/dateutil is automatically generated.
