### PR TITLE
[sprint] Fix for generating documentation

### DIFF
--- a/doc/sphinxext/gen_gallery.py
+++ b/doc/sphinxext/gen_gallery.py
@@ -125,7 +125,7 @@ def gen_gallery(app, doctree):
                 link = 'examples/%s/%s.html'%(subdir, basename)
                 rows.append(link_template.format(link=link,
                                                  thumb=thumbfile,
-                                                 basename=basename
+                                                 basename=basename,
                                                  title=basename))
 
         if len(data) == 0:


### PR DESCRIPTION
Introduced a syntax error in PR #2161, whoops! This fixes it, and documentation builds correctly.
