### PR TITLE
 support tight_bbox for pgf output, fixes #2342

### DIFF
--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -134,5 +134,5 @@ def process_figure_for_rasterizing(figure,
 _adjust_bbox_handler_d = {}
 for format in ["png", "raw", "rgba", "jpg", "jpeg", "tiff"]:
     _adjust_bbox_handler_d[format] = adjust_bbox_png
-for format in ["pdf", "eps", "svg", "svgz"]:
+for format in ["pgf", "pdf", "eps", "svg", "svgz"]:
     _adjust_bbox_handler_d[format] = adjust_bbox_pdf


### PR DESCRIPTION
EDIT:

Instead of modifying `tight_bbox`, I added support for the `dryrun` kwarg used by tight_bbox to announce the dummy draw procedure. Saving figures with `bbox_inches='tight'` now works for pgf files as well (fixes #2342).
