### PR TITLE
Fixed a typo in histogram example code

### DIFF
--- a/examples/pylab_examples/histogram_demo_extended.py
+++ b/examples/pylab_examples/histogram_demo_extended.py
@@ -111,7 +111,7 @@ w0[:len(x0)/2] = 0.5
 w1 = np.ones_like(x1)
 w1[:len(x1)/2] = 0.5
 w2 = np.ones_like(x2)
-w0[:len(x2)/2] = 0.5
+w2[:len(x2)/2] = 0.5
 
 
 


### PR DESCRIPTION
`w0` should have been `w2`
