### PR TITLE
Set locale for tests

### DIFF
--- a/lib/matplotlib/tests/__init__.py
+++ b/lib/matplotlib/tests/__init__.py
@@ -8,6 +8,11 @@ _multiprocess_can_split_ = True
 
 
 def setup():
+    # The baseline images are created in this locale, so we should use
+    # it during all of the tests.
+    import locale
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+
     use('Agg', warn=False) # use Agg backend for these tests
 
     # These settings *must* be hardcoded for running the comparison


### PR DESCRIPTION
This fixes the part of #2343 related to the date strings not matching the baseline images.  Since the baseline images were created (by me) in the en_US.UTF-8 locale, we should run the tests in that locale, too, so the output files will match the baseline images.
