### PR TITLE
Crash when using character with umlaut

### DIFF
--- a/ttconv/pprdrv_tt2.cpp
+++ b/ttconv/pprdrv_tt2.cpp
@@ -700,7 +700,7 @@ void ttfont_add_glyph_dependencies(struct TTFONT *font, std::vector<int>& glyph_
 
                     std::vector<int>::iterator insertion =
                         std::lower_bound(glyph_ids.begin(), glyph_ids.end(), gind);
-                    if (*insertion != gind)
+                    if (insertion == glyph_ids.end() || *insertion != gind)
                     {
                         glyph_ids.insert(insertion, gind);
                         glyph_stack.push(gind);


### PR DESCRIPTION
From the matplotlib-users thread entitled "problem with a umlaut" started by Ojala Janne.

```
    -*- coding: utf-8 -*-
    import matplotlib.pyplot as plt

    fig = plt.figure( )

    ax = fig.add_subplot(111)
    ax.hist([1,2,3,4,5,6,7,8,9,10], bins=range(1,11) )

    plt.ylabel(u'ä')
    fig.savefig('test.eps')
```

Christoph Gohlke adds:

   I can reproduce the crash on Python 2.7, 32 and 64 bit. Python 2.6 and 3.3 appear to work. The call stack is attached. The crash is in ttfont_add_glyph_dependencies() at https://github.com/matplotlib/matplotlib/blob/v1.2.x/ttconv/pprdrv_tt2.cpp#L703 
