### PR TITLE
Handle pep8 missing

### DIFF
--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -15,159 +15,160 @@ else:
 import matplotlib
 
 
-class StandardReportWithExclusions(pep8.StandardReport):
-    #; A class attribute to store the exception exclusion file patterns.
-    expected_bad_files = [
-        '*/matplotlib/__init__.py',
-        '*/matplotlib/_cm.py',
-        '*/matplotlib/_mathtext_data.py',
-        '*/matplotlib/_pylab_helpers.py',
-        '*/matplotlib/afm.py',
-        '*/matplotlib/artist.py',
-        '*/matplotlib/axes.py',
-        '*/matplotlib/axis.py',
-        '*/matplotlib/backend_bases.py',
-        '*/matplotlib/bezier.py',
-        '*/matplotlib/cbook.py',
-        '*/matplotlib/collections.py',
-        '*/matplotlib/docstring.py',
-        '*/matplotlib/dviread.py',
-        '*/matplotlib/finance.py',
-        '*/matplotlib/font_manager.py',
-        '*/matplotlib/fontconfig_pattern.py',
-        '*/matplotlib/gridspec.py',
-        '*/matplotlib/legend.py',
-        '*/matplotlib/legend_handler.py',
-        '*/matplotlib/mathtext.py',
-        '*/matplotlib/mlab.py',
-        '*/matplotlib/path.py',
-        '*/matplotlib/patheffects.py',
-        '*/matplotlib/pylab.py',
-        '*/matplotlib/pyplot.py',
-        '*/matplotlib/rcsetup.py',
-        '*/matplotlib/stackplot.py',
-        '*/matplotlib/texmanager.py',
-        '*/matplotlib/text.py',
-        '*/matplotlib/transforms.py',
-        '*/matplotlib/type1font.py',
-        '*/matplotlib/widgets.py',
-        '*/matplotlib/testing/compare.py',
-        '*/matplotlib/testing/decorators.py',
-        '*/matplotlib/testing/image_util.py',
-        '*/matplotlib/testing/noseclasses.py',
-        '*/matplotlib/testing/jpl_units/Duration.py',
-        '*/matplotlib/testing/jpl_units/Epoch.py',
-        '*/matplotlib/testing/jpl_units/EpochConverter.py',
-        '*/matplotlib/testing/jpl_units/StrConverter.py',
-        '*/matplotlib/testing/jpl_units/UnitDbl.py',
-        '*/matplotlib/testing/jpl_units/UnitDblConverter.py',
-        '*/matplotlib/testing/jpl_units/UnitDblFormatter.py',
-        '*/matplotlib/testing/jpl_units/__init__.py',
-        '*/matplotlib/tri/tricontour.py',
-        '*/matplotlib/tri/triinterpolate.py',
-        '*/matplotlib/tri/tripcolor.py',
-        '*/matplotlib/tri/triplot.py',
-        '*/matplotlib/tests/__init__.py',
-        '*/matplotlib/tests/test_agg.py',
-        '*/matplotlib/tests/test_animation.py',
-        '*/matplotlib/tests/test_arrow_patches.py',
-        '*/matplotlib/tests/test_artist.py',
-        '*/matplotlib/tests/test_axes.py',
-        '*/matplotlib/tests/test_backend_pdf.py',
-        '*/matplotlib/tests/test_backend_pgf.py',
-        '*/matplotlib/tests/test_backend_svg.py',
-        '*/matplotlib/tests/test_basic.py',
-        '*/matplotlib/tests/test_bbox_tight.py',
-        '*/matplotlib/tests/test_cbook.py',
-        '*/matplotlib/tests/test_colorbar.py',
-        '*/matplotlib/tests/test_colors.py',
-        '*/matplotlib/tests/test_compare_images.py',
-        '*/matplotlib/tests/test_contour.py',
-        '*/matplotlib/tests/test_dates.py',
-        '*/matplotlib/tests/test_delaunay.py',
-        '*/matplotlib/tests/test_dviread.py',
-        '*/matplotlib/tests/test_image.py',
-        '*/matplotlib/tests/test_legend.py',
-        '*/matplotlib/tests/test_lines.py',
-        '*/matplotlib/tests/test_mathtext.py',
-        '*/matplotlib/tests/test_patches.py',
-        '*/matplotlib/tests/test_pickle.py',
-        '*/matplotlib/tests/test_png.py',
-        '*/matplotlib/tests/test_rcparams.py',
-        '*/matplotlib/tests/test_simplification.py',
-        '*/matplotlib/tests/test_spines.py',
-        '*/matplotlib/tests/test_streamplot.py',
-        '*/matplotlib/tests/test_subplots.py',
-        '*/matplotlib/tests/test_text.py',
-        '*/matplotlib/tests/test_tightlayout.py',
-        '*/matplotlib/tests/test_transforms.py',
-        '*/matplotlib/tests/test_triangulation.py',
-        '*/matplotlib/compat/subprocess.py',
-        '*/matplotlib/backends/__init__.py',
-        '*/matplotlib/backends/backend_agg.py',
-        '*/matplotlib/backends/backend_cairo.py',
-        '*/matplotlib/backends/backend_cocoaagg.py',
-        '*/matplotlib/backends/backend_gdk.py',
-        '*/matplotlib/backends/backend_gtk.py',
-        '*/matplotlib/backends/backend_gtk3.py',
-        '*/matplotlib/backends/backend_gtk3cairo.py',
-        '*/matplotlib/backends/backend_gtkagg.py',
-        '*/matplotlib/backends/backend_gtkcairo.py',
-        '*/matplotlib/backends/backend_macosx.py',
-        '*/matplotlib/backends/backend_mixed.py',
-        '*/matplotlib/backends/backend_pdf.py',
-        '*/matplotlib/backends/backend_pgf.py',
-        '*/matplotlib/backends/backend_ps.py',
-        '*/matplotlib/backends/backend_qt4.py',
-        '*/matplotlib/backends/backend_qt4agg.py',
-        '*/matplotlib/backends/backend_svg.py',
-        '*/matplotlib/backends/backend_template.py',
-        '*/matplotlib/backends/backend_tkagg.py',
-        '*/matplotlib/backends/backend_webagg.py',
-        '*/matplotlib/backends/backend_wx.py',
-        '*/matplotlib/backends/backend_wxagg.py',
-        '*/matplotlib/backends/qt4_compat.py',
-        '*/matplotlib/backends/tkagg.py',
-        '*/matplotlib/backends/windowing.py',
-        '*/matplotlib/backends/qt4_editor/figureoptions.py',
-        '*/matplotlib/backends/qt4_editor/formlayout.py',
-        '*/matplotlib/sphinxext/__init__.py',
-        '*/matplotlib/sphinxext/ipython_console_highlighting.py',
-        '*/matplotlib/sphinxext/ipython_directive.py',
-        '*/matplotlib/sphinxext/mathmpl.py',
-        '*/matplotlib/sphinxext/only_directives.py',
-        '*/matplotlib/sphinxext/plot_directive.py',
-        '*/matplotlib/projections/__init__.py',
-        '*/matplotlib/projections/geo.py',
-        '*/matplotlib/projections/polar.py']
+if HAS_PEP8:
+    class StandardReportWithExclusions(pep8.StandardReport):
+        #; A class attribute to store the exception exclusion file patterns.
+        expected_bad_files = [
+            '*/matplotlib/__init__.py',
+            '*/matplotlib/_cm.py',
+            '*/matplotlib/_mathtext_data.py',
+            '*/matplotlib/_pylab_helpers.py',
+            '*/matplotlib/afm.py',
+            '*/matplotlib/artist.py',
+            '*/matplotlib/axes.py',
+            '*/matplotlib/axis.py',
+            '*/matplotlib/backend_bases.py',
+            '*/matplotlib/bezier.py',
+            '*/matplotlib/cbook.py',
+            '*/matplotlib/collections.py',
+            '*/matplotlib/docstring.py',
+            '*/matplotlib/dviread.py',
+            '*/matplotlib/finance.py',
+            '*/matplotlib/font_manager.py',
+            '*/matplotlib/fontconfig_pattern.py',
+            '*/matplotlib/gridspec.py',
+            '*/matplotlib/legend.py',
+            '*/matplotlib/legend_handler.py',
+            '*/matplotlib/mathtext.py',
+            '*/matplotlib/mlab.py',
+            '*/matplotlib/path.py',
+            '*/matplotlib/patheffects.py',
+            '*/matplotlib/pylab.py',
+            '*/matplotlib/pyplot.py',
+            '*/matplotlib/rcsetup.py',
+            '*/matplotlib/stackplot.py',
+            '*/matplotlib/texmanager.py',
+            '*/matplotlib/text.py',
+            '*/matplotlib/transforms.py',
+            '*/matplotlib/type1font.py',
+            '*/matplotlib/widgets.py',
+            '*/matplotlib/testing/compare.py',
+            '*/matplotlib/testing/decorators.py',
+            '*/matplotlib/testing/image_util.py',
+            '*/matplotlib/testing/noseclasses.py',
+            '*/matplotlib/testing/jpl_units/Duration.py',
+            '*/matplotlib/testing/jpl_units/Epoch.py',
+            '*/matplotlib/testing/jpl_units/EpochConverter.py',
+            '*/matplotlib/testing/jpl_units/StrConverter.py',
+            '*/matplotlib/testing/jpl_units/UnitDbl.py',
+            '*/matplotlib/testing/jpl_units/UnitDblConverter.py',
+            '*/matplotlib/testing/jpl_units/UnitDblFormatter.py',
+            '*/matplotlib/testing/jpl_units/__init__.py',
+            '*/matplotlib/tri/tricontour.py',
+            '*/matplotlib/tri/triinterpolate.py',
+            '*/matplotlib/tri/tripcolor.py',
+            '*/matplotlib/tri/triplot.py',
+            '*/matplotlib/tests/__init__.py',
+            '*/matplotlib/tests/test_agg.py',
+            '*/matplotlib/tests/test_animation.py',
+            '*/matplotlib/tests/test_arrow_patches.py',
+            '*/matplotlib/tests/test_artist.py',
+            '*/matplotlib/tests/test_axes.py',
+            '*/matplotlib/tests/test_backend_pdf.py',
+            '*/matplotlib/tests/test_backend_pgf.py',
+            '*/matplotlib/tests/test_backend_svg.py',
+            '*/matplotlib/tests/test_basic.py',
+            '*/matplotlib/tests/test_bbox_tight.py',
+            '*/matplotlib/tests/test_cbook.py',
+            '*/matplotlib/tests/test_colorbar.py',
+            '*/matplotlib/tests/test_colors.py',
+            '*/matplotlib/tests/test_compare_images.py',
+            '*/matplotlib/tests/test_contour.py',
+            '*/matplotlib/tests/test_dates.py',
+            '*/matplotlib/tests/test_delaunay.py',
+            '*/matplotlib/tests/test_dviread.py',
+            '*/matplotlib/tests/test_image.py',
+            '*/matplotlib/tests/test_legend.py',
+            '*/matplotlib/tests/test_lines.py',
+            '*/matplotlib/tests/test_mathtext.py',
+            '*/matplotlib/tests/test_patches.py',
+            '*/matplotlib/tests/test_pickle.py',
+            '*/matplotlib/tests/test_png.py',
+            '*/matplotlib/tests/test_rcparams.py',
+            '*/matplotlib/tests/test_simplification.py',
+            '*/matplotlib/tests/test_spines.py',
+            '*/matplotlib/tests/test_streamplot.py',
+            '*/matplotlib/tests/test_subplots.py',
+            '*/matplotlib/tests/test_text.py',
+            '*/matplotlib/tests/test_tightlayout.py',
+            '*/matplotlib/tests/test_transforms.py',
+            '*/matplotlib/tests/test_triangulation.py',
+            '*/matplotlib/compat/subprocess.py',
+            '*/matplotlib/backends/__init__.py',
+            '*/matplotlib/backends/backend_agg.py',
+            '*/matplotlib/backends/backend_cairo.py',
+            '*/matplotlib/backends/backend_cocoaagg.py',
+            '*/matplotlib/backends/backend_gdk.py',
+            '*/matplotlib/backends/backend_gtk.py',
+            '*/matplotlib/backends/backend_gtk3.py',
+            '*/matplotlib/backends/backend_gtk3cairo.py',
+            '*/matplotlib/backends/backend_gtkagg.py',
+            '*/matplotlib/backends/backend_gtkcairo.py',
+            '*/matplotlib/backends/backend_macosx.py',
+            '*/matplotlib/backends/backend_mixed.py',
+            '*/matplotlib/backends/backend_pdf.py',
+            '*/matplotlib/backends/backend_pgf.py',
+            '*/matplotlib/backends/backend_ps.py',
+            '*/matplotlib/backends/backend_qt4.py',
+            '*/matplotlib/backends/backend_qt4agg.py',
+            '*/matplotlib/backends/backend_svg.py',
+            '*/matplotlib/backends/backend_template.py',
+            '*/matplotlib/backends/backend_tkagg.py',
+            '*/matplotlib/backends/backend_webagg.py',
+            '*/matplotlib/backends/backend_wx.py',
+            '*/matplotlib/backends/backend_wxagg.py',
+            '*/matplotlib/backends/qt4_compat.py',
+            '*/matplotlib/backends/tkagg.py',
+            '*/matplotlib/backends/windowing.py',
+            '*/matplotlib/backends/qt4_editor/figureoptions.py',
+            '*/matplotlib/backends/qt4_editor/formlayout.py',
+            '*/matplotlib/sphinxext/__init__.py',
+            '*/matplotlib/sphinxext/ipython_console_highlighting.py',
+            '*/matplotlib/sphinxext/ipython_directive.py',
+            '*/matplotlib/sphinxext/mathmpl.py',
+            '*/matplotlib/sphinxext/only_directives.py',
+            '*/matplotlib/sphinxext/plot_directive.py',
+            '*/matplotlib/projections/__init__.py',
+            '*/matplotlib/projections/geo.py',
+            '*/matplotlib/projections/polar.py']
 
