### PR TITLE
Fix MacOSX backend installation issues.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -553,6 +553,7 @@ class Matplotlib(SetupPackage):
                 'backends/web_backend/jquery/css/themes/base/*.*',
                 'backends/web_backend/jquery/css/themes/base/images/*',
                 'backends/web_backend/css/*.*',
+                'backends/Matplotlib.nib/*'
              ]}
 
 
@@ -1605,8 +1606,7 @@ class BackendMacOSX(OptionalBackendPackage):
         if sys.platform != 'darwin':
             raise CheckFailed("Mac OS-X only")
 
-    def get_package_data(self):
-        return {'matplotlib': ['backends/Matplotlib.nib/*']}
+        return 'darwin'
 
     def get_extension(self):
         sources = [


### PR DESCRIPTION
As reported by @mdehoon:

> I noticed that this release candidate will always skip the Mac OS X backend,
> as the .check() method of BackendMacOSX in setupext.py returns None. Adding
>     return "darwin"
> or some other string solves the issue.
> Also, if I am not mistaken, the files under
> lib/matplotlib/backends/Matplotlib.nib (as returned by the
> get_package_data() method of BackendMacOSX in setupext.py) are needed
> by the cocoaagg backend, not by the MacOSX backend.
