### PR TITLE
ignore singleton dimensions in ndarrays passed to imshow

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -7096,7 +7096,8 @@ class Axes(martist.Artist):
         """
 
         if not self._hold: self.cla()
-
+        if isinstance(X, np.ndarray):
+            X = X.squeeze()
         if norm is not None: assert(isinstance(norm, mcolors.Normalize))
         if aspect is None: aspect = rcParams['image.aspect']
         self.set_aspect(aspect)


### PR DESCRIPTION
instigated by this: http://stackoverflow.com/questions/15008045/showing-an-image-with-pylab-imshow/15008830#15008830

This just gets rid of singleton dimensions in ndarrays that are passed in.
