### PR TITLE
Follow the PSF code of conduct

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -141,6 +141,10 @@ function getSnippet(id, url) {
 
   <h4>Need help?</h4>
 
+<p>matplotlib is a welcoming, inclusive project, and we try to follow
+the <a href="http://www.python.org/psf/codeofconduct/">Python Software
+Foundation Code of Conduct</a> in everything we do.</p>
+
 <p>Check the <a href="{{ pathto('faq/index') }}">faq</a>,
 the <a href="{{ pathto('api/index') }}">api</a> docs,
 <a href="http://matplotlib.1069221.n5.nabble.com/matplotlib-users-f3.html">mailing


### PR DESCRIPTION
Given the movement to support the policy by other related projects (astropy, scipy) should we consider making it explicit for matplotlib also?  This would basically just amount to linking to the PSF code of conduct from our docs.
