### PR TITLE
Rename C++ variables to avoid use of reserved identifiers

### DIFF
--- a/lib/matplotlib/tri/_tri.cpp
+++ b/lib/matplotlib/tri/_tri.cpp
@@ -2177,14 +2177,14 @@ TrapezoidMapTriFinder::Trapezoid::set_upper_right(Trapezoid* upper_right_)
 
 
 RandomNumberGenerator::RandomNumberGenerator(unsigned long seed)
-    : _M(21870), _A(1291), _C(4621), _seed(seed % _M)
+    : _m(21870), _a(1291), _c(4621), _seed(seed % _m)
 {}
 
 unsigned long
 RandomNumberGenerator::operator()(unsigned long max_value)
 {
-    _seed = (_seed*_A + _C) % _M;
-    return (_seed*max_value) / _M;
+    _seed = (_seed*_a + _c) % _m;
+    return (_seed*max_value) / _m;
 }
 
 

--- a/lib/matplotlib/tri/_tri.h
+++ b/lib/matplotlib/tri/_tri.h
@@ -818,7 +818,7 @@ public:
     unsigned long operator()(unsigned long max_value);
 
 private:
-    const unsigned long _M, _A, _C;
+    const unsigned long _m, _a, _c;
     unsigned long _seed;
 };
 


### PR DESCRIPTION
This is a bug fix for issue #2463.

The C++ triangulation code (_tri.h and _tri.cpp) uses variables with names _A, _C and _M.  However, in C++ identifiers that begin with an underscore followed by a capital letter are reserved.  This PR changes such variables to their lowercase equivalents.

I have confirmed that following the changes the triangulation tests pass OK and there is no change to any of the triangulation examples. 
