### PR TITLE
SubplotBase._make_twin_axes always creates a new subplot instance. 

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -9283,7 +9283,14 @@ class SubplotBase:
         """
         make a twinx axes of self. This is used for twinx and twiny.
         """
-        ax2 = self.figure.add_subplot(self.get_subplotspec(), *kl, **kwargs)
+        from matplotlib.projections import process_projection_requirements
+        kl = (self.get_subplotspec(),) + kl
+        projection_class, kwargs, key = process_projection_requirements(
+            self.figure, *kl, **kwargs)
+
+        ax2 = subplot_class_factory(projection_class)(self.figure,
+                                                      *kl, **kwargs)
+        self.figure.add_subplot(ax2)
         return ax2
 
 _subplot_classes = {}


### PR DESCRIPTION
This is to fix #1957.
