### PR TITLE
Rotate markers in Scatter plot

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -801,6 +801,13 @@ values to the interval [0,1] with power-law scaling with the exponent
 provided by the constructor's `gamma` argument. Power law normalization
 can be useful for, e.g., emphasizing small populations in a histogram.
 
+Add Rotate marker capabilities in scatter plot
+``````````````````````````````````````````````
+
+mgoacolou add `angles` parameter to :func:`~matplotlib.pyplot.scatter`.
+:ref:`~examples/pylab_examples/scatter_rotate_symbol.py`
+
+
 Fully customizable boxplots
 ```````````````````````````
 Paul Hobson overhauled the :func:`~matplotlib.pyplot.boxplot` method such

--- a/examples/pylab_examples/scatter_rotate_symbol.py
+++ b/examples/pylab_examples/scatter_rotate_symbol.py
@@ -1,0 +1,15 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.markers import TICKRIGHT
+
+rx, ry = 3., 1.
+area = rx * ry * np.pi
+angles = np.linspace(0., 360., 30.)
+
+x, y, sizes, colors = np.random.rand(4, 30)
+sizes *= 20**2.
+
+plt.scatter(x, y, sizes, colors, marker="*", angles=angles, zorder=2)
+plt.scatter(x, y, 2.5*sizes, colors, marker=TICKRIGHT, angles=angles, zorder=2)
+
+plt.show()

--- a/examples/pylab_examples/scatter_rotate_symbol.py
+++ b/examples/pylab_examples/scatter_rotate_symbol.py
@@ -8,7 +8,7 @@ area = rx * ry * np.pi
 angles = np.linspace(0., 360., nbpts)
 
 x, y, sizes, colors = np.random.rand(4, nbpts)
-sizes *= 20.
+sizes *= 2000.
 
 plt.scatter(x, y, sizes, colors, marker="*", angles=angles, zorder=2)
 plt.scatter(x, y, 2.5*sizes, colors, marker=TICKRIGHT, angles=angles, zorder=2)

--- a/examples/pylab_examples/scatter_rotate_symbol.py
+++ b/examples/pylab_examples/scatter_rotate_symbol.py
@@ -2,14 +2,16 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.markers import TICKRIGHT
 
+nbpts = 50
 rx, ry = 3., 1.
 area = rx * ry * np.pi
-angles = np.linspace(0., 360., 30.)
+angles = np.linspace(0., 360., nbpts)
 
-x, y, sizes, colors = np.random.rand(4, 30)
-sizes *= 20**2.
+x, y, sizes, colors = np.random.rand(4, nbpts)
+sizes *= 20.
 
 plt.scatter(x, y, sizes, colors, marker="*", angles=angles, zorder=2)
 plt.scatter(x, y, 2.5*sizes, colors, marker=TICKRIGHT, angles=angles, zorder=2)
 
 plt.show()
+

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3758,6 +3758,9 @@ class Axes(_AxesBase):
             an instance of the class or the text shorthand for a particular
             marker.
 
+        angles : scalar or array_like, shape (n, ), optional, default: 0
+                 degrees counter clock-wise from X axis
+
         cmap : `~matplotlib.colors.Colormap`, optional, default: None
             A `~matplotlib.colors.Colormap` instance or registered name.
             `cmap` is only used if `c` is an array of floats. If None,
@@ -3861,13 +3864,15 @@ class Axes(_AxesBase):
         if x.size != y.size:
             raise ValueError("x and y must be the same size")
 
+        angles = np.ma.ravel(angles)  # This doesn't have to match x, y in size.
+
         if s is None:
             if rcParams['_internal.classic_mode']:
                 s = 20
             else:
                 s = rcParams['lines.markersize'] ** 2.0
 
-        s = np.ma.ravel(s)  # This doesn't have to match x, y in size.
+        x, y, s, c, angles = cbook.delete_masked_points(x, y, s, c, angles)
 
         # After this block, c_array will be None unless
         # c is an array for mapping.  The potential ambiguity
@@ -3913,7 +3918,7 @@ class Axes(_AxesBase):
         offsets = np.dstack((x, y))
 
         collection = mcoll.PathCollection(
-                (path,), scales,
+                (path,), scales, angles,
                 facecolors=colors,
                 edgecolors=edgecolors,
                 linewidths=linewidths,

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -778,6 +778,9 @@ class _CollectionWithSizes(Collection):
     """
     _factor = 1.0
 
+    def __init__(self):
+        self._sizes = np.array([])
+        
     def get_sizes(self):
         """
         Returns the sizes of the elements in the collection.  The
@@ -833,6 +836,9 @@ class _CollectionWithSizes(Collection):
                 s[:, 0, 0] = scale
                 s[:, 1, 1] = scale
                 s[:, 2, 2] = 1.0
+                if self._transforms.shape[0] < len(self._sizes):
+                    # resize transforms to feat at least the sizes length
+                    self._transforms = np.resize(self._transforms,(len(self._sizes),3,3))
                 for i in xrange(self._transforms.shape[0]):
                     self._transforms[i,:,:] = np.dot(s[i%len(self._sizes),:,:], self._transforms[i,:,:])
 
@@ -844,6 +850,9 @@ class _CollectionWithAngles(Collection):
     """
     Base class for collections that have an array of angles.
     """
+    def __init__(self):
+        self._angles = np.array([])
+
     def get_angles(self):
         return self._angles
 
@@ -889,6 +898,9 @@ class _CollectionWithAngles(Collection):
                 r[:, 1, 1] = rot_c
                 r[:, 1, 0] = rot_s
                 r[:, 2, 2] = 1.0
+                if self._transforms.shape[0] < len(self._angles):
+                    # resize transforms to feat at least the angles length
+                    self._transforms = np.resize(self._transforms,(len(self._angles),3,3))
                 for i in xrange(self._transforms.shape[0]):
                     self._transforms[i,:,:] = np.dot(r[i%len(self._angles),:,:], self._transforms[i,:,:])
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -778,7 +778,8 @@ class _CollectionWithSizes(Collection):
     """
     _factor = 1.0
 
-    def __init__(self):
+    def __init__(self, *arg, **kw):
+        super(_CollectionWithSizes, self).__init__(*arg, **kw)
         self._sizes = np.array([])
         
     def get_sizes(self):
@@ -850,7 +851,8 @@ class _CollectionWithAngles(Collection):
     """
     Base class for collections that have an array of angles.
     """
-    def __init__(self):
+    def __init__(self, *arg, **kw):
+        super(_CollectionWithAngles, self).__init__(*arg, **kw)
         self._angles = np.array([])
 
     def get_angles(self):
@@ -920,8 +922,7 @@ class PathCollection(_CollectionWithSizes, _CollectionWithAngles):
 
         %(Collection)s
         """
-
-        Collection.__init__(self, **kwargs)
+        super(PathCollection, self).__init__(**kwargs)
         self.set_paths(paths)
         self.set_sizes(sizes)
         self.stale = True

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -841,7 +841,7 @@ class _CollectionWithAngles(Collection):
             self._transforms = np.empty((0, 3, 3))
         else:
             self._angles = np.asarray(angles)
-            rot = np.deg2rad(self._angles)
+            rot = np.deg2rad(-self._angles)
             rot_c = np.cos(rot)
             rot_s = np.sin(rot)
             if self._transforms is None or \

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -822,11 +822,10 @@ class _CollectionWithSizes(Collection):
                 s[:, 1, 1] = scale
                 s[:, 2, 2] = 1.0
                 for i in xrange(self._transforms.shape[0]):
-                    self._transforms[i,:,:] = self._transforms[i,:,:].dot(s[i%len(self._sizes),:,:])
+                    self._transforms[i,:,:] = np.dot(s[i%len(self._sizes),:,:], self._transforms[i,:,:])
 
     @allow_rasterization
     def draw(self, renderer):
-        self.set_sizes(self._sizes, self.figure.dpi)
         super(_CollectionWithSizes, self).draw(renderer)
 
 class _CollectionWithAngles(Collection):
@@ -842,7 +841,7 @@ class _CollectionWithAngles(Collection):
             self._transforms = np.empty((0, 3, 3))
         else:
             self._angles = np.asarray(angles)
-            rot = np.deg2rad(90.-self._angles)
+            rot = np.deg2rad(self._angles)
             rot_c = np.cos(rot)
             rot_s = np.sin(rot)
             if self._transforms is None or \
@@ -862,10 +861,9 @@ class _CollectionWithAngles(Collection):
                 r[:, 1, 0] = rot_s
                 r[:, 2, 2] = 1.0
                 for i in xrange(self._transforms.shape[0]):
-                    self._transforms[i,:,:] = self._transforms[i,:,:].dot(r[i%len(self._angles),:,:])
+                    self._transforms[i,:,:] = np.dot(r[i%len(self._angles),:,:], self._transforms[i,:,:])
 
     def draw(self, renderer):
-        self.set_angles(self._angles)
         super(_CollectionWithAngles, self).draw(renderer)
 
 


### PR DESCRIPTION
This a re-summit of the #2432

Make possible to give a scalar or an array for rotate markers. This is usefull for representing for example Speed, Type, Direction of mobile targets.
