### PR TITLE
Fix interactive mode detection

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1191,6 +1191,9 @@ def interactive(b):
 
 def is_interactive():
     'Return true if plot mode is interactive'
+    # ps1 exists if the python interpreter is running in an
+    # interactive console; sys.flags.interactive is true if a script
+    # is being run via "python -i".
     b = rcParams['interactive'] and (
         hasattr(sys, 'ps1') or sys.flags.interactive)
     return b


### PR DESCRIPTION
@jrevans: Does fix the bulk of your issue in this comment?

https://github.com/matplotlib/matplotlib/commit/9fbd29fa9f41f0c3291ab14220d61ba4029eb405#commitcomment-4267815

I'm not sure I agree with your assertion that `is_interactive() === rcParams['interactive']`, but I do think we should keep `python -i script.py` working.
