### PR TITLE
Default quit keymap - support for cmd+w on OSX

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -750,7 +750,7 @@ defaultParams = {
     'keymap.pan':          ['p', validate_stringlist],
     'keymap.zoom':         ['o', validate_stringlist],
     'keymap.save':         [('s', 'ctrl+s'), validate_stringlist],
-    'keymap.quit':         [('ctrl+w', ), validate_stringlist],
+    'keymap.quit':         [('ctrl+w', 'cmd+w'), validate_stringlist],
     'keymap.grid':         ['g', validate_stringlist],
     'keymap.yscale':       ['l', validate_stringlist],
     'keymap.xscale':       [['k', 'L'], validate_stringlist],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -432,7 +432,7 @@ text.hinting_factor : 8 # Specifies the amount of softness for hinting in the
 #keymap.pan : p                      # pan mnemonic
 #keymap.zoom : o                     # zoom mnemonic
 #keymap.save : s                     # saving current figure
-#keymap.quit : ctrl+w                # close the current figure
+#keymap.quit : ctrl+w, cmd+w         # close the current figure
 #keymap.grid : g                     # switching on/off a grid in current axes
 #keymap.yscale : l                   # toggle scaling of y-axes ('log'/'linear')
 #keymap.xscale : L, k                # toggle scaling of x-axes ('log'/'linear')


### PR DESCRIPTION
Updated default quit keymap to include cmd+w so people running on OS X would have a native cmd+w to close the window.
