### PR TITLE
bytes regex matching issue in font_manager.py around 1283 (line number)

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1292,7 +1292,7 @@ if USE_FONTCONFIG and sys.platform != 'win32':
                     return file
         return None
 
-    _fc_match_regex = re.compile(r'\sfile:\s+"([^"]*)"')
+    _fc_match_regex = re.compile(br'\sfile:\s+"([^"]*)"')
     _fc_match_cache = {}
 
     def findfont(prop, fontext='ttf'):


### PR DESCRIPTION
for match in _fc_match_regex.finditer(output):

the 'output' is a byte array, but expected is string runtime type-error, 

i think this issue might already have been raised. I am using python3-mapltplotlib-tk backend on fedora 18. I am not sure if it is fixed or not.

THE FIX(atleast for me):
I change the above line to (I changed the byte array to utf-8 string)
for match in _fc_match_regex.finditer(output.decode("utf-8")):
and I am able to plot.No type-error
