### PR TITLE
New doc build failure

### DIFF
--- a/doc/mpl_toolkits/index.rst
+++ b/doc/mpl_toolkits/index.rst
@@ -5,7 +5,7 @@
 
    axes_grid/index.rst
    mplot3d/index.rst
-   
+
 
 ########
 Toolkits
@@ -89,8 +89,7 @@ line, mesh) tools.  Not the fastest or feature complete 3D library out
 there, but ships with matplotlib and thus may be a lighter weight
 solution for some use cases.
 
-.. image:: /_images/contourf3d_demo21.png
-
+.. plot:: mpl_examples/mplot3d/contourf3d_demo2.py
 
 .. _toolkit_axes_grid:
 


### PR DESCRIPTION
Latex problems again. Doc pull requests merged in the last day are #1924 and #1918, by the looks of it.

There's a lot of warnings, ending in:

```
LaTeX Warning: Hyper reference `mpl_toolkits/mplot3d/index:toolkit-mplot3d-inde
x' on page 521 undefined on input line 29783.


LaTeX Warning: File `_images/contourf3d_demo21.png' not found on input line 297
88.


! Package pdftex.def Error: File `_images/contourf3d_demo21.png' not found.

See the pdftex.def package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              

l.29788 ...graphics{_images/contourf3d_demo21.png}

? 
! Emergency stop.
 ...                                              

l.29788 ...graphics{_images/contourf3d_demo21.png}

!  ==> Fatal error occurred, no output PDF file produced!
```

[Build log](https://launchpadlibrarian.net/138514402/buildlog_ubuntu-raring-i386.matplotlib_1.2.0~1%2B6570%2B23~raring1_FAILEDTOBUILD.txt.gz)
