### PR TITLE
ENH: use an artist's update() method instead of the setp() function

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -444,7 +444,7 @@ class _AxesBase(martist.Artist):
             self.set_yscale(yscale)
 
         if len(kwargs):
-            martist.setp(self, **kwargs)
+            self.update(kwargs)
 
         if self.xaxis is not None:
             self._xcid = self.xaxis.callbacks.connect('units finalize',

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1307,7 +1307,7 @@ class Axis(artist.Artist):
                     continue
                 tick.gridOn = self._gridOnMinor
                 if len(kwargs):
-                    artist.setp(tick.gridline, **kwargs)
+                    tick.gridline.update(kwargs)
             self._minor_tick_kw['gridOn'] = self._gridOnMinor
         if which in ['major', 'both']:
             if b is None:
@@ -1319,7 +1319,7 @@ class Axis(artist.Artist):
                     continue
                 tick.gridOn = self._gridOnMajor
                 if len(kwargs):
-                    artist.setp(tick.gridline, **kwargs)
+                    tick.gridline.update(kwargs)
             self._major_tick_kw['gridOn'] = self._gridOnMajor
 
     def update_units(self, data):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -98,7 +98,7 @@ class Patch(artist.Artist):
         self._combined_transform = transforms.IdentityTransform()
 
         if len(kwargs):
-            artist.setp(self, **kwargs)
+            self.update(kwargs)
 
     def get_verts(self):
         """


### PR DESCRIPTION
The artist.setp() function is a Matlab-compatible function intended
for interactive use.  Its extensive capabilities are not needed
in places like Patch.**init**, where the much faster Artist.update()
method suffices.
