### PR TITLE
ValueError exception in drag_zoom (tk backend)

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2868,12 +2868,11 @@ class NavigationToolbar2(object):
         if self._ids_zoom != []:
             for zoom_id in self._ids_zoom:
                 self.canvas.mpl_disconnect(zoom_id)
-            self.zoom()
             self.release(event)
             self.draw()
             self._xypress = None
             self._button_pressed = None
-            self._zoom_mode = None
+            self._ids_zoom = []
             return
 
         if event.button == 1:


### PR DESCRIPTION
I have an application that uses Tkinter and matplotlib 1.1.1rc to visualize some plots and axvspans. From time to time, when I drag the plot in pan mode I've got this Exception and I should kill the application:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1413, in __call__
    return self.func(*args)
  File "/usr/lib/pymodules/python2.7/matplotlib/backends/backend_tkagg.py", line 271, in motion_notify_event
    FigureCanvasBase.motion_notify_event(self, x, y, guiEvent=event)
  File "/usr/lib/pymodules/python2.7/matplotlib/backend_bases.py", line 1681, in motion_notify_event
    self.callbacks.process(s, event)
  File "/usr/lib/pymodules/python2.7/matplotlib/cbook.py", line 262, in process
    proxy(*args, **kwargs)
  File "/usr/lib/pymodules/python2.7/matplotlib/cbook.py", line 192, in __call__
    return mtd(*args, **kwargs)
  File "/usr/lib/pymodules/python2.7/matplotlib/backend_bases.py", line 2660, in drag_zoom
    lastx, lasty, a, ind, lim, trans = self._xypress[0]
ValueError: need more than 2 values to unpack
```

It does not happen always, only from time to time so it makes difficult to reproduce it.
