### PR TITLE
Replace the obsolete wx.PySimpleApp in the demo file embedding_in_wx5

### DIFF
--- a/examples/user_interfaces/embedding_in_wx5.py
+++ b/examples/user_interfaces/embedding_in_wx5.py
@@ -36,7 +36,7 @@ class PlotNotebook(wx.Panel):
 
 
 def demo():
-    app = wx.PySimpleApp()
+    app = wx.App(0)
     frame = wx.Frame(None,-1,'Plotter')
     plotter = PlotNotebook(frame)
     axes1 = plotter.add('figure 1').gca()


### PR DESCRIPTION
Replace wx.PySimpleApp with wx.App
to avoid the wxPyDeprecationWarning.
