### PR TITLE
test_backend_pgf: TypeError

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -57,7 +57,7 @@ def compare_figure(fname):
 
     expected = os.path.join(result_dir, "expected_%s" % fname)
     shutil.copyfile(os.path.join(baseline_dir, fname), expected)
-    err = compare_images(expected, actual, tol=10)
+    err = compare_images(expected, actual, tol=14)
     if err:
         raise ImageComparisonFailure('images not close: %s vs. %s' % (actual, expected))
 


### PR DESCRIPTION
The tol parameter was missing in the call to `compare_images()`.
