### PR TITLE
matplotlibrc and the XDG base directory standard

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -718,11 +718,11 @@ def matplotlib_fname():
                 fname == os.path.join(
                     get_home(), '.matplotlib', 'matplotlibrc')):
                 warnings.warn(
-                    "Found matplotlib configuration in ~/.matplotlib. "
+                    "Found matplotlib configuration in ~/.matplotlib/. "
                     "To conform with the XDG base directory standard, "
                     "this configuration location has been deprecated "
-                    "on Linux, and the new location is now %r.  Please "
-                    "move your configuration there to ensure that "
+                    "on Linux, and the new location is now %r/matplotlib/. "
+                    "Please move your configuration there to ensure that "
                     "matplotlib will continue to find it in the future." %
                     _get_xdg_config_dir())
             return fname


### PR DESCRIPTION
After updating Ipython (1.0dev) and Matplotlib (1.4.x), a warning comes up when starting the Ipython notebook:

> UserWarning: Found matplotlib configuration in ~/.matplotlib. To conform with the >XDG base directory standard, this configuration location has been deprecated on >Linux, and the new location is now '/home/user/.config'.  Please move your >configuration there to ensure that matplotlib will continue to find it in the future.

I tried to follow the instructions so I created a new directory 'matplotlib' in ~/.config and moved matplotlibrc there. However, no customization is taking place. 

Is this a bug? I'm running Linux Mint 15 and as I said, Matplotlib 1.4 and Ipython 1.0dev.
