### PR TITLE
WebAgg favicon serving error in Python 3

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -378,7 +378,7 @@ class WebAggApplication(tornado.web.Application):
         def get(self):
             self.set_header('Content-Type', 'image/png')
             with open(os.path.join(WebAggApplication._mpl_dirs['images'],
-                                   'matplotlib.png')) as fd:
+                                   'matplotlib.png'), 'rb') as fd:
                 self.write(fd.read())
 
     class SingleFigurePage(tornado.web.RequestHandler):


### PR DESCRIPTION
backend_webagg.py, near line 381:

``` python
class FavIcon(tornado.web.RequestHandler):
        def get(self):
            self.set_header('Content-Type', 'image/png')
            with open(os.path.join(WebAggApplication._mpl_dirs['images'],
                                   'matplotlib.png')) as fd:
                self.write(fd.read())
```

Doing self.write(fd.read()) is an error: Tornado converts everything passed into write() to utf-8 at least in Python 3, so that I get the following runtime error after opening a web browser:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/tornado/web.py", line 1042, in _execute
    getattr(self, self.request.method.lower())(_args, *_kwargs)
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_webagg.py", line 381, in get
    self.write(fd.read())
  File "/usr/lib/python3.3/codecs.py", line 300, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte

This error is reasonable: trying to convert binary data - matplotlib.png - to utf8 is definitely a bad idea. I am not sure how to fix it, as I am novice to Tornado and Python in general.
