### PR TITLE
Enable to switch off the removal of comments in csv2rec.

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2109,7 +2109,7 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
       files is automatic, if the filename ends in '.gz'
 
     - *comments*: the character used to indicate the start of a comment
-      in the file, or None to switch off the removal of comments
+      in the file, or *None* to switch off the removal of comments
 
     - *skiprows*: is the number of rows from the top to skip
 
@@ -2274,7 +2274,7 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
     if needheader:
         for row in reader:
             #print 'csv2rec', row
-            if len(row) and comments != None and row[0].startswith(comments):
+            if len(row) and comments is not None and row[0].startswith(comments):
                 continue
             headers = row
             break
@@ -2317,7 +2317,7 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
         while 1:
             # skip past any comments and consume one line of column header
             row = next(reader)
-            if len(row) and comments != None and row[0].startswith(comments):
+            if len(row) and comments is not None and row[0].startswith(comments):
                 continue
             break
 
@@ -2326,8 +2326,10 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
     rows = []
     rowmasks = []
     for i, row in enumerate(reader):
-        if not len(row): continue
-        if comments != None and row[0].startswith(comments): continue
+        if not len(row):
+            continue
+        if comments is not None and row[0].startswith(comments):
+            continue
         # Ensure that the row returned always has the same nr of elements
         row.extend([''] * (len(converters) - len(row)))
         rows.append([func(name, val) for func, name, val in zip(converters, names, row)])


### PR DESCRIPTION
This patch adds a possibility to pass comments=None to csv2rec in order to switch off comments removal.

A real world example are CSV files where the header on the first line is introduced by a hash #. As a hash is the default value for the comments option, the header is ignored. To read such files including the header one has to call csv2rec with something like comments='AStringThatNeverHappensToBeAtTheBeginingOfTheLine' which is not clear from the documentation and which seems more like a hack than a solution.

Currently, the docstring gives no hint about this behaviour and is misleading in the sense that it speaks about a character not a string:

```
- *comments*: the character used to indicate the start of a comment  in the file
```
