### PR TITLE
Move external libraries to 'extern' directory - correction

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -947,6 +947,7 @@ class TTConv(SetupPackage):
         ext = make_extension('matplotlib.ttconv', sources)
         Numpy().add_flags(ext)
         CXX().add_flags(ext)
+        ext.include_dirs.append('extern')
         return ext
 
 


### PR DESCRIPTION
This is a correction for PR #2531.

Todd Jennings reported on the matplotlib-devel mailing list a problem building on openSUSE.  In my previous PR I had omitted a compiler flag when building the TTConv package.  Todd confirms this fixes his problem. 
