### PR TITLE
backend_pgf: clip paths within the backend (fixes #1857)

### DIFF
--- a/lib/matplotlib/compat/subprocess.py
+++ b/lib/matplotlib/compat/subprocess.py
@@ -75,3 +75,5 @@ if hasattr(subprocess, 'check_output'):
     check_output = subprocess.check_output
 else:
     check_output = _check_output
+
+CalledProcessError = subprocess.CalledProcessError

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -130,6 +130,21 @@ def test_rcupdate():
         create_figure()
         compare_figure('pgf_rcupdate%d.pdf' % (i+1))
 
+
+# test backend-side clipping, since large numbers are not supported by TeX
+@switch_backend('pgf')
+def test_pathclip():
+    if not check_for('xelatex'):
+        raise SkipTest('xelatex + pgf is required')
+
+    plt.figure()
+    plt.plot([0., 1e100], [0., 1e100])
+    plt.xlim(0, 1)
+    plt.ylim(0, 1)
+    # this test passes if compiling/saving to pdf works (no image comparison)
+    plt.savefig(os.path.join(result_dir, "pgf_pathclip.pdf"))
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s','--with-doctest'], exit=False)


### PR DESCRIPTION
Because LaTeX doesn't handle very large numbers (#1857), this PR moves some of the clipping operations from the pgf-code into backend_pgf.
