### PR TITLE
Don't enable "interactive mode" if not at the console

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1169,7 +1169,7 @@ def interactive(b):
 
 def is_interactive():
     'Return true if plot mode is interactive'
-    b = rcParams['interactive']
+    b = rcParams['interactive'] and hasattr(sys, 'ps1')
     return b
 
 def tk_window_focus():
@@ -1276,6 +1276,6 @@ test.__test__ = False # nose: this function is not a test
 
 verbose.report('matplotlib version %s'%__version__)
 verbose.report('verbose.level %s'%verbose.level)
-verbose.report('interactive is %s'%rcParams['interactive'])
+verbose.report('interactive is %s'%is_interactive())
 verbose.report('platform is %s'%sys.platform)
 verbose.report('loaded modules: %s'%sys.modules.iterkeys(), 'debug')


### PR DESCRIPTION
This is a very small patch, but one which probably deserves a lot of discussion, as it's a rather core part of the code and an area that predates my arrival on the scene.

Currently, when the `rcParam` `interactive` is set to `True`, it is impossible to display anything using a simple script:

```
from matplotlib import pyplot as plt

plt.plot([1,2,3])
plt.show()

while True:
   pass
```

(The infinite loop makes no difference, I just want to demonstrate that even by blocking the interpreter, nothing is shown).  All GUI backends (excepting macosx, which I didn't test) display nothing, with the exception of TkAgg which displays an empty window.

I think this is not a good situation, because a user may set `interactive` to `True` because they prefer that behavior at the console, but will then be surprised when their standalone scripts break.  This was the source of an internal bug report at STScI, that took even myself a while to track down.

The fix here is to disable interactive mode if not at an interactive prompt (detected by checking the presence of `sys.ps1`).

Are there any negative consequences to this that I'm not envisioning?  I have tested and found no behavior change in any backend within IPython, both "classic" and notebook.  Is there a use case for "interactive" outside of a standard console that I'm not aware of?

Cc: @fperez, @efiring, @stsci-sienkiew

FWIW: interactive mode, in its "native habitat" at the console seems to work most places now.  Only wx doesn't work in the vanilla python console (but it does in IPython).
