### PR TITLE
fix the pyplot version of rc_context

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -197,7 +197,7 @@ def rc(*args, **kwargs):
 
 @docstring.copy_dedent(matplotlib.rc_context)
 def rc_context(rc=None, fname=None):
-    matplotlib.rc_context(rc, fname)
+    return matplotlib.rc_context(rc, fname)
 
 @docstring.copy_dedent(matplotlib.rcdefaults)
 def rcdefaults():


### PR DESCRIPTION
Before this, when using the rc_context dangling from pyplot, one would
get an AttributeError for `__exit__`, because plt.rc_context wasn't
actually returning anything before this change.
