### PR TITLE
[DOC] Mathtext and matshow examples

### DIFF
--- a/examples/pylab_examples/mathtext_examples.py
+++ b/examples/pylab_examples/mathtext_examples.py
@@ -1,49 +1,118 @@
-#!/usr/bin/env python
-
+"""
+Selected features of Matplotlib's math rendering engine.
+"""
 from __future__ import print_function
-
-import os, sys, re
-
+import matplotlib.pyplot as plt
+import os
+import sys
+import re
 import gc
 
-stests = [
-    r'$\left[\left\lfloor\frac{5}{\frac{\left(3\right)}{4}} y\right)\right]$',
-    r"$\gamma = \frac{x=\frac{6}{8}}{y} \delta$",
-    r'$\limsup_{x\to\infty}$',
-    r'$\oint^\infty_0$',
-    r"$\sqrt[5]{\prod^\frac{x}{2\pi^2}_\infty}$",
-    # From UTR #25
-    r"$W^{3\beta}_{\delta_1 \rho_1 \sigma_2} = U^{3\beta}_{\delta_1 \rho_1} + \frac{1}{8 \pi 2} \int^{\alpha_2}_{\alpha_2} d \alpha^\prime_2 \left[\frac{ U^{2\beta}_{\delta_1 \rho_1} - \alpha^\prime_2U^{1\beta}_{\rho_1 \sigma_2} }{U^{0\beta}_{\rho_1 \sigma_2}}\right]$",
-    r'$\mathcal{H} = \int d \tau \left(\epsilon E^2 + \mu H^2\right)$',
-    r'$\widehat{abc}\widetilde{def}$',
-    #ur'Generic symbol: $\u23ce$',
-   ]
+# Selection of features following "Writing mathematical expressions" tutorial
+mathtext_titles = {
+    0: "Header demo",
+    1: "Subscripts and superscripts",
+    2: "Fractions, binomials and stacked numbers",
+    3: "Radicals",
+    4: "Fonts",
+    5: "Accents",
+    6: "Greek, Hebrew",
+    7: "Delimiters, functions and Symbols"}
+n_lines = len(mathtext_titles)
 
-#if sys.maxunicode > 0xffff:
-#    stests.append(ur'$\mathrm{\ue0f2 \U0001D538}$')
+# Randomly picked examples
+mathext_demos = {
+    0: r"$W^{3\beta}_{\delta_1 \rho_1 \sigma_2} = "
+    r"U^{3\beta}_{\delta_1 \rho_1} + \frac{1}{8 \pi 2} "
+    r"\int^{\alpha_2}_{\alpha_2} d \alpha^\prime_2 \left[\frac{ "
+    r"U^{2\beta}_{\delta_1 \rho_1} - \alpha^\prime_2U^{1\beta}_"
+    r"{\rho_1 \sigma_2} }{U^{0\beta}_{\rho_1 \sigma_2}}\right]$",
 
+    1: r"$\alpha_i > \beta_i,\ "
+    r"\alpha_{i+1}^j = {\rm sin}(2\pi f_j t_i) e^{-5 t_i/\tau},\ "
+    r"\ldots$",
 
-from pylab import *
+    2: r"$\frac{3}{4},\ \binom{3}{4},\ \stackrel{3}{4},\ "
+    r"\left(\frac{5 - \frac{1}{x}}{4}\right),\ \ldots$",
+
+    3: r"$\sqrt{2},\ \sqrt[3]{x},\ \ldots$",
+
+    4: r"$\mathrm{Roman}\ , \ \mathit{Italic}\ , \ \mathtt{Typewriter} \ "
+    r"\mathrm{or}\ \mathcal{CALLIGRAPHY}$",
+
+    5: r"$\acute a,\ \bar a,\ \breve a,\ \dot a,\ \ddot a, \ \grave a, \ "
+    r"\hat a,\ \tilde a,\ \vec a,\ \widehat{xyz},\ \widetilde{xyz},\ "
+    r"\ldots$",
+
+    6: r"$\alpha,\ \beta,\ \chi,\ \delta,\ \lambda,\ \mu,\ "
+    r"\Delta,\ \Gamma,\ \Omega,\ \Phi,\ \Pi,\ \Upsilon,\ \nabla,\ "
+    r"\aleph,\ \beth,\ \daleth,\ \gimel,\ \ldots$",
+
+    7: r"$\coprod,\ \int,\ \oint,\ \prod,\ \sum,\ "
+    r"\log,\ \sin,\ \approx,\ \oplus,\ \star,\ \varpropto,\ "
+    r"\infty,\ \partial,\ \Re,\ \leftrightsquigarrow, \ \ldots$"}
+
 
 def doall():
-    tests = stests
+    # Colors used in mpl online documentation.
+    mpl_blue_rvb = (191./255., 209./256., 212./255.)
+    mpl_orange_rvb = (202/255., 121/256., 0./255.)
+    mpl_grey_rvb = (51./255., 51./255., 51./255.)
 
-    figure(figsize=(8, (len(tests) * 1.0) + 2), facecolor='w')
-    for i, s in enumerate(tests):
-        print (i, s)
-        figtext(0.1, float(i + 1) / (len(tests) + 2), s, fontsize=20)
+    # Creating figure and axis.
+    plt.figure(figsize=(6, 7))
+    plt.axes([0.01, 0.01, 0.98, 0.90], axisbg="white", frameon=True)
+    plt.gca().set_xlim(0., 1.)
+    plt.gca().set_ylim(0., 1.)
+    plt.gca().set_title("Matplotlib's math rendering engine",
+                        color=mpl_grey_rvb, fontsize=14, weight='bold')
+    plt.gca().set_xticklabels("", visible=False)
+    plt.gca().set_yticklabels("", visible=False)
 
-    savefig('mathtext_examples')
-    #close('all')
-    show()
+    # Gap between lines in axes coords
+    line_axesfrac = (1. / (n_lines))
+
+    # Plotting header demonstration formula
+    full_demo = mathext_demos[0]
+    plt.annotate(full_demo,
+                 xy=(0.5, 1. - 0.59*line_axesfrac),
+                 xycoords='data', color=mpl_orange_rvb, ha='center',
+                 fontsize=20)
+
+    # Plotting features demonstration formulae
+    for i_line in range(1, n_lines):
+        baseline = 1. - (i_line)*line_axesfrac
+        baseline_next = baseline - line_axesfrac*1.
+        title = mathtext_titles[i_line] + ":"
+        fill_color = ['white', mpl_blue_rvb][i_line % 2]
+        plt.fill_between([0., 1.], [baseline, baseline],
+                         [baseline_next, baseline_next],
+                         color=fill_color, alpha=0.5)
+        plt.annotate(title,
+                     xy=(0.07, baseline - 0.3*line_axesfrac),
+                     xycoords='data', color=mpl_grey_rvb, weight='bold')
+        demo = mathext_demos[i_line]
+        plt.annotate(demo,
+                     xy=(0.05, baseline - 0.75*line_axesfrac),
+                     xycoords='data', color=mpl_grey_rvb,
+                     fontsize=16)
+
+    for i in range(n_lines):
+        s = mathext_demos[i]
+        print(i, s)
+    plt.show()
 
 if '--latex' in sys.argv:
+    # Run: python mathtext_examples.py --latex
+    # Need amsmath and amssymb packages.
     fd = open("mathtext_examples.ltx", "w")
     fd.write("\\documentclass{article}\n")
+    fd.write("\\usepackage{amsmath, amssymb}\n")
     fd.write("\\begin{document}\n")
     fd.write("\\begin{enumerate}\n")
 
-    for i, s in enumerate(stests):
+    for i in range(n_lines):
+        s = mathext_demos[i]
         s = re.sub(r"(?<!\\)\$", "$$", s)
         fd.write("\\item %s\n" % s)
 

--- a/examples/pylab_examples/matshow.py
+++ b/examples/pylab_examples/matshow.py
@@ -1,22 +1,22 @@
-#!/usr/bin/env python
 """Simple matshow() example."""
-
 from matplotlib.pylab import *
+
 
 def samplemat(dims):
     """Make a matrix with all zeros and increasing elements on the diagonal"""
     aa = zeros(dims)
     for i in range(min(dims)):
-        aa[i,i] = i
+        aa[i, i] = i
     return aa
 
-# Make a few matrices of strange sizes
-dimlist = [(12,12),(128,64),(64,512),(1024,128)]
 
+# Display 2 matrices of different sizes
+dimlist = [(12, 12), (15, 35)]
 for d in dimlist:
     matshow(samplemat(d))
 
-# Display a random matrix with a specified figure number and a grayscale colormap
-matshow(rand(64,64),fignum=100,cmap=cm.gray)
+# Display a random matrix with a specified figure number and a grayscale
+# colormap
+matshow(rand(64, 64), fignum=100, cmap=cm.gray)
 
 show()


### PR DESCRIPTION
I did this because of #2024.
When rebasing, I saw the mathtext example has already been improved in 40340fc, so no problem if the consensus is to close this without merging (since I had completed the work I thought I would do the PR anyway).

The "Writing mathematical expressions" tutorial is of high quality, so I felt it would be better to try to improve the related example in the screenshot http://matplotlib.org/users/screenshots.html.
I have checked pep8 and that the pdf output is correct when running `python mathtext_examples.py --latex` (amsmath and amssymb packages are needed).

I attach the result of doc building, since it is sometimes tricky to figure it out: ![mathtext_examples_01_00](https://f.cloud.github.com/assets/2669128/565237/b01817d6-c5f4-11e2-8b1c-087b6f69f4e6.png)

The matshow example with its 2 oversized figures suffers from a similar problem, so I took this opportunity to modify it as well.
