### PR TITLE
fix forgotten cStringIO replacement when replacing 2to3 with six

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1245,10 +1245,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
             self._pswriter = NullWriter()
         else:
-            if six.PY3:
-                self._pswriter = io.StringIO()
-            else:
-                self._pswriter = cStringIO.StringIO()
+            self._pswriter = io.StringIO()
 
 
         # mixed mode rendering


### PR DESCRIPTION
...x

Error introduced with commit f4adec7b56 (Use six instead of 2to3). For Python2 cStringIO was still being used, but the import statement was removed. Both Python2 and 3 should use io.StringIO, which is the same as elsewhere in the code.
