### PR TITLE
Add namespace package mpl_toolkits to package meta-data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ if __name__ == '__main__':
     # These are distutils.setup parameters that the various packages add
     # things to.
     packages = []
+    namespace_packages = []
     py_modules = []
     ext_modules = []
     package_data = {}
@@ -177,6 +178,7 @@ if __name__ == '__main__':
         if isinstance(package, str):
             continue
         packages.extend(package.get_packages())
+        namespace_packages.extend(package.get_namespace_packages())
         py_modules.extend(package.get_py_modules())
         ext = package.get_extension()
         if ext is not None:
@@ -220,6 +222,7 @@ if __name__ == '__main__':
           """,
           license="BSD",
           packages=packages,
+          namespace_packages = namespace_packages,
           platforms='any',
           py_modules=py_modules,
           ext_modules=ext_modules,

--- a/setupext.py
+++ b/setupext.py
@@ -361,6 +361,15 @@ class SetupPackage(object):
         """
         return []
 
+    def get_namespace_packages(self):
+        """
+        Get a list of namespace package names to add to the configuration.
+        These are added to the `namespace_packages` list passed to
+        `distutils.setup`.
+        """
+        return []
+
+
     def get_py_modules(self):
         """
         Get a list of top-level modules to add to the configuration.
@@ -575,6 +584,9 @@ class Toolkits(OptionalPackage):
             'mpl_toolkits.axes_grid1',
             'mpl_toolkits.axisartist',
             ]
+
+    def get_namespace_packages(self):
+        return ['mpl_toolkits']
 
 
 class Tests(OptionalPackage):


### PR DESCRIPTION
This is a companion to https://github.com/matplotlib/basemap/pull/116, so that both basemap and mpl will be declaring mpl_toolkits as a namespace package.
