### PR TITLE
Correcting bad string comparsion in lin-log plot aspect verification

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1142,7 +1142,7 @@ class _AxesBase(martist.Artist):
                 aspect_scale_mode = "log"
             elif ((xscale == "linear" and yscale == "log") or
                   (xscale == "log" and yscale == "linear")):
-                if aspect is not "auto":
+                if aspect != "auto":
                     warnings.warn(
                         'aspect is not supported for Axes with xscale=%s, '
                         'yscale=%s' % (xscale, yscale))


### PR DESCRIPTION
Correction to little bug in the aspect verification

If trying to plot a lin/log, it wrongly raises the following warning

```
matplotlib/lib/matplotlib/axes/_base.py:1148: UserWarning: aspect is not supported for Axes with xscale=linear, 
yscale=log 'yscale=%s' % (xscale, yscale))
```
