### PR TITLE
BUG: Fix ValueError: setting an array element with a sequence

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -873,8 +873,8 @@ class GraphicsContextBase:
 
         """
         if dash_list is not None:
-            dash_list = np.asarray(dash_list)
-            if np.any(dash_list <= 0.0):
+            dl = np.asarray(dash_list)
+            if np.any(dl <= 0.0):
                 raise ValueError("All values in the dash list must be positive")
         self._dashes = dash_offset, dash_list
 


### PR DESCRIPTION
This is fixed in the master branch. It affects the matplotlib:v1.2.x branch only, not the not 1.2.1 release.
The bug was reported at http://code.google.com/p/winpython/issues/detail?id=61
