### PR TITLE
Make setup work on platforms where multiprocessing does not (1.3.x version)

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1466,7 +1466,10 @@ class BackendGtk3Agg(OptionalBackendPackage):
         # This check needs to be performed out-of-process, because
         # importing gi and then importing regular old pygtk afterward
         # segfaults the interpreter.
-        p = multiprocessing.Pool()
+        try:
+            p = multiprocessing.Pool()
+        except:
+            return "unknown (can not use multiprocessing to determine)"
         success, msg = p.map(backend_gtk3agg_internal_check, [0])[0]
         p.close()
         p.join()
@@ -1518,7 +1521,10 @@ class BackendGtk3Cairo(OptionalBackendPackage):
         # This check needs to be performed out-of-process, because
         # importing gi and then importing regular old pygtk afterward
         # segfaults the interpreter.
-        p = multiprocessing.Pool()
+        try:
+            p = multiprocessing.Pool()
+        except:
+            return "unknown (can not use multiprocessing to determine)"
         success, msg = p.map(backend_gtk3cairo_internal_check, [0])[0]
         p.close()
         p.join()


### PR DESCRIPTION
multiprocessing is used during setup to check the version of Gtk 3 installed (since importing Gtk2 and Gtk3 in the same process causes problems).  On platforms where multiprocessing doesn't work, this check will just be skipped.
