### PR TITLE
BUG FIX for Pull Request #2275: Fix incorrect function calls

### DIFF
--- a/lib/matplotlib/backends/qt4_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt4_editor/formlayout.py
@@ -79,7 +79,7 @@ class ColorButton(QtGui.QPushButton):
     def get_color(self):
         return self._color
 
-    @QtCore.pyqtSignature("QColor")
+    @QtCore.Slot("QColor")
     def set_color(self, color):
         if color != self._color:
             self._color = color
@@ -88,7 +88,7 @@ class ColorButton(QtGui.QPushButton):
             pixmap.fill(color)
             self.setIcon(QtGui.QIcon(pixmap))
 
-    color = QtCore.pyqtProperty("QColor", get_color, set_color)
+    color = QtCore.Property("QColor", get_color, set_color)
 
 def col2hex(color):
     """Convert matplotlib color to hex before passing to Qt"""


### PR DESCRIPTION
In PR #2275, all the individual Qt functions were changed from being imported individually to being referenced from their parent QtCore or QtGui module. Unfortunately, this pull request accidentally kept pyqtSignature and pyqtProperty (which were aliased Qt calls) instead of utilizing the correct underlying Qt calls. This pull request changes the QtCore.pyqtSignature and QtCore.pyqtProperty calls from PR #2275 to the correct QtCore.Slot and QtCore.Property calls.
