### PR TITLE
Correct setup of margins for logarithmic plots

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1907,18 +1907,14 @@ class _AxesBase(martist.Artist):
                                                  expander=0.05)
             if self._xmargin > 0:
                 xscale = self.get_xscale()
-                print x0, x1,
                 if xscale == 'log':
                     delta = (x1 / x0) ** self._xmargin
-                    print delta
                     x0 /= delta
                     x1 *= delta
                 else:
                     delta = (x1 - x0) * self._xmargin
-                    print delta
                     x0 -= delta
                     x1 += delta
-                print x0, x1
             if not _tight:
                 x0, x1 = xlocator.view_limits(x0, x1)
             self.set_xbound(x0, x1)


### PR DESCRIPTION
The current formula for setting margins is false in case of log plots. Here is a tested suggestion handling the special case. Please see if this can be backported to the current release candidate (perhaps even beyond), as it seems mandatory to have a correct way of setting margins for log plots.
