### PR TITLE
BF - correct return type for Axes.get_title

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -3171,8 +3171,8 @@ class Axes(martist.Artist):
 
         Returns
         -------
-        text : :class:`~matplotlib.text.Text`
-            The matplotlib text instance representing the title
+        title: str
+            The title text string.
 
         """
         try:
@@ -3181,7 +3181,7 @@ class Axes(martist.Artist):
                      'right': self._right_title}[loc.lower()]
         except KeyError:
             raise ValueError("'%s' is not a valid location" % loc)
-        return title
+        return title.get_text()
 
     @docstring.dedent_interpd
     def set_title(self, label, loc="center", fontdict=None, **kwargs):


### PR DESCRIPTION
Return type of `Axes.get_title` was changed by mistake. This PR reverts to the previous MPL behaviour. Caused by #1644 and reported in #1714.
