### PR TITLE
Fixes issue #1259 - Added modifier key handling for macosx backend

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5491,8 +5491,6 @@ set_cursor(PyObject* unused, PyObject* args)
         [returnkey appendString:@"alt+" ];
     if ([event modifierFlags] & NSCommandKeyMask)
         [returnkey appendString:@"cmd+" ];
-    if ([event modifierFlags] & NSShiftKeyMask)
-        [returnkey appendString:@"shift+" ];
 
     unichar uc = [[event charactersIgnoringModifiers] characterAtIndex:0];
     NSString* specialchar = [specialkeymappings objectForKey:[NSNumber numberWithUnsignedLong:uc]];


### PR DESCRIPTION
Add modifier key handling to key event handlers for macosx backend. Clean up code to use NS foundation constants for keys and simplified convertKeyEvent selector
