### PR TITLE
add pkgconfig to homebrew install instruction

### DIFF
--- a/README.osx
+++ b/README.osx
@@ -9,7 +9,7 @@ homebrew.
 
 Example usage::
 
-  brew install libpng freetype
+  brew install libpng freetype pkgconfig
 
 If you are using MacPorts, execute the following instead:
 


### PR DESCRIPTION
build will not find freetype headers without it.

Alternate fix would be to search for freetype in the homebrew location (`/usr/local/Cellar/freetype/VERSION/`), or add the right location to the include path (`/usr/local/include/freetype2`).
