### PR TITLE
fill_betweenx signature fixed

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -7069,7 +7069,7 @@ class Axes(martist.Artist):
 
         Call signature::
 
-          fill_between(y, x1, x2=0, where=None, **kwargs)
+          fill_betweenx(y, x1, x2=0, where=None, **kwargs)
 
         Create a :class:`~matplotlib.collections.PolyCollection`
         filling the regions between *x1* and *x2* where


### PR DESCRIPTION
the signature of `fill_betweenx` on the master and on the matplotlib website (at least for v1.2) has a cut-and-paste error. 
