### PR TITLE
fix position of rotated mathtext in agg backend

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -155,7 +155,7 @@ class RendererAgg(RendererBase):
 
         xd = descent * np.sin(np.deg2rad(angle))
         yd = descent * np.cos(np.deg2rad(angle))
-        x = np.round(x + ox - xd)
+        x = np.round(x + ox + xd)
         y = np.round(y - oy + yd)
         self._renderer.draw_text_image(font_image, x, y + 1, angle, gc)
 


### PR DESCRIPTION
``` python
import matplotlib.pyplot as plt

plt.figure(figsize=(7,3))
angle, mode = 45, "anchor"
plt.text(0.2, 0.5, "lp",
         size=40, rotation=angle, rotation_mode=mode,
         bbox=dict(boxstyle="square,pad=0.", alpha=0.3))
plt.text(0.5, 0.5, "$o^{o^{o^o}}$",
         size=40, rotation=angle, rotation_mode=mode,
         bbox=dict(boxstyle="square,pad=0.", alpha=0.3))
plt.text(0.8, 0.5, "$o_{o_{o_o}}$",
         size=40, rotation=angle, rotation_mode=mode,
         bbox=dict(boxstyle="square,pad=0.", alpha=0.3))
plt.plot([0.2, 0.5, 0.8], [0.5, 0.5, 0.5], "+r", ms=10, mew=4)
plt.xlim(0, 1)
plt.ylim(0, 1)
plt.show()
```

With v1.3.x and current master, above code with agg backend (w/ usetex=False) produces 

![agg_text_position_current](https://f.cloud.github.com/assets/95962/596040/24d6a8fc-cb5a-11e2-9af8-eee2cfa74ad0.png)

With the proposed fix,

![agg_text_position_fixed](https://f.cloud.github.com/assets/95962/596047/ab02f66a-cb5a-11e2-9308-6356c20788fe.png)
