### PR TITLE
Parsing errors when installing 1.3.0rc2

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1261,9 +1261,8 @@ def setp(obj, *args, **kwargs):
     :func:`setp` works with the MATLAB style string/value pairs or
     with python kwargs.  For example, the following are equivalent::
 
-      >>> setp(lines, 'linewidth', 2, 'color', r')  # MATLAB style
-          ...
-      >>> setp(lines, linewidth=2, color='r')       # python style
+      >>> setp(lines, 'linewidth', 2, 'color', 'r')  # MATLAB style
+      >>> setp(lines, linewidth=2, color='r')        # python style
     """
 
     insp = ArtistInspector(obj)

--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -3343,8 +3343,8 @@ class Axes(martist.Artist):
         text in the center of the axes::
 
             >>> text(0.5, 0.5,'matplotlib', horizontalalignment='center',
-            >>>      verticalalignment='center',
-            >>>      transform = ax.transAxes)
+            ...      verticalalignment='center',
+            ...      transform=ax.transAxes)
 
         You can put a rectangular box around the text instance (e.g., to
         set a background color) by using the keyword *bbox*.  *bbox* is

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -320,7 +320,7 @@ class RendererAgg(RendererBase):
         >>> region = renderer.copy_from_bbox()
         >>> x1, y1, x2, y2 = region.get_extents()
         >>> renderer.restore_region(region, bbox=(x1+dx, y1, x2, y2),
-                                    xy=(x1-dx, y1))
+        ...                         xy=(x1-dx, y1))
 
         """
         if bbox is not None or xy is not None:


### PR DESCRIPTION
I just tried installing RC2 on Mac and I get a few warnings/errors during the installation, related to parsing docstrings:

http://pastebin.com/MZCZjg9n

This is with Python 3.2
