### PR TITLE
hist() bottom line now showing (regression?)

### DIFF
--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -8468,18 +8468,22 @@ class Axes(martist.Artist):
                 xvals.append(x.copy())
                 yvals.append(y.copy())
 
-            # add patches in reverse order so that when stacking,
-            # items lower in the stack are plottted on top of
-            # items higher in the stack
-            for x, y, c in reversed(zip(xvals, yvals, color)):
-                if fill:
-                    patches.append(self.fill(x, y,
-                                             closed=True,
-                                             facecolor=c))
-                else:
-                    patches.append(self.fill(x, y,
-                                             closed=True, edgecolor=c,
-                                             fill=False))
+            if fill:
+                # add patches in reverse order so that when stacking,
+                # items lower in the stack are plottted on top of
+                # items higher in the stack
+                for x, y, c in reversed(zip(xvals, yvals, color)):
+                    patches.append(self.fill(
+                        x, y,
+                        closed=True,
+                        facecolor=c))
+            else:
+                for x, y, c in reversed(zip(xvals, yvals, color)):
+                    split = int(len(x) / 2) + 1
+                    patches.append(self.fill(
+                        x[:split], y[:split],
+                        closed=False, edgecolor=c,
+                        fill=False))
 
             # we return patches, so put it back in the expected order
             patches.reverse()


### PR DESCRIPTION
The following:

``` python
import numpy as np
import matplotlib.pyplot as plt

mu, sigma = 100, 15
x = mu + sigma * np.random.randn(10000)
fig = plt.figure()
ax = fig.add_subplot(111)
n, bins, patches = ax.hist(x, 50, normed=1, histtype='step')
plt.ylim(-.005, plt.ylim()[1])
plt.show()
```

produces this in 1.1.0 (although I manually zoomed in here since 1.1.0 didn't set the upper limit on ylim correctly):

![mpl_1 1 0](https://f.cloud.github.com/assets/202816/596263/5b18faf4-cb79-11e2-9f22-b638e9e0c021.png)

but at the HEAD the path is now closed by a bottom line:

![mpl_head](https://f.cloud.github.com/assets/202816/596264/6c13a5de-cb79-11e2-9c26-92c91d3f7eee.png)

Would this be considered as a regression? Could an argument be created to allow the user to decide if the bottom line should be displayed? In most of my plots showing a step histogram (usually overlaid on some filled histograms) the bottom line is not desirable.

I originally asked how to remove the bottom line on SO (thanks to @tacaswell for the answer!):

http://stackoverflow.com/questions/16862501/draw-a-step-histogram-without-closing-the-polygon-with-the-bottom-line
