### PR TITLE
Make wx and wxagg work with wx 2.9.x on Mac.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1506,21 +1506,14 @@ class FigureFrameWx(wx.Frame):
 
         if self.toolbar is not None:
             self.toolbar.Realize()
-            if wx.Platform == '__WXMAC__':
-                # Mac platform (OSX 10.3, MacPython) does not seem to cope with
-                # having a toolbar in a sizer. This work-around gets the buttons
-                # back, but at the expense of having the toolbar at the top
-                self.SetToolBar(self.toolbar)
-            else:
-                # On Windows platform, default window size is incorrect, so set
-                # toolbar width to figure width.
-                tw, th = self.toolbar.GetSizeTuple()
-                fw, fh = self.canvas.GetSizeTuple()
-                # By adding toolbar in sizer, we are able to put it at the bottom
-                # of the frame - so appearance is closer to GTK version.
-                # As noted above, doesn't work for Mac.
-                self.toolbar.SetSize(wx.Size(fw, th))
-                self.sizer.Add(self.toolbar, 0, wx.LEFT | wx.EXPAND)
+            # On Windows platform, default window size is incorrect, so set
+            # toolbar width to figure width.
+            tw, th = self.toolbar.GetSizeTuple()
+            fw, fh = self.canvas.GetSizeTuple()
+            # By adding toolbar in sizer, we are able to put it at the bottom
+            # of the frame - so appearance is closer to GTK version.
+            self.toolbar.SetSize(wx.Size(fw, th))
+            self.sizer.Add(self.toolbar, 0, wx.LEFT | wx.EXPAND)
         self.SetSizer(self.sizer)
         self.Fit()
 


### PR DESCRIPTION
This affects the wx\* backends on OSX only.  It removes Mac-specific
code that was letting the Frame manage the toolbar directly, without
using the Sizer.  There was a comment saying that this was needed
for OSX 10.3.  With wx 2.9.x, however, this method of handling
the toolbar does not work at all; no toolbar appears, and the
program can hang or otherwise behave erratically.  The Sizer
method, however, works.

The big question is whether the Sizer method works on the Mac
with wx 2.8.x.  If it does, then this can be merged.
