### PR TITLE
Lightsource shade method parameters for color range definition

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1368,7 +1368,7 @@ class LightSource(object):
         if norm is None:
             norm = Normalize(vmin=data.min(), vmax=data.max())
 
-        rgb0 = cmap((data - norm.vmin) / (norm.vmax - norm.vmin))
+        rgb0 = cmap(norm(data))
         rgb1 = self.shade_rgb(rgb0, elevation=data)
         rgb0[:, :, 0:3] = rgb1
         return rgb0

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -210,28 +210,27 @@ def test_light_source_shading_color_range():
     #http://matplotlib.org/examples/pylab_examples/shading_example.html
 
     from matplotlib.colors import LightSource
+    from matplotlib.colors import Normalize
 
-    norm = mcolors.Normalize(vmin=0, vmax=50)
-    # test data
-    X, Y = np.mgrid[-5:5:0.05, -5:5:0.05]
-    Z = np.sqrt(X**2 + Y**2) + np.sin(X**2 + Y**2)
-    # create light source object.
+    refinput = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
+    norm = Normalize(vmin=0, vmax=50)
     ls = LightSource(azdeg=0, altdeg=65)
-    # shade data, creating an rgb array.
-    rgb = ls.shade(Z, plt.cm.jet, norm=norm)
-    # plot un-shaded and shaded images.
-    plt.figure(figsize=(12, 5))
-    plt.subplot(121)
-    plt.imshow(Z, cmap=plt.cm.jet, norm=norm)
-    plt.title('imshow')
-    plt.xticks([])
-    plt.yticks([])
-    plt.subplot(122)
-    plt.imshow(rgb)
-    plt.title('imshow with shading')
-    plt.xticks([])
-    plt.yticks([])
-    plt.draw()
+    testoutput = ls.shade(refinput, plt.cm.jet, norm=norm)
+    refoutput = np.array([
+        [[0., 0., 0.58912656, 1.],
+        [0., 0., 0.67825312, 1.],
+        [0., 0., 0.76737968, 1.],
+        [0., 0., 0.85650624, 1.]],
+        [[0., 0., 0.9456328, 1.],
+        [0., 0., 1., 1.],
+        [0., 0.04901961, 1., 1.],
+        [0., 0.12745098, 1., 1.]],
+        [[0., 0.22156863, 1., 1.],
+        [0., 0.3, 1., 1.],
+        [0., 0.37843137, 1., 1.],
+        [0., 0.45686275, 1., 1.]]
+        ])
+    assert_array_almost_equal(refoutput, testoutput)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added vmin and vmax arguments to LigthSource shade method which, if set, changes the lower and upper border of the colorspace. Compare with method contourf where these parameters are available. Basically they are needed if one has data in a smaller range than the colospace one wants to use. Normally the shade method just takes data.min() and data.max() as the range, by defining vmin and vmax thos get overwritten.
