### PR TITLE
Improved test_triinterp_colinear

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -545,7 +545,7 @@ def test_triinterp_colinear():
     # avoid issues related to round-off errors we only use integer
     # coefficients (otherwise the Triangulation might become invalid even with
     # delta == 0).
-    transformations = [[1, 0], [0, 1], [1, 1], [3, 7], [-5, -2], [-3, 2]]
+    transformations = [[1, 0], [0, 1], [1, 1], [1, 2], [-2, -1], [-2, 1]]
     for transformation in transformations:
         x_rot = transformation[0]*x0 + transformation[1]*y0
         y_rot = -transformation[1]*x0 + transformation[0]*y0


### PR DESCRIPTION
This is a one-line change to one of the triangular grid tests.

The various triangular grid functions do not support triangulations containing triangles with colinear points, i.e. zero area.  However, some effort has been made to deal with simple situations containing colinear point triangles.  One of the tests for these "not supported but we try to deal with" situations was overenthusiastic, testing a case that was OK on some but not all compilers.
