### PR TITLE
Broken IPython notebook integration

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -344,8 +344,12 @@ class Figure(Artist):
     # use it, for some reason.
 
     def _repr_html_(self):
-        from matplotlib.backends import backend_webagg
-        return backend_webagg.ipython_inline_display(self)
+        # We can't use "isinstance" here, because then we'd end up importing
+        # webagg unconditiionally.
+        if (self.canvas is not None and
+            'WebAgg' in self.canvas.__class__.__name__):
+            from matplotlib.backends import backend_webagg
+            return backend_webagg.ipython_inline_display(self)
 
     def show(self, warn=True):
         """


### PR DESCRIPTION
I recently updated my MPL version from 1.3 to master, and noticed IPython notebook integration is broken for me (Mac, Chrome). See the error message at http://nbviewer.ipython.org/6386054

I bisected this to 27482be73b5ad69d2d52cc77cdf698d3a0a6d3e1

Is this a known issue? Is it still possible to use IPython's (static) inline backend after this commit?
