### PR TITLE
finance: Fixed making directories for explicit cachename

### DIFF
--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -4,7 +4,7 @@ financial data.   User contributions welcome!
 
 """
 from __future__ import division, print_function
-import os, sys, warnings
+import contextlib, os, sys, warnings
 from urllib2 import urlopen
 
 if sys.version_info[0] < 3:
@@ -185,11 +185,9 @@ def fetch_historical_yahoo(ticker, date1, date2, cachename=None,dividends=False)
         verbose.report('Using cachefile %s for %s'%(cachename, ticker))
     else:
         mkdirs(os.path.abspath(os.path.dirname(cachename)))
-        urlfh = urlopen(url)
-
-        fh = open(cachename, 'wb')
-        fh.write(urlfh.read())
-        fh.close()
+        with contextlib.closing(urlopen(url)) as urlfh:
+            with open(cachename, 'wb') as fh:
+                fh.write(urlfh.read())
         verbose.report('Saved %s data to cache file %s'%(ticker, cachename))
         fh = open(cachename, 'r')
 


### PR DESCRIPTION
In `finance.fetch_historical_yahoo`, if an explicit `cachename` is supplied, the code still attempts to create a directory in the usual cache location (which is not necessary), and fails to create directories required for the supplied cache directory.

I have patched it so that it creates the necessary directories leading up to `cachename`.

As an aside, I also fixed it so that it explicitly closes the URL object opened by `urlopen` and uses the modern `with` style context managers.
