### PR TITLE
Added labels to images in the gallery [sprint]

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -566,3 +566,18 @@ table.docutils td {
   width: 30em;
 }
 
+figure {
+  margin: 1em;
+  display: inline-block;
+}
+
+figure img {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+figcaption {
+  text-align: center;
+}
+
+

--- a/doc/sphinxext/gen_gallery.py
+++ b/doc/sphinxext/gen_gallery.py
@@ -41,7 +41,10 @@ header_template = """\
 </h4>"""
 
 link_template = """\
-<a href="{link}"><img src="{thumb}" border="0" alt="{basename}"/></a>
+<figure>
+  <a href="{link}"><img src="{thumb}" border="0" alt="{basename}"/></a><br>
+  <figcaption><a href="{link}">{title}</a></figcaption>
+</figure>
 """
 
 toc_template = """\
@@ -122,7 +125,8 @@ def gen_gallery(app, doctree):
                 link = 'examples/%s/%s.html'%(subdir, basename)
                 rows.append(link_template.format(link=link,
                                                  thumb=thumbfile,
-                                                 basename=basename))
+                                                 basename=basename
+                                                 title=basename))
 
         if len(data) == 0:
             warnings.warn("No thumbnails were found in %s" % subdir)

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -121,6 +121,7 @@ Matplotlib Examples
             rstfile = '%s.rst'%basename
             outrstfile = os.path.join(rstdir, rstfile)
 
+            # XXX make into title
             fhsubdirIndex.write('    %s <%s>\n'%(os.path.basename(basename),rstfile))
 
             do_plot = (subdir in example_subdirs


### PR DESCRIPTION
Right now the label is just the filename of the example, but it should be a string that we define in the example file (like in scikits-image / scikits-learn).
