### PR TITLE
make pep8 test routine reusable for other projects

### DIFF
--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -188,9 +188,9 @@ if HAS_PEP8:
             return self.file_errors
 
 
-def test_pep8_conformance(module=matplotlib, exclude_files=EXCLUDE_FILES,
-                          extra_exclude_file=EXTRA_EXCLUDE_FILE,
-                          pep8_additional_ignore=PEP8_ADDITIONAL_IGNORE):
+def assert_pep8_conformance(module=matplotlib, exclude_files=EXCLUDE_FILES,
+                            extra_exclude_file=EXTRA_EXCLUDE_FILE,
+                            pep8_additional_ignore=PEP8_ADDITIONAL_IGNORE):
     """
     Tests the matplotlib codebase against the "pep8" tool.
 
@@ -246,8 +246,11 @@ def test_pep8_conformance(module=matplotlib, exclude_files=EXCLUDE_FILES,
                              '{}'.format('\n  '.join(unexpectedly_good)))
 
 
+## Temporarily disabling test
+#def test_pep8_conformance():
+#    assert_pep8_conformance()
+
+
 if __name__ == '__main__':
     import nose
-    # Temporarily disabling test
-    raise nose.SkipTest('Test is disabled in the code')
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
I'd like to reuse the pep8 testing routine from matplotlib in one of our projects (since it's a dependency anyway) rather than duplicate code (and maintenance) by copy/patching it into our codebase. These are the minimal changes necessary for reusability.

Nothing changes for matplotlib test case but the routine can now be imported and used from another project.
Also, it's better readable I think, to have all the custom exclusions grouped at the head of the file.
I also had to move the currently active manual skip to the bottom.

Furthermore, in principle I think the whole logic rather belongs into `/testing/..` and should only be imported and called in `/tests/..`, but I did not want to change this without a go-ahead (and its not that important, I guess).

Also, I will include a check if failing files are untracked to exclude them from the results by using a system call to `git` (try/excepted if `git` is available of course). If this PR gets a nod, I would offer to implement this right here, otherwise I'll do that in our test setup.
