### PR TITLE
Crash on saving figure if text.usetex is True

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -978,11 +978,11 @@ FT2Font::~FT2Font()
 
     if (face) {
         FT_Done_Face(face);
-    }
 
-    for (size_t i = 0; i < glyphs.size(); i++)
-    {
-        FT_Done_Glyph(glyphs[i]);
+        for (size_t i = 0; i < glyphs.size(); i++)
+        {
+            FT_Done_Glyph(glyphs[i]);
+        }
     }
 }
 


### PR DESCRIPTION
The following test program crashes when matplotlib is built from master on Mac OS X 10.9 (Mountain Lion):

```
#!/usr/bin/env python
import matplotlib
matplotlib.rc('text', usetex=True)
from matplotlib import pyplot as plt
plt.figure()
plt.plot([0, 1], [0, 1])
plt.savefig('test.pdf')
```

The error message looks like this:

```
Python(72585,0x7fff72971310) malloc: *** error for object 0x7fa36671ba60: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```

`gdb` reveals that the crash occurs in FreeType:

```
(gdb) bt
#0  0x00007fff8383a866 in __pthread_kill ()
#1  0x00007fff8734235c in pthread_kill ()
#2  0x00007fff8c206bba in abort ()
#3  0x00007fff8ca47093 in free ()
#4  0x00000001038fa296 in destroy_face ()
#5  0x00000001038fa1d0 in FT_Done_Face ()
#6  0x000000010388c1ea in std::__1::vector<FT_GlyphRec_*, std::__1::allocator<FT_GlyphRec_*> >::size () at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/c++/v1/vector:977
#7  0x000000010388c1ea in FT2Font::~FT2Font (this=0x1097151c0) at src/ft2font.cpp:979
#8  0x000000010388c16f in FT2Font::~FT2Font (this=0x1097151c0) at src/ft2font.cpp:974
#9  0x00000001038a4608 in Py::PythonClass<FT2Font>::extension_object_deallocator (_self=0x1097274d0) at ExtensionType.hxx:300
#10 0x00000001000334b4 in frame_dealloc ()
#11 0x00000001000a20fc in PyEval_EvalCodeEx ()
```

And `git bisect` identifies this as a regression in commit f4adec7b569cfd0b30e0f8367ba8618b9e160f92:

```
f4adec7b569cfd0b30e0f8367ba8618b9e160f92 is the first bad commit
commit f4adec7b569cfd0b30e0f8367ba8618b9e160f92
Author: Michael Droettboom <mdboom@gmail.com>
Date:   Wed Aug 14 10:18:10 2013 -0400

    Use six instead of 2to3
```
