### PR TITLE
Implement draw_markers in the cairo backend.

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -173,7 +173,7 @@ class RendererCairo(RendererBase):
             Affine2D().scale(1.0, -1.0).translate(0, self.height)
 
         ctx.new_path()
-        for vertices, codes in path.iter_segments(transform, simplify=False):
+        for i, (vertices, codes) in enumerate(path.iter_segments(transform, simplify=False)):
             if len(vertices):
                 x, y = vertices[-2:]
                 ctx.save()
@@ -182,12 +182,14 @@ class RendererCairo(RendererBase):
                 ctx.translate(x, y)
                 ctx.append_path(marker_path)
 
+                ctx.restore()
+
                 # Slower code path if there is a fill; we need to draw
                 # the fill and stroke for each marker at the same time.
-                if filled:
+                # Also flush out the drawing every once in a while to
+                # prevent the paths from getting way too long.
+                if filled or i % 1000 == 0:
                     self._fill_and_stroke(ctx, rgbFace, gc.get_alpha(), gc.get_forced_alpha())
-
-                ctx.restore()
 
         # Fast path, if there is no fill, draw everything in one step
         if not filled:

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -152,6 +152,47 @@ class RendererCairo(RendererBase):
 
         self._fill_and_stroke(ctx, rgbFace, gc.get_alpha(), gc.get_forced_alpha())
 
+    def draw_markers(self, gc, marker_path, marker_trans, path, transform, rgbFace=None):
+        ctx = gc.ctx
+
+        ctx.new_path()
+        # Create the path for the marker; it needs to be flipped here already!
+        self.convert_path(ctx, marker_path, marker_trans + Affine2D().scale(1.0, -1.0))
+        marker_path = ctx.copy_path_flat()
+
+        # Figure out whether the path has a fill
+        x1, y1, x2, y2 = ctx.fill_extents()
+        if x1 == 0 and y1 == 0 and x2 == 0 and y2 == 0:
+            filled = False
+            # No fill, just unset this (so we don't try to fill it later on)
+            rgbFace = None
+        else:
+            filled = True
+
+        transform = transform + \
+            Affine2D().scale(1.0, -1.0).translate(0, self.height)
+
+        ctx.new_path()
+        for vertices, codes in path.iter_segments(transform, simplify=False):
+            if len(vertices):
+                x, y = vertices[-2:]
+                ctx.save()
+
+                # Translate and apply path
+                ctx.translate(x, y)
+                ctx.append_path(marker_path)
+
+                # Slower code path if there is a fill; we need to draw
+                # the fill and stroke for each marker at the same time.
+                if filled:
+                    self._fill_and_stroke(ctx, rgbFace, gc.get_alpha(), gc.get_forced_alpha())
+
+                ctx.restore()
+
+        # Fast path, if there is no fill, draw everything in one step
+        if not filled:
+            self._fill_and_stroke(ctx, rgbFace, gc.get_alpha(), gc.get_forced_alpha())
+
     def draw_image(self, gc, x, y, im):
         # bbox - not currently used
         if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))


### PR DESCRIPTION
This commit increases the speed of marker drawing in the caior backend.
It directly uses cairo paths for this. If the marker is only stroked
(and not filled) then only one drawing operation is used. If it is
filled then each marker is filled and stroked separately.