### PR TITLE
Fix bugs in stacked histograms

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -4450,7 +4450,7 @@ class Axes(martist.Artist):
 
           *framealpha*: [*None* | float]
             If not None, alpha channel for legend frame. Default *None*.
-        
+
           *ncol* : integer
             number of columns. default is 1
 
@@ -8140,8 +8140,8 @@ class Axes(martist.Artist):
                 patch = _barfunc(bins[:-1] + boffset, m, width,
                                  align='center', log=log,
                                  color=c)
-		# need to turn this into a collection so that it's consistent
-		# with the step histogram
+                # need to turn this into a collection so that it's consistent
+                # with the step histogram
                 patches.append(mcoll.PatchCollection(patch))
                 boffset += dw
 
@@ -8169,10 +8169,10 @@ class Axes(martist.Artist):
             # overriding this
             fill = (histtype == 'stepfilled')
 
-	    y_bottom = y[:]
+            y_bottom = y[:]
             for m, c in zip(n, color):
-		if stacked:
-		    y_bottom = y[:]
+                if stacked:
+                    y_bottom = y[:]
                 y[1:-1:2], y[2::2] = m, m
                 if log:
                     y[y < minimum] = minimum


### PR DESCRIPTION
Hi,

This is an attempt to fix both #1679 and #1631, which both came about because of the way that stacked histograms are handled, introduced in #847.

This isn't ready to go in yet, but I'm running into some problems getting it to work correctly, so I thought I'd try to get some more eyes on it.

There are two problems I'm running into:
1. `fill_between` isn't actually filling
2. `fill_between` seems to be screwing up autosetting the y axis limits.

Here is the image I get when I run `test_hist_stacked`. The two histograms are now in the proper order, fixing #1679, you can see the two problems I mentioned. The histograms should be filled and the minimum of the y-axis should be 0.

![hist_stacked](https://f.cloud.github.com/assets/1271014/99857/d5397a56-67ca-11e2-80a2-075c8f6fcbc6.png)

Could someone a little more familiar with `fill_between` take a look at this?
