### PR TITLE
minor docstring fix in dates.py

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -495,7 +495,7 @@ class AutoDateFormatter(ticker.Formatter):
            365.0  : '%Y',
            30.    : '%b %Y',
            1.0    : '%b %d %Y',
-           1./24. : '%H:%M:%D',
+           1./24. : '%H:%M:%S',
            1. / (24. * 60.): '%H:%M:%S.%f',
            }
 


### PR DESCRIPTION
It's set correctly in the code, just a typo in the docstring.
