### PR TITLE
Write a dependency policy

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -141,6 +141,10 @@ function getSnippet(id, url) {
 
   <h4>Need help?</h4>
 
+<p>matplotlib is a welcoming, inclusive project, and we try to follow
+the <a href="http://www.python.org/psf/codeofconduct/">Python Software
+Foundation Code of Conduct</a> in everything we do.</p>
+
 <p>Check the <a href="{{ pathto('faq/index') }}">faq</a>,
 the <a href="{{ pathto('api/index') }}">api</a> docs,
 <a href="http://matplotlib.1069221.n5.nabble.com/matplotlib-users-f3.html">mailing


### PR DESCRIPTION
We should have a written policy about what versions of dependencies we will support.

A good rule of thumb is probably what the current LTS releases of the major Linux distributions (Debian, RedHat, Ubuntu) provide.
