### PR TITLE
Contour does not pass a list of linestyles to LineCollection

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -854,7 +854,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                 col = mcoll.LineCollection(segs,
                                      antialiaseds=aa,
                                      linewidths=width,
-                                     linestyle=lstyle,
+                                     linestyle=[lstyle],
                                      alpha=self.alpha,
                                      transform=self.get_transform(),
                                      zorder=zorder)


### PR DESCRIPTION
This is a possible fix for #1701.  The LineCollection constructor's linestyle/linestyles kwarg expects a list of styles, but contour was passing it a single value.
