### PR TITLE
Fixed call to path.Path.contains_point from pnpoly. 

### DIFF
--- a/lib/matplotlib/nxutils.py
+++ b/lib/matplotlib/nxutils.py
@@ -23,7 +23,7 @@ def pnpoly(x, y, xyverts):
         mplDeprecation)
 
     p = path.Path(xyverts)
-    return p.contains_point(x, y)
+    return p.contains_point([x, y])
 
 def points_inside_poly(xypoints, xyverts):
     """


### PR DESCRIPTION
contains_point accepts a list as its first argument. It was being called with `contains_point(x,y)` rather than `contains_point([x,y])`.
