### PR TITLE
Pyparsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ python:
   - 3.3
 
 install:
-  - pip install -q --use-mirrors nose python-dateutil numpy pep8
-  # This is a workaround to install the latest versions of pyparsing,
-  # which are not yet available on PyPI
-  - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then pip -q install http://sourceforge.net/projects/pyparsing/files/pyparsing/pyparsing-2.0.0/pyparsing-2.0.0.tar.gz; fi'
-  - 'if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip -q install http://sourceforge.net/projects/pyparsing/files/pyparsing/pyparsing-1.5.7/pyparsing-1.5.7.tar.gz; fi'
+  - pip install -q --use-mirrors nose python-dateutil numpy pep8 pyparsing
   - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then pip -q install --use-mirrors PIL; fi
   - sudo apt-get update && sudo apt-get -qq install inkscape
   - python setup.py install

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -120,6 +120,21 @@ else:
             "matplotlib requires pyparsing >= {0}".format(
                 '.'.join(str(x) for x in _required)))
 
+    if pyparsing.__version__ == '2.0.0':
+        raise ImportError(
+            "pyparsing 2.0.0 has bugs that prevent its use with "
+            "matplotlib")
+
+    # pyparsing 1.5.6 does not have <<= on the Forward class, but
+    # pyparsing 2.0.0 and later will spew deprecation warnings if
+    # using << instead.  In order to support pyparsing 1.5.6 and above
+    # with a common code base, this small monkey patch is applied.
+    if not hasattr(pyparsing.Forward, '__ilshift__'):
+        def _forward_ilshift(self, other):
+            self.__lshift__(other)
+            return self
+        pyparsing.Forward.__ilshift__ = _forward_ilshift
+
 import os, re, shutil, warnings
 import distutils.sysconfig
 import distutils.version

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -40,7 +40,14 @@ from pyparsing import Combine, Group, Optional, Forward, \
      ParseResults, Suppress, oneOf, StringEnd, ParseFatalException, \
      FollowedBy, Regex, ParserElement, QuotedString, ParseBaseException
 
-ParserElement.enablePackrat()
+# Enable packrat parsing
+if (sys.version_info[0] >= 3 and
+    [int(x) for x in pyparsing.__version__.split('.')] < [2, 0, 0]):
+    warn("Due to a bug in pyparsing <= 2.0.0 on Python 3.x, packrat parsing "
+         "has been disabled.  Mathtext rendering will be much slower as a "
+         "result.  Install pyparsing 2.0.0 or later to improve performance.")
+else:
+    ParserElement.enablePackrat()
 
 from matplotlib.afm import AFM
 from matplotlib.cbook import Bunch, get_realpath_and_stat, \

--- a/setupext.py
+++ b/setupext.py
@@ -971,15 +971,25 @@ class Pyparsing(SetupPackage):
                 "support. pip/easy_install may attempt to install it "
                 "after matplotlib.")
 
-        required = [2, 0, 1]
+        required = [1, 5, 6]
         if [int(x) for x in pyparsing.__version__.split('.')] < required:
             return (
                 "matplotlib requires pyparsing >= {0}".format(
                     '.'.join(str(x) for x in required)))
+
+        if pyparsing.__version__ == "2.0.0":
+            if sys.version_info[0] == 2:
+                return (
+                    "pyparsing 2.0.0 is not compatible with Python 2.x")
+            else:
+                return (
+                    "pyparsing 2.0.0 has bugs that prevent its use with "
+                    "matplotlib")
+
         return "using pyparsing version %s" % pyparsing.__version__
 
     def get_install_requires(self):
-        return ['pyparsing>=2.0.1']
+        return ['pyparsing>=1.5.6,!=2.0.0']
 
 
 class BackendAgg(OptionalBackendPackage):


### PR DESCRIPTION
Bump minimum pyparsing version to 2.0.1. By doing this we can replace the deprecated << with <<= and simplify the version logic for pyparsing. In addition a no longer relevant work around for pyparsing <2.0.0 on python 3 has been removed. This fixes #2240 and #2244 
