### PR TITLE
Setting dashes to (0,0) results in infinite loop for agg backends

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -872,6 +872,10 @@ class GraphicsContextBase:
             specifies the on-off sequence as points.  ``(None, None)`` specifies a solid line
 
         """
+        if dash_list is not None:
+            dash_list = np.asarray(dash_list)
+            if np.any(dash_list <= 0.0):
+                raise ValueError("All values in the dash list must be positive")
         self._dashes = dash_offset, dash_list
 
     def set_foreground(self, fg, isRGB=False):


### PR DESCRIPTION
Other backends may also be affected. I have not tested exhaustively.

It would be good to check in GraphicsContextBase.set_dashes that dash_list is not all 0's. Some backends (cairo and gdk) override set_dashes, so those may need to be modified as well.
