### PR TITLE
Fixes problem raised in #1431 (```get_transform``` should not affect ```is_transform_set```)

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -240,7 +240,7 @@ class Artist(object):
         instance used by this artist.
         """
         if self._transform is None:
-            self.set_transform(IdentityTransform())
+            self._transform = IdentityTransform()
         elif (not isinstance(self._transform, Transform)
               and hasattr(self._transform, '_as_mpl_transform')):
             self._transform = self._transform._as_mpl_transform(self.axes)

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -18,26 +18,38 @@ def test_patch_transform_of_none():
     ax.set_xlim([1, 3])
     ax.set_ylim([1, 3])
     
-    #draw an ellipse over data coord (2,2) by specifying device coords
+    # Draw an ellipse over data coord (2,2) by specifying device coords.
     xy_data = (2, 2)
     xy_pix = ax.transData.transform_point(xy_data)
     
-    # not providing a transform of None puts the ellipse in data coordinates 
+    # Not providing a transform of None puts the ellipse in data coordinates .
     e = mpatches.Ellipse(xy_data, width=1, height=1, fc='yellow', alpha=0.5)
     ax.add_patch(e)
     assert e._transform == ax.transData
     
-    # providing a transform of None puts the ellipse in device coordinates
+    # Providing a transform of None puts the ellipse in device coordinates.
     e = mpatches.Ellipse(xy_pix, width=120, height=120, fc='coral', 
                          transform=None, alpha=0.5)
+    assert e.is_transform_set() is True
     ax.add_patch(e)
     assert isinstance(e._transform, mtrans.IdentityTransform)
     
-    # providing an IdentityTransform puts the ellipse in device coordinates
+    # Providing an IdentityTransform puts the ellipse in device coordinates.
     e = mpatches.Ellipse(xy_pix, width=100, height=100, 
                          transform=mtrans.IdentityTransform(), alpha=0.5)
     ax.add_patch(e)
     assert isinstance(e._transform, mtrans.IdentityTransform)
+
+    # Not providing a transform, and then subsequently "get_transform" should
+    # not mean that "is_transform_set".
+    e = mpatches.Ellipse(xy_pix, width=120, height=120, fc='coral',
+                         alpha=0.5)
+    intermediate_transform = e.get_transform()
+    assert e.is_transform_set() is False
+    ax.add_patch(e)
+    assert e.get_transform() != intermediate_transform
+    assert e.is_transform_set() is True
+    assert e._transform == ax.transData
     
 
 @cleanup


### PR DESCRIPTION
Please note:

The _expected_ behaviour here is that specifying a `transform=None` is different to not providing the transform argument at all.
