### PR TITLE
fix removed api change regarding spectral functions

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -76,13 +76,6 @@ original location:
     - `xycoords` -> set the units of the point location
     - `set_position()` -> `Annotation` only set location of annotation
 
-* NFFT being even is now enforced in `matplotlib.mlab.specgram`,
-  `matplotlib.mlab.psd`,  `matplotlib.mlab.csd`,
-  `matplotlib.mlab.cohere`, `matplotlib.mlab.cohere_pairs`,
-  `matplotlib.pyplot.specgram`, `matplotlib.pyplot.psd`,
-  `matplotlib.pyplot.csd`, and `matplotlib.pyplot.cohere`.  This was
-  listed as a requirement but was not actually checked.
-
 * `matplotlib.mlab.specgram`, `matplotlib.mlab.psd`,  `matplotlib.mlab.csd`,
   `matplotlib.mlab.cohere`, `matplotlib.mlab.cohere_pairs`,
   `matplotlib.pyplot.specgram`, `matplotlib.pyplot.psd`,


### PR DESCRIPTION
pierre-haessig pointed out that this API change is no longer there, NFFT can support odd and even values safely now.  But I forgot to remove this note in the api_changes file, so here it is removed.
