### PR TITLE
improved get_ticklabels kwarg

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -80,6 +80,14 @@ Consistent grid sizes in streamplots
 `density=1` and `density=(1, 1)`. Previously a grid size of 30x30 was used for
 `density=1`, but a grid size of 25x25 was used for `density=(1, 1)`.
 
+Get a list of all tick labels (major and minor)
+```````````````````````````````````````````````
+Added the `kwarg` 'which' to :func:`~matplotlib.Axes.get_xticklabels`,
+:func:`~matplotlib.Axes.get_yticklabels` and
+:func:`~matplotlib.Axis.get_ticklabels`.  'which' can be 'major', 'minor', or
+'both' select which ticks to return, like
+:func:`~matplotlib.Axis.set_ticks_position`.  If 'which' is `None` then the old
+behaviour (controlled by the bool `minor`).
 
 Date handling
 -------------

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2601,13 +2601,30 @@ class _AxesBase(martist.Artist):
         return cbook.silent_list('Text xticklabel',
                                  self.xaxis.get_minorticklabels())
 
-    def get_xticklabels(self, minor=False):
+    def get_xticklabels(self, minor=False, which=None):
         """
         Get the x tick labels as a list of :class:`~matplotlib.text.Text`
         instances.
+
+        Parameter
+        ---------
+        minor : bool
+           If True return the minor ticklabels,
+           else return the major ticklabels
+
+        which : None, ('minor', 'major', 'both')
+           Overrides `minor`.
+
+           Selects which ticklabels to return
+
+        Returns
+        -------
+        ret : list
+           List of :class:`~matplotlib.text.Text` instances.
         """
         return cbook.silent_list('Text xticklabel',
-                                 self.xaxis.get_ticklabels(minor=minor))
+                                 self.xaxis.get_ticklabels(minor=minor,
+                                                           which=which))
 
     @docstring.dedent_interpd
     def set_xticklabels(self, labels, fontdict=None, minor=False, **kwargs):
@@ -2837,13 +2854,30 @@ class _AxesBase(martist.Artist):
         return cbook.silent_list('Text yticklabel',
                                  self.yaxis.get_minorticklabels())
 
-    def get_yticklabels(self, minor=False):
+    def get_yticklabels(self, minor=False, which=None):
         """
-        Get the y tick labels as a list of :class:`~matplotlib.text.Text`
-        instances
+        Get the x tick labels as a list of :class:`~matplotlib.text.Text`
+        instances.
+
+        Parameter
+        ---------
+        minor : bool
+           If True return the minor ticklabels,
+           else return the major ticklabels
+
+        which : None, ('minor', 'major', 'both')
+           Overrides `minor`.
+
+           Selects which ticklabels to return
+
+        Returns
+        -------
+        ret : list
+           List of :class:`~matplotlib.text.Text` instances.
         """
         return cbook.silent_list('Text yticklabel',
-                                 self.yaxis.get_ticklabels(minor=minor))
+                                  self.yaxis.get_ticklabels(minor=minor,
+                                                            which=which))
 
     @docstring.dedent_interpd
     def set_yticklabels(self, labels, fontdict=None, minor=False, **kwargs):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1166,8 +1166,38 @@ class Axis(artist.Artist):
         labels2 = [tick.label2 for tick in ticks if tick.label2On]
         return cbook.silent_list('Text minor ticklabel', labels1 + labels2)
 
-    def get_ticklabels(self, minor=False):
-        'Return a list of Text instances for ticklabels'
+    def get_ticklabels(self, minor=False, which=None):
+        """
+        Get the x tick labels as a list of :class:`~matplotlib.text.Text`
+        instances.
+
+        Parameter
+        ---------
+        minor : bool
+           If True return the minor ticklabels,
+           else return the major ticklabels
+
+        which : None, ('minor', 'major', 'both')
+           Overrides `minor`.
+
+           Selects which ticklabels to return
+
+        Returns
+        -------
+        ret : list
+           List of :class:`~matplotlib.text.Text` instances.
+        """
+
+        if which is not None:
+            if which == 'minor':
+                return self.get_minorticklabels()
+            elif which == 'major':
+                return self.get_majorticklabels()
+            elif which =='both':
+                return self.get_majorticklabels() + self.get_minorticklabels()
+            else:
+                raise ValueError("`which` must be one of ('minor', 'major', 'both')" +
+                                 "not " + str(which))
         if minor:
             return self.get_minorticklabels()
         return self.get_majorticklabels()


### PR DESCRIPTION
Adds kwarg `which` to Axis.get_ticklabels, Axes.get_xticklabels, and Axes.get_yticklabels to match the pattern in other tick-related
functions

Closes #1715
