### PR TITLE
GTK segfault with GTK3 and mpl_toolkits

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -11,12 +11,14 @@ except ImportError:
 try:
     gi.require_version("Gtk", "3.0")
 except ValueError:
-    raise ImportError("Gtk3 backend gtk3 development files to be installed.")
+    raise ImportError(
+        "Gtk3 backend requires the GObject introspection bindings for Gtk 3 "
+        "to be installed.")
 
 try:
     from gi.repository import Gtk, Gdk, GObject
 except ImportError:
-    raise ImportError("GTK3 backend requires pygobject to be installed.")
+    raise ImportError("Gtk3 backend requires pygobject to be installed.")
 
 import matplotlib
 from matplotlib._pylab_helpers import Gcf


### PR DESCRIPTION
Something goes wrong when using a GTK3 backend and the mpl_toolkits. See this very minimal testcase:

``` python
>>> from gi.repository import Gtk
>>> import mpl_toolkits.axisartist
/usr/lib/python2.7/dist-packages/gobject/constants.py:24: Warning: g_boxed_type_register_static: assertion `g_type_from_name (name) == 0' failed
  import gobject._gobject
/usr/lib/python2.7/dist-packages/gtk-2.0/gtk/__init__.py:40: Warning: specified class size for type `PyGtkGenericCellRenderer' is smaller than the parent type's `GtkCellRenderer' class size
  from gtk import _gtk
/usr/lib/python2.7/dist-packages/gtk-2.0/gtk/__init__.py:40: Warning: g_type_get_qdata: assertion `node != NULL' failed
  from gtk import _gtk
Segmentatiefout (geheugendump gemaakt)
```

Most likely, something imports the old GTK2 bindings, run following for the same error:

``` python
>>> from gi.repository import Gtk
>>> import gtk
```

Grepping the sourcecode gives mpl_toolkits/gtktools.py where it is used, but I can't even find where it is imported.
