### PR TITLE
Axes.plot: remove set_default_color_cycle from the docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1224,8 +1224,7 @@ class Axes(_AxesBase):
 
         By default, each line is assigned a different color specified by a
         'color cycle'.  To change this behavior, you can edit the
-        axes.color_cycle rcParam. Alternatively, you can use
-        :meth:`~matplotlib.axes.Axes.set_default_color_cycle`.
+        axes.color_cycle rcParam.
 
         The following format string characters are accepted to control
         the line style or marker:


### PR DESCRIPTION
It has been removed in 2c24a7c13645fbf0c79bb102274604c3f37b70d2.
