### PR TITLE
Qt4 clear before draw

### DIFF
--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -102,10 +102,16 @@ class FigureCanvasQTAgg( FigureCanvasQT, FigureCanvasAgg ):
 
             refcnt = sys.getrefcount(stringBuffer)
 
+            # convert the Agg rendered image -> qImage
             qImage = QtGui.QImage(stringBuffer, self.renderer.width,
                                   self.renderer.height,
                                   QtGui.QImage.Format_ARGB32)
+            # get the rectangle for the image
+            rect = qImage.rect()
             p = QtGui.QPainter(self)
+            # reset the image area of the canvas to be the back-ground color
+            p.eraseRect(rect)
+            # draw the rendered image on to the canvas
             p.drawPixmap(QtCore.QPoint(0, 0), QtGui.QPixmap.fromImage(qImage))
 
             # draw the zoom rectangle to the QPainter


### PR DESCRIPTION
Clears the canvas before re-drawing the QtAgg canvas.  This matters if you have an updating figure with a transparent patch (http://stackoverflow.com/questions/18944561/matplotlib-pyqt4-transparent-figure).

I think this is a bug fix, but this will rebase cleanly to master if people disagree.
