### PR TITLE
Macosx backend: tweak to coordinates position

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -4747,7 +4747,7 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     NSFont* font = [NSFont systemFontOfSize: 0.0];
     rect.size.width = 300;
     rect.size.height = 0;
-    rect.origin.x += 200;
+    rect.origin.x += height;
     NSText* messagebox = [[NSText alloc] initWithFrame: rect];
     [messagebox setFont: font];
     [messagebox setDrawsBackground: NO];


### PR DESCRIPTION
With the current macosx backend, the message that shows the (x,y) coordinates of the cursors keeps getting clipped by the window. This pull request moves the coordinates a little closer to the icons to the left side to prevent this.
