### PR TITLE
DOC: Add axes_api to documentation after the refactoring

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -6,7 +6,7 @@ axes
 :mod:`matplotlib.axes`
 ======================
 
-.. automodule:: matplotlib.axes._axes
+.. autoclass:: matplotlib.axes.Axes
    :members:
    :undoc-members:
  


### PR DESCRIPTION
Recently, axes was converted from a module to a package.
This adds axes_api to the doctree back.
`show-inheritance` was removed because it tells the user that
`Axes` `Bases: matplotlib.axes._base._AxesBase`
which is not that relevant I think.
This is mentioned in issue #1461
