### PR TITLE
Fix for the custom scale example

### DIFF
--- a/examples/api/custom_scale_example.py
+++ b/examples/api/custom_scale_example.py
@@ -110,7 +110,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
             mtransforms.Transform.__init__(self)
             self.thresh = thresh
 
-        def transform(self, a):
+        def transform_non_affine(self, a):
             """
             This transform takes an Nx1 ``numpy`` array and returns a
             transformed copy.  Since the range of the Mercator scale
@@ -144,7 +144,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
             mtransforms.Transform.__init__(self)
             self.thresh = thresh
 
-        def transform(self, a):
+        def transform_non_affine(self, a):
             return np.arctan(np.sinh(a))
 
         def inverted(self):


### PR DESCRIPTION
I have not checked, if this is the only place that needs fixing. Maybe there are other places in matplotlib or the examples that are affected.
