### PR TITLE
Fixed polygon3d rendering bug issue #178

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -745,6 +745,16 @@ class PolyCollection(Collection):
 
     set_paths = set_verts
 
+    def set_verts_and_codes(self, verts, codes):
+        assert(len(verts) == len(codes))
+        self._paths = []
+        for xy, cds in zip(verts, codes):
+            assert(len(xy) == len(cds))
+            if len(xy):
+                self._paths.append(mpath.Path(xy, cds))
+            else:
+                self._paths.append(mpath.Path(xy))
+
     @allow_rasterization
     def draw(self, renderer):
         if self._sizes is not None:

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -132,11 +132,13 @@ def path_to_3d_segment(path, zs=0, zdir='z'):
         zs = np.ones(len(path)) * zs
 
     seg = []
+    codes = []
     pathsegs = path.iter_segments(simplify=False, curves=False)
     for (((x, y), code), z) in zip(pathsegs, zs):
         seg.append((x, y, z))
+        codes.append(code)
     seg3d = [juggle_axes(x, y, z, zdir) for (x, y, z) in seg]
-    return seg3d
+    return seg3d, codes
 
 def paths_to_3d_segments(paths, zs=0, zdir='z'):
     '''
@@ -147,9 +149,12 @@ def paths_to_3d_segments(paths, zs=0, zdir='z'):
         zs = np.ones(len(paths)) * zs
 
     segments = []
+    codes_list = []
     for path, pathz in zip(paths, zs):
-        segments.append(path_to_3d_segment(path, pathz, zdir))
-    return segments
+        segs, codes = path_to_3d_segment(path, pathz, zdir)
+        segments.append(segs)
+        codes_list.append(codes)
+    return segments, codes_list
 
 class Line3DCollection(LineCollection):
     '''
@@ -196,7 +201,7 @@ class Line3DCollection(LineCollection):
 
 def line_collection_2d_to_3d(col, zs=0, zdir='z'):
     """Convert a LineCollection to a Line3DCollection object."""
-    segments3d = paths_to_3d_segments(col.get_paths(), zs, zdir)
+    segments3d = paths_to_3d_segments(col.get_paths(), zs, zdir)[0]
     col.__class__ = Line3DCollection
     col.set_segments(segments3d)
 
@@ -363,6 +368,8 @@ class Poly3DCollection(PolyCollection):
 
         PolyCollection.__init__(self, verts, *args, **kwargs)
 
+        self._codes3d = None
+
     _zsort_functions = {
         'average': np.average,
         'min': np.min,
@@ -419,6 +426,10 @@ class Poly3DCollection(PolyCollection):
         # 2D verts will be updated at draw time
         PolyCollection.set_verts(self, [], closed)
 
+    def set_verts_and_codes(self, verts, codes):
+        self.set_verts(verts, closed=False)
+        self._codes3d = codes
+
     def set_3d_properties(self):
         # Force the collection to initialize the face and edgecolors
         # just in case it is a scalarmappable with a colormap.
@@ -457,18 +468,24 @@ class Poly3DCollection(PolyCollection):
 
         # if required sort by depth (furthest drawn first)
         if self._zsort:
-            z_segments_2d = [(self._zsortfunc(zs), zip(xs, ys), fc, ec) for
-                    (xs, ys, zs), fc, ec in zip(xyzlist, cface, cedge)]
+            indices = range(len(xyzlist))
+            z_segments_2d = [(self._zsortfunc(zs), zip(xs, ys), fc, ec, idx)
+                for (xs, ys, zs), fc, ec, idx in zip(xyzlist, cface, cedge,
+                indices)]
             z_segments_2d.sort(key=lambda x: x[0], reverse=True)
         else:
             raise ValueError, "whoops"
 
-        segments_2d = [s for z, s, fc, ec in z_segments_2d]
-        PolyCollection.set_verts(self, segments_2d)
+        segments_2d = [s for z, s, fc, ec, idx in z_segments_2d]
+        if self._codes3d is not None:
+            codes = [self._codes3d[idx] for z, s, fc, ec, idx in z_segments_2d]
+            PolyCollection.set_verts_and_codes(self, segments_2d, codes)
+        else:
+            PolyCollection.set_verts(self, segments_2d)
 
-        self._facecolors2d = [fc for z, s, fc, ec in z_segments_2d]
+        self._facecolors2d = [fc for z, s, fc, ec, idx in z_segments_2d]
         if len(self._edgecolors3d) == len(cface):
-            self._edgecolors2d = [ec for z, s, fc, ec in z_segments_2d]
+            self._edgecolors2d = [ec for z, s, fc, ec, idx in z_segments_2d]
         else:
             self._edgecolors2d = self._edgecolors3d
 
@@ -508,9 +525,9 @@ class Poly3DCollection(PolyCollection):
 
 def poly_collection_2d_to_3d(col, zs=0, zdir='z'):
     """Convert a PolyCollection to a Poly3DCollection object."""
-    segments_3d = paths_to_3d_segments(col.get_paths(), zs, zdir)
+    segments_3d, codes = paths_to_3d_segments(col.get_paths(), zs, zdir)
     col.__class__ = Poly3DCollection
-    col.set_verts(segments_3d)
+    col.set_verts_and_codes(segments_3d, codes)
     col.set_3d_properties()
 
 def juggle_axes(xs, ys, zs, zdir):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -464,7 +464,7 @@ class Axes3D(Axes):
         .. versionchanged :: 1.1.0
             Function signature was changed to better match the 2D version.
             *tight* is now explicitly a kwarg and placed first.
-            
+
         .. versionchanged :: 1.2.1
             This is now fully functional.
 
@@ -668,7 +668,7 @@ class Axes3D(Axes):
         Set 3D z limits.
 
         See :meth:`matplotlib.axes.Axes.set_ylim` for full documentation
-        
+
         """
         if 'zmin' in kw:
             bottom = kw.pop('zmin')
@@ -1860,8 +1860,8 @@ class Axes3D(Axes):
         dz = (levels[1] - levels[0]) / 2
 
         for z, linec in zip(levels, colls):
-            topverts = art3d.paths_to_3d_segments(linec.get_paths(), z - dz)
-            botverts = art3d.paths_to_3d_segments(linec.get_paths(), z + dz)
+            topverts = art3d.paths_to_3d_segments(linec.get_paths(), z - dz)[0]
+            botverts = art3d.paths_to_3d_segments(linec.get_paths(), z + dz)[0]
 
             color = linec.get_color()[0]
 


### PR DESCRIPTION
This is a candidate fix for the mplot3d polygon rendering bug of issue #178; it will also allow PR #1299 to proceed.

The changes are all in the mplot3d code, except for one new function in `collections.py` which is only called from mplot3d code.  With this fix the test script added by @WeatherGod to #178 works OK, and all the existing mplot3d examples work as before.

The code changes are not elegant, but are consistent with existing mplot3d code.

I haven't PEP8'd the changes as the original mplot3d files haven't been PEP8'd yet.
