### PR TITLE
Add .directory files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dist
 
 # OS generated files #
 ######################
+.directory
 .gdb_history
 .DS_Store?
 ehthumbs.db


### PR DESCRIPTION
.directory files are used on Linux to store per-directory view settings, such as whether to show previews or hidden files and what order to sort the view.  They don't belong on git.
