### PR TITLE
slight tweak to the documentation of `errorbar`

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -5324,7 +5324,7 @@ class Axes(martist.Artist):
             array-like object, errorbars are drawn at +/-value relative
             to the data.
 
-            If a sequence of shape 2xN, errorbars are drawn at - row1
+            If a sequence of shape 2xN, errorbars are drawn at -row1
             and +row2 relative to the data.
 
           *fmt*: '-'


### PR DESCRIPTION
Instigated by this [thread](http://sourceforge.net/mailarchive/forum.php?thread_name=5117DBEB.6050301%40uibk.ac.at&forum_name=matplotlib-devel)  on matplotlib-devel.
