### PR TITLE
Can't find 64-bit GhostScript on win64

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -324,15 +324,21 @@ def checkdep_dvipng():
 def checkdep_ghostscript():
     try:
         if sys.platform == 'win32':
-            command_args = ['gswin32c', '--version']
+            gs_execs = ['gswin32c', 'gswin64c', 'gs']
         else:
-            command_args = ['gs', '--version']
-        s = subprocess.Popen(command_args, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-        v = byte2str(s.stdout.read()[:-1])
-        return v
+            gs_execs = ['gs']
+        for gs_exec in gs_execs:
+            s = subprocess.Popen(
+                [gs_exec, '--version'], stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+            stdout, stderr = s.communicate()
+            if s.returncode == 0:
+                v = byte2str(stdout[:-1])
+                return gs_exec, v
+
+        return None, None
     except (IndexError, ValueError, OSError):
-        return None
+        return None, None
 
 def checkdep_tex():
     try:
@@ -397,7 +403,7 @@ def checkdep_ps_distiller(s):
     flag = True
     gs_req = '7.07'
     gs_sugg = '7.07'
-    gs_v = checkdep_ghostscript()
+    gs_exec, gs_v = checkdep_ghostscript()
     if compare_versions(gs_v, gs_sugg): pass
     elif compare_versions(gs_v, gs_req):
         verbose.report(('ghostscript-%s found. ghostscript-%s or later '
@@ -452,7 +458,7 @@ def checkdep_usetex(s):
                        'backend unless dvipng-1.5 or later is '
                        'installed on your system')
 
-    gs_v = checkdep_ghostscript()
+    gs_exec, gs_v = checkdep_ghostscript()
     if compare_versions(gs_v, gs_sugg): pass
     elif compare_versions(gs_v, gs_req):
         verbose.report(('ghostscript-%s found. ghostscript-%s or later is '

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -141,12 +141,8 @@ def make_external_conversion_command(cmd):
 
    return convert
 
-if matplotlib.checkdep_ghostscript() is not None:
-    if sys.platform == 'win32':
-        gs = 'gswin32c'
-    else:
-        gs = 'gs'
-
+gs, gs_v = matplotlib.checkdep_ghostscript()
+if gs_v is not None:
     cmd = lambda old, new: \
         [gs, '-q', '-sDEVICE=png16m', '-dNOPAUSE', '-dBATCH',
         '-sOutputFile=' + new, old]


### PR DESCRIPTION
Matplotlib can't find 64-bit GhostScript which executable is 'gswin64c.exe', not 'gswin32c.exe'. 
