### PR TITLE
Offset is empty with usetex when offset is equal to 1

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -581,7 +581,7 @@ class ScalarFormatter(Formatter):
             sign = tup[1][0].replace(positive_sign, '')
             exponent = tup[1][1:].lstrip('0')
             if self._useMathText or self._usetex:
-                if significand == '1':
+                if significand == '1' and exponent != '':
                     # reformat 1x10^y as 10^y
                     significand = ''
                 if exponent:


### PR DESCRIPTION
Example:

```
from pylab import *
rc('text',usetex=True)
t=arange(1,1+1e-6,1e-7)
f = lambda x: 1e6*(x-1)
plot(t,vectorize(f)(t))
show()
```

![Missing offset](http://i1144.photobucket.com/albums/o488/idrathermeetyouatthebottom/bug_zps6041be28.png)

The problem arises in ScalarFormatter._formatSciNotation; a solution could be replacing

```
if significand == '1':
```

with 

```
if significand == '1' and not exponent == '':
```
