### PR TITLE
Unable to build with setuptools 0.7.2 on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,20 @@ setup.cfg.template for more information.
 
 from __future__ import print_function, absolute_import
 
-# This needs to be the very first thing to use distribute
-from distribute_setup import use_setuptools
-use_setuptools()
+# We require either distribute or setuptools >= 0.7, and it must be
+# the very first thing we import.
+try:
+    import setuptools
+except ImportError:
+    HAS_SETUPTOOLS_07 = False
+else:
+    setuptools_version = [
+        int(x) for x in setuptools.__version__.split('.')]
+    HAS_SETUPTOOLS_07 = setuptools_version >= [0, 7]
+
+if not HAS_SETUPTOOLS_07:
+    from distribute_setup import use_setuptools
+    use_setuptools()
 
 import sys
 


### PR DESCRIPTION
Using `setuptools 0.7.2` instead of the deprecated `distribute` package breaks `python setup.py build`:

```
Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.28.tar.gz
Extracting in \temp\tmprvezui
Now working in \temp\tmprvezui\distribute-0.6.28
Building a Distribute egg in \matplotlib-1.3.x-git
Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    exec(open(init_path).read(), d)
  File "<string>", line 8, in <module>
  File "\temp\tmprvezui\distribute-0.6.28\setuptools\__init__.py", line 2, in <module>
    from setuptools.extension import Extension, Library
  File "\temp\tmprvezui\distribute-0.6.28\setuptools\extension.py", line 5, in <module>
    from setuptools.dist import _get_unpatched
  File "\temp\tmprvezui\distribute-0.6.28\setuptools\dist.py", line 6, in <module>
    from setuptools.command.install import install
  File "\temp\tmprvezui\distribute-0.6.28\setuptools\command\__init__.py", line 8, in <module>
    from setuptools.command import install_scripts
  File "\temp\tmprvezui\distribute-0.6.28\setuptools\command\install_scripts.py", line 3, in <module>
    from pkg_resources import Distribution, PathMetadata, ensure_directory
  File "\temp\tmprvezui\distribute-0.6.28\pkg_resources.py", line 2835, in <module>
    add_activation_listener(lambda dist: dist.activate())
  File "\temp\tmprvezui\distribute-0.6.28\pkg_resources.py", line 704, in subscribe
    callback(dist)
  File "\temp\tmprvezui\distribute-0.6.28\pkg_resources.py", line 2835, in <lambda>
    add_activation_listener(lambda dist: dist.activate())
  File "\temp\tmprvezui\distribute-0.6.28\pkg_resources.py", line 2259, in activate
    self.insert_on(path)
  File "\temp\tmprvezui\distribute-0.6.28\pkg_resources.py", line 2360, in insert_on
    "with distribute. Found one at %s" % str(self.location))
ValueError: A 0.7-series setuptools cannot be installed with distribute. Found one at x:\python27\lib\site-packages
matplotlib-1.3.x-git\distribute-0.6.28-py2.7.egg
Traceback (most recent call last):
  File "setup.py", line 10, in <module>
    use_setuptools()
  File "matplotlib-1.3.x-git\distribute_setup.py", line 145, in use_setuptools
    return _do_download(version, download_base, to_dir, download_delay)
  File "matplotlib-1.3.x-git\distribute_setup.py", line 125, in _do_download
    _build_egg(egg, tarball, to_dir)
  File "matplotlib-1.3.x-git\distribute_setup.py", line 116, in _build_egg
    raise IOError('Could not build the egg.')
IOError: Could not build the egg.
```

This patch works for me:

``` patch
diff --git a/setup.py b/setup.py
index 5f1b561..12a035b 100644
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,11 @@ setup.cfg.template for more information.
 from __future__ import print_function, absolute_import

 # This needs to be the very first thing to use distribute
-from distribute_setup import use_setuptools
-use_setuptools()
+try:
+    import setuptools
+except ImportError:
+    from distribute_setup import use_setuptools
+    use_setuptools()

 import sys
```
