### PR TITLE
Bug in cbook.exception_to_str() in v 1.2

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -987,8 +987,10 @@ def pieces(seq, num=2):
 
 
 def exception_to_str(s=None):
-
-    sh = io.StringIO()
+    if sys.version_info[0] < 3:
+        sh = io.BytesIO()
+    else:
+        sh = io.StringIO()
     if s is not None:
         print(s, file=sh)
     traceback.print_exc(file=sh)


### PR DESCRIPTION
The exception_to_str() function was changed between mpl 1.1 and 1.2.
In my installation I show it going from this:

def exception_to_str(s = None):

```
sh = StringIO.StringIO()
if s is not None: print >>sh, s
traceback.print_exc(file=sh)
return sh.getvalue()
```

to this:

def exception_to_str(s=None):

```
sh = io.StringIO()
if s is not None:
    print(s, file=sh)
traceback.print_exc(file=sh)
return sh.getvalue()
```

At first glance, the change seems innocuous enough, but I think it
introduced an error.  (It appears that mpl 1.2 is supposed to work on
Python 2.7 and 3.x.) From a thread I started on comp.lang.python
(http://thread.gmane.org/gmane.comp.python.general/733938), it appears
that io.StringIO instances only accept Unicode strings as input.
Unless v 1.2 is only supposed to run on Python 3 (that doesn't seem to
be the case), you need to do something to convert the traceback
module's output to Unicode before feeding to the io.StringIO object.

Here's a simple demonstration of the problem:

% python2.7
Python 2.7.5+ (2.7:93eb15779050, May 30 2013, 15:27:39)
[GCC 4.4.6 [TWW]] on linux2
Type "help", "copyright", "credits" or "license" for more information.

> > > import traceback, StringIO, io
> > > s1 = StringIO.StringIO()
> > > traceback.print_stack(file=s1)
> > > print repr(s1.getvalue())
> > > '  File "<stdin>", line 1, in <module>\n'
> > > 
> > > s2 = io.StringIO()
> > > traceback.print_stack(file=s2)
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/home/skipm/x86_64-linux3.1/lib/python2.7/traceback.py", line
> > > 269, in print_stack
> > >     print_list(extract_stack(f, limit), file)
> > >   File "/home/skipm/x86_64-linux3.1/lib/python2.7/traceback.py", line
> > > 23, in print_list
> > >     '  File "%s", line %d, in %s' % (filename,lineno,name))
> > >   File "/home/skipm/x86_64-linux3.1/lib/python2.7/traceback.py", line
> > > 13, in _print
> > >     file.write(str+terminator)
> > > TypeError: unicode argument expected, got 'str'
