### PR TITLE
qt4_editor formlayout now works with colour tuples (fixes Issue #1690)

### DIFF
--- a/lib/matplotlib/backends/qt4_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt4_editor/formlayout.py
@@ -125,6 +125,19 @@ def text_to_qcolor(text):
     color.setNamedColor(text)
     return color
 
+def is_matplotlib_color(value):
+    """
+    Check if value is a color passed to us from matplotlib.
+    It could either be a valid color string or a 3-tuple of floats between 0. and 1.
+    """
+    if text_to_qcolor(value).isValid():
+        return True
+    if isinstance(value,tuple) and len(value)==3 and all(map(lambda v: isinstance(v,float),value)):
+        for c in value:
+            if c < 0. or c > 1.:
+                return False
+        return True
+    return False
 
 class ColorLayout(QHBoxLayout):
     """Color-specialized QLineEdit layout"""
@@ -268,7 +281,7 @@ class FormWidget(QWidget):
                 continue
             elif tuple_to_qfont(value) is not None:
                 field = FontLayout(value, self)
-            elif text_to_qcolor(value).isValid():
+            elif is_matplotlib_color(value):
                 field = ColorLayout(QColor(value), self)
             elif isinstance(value, (str, unicode)):
                 field = QLineEdit(value, self)
@@ -329,7 +342,7 @@ class FormWidget(QWidget):
                 continue
             elif tuple_to_qfont(value) is not None:
                 value = field.get_font()
-            elif isinstance(value, (str, unicode)):
+            elif isinstance(value, (str, unicode)) or is_matplotlib_color(value):
                 value = unicode(field.text())
             elif isinstance(value, (list, tuple)):
                 index = int(field.currentIndex())


### PR DESCRIPTION
The form layout wasn't recognising colours that were in 3-tuple form. I added in a function to test for proper 3-tuples (ie: floats between 0 and 1). This is used when setting up the edit form in `FormWidget`'s `setup()` and when compiling the forms value in `get()`.

This fixes issue #1690 
