### PR TITLE
DOC - two modules link appeared in the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -161,6 +161,7 @@ html_additional_pages = {'index': 'index.html',
 
 # If false, no module index is generated.
 #html_use_modindex = True
+html_domain_indices = ["py-modindex"]
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
 #html_copy_source = True


### PR DESCRIPTION
ref #1837

Thanks to @GBillotey for the fix.
2 modules links appears in the top toolbar at once. Now, only one appear.
