### PR TITLE
Upload test result images to Amazon S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
+env:
+  global:
+    - ARTIFACTS_AWS_REGION=us-east-1
+    - ARTIFACTS_S3_BUCKET=matplotlib-test-results
+    - secure: RgJI7BBL8aX5FTOQe7xiXqWHMxWokd6GNUWp1NUV2mRLXPb9dI0RXqZt3UJwKTAzf1z/OtlHDmEkBoTVK81E9iUxK5npwyyjhJ8yTJmwfQtQF2n51Q1Ww9p+XSLORrOzZc7kAo6Kw6FIXN1pfctgYq2bQkrwJPRx/oPR8f6hcbY=
+    - secure: E7OCdqhZ+PlwJcn+Hd6ns9TDJgEUXiUNEI0wu7xjxB2vBRRIKtZMbuaZjd+iKDqCKuVOJKu0ClBUYxmgmpLicTwi34CfTUYt6D4uhrU+8hBBOn1iiK51cl/aBvlUUrqaRLVhukNEBGZcyqAjXSA/Qsnp2iELEmAfOUa92ZYo1sk=
+
+before_script:
+  - gem install travis-artifacts
+
 language: python
 
 python:
@@ -23,3 +33,12 @@ script:
   # multiple processes
   - python -c "from matplotlib import font_manager"
   - python ../matplotlib/tests.py -sv --processes=8 --process-timeout=300
+
+after_failure:
+  - cd ../tmp_test_dir
+  - echo Compressing results...
+  - tar cjf result_images.tar.bz2 result_images
+  - echo Uploading results...
+  - travis-artifacts upload --path result_images.tar.bz2
+  - 'echo Test results available at:'
+  - echo https://s3.amazonaws.com/matplotlib-test-results/artifacts/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/matplotlib-results.tar.bz2


### PR DESCRIPTION
As discussed in today's MEP19 Google Hangout, this will upload the result images from a test run to an Amazon S3 account when the test fails.

This will only work in the main fork, not in a PR, so we can't really test this before merging.  But we can use this PR for manual feedback, of course.

An open question about Amazon S3 is to how to give others admin rights to it without sharing my account (which is of course linked to my credit card for payment).
