### PR TITLE
Using a single-shot timer with the Wx backend raises an AttributeError

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -206,7 +206,7 @@ class TimerWx(TimerBase):
         self._timer_start()
 
     def _timer_set_single_shot(self):
-        self._timer.start()
+        self._timer.Start()
 
     def _on_timer(self, *args):
         TimerBase._on_timer(self)


### PR DESCRIPTION
With the WxAgg backend, the following results in an error (it works properly on any other backend):

```
import matplotlib
matplotlib.use('WxAgg')
import matplotlib.pyplot as plt

def ping():
    print 'ping'

fig, ax = plt.subplots()

timer = fig.canvas.new_timer(interval=1, callbacks=[(ping, [], {})])
timer.single_shot = True
timer.start()

plt.show()
```

This yields:

```
Traceback (most recent call last):
  File "wx_timer_issue.py", line 10, in <module>
    tim.single_shot = True
  File "/usr/local/lib64/python2.7/site-packages/matplotlib/backend_bases.py", line 1164, in _set_single_shot
    self._timer_set_single_shot()
  File "/usr/local/lib64/python2.7/site-packages/matplotlib/backends/backend_wx.py", line 206, in _timer_set_single_shot
    self._timer.start()
AttributeError: 'Timer' object has no attribute 'start'
```

This appears to be the result of a simple typo in wx_backend.py.
