### PR TITLE
Make it possible to add mpl.rcParams to itself or deepcopy

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -762,14 +762,14 @@ def matplotlib_fname():
 
 
 _deprecated_map = {
-    'text.fontstyle':   'font.style',
-    'text.fontangle':   'font.style',
-    'text.fontvariant': 'font.variant',
-    'text.fontweight':  'font.weight',
-    'text.fontsize':    'font.size',
-    'tick.size' :       'tick.major.size',
-    'svg.embed_char_paths' : 'svg.fonttype',
-    'savefig.extension' : 'savefig.format'
+    'text.fontstyle':   ('font.style',lambda x: x),
+    'text.fontangle':   ('font.style',lambda x: x),
+    'text.fontvariant': ('font.variant',lambda x: x),
+    'text.fontweight':  ('font.weight',lambda x: x),
+    'text.fontsize':    ('font.size',lambda x: x),
+    'tick.size' :       ('tick.major.size',lambda x: x),
+    'svg.embed_char_paths' : ('svg.fonttype',lambda x: "path" if x else "none"),
+    'savefig.extension' : ('savefig.format',lambda x: x),
     }
 
 _deprecated_ignore_map = {
@@ -793,14 +793,18 @@ class RcParams(dict):
     def __setitem__(self, key, val):
         try:
             if key in _deprecated_map:
-                alt = _deprecated_map[key]
-                warnings.warn(self.msg_depr % (key, alt))
-                key = alt
+                alt_key, alt_val  = _deprecated_map[key]
+                warnings.warn(self.msg_depr % (key, alt_key))
+                key = alt_key
+                val = alt_val(val)
             elif key in _deprecated_ignore_map:
                 alt = _deprecated_ignore_map[key]
                 warnings.warn(self.msg_depr_ignore % (key, alt))
                 return
-            cval = self.validate[key](val)
+            try:
+                cval = self.validate[key](val)
+            except ValueError as ve:
+                raise ValueError("Key %s: %s" % (key, str(ve)))
             dict.__setitem__(self, key, cval)
         except KeyError:
             raise KeyError('%s is not a valid rc parameter.\
@@ -808,9 +812,9 @@ See rcParams.keys() for a list of valid parameters.' % (key,))
 
     def __getitem__(self, key):
         if key in _deprecated_map:
-            alt = _deprecated_map[key]
-            warnings.warn(self.msg_depr % (key, alt))
-            key = alt
+            alt_key, alt_val  = _deprecated_map[key]
+            warnings.warn(self.msg_depr % (key, alt_key))
+            key = alt_key
         elif key in _deprecated_ignore_map:
             alt = _deprecated_ignore_map[key]
             warnings.warn(self.msg_depr_ignore % (key, alt))

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -88,7 +88,7 @@ def validate_bool_maybe_none(b):
     'Convert b to a boolean or raise'
     if isinstance(b, six.string_types):
         b = b.lower()
-    if b == 'none':
+    if b is None or b == 'none':
         return None
     if b in ('t', 'y', 'yes', 'on', 'true', '1', 1, True):
         return True
@@ -336,7 +336,6 @@ validate_ps_papersize = ValidateInStrings(
 def validate_ps_distiller(s):
     if isinstance(s, six.string_types):
         s = s.lower()
-
     if s in ('none', None):
         return None
     elif s in ('false', False):
@@ -395,7 +394,7 @@ def deprecate_svg_embed_char_paths(value):
     warnings.warn("svg.embed_char_paths is deprecated.  Use "
                   "svg.fonttype instead.")
 
-validate_svg_fonttype = ValidateInStrings('fonttype',
+validate_svg_fonttype = ValidateInStrings('svg.fonttype',
                                           ['none', 'path', 'svgfont'])
 
 
@@ -430,7 +429,9 @@ def validate_bbox(s):
         raise ValueError("bbox should be 'tight' or 'standard'")
 
 def validate_sketch(s):
-    if s == 'None' or s is None:
+    if isinstance(s, six.string_types):
+        s = s.lower()
+    if s == 'none' or s is None:
         return None
     if isinstance(s, six.string_types):
         result = tuple([float(v.strip()) for v in s.split(',')])


### PR DESCRIPTION
Before it was not possible to set all rcParams to mpl.rcParams or use
copy.deepcopy on mpl.rcParams.

There were two problems:
1. validate_bool_maybe_none(None) was raising ValueError
   -> fixed by accepting this value
2. svg.embed_char_paths was deprecated by svg.fonttype but both have
   different valid values (bool vs strings).
   -> fixed by adding a "value translation" lambda to _deprecated_map
   which translates the boolean values to the string values of
   svg.fonttype.

[EDIT]
Also changed all validators, which accept None to check strings
without case ("none" vs "None").

removed rcPrams.update method because there were too many warnings when using rc_context()
[/EDIT]

Also added a new test for this: mpl.tests.test_rcparams.test_Bug_2543()

I wasn't able to compile matplotlib under my windows environment and only did the changes in my original installed mathplot and the test in a ipyhton notebook. So please check and test before merging...

Closes: #2543
