### PR TITLE
Make matplotlib.test() print meaninful messages when baseline images are not installed

### DIFF
--- a/lib/matplotlib/tests/__init__.py
+++ b/lib/matplotlib/tests/__init__.py
@@ -2,11 +2,22 @@ from __future__ import print_function
 from matplotlib import rcParams, rcdefaults, use
 
 import difflib
+import os
 
 from matplotlib import rcParams, rcdefaults, use
 
 
 _multiprocess_can_split_ = True
+
+
+# Check that the test directories exist
+if not os.path.exists(os.path.join(
+        os.path.dirname(__file__), 'baseline_images')):
+    raise IOError(
+        'The baseline image directory does not exist. '
+        'This is most likely because the test data is not installed. '
+        'You may need to install matplotlib from source to get the '
+        'test data.')
 
 
 def setup():


### PR DESCRIPTION
Reported originally in the mailing list
http://www.mail-archive.com/matplotlib-users@lists.sourceforge.net/msg27140.html

After installing matplotlib from standard Ubuntu packages, calling matplotlib.test() results in a lot of errors like:

```
IOError: Baseline image
'/home/user/result_images/test_triangulation/tripcolor1-expected.svg' does not exist.
```

This seems to be because baseline images are not included in the package (is it also required to run the tests from a particular directory?). I guess it happens in other distros and with windows installers too.
