### PR TITLE
fix draw_idle reference in  NavigationToolbar2

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3146,7 +3146,7 @@ class NavigationToolbar2(object):
             a.set_position(pos[i][0], 'original')
             a.set_position(pos[i][1], 'active')
 
-        self.draw_idle()
+        self.canvas.draw_idle()
 
     def save_figure(self, *args):
         """Save the current figure"""


### PR DESCRIPTION
NavigationToolbar2 sub-classes do not (all?) have a draw_idle method (strictly speaking, the QT one does not).  I assume this should have bounce strait to the canvas, not through the `NavigationToolbar2.draw()` method.

Change introduced in 25ff2f70764b71c7126929e0ef08e7b18c42a0d4