-    #: A class attribute to store patterns which have seen exceptions.
-    matched_exclusions = set()
+        #: A class attribute to store patterns which have seen exceptions.
+        matched_exclusions = set()
 
-    def get_file_results(self):
-        # If the file had no errors, return self.file_errors (which will be 0)
-        if not self._deferred_print:
-            return self.file_errors
-
-        # Iterate over all of the patterns, to find a possible exclusion. If we
-        # the filename is to be excluded, go ahead and remove the counts that
-        # self.error added.
-        for pattern in self.expected_bad_files:
-            if fnmatch(self.filename, pattern):
-                self.matched_exclusions.add(pattern)
-                # invert the error method's counters.
-                for _, _, code, _, _ in self._deferred_print:
-                    self.counters[code] -= 1
-                    if self.counters[code] == 0:
-                        self.counters.pop(code)
-                        self.messages.pop(code)
-                    self.file_errors -= 1
-                    self.total_errors -= 1
+        def get_file_results(self):
+            # If the file had no errors, return self.file_errors (which will be 0)
+            if not self._deferred_print:
                 return self.file_errors
 
-        # Otherwise call the superclass' method to print the bad results.
-        return super(StandardReportWithExclusions,
-                     self).get_file_results()
+            # Iterate over all of the patterns, to find a possible exclusion. If we
+            # the filename is to be excluded, go ahead and remove the counts that
+            # self.error added.
+            for pattern in self.expected_bad_files:
+                if fnmatch(self.filename, pattern):
+                    self.matched_exclusions.add(pattern)
+                    # invert the error method's counters.
+                    for _, _, code, _, _ in self._deferred_print:
+                        self.counters[code] -= 1
+                        if self.counters[code] == 0:
+                            self.counters.pop(code)
+                            self.messages.pop(code)
+                        self.file_errors -= 1
+                        self.total_errors -= 1
+                    return self.file_errors
+
+            # Otherwise call the superclass' method to print the bad results.
+            return super(StandardReportWithExclusions,
+                         self).get_file_results()
 
 
 def _test_pep8_conformance():


### PR DESCRIPTION
If pep8 is installed, we shouldn't create a subclass of pep8.StandardReport.
