### PR TITLE
Fix compiler warnings

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1030,7 +1030,7 @@ def add_tk_flags(module):
                 if not exists(join(F, fw + '.framework')):
                     break
             else:
-                # ok, F is now directory with both frameworks. Continure
+                # ok, F is now directory with both frameworks. Continue
                 # building
                 tk_framework_found = 1
                 break

--- a/src/_image.cpp
+++ b/src/_image.cpp
@@ -406,10 +406,6 @@ Image::resize(const Py::Tuple& args, const Py::Dict& kwargs)
 
     typedef agg::span_allocator<agg::rgba8> span_alloc_type;
     span_alloc_type sa;
-    agg::rgba8 background(agg::rgba8(int(255*bg.r),
-                                     int(255*bg.g),
-                                     int(255*bg.b),
-                                     int(255*bg.a)));
 
     // the image path
     agg::path_storage path;

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -27,6 +27,13 @@
 #include "CXX/Extensions.hxx"
 #include "numpy/arrayobject.h"
 #include "mplutils.h"
+
+// This C function resides in npy_3kcompat.h and is unused by
+// matplotlib. This is here so that the compiler doesn't complain
+// that it is unused.
+extern "C" {
+__attribute__((unused)) static void simple_capsule_dtor(void *ptr);
+}
 #include "file_compat.h"
 
 // As reported in [3082058] build _png.so on aix
@@ -239,7 +246,9 @@ Py::Object _png_module::write_png(const Py::Tuple& args)
 
         if (close_dup_file)
         {
-            npy_PyFile_DupClose(py_file, fp);
+            if (npy_PyFile_DupClose(py_file, fp)) {
+              throw Py::RuntimeError("Error closing dupe file handle");
+            }
         }
 
         if (close_file)
@@ -258,7 +267,9 @@ Py::Object _png_module::write_png(const Py::Tuple& args)
     delete [] row_pointers;
     if (close_dup_file)
     {
-        npy_PyFile_DupClose(py_file, fp);
+        if (npy_PyFile_DupClose(py_file, fp)) {
+          throw Py::RuntimeError("Error closing dupe file handle");
+        }
     }
 
     if (close_file)
@@ -569,7 +580,9 @@ _png_module::_read_png(const Py::Object& py_fileobj, const bool float_result,
 #endif
     if (close_dup_file)
     {
-        npy_PyFile_DupClose(py_file, fp);
+        if (npy_PyFile_DupClose(py_file, fp)) {
+          throw Py::RuntimeError("Error closing dupe file handle");
+        }
     }
 
     if (close_file)


### PR DESCRIPTION
Some of the compiler warnings started to bug me, so I tried to fix them. They're usually harmless, but sometimes they are not, as I will explain.

Currently, [these](https://gist.github.com/4678787) are the warnings that are thrown during a python2.7 build of matplotlib (`clang` on a mac is used here)

After this patch is applied, [these](https://gist.github.com/4678809) are the warnings that are still left. The first four are due to a 'bug' in the python API; treating string literals as `char *` rather than `const char *`. There is a patch [upstream](http://bugs.python.org/issue9369) for it, but I'm not sure if it will be back-ported to python 2.7.4.

The last bunch of `Tcl`/`Tk` warnings are because the compiler is being handed both a `-c` flag and a `-framework T{cl,k}` flag, which are meant solely for the compilation and linking steps, respectively. To fix them, one would need to separate out the compile and link steps, but I don't know how to do that with `distutils`, and they only appear on the mac. Linux and windows compilers do not support the `-framework` flag.

I have tested this patch and I get a successful build with both Apple's builds of gcc and clang. All the tests pass locally with python 2.7. It would be nice to have these tested with python3, and a linux flavour of compiler.

I also fixed a typo in a comment.
