### PR TITLE
Document API change in hist

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -197,6 +197,10 @@ Code changes
 * The :func:`matplotlib.cbook.check_output` function has been moved to
   :func:`matplotlib.compat.subprocess`.
 
+* The method :meth:`~matplotlib.axes.Axes.hist` now always returns bin
+  occupancies as an array of type `float`. Previously, it was sometimes
+  an array of type `int`, depending on the call.
+
 Configuration and rcParams
 --------------------------
 


### PR DESCRIPTION
Per discussion in #2293. I was having issues getting the documentation to compile (exception: cannot import name _string_to_bool), but I think this is simple enough that it should be okay.
