### PR TITLE
Legend tuple handler improve

### DIFF
--- a/examples/pylab_examples/legend_demo5.py
+++ b/examples/pylab_examples/legend_demo5.py
@@ -1,0 +1,22 @@
+import matplotlib.pyplot as plt
+from matplotlib.legend_handler import HandlerTuple
+
+fig, (ax1, ax2) = plt.subplots(2, 1)
+p1 = ax1.scatter([1],[5], c='r', marker='s', s=100)
+p2 = ax1.scatter([3],[2], c='b', marker='o', s=100)
+
+l = ax1.legend([(p1, p2)],['points'], scatterpoints=1,
+               handler_map={tuple: HandlerTuple(ndivide=0)})
+
+ind = [1,2,3]
+pos1 = [1, 3, 2]
+neg1 = [2, 1, 4]
+width=[0.5, 0.5, 0.5]
+
+rpos1 = ax2.bar(ind, pos1, width=0.5, color='k', label='+1')
+rneg1 = ax2.bar(ind, neg1, width=0.5, color='w', hatch='///', label='-1')
+
+l = ax2.legend([(rpos1, rneg1)],['Test'],
+               handler_map={(rpos1, rneg1): HandlerTuple(ndivide=0, pad=0.)})
+
+plt.show()

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -539,7 +539,9 @@ class HandlerTuple(HandlerBase):
     """
     Handler for Tuple
     """
-    def __init__(self, **kwargs):
+    def __init__(self, ndivide=1, pad=None, **kwargs):
+        self._ndivide = ndivide
+        self._pad = pad
         HandlerBase.__init__(self, **kwargs)
 
     def create_artists(self, legend, orig_handle,
@@ -547,11 +549,30 @@ class HandlerTuple(HandlerBase):
                        trans):
 
         handler_map = legend.get_legend_handler_map()
+
+        if self._ndivide == 0:
+            ndivide = len(orig_handle)
+        else:
+            ndivide = self._ndivide
+
+        if self._pad is None:
+            pad = legend.borderpad * fontsize
+        else:
+            pad = self._pad * fontsize
+
+        if ndivide > 1:
+            width = (width - pad*(ndivide - 1)) / ndivide
+
+        xds = [xdescent - (width + pad) * i for i in range(ndivide)]
+        from itertools import cycle
+        xd_next = cycle(xds).next
+
         a_list = []
         for handle1 in orig_handle:
             handler = legend.get_legend_handler(handler_map, handle1)
             _a_list = handler.create_artists(legend, handle1,
-                                             xdescent, ydescent, width, height,
+                                             xd_next(), ydescent,
+                                             width, height,
                                              fontsize,
                                              trans)
             a_list.extend(_a_list)


### PR DESCRIPTION
HandlerTuple now takes optional argument of `ndivide`. With this parameter, the handle area of legend item will be horizontally divided and the handle will be drawn for each subdivided area separately. The default is `ndivide=1` which is backward compatible, but this needs some discussion I guess. This is a PR in progress and and I guess some more improvement is still needed. And suggestion for better keyword name will be appreciated.

This addresses #2018.
