### PR TITLE
PyList_SetItem return value bug in clip_path_to_rect (_path.cpp).

### DIFF
--- a/src/_path.cpp
+++ b/src/_path.cpp
@@ -1075,7 +1075,7 @@ _path_module::clip_path_to_rect(const Py::Tuple &args)
                 ((double *)pyarray->data)[2*i]   = (*p)[i].x;
                 ((double *)pyarray->data)[2*i+1] = (*p)[i].y;
             }
-            if (PyList_SetItem(py_results, p - results.begin(), (PyObject *)pyarray) != -1)
+            if (PyList_SetItem(py_results, p - results.begin(), (PyObject *)pyarray) == -1)
             {
                 throw Py::RuntimeError("Error creating results list");
             }


### PR DESCRIPTION
Fixes a bug in the code which erroneously checks the result of [PyList_SetItem](http://docs.python.org/2/c-api/list.html#PyList_SetItem).

I have some feature enhancing code to go with this. I was tempted to add it to this PR, but strictly speaking, that wouldn't be a bug-fix. A picture + some code is worth a 1000 words:

```
import numpy as np

import matplotlib.patches as mpatches
import matplotlib.path as mpath
import matplotlib.transforms as mtrans
import matplotlib.pyplot as plt
from matplotlib._path import clip_path_to_rect


def clip_path_mpl(path, bbox):
    """
    *THIS COULD BE A PATH METHOD*
    Clip the given path to the given bounding box. 

    """
    resultant_verts = clip_path_to_rect(path, bbox, True)

    if len(resultant_verts) == 0:
        result_path = mpath.Path([[0, 0]], codes=[mpath.Path.MOVETO])
    else:
        # Closed polygons going in to clip_path_to_rect are returned with
        # their final vertex missing. Add this back in if appropriate.
        is_closed = (np.all(path.vertices[0, :] == path.vertices[-1, :]) or
                     (path.codes is not None and 
                      path.codes[-1] == path.CLOSEPOLY))
        if is_closed:

            for i, verts in enumerate(resultant_verts):
                resultant_verts[i] = np.append(verts, verts[0:1, :], axis=0)
        vertices = np.concatenate(resultant_verts)
        result_path = mpath.Path(vertices=vertices)

    return result_path

ax = plt.axes()
ax.set_xlim([-20, 10])
ax.set_ylim([-150, 100])

path = mpath.Path.unit_regular_star(8)
path.vertices *= [10, 100]
path.vertices -= [5, 25]

patch = mpatches.PathPatch(path, alpha=0.5, facecolor='coral', edgecolor='none')
ax.add_patch(patch)

bbox = mtrans.Bbox([[-12, -77.5], [-2, 50]])
result_path = clip_path_mpl(path, bbox)
result_patch = mpatches.PathPatch(result_path, alpha=0.5, facecolor='green', lw=4, edgecolor='black')

ax.add_patch(result_patch)
plt.show()
```

![clip_star](https://f.cloud.github.com/assets/810663/185207/6d10227e-7cfe-11e2-8b80-1b600f8f1d15.png)
