### PR TITLE
Decode subprocess output to utf-8 or regex will fail

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1287,7 +1287,7 @@ if USE_FONTCONFIG and sys.platform != 'win32':
         except OSError:
             return None
         if pipe.returncode == 0:
-            for match in _fc_match_regex.finditer(output):
+            for match in _fc_match_regex.finditer(output.decode("utf-8")):
                 file = match.group(1)
                 if os.path.splitext(file)[1][1:] in fontexts:
                     return file


### PR DESCRIPTION
This is an alternative fix for issue #1767, which changes the regular expression to bytes instead. But that will fail later on in `if os.path.splitext(file)[1][1:] in fontexts`, as fontexts will then be a set of strings and the former will be the current extension, but in bytes.

After this patch both will be strings and anything works here for me so far.

The RH bug for this is at:
https://bugzilla.redhat.com/show_bug.cgi?id=928326
