### PR TITLE
rcParams.keys() is not Python 3 compatible

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -733,7 +733,7 @@ See rcParams.keys() for a list of valid parameters.' % (key,))
         """
         Return sorted list of keys.
         """
-        k = dict.keys(self)
+        k = list(dict.keys(self))
         k.sort()
         return k
 


### PR DESCRIPTION
When I run rcParams.keys() in Python 3 I get the following exception:

AttributeError: 'dict_keys' object has no attribute 'sort'

This is due to the fact that the keys method does not return a list but a dict_keys object, which has no sort method.

To retain the behavior from Python 2 I suggest the following patch:

``` patch
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -733,7 +733,7 @@ See rcParams.keys() for a list of valid parameters.' % (key,))
         """
         Return sorted list of keys.
         """
-        k = dict.keys(self)
+        k = list(dict.keys(self))
         k.sort()
         return k
```

 This works fine in Python 2 and 3.

For completeness, I used Python 3.2.3 and matplotlib 1.2.0 from Debian unstable/experimental.

Thanks for the great work.
