### PR TITLE
re-ordered the list of artists returned by `legend_handler.HandlerErrorbar`

### DIFF
--- a/doc/api/api_changes/2013-10_errorbar_legendhandler_order.rst
+++ b/doc/api/api_changes/2013-10_errorbar_legendhandler_order.rst
@@ -1,0 +1,8 @@
+Change artist associated with error bar in legend
+`````````````````````````````````````````````````
+
+Changed the order of the artist list returned by
+`legend_handler.HandlerErrorbar.create_artists` so that the artist
+associated with the legend marker in `legend.legendHandles` is the
+`Line2D` object for the markers not the `LineCollection` object for
+the error bars.

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -486,10 +486,10 @@ class HandlerErrorbar(HandlerLine2D):
                 handle_caplines.append(capline_right)
 
         artists = []
+        artists.append(legline_marker)
         artists.extend(handle_barlinecols)
         artists.extend(handle_caplines)
         artists.append(legline)
-        artists.append(legline_marker)
 
         for artist in artists:
             artist.set_transform(trans)


### PR DESCRIPTION
This is to address an issue raised on SO http://stackoverflow.com/questions/19470104/python-matplotlib-errobar-legend-picking.

As near as I can tell, `create_artists` is only ever called by `HandlerBase.__call__()` which then drops all but the first artist, which is returned by `__call__` and added to `legend.ledgendHandles`.  

Re-ordering the artist makes picking on them behave better (see the SO question at the top).

This technically breaks the API, but I would be surprised if anyone is actually using this (yes, http://xkcd.com/1172/).
