### PR TITLE
Workaround for Python 3 with pyparsing <= 2.0.0

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -114,15 +114,11 @@ try:
 except ImportError:
     raise ImportError("matplotlib requires pyparsing")
 else:
-    if sys.version_info[0] >= 3:
-        _required = [2, 0, 0]
-    else:
-        _required = [1, 5, 6]
+    _required = [1, 5, 6]
     if [int(x) for x in pyparsing.__version__.split('.')] < _required:
         raise ImportError(
-            "matplotlib requires pyparsing >= {0} on Python {1}".format(
-                '.'.join(str(x) for x in _required),
-                sys.version_info[0]))
+            "matplotlib requires pyparsing >= {0}".format(
+                '.'.join(str(x) for x in _required)))
 
 import os, re, shutil, warnings
 import distutils.sysconfig

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -34,13 +34,20 @@ from warnings import warn
 from numpy import inf, isinf
 import numpy as np
 
+import pyparsing
 from pyparsing import Combine, Group, Optional, Forward, \
      Literal, OneOrMore, ZeroOrMore, ParseException, Empty, \
      ParseResults, Suppress, oneOf, StringEnd, ParseFatalException, \
      FollowedBy, Regex, ParserElement, QuotedString, ParseBaseException
 
 # Enable packrat parsing
-ParserElement.enablePackrat()
+if (sys.version_info[0] >= 3 and
+    [int(x) for x in pyparsing.__version__.split('.')] < [2, 0, 0]):
+    warn("Due to a bug in pyparsing <= 2.0.0 on Python 3.x, packrat parsing "
+         "has been disabled.  Mathtext rendering will be much slower as a "
+         "result.  Install pyparsing 2.0.0 or later to improve performance.")
+else:
+    ParserElement.enablePackrat()
 
 from matplotlib.afm import AFM
 from matplotlib.cbook import Bunch, get_realpath_and_stat, \

--- a/setupext.py
+++ b/setupext.py
@@ -940,7 +940,7 @@ class Pyparsing(SetupPackage):
 
     def get_install_requires(self):
         if sys.version_info[0] >= 3:
-            return ['pyparsing>=2.0.0']
+            return ['pyparsing>=1.5.6']
         else:
             # pyparsing >= 2.0.0 is not compatible with Python 2
             return ['pyparsing>=1.5.6,<2.0.0']


### PR DESCRIPTION
Turning off packrat parsing will avoid a bug in pyparsing <= 2.0.0, however it is much slower.

http://pyparsing.svn.sourceforge.net/viewvc/pyparsing/src/pyparsing_py3.py?r1=219&r2=218&pathrev=219

This is a follow on to the discussion in #1788
