### PR TITLE
added `add_collection` call to `finance.volume_overlay`

### DIFF
--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -573,6 +573,7 @@ def volume_overlay(ax, opens, closes, volumes,
                                    linewidths   = (0.5,),
                                    )
 
+    ax.add_collection(barCollection)
     corners = (0, 0), (len(bars), max(volumes))
     ax.update_datalim(corners)
     ax.autoscale_view()


### PR DESCRIPTION
This was raised in http://stackoverflow.com/questions/17251871/adding-volume-overlay-in-matplotlib/17252516#17252516

With out this line, the function updates the axes limits, but
does not actually plot anything.

This is (imo) a bug and should probably get cherry-picked into 1.3 if that is not too late and the 1.2.x branch.
