### PR TITLE
use six.move for cStringIO

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1083,7 +1083,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
             self._pswriter = NullWriter()
         else:
-            self._pswriter = io.StringIO()
+            self._pswriter = six.moves.cStringIO()
 
 
         # mixed mode rendering
@@ -1245,10 +1245,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
             self._pswriter = NullWriter()
         else:
-            if six.PY3:
-                self._pswriter = io.StringIO()
-            else:
-                self._pswriter = cStringIO.StringIO()
+            self._pswriter = six.moves.cStringIO()
 
 
         # mixed mode rendering

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -23,10 +23,7 @@ import six
 
 import os, sys
 if six.PY3:
-    from io import StringIO
     unichr = chr
-else:
-    from cStringIO import StringIO
 from math import ceil
 try:
     set
@@ -245,7 +242,7 @@ class MathtextBackendPs(MathtextBackend):
     backend.
     """
     def __init__(self):
-        self.pswriter = StringIO()
+        self.pswriter = six.moves.cStringIO()
         self.lastfont = None
 
     def render_glyph(self, ox, oy, info):
@@ -1052,7 +1049,7 @@ class StandardPsFonts(Fonts):
 
         self.fonts['default'] = default_font
         self.fonts['regular'] = default_font
-        self.pswriter = StringIO()
+        self.pswriter = six.moves.cStringIO()
 
     def _get_font(self, font):
         if font in self.fontmap:


### PR DESCRIPTION
I've tried this before in PR #2385, but now took into account the review comments and committed against a named-bug-tree (or how do properly you call such a thing?) instead of the master. This commits should be considered as a follow up for commit f4adec7.
