### PR TITLE
locale breaks test suite

### DIFF
--- a/lib/matplotlib/tests/__init__.py
+++ b/lib/matplotlib/tests/__init__.py
@@ -11,7 +11,7 @@ def setup():
     # The baseline images are created in this locale, so we should use
     # it during all of the tests.
     import locale
-    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+    locale.setlocale(locale.LC_ALL, str('en_US.UTF-8'))
 
     use('Agg', warn=False) # use Agg backend for these tests
 


### PR DESCRIPTION
When I run the test suite on current master I get a lot of errors that look like this:

```
======================================================================
ERROR: test suite for <module 'matplotlib.tests.test_axes' from '/home/tcaswell/local_installs/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-linux-x86_64.egg/matplotlib/tests/test_axes.pyc'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tcaswell/local_installs/lib/python2.7/site-packages/nose-1.3.0-py2.7.egg/nose/plugins/multiprocess.py", line 788, in run
    self.setUp()
  File "/home/tcaswell/local_installs/lib/python2.7/site-packages/nose-1.3.0-py2.7.egg/nose/suite.py", line 291, in setUp
    self.setupContext(ancestor)
  File "/home/tcaswell/local_installs/lib/python2.7/site-packages/nose-1.3.0-py2.7.egg/nose/plugins/multiprocess.py", line 770, in setupContext
    super(NoSharedFixtureContextSuite, self).setupContext(context)
  File "/home/tcaswell/local_installs/lib/python2.7/site-packages/nose-1.3.0-py2.7.egg/nose/suite.py", line 314, in setupContext
    try_run(context, names)
  File "/home/tcaswell/local_installs/lib/python2.7/site-packages/nose-1.3.0-py2.7.egg/nose/util.py", line 469, in try_run
    return func()
  File "/home/tcaswell/local_installs/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-linux-x86_64.egg/matplotlib/tests/__init__.py", line 17, in setup
    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
  File "/usr/lib/python2.7/locale.py", line 546, in setlocale
    locale = normalize(_build_localename(locale))
  File "/usr/lib/python2.7/locale.py", line 453, in _build_localename
    language, encoding = localetuple
ValueError: too many values to unpack
```

but

```
$ python
Python 2.7.5+ (default, Aug  4 2013, 10:07:17) 
[GCC 4.8.1] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import locale
>>> locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
'en_US.UTF-8'
```

Works (or at least does not raise an error).  I also noticed this happening on travis.

up-to-date debian sid box, python 2.7
