### PR TITLE
BUG: Fixed github stats retrieval

### DIFF
--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -13,7 +13,7 @@ import sys
 
 from datetime import datetime, timedelta
 from subprocess import check_output
-from urllib import urlopen
+from urllib2 import urlopen
 
 #-----------------------------------------------------------------------------
 # Globals


### PR DESCRIPTION
Currently urllib is used to retrieve a json file from Github, however
Github url used is not 'static', urllib2 required to retrieve
information from Github.
