### PR TITLE
Name missmatch in filetypes.rgba and print_rgb of backend_bases.py

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1899,7 +1899,7 @@ class FigureCanvasBase(object):
         from backends.backend_agg import FigureCanvasAgg  # lazy import
         agg = self.switch_backends(FigureCanvasAgg)
         return agg.print_raw(*args, **kwargs)
-    print_bmp = print_rgb = print_raw
+    print_bmp = print_rgba = print_raw
 
     def print_svg(self, *args, **kwargs):
         from backends.backend_svg import FigureCanvasSVG  # lazy import


### PR DESCRIPTION
Some error showed up when creating animation:

Traceback (most recent call last):
  File "dd.py", line 31, in <module>
    anim.save('basic_animation.mp4')
  File "/Library/Python/2.7/site-packages/matplotlib/animation.py", line 615, in save
    writer.grab_frame()
  File "/Library/Python/2.7/site-packages/matplotlib/animation.py", line 199, in grab_frame
    dpi=self.dpi)
  File "/Library/Python/2.7/site-packages/matplotlib/figure.py", line 1363, in savefig
    self.canvas.print_figure(_args, *_kwargs)
  File "/Library/Python/2.7/site-packages/matplotlib/backend_bases.py", line 2012, in print_figure
    print_method = self._get_print_method(format)
  File "/Library/Python/2.7/site-packages/matplotlib/backend_bases.py", line 1953, in _get_print_method
    '%s.' % (format, ', '.join(formats)))
ValueError: Format "rgba" is not supported.
Supported formats: bmp, emf, eps, gif, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff.

The change fix this problem.
