### PR TITLE
Build: allow local static png dependency

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -797,9 +797,13 @@ class Png(SetupPackage):
     name = "png"
 
     def check(self):
-        return self._check_for_pkg_config(
-            'libpng', 'png.h',
-            min_version='1.2')
+        try:
+            return self._check_for_pkg_config(
+                'libpng', 'png.h',
+                min_version='1.2')
+        except CheckFailed as e:
+            self.__class__.found_external = False
+            return str(e) + ' Using local copy.'
 
     def get_extension(self):
         sources = [


### PR DESCRIPTION
To start with, I am very new to building with windows SDK - so this issue is probably related with a bad practise: please tell.

Since commit 386b4e53bb I have been unable to build using a local static png dependency (the one generously provided online by: http://www.lfd.uci.edu/~gohlke/pythonlibs/#matplotlib). Previously it would build even with png version = None ; now a `CheckFailed` error is raised.

As a workaround I ended adding the same try / catch pattern in check method of
`Png` class as in the `LibAgg` class of `setupext.py`. I am really unsure this the good thing to do ; however in this case I would be happy to learn.
