### PR TITLE
Fix infinite recursion in units with ndarray subclasses.

### DIFF
--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -149,7 +149,13 @@ class Registry(dict):
                     return converter
             except AttributeError:
                 # not a masked_array
-                converter = self.get_converter(xravel[0])
+                # Make sure we don't recurse forever -- it's possible for
+                # ndarray subclasses to continue to return subclasses and
+                # not ever return a non-subclass for a single element.
+                next_item = xravel[0]
+                if (not isinstance(next_item, np.ndarray) or
+                    next_item.shape != x.shape):
+                    converter = self.get_converter(next_item)
                 return converter
 
         if converter is None and iterable(x):


### PR DESCRIPTION
This was partially addressed for masked arrays in #2290. However,
this does not work for all ndarray sub-classes, like the quantities
package. The fix here is to make sure ravel is actually succeeding
in changing the shape of the object. If it doesn't just return
what we've got.
