### PR TITLE
fixed an enconding bug when checking for gs version

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -341,7 +341,7 @@ def checkdep_ghostscript():
                 stderr=subprocess.PIPE)
             stdout, stderr = s.communicate()
             if s.returncode == 0:
-                v = stdout[:-1]
+                v = stdout[:-1].decode('ascii')
                 return gs_exec, v
 
         return None, None


### PR DESCRIPTION
The text read from `stdout` needs to be decoded from a byte stream object to an ascii string. As it were one could not import `maptlotlib` in py3 using the `text.usetex = True` rc option.

Using python 3.3 on arch, I get the following error:

```
>  python3                 
Python 3.3.2 (default, Sep  6 2013, 09:30:10) 
[GCC 4.8.1 20130725 (prerelease)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from matplotlib import plt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.3/site-packages/matplotlib-1.4.x-py3.3-linux-x86_64.egg/matplotlib/__init__.py", line 961, in <module>
    rcParams['text.usetex'] = checkdep_usetex(rcParams['text.usetex'])
  File "/usr/lib/python3.3/site-packages/matplotlib-1.4.x-py3.3-linux-x86_64.egg/matplotlib/__init__.py", line 461, in checkdep_usetex
    if compare_versions(gs_v, gs_sugg): pass
  File "/usr/lib/python3.3/site-packages/matplotlib-1.4.x-py3.3-linux-x86_64.egg/matplotlib/__init__.py", line 118, in compare_versions
    a = distutils.version.LooseVersion(a)
  File "/usr/lib/python3.3/distutils/version.py", line 310, in __init__
    self.parse(vstring)
  File "/usr/lib/python3.3/distutils/version.py", line 318, in parse
    components = [x for x in self.component_re.split(vstring)
TypeError: can't use a string pattern on a bytes-like object
>>> 
```
