### PR TITLE
fix Travis failures on 2.6 and 2.7

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1294,7 +1294,7 @@ if USE_FONTCONFIG and sys.platform != 'win32':
                     return file
         return None
 
-    _fc_match_regex = re.compile(rb'\sfile:\s+"([^"]*)"')
+    _fc_match_regex = re.compile(br'\sfile:\s+"([^"]*)"')
     _fc_match_cache = {}
 
     def findfont(prop, fontext='ttf'):


### PR DESCRIPTION
br'' syntax is the way to go on 2.6 and 2.7, rb'' does not work

@mdboom, can you take a look at this - git blame tells me you're the one that put the offending line in ;)
