### PR TITLE
Resolving Issue #1737 - MacOSX backend unicode problems in python 3.3

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2658,6 +2658,7 @@ GraphicsContext_get_text_width_height_descent(GraphicsContext* self, PyObject* a
     float size;
     const char* weight;
     const char* italic;
+
 #if PY33
     const char* text;
 #else


### PR DESCRIPTION
This is to resolve an issue with the macosx backend when using Python 3.3 that the text printed during plots is only half of the string. I have resolved my issues, but I would request that someone knowledgable in objective-c and python take a look.
