### PR TITLE
Fix Gtk3 crash when running inside of IPython

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -427,7 +427,6 @@ class FigureManagerGTK3(FigureManagerBase):
         self.canvas.destroy()
         if self.toolbar:
             self.toolbar.destroy()
-        self.__dict__.clear()   #Is this needed? Other backends don't have it.
 
         if Gcf.get_num_fig_managers()==0 and \
                not matplotlib.is_interactive() and \


### PR DESCRIPTION
As reported in #2624, the Gtk3 backends and IPython are not playing well together, and either no window is displayed, or Python exceptions or even segfaults are thrown.

This, along with https://github.com/ipython/ipython/pull/4640 seem to make everyone happy.
