### PR TITLE
texmanager font family fix

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -169,6 +169,8 @@ Could not rename old TeX cache dir "%s": a suitable configuration
         ff = rcParams['font.family']
         if len(ff) == 1 and ff[0].lower() in self.font_families:
             self.font_family = ff[0].lower()
+        elif ff.lower() in self.font_families:
+            self.font_family = ff.lower()
         else:
             mpl.verbose.report(
                 'font.family must be one of (%s) when text.usetex is True. '


### PR DESCRIPTION
Fixes a bug introduced in b5c340 that broke font selection in the TeX backend.
