### PR TITLE
Commented line which was meant to be commented

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -191,7 +191,7 @@ backend      : %(backend)s
                        #             or the autohinter if none is available.
                        # For backward compatibility, this value may also be
                        # True === 'auto' or False === 'none'.
-text.hinting_factor : 8 # Specifies the amount of softness for hinting in the
+#text.hinting_factor : 8 # Specifies the amount of softness for hinting in the
                          # horizontal direction.  A value of 1 will hint to full
                          # pixels.  A value of 2 will hint to half pixels etc.
 


### PR DESCRIPTION
When starting ipython, I was getting the following message:
"""
Bad key "text.hinting_factor" on line 184 in
/home/marianne/.matplotlib/matplotlibrc.
You probably need to get an updated matplotlibrc file from
http://matplotlib.sf.net/_static/matplotlibrc or from the matplotlib source
distribution
"""
I love you all :)
