### PR TITLE
Fix building when Gtk doesn't support version check

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1408,11 +1408,13 @@ def backend_gtk3agg_internal_check(x):
     if sys.version_info[0] >= 3:
         return (False, "gtk3agg does not work on Python 3")
 
-    return (True, "version %s.%s.%s" % (
-        Gtk.get_major_version(),
-        Gtk.get_micro_version(),
-        Gtk.get_minor_version()))
-
+    try:
+        return (True, "version %s.%s.%s" % (
+            Gtk.get_major_version(),
+            Gtk.get_micro_version(),
+            Gtk.get_minor_version()))
+    except AttributeError:
+        return (True, "version unknown")
 
 class BackendGtk3Agg(OptionalBackendPackage):
     name = "gtk3agg"
@@ -1450,11 +1452,13 @@ def backend_gtk3cairo_internal_check(x):
     except ImportError:
         return (False, "Requires pygobject to be installed.")
 
-    return (True, "version %s.%s.%s" % (
-        Gtk.get_major_version(),
-        Gtk.get_micro_version(),
-        Gtk.get_minor_version()))
-
+    try:
+        return (True, "version %s.%s.%s" % (
+            Gtk.get_major_version(),
+            Gtk.get_micro_version(),
+            Gtk.get_minor_version()))
+    except AttributeError:
+        return (True, "version unknown")
 
 class BackendGtk3Cairo(OptionalBackendPackage):
     name = "gtk3cairo"


### PR DESCRIPTION
This is a quick patch to fix a build problem that I ran into this morning when updating matplotlib via pyston on my Ubuntu 12 laptop.  I haven't dug into this deeply, but this
is my current understanding (and the patch _does_ fix the build problem on my laptop):

python setup.py install --user
fails with
AttributeError: 'gi.repository.Gtk' object has no attribute 'get_major_version'

for old versions of Gtk without support for introspection
(specifically, on Ubuntu 12 with python-gtk2 2.24.0-3)

This commit silently drops the associated exceptions for the two Gtk
version checks in setupext.py
