### PR TITLE
pyplot.gci: Look first in current axes, not most recently added axes.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1204,6 +1204,17 @@ class Figure(Artist):
         helper for :func:`~matplotlib.pyplot.gci`;
         do not use elsewhere.
         """
+        # Look first for an image in the current Axes:
+        cax = self._axstack.current_key_axes()[1]
+        if cax is None:
+            return None
+        im = cax._gci()
+        if im is not None:
+            return im
+
+        # If there is no image in the current Axes, search for
+        # one in a previously created Axes.  Whether this makes
+        # sense is debatable, but it is the documented behavior.
         for ax in reversed(self.axes):
             im = ax._gci()
             if im is not None:


### PR DESCRIPTION
This fixes a bug in which the behavior of gci did not match its
docstring, as pointed out by Julien Cornebise.
