### PR TITLE
sphinxext.ipython_directive broken

### DIFF
--- a/lib/matplotlib/sphinxext/ipython_directive.py
+++ b/lib/matplotlib/sphinxext/ipython_directive.py
@@ -80,9 +80,15 @@ from sphinx.util.compat import Directive
 matplotlib.use('Agg')
 
 # Our own
-from IPython import Config, InteractiveShell
-from IPython.core.profiledir import ProfileDir
-from IPython.utils import io
+try:
+    from IPython import Config, InteractiveShell
+    from IPython.core.profiledir import ProfileDir
+    from IPython.utils import io
+except ImportError:
+    raise ImportError(
+        "Unable to import the necessary objects from IPython. "
+        "You may need to install or upgrade your IPython installation.")
+
 
 #-----------------------------------------------------------------------------
 # Globals


### PR DESCRIPTION
When I installed MPL 1.2.1, my sphinx broke.  I now get this error that I didn't before:

```
Could not import extension matplotlib.sphinxext.ipython_directive (exception: cannot import name Config)
```
