### PR TITLE
register Axes3D along with other projections

### DIFF
--- a/lib/matplotlib/projections/__init__.py
+++ b/lib/matplotlib/projections/__init__.py
@@ -46,6 +46,13 @@ projection_registry.register(
     LambertAxes,
     MollweideAxes)
 
+try:
+    from mpl_toolkits.mplot3d import Axes3D
+except ImportError:
+    pass
+else:
+    projection_registry.register(Axes3D)
+
 
 def register_projection(cls):
     projection_registry.register(cls)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2389,12 +2389,3 @@ def get_test_data(delta=0.05):
     Y = Y * 10
     Z = Z * 500
     return X, Y, Z
-
-
-
-########################################################
-# Register Axes3D as a 'projection' object available
-# for use just like any other axes
-########################################################
-import matplotlib.projections as proj
-proj.projection_registry.register(Axes3D)


### PR DESCRIPTION
The docs state the following for `mplot3d` as preferred usage:

``` python
import matplotlib.pyplot as plt
from mpl_toolkits.mplot3d import Axes3D
fig = plt.figure()
ax = fig.add_subplot(111, projection='3d')
```

Because Axes3D is only registered as a projection in `mpl_toolkits.mplot3d.axes3d` one has to import from there even though the module is otherwise integrated rather seamlessly. It feels a bit odd to have an unused import as the preferred usage.

How about registering the projection earlier, within matplotlib, thus obviating this import? As far as I can see mplot3d is always there when matplotlib is installed (I put an `except ImportError` anyway to make double sure to not break anything). Well.. just cosmetics, I guess, so feel free to just close.

If this gets a thumbs up, I'll also change the docs accordingly.
