### PR TITLE
GTK error, failed building on command line

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1463,7 +1463,7 @@ def backend_gtk3agg_internal_check(x):
 
     try:
         from gi.repository import Gtk, Gdk, GObject
-    except ImportError:
+    except (ImportError, RuntimeError):
         return (False, "Requires pygobject to be installed.")
 
     return (True, "version %s.%s.%s" % (
@@ -1489,9 +1489,14 @@ class BackendGtk3Agg(OptionalBackendPackage):
             p = multiprocessing.Pool()
         except:
             return "unknown (can not use multiprocessing to determine)"
-        success, msg = p.map(backend_gtk3agg_internal_check, [0])[0]
-        p.close()
-        p.join()
+        try:
+            success, msg = p.map(backend_gtk3agg_internal_check, [0])[0]
+        except:
+            success = False
+            msg = "Could not determine"
+        finally:
+            p.close()
+            p.join()
         if success:
             BackendAgg.force = True
 
@@ -1521,7 +1526,7 @@ def backend_gtk3cairo_internal_check(x):
 
     try:
         from gi.repository import Gtk, Gdk, GObject
-    except ImportError:
+    except (RuntimeError, ImportError):
         return (False, "Requires pygobject to be installed.")
 
     return (True, "version %s.%s.%s" % (


### PR DESCRIPTION
My guess is that the build script is trying to initialise X11 over the terminal, and failing. This only happens in the dev branch.

```
** (-c:27437): WARNING **: Command line `dbus-launch --autolaunch=613af6694c211a25d65930af0000001a --b
inary-syntax --close-stderr' exited with non-zero exit status 1: Autolaunch error: X11 initialization
failed.\n

Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/tmp/pip-mxUubW-build/setup.py", line 131, in <module>

    result = package.check()

  File "setupext.py", line 1428, in check

    success, msg = p.map(backend_gtk3agg_internal_check, [0])[0]

  File "/usr/lib/python2.7/multiprocessing/pool.py", line 227, in map

    return self.map_async(func, iterable, chunksize).get()

  File "/usr/lib/python2.7/multiprocessing/pool.py", line 528, in get

    raise self._value

RuntimeError: Gtk couldn't be initialized
```
