### PR TITLE
Fix wrong syntax for assert

### DIFF
--- a/lib/matplotlib/docstring.py
+++ b/lib/matplotlib/docstring.py
@@ -33,8 +33,8 @@ class Substitution(object):
         "%s %s wrote the Raven"
     """
     def __init__(self, *args, **kwargs):
-        assert (not (args and kwargs),
-                "Only positional or keyword args are allowed")
+        assert not (args and kwargs), \
+                "Only positional or keyword args are allowed"
         self.params = args or kwargs
 
     def __call__(self, func):


### PR DESCRIPTION
The assert statement doesn't take parentheses, see
http://docs.python.org/3.2/reference/simple_stmts.html#assert
http://docs.python.org/2/reference/simple_stmts.html#grammar-token-assert_stmt

I found this because python gave me the following
`SyntaxWarning: assertion is always true, perhaps remove parentheses?`
