### PR TITLE
AutoDateFormatter: More customizable formatting

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -561,10 +561,10 @@ class AutoDateFormatter(ticker.Formatter):
                 fmt = self.scaled[k]
                 break
 
-        if isinstance(fmt, basestring):
+        if isinstance(fmt, six.string_types):
             self._formatter = DateFormatter(fmt, self._tz)
             return self._formatter(x, pos)
-        elif hasattr(fmt, '__call__'):
+        elif six.callable(fmt):
             return fmt(x, pos)
         else:
             raise NotImplementedError()


### PR DESCRIPTION
The `AutoDateFormatter` is a great tool, one does not have to worry about the scaling of the time range. However, I found for myself that only having a `strftime` format string as control is not enough. In particular I found it annoying to not be able to get rid of all-zero decimal seconds where possible and have decimal seconds show up where there really are dcimal seconds.
The example I added in the docstring should make clear what I mean.

This PR allows custom functions to be used for formatting in the style of `FuncFormatter`.

EDIT: I changed the docstring example to using a FuncFormatter so that it looks less hackish and uses matplotlib classes.

I will have to inherit/override this in our project (so that it works across matplotlib versions), but I thought this might be useful for other matplotlib users in future versions as well.

Also in `AutoDateFormatter.__call__()` the `pos` kwarg should default to `None` rather than `0`, I think.
