### PR TITLE
ValueError: stretch is invalid

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -862,7 +862,7 @@ class FontProperties(object):
         'ultra-expanded', or a numeric value in the range 0-1000.
         """
         if stretch is None:
-            stretch = rcParams['font.weight']
+            stretch = rcParams['font.stretch']
         try:
             stretch = int(stretch)
             if stretch < 0 or stretch > 1000:


### PR DESCRIPTION
On current master

``` python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
```

results in

``` python
Traceback (most recent call last):
  File "mpl_xkcd.py", line 19, in <module>
    fig, ax = plt.subplots()
  File "/scratch/matplotlib/lib/matplotlib/pyplot.py", line 1034, in subplots
    ax0 = fig.add_subplot(nrows, ncols, 1, **subplot_kw)
  File "/scratch/matplotlib/lib/matplotlib/figure.py", line 914, in add_subplot
    a = subplot_class_factory(projection_class)(self, *args, **kwargs)
  File "/scratch/matplotlib/lib/matplotlib/axes.py", line 9225, in __init__
    self._axes_class.__init__(self, fig, self.figbox, **kwargs)
  File "/scratch/matplotlib/lib/matplotlib/axes.py", line 450, in __init__
    self._init_axis()
  File "/scratch/matplotlib/lib/matplotlib/axes.py", line 507, in _init_axis
    self.xaxis = maxis.XAxis(self)
  File "/scratch/matplotlib/lib/matplotlib/axis.py", line 645, in __init__
    self.label = self._get_label()
  File "/scratch/matplotlib/lib/matplotlib/axis.py", line 1615, in _get_label
    weight=rcParams['axes.labelweight']),
  File "/scratch/matplotlib/lib/matplotlib/font_manager.py", line 689, in __init__
    self.set_stretch(stretch)
  File "/scratch/matplotlib/lib/matplotlib/font_manager.py", line 872, in set_stretch
    raise ValueError("stretch is invalid")
ValueError: stretch is invalid
```

Maybe this is related to commit cc617006f7f0a18396cecf4a9f1e222f1ee5204e
