### PR TITLE
backend_pgf: fix str/unicode comparison errors

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -52,10 +52,10 @@ def get_fontspec():
     latex_fontspec = []
     texcommand = get_texcommand()
 
-    if texcommand is not "pdflatex":
+    if texcommand != "pdflatex":
         latex_fontspec.append("\\usepackage{fontspec}")
 
-    if texcommand is not "pdflatex" and rcParams.get("pgf.rcfonts", True):
+    if texcommand != "pdflatex" and rcParams.get("pgf.rcfonts", True):
         # try to find fonts from rc parameters
         families = ["serif", "sans-serif", "monospace"]
         fontspecs = [r"\setmainfont{%s}", r"\setsansfont{%s}",
@@ -139,7 +139,7 @@ def _font_properties_str(prop):
     family = prop.get_family()[0]
     if family in families:
         commands.append(families[family])
-    elif family in system_fonts and get_texcommand() is not "pdflatex":
+    elif family in system_fonts and get_texcommand() != "pdflatex":
         commands.append(r"\setmainfont{%s}\rmfamily" % family)
     else:
         pass  # print warning?
@@ -173,7 +173,7 @@ def make_pdf_to_png_converter():
         pass
     # check for ghostscript
     try:
-        gs = "gs" if sys.platform is not "win32" else "gswin32c"
+        gs = "gs" if sys.platform != "win32" else "gswin32c"
         check_output([gs, "-v"], stderr=subprocess.STDOUT)
         tools_available.append("gs")
     except:


### PR DESCRIPTION
When python 2.x starts mixing str and unicode instances, the string comparisons in backend_pgf.py will fail. Correct this problem by using the normal comparison operators.
