### PR TITLE
Upgrade requirement to pyparsing 2.0.1

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -972,13 +972,19 @@ class Pyparsing(SetupPackage):
 
         if sys.version_info[0] >= 3:
             required = [2, 0, 0]
+            if [int(x) for x in pyparsing.__version__.split('.')] < required:
+                return (
+                    "matplotlib requires pyparsing >= {0} on Python 3.x".format(
+                        '.'.join(str(x) for x in required)))
         else:
             required = [1, 5, 6]
-        if [int(x) for x in pyparsing.__version__.split('.')] < required:
-            return (
-                "matplotlib requires pyparsing >= {0} on Python {1}".format(
-                    '.'.join(str(x) for x in required),
-                    sys.version_info[0]))
+            if [int(x) for x in pyparsing.__version__.split('.')] < required:
+                return (
+                    "matplotlib requires pyparsing >= {0} on Python 2.x".format(
+                        '.'.join(str(x) for x in required)))
+            if pyparsing.__version__ == "2.0.0":
+                return (
+                    "pyparsing 2.0.0 is not compatible with Python 2.x")
 
         return "using pyparsing version %s" % pyparsing.__version__
 
@@ -987,7 +993,7 @@ class Pyparsing(SetupPackage):
             return ['pyparsing>=1.5.6']
         else:
             # pyparsing >= 2.0.0 is not compatible with Python 2
-            return ['pyparsing>=1.5.6,<2.0.0']
+            return ['pyparsing>=1.5.6,!=2.0.0']
 
 
 class BackendAgg(OptionalBackendPackage):


### PR DESCRIPTION
The newly released pyparsing 2.0.1 fixes a number of problems with supporting Python 2.x and 3.x at the same time.  Unfortunately, I think the ship has sailed to get this in for 1.3.0, but for 1.3.1 we should be able to do this.

http://code.activestate.com/lists/python-list/647675/
