### PR TITLE
stackplot_test_baseline has different results on 32-bit and 64-bit platforms

### DIFF
--- a/src/_path.cpp
+++ b/src/_path.cpp
@@ -1159,14 +1159,24 @@ _path_module::affine_transform(const Py::Tuple& args)
             size_t stride1 = PyArray_STRIDE(vertices, 1);
             double x;
             double y;
+            volatile double t0;
+	    volatile double t1;
+	    volatile double t;
 
             for (size_t i = 0; i < n; ++i)
             {
                 x = *(double*)(vertex_in);
                 y = *(double*)(vertex_in + stride1);
 
-                *vertex_out++ = a * x + c * y + e;
-                *vertex_out++ = b * x + d * y + f;
+		t0 = a * x;
+		t1 = c * y;
+                t = t0 + t1 + e;
+                *(vertex_out++) = t;
+
+		t0 = b * x;
+		t1 = d * y;
+                t = t0 + t1 + f;
+                *(vertex_out++) = t;
 
                 vertex_in += stride0;
             }


### PR DESCRIPTION
I haven't quite gotten down to the bottom of this one yet, but this is the cause of the current failures on Travis.

On a 64-bit Linux, I get the following for `stackplot_test_baseline` (and I suspect this is correct):

![stackplot_test_baseline-expected](https://f.cloud.github.com/assets/38294/113353/7225c104-6b4e-11e2-84c5-26ce7ea1b4a6.png)

And on 32-bit:

![stackplot_test_baseline](https://f.cloud.github.com/assets/38294/113354/7a4db882-6b4e-11e2-8ccd-cfb3688c3934.png)

The problem appears to be somewhere in the calculation of the data limits.  On 64-bit, the xmin is exactly 0, on 32-bit it's a very small negative number which causes the locator to add an extra step on the left.
