### PR TITLE
Error with installing latest developer version of matplotlib on Travis

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -49,6 +49,7 @@ except ImportError:
             args = [quote(arg) for arg in args]
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
+MINIMUM_VERSION = "0.6.28"
 DEFAULT_VERSION = "0.6.45"
 DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
@@ -135,7 +136,7 @@ def _do_download(version, download_base, to_dir, download_delay):
     setuptools.bootstrap_install_from = egg
 
 
-def use_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
+def use_setuptools(version=MINIMUM_VERSION, download_base=DEFAULT_URL,
                    to_dir=os.curdir, download_delay=15, no_fake=True):
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)


### PR DESCRIPTION
I am using Travis to test another package (http://github.com/aplpy/aplpy) that depends on Matplotlib, and when executing this line:

```
- pip install git+http://github.com/matplotlib/matplotlib.git#egg=matplotlib
```

I get the error:

```
$ pip install git+http://github.com/matplotlib/matplotlib.git#egg=matplotlib
Downloading/unpacking matplotlib from git+http://github.com/matplotlib/matplotlib.git#egg=matplotlib
  Cloning http://github.com/matplotlib/matplotlib.git to /home/travis/virtualenv/python2.6/build/matplotlib
  Running setup.py egg_info for package matplotlib
    The required version of distribute (>=0.6.45) is not available,
    and can't be installed while this script is running. Please
    install a more recent version first, using
    'easy_install -U distribute'.

    (Currently using distribute 0.6.34 (/home/travis/virtualenv/python2.6/lib/python2.6/site-packages/distribute-0.6.34-py2.6.egg))
    Complete output from command python setup.py egg_info:
    The required version of distribute (>=0.6.45) is not available,
and can't be installed while this script is running. Please
install a more recent version first, using
'easy_install -U distribute'.
(Currently using distribute 0.6.34 (/home/travis/virtualenv/python2.6/lib/python2.6/site-packages/distribute-0.6.34-py2.6.egg))
```

@mdboom - I think this is why the header of `setup.py` in Astropy is more complex: https://github.com/astropy/astropy/blob/master/setup.py
