### PR TITLE
adding global variable to keep track if gtkmain has been called

### DIFF
--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -79,10 +79,12 @@ def draw_if_interactive():
         if figManager is not None:
             figManager.canvas.draw_idle()
 
-
+gtk_main_called = False
 class Show(ShowBase):
     def mainloop(self):
         if gtk.main_level() == 0:
+            global gtk_main_called
+            gtk_main_called = True
             gtk.main()
 
 show = Show()
@@ -606,7 +608,8 @@ class FigureManagerGTK(FigureManagerBase):
 
         if Gcf.get_num_fig_managers()==0 and \
                not matplotlib.is_interactive() and \
-               gtk.main_level() >= 1:
+               gtk.main_level() >= 1 and \
+               gtk_main_called:
             gtk.main_quit()
 
     def show(self):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -67,9 +67,12 @@ def draw_if_interactive():
         if figManager is not None:
             figManager.canvas.draw_idle()
 
+gtk_main_called = False
 class Show(ShowBase):
     def mainloop(self):
         if Gtk.main_level() == 0:
+            global gtk_main_called
+            gtk_main_called = True
             Gtk.main()
 
 show = Show()
@@ -437,7 +440,8 @@ class FigureManagerGTK3(FigureManagerBase):
 
         if Gcf.get_num_fig_managers()==0 and \
                not matplotlib.is_interactive() and \
-               Gtk.main_level() >= 1:
+               Gtk.main_level() >= 1 and \
+               gtk_main_called:
             Gtk.main_quit()
 
     def show(self):


### PR DESCRIPTION
When embedding plot creation in gtk (see example below)
The mainloop does not call `Gtk.main()` because it has been called by the embedder.

But `Gtk.main_quit()` is called depending on `is_interactive()`, it doesn't take in count who called `Gtk.main()` 

This causes that the embedder program, gets destroyed when destroying the last window of the plots.

The proposed solution is just an ugly variable added to keep track if `Gtk.main()` was called inside the mainloop to restrict  the call of `Gtk.main_quit()` 

This may be related to PR https://github.com/matplotlib/matplotlib/pull/2503

```
import matplotlib
matplotlib.use('GTK3AGG')
import matplotlib.pyplot as plt

from gi.repository import Gtk

class MyWindow(Gtk.Window):

    def __init__(self):
        Gtk.Window.__init__(self, title="Hello World")
        self.button = Gtk.Button(label="Click Here")
        self.button.connect("clicked", self.on_button_clicked)
        self.add(self.button)

    def on_button_clicked(self, widget):
        fig = plt.figure()
        ax = fig.add_subplot(111)
        ax.plot([1,2,3])
        plt.show()

win = MyWindow()
win.connect("delete-event", Gtk.main_quit)
win.show_all()
Gtk.main()
```
