### PR TITLE
fix pstoeps function in backend_ps.py

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1697,15 +1697,12 @@ def pstoeps(tmpfile, bbox=None, rotated=False):
             # eps file is not modified.
             line = tmph.readline()
             while line:
-                if line.startswith(b'%%Trailer'):
-                    write(b'%%Trailer\n')
+                if line.startswith(b'%%EOF'):
                     write(b'cleartomark\n')
                     write(b'countdictstack\n')
                     write(b'exch sub { end } repeat\n')
                     write(b'restore\n')
-                    if rcParams['ps.usedistiller'] == 'xpdf':
-                        # remove extraneous "end" operator:
-                        line = tmph.readline()
+                    write(b'%%EOF\n')
                 elif line.startswith(b'%%PageBoundingBox'):
                     pass
                 else:


### PR DESCRIPTION
This is a possible fix for  #1997. It works for ubuntu 13.04 and 12.10.
I am no way an expert of postscript, so I am not sure if this is a correct fix though.

If this turned out to be a good fix, maybe this need to be picked up by the v1.2.x branch also?
