### PR TITLE
Mixing Arial with mathtext on Windows 8 fails

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -1617,7 +1617,7 @@ FT2Font::get_glyph_name(const Py::Tuple & args)
     args.verify_length(1);
 
     char buffer[128];
-    FT_UInt glyph_number = Py::Int(args[0]);
+    FT_UInt glyph_number = (FT_UInt)(unsigned long long)Py::Int(args[0]);
 
     if (!FT_HAS_GLYPH_NAMES(face))
     {


### PR DESCRIPTION
Along with quite a few other fonts as well, but I've not been able to identify exactly which ones; but Arial is the easiest one to test.  Trying to use the Arial font with some mathtext in the string that you are trying to show leads to a lengthy stack trace (when I get the chance I'll regenerate it and post it).

Reference:
http://matplotlib.1069221.n5.nabble.com/mathtext-and-fonts-under-Windows-8-td40172.html

A related fix from some other software:
http://code.google.com/p/sumatrapdf/issues/detail?id=2056
http://code.google.com/p/sumatrapdf/source/diff?spec=svn6770&r=6770&format=side&path=/trunk/mupdf/pdf/pdf_font.c

According to a poster in that thread,

"It seems that at least some of the fonts in Windows 8 no longer contain a glyph names table. MuPDF has under some circumstances relied too much on such a table being present. I've adjusted the logic so that it no longer does. The next (pre)release version (2.2.6770 or later) should thus be able to display PDF documents without embedded fonts under Windows 8 as intended. Thanks again for all your help for debugging this issue."
