### PR TITLE
overloaded `_make_twin_axes` on `LocateableAxesBase` 

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -896,6 +896,15 @@ class LocatableAxesBase:
 
         self._axes_class.draw(self, renderer, inframe)
 
+    def _make_twin_axes(self, *kl, **kwargs):
+        """
+        Need to overload so that twinx/twiny will work with
+        these axes.
+        """
+        ax2 = type(self)(self.figure, self.get_position(True), *kl, **kwargs)
+        ax2.set_axes_locator(self.get_axes_locator())
+        self.figure.add_axes(ax2)
+        return ax2
 
 
 _locatableaxes_classes = {}


### PR DESCRIPTION
so that twinx and will work.

Didn't worry about a proper doc-string because this should be a private function.

Does not have a test.

Not sure if this is the best way to do this, but it works.
