### PR TITLE
embedding_webagg example: Download button does not work

### DIFF
--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -193,7 +193,7 @@ mpl.figure.prototype._init_toolbar = function() {
     fmt_picker.addClass('mpl-toolbar-option ui-widget ui-widget-content');
     fmt_picker_span.append(fmt_picker);
     nav_element.append(fmt_picker_span);
-    this.format_dropdown = fmt_picker;
+    this.format_dropdown = fmt_picker[0];
 
     for (var ind in mpl.extensions) {
         var fmt = mpl.extensions[ind];


### PR DESCRIPTION
If you ran the example (https://github.com/matplotlib/matplotlib/blob/master/examples/user_interfaces/embedding_webagg.py) the download button does not work.

(You can download the figure when you go to http://127.0.0.1:8080/download.png, it's just the button which does not work)

One related question: 
Is there any chance to integrate the webagg backend with flask? If yes, a full working example would be nice (maybe an example using any webframework for serving the html would be helpful).
