### PR TITLE
speedup figure rendering removal of .startswith() calls and use generato...

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -892,7 +892,7 @@ class ArtistInspector:
 
         """
         names = [name for name in dir(self.o) if
-                 (name.startswith('set_') or name.startswith('get_'))
+                 (name[:4] in ['set_', 'get_'])
                  and callable(getattr(self.o, name))]
         aliases = {}
         for name in names:
@@ -927,7 +927,7 @@ class ArtistInspector:
         if docstring is None:
             return 'unknown'
 
-        if docstring.startswith('alias for '):
+        if docstring[:10] == 'alias for ':
             return None
 
         match = self._get_valid_values_regex.search(docstring)
@@ -943,7 +943,7 @@ class ArtistInspector:
 
         setters = []
         for name in dir(self.o):
-            if not name.startswith('set_'):
+            if name[:4] != 'set_':
                 continue
             o = getattr(self.o, name)
             if not callable(o):
@@ -975,7 +975,7 @@ class ArtistInspector:
         ds = o.__doc__
         if ds is None:
             return False
-        return ds.startswith('alias for ')
+        return ds[:10] == 'alias for '
 
     def aliased_name(self, s):
         """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -238,7 +238,7 @@ class Axes(_AxesBase):
         labels = []
         for handle in self._get_legend_handles(legend_handler_map):
             label = handle.get_label()
-            if label and not label.startswith('_'):
+            if label and label[0] != '_':
                 handles.append(handle)
                 labels.append(label)
 
@@ -5264,7 +5264,7 @@ class Axes(_AxesBase):
 
         patches = []
 
-        if histtype.startswith('bar'):
+        if histtype[:3] == 'bar':
             # Save autoscale state for later restoration; turn autoscaling
             # off so we can do it all a single time at the end, instead
             # of having it done by bar or fill and then having to be redone.
@@ -5326,7 +5326,7 @@ class Axes(_AxesBase):
             self.set_autoscaley_on(_saved_autoscaley)
             self.autoscale_view()
 
-        elif histtype.startswith('step'):
+        elif histtype[:4] == 'step':
             # these define the perimeter of the polygon
             x = np.zeros(4 * len(bins) - 3, np.float)
             y = np.zeros(4 * len(bins) - 3, np.float)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -972,17 +972,12 @@ class Figure(Artist):
             self.patch.draw(renderer)
 
         # a list of (zorder, func_to_call, list_of_args)
-        dsu = []
+        dsu = [(x.get_zorder(), x, x.draw, [renderer]) for x in self.patches ]
 
-        for a in self.patches:
-            dsu.append((a.get_zorder(), a, a.draw, [renderer]))
+        dsu.extend((x.get_zorder(), x, x.draw, [renderer]) for x in self.lines)
 
-        for a in self.lines:
-            dsu.append((a.get_zorder(), a, a.draw, [renderer]))
-
-        for a in self.artists:
-            dsu.append((a.get_zorder(), a, a.draw, [renderer]))
-
+        dsu.extend((x.get_zorder(), x, x.draw, [renderer]) for x in self.artists)
+ 
         # override the renderer default if self.suppressComposite
         # is not None
         not_composite = renderer.option_image_nocomposite()
@@ -1018,19 +1013,17 @@ class Figure(Artist):
                         draw_composite, []))
 
         # render the axes
-        for a in self.axes:
-            dsu.append((a.get_zorder(), a, a.draw, [renderer]))
+        dsu.extend((x.get_zorder(), x, x.draw, [renderer]) for x in self.axes)
 
         # render the figure text
-        for a in self.texts:
-            dsu.append((a.get_zorder(), a, a.draw, [renderer]))
+        dsu.extend((x.get_zorder(), x, x.draw, [renderer]) for x in self.texts)
 
-        for a in self.legends:
-            dsu.append((a.get_zorder(), a, a.draw, [renderer]))
+        # render the figure legends
+        dsu.extend((x.get_zorder(), x, x.draw, [renderer]) for x in self.legends)
 
         dsu = [row for row in dsu if not row[1].get_animated()]
         dsu.sort(key=itemgetter(0))
-        for zorder, a, func, args in dsu:
+        for zorder, a, func, args in dsu: # this also needs to go away for speed
             func(*args)
 
         renderer.close_group('figure')


### PR DESCRIPTION
speedup figure rendering removal of .startswith() calls and use generators instead of for loops

Please see the email thread:
    [Matplotlib-users] mpl-1.2.1: Speedup code by removing .startswith() calls and some for loops
for more details.
