### PR TITLE
"\usepackage[russian]{babel}" does not work in matplotlib 1.3.1

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1745,7 +1745,9 @@ class RendererPdf(RendererBase):
                         dvifont=dvifont)
                 seq += [['font', pdfname, dvifont.size]]
                 oldfont = dvifont
-            seq += [['text', x1, y1, [chr(glyph)], x1+width]]
+            # We need to convert the glyph numbers to bytes, and the easiest
+            # way to do this on both Python 2 and 3 is .encode('latin-1')
+            seq += [['text', x1, y1, [chr(glyph).encode('latin-1')], x1+width]]
 
         # Find consecutive text strings with constant y coordinate and
         # combine into a sequence of strings and kerns, or just one


### PR DESCRIPTION
Example:

```
from matplotlib import rc
#rc('font', **{'family': 'serif'})
rc('text', usetex=True)
rc('text.latex', unicode=True)
rc('text.latex', preamble=r"\usepackage[utf8]{inputenc}")
rc('text.latex', preamble=r"\usepackage[russian]{babel}")

import matplotlib.pyplot as plt

plt.figure(1)

plt.plot([1, 2, 3, 4], [1, 2, 3, 4], '-')
plt.xlabel(u"ось абсцисс")
plt.ylabel(u"ось ординат")
plt.title(u"Заголовок")
plt.show()
```

The error message:

```
Traceback (most recent call last):
  File "/usr/lib64/python3.3/tkinter/__init__.py", line 1475, in __call__
    return self.func(*args)
  File "/usr/lib64/python3.3/site-packages/matplotlib/backends/backend_tkagg.py", line 276, in resize
    self.show()
  File "/usr/lib64/python3.3/site-packages/matplotlib/backends/backend_tkagg.py", line 348, in draw
    FigureCanvasAgg.draw(self)
  File "/usr/lib64/python3.3/site-packages/matplotlib/backends/backend_agg.py", line 451, in draw
    self.figure.draw(self.renderer)
  File "/usr/lib64/python3.3/site-packages/matplotlib/artist.py", line 56, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/usr/lib64/python3.3/site-packages/matplotlib/figure.py", line 1035, in draw
    func(*args)
  File "/usr/lib64/python3.3/site-packages/matplotlib/artist.py", line 56, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/usr/lib64/python3.3/site-packages/matplotlib/axes.py", line 2088, in draw
    a.draw(renderer)
  File "/usr/lib64/python3.3/site-packages/matplotlib/artist.py", line 56, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/usr/lib64/python3.3/site-packages/matplotlib/axis.py", line 1094, in draw
    renderer)
  File "/usr/lib64/python3.3/site-packages/matplotlib/axis.py", line 1043, in _get_tick_bboxes
    extent = tick.label1.get_window_extent(renderer)
  File "/usr/lib64/python3.3/site-packages/matplotlib/text.py", line 755, in get_window_extent
    bbox, info, descent = self._get_layout(self._renderer)
  File "/usr/lib64/python3.3/site-packages/matplotlib/text.py", line 321, in _get_layout
    ismath=False)
  File "/usr/lib64/python3.3/site-packages/matplotlib/backends/backend_agg.py", line 205, in get_text_width_height_descent
    renderer=self)
  File "/usr/lib64/python3.3/site-packages/matplotlib/texmanager.py", line 669, in get_text_width_height_descent
    page = next(iter(dvi))
  File "/usr/lib64/python3.3/site-packages/matplotlib/dviread.py", line 85, in __iter__
    have_page = self._read()
  File "/usr/lib64/python3.3/site-packages/matplotlib/dviread.py", line 146, in _read
    self._dispatch(byte)
  File "/usr/lib64/python3.3/site-packages/matplotlib/dviread.py", line 234, in _dispatch
    self._fnt_def(k, c, s, d, a, l, n)
  File "/usr/lib64/python3.3/site-packages/matplotlib/dviread.py", line 395, in _fnt_def
    if c != 0 and tfm.checksum != 0 and c != tfm.checksum:
AttributeError: 'NoneType' object has no attribute 'checksum'
```
