### PR TITLE
TypeError occurs when self.button=None in MouseEvents

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1448,7 +1448,7 @@ class MouseEvent(LocationEvent):
         self.dblclick = dblclick
 
     def __str__(self):
-        return ("MPL MouseEvent: xy=(%d,%d) xydata=(%s,%s) button=%d " +
+        return ("MPL MouseEvent: xy=(%d,%d) xydata=(%s,%s) button=%s " +
                 "dblclick=%s inaxes=%s") % (self.x, self.y, self.xdata,
                                             self.ydata, self.button,
                                             self.dblclick, self.inaxes)


### PR DESCRIPTION
when printing MouseEvent with button=None a typeError would occur
