### PR TITLE
would crash if get_home() returns None

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1324,6 +1324,8 @@ if USE_FONTCONFIG and sys.platform != 'win32':
         return result
 
 else:
+    _fmcache = None
+
     if not 'TRAVIS' in os.environ:
         cachedir = get_cachedir()
         if cachedir is not None:
@@ -1331,8 +1333,6 @@ else:
                 _fmcache = os.path.join(cachedir, 'fontList.py3k.cache')
             else:
                 _fmcache = os.path.join(cachedir, 'fontList.cache')
-    else:
-        _fmcache = None
 
     fontManager = None
 


### PR DESCRIPTION
See http://bugs.debian.org/719384 for original reports.

ATM `get_home()` would return None if none of the home directories current exists, even though e.g. HOME environment variable is set.
As a result os.path.join would spit out exception since it was not devised to have any opinion about None.

IMHO the logic here should be fixed and get_home should not return None even if a directory pointed to by HOME environment variable on a POSIX platform is defined 
