### PR TITLE
removing items from the call to six.iteritems

### DIFF
--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -832,7 +832,7 @@ class FileChooserDialog(gtk.FileChooserDialog):
         hbox.pack_start (cbox)
 
         self.filetypes = filetypes
-        self.sorted_filetypes = list(six.iteritems(filetypes.items))
+        self.sorted_filetypes = list(six.iteritems(filetypes))
         self.sorted_filetypes.sort()
         default = 0
         for i, (ext, name) in enumerate(self.sorted_filetypes):


### PR DESCRIPTION
When using the GTK backend, and calling the save dialog (click on save button)

```
 Traceback (most recent call last):
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/backends/backend_gtk.py", line 752, in save_figure
    chooser = self.get_filechooser()
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/backends/backend_gtk.py", line 747, in get_filechooser
    default_filetype=self.canvas.get_default_filetype())
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/backends/backend_gtk.py", line 835, in __init__
    self.sorted_filetypes = list(six.iteritems(filetypes.items))
  File "/usr/lib/python2.7/dist-packages/six.py", line 254, in iteritems
    return iter(getattr(d, _iteritems)())
AttributeError: 'builtin_function_or_method' object has no attribute 'iteritems'
```

Removing the items from the filetypes fixes the problem
