### PR TITLE
Incorrect overriding of sys.stdout

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -682,7 +682,11 @@ class CXX(SetupPackage):
 
         self.__class__.found_external = True
         old_stdout = sys.stdout
-        sys.stdout = io.BytesIO()
+        if sys.version_info[0] >= 3:
+            sys.stdout = io.StringIO()
+        else:
+            sys.stdout = io.BytesIO()
+
         try:
             import CXX
         except ImportError:


### PR DESCRIPTION
setupext.py temporarily overrides sys.stdout in way incompatible with Python 3, which results in traceback:

```
$ python3.3 setup.py build
...
Traceback (most recent call last):
  File "setup.py", line 145, in <module>
    result = package.check()
  File "/tmp/matplotlib-1.3.0/setupext.py", line 687, in check
    import CXX
  File "/usr/lib64/python3.3/site-packages/CXX/__init__.py", line 41, in <module>
    """)
TypeError: 'str' does not support the buffer interface
$
```

Patch:

```
--- setupext.py
+++ setupext.py
@@ -682,7 +682,10 @@

         self.__class__.found_external = True
         old_stdout = sys.stdout
-        sys.stdout = io.BytesIO()
+        if sys.version_info[0] >= 3:
+            sys.stdout = io.StringIO()
+        else:
+            sys.stdout = io.BytesIO()
         try:
             import CXX
         except ImportError:
```
