### PR TITLE
Fix backend_svg.RendererSVG.draw_text to render urls

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -141,6 +141,19 @@ added. Furthermore, the the subplottool is now implemented as a modal
 dialog. It was previously a QMainWindow, leaving the SPT open if one closed the
 plotwindow.
 
+
+Text
+----
+
+Text URLs supported by SVG backend
+``````````````````````````````````
+
+The `svg` backend will now render :class:`~matplotlib.text.Text` objects'
+url as a link in output SVGs.  This allows one to make clickable text in
+saved figures using the url kwarg of the :class:`~matplotlib.text.Text`
+class.
+
+
 .. _whats-new-1-3:
 
 new in matplotlib-1.3

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1128,10 +1128,16 @@ class RendererSVG(RendererBase):
             self.writer.start(
                 'g', attrib={'clip-path': 'url(#%s)' % clipid})
 
+        if gc.get_url() is not None:
+            self.writer.start('a', {'xlink:href': gc.get_url()})
+
         if rcParams['svg.fonttype'] == 'path':
             self._draw_text_as_path(gc, x, y, s, prop, angle, ismath, mtext)
         else:
             self._draw_text_as_text(gc, x, y, s, prop, angle, ismath, mtext)
+
+        if gc.get_url() is not None:
+            self.writer.end('a')
 
         if clipid is not None:
             self.writer.end('g')

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -55,6 +55,23 @@ def test_noscale():
     plt.rcParams['svg.image_noscale'] = True
 
 
+@cleanup
+def test_text_urls():
+    fig = plt.figure()
+
+    test_url = "http://test_text_urls.matplotlib.org"
+    fig.suptitle("test_text_urls", url=test_url)
+
+    fd = BytesIO()
+    fig.savefig(fd, format='svg')
+    fd.seek(0)
+    buf = fd.read().decode()
+    fd.close()
+
+    expected = '<a xlink:href="{0}">'.format(test_url)
+    assert expected in buf
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
The SVG backend does nothing with Text object's URLs.  In particular, the rendering path below
backend_svg.RendererSVG.draw_text does nothing with the provided GraphicsContext's _url field.

This commit fixes that issue, causing Text objects' URLs to become &lt;a&gt; tags around the rendered text in the rendered SVG.
