### PR TITLE
BUG: Fix IndexError: too many indices with numpy 1.8

### DIFF
--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -1050,8 +1050,8 @@ class _DOF_estimator():
         gradient.
         """
         J = CubicTriInterpolator._get_jacobian(self._tris_pts)
-        tri_z = self.z[self._triangles, :]
-        tri_dz = self.dz[self._triangles, :]
+        tri_z = self.z[self._triangles]
+        tri_dz = self.dz[self._triangles]
         tri_dof = self.get_dof_vec(tri_z, tri_dz, J)
         return tri_dof
 


### PR DESCRIPTION
The following tests fail when using matplotlib 1.3.0 with numpy 1.8.0dev on win-amd64-py2.7. All other tests pass. Apparently statements like `np.zeros(2)[[1], :]` raise an `IndexError` under numpy 1.8.

```
======================================================================
ERROR: test suite for <class 'matplotlib.tests.test_triangulation.test_tri_smooth_contouring'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 208, in run
    self.setUp()
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 291, in setUp
    self.setupContext(ancestor)
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 314, in setupContext
    try_run(context, names)
  File "X:\Python27-x64\lib\site-packages\nose\util.py", line 469, in try_run
    return func()
  File "X:\Python27-x64\lib\site-packages\matplotlib\testing\decorators.py", line 102, in setup_class
    cls._func()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_triangulation.py", line 715, in test_tri_smooth_contouring
    tri_refi, z_test_refi = refiner.refine_field(z0, subdiv=4)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\trirefine.py", line 171, in refine_field
    self._triangulation, z)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 424, in __init__
    self._dof = self._compute_dof(kind, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 494, in _compute_dof
    TE = _DOF_estimator_min_E(self)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1182, in __init__
    _DOF_estimator_geom.__init__(self, Interpolator)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1032, in __init__
    self.compute_dof_from_df()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1043, in compute_dof_from_df
    tri_z = self.z[self._triangles, :]
IndexError: too many indices

======================================================================
ERROR: test suite for <class 'matplotlib.tests.test_triangulation.test_tri_smooth_gradient'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 208, in run
    self.setUp()
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 291, in setUp
    self.setupContext(ancestor)
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 314, in setupContext
    try_run(context, names)
  File "X:\Python27-x64\lib\site-packages\nose\util.py", line 469, in try_run
    return func()
  File "X:\Python27-x64\lib\site-packages\matplotlib\testing\decorators.py", line 102, in setup_class
    cls._func()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_triangulation.py", line 752, in test_tri_smooth_gradient
    tri_refi, z_test_refi = refiner.refine_field(V, subdiv=3)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\trirefine.py", line 171, in refine_field
    self._triangulation, z)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 424, in __init__
    self._dof = self._compute_dof(kind, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 494, in _compute_dof
    TE = _DOF_estimator_min_E(self)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1182, in __init__
    _DOF_estimator_geom.__init__(self, Interpolator)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1032, in __init__
    self.compute_dof_from_df()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1043, in compute_dof_from_df
    tri_z = self.z[self._triangles, :]
IndexError: too many indices

======================================================================
ERROR: matplotlib.tests.test_triangulation.test_triinterp
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_triangulation.py", line 253, in test_triinterp
    cubic_min_E = mtri.CubicTriInterpolator(triang, z)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 424, in __init__
    self._dof = self._compute_dof(kind, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 494, in _compute_dof
    TE = _DOF_estimator_min_E(self)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1182, in __init__
    _DOF_estimator_geom.__init__(self, Interpolator)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1032, in __init__
    self.compute_dof_from_df()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1043, in compute_dof_from_df
    tri_z = self.z[self._triangles, :]
IndexError: too many indices

======================================================================
ERROR: matplotlib.tests.test_triangulation.test_triinterpcubic_C1_continuity
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_triangulation.py", line 403, in test_triinterpcubic_C1_continuity
    dz=(dzx, dzy))
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 424, in __init__
    self._dof = self._compute_dof(kind, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 490, in _compute_dof
    TE = _DOF_estimator_user(self, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1032, in __init__
    self.compute_dof_from_df()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1043, in compute_dof_from_df
    tri_z = self.z[self._triangles, :]
IndexError: too many indices

======================================================================
ERROR: matplotlib.tests.test_triangulation.test_triinterpcubic_geom_weights
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_triangulation.py", line 516, in test_triinterpcubic_geom_weights
    cubic_geom = mtri.CubicTriInterpolator(triang, z, kind='geom')
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 424, in __init__
    self._dof = self._compute_dof(kind, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 492, in _compute_dof
    TE = _DOF_estimator_geom(self)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1032, in __init__
    self.compute_dof_from_df()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1043, in compute_dof_from_df
    tri_z = self.z[self._triangles, :]
IndexError: too many indices

======================================================================
ERROR: matplotlib.tests.test_triangulation.test_triinterp_colinear
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_triangulation.py", line 566, in test_triinterp_colinear
    cubic_min_E = mtri.CubicTriInterpolator(triang, z)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 424, in __init__
    self._dof = self._compute_dof(kind, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 494, in _compute_dof
    TE = _DOF_estimator_min_E(self)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1182, in __init__
    _DOF_estimator_geom.__init__(self, Interpolator)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1032, in __init__
    self.compute_dof_from_df()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1043, in compute_dof_from_df
    tri_z = self.z[self._triangles, :]
IndexError: too many indices

======================================================================
ERROR: matplotlib.tests.test_triangulation.test_triinterp_transformations
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_triangulation.py", line 639, in test_triinterp_transformations
    cubic_min_E = mtri.CubicTriInterpolator(triang, z0)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 424, in __init__
    self._dof = self._compute_dof(kind, dz=dz)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 494, in _compute_dof
    TE = _DOF_estimator_min_E(self)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1182, in __init__
    _DOF_estimator_geom.__init__(self, Interpolator)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1032, in __init__
    self.compute_dof_from_df()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tri\triinterpolate.py", line 1043, in compute_dof_from_df
    tri_z = self.z[self._triangles, :]
IndexError: too many indices

----------------------------------------------------------------------

```
