### PR TITLE
axes_grid1: ImageGrid respect the aspect ratio of axes. 

### DIFF
--- a/examples/axes_grid/demo_imagegrid_aspect.py
+++ b/examples/axes_grid/demo_imagegrid_aspect.py
@@ -1,0 +1,20 @@
+import matplotlib.pyplot as plt
+
+from mpl_toolkits.axes_grid1 import ImageGrid
+fig = plt.figure(1)
+
+grid1 = ImageGrid(fig, 121, (2,2), axes_pad=0.1,
+                 aspect=True, share_all=True)
+
+for i in [0, 1]:
+    grid1[i].set_aspect(2)
+
+
+grid2 = ImageGrid(fig, 122, (2,2), axes_pad=0.1,
+                 aspect=True, share_all=True)
+
+
+for i in [1, 3]:
+    grid2[i].set_aspect(2)
+
+plt.show()

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -73,19 +73,39 @@ class Scaled(_Base):
 
 Scalable=Scaled
 
+def _get_axes_aspect(ax):
+    aspect = ax.get_aspect()
+    # when aspec is "auto", consider it as 1.
+    if aspect in ('normal', 'auto'):
+        aspect = 1.
+    elif aspect == "equal":
+        aspect = 1
+    else:
+        aspect = float(aspect)
+
+    return aspect
 
 class AxesX(_Base):
     """
     Scaled size whose relative part corresponds to the data width
     of the *axes* multiplied by the *aspect*.
     """
-    def __init__(self, axes, aspect=1.):
+    def __init__(self, axes, aspect=1., ref_ax=None):
         self._axes = axes
         self._aspect = aspect
+        if aspect == "axes" and ref_ax is None:
+            raise ValueError("ref_ax must be set when aspect='axes'")
+        self._ref_ax = ref_ax
 
     def get_size(self, renderer):
         l1, l2 = self._axes.get_xlim()
-        rel_size = abs(l2-l1)*self._aspect
+        if self._aspect == "axes":
+            ref_aspect = _get_axes_aspect(self._ref_ax)
+            aspect = ref_aspect/_get_axes_aspect(self._axes)
+        else:
+            aspect = self._aspect
+
+        rel_size = abs(l2-l1)*aspect
         abs_size = 0.
         return rel_size, abs_size
 
@@ -94,13 +114,23 @@ class AxesY(_Base):
     Scaled size whose relative part corresponds to the data height
     of the *axes* multiplied by the *aspect*.
     """
-    def __init__(self, axes, aspect=1.):
+    def __init__(self, axes, aspect=1., ref_ax=None):
         self._axes = axes
         self._aspect = aspect
+        if aspect == "axes" and ref_ax is None:
+            raise ValueError("ref_ax must be set when aspect='axes'")
+        self._ref_ax = ref_ax
 
     def get_size(self, renderer):
         l1, l2 = self._axes.get_ylim()
-        rel_size = abs(l2-l1)*self._aspect
+
+        if self._aspect == "axes":
+            ref_aspect = _get_axes_aspect(self._ref_ax)
+            aspect = _get_axes_aspect(self._axes)
+        else:
+            aspect = self._aspect
+
+        rel_size = abs(l2-l1)*aspect
         abs_size = 0.
         return rel_size, abs_size
 


### PR DESCRIPTION
I thought I committed this change a while ago. There is a reference to my commit 

https://github.com/matplotlib/matplotlib/commit/f6b344e

but somehow this is not shown in the commit history of the master branch (nor the release branch).

This PR is to resolve #955, which I closed sometime ago since I thought I made this commit.
I am making this PR against the v1.3.x branch as this is more like a bug fix, but if others think this is not appropriate, I will rebase and make another PR.
