### PR TITLE
Fix bug in SpanSelector, introduced in commit #dd325759

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1072,10 +1072,12 @@ class SpanSelector(AxesWidget):
         self.buttonDown = False
         self.prev = (0, 0)
 
+        # Set useblit based on original canvas.
+        self.useblit = useblit and self.canvas.supports_blit
+
         # Reset canvas so that `new_axes` connects events.
         self.canvas = None
         self.new_axes(ax)
-        self.useblit = useblit and self.canvas.supports_blit
 
     def new_axes(self, ax):
         self.ax = ax


### PR DESCRIPTION
The useblit attribute was being set after calling new_axes,
but new_axes needs that attribute.  By setting useblit before
calling new_axes, we set it based on the initial canvas; even
though new_axes might change to a different canvas, we assume
it will be the same type of canvas (same backend), so its
supports_blit attribute will not change.
