### PR TITLE
more informative exceptions for empty/not-existing images in compare_images()

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -280,6 +280,13 @@ def compare_images( expected, actual, tol, in_decorator=False ):
    - in_decorator If called from image_comparison decorator, this should be
                True. (default=False)
    '''
+   if not os.path.exists(actual):
+       msg = "Output image %s does not exist." % actual
+       raise Exception(msg)
+
+   if os.stat(actual).st_size == 0:
+       msg = "Output image file %s is empty." % actual
+       raise Exception(msg)
 
    verify(actual)
 


### PR DESCRIPTION
[We're reusing the `compare_images()` function in a context manager](https://github.com/obspy/obspy/blob/master/obspy/core/util/testing.py#L129) that triggers a `compare_images()` in `__exit__()` (to have as little duplicated code as possible). In case of problems during plotting inside the with statement, `compare_images()` is triggered on an empty file, raising misleading exceptions like:

``` python
  File "/home/megies/git/obspy/obspy/core/util/testing.py", line 243, in compare
    msg = compare_images(self.baseline_image, self.name, tol=self.tol)
  File "/home/megies/git/matplotlib/lib/matplotlib/testing/compare.py", line 298, in compare_images
    actualImage = _png.read_png_int( actual )
RuntimeError: _image_module::readpng: error reading PNG header
```

I've taken care of this on our end, but I thought this might be useful for matplotlib in general, too (or at least won't hurt). Allthough.. when not wrapped in a context manager a different exception will likely be raised earlier when plotting fails, so, feel free to close without merging. ;)
