### PR TITLE
Setting font type using rcParams does not work under Python 3.*

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -970,7 +970,7 @@ end"""
                      " ".join(["<%04x>" % x for x in range(start, end+1)])))
             unicode_cmap = (self._identityToUnicodeCMap %
                             (len(unicode_groups),
-                             "\n".join(unicode_bfrange)))
+                             "\n".join(unicode_bfrange))).encode('ascii')
 
             # CIDToGIDMap stream
             cid_to_gid_map = "".join(cid_to_gid_map).encode("utf-16be")

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -22,3 +22,15 @@ def test_use14corefonts():
     plt.title(title)
     plt.text(0.5, 0.5, text, horizontalalignment='center', fontsize=24)
     plt.axhline(0.5, linewidth=0.5)
+
+
+def test_type42():
+    import io
+
+    rcParams['backend'] = 'pdf'
+    rcParams['pdf.fonttype'] = 42
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.plot([1,2,3])
+    fig.savefig(io.BytesIO())


### PR DESCRIPTION
The following code:

``` python
import matplotlib as mpl
import matplotlib.pyplot as plt
# if I omit the next line, the plot saves without error, but with outlined fonts
mpl.rcParams['pdf.fonttype'] = 42        #set Truetype fonts for Adobe
plt.plot(range(5),range(5),'r-')
plt.ylabel('y')
plt.xlabel('x')
plt.title('title')
plt.savefig("myfig.pdf")
```

runs fine in Python 2.7.3, but causes `TypeError: 'str' does not support the buffer interface` error in Python 3.3 on OsX and Python 3.2.3 on Linux.

(se also http://stackoverflow.com/questions/16391280/python-3-3-matplotlib-1-2-0-pdf-export-generates-str-does-not-support-the )
