### PR TITLE
Raise exception when user tries to use set_xlim or set_ylim on a geographic projection

### DIFF
--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -159,7 +159,8 @@ class GeoAxes(Axes):
 
     def set_xlim(self, *args, **kwargs):
         raise TypeError("It is not possible to change axes limits "
-                        "for geographic projections.")
+                        "for geographic projections. Please consider "
+                        "using Basemap or Cartopy.")
 
     set_ylim = set_xlim
 


### PR DESCRIPTION
This is a pretty simple, atomic change but may require some documentation if accepted. I've found that when teaching users about projections, many people expect to be able to change the projection limits (rotate the projection) by using `set_xlim()` and `set_ylim()`. The functions work on projection axes:

```
>>> fig,axes = plt.subplots(1,1,subplots_kw=dict(projection="aitoff"))
>>> axes.set_xlim(0,360)
```

but don't actually do anything. I propose (with this PR) that these functions explicitly throw a `NotImplementedError` so it is obvious to the user that they are not actually changing anything by using the limit functions:

```
>>> axes.set_xlim(0,360)
NotImplementedError: set_xlim and set_ylim are not implemented for geographic projections
```
