### PR TITLE
overriding "__loader__" is ok

### DIFF
--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -16,6 +16,7 @@ def test_override_builtins():
         '__name__',
         '__doc__',
         '__package__',
+        '__loader__',
         'any',
         'all',
         'sum'


### PR DESCRIPTION
I'm not quite sure why this has started happening on Travis.  On Python 3.3, the **loader** variable may be set on a module to indicate which module loader was used to load it.  This is now showing up in the namespace of pyplot and then looks like an overridden builtin.  This is an ok thing to do, this adds it to the list of things to ignore.
