### PR TITLE
Build: avoid win32-incompatible functions

### DIFF
--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -866,8 +866,10 @@ public:
         if (m_has_last) {
             // We want the "cursor" along the sine wave to move at a
             // random rate.
-            m_p += pow(m_randomness, drand48() * 2.0 - 1.0);
-            double r = sin(m_p / (m_length / (M_PI * 2.0))) * m_scale;
+            float _drand48 = rand() / float(RAND_MAX);
+            float _M_PI = 3.14159265358979323846;
+            m_p += pow(m_randomness, _drand48 * 2.0 - 1.0);
+            double r = sin(m_p / (m_length / (_M_PI * 2.0))) * m_scale;
             double den = m_last_x - *x;
             double num = m_last_y - *y;
             double len = num*num + den*den;
@@ -891,8 +893,7 @@ public:
     inline void
     rewind(unsigned path_id)
     {
-        unsigned short seed[] = {0, 0, 0};
-        seed48(seed);
+        srand(0);
         m_has_last = false;
         m_p = 0.0;
         if (m_scale != 0.0) {


### PR DESCRIPTION
Dating from commit e1e0848625, I have been experimenting compiling errors (under win32).

```
c:\users\geoffroy\documents\github\matplotlib\src\path_converters.h(895) : error C3861: 'seed48': identifier not found
        c:\users\geoffroy\documents\github\matplotlib\src\path_converters.h(893) : while compiling class template member function 'void Sketch<VertexSource>::rewind(unsigned int)'
        with
        [
            VertexSource=curve_t
        ]
        src/_path.cpp(1516) : see reference to class template instantiation 'Sketch<VertexSource>' being compiled
        with
        [
            VertexSource=curve_t
        ]
```

They seem to be linked with the use of traditional UNIX functions like `drand48` in _path_converters.h_. `seed48` and `M_PI` are also problematic.

Enclosed is a patch attempt which uses ANSI C function `rand` and `srand` instead, and at least compile correctly - with win SDK. (The code being quite complex I can't be sure with my limited C++ knowledge this is the best way to deal with it ; hope it can help though)
