### PR TITLE
Tidy up the matplotlib.__init__ documentation.

### DIFF
--- a/doc/api/matplotlib_configuration_api.rst
+++ b/doc/api/matplotlib_configuration_api.rst
@@ -1,7 +1,37 @@
 The top level :mod:`matplotlib` module
 ======================================
 
-.. automodule:: matplotlib
-   :members: rc, rcdefaults, use
-   :undoc-members:
-   :show-inheritance:
+
+.. py:currentmodule:: matplotlib
+
+.. autofunction:: use
+
+.. autofunction:: get_backend 
+
+.. py:data:: matplotlib.rcParams
+
+    An instance of :class:`RcParams` for handling default matplotlib values.
+
+.. autofunction:: rc
+
+.. autofunction::rcdefaults
+
+.. autofunction::rc_file
+
+.. autofunction::rc_context
+
+.. autofunction:: matplotlib_fname
+
+.. autofunction::rc_file_defaults
+
+.. autofunction::interactive
+
+.. autofunction::is_interactive
+
+.. autoclass:: RcParams
+
+.. autofunction:: rc_params
+
+.. autofunction:: rc_params_from_file
+
+.. autoclass:: rc_context

--- a/doc/sphinxext/gen_gallery.py
+++ b/doc/sphinxext/gen_gallery.py
@@ -151,9 +151,10 @@ def gen_gallery(app, doctree):
         fh.close()
 
     for key in app.builder.status_iterator(
-        iter(thumbnails.keys()), "generating thumbnails... ",
-        length=len(thumbnails)):
-        image.thumbnail(key, thumbnails[key], 0.3)
+            iter(thumbnails.keys()), "generating thumbnails... ",
+            length=len(thumbnails)):
+        if out_of_date(key, thumbnails[key]):
+            image.thumbnail(key, thumbnails[key], 0.3)
 
 
 def setup(app):


### PR DESCRIPTION
The matplotlib namespace is _really_ cluttered. Many of the functions here could be static methods or instance methods of the RcParams dictionary class.

I don't want to hold up this PR, but if there is appetite to break backwards compatibility, I'd be willing to tidy it up in a follow-on PR.
