### PR TITLE
Fix matplotlib.tests.test_agg.test_repeated_save_with_alpha.test error

### DIFF
--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -25,7 +25,8 @@ def test_repeated_save_with_alpha():
 
     # The target color is fig.patch.get_facecolor()
 
-    _, img_fname = tempfile.mkstemp(suffix='.png')
+    img_fd, img_fname = tempfile.mkstemp(suffix='.png')
+    os.close(img_fd)
     try:
         fig.savefig(img_fname,
                     facecolor=fig.get_facecolor(),


### PR DESCRIPTION
The full error message is `WindowsError: [Error 32] The process cannot access the file because it is being used by another process 'c:\\users\\...\\temp\\tmpetdan3.png'`. On Windows, open files can not be deleted.
