### PR TITLE
text is not properly clipped in 1.2.1

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -3394,6 +3394,7 @@ class Axes(martist.Artist):
             'verticalalignment' : 'baseline',
             'horizontalalignment' : 'left',
             'transform' : self.transData,
+            'clip_on' : False
             }
 
         # At some point if we feel confident that TextWithDash
@@ -3418,9 +3419,7 @@ class Axes(martist.Artist):
         self.texts.append(t)
         t._remove_method = lambda h: self.texts.remove(h)
 
-
-        #if t.get_clip_on():  t.set_clip_box(self.bbox)
-        if 'clip_on' in kwargs:  t.set_clip_box(self.bbox)
+        t.set_clip_path(self.patch)
         return t
 
     @docstring.dedent_interpd


### PR DESCRIPTION
matplotlib 1.2.1, python 2.7.3, OS X 10.8.3, TkAgg backend

Calling text() to render and then interactively panning the image, the resulting text is not properly clipped to the data window, and over flows it.

Code to reproduce:

``` python
import matplotlib.pyplot as plt

plt.ion()
fig = plt.figure()
ax = fig.add_subplot(111)

t1 = ax.text(0.5, 0.2, 'no clip')
t2 = ax.text(0.5, 0.3, 'clipped', clip_on=True)
```

Now pan the text to the data window borders and watch the clipping.

Possible resolution:
So the bug appears to be that the initial bounding box for text is not set if 'clip_on' is not supplied as an arg.

t1.get_clip_on() == True
t1.get_clip_box() == None
t2.get_clip_on() == True
t2.get_clip_box() == TransformedBbox(...)

Toggling clip_on does not fix the problem.
