### PR TITLE
pyparsing version parsing error

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -97,7 +97,7 @@ Occasionally the internal documentation (python docstrings) will refer
 to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
 
 """
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import sys
 


### PR DESCRIPTION
With the 1.3.0 build from Gohlke's site (http://www.lfd.uci.edu/~gohlke/pythonlibs/), when I try to import matplotlib, I get a pyparsing error.  I have pyparsing 2.0.1 installed.  Here's the error:

```
Python 2.7.2 (default, Jun 12 2011, 15:08:59) [MSC v.1500 32 bit (Intel)] on win
32
Type "help", "copyright", "credits" or "license" for more information.
>>> import matplotlib
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python27\lib\site-packages\matplotlib\__init__.py", line 121, in <mod
ule>
    '.'.join(str(x) for x in _required)))
ImportError: matplotlib requires pyparsing >= 1.5.6
```
