### PR TITLE
Typo in "Annotation" docstring.

### DIFF
--- a/doc/users/annotations_intro.rst
+++ b/doc/users/annotations_intro.rst
@@ -30,10 +30,10 @@ argument              coordinate system
 ====================  ====================================================
   'figure points'     points from the lower left corner of the figure
   'figure pixels'     pixels from the lower left corner of the figure
-  'figure fraction'   0,0 is lower left of figure and 1,1 is upper, right
+  'figure fraction'   0,0 is lower left of figure and 1,1 is upper right
   'axes points'       points from lower left corner of axes
   'axes pixels'       pixels from lower left corner of axes
-  'axes fraction'     0,1 is lower left of axes and 1,1 is upper right
+  'axes fraction'     0,0 is lower left of axes and 1,1 is upper right
   'data'              use the axes data coordinate system
 ====================  ====================================================
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1777,10 +1777,10 @@ class Annotation(Text, _AnnotationBase):
         =================   ===================================================
         'figure points'     points from the lower left corner of the figure
         'figure pixels'     pixels from the lower left corner of the figure
-        'figure fraction'   0,0 is lower left of figure and 1,1 is upper, right
+        'figure fraction'   0,0 is lower left of figure and 1,1 is upper right
         'axes points'       points from lower left corner of axes
         'axes pixels'       pixels from lower left corner of axes
-        'axes fraction'     0,1 is lower left of axes and 1,1 is upper right
+        'axes fraction'     0,0 is lower left of axes and 1,1 is upper right
         'data'              use the coordinate system of the object being
                             annotated (default)
         'offset points'     Specify an offset (in points) from the *xy* value


### PR DESCRIPTION
The "axes fraction" description in the table of values for 'xycoords'
and 'textcoords' had a typo, suggesting that (0,1) represents the lower
left corner of the figure when it is actually (0,0).

I also removed what looked like an extraneous typo in the description of
the "figure fraction" property.

The corresponding table in the users guide was similarly updated.
