### PR TITLE
MultiCursor: make events connected during __init__ accessible (for later removal)

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -974,14 +974,14 @@ class MultiCursor(Widget):
 
     def connect(self):
         """connect events"""
-        self.cidmotion = self.canvas.mpl_connect('motion_notify_event',
-                                                 self.onmove)
-        self.ciddraw = self.canvas.mpl_connect('draw_event', self.clear)
+        self._cidmotion = self.canvas.mpl_connect('motion_notify_event',
+                                                  self.onmove)
+        self._ciddraw = self.canvas.mpl_connect('draw_event', self.clear)
 
     def disconnect(self):
         """disconnect events"""
-        self.canvas.mpl_disconnect(self.cidmotion)
-        self.canvas.mpl_disconnect(self.ciddraw)
+        self.canvas.mpl_disconnect(self._cidmotion)
+        self.canvas.mpl_disconnect(self._ciddraw)
 
     def clear(self, event):
         """clear the cursor"""


### PR DESCRIPTION
In a custom application where I repeatedly clear figures and reinitialize a `MultiCursor` object I need to inherit and override its `__init__` method (which I now have to maintain with `if`/`else`s depending on installed matplotlib version because of changes in upstream, like 349ccecb64) because I need to disconnect the events again.
This would not have been necessary on my end had `MultiCursor` been aware of the IDs of its connected events. So, I think this might be useful for other people and it would make it possible for me to reuse `__init__` for future matplotlib versions.

(Or maybe I just don't see the easy solution to disconnect these events again without saving their IDs?)
