### PR TITLE
Adding the possibility to exclude invisible lines and patches in relim

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1592,7 +1592,9 @@ class _AxesBase(martist.Artist):
 
     def relim(self, visible_only=False):
         """
-        Recompute the data limits based on current artists.
+        Recompute the data limits based on current artists. If you want to exclude
+        invisible artists from the calculation, set
+        `include_invisible=False`
 
         At present, :class:`~matplotlib.collections.Collection`
         instances are not supported.

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -475,6 +475,12 @@ class FigureManagerGTK3(FigureManagerBase):
         self.window.resize(width, height)
 
 
+
+class TabbedFigureManagerGTK3(FigureManagerGTK3):
+    pass
+
+
+
 class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
     def __init__(self, canvas, window):
         self.win = window

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -39,14 +39,17 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
         return False  # finish event propagation?
 
 
-class FigureManagerGTK3Cairo(backend_gtk3.FigureManagerGTK3):
-    pass
+#class FigureManagerGTK3Cairo(backend_gtk3.FigureManagerGTK3):
+#    pass
 
+class FigureManagerGTK3Cairo(backend_gtk3.TabbedFigureManagerGTK3):
+    pass
 
 def new_figure_manager(num, *args, **kwargs):
     """
     Create a new figure manager instance
     """
+    print ('new fiogure manager')
     FigureClass = kwargs.pop('FigureClass', Figure)
     thisFig = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, thisFig)


### PR DESCRIPTION
Following the suggestion from John
http://sourceforge.net/mailarchive/forum.php?thread_name=4F5FB1F7.9050909%40hawaii.edu&forum_name=matplotlib-users

I included the visible_only argument, to be able to perform a relim with only the visible elements.

I didn't update the docstring because I do not know I should replace the whole docstring for the new format or how to mix and match new/old format.
