### PR TITLE
Wx backend broken

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -263,6 +263,7 @@ class RendererWx(RendererBase):
         """
         Initialise a wxWindows renderer instance.
         """
+        RendererBase.__init__(self)
         DEBUG_MSG("__init__()", 1, self)
         if wx.VERSION_STRING < "2.8":
             raise RuntimeError("matplotlib no longer supports wxPython < 2.8 for the Wx backend.\nYou may, however, use the WxAgg backend.")


### PR DESCRIPTION
Running `simple_plot.py` with the Wx backend gives:

```
Traceback (most recent call last):
  File "simple_plot.py", line 11, in <module>
    savefig("test.png")
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/pyplot.py", line 472, in savefig
    return fig.savefig(*args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/figure.py", line 1370, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/backends/backend_wx.py", line 1128, in print_figure
    FigureCanvasBase.print_figure(self, filename, *args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 2104, in print_figure
    **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/backends/backend_wx.py", line 1147, in print_png
    return self._print_image(filename, wx.BITMAP_TYPE_PNG, *args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/backends/backend_wx.py", line 1168, in _print_image
    self.figure.draw(renderer)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/figure.py", line 1006, in draw
    func(*args)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/axes.py", line 2086, in draw
    a.draw(renderer)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/axis.py", line 1055, in draw
    tick.draw(renderer)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/axis.py", line 240, in draw
    self.label1.draw(renderer)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/text.py", line 576, in draw
    self._fontproperties, angle)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 454, in draw_tex
    self._draw_text_as_path(gc, x, y, s, prop, angle, ismath="TeX")
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 548, in _draw_text_as_path
    path, transform = self._get_text_path_transform(x, y, s, prop, angle, ismath)
  File "/home/mdboom/python/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 509, in _get_text_path_transform
    text2path = self._text2path
AttributeError: RendererWx instance has no attribute '_text2path'
```

Fix coming shortly....
