### PR TITLE
qt4_editor/formlayout.py TypeError: float() argument must be a string or a number

### DIFF
--- a/lib/matplotlib/backends/qt4_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt4_editor/formlayout.py
@@ -353,7 +353,7 @@ class FormWidget(QWidget):
             elif isinstance(value, bool):
                 value = field.checkState() == Qt.Checked
             elif isinstance(value, float):
-                value = float(field.text())
+                value = float(str(field.text()))
             elif isinstance(value, int):
                 value = int(field.value())
             elif isinstance(value, datetime.datetime):


### PR DESCRIPTION
Using matplotlib 1.2 within pyqt on Python 3.3 I receive

formlayout.py", line 343, in get
    value = float(field.text())
TypeError: float() argument must be a string or a number

That does not happen under Python 2.7.
Modifying that line in backends/qt4_editor/formlayout.py by wrapping the field.text() into a str() like

value = float(str(field.text()))

solves this.
