### PR TITLE
DOC annotate is now in numpydoc format

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -570,7 +570,7 @@ class Axes(_AxesBase):
         a : `~matplotlib.text.Annotation`
 
 
-        Others parameters
+        Other parameters
         -----------------
 
         %(Annotation)s


### PR DESCRIPTION
Attempt to move the docstring of the annotate methods to numpydoc format.
