### PR TITLE
Remove DeprecationWarning in simple_linear_interpolation

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1712,8 +1712,8 @@ def simple_linear_interpolation(a, steps):
     a0 = a[0:-1]
     a1 = a[1:]
     delta = ((a1 - a0) / steps)
-
-    for i in range(1, int(steps)):
+    steps = int(steps)
+    for i in range(1, steps):
         result[i::steps] = delta * i + a0
     result[steps::steps] = a1
 


### PR DESCRIPTION
`simple_linear_interpolation` is rising a `DeprecationWarning`:

> /usr/local/lib/python2.7/dist-packages/matplotlib-1.4.x-py2.7-linux-i686.egg/matplotlib
> /cbook.py:1717: DeprecationWarning: non-integer slice parameter. In a future numpy 
> release, this will raise an error.
>  result[i::steps] = delta \* i + a0

This PR is a simple fix to that, which is annoying when drawing polar plots (notably, it bloats firefox when doing this through ipython notebook)
