### PR TITLE
datestr2num of year and month fails on 29th, 30th, and 31st of month

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -246,17 +246,24 @@ class strpdate2num:
         return date2num(datetime.datetime(*time.strptime(s, self.fmt)[:6]))
 
 
-def datestr2num(d):
+def datestr2num(d, default=None):
     """
     Convert a date string to a datenum using
-    :func:`dateutil.parser.parse`.  *d* can be a single string or a
-    sequence of strings.
+    :func:`dateutil.parser.parse`.
+
+    Parameters
+    ----------
+    d : string or sequence of strings
+        The dates to convert.
+
+    default : datetime instance
+        The default date to use when fields are missing in `d`.
     """
     if cbook.is_string_like(d):
-        dt = dateutil.parser.parse(d)
+        dt = dateutil.parser.parse(d, default=default)
         return date2num(dt)
     else:
-        return date2num([dateutil.parser.parse(s) for s in d])
+        return date2num([dateutil.parser.parse(s, default=default) for s in d])
 
 
 def date2num(d):


### PR DESCRIPTION
datestr2num by default uses the current day if year-month data is converted.
This means that on the 29th, 30th or 31st of any month, datestr2num cannot be used to convert February, and on the 31st of any month, a number of other months cannot be converted. 
For example, on September 30 I cannot convert monthly data, as February doesn't have 30 days. Conversion of:
datestr2num('2000-02')
Gives an error:
ValueError: day is out of range for month

datestr2num calls dateutil.parser.parse, which by default uses the
current date at 00:00:00 for missing fields. The dateutil function
also can use a "default" argument to change this bahavoir but it is
not available in datestr2num. datestr2num needs a keyword argument to change the day that is used when it is not supplied.
