### PR TITLE
Unicode issue in EPS output when using custom font

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -756,7 +756,7 @@ grestore
             except KeyError:
                 ps_name = sfnt[(3,1,0x0409,6)].decode(
                     'utf-16be')
-            ps_name = ps_name.encode('ascii','replace')
+            ps_name = ps_name.encode('ascii', 'replace')
             self.set_font(ps_name, prop.get_size_in_points())
 
             cmap = font.get_charmap()
@@ -1184,7 +1184,7 @@ class FigureCanvasPS(FigureCanvasBase):
             # We are going to use an external program to process the output.
             # Write to a temporary file.
             fd, tmpfile = mkstemp()
-            with io.open(fd, 'w', encoding='ascii') as fh:
+            with io.open(fd, 'w', encoding='latin-1') as fh:
                 print_figure_impl()
         else:
             # Write directly to outfile.
@@ -1193,7 +1193,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
                 if (not requires_unicode and
                     (six.PY3 or not isinstance(outfile, StringIO))):
-                    fh = io.TextIOWrapper(outfile, encoding="ascii")
+                    fh = io.TextIOWrapper(outfile, encoding="latin-1")
                     # Prevent the io.TextIOWrapper from closing the
                     # underlying file
                     def do_nothing():
@@ -1204,7 +1204,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
                 print_figure_impl()
             else:
-                with io.open(outfile, 'w', encoding='ascii') as fh:
+                with io.open(outfile, 'w', encoding='latin-1') as fh:
                     print_figure_impl()
 
         if rcParams['ps.usedistiller']:
@@ -1216,7 +1216,7 @@ class FigureCanvasPS(FigureCanvasBase):
             if passed_in_file_object:
                 if file_requires_unicode(outfile):
                     with io.open(tmpfile, 'rb') as fh:
-                        outfile.write(fh.read().decode('ascii'))
+                        outfile.write(fh.read().decode('latin-1'))
                 else:
                     with io.open(tmpfile, 'rb') as fh:
                         outfile.write(fh.read())
@@ -1290,7 +1290,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
         # write to a temp file, we'll move it to outfile when done
         fd, tmpfile = mkstemp()
-        with io.open(fd, 'w', encoding='ascii') as fh:
+        with io.open(fd, 'w', encoding='latin-1') as fh:
             # write the Encapsulated PostScript headers
             print("%!PS-Adobe-3.0 EPSF-3.0", file=fh)
             if title: print("%%Title: "+title, file=fh)
@@ -1373,7 +1373,7 @@ class FigureCanvasPS(FigureCanvasBase):
         if is_writable_file_like(outfile):
             if file_requires_unicode(outfile):
                 with io.open(tmpfile, 'rb') as fh:
-                    outfile.write(fh.read().decode('ascii'))
+                    outfile.write(fh.read().decode('latin-1'))
             else:
                 with io.open(tmpfile, 'rb') as fh:
                     outfile.write(fh.read())

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -48,17 +48,13 @@ public:
         PyObject* result = NULL;
         if (_write_method)
         {
-            #if PY3K
-            result = PyObject_CallFunction(_write_method, (char *)"s", a);
-            #else
             PyObject* decoded = NULL;
-            decoded = PyUnicode_FromString(a);
+            decoded = PyUnicode_DecodeLatin1(a, strlen(a), "");
             if (decoded == NULL) {
                 throw PythonExceptionOccurred();
             }
             result = PyObject_CallFunction(_write_method, "O", decoded);
             Py_DECREF(decoded);
-            #endif
             if (! result)
             {
                 throw PythonExceptionOccurred();


### PR DESCRIPTION
If I do:

```
import matplotlib
matplotlib.use('Agg')
import matplotlib.pyplot as plt

plt.rcParams['font.family'] = 'Georgia'

fig = plt.figure()
ax = fig.add_subplot(1,1,1)
ax.scatter([1,2,3],[1,2,3])
fig.savefig('test.eps')
```

I get:

```
Traceback (most recent call last):
  File "test_helvetica.py", line 10, in <module>
    fig.savefig('test.eps')
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.4.x-py2.7-macosx-10.8-x86_64.egg/matplotlib/figure.py", line 1439, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.4.x-py2.7-macosx-10.8-x86_64.egg/matplotlib/backend_bases.py", line 2228, in print_figure
    **kwargs)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.4.x-py2.7-macosx-10.8-x86_64.egg/matplotlib/backend_bases.py", line 1953, in print_eps
    return ps.print_eps(*args, **kwargs)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.4.x-py2.7-macosx-10.8-x86_64.egg/matplotlib/backends/backend_ps.py", line 982, in print_eps
    return self._print_ps(outfile, 'eps', *args, **kwargs)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.4.x-py2.7-macosx-10.8-x86_64.egg/matplotlib/backends/backend_ps.py", line 1010, in _print_ps
    **kwargs)
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.4.x-py2.7-macosx-10.8-x86_64.egg/matplotlib/backends/backend_ps.py", line 1208, in _print_figure
    print_figure_impl()
  File "/Users/tom/Library/Python/2.7/lib/python/site-packages/matplotlib-1.4.x-py2.7-macosx-10.8-x86_64.egg/matplotlib/backends/backend_ps.py", line 1159, in print_figure_impl
    fh, fonttype, glyph_ids)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xa9 in position 13: invalid start byte
```

This is using the latest developer version of Matplotlib (a3d2992e2af170313834f922f2212201e2c61a2a at the time of writing). I can save it to PDF and convert to PS with `pdf2ps` but it would be nice to be able to save to EPS directly.
