### PR TITLE
BUG: Fixed object type missmatch in SymLogNorm

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1054,7 +1054,7 @@ class SymLogNorm(Normalize):
         the logarithmic range. Defaults to 1.
         """
         Normalize.__init__(self, vmin, vmax, clip)
-        self.linthresh = linthresh
+        self.linthresh = float(linthresh)
         self._linscale_adj = (linscale / (1.0 - np.e ** -1))
 
     def __call__(self, value, clip=None):
@@ -1112,7 +1112,7 @@ class SymLogNorm(Normalize):
         Calculates vmin and vmax in the transformed system.
         """
         vmin, vmax = self.vmin, self.vmax
-        arr = np.array([vmax, vmin])
+        arr = np.array([vmax, vmin]).astype(np.float)
         self._upper, self._lower = self._transform(arr)
 
     def inverse(self, value):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -75,6 +75,11 @@ def test_SymLogNorm():
     _scalar_tester(norm, vals)
     _mask_tester(norm, vals)
 
+    # Ensure that specifying vmin returns the same result as above
+    norm = mcolors.SymLogNorm(3, vmin=-30, vmax=5, linscale=1.2)
+    normed_vals = norm(vals)
+    assert_array_almost_equal(normed_vals, expected)
+
 
 def _inverse_tester(norm_instance, vals):
     """


### PR DESCRIPTION
Currently SymLogNorm accepts both linthresh and vmin, vmax with their
native dtype, meaning that the contents of one object cannot be updated
with another due to a mismatch of types.

`a[masked] = log` within `_transform` and `_inv_transform` requires both to be of the same type for such an operation.
