### PR TITLE
remove some redunancy in _BaseAxes

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -329,9 +329,6 @@ class _AxesBase(martist.Artist):
                  frameon=True,
                  sharex=None,  # use Axes instance's xaxis info
                  sharey=None,  # use Axes instance's yaxis info
-                 label='',
-                 xscale=None,
-                 yscale=None,
                  **kwargs
                  ):
         """
@@ -412,7 +409,8 @@ class _AxesBase(martist.Artist):
                 #warnings.warn(
                 #    'shared axes: "adjustable" is being changed to "datalim"')
             self._adjustable = 'datalim'
-        self.set_label(label)
+
+        kwargs.setdefault('label','')
         self.set_figure(fig)
 
         self.set_axes_locator(kwargs.get("axes_locator", None))
@@ -422,14 +420,18 @@ class _AxesBase(martist.Artist):
         # this call may differ for non-sep axes, eg polar
         self._init_axis()
 
+        # These duplicate parameters should be removed.
+        ## axisbg ~ axis_bgcolor  (shouln't actually be axes?)
+        ## frameon == frame_on
         if axisbg is None:
             axisbg = rcParams['axes.facecolor']
-        self._axisbg = axisbg
-        self._frameon = frameon
+        ## push both to kwargs, which will be processed by update.
+        ## _axisbg must be assignd before cla().
+        self._axisbg = kwargs.setdefault('axis_bgcolor', axisbg)
+        kwargs.setdefault('frame_on', frameon)
         self._axisbelow = rcParams['axes.axisbelow']
 
         self._rasterization_zorder = None
-
         self._hold = rcParams['axes.hold']
         self._connected = {}  # a dict from events to (id, func)
         self.cla()
@@ -443,10 +445,6 @@ class _AxesBase(martist.Artist):
         self.set_navigate(True)
         self.set_navigate_mode(None)
 
-        if xscale:
-            self.set_xscale(xscale)
-        if yscale:
-            self.set_yscale(yscale)
 
         if len(kwargs):
             self.update(kwargs)


### PR DESCRIPTION
While working on #1461, I've found that the `__init__` of `_BaseAxes`
takes some redundant arguments. Of the 7 arguments it takes,
3 (`xscale, yscale, label`) can be removed without harm, because
they are automatically used in `update(kwargs)` (they have matching `set_`
methods). Another two have different names as setters: `frameon` == `frame_on`
and `axisbg` ~ `axis_bgcolor`. Note that the later are mispelled, as they
refer to axes and not axis. The following call is actually legal:

```
plt.subplot(111, axisbg='green', axis_bgcolor='red')
```

I do not know what to do with the other two arguments. (`sharex` `sharey`)

I've tried to remove this redunancy, keeping the old defaults
intact, and without breaking the api. My opinion is that axisbg and frameon
should be reomved, but api changes and deprectations are above my level.

See also issue #1461
