### PR TITLE
DOC: `axis_off` wrongfuly appears as a parameter to Figure.add_subplot

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 import re
 import warnings
+import inspect
 import matplotlib
 import matplotlib.cbook as cbook
 from matplotlib import docstring, rcParams
@@ -947,6 +948,8 @@ class ArtistInspector:
                 continue
             o = getattr(self.o, name)
             if not callable(o):
+                continue
+            if len(inspect.getargspec(o)[0]) < 2:
                 continue
             func = o
             if self.is_alias(func):


### PR DESCRIPTION
`axis_off` and `axis_on` appear as parameters on Figure.add_subplot,
and anywhere %(Axes)s is used. The introspection picks them up
because they have setters: `_BaseAxes.set_axis_off()`,
but they do not accept any argument and therefore cannot be passed as parameters.
