### PR TITLE
BUG Raise exception for invalid input

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -248,6 +248,8 @@ class ScalarMappable:
                     xx = x
                 else:
                     raise ValueError("third dimension must be 3 or 4")
+                if xx.dtype != np.uint8 and xx.max() > 1:
+                    raise ValueError("image must be either uint8 or in the 0..1 range")
                 if bytes and xx.dtype != np.uint8:
                     xx = (xx * 255).astype(np.uint8)
                 if not bytes and xx.dtype == np.uint8:


### PR DESCRIPTION
Arrays of non-uint8 types were assumed to be in 0..1 range, resulting in
the small bits being showing when this was not true. Now, an explicit
exception is raised.

Closes issue #2499
