### PR TITLE
setupext: put pkg-config -I, -L, -l locations at the head of the list

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -289,7 +289,7 @@ class PkgConfig(object):
                 for token in output.split():
                     attr = flag_map.get(token[:2])
                     if attr is not None:
-                        getattr(ext, attr).append(token[2:])
+                        getattr(ext, attr).insert(0, token[2:])
 
         if use_defaults:
             basedirs = get_base_dirs()


### PR DESCRIPTION
This addresses #2622.
The assumption here is that we want the pkg-config info to take
precedence, so its -I and -L output should be prepended, not
appended to the lists used to construct the compiler and linker
commands.  It is less clear whether the -l info also should
be prepended, as it is in the changeset; ideally, it wouldn't
matter, but for some compilers, it might.  If so, -l can
be handled separately from -I and -L.
