### PR TITLE
Updated the position of a few of the text examples because they were overlapping and hard to read.

### DIFF
--- a/examples/mplot3d/text3d_demo.py
+++ b/examples/mplot3d/text3d_demo.py
@@ -5,15 +5,15 @@ fig = plt.figure()
 ax = fig.gca(projection='3d')
 
 zdirs = (None, 'x', 'y', 'z', (1, 1, 0), (1, 1, 1))
-xs = (2, 4, 4, 9, 6, 2)
-ys = (6, 4, 8, 7, 2, 2)
-zs = (8, 2, 5, 6, 1, 7)
+xs = (1, 4, 4, 9, 4, 1)
+ys = (2, 5, 8, 10, 1, 2)
+zs = (10, 3, 8, 9, 1, 8)
 
 for zdir, x, y, z in zip(zdirs, xs, ys, zs):
     label = '(%d, %d, %d), dir=%s' % (x, y, z, zdir)
     ax.text(x, y, z, label, zdir)
 
-ax.text(1, 1, 1, "red", color='red')
+ax.text(9, 0, 0, "red", color='red')
 ax.text2D(0.05, 0.95, "2D Text", transform=ax.transAxes)
 
 ax.set_xlim3d(0, 10)


### PR DESCRIPTION
Current:
![text3ddemocurrent](https://f.cloud.github.com/assets/5473675/1233997/d51ebec0-2951-11e3-98a8-94f23a72597a.png)

Updated:
![text3ddemoupdated](https://f.cloud.github.com/assets/5473675/1234022/8810cacc-2953-11e3-95c0-2672c27bfee8.png)
