### PR TITLE
check if pyparsing <<= is broken instead of checking the version

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -128,10 +128,13 @@ else:
         raise ImportError(
             "matplotlib requires pyparsing >= 1.5.6")
 
-    if pyparsing.__version__ == '2.0.0':
-        raise ImportError(
-            "pyparsing 2.0.0 has bugs that prevent its use with "
-            "matplotlib")
+    # pyparsing 2.0.0 bug, but it may be patched in distributions
+    try:
+        f = pyparsing.Forward()
+        f <<= pyparsing.Literal('a')
+        bad_pyparsing = f is None
+    except:
+        bad_pyparsing = True
 
     # pyparsing 1.5.6 does not have <<= on the Forward class, but
     # pyparsing 2.0.0 and later will spew deprecation warnings if
@@ -139,7 +142,7 @@ else:
     # broken, since it doesn't return self.  In order to support
     # pyparsing 1.5.6 and above with a common code base, this small
     # monkey patch is applied.
-    if not compare_versions(pyparsing.__version__, '2.0.1'):
+    if bad_pyparsing:
         def _forward_ilshift(self, other):
             self.__lshift__(other)
             return self

--- a/setupext.py
+++ b/setupext.py
@@ -949,6 +949,16 @@ class Tornado(SetupPackage):
 class Pyparsing(SetupPackage):
     name = "pyparsing"
 
+    def is_ok(self):
+        # pyparsing 2.0.0 bug, but it may be patched in distributions
+        try:
+            import pyparsing
+            f = pyparsing.Forward()
+            f <<= pyparsing.Literal('a')
+            return f is not None
+        except:
+            return False
+
     def check(self):
         try:
             import pyparsing
@@ -964,19 +974,18 @@ class Pyparsing(SetupPackage):
                 "matplotlib requires pyparsing >= {0}".format(
                     '.'.join(str(x) for x in required)))
 
-        if pyparsing.__version__ == "2.0.0":
-            if sys.version_info[0] == 2:
-                return (
-                    "pyparsing 2.0.0 is not compatible with Python 2.x")
-            else:
-                return (
-                    "pyparsing 2.0.0 has bugs that prevent its use with "
-                    "matplotlib")
+        if not self.is_ok():
+            return (
+                "pyparsing 2.0.0 has bugs that prevent its use with "
+                "matplotlib")
 
         return "using pyparsing version %s" % pyparsing.__version__
 
     def get_install_requires(self):
-        return ['pyparsing>=1.5.6,!=2.0.0']
+        if self.is_ok():
+            return ['pyparsing>=1.5.6']
+        else:
+            return ['pyparsing>=1.5.6,!=2.0.0']
 
 
 class BackendAgg(OptionalBackendPackage):


### PR DESCRIPTION
distributions with packaged pyparsing might have already patched
pyparsing but not bumped the version number.
closes #2376
