### PR TITLE
changed URL to the current CSV API for yahoo finance

### DIFF
--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -177,7 +177,7 @@ def fetch_historical_yahoo(ticker, date1, date2, cachename=None,dividends=False)
     else:
         g='d'
 
-    urlFmt = 'http://table.finance.yahoo.com/table.csv?a=%d&b=%d&c=%d&d=%d&e=%d&f=%d&s=%s&y=0&g=%s&ignore=.csv'
+    urlFmt = 'http://ichart.yahoo.com/table.csv?a=%d&b=%d&c=%d&d=%d&e=%d&f=%d&s=%s&y=0&g=%s&ignore=.csv'
 
 
     url =  urlFmt % (d1[0], d1[1], d1[2],


### PR DESCRIPTION
I noticed a example on clustering was not working in scikit-learn and tracked it back to a yahoo CSV api url in finance.py of matplotlib being out of date.  I looked around yahoo's documentation and it appears that their base url has changed to 

http://table.finance.yahoo.com/table.csv

to

http://ichart.yahoo.com/table.csv
