### PR TITLE
Prevent Qt4 from stopping the interpreter

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 import math
 import os
+import re
 import signal
 import sys
 
@@ -57,7 +58,7 @@ def _create_qApp():
             # check for DISPLAY env variable on X11 build of Qt
             if hasattr(QtGui, "QX11Info"):
                 display = os.environ.get('DISPLAY')
-                if (display is None) or (not ':' in display):
+                if display is None or not re.search(':\d', display):
                     raise RuntimeError('Invalid DISPLAY variable')
         
             qApp = QtGui.QApplication( [" "] )


### PR DESCRIPTION
Hi,

This commit prevents Qt4 from stopping the interpreter:
If there's no X server available, or if you export DISPLAY="", and try to initialize a QApp, Qt4 stops:

```
: cannot connect to X server
```

It's a non-feature of Qt4 to not use exceptions to be lightweight.
But in python, that's not really the spirit, we'd expect a python backtrace, so here's what the patch does:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/schueller/projects/matplotlib/install/lib/python2.7/site-packages/matplotlib-1.3.x-py2.7-linux-x86_64.egg/matplotlib/pyplot.py", line 348, in figure
    **kwargs)
 ...
    raise RuntimeError( 'Qt4 failed to initialize ' + p.stderr.readline().rstrip() )     
RuntimeError: Qt4 failed to initialize : cannot connect to X server
```

And it's more like the other backends do:

```
_tkinter.TclError: couldn't connect to display ""
```

Regards.

(EDIT by @pelson: Added code blocks)
