### PR TITLE
Bar demo2 improve

### DIFF
--- a/examples/pylab_examples/barchart_demo2.py
+++ b/examples/pylab_examples/barchart_demo2.py
@@ -65,14 +65,20 @@ def withnew(i, scr):
 
 scoreLabels = [withnew(i, scr) for i, scr in enumerate(scores)]
 scoreLabels = [i+j for i, j in zip(scoreLabels, testMeta)]
-pylab.yticks(pos, scoreLabels)
+# set the tick locations
+ax2.set_yticks(pos)
+# set the tick labels
+ax2.set_yticklabels(scoreLabels)
+# make sure that the limits are set equally on both yaxis so the ticks line up
+ax2.set_ylim(ax1.get_ylim())
+
+
 ax2.set_ylabel('Test Scores')
 #Make list of numerical suffixes corresponding to position in a list
 #            0     1     2     3     4     5     6     7     8     9
 suffixes = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th']
 ax2.set_xlabel('Percentile Ranking Across ' + str(grade) + suffixes[grade]
               + ' Grade ' + gender.title() + 's')
-
 
 # Lastly, write in the ranking inside each bar to aid in interpretation
 for rect in rects:


### PR DESCRIPTION
Prompted by this: http://stackoverflow.com/questions/18369798/how-to-get-ticks-on-both-sides-at-same-tick-locations/18371449#18371449

The demo looks like it relies on some auto-range magic to work correctly.  Made more fool-proof.

Not sure if this should go against 1.3.x or master, targeted 1.3.x because (I think) it is easier to move the other way.

Also include pep8 clean-up
