### PR TITLE
strange output from wx and wxagg when trying to render to JPEG or TIFF

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -128,6 +128,7 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase,\
      FigureCanvasBase, FigureManagerBase, NavigationToolbar2, \
      cursors, TimerBase
 from matplotlib.backend_bases import ShowBase
+from matplotlib.backend_bases import _has_pil
 
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.artist import Artist
@@ -1132,9 +1133,10 @@ The current aspect ratio will be kept."""
     def print_bmp(self, filename, *args, **kwargs):
         return self._print_image(filename, wx.BITMAP_TYPE_BMP, *args, **kwargs)
 
-    def print_jpeg(self, filename, *args, **kwargs):
-        return self._print_image(filename, wx.BITMAP_TYPE_JPEG, *args, **kwargs)
-    print_jpg = print_jpeg
+    if not _has_pil:
+        def print_jpeg(self, filename, *args, **kwargs):
+            return self._print_image(filename, wx.BITMAP_TYPE_JPEG, *args, **kwargs)
+        print_jpg = print_jpeg
 
     def print_pcx(self, filename, *args, **kwargs):
         return self._print_image(filename, wx.BITMAP_TYPE_PCX, *args, **kwargs)
@@ -1142,9 +1144,10 @@ The current aspect ratio will be kept."""
     def print_png(self, filename, *args, **kwargs):
         return self._print_image(filename, wx.BITMAP_TYPE_PNG, *args, **kwargs)
 
-    def print_tiff(self, filename, *args, **kwargs):
-        return self._print_image(filename, wx.BITMAP_TYPE_TIF, *args, **kwargs)
-    print_tif = print_tiff
+    if not _has_pil:
+        def print_tiff(self, filename, *args, **kwargs):
+            return self._print_image(filename, wx.BITMAP_TYPE_TIF, *args, **kwargs)
+        print_tif = print_tiff
 
     def print_xpm(self, filename, *args, **kwargs):
         return self._print_image(filename, wx.BITMAP_TYPE_XPM, *args, **kwargs)


### PR DESCRIPTION
This patch has been tested under Windows, OSX, and Linux.  If PIL is present, it gives an accurate rendering of the graph, whereas the wx backend's print_jpeg and print_tiff don't.  I've attached before and after pictures (before and after this patch).

Other backends that might exhibit similar behavior, but I am not in a position to test, are:
- gdk
- gtk
- macosx

A test script that generates the images is below.

``` python
#!/usr/bin/env python
import matplotlib
matplotlib.use('WxAgg')
import numpy as np
import matplotlib.pyplot as plt

x = np.linspace(0.0,2.0*np.pi,50)
y = np.sin(x)  

plt.plot(x,y,color='red')
plt.title("Any text can have math: $E = m\sqrt{c^4}$")
plt.xlim(0.0,2.0*np.pi)


canvas = plt.gcf().get_canvas()
canvas.print_tiff('out.tif')
canvas.print_png('out.png')
canvas.print_jpeg('out.jpg')

plt.show()
```

Before, png
![before](https://f.cloud.github.com/assets/1141744/178510/290ac7b6-7bbc-11e2-9ba9-2ab2f1723894.png)
Before,jpeg
![before](https://f.cloud.github.com/assets/1141744/178509/28de8d4a-7bbc-11e2-9dbb-d17429ec6d8b.jpg)
Before, tif
[Could not display because file type unsupported...it looked very similar to the "before" jpeg]

After, png
![after](https://f.cloud.github.com/assets/1141744/178512/30c4d64a-7bbc-11e2-940a-f7b5d921236a.png)

After, jpeg
![after](https://f.cloud.github.com/assets/1141744/178513/30c37228-7bbc-11e2-9561-ecf77003431f.jpg)

After,tif
[Could not display because file type unsupported...it looked very similar to the "after" jpeg]
