### PR TITLE
AffineBase.__eq__ should not raise an exception when the other does not ...

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1559,7 +1559,7 @@ class AffineBase(Transform):
         return np.dot(b, a)
 
     def __eq__(self, other):
-        if other.is_affine:
+        if getattr(other, "is_affine", False):
             return np.all(self.get_matrix() == other.get_matrix())
         return NotImplemented
 


### PR DESCRIPTION
...have "is_affine" attribute.

I think the following code

``` python
ax.transAxes == "data"
```

should return False. It currently raises an exception.
