### PR TITLE
imsave should preserve alpha channel

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1273,7 +1273,7 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
     fig = Figure(figsize=figsize, dpi=dpi, frameon=False)
     canvas = FigureCanvas(fig)
     im = fig.figimage(arr, cmap=cmap, vmin=vmin, vmax=vmax, origin=origin)
-    fig.savefig(fname, dpi=dpi, format=format)
+    fig.savefig(fname, dpi=dpi, format=format, transparent=True)
 
 
 def pil_to_array( pilImage ):


### PR DESCRIPTION
While looking at test_image, I noticed the comment that `imsave` was flattening alpha channel data. I figured this was related to #1868 (it is, partially), and decided to fix it.

I've updated the test to reflect that an imsave/imread round-trip should now preserve full RGBA data to within 1/255.

Passing the test, however, requires that the patches from #1868 also be applied.
