### PR TITLE
Fix PySide compatibility

### DIFF
--- a/lib/matplotlib/backends/qt4_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt4_editor/formlayout.py
@@ -97,8 +97,7 @@ def col2hex(color):
 def to_qcolor(color):
     """Create a QColor from a matplotlib color"""
     qcolor = QtGui.QColor()
-    if isinstance(color, QtCore.QString):
-        color = str(color)
+    color = str(color)
     try:
         color = col2hex(color)
     except ValueError:


### PR DESCRIPTION
This uses PR #2326 from @pmarshwx, plus a fix for an AttributeError for QtCore.QString in PySide when opening the qt editor. This fixes issue #2318.

This works for me in PyQt4 API 1 and PySide, both on Python 2.7.3 in Linux. I've tested about as much of the functionality of the qt editor as I can think of, in both libraries, and I can't get it to break.
