### PR TITLE
Off-axes markers unnecessarily saved to PDF

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1615,9 +1615,17 @@ class RendererPdf(RendererBase):
 
         output(Op.gsave)
         lastx, lasty = 0, 0
-        for vertices, code in path.iter_segments(trans, simplify=False):
+        for vertices, code in path.iter_segments(
+                trans,
+                clip=(0, 0, self.file.width*72, self.file.height*72),
+                simplify=False):
             if len(vertices):
                 x, y = vertices[-2:]
+                if (x < 0 or
+                    y < 0 or
+                    x > self.file.width * 72 or
+                    y > self.file.height * 72):
+                    continue
                 dx, dy = x - lastx, y - lasty
                 output(1, 0, 0, 1, dx, dy, Op.concat_matrix,
                        marker, Op.use_xobject)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -615,7 +615,10 @@ grestore
             ps_cmd.append('stroke')
         ps_cmd.extend(['grestore', '} bind def'])
 
-        for vertices, code in path.iter_segments(trans, simplify=False):
+        for vertices, code in path.iter_segments(
+                trans,
+                clip=(0, 0, self.width*72, self.height*72),
+                simplify=False):
             if len(vertices):
                 x, y = vertices[-2:]
                 ps_cmd.append("%g %g o" % (x, y))

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -593,7 +593,9 @@ class RendererSVG(RendererBase):
 
         trans_and_flip = self._make_flip_transform(trans)
         attrib = {'xlink:href': '#%s' % oid}
-        for vertices, code in path.iter_segments(trans_and_flip, simplify=False):
+        clip = (0, 0, self.width*72, self.height*72)
+        for vertices, code in path.iter_segments(
+                trans_and_flip, clip=clip, simplify=False):
             if len(vertices):
                 x, y = vertices[-2:]
                 attrib['x'] = six.text_type(x)

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -41,8 +41,7 @@ def test_type42():
 @cleanup
 def test_multipage_pagecount():
     from matplotlib.backends.backend_pdf import PdfPages
-    from io import BytesIO
-    with PdfPages(BytesIO()) as pdf:
+    with PdfPages(io.BytesIO()) as pdf:
         assert pdf.get_pagecount() == 0
         fig = plt.figure()
         ax = fig.add_subplot(111)
@@ -51,6 +50,21 @@ def test_multipage_pagecount():
         assert pdf.get_pagecount() == 1
         pdf.savefig()
         assert pdf.get_pagecount() == 2
+
+
+@cleanup
+def test_cull_markers():
+    x = np.random.random(20000)
+    y = np.random.random(20000)
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.plot(x, y, 'k.')
+    ax.set_xlim(2, 3)
+
+    pdf = io.BytesIO()
+    fig.savefig(pdf, format="pdf")
+    assert len(pdf.getvalue()) < 8000
 
 
 @cleanup


### PR DESCRIPTION
Plotting a bunch of markers without lines, then changing the axes limits so none of the points are visible, and then saving the result to a PDF, results in a file just as big as if the markers were all visible within their default axes limits. This doesn't happen for line only plots.

I guess the PDF backend clips the lines before deciding what to save to file, but it doesn't clip the markers. Not only does this result in an unnecessarily large PDF file (and potentially a security issue, because data is unintentionally leaking out), but rendering that file in a PDF viewer can be a lot slower as well.

Here's some demo code:

``` python
import numpy as np
x = np.random.random(20000)
y = np.random.random(20000)

figure()
plot(x, y, 'k.') # use markers only
pyplot.savefig('dots.pdf')
xlim(2, 3) # move axes away for empty plot
pyplot.savefig('dots_empty.pdf')
'''
file sizes in bytes:
dots.pdf:       327505
dots_empty.pdf: 327921
'''
figure()
plot(x, y, 'k-') # use lines only
pyplot.savefig('lines.pdf')
xlim(2, 3) # move axes away for empty plot
pyplot.savefig('lines_empty.pdf')
'''
file sizes in bytes:
lines.pdf:       310071
lines_empty.pdf:   5905
'''
```
