### PR TITLE
Ignore any non-ascii characters when reading font information.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -391,11 +391,11 @@ def ttfFontProperty(font):
     sfnt2 = sfnt.get((1,0,0,2))
     sfnt4 = sfnt.get((1,0,0,4))
     if sfnt2:
-        sfnt2 = sfnt2.decode('ascii').lower()
+        sfnt2 = sfnt2.decode('ascii', errors='ignore').lower()
     else:
         sfnt2 = ''
     if sfnt4:
-        sfnt4 = sfnt4.decode('ascii').lower()
+        sfnt4 = sfnt4.decode('ascii', errors='ignore').lower()
     else:
         sfnt4 = ''
     if sfnt4.find('oblique') >= 0:


### PR DESCRIPTION
I seem to have some fonts locally that have broken font information. These contain non-ascii characters, and I wouldn't be surprised if these are not even all the same encoding.

Well, simply ignoring the characters seems to work nicely.
