### PR TITLE
Fail to export properly to svg and pdf with interactive paths

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -2014,8 +2014,11 @@ class Axes(martist.Artist):
         if self.axison and self._frameon:
             artists.extend(self.spines.itervalues())
 
-        dsu = [ (a.zorder, a) for a in artists
-                if not a.get_animated() ]
+        if self.figure.canvas.is_saving():
+            dsu = [(a.zorder, a) for a in artists]
+        else:
+            dsu = [(a.zorder, a) for a in artists
+                   if not a.get_animated()]
 
         # add images to dsu if the backend support compositing.
         # otherwise, does the manaul compositing  without adding images to dsu.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1485,12 +1485,20 @@ class FigureCanvasBase(object):
         self.scroll_pick_id = self.mpl_connect('scroll_event',self.pick)
         self.mouse_grabber = None # the axes currently grabbing mouse
         self.toolbar = None  # NavigationToolbar2 will set me
+        self._is_saving = False
         if False:
             ## highlight the artists that are hit
             self.mpl_connect('motion_notify_event',self.onHilite)
             ## delete the artists that are clicked on
             #self.mpl_disconnect(self.button_pick_id)
             #self.mpl_connect('button_press_event',self.onRemove)
+
+    def is_saving(self):
+        """
+        Returns `True` when the renderer is in the process of saving
+        to a file, rather than rendering for an on-screen buffer.
+        """
+        return self._is_saving
 
     def onRemove(self, ev):
         """
@@ -2096,6 +2104,7 @@ class FigureCanvasBase(object):
         else:
             _bbox_inches_restore = None
 
+        self._is_saving = True
         try:
             #result = getattr(self, method_name)(
             result = print_method(
@@ -2114,6 +2123,7 @@ class FigureCanvasBase(object):
             self.figure.set_facecolor(origfacecolor)
             self.figure.set_edgecolor(origedgecolor)
             self.figure.set_canvas(self)
+            self._is_saving = False
             #self.figure.canvas.draw() ## seems superfluous
         return result
 
@@ -2160,6 +2170,7 @@ class FigureCanvasBase(object):
         figure size or line props), will be reflected in the other
         """
         newCanvas = FigureCanvasClass(self.figure)
+        newCanvas._is_saving = self._is_saving
         return newCanvas
 
     def mpl_connect(self, s, func):


### PR DESCRIPTION
Export to SVG and PDF fails with [path_editor.py](http://matplotlib.org/examples/event_handling/path_editor.html) and similar programs, but it works fine with PNG. Indeed, the paths generated interactively are missing on the saved images.

It was tested on 1.2.1 and master.

**PNG** file:
![PNG file](http://i.stack.imgur.com/nW2Td.png)

**SVG** file:
![SVG file](http://i.stack.imgur.com/b82zJ.png)

I also opened a [question on Stack Overflow](http://stackoverflow.com/questions/16555845/failing-to-export-properly-to-svg-and-pdf-with-matplotlib).
