### PR TITLE
Fix texmanager.dvipng_hack_alpha() to correctly use Popen.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -65,8 +65,8 @@ else:
 
 def dvipng_hack_alpha():
     try:
-        p = Popen('dvipng -version', stdin=PIPE, stdout=PIPE, stderr=STDOUT,
-                  close_fds=(sys.platform != 'win32'))
+        p = Popen(['dvipng', '-version'], stdin=PIPE, stdout=PIPE,
+                  stderr=STDOUT, close_fds=(sys.platform != 'win32'))
     except OSError:
         mpl.verbose.report('No dvipng was found', 'helpful')
         return False


### PR DESCRIPTION
Previously would never find dvipng, so always returned `False`.

Fixes Issue #1911.
