### PR TITLE
matplotlib 1.2.0 doesn't compile with Solaris Studio 12.3 CC

### DIFF
--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -81,7 +81,7 @@ class Glyph : public Py::PythonClass<Glyph>
 {
 public:
     Glyph(Py::PythonClassInstance *self, Py::Tuple &args, Py::Dict &kwds) :
-        Py::PythonClass<Glyph>::PythonClass(self, args, kwds) { }
+        Py::PythonClass<Glyph>(self, args, kwds) { }
     virtual ~Glyph();
     static Py::PythonClassObject<Glyph> factory(const FT_Face&, const FT_Glyph&, size_t, long);
     int setattro(const Py::String &name, const Py::Object &value);


### PR DESCRIPTION
Unlike the matplotlib 1.1.0 release, which compiles seamlessly with the Solaris Studio 12.3
CC compiler (with a few caveats related to linking as described in http://www.timswast.com/blog/2012/08/06/compiling-matplotlib-with-solaris-studio/), the 1.2.0 release fails to compile
immediately:

building 'matplotlib.ft2font' extension
CC -g -DNDEBUG -O -Kpic -DPY_ARRAY_UNIQUE_SYMBOL=MPL_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -I/usr/local/include -I/vol/python-2.7/lib/python2.7/site-packages/numpy/core/include -I/vol/X11/include/freetype2 -I/vol/X11/include -I. -I/vol/python-2.7/include/python2.7 -c src/ft2font.cpp -o build/temp.solaris-2.10-i86pc-2.7/src/ft2font.o
"/vol/python-2.7/include/python2.7/pyconfig.h", line 1127: Warning (Anachronism): Attempt to redefine _FILE_OFFSET_BITS without using #undef.
"src/ft2font.h", line 84: Error: PythonClass may not have a type qualifier.
"src/ft2font.h", line 84: Error: Py::PythonClassPy::T cannot be initialized in a constructor.
"src/ft2font.h", line 84: Error: Could not find Py::PythonClass<Glyph>::PythonClass() to initialize base class.
"src/ft2font.cpp", line 44: Error: PythonClass may not have a type qualifier.
"src/ft2font.cpp", line 44: Error: Py::PythonClassPy::T cannot be initialized in a constructor.
"src/ft2font.cpp", line 48: Error: Could not find Py::PythonClass<FT2Image>::PythonClass() to initialize base class.
"src/ft2font.cpp", line 839: Error: PythonClass may not have a type qualifier.
"src/ft2font.cpp", line 839: Error: Py::PythonClassPy::T cannot be initialized in a constructor.
"src/ft2font.cpp", line 841: Error: Could not find Py::PythonClass<FT2Font>::PythonClass() to initialize base class.
"src/ft2font.cpp", line 849: Warning: error hides FT2Font::error.
"src/ft2font.cpp", line 1026: Warning: ptsize hides FT2Font::ptsize.
"src/ft2font.cpp", line 1027: Warning: dpi hides FT2Font::dpi.
"src/ft2font.cpp", line 1029: Warning: error hides FT2Font::error.
"src/ft2font.cpp", line 1333: Warning: error hides FT2Font::error.
"src/ft2font.cpp", line 1383: Warning: error hides FT2Font::error.
"src/ft2font.cpp", line 1738: Warning: error hides FT2Font::error.
"src/ft2font.cpp", line 1788: Warning: error hides FT2Font::error.
"src/ft2font.cpp", line 1991: Warning: angle hides FT2Font::angle.
"src/ft2font.cpp", line 2069: Warning: error hides FT2Font::error.
9 Error(s) and 11 Warning(s) detected.
error: command 'CC' failed with exit status 2

Since I don't know any C++, I've no idea what's wrong, but it would be good to restore
compilation with non-g++ compilers.

Thanks.
  Rainer
