### PR TITLE
Clarify documentation for FuncAnimation

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -954,8 +954,8 @@ class FuncAnimation(TimedAnimation):
     results of drawing from the first item in the frames sequence will be
     used. This function will be called once before the first frame. 
 
-    If blit=True, *func* and *init_func* should return a list of drawables to
-    clear.
+    If blit=True, *func* and *init_func* should return an iterable of
+    drawables to clear.
     '''
     def __init__(self, fig, func, frames=None, init_func=None, fargs=None,
             save_count=None, **kwargs):


### PR DESCRIPTION
The current documentation for the init_func in FuncAnimation could be interpreted to mean that it is called before every frame.  At least that's how I interpreted until I tested.

More importantly, in the case when blit == True, if the init function doesn't return an iterable you get quite an opaque exception thrown.
