### PR TITLE
'annotate' ignores path_effects argument.

### DIFF
--- a/examples/pylab_examples/patheffect_demo.py
+++ b/examples/pylab_examples/patheffect_demo.py
@@ -9,9 +9,7 @@ if 1:
     txt = ax1.annotate("test", (1., 1.), (0., 0),
                        arrowprops=dict(arrowstyle="->",
                                        connectionstyle="angle3", lw=2),
-                       size=20, ha="center")
-
-    txt.set_path_effects([PathEffects.withStroke(linewidth=3,
+                       size=20, ha="center", path_effects=[PathEffects.withStroke(linewidth=3,
                                                  foreground="w")])
     txt.arrow_patch.set_path_effects([
         PathEffects.Stroke(linewidth=5, foreground="w"),

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -91,7 +91,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
                  urls=None,
                  offset_position='screen',
                  zorder=1,
-                 path_effects=None,
                  **kwargs
                  ):
         """

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -149,7 +149,6 @@ class Line2D(Artist):
                  pickradius=5,
                  drawstyle=None,
                  markevery=None,
-                 path_effects = None,
                  **kwargs
                  ):
         """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -64,7 +64,6 @@ class Patch(artist.Artist):
                  antialiased=None,
                  hatch=None,
                  fill=True,
-                 path_effects=None,
                  **kwargs):
         """
         The following kwarg properties are supported

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -13,9 +13,8 @@ def test_patheffect1():
     txt = ax1.annotate("test", (1., 1.), (0., 0),
                        arrowprops=dict(arrowstyle="->",
                                        connectionstyle="angle3", lw=2),
-                       size=20, ha="center")
-
-    txt.set_path_effects([withStroke(linewidth=3,
+                       size=20, ha="center",
+                       path_effects=[withStroke(linewidth=3,
                                      foreground="w")])
     txt.arrow_patch.set_path_effects([Stroke(linewidth=5,
                                              foreground="w"),

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -158,7 +158,6 @@ class Text(Artist):
                  rotation=None,
                  linespacing=None,
                  rotation_mode=None,
-                 path_effects=None,
                  **kwargs
                  ):
         """


### PR DESCRIPTION
With current master, `annotate` ignores `path_effects` argument.

``` python
import matplotlib.pyplot as plt
from matplotlib.patheffects import withStroke
myeffect = withStroke(foreground="y", linewidth=3)
kwargs = dict(path_effects=[myeffect])

plt.annotate("test", (0.5, 0.5), path_effects=[myeffect])
```

text is drawn, but without path_effects.
