### PR TITLE
AssertionError with quiver, quiverkey, and an additional patch.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2139,11 +2139,12 @@ class GraphicsContextPdf(GraphicsContextBase):
         """Set clip rectangle. Calls self.pop() and self.push()."""
         cmds = []
         # Pop graphics state until we hit the right one or the stack is empty
-        while (self._cliprect, self._clippath) != (cliprect, clippath) \
-                and self.parent is not None:
+        while ((self._cliprect, self._clippath) != (cliprect, clippath)
+                and self.parent is not None):
             cmds.extend(self.pop())
         # Unless we hit the right one, set the clip polygon
-        if (self._cliprect, self._clippath) != (cliprect, clippath):
+        if ((self._cliprect, self._clippath) != (cliprect, clippath) or
+            self.parent is None):
             cmds.extend(self.push())
             if self._cliprect != cliprect:
                 cmds.extend([cliprect, Op.rectangle, Op.clip, Op.endpath])


### PR DESCRIPTION
The following code produces an AssertionError on my system (matplotlib 1.3.0 from macports, python 2.7 on MacOSX 10.8.4 with the MacOSX backend).

```
#!/usr/bin/env python

import numpy as np
import matplotlib.pyplot as plt

X,Y = np.meshgrid(np.arange(0, 2*np.pi, .2), np.arange(0, 2*np.pi, .2))
U = np.cos(X)
V = np.sin(Y)

Q = plt.quiver(U, V)
plt.quiverkey(Q, 0.5, .9, 1., 'Label')

plt.gca().add_patch(plt.Circle((10, 10), 1))
plt.savefig('test.pdf')
```

Three parts of this code are required for me to reproduce the error:
1. The quiver plot has to have a key created with quiver key
2. I have to add an additional patch to the current axes
3. I have to save the figure as a PDF (I can display it just fine)

The traceback reads

```
Traceback (most recent call last):
  File "test.py", line 14, in <module>
    plt.savefig('test.pdf')
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/pyplot.py", line 561, in savefig
    return fig.savefig(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/figure.py", line 1421, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 2220, in print_figure
    **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 1952, in print_pdf
    return pdf.print_pdf(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/backends/backend_pdf.py", line 2340, in print_pdf
    self.figure.draw(renderer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/figure.py", line 1034, in draw
    func(*args)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/axes.py", line 2086, in draw
    a.draw(renderer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/quiver.py", line 307, in draw
    self.vector.draw(renderer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/collections.py", line 779, in draw
    return Collection.draw(self, renderer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/artist.py", line 54, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/collections.py", line 278, in draw
    self._offset_position)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/backends/backend_pdf.py", line 1589, in draw_path_collection
    output(*self.gc.pop())
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/matplotlib/backends/backend_pdf.py", line 2131, in pop
    assert self.parent is not None
AssertionError
```
