### PR TITLE
Symbol not found: _CGAffineTransformIdentity on MacOS 10.6

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1540,6 +1540,7 @@ class BackendMacOSX(OptionalBackendPackage):
         Numpy().add_flags(ext)
         LibAgg().add_flags(ext)
         CXX().add_flags(ext)
+        ext.extra_link_args.extend(['-framework', 'Cocoa'])
         return ext
 
 


### PR DESCRIPTION
On MacOS 10.6, Matplotlib installs without error, but is then not importable:

```
Python 3.2.3 (default, Apr 13 2012, 00:15:25) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import matplotlib.pyplot as plt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/Library/Python/3.2/lib/python/site-packages/matplotlib-1.3.x-py3.2-macosx-10.6-x86_64.egg/matplotlib/pyplot.py", line 98, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/Users/tom/Library/Python/3.2/lib/python/site-packages/matplotlib-1.3.x-py3.2-macosx-10.6-x86_64.egg/matplotlib/backends/__init__.py", line 25, in pylab_setup
    globals(),locals(),[backend_name])
  File "/Users/tom/Library/Python/3.2/lib/python/site-packages/matplotlib-1.3.x-py3.2-macosx-10.6-x86_64.egg/matplotlib/backends/backend_macosx.py", line 21, in <module>
    from matplotlib.backends import _macosx
ImportError: dlopen(/Users/tom/Library/Python/3.2/lib/python/site-packages/matplotlib-1.3.x-py3.2-macosx-10.6-x86_64.egg/matplotlib/backends/_macosx.so, 2): Symbol not found: _CGAffineTransformIdentity
  Referenced from: /Users/tom/Library/Python/3.2/lib/python/site-packages/matplotlib-1.3.x-py3.2-macosx-10.6-x86_64.egg/matplotlib/backends/_macosx.so
  Expected in: flat namespace
 in /Users/tom/Library/Python/3.2/lib/python/site-packages/matplotlib-1.3.x-py3.2-macosx-10.6-x86_64.egg/matplotlib/backends/_macosx.so
```

On Python 2.7, pyparsing doesn't even work:

```
>>> import matplotlib.pyplot as plt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.3.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/__init__.py", line 113, in <module>
    import pyparsing
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/pyparsing-1.5.3-py2.7.egg/pyparsing.py", line 629
    nonlocal limit,foundArity
                 ^
SyntaxError: invalid syntax
```

but I'll report that to the pyparsing developers.
