### PR TITLE
Explicitly catch TypeError when doing pyparsing monkeypatch check

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -133,7 +133,7 @@ else:
         f = pyparsing.Forward()
         f <<= pyparsing.Literal('a')
         bad_pyparsing = f is None
-    except:
+    except TypeError:
         bad_pyparsing = True
 
     # pyparsing 1.5.6 does not have <<= on the Forward class, but

--- a/setupext.py
+++ b/setupext.py
@@ -998,7 +998,7 @@ class Pyparsing(SetupPackage):
             f = pyparsing.Forward()
             f <<= pyparsing.Literal('a')
             return f is not None
-        except:
+        except TypeError:
             return False
 
     def check(self):


### PR DESCRIPTION
This is follow-on to @pelson's comments in @2380.
