### PR TITLE
ENH better error message when wrong cmap name.

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -160,8 +160,10 @@ def get_cmap(name=None, lut=None):
             return cmap_d[name]
         elif name in datad:
             return _generate_cmap(name, lut)
-
-    raise ValueError("Colormap %s is not recognized" % name)
+    else:
+        raise ValueError(
+            "Colormap %s is not recognized. Possible values are: %s"
+            % (name, ', '.join(cmap_d.keys())))
 
 
 class ScalarMappable:


### PR DESCRIPTION
Small PR for a better error message when we provide a wrong cmap name.

Now, prints all possible values for cmap: it's pretty useful not to have to go online to check the documentation just for a typo in a colormap.
