### PR TITLE
fix the docstring for scale_docs

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -534,5 +534,5 @@ def get_scale_docs():
 
 docstring.interpd.update(
     scale=' | '.join([repr(x) for x in get_scale_names()]),
-    scale_docs=get_scale_docs().strip(),
+    scale_docs=get_scale_docs().rstrip(),
     )


### PR DESCRIPTION
Current version of `scale_docs` string strips the leading whitespace from the `get_scale_docs` function. This fixes the alignment so that 'linear' aligns with 'log', which is not currently happening in the below screenshot from the documentation page:

![screen shot 2013-08-19 at 15 52 36](https://f.cloud.github.com/assets/255672/989299/ade9e718-0911-11e3-88c6-f7b66a75af0f.png)
