### PR TITLE
Corrupt/invalid PDF and EPS files when saving a logscaled plot made with negative values

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -372,6 +372,8 @@ class RendererBase:
                     xp, yp = transform.transform_point((0, 0))
                     xo = -(xp - xo)
                     yo = -(yp - yo)
+            if not (np.isfinite(xo) and np.isfinite(yo)):
+                continue
             if Nfacecolors:
                 rgbFace = facecolors[i % Nfacecolors]
             if Nedgecolors:

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -1,12 +1,34 @@
 from __future__ import print_function
 
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
+import numpy as np
+import io
 
 
 @image_comparison(baseline_images=['log_scales'], remove_text=True)
 def test_log_scales():
     ax = plt.subplot(122, yscale='log', xscale='symlog')
-    
+
     ax.axvline(24.1)
     ax.axhline(24.1)
+
+
+@cleanup
+def test_log_scatter():
+    """Issue #1799"""
+    fig, ax = plt.subplots(1)
+
+    x = np.arange(10)
+    y = np.arange(10) - 1
+
+    ax.scatter(x, y)
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format='pdf')
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format='eps')
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format='svg')


### PR DESCRIPTION
This is with matplotlib 1.1.0, via the Pylab interface (I'm using a version supplied with PythonXY):

```
import pylab as p
import numpy as np

x = np.arange(10)
y = np.arange(10)-1

p.scatter(x,y)
p.xscale('log')
p.yscale('log')
```

Saving the plot as an EPS or PDF produces an invalid file; when opening the PDF, Adobe Reader says "Path lacks initial MOVETO".  PNG output looks fine.

Granted, negative values can't be plotted on a log scale, but creating a bad output file seems like a bug.  As a workaround, I now filter my data for negative values before plotting.
