### PR TITLE
Handle prop=None case in AnchoredText.__init__()

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1099,6 +1099,8 @@ class AnchoredText(AnchoredOffsetbox):
         other keyword parameters of AnchoredOffsetbox are also allowed.
         """
 
+        if prop is None:
+            prop = {}
         propkeys = prop.keys()
         badkwargs = ('ha', 'horizontalalignment', 'va', 'verticalalignment')
         if set(badkwargs) & set(propkeys):


### PR DESCRIPTION
The line `propkeys = prop.keys()` will raise an AttributeError if `prop`
has its default value of None.
