### PR TITLE
texmanager font selection crashes

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -169,7 +169,7 @@ Could not rename old TeX cache dir "%s": a suitable configuration
         ff = rcParams['font.family']
         if len(ff) == 1 and ff[0].lower() in self.font_families:
             self.font_family = ff[0].lower()
-        elif ff.lower() in self.font_families:
+        elif isinstance(ff, basestring) and ff.lower() in self.font_families:
             self.font_family = ff.lower()
         else:
             mpl.verbose.report(


### PR DESCRIPTION
As reported here:

https://github.com/matplotlib/matplotlib/commit/89a314e9ee70f0598e228f6a896706517034aef1#commitcomment-3925144

@akrherz
