### PR TITLE
PS backend fails to savefig() pcolormesh with gouraud shading

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -824,14 +824,13 @@ grestore
         assert colors.shape[1] == 3
         assert colors.shape[2] == 4
 
-        points = trans.transform(points)
-
         shape = points.shape
         flat_points = points.reshape((shape[0] * shape[1], 2))
+        flat_points = trans.transform(flat_points)
         flat_colors = colors.reshape((shape[0] * shape[1], 4))
-        points_min = np.min(flat_points, axis=0) - (1 << 8)
-        points_max = np.max(flat_points, axis=0) + (1 << 8)
-        factor = float(0xffffffff) / (points_max - points_min)
+        points_min = np.min(flat_points, axis=0) - (1 << 12)
+        points_max = np.max(flat_points, axis=0) + (1 << 12)
+        factor = np.ceil(float(2 ** 32 - 1) / (points_max - points_min))
 
         xmin, ymin = points_min
         xmax, ymax = points_max


### PR DESCRIPTION
Following script

``` python
import numpy as np
from matplotlib.pyplot import figure, savefig

n = 12
x = np.linspace(-1.5,1.5,n)
y = np.linspace(-1.5,1.5,n*2)
X,Y = np.meshgrid(x,y);

Qx = np.cos(Y) - np.cos(X)
Qz = np.sin(Y) + np.sin(X)
Qx = (Qx + 1.1)
Z = np.sqrt(X**2 + Y**2)/5;
Z = (Z - Z.min()) / (Z.max() - Z.min())

fig = figure()
ax = fig.add_subplot(111)
ax.pcolormesh(Qx,Qz,Z, shading='gouraud')
savefig('bug.eps')
```

results in

``` text
Traceback (most recent call last):
  File "quad.py", line 20, in <module>
    savefig('bug.eps')
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/pyplot.py", line 494, in savefig
    return fig.savefig(*args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/figure.py", line 1403, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/backends/backend_qt4agg.py", line 161, in print_figure
    FigureCanvasAgg.print_figure(self, *args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/backend_bases.py", line 2158, in print_figure
    **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/backend_bases.py", line 1886, in print_eps
    return ps.print_eps(*args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/backends/backend_ps.py", line 974, in print_eps
    return self._print_ps(outfile, 'eps', *args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/backends/backend_ps.py", line 1002, in _print_ps
    **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/backends/backend_ps.py", line 1095, in _print_figure
    self.figure.draw(renderer)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/figure.py", line 1027, in draw
    func(*args)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/axes.py", line 2086, in draw
    a.draw(renderer)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/collections.py", line 1745, in draw
    gc, triangles, colors, transform.frozen())
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/backends/backend_ps.py", line 827, in draw_gouraud_triangles
    points = trans.transform(points)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/transforms.py", line 1561, in transform
    return self.transform_affine(values)
  File "/tmp/matplotlib/build/lib.linux-x86_64-2.7/matplotlib/transforms.py", line 1645, in transform_affine
    return affine_transform(points, mtx)
ValueError: Invalid vertices array.
```

Tested with

``` text
commit af07100823d219e51f061cfc8e96d957fa661126

BUILDING MATPLOTLIB
            matplotlib: yes [1.3.x]
                python: yes [2.7.4 (default, Apr 21 2013, 14:51:13)  [GCC
                        4.7.2]]
              platform: yes [linux2]

REQUIRED DEPENDENCIES AND EXTENSIONS
                 numpy: yes [version 1.6.2]
              dateutil: yes [using dateutil version 2.1]
               tornado: yes [using tornado version 2.3]
             pyparsing: yes [using pyparsing version 1.5.7]
                 pycxx: yes [pkg-config information for 'PyCXX' could not be
                        found. Using local copy.]
                libagg: yes [pkg-config information for 'libagg' could not
                        be found. Using local copy.]
              freetype: yes [version 16.0.10]
                   png: yes [version 1.6.1]

OPTIONAL SUBPACKAGES
           sample_data: yes [installing]
              toolkits: yes [installing]
                 tests: yes [using nose version 1.1.2]

OPTIONAL BACKEND EXTENSIONS
                macosx: no  [Mac OS-X only]
                qt4agg: yes [Qt: 4.8.2, PyQt4: 4.9.2]
               gtk3agg: yes [version 3.3.6]
             gtk3cairo: yes [version 3.3.6]
                gtkagg: yes [Gtk: 2.24.17 pygtk: 2.24.0]
                 tkagg: yes [version 81008]
                 wxagg: yes [version 2.8.12.1]
                   gtk: yes [Gtk: 2.24.17 pygtk: 2.24.0]
                 qtagg: no  [pyqt not found]
                   agg: yes [installing]
                 cairo: yes [version 1.10.0]

OPTIONAL LATEX DEPENDENCIES
                dvipng: yes [version Larsson]
           ghostscript: yes [version 9.06]
                 latex: yes [version 3.1415926]
               pdftops: yes [version 0.22.3]
```
