### PR TITLE
mlab.FIFOBuffer: remove fossil line referring to nonexistent method

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1308,7 +1308,6 @@ class FIFOBuffer:
         x, y = self.asarrays()
         self.dataLim.update_from_data(x, y, True)
 
-        self.dataLim.update_numerix(x, y, True)
 
 def movavg(x,n):
     """


### PR DESCRIPTION
Evidently no one has been using the method in which the offending line occurred; the bug dates back to 2009.
