### PR TITLE
Keyboard shortcuts work when toolbar not displayed

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2399,6 +2399,7 @@ def key_press_handler(event, canvas, toolbar=None):
         # saving current figure (default key 's')
         elif event.key in save_keys:
             toolbar.save_figure()
+        toolbar.display_cursor(event)
 
     if event.inaxes is None:
         return
@@ -2676,7 +2677,7 @@ class NavigationToolbar2(object):
         """
         raise NotImplementedError
 
-    def mouse_move(self, event):
+    def display_cursor(self, event):
         if not event.inaxes or not self._active:
             if self._lastCursor != cursors.POINTER:
                 self.set_cursor(cursors.POINTER)
@@ -2692,8 +2693,9 @@ class NavigationToolbar2(object):
 
                 self._lastCursor = cursors.MOVE
 
+    def mouse_move(self, event):
+        self.display_cursor(event)
         if event.inaxes and event.inaxes.get_navigate():
-
             try:
                 s = event.inaxes.format_coord(event.xdata, event.ydata)
             except (ValueError, OverflowError):
@@ -3095,4 +3097,8 @@ class NavigationToolbar2(object):
 
     def set_history_buttons(self):
         """Enable or disable back/forward button"""
+        pass
+
+    def set_hidden(self, is_hidden):
+        """Set the toolbars visibility."""
         pass

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -783,6 +783,9 @@ class NavigationToolbar2GTK(NavigationToolbar2, gtk.Toolbar):
     def _get_canvas(self, fig):
         return FigureCanvasGTK(fig)
 
+    def set_hidden(self, hidden):
+        self.set_visible(hidden)
+
 
 class NavigationToolbar(gtk.Toolbar):
     """

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -592,6 +592,9 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
     def _get_canvas(self, fig):
         return self.canvas.__class__(fig)
 
+    def set_hidden(self, hidden):
+        self.set_visible(hidden)
+
 
 class NavigationToolbar(Gtk.Toolbar):
     """

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -464,6 +464,9 @@ class NavigationToolbar2QT( NavigationToolbar2, qt.QWidget ):
         self.buttons[ 'Back' ].setEnabled( canBackward )
         self.buttons[ 'Forward' ].setEnabled( canForward )
 
+    def set_hidden(self, hidden):
+        self.setVisible(hidden)
+
 # set icon used when windows are minimized
 try:
     # TODO: This is badly broken

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -672,7 +672,8 @@ class NavigationToolbar2QT( NavigationToolbar2, QtGui.QToolBar ):
                     self, "Error saving file", str(e),
                     QtGui.QMessageBox.Ok, QtGui.QMessageBox.NoButton)
 
-
+    def set_hidden(self, hidden):
+        self.setVisible(hidden)
 
 class SubplotToolQt( SubplotTool, QtGui.QWidget ):
     def __init__(self, targetfig, parent):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -339,6 +339,16 @@ def figure(num=None, # autoincrement if None, else integer from 1-N
     if figManager is None:
         if get_backend().lower() == 'ps':  dpi = 72
 
+        # If toolbar is set to 'None', it should still be instantiated if
+        # the backend supports setting it's visibility, so that keyboard
+        # shortcut logic is preserved
+        invisible_toolbar = False
+        if rcParams['toolbar'] not in ('toolbar2', 'classic'):
+            if get_backend().lower() in ('qt4agg', 'qtagg', 'gtk', 'gtkagg',
+                    'gtkcairo'):
+                rcParams['toolbar'] = 'toolbar2'
+                invisible_toolbar = True
+
         figManager = new_figure_manager(num, figsize=figsize,
                                              dpi=dpi,
                                              facecolor=facecolor,
@@ -346,6 +356,10 @@ def figure(num=None, # autoincrement if None, else integer from 1-N
                                              frameon=frameon,
                                              FigureClass=FigureClass,
                                              **kwargs)
+
+        if invisible_toolbar:
+            figManager.toolbar.set_hidden(False)
+            rcParams['toolbar'] = 'None'
 
         if figLabel:
             figManager.set_window_title(figLabel)


### PR DESCRIPTION
Following from issue #1829, I've implemented a fix for keyboard shortcuts when the toolbar is not displayed.

In the existing code, state/logic of pan/zoom tools are coupled to the existence of a toolbar, so I went for the easiest fix possible: keeping the toolbar but setting visibility to false when None is chosen in matplotlibrc.

So far it's only implemented in the Qt and GTK backends: I don't have the others so no way to test.
