### PR TITLE
mixed backend rely on __getattr__ method

### DIFF
--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -53,24 +53,11 @@ class MixedModeRenderer(object):
 
         self._set_current_renderer(vector_renderer)
 
-    _methods = """
-        close_group draw_image draw_markers draw_path
-        draw_path_collection draw_quad_mesh draw_tex draw_text
-        finalize flipy get_canvas_width_height get_image_magnification
-        get_texmanager get_text_width_height_descent new_gc open_group
-        option_image_nocomposite points_to_pixels strip_math
-        start_filter stop_filter draw_gouraud_triangle
-        draw_gouraud_triangles option_scale_image
-        """.split()
     def _set_current_renderer(self, renderer):
         self._renderer = renderer
 
-        for method in self._methods:
-            if hasattr(renderer, method):
-                setattr(self, method, getattr(renderer, method))
-        renderer.start_rasterizing = self.start_rasterizing
-        renderer.stop_rasterizing = self.stop_rasterizing
-
+    def __getattr__(self, name):
+        return getattr(self._renderer, name)
 
     def start_rasterizing(self):
         """


### PR DESCRIPTION
In the current implementation, when `MixedRenerer._set_current_renderer` is called, it replaces self's methods (e.g., draw_path, etc.) with the methods of the given render where the list of methods to be replaced is hard-coded. Unless there are severe disadvantages, I propose an alternative of using `__getattr__` method, which is much simpler (at least to me). 
