### PR TITLE
Offset between plot and LineCollection

### DIFF
--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -1751,7 +1751,7 @@ RendererAgg::draw_path_collection(const Py::Tuple& args)
 
     try
     {
-        _draw_path_collection_generic<PathListGenerator, 0, 1>
+        _draw_path_collection_generic<PathListGenerator, 1, 1>
         (gc,
          master_transform,
          gc.cliprect,


### PR DESCRIPTION
There is a 1 pixel offset between the result of `ax.plot` and a `LineCollection` with the same values:

```
from matplotlib import pyplot as plt
from matplotlib.collections import LineCollection

x1, x2, y1, y2 = -6.87194525904,-6.87194525904,0.0446252911239,0.0478759487178

fig = plt.figure(figsize=(10,8))
ax = fig.add_subplot(1,1,1)

lc = LineCollection([([[x1, y1], [x2, y2]])], color='green')
ax.add_collection(lc)        
ax.plot([x1, x2], [y1, y2], color='red')

fig.savefig('offset.png')
```

gives:

![offset](https://f.cloud.github.com/assets/314716/870345/f39c4d44-f829-11e2-8912-65bd94537ba2.png)

If you zoom in, you'll see:

![offset_zoom](https://f.cloud.github.com/assets/314716/870347/f9a61256-f829-11e2-8b96-dd11bf4f43b8.png)

I think there is a 1 pixel offset in the two lines.

@mdboom, I'm mentioning you here since in my opinion this is bad enough to be potentially considered for a fix that should be included in 1.3.0.
