### PR TITLE
DOC: Remove redundant colormaps from examples

### DIFF
--- a/examples/color/colormaps_reference.py
+++ b/examples/color/colormaps_reference.py
@@ -44,13 +44,15 @@ cmaps = [('Sequential',     ['Blues', 'BuGn', 'BuPu',
                              'gist_heat', 'gray', 'hot', 'pink',
                              'spring', 'summer', 'winter']),
          ('Diverging',      ['BrBG', 'bwr', 'coolwarm', 'PiYG', 'PRGn', 'PuOr',
-                             'RdBu', 'RdGy', 'RdYlBu', 'RdYlGn', 'seismic']),
-         ('Qualitative',    ['Accent', 'Dark2', 'hsv', 'Paired', 'Pastel1',
-                             'Pastel2', 'Set1', 'Set2', 'Set3', 'nipy_spectral']),
-         ('Miscellaneous',  ['gist_earth', 'gist_ncar', 'gist_rainbow',
-                             'gist_stern', 'jet', 'brg', 'CMRmap', 'cubehelix',
-                             'gnuplot', 'gnuplot2', 'ocean', 'rainbow',
-                             'terrain', 'flag', 'prism'])]
+                             'RdBu', 'RdGy', 'RdYlBu', 'RdYlGn', 'Spectral',
+                             'seismic']),
+         ('Qualitative',    ['Accent', 'Dark2', 'Paired', 'Pastel1',
+                             'Pastel2', 'Set1', 'Set2', 'Set3']),
+         ('Miscellaneous',  ['gist_earth', 'terrain', 'ocean', 'gist_stern',
+                             'brg', 'CMRmap', 'cubehelix',
+                             'gnuplot', 'gnuplot2', 'gist_ncar',
+                             'nipy_spectral', 'jet', 'rainbow',
+                             'gist_rainbow', 'hsv', 'flag', 'prism'])]
 
 
 nrows = max(len(cmap_list) for cmap_category, cmap_list in cmaps)


### PR DESCRIPTION
`gist_yarg`, `gist_gray`, and `binary` are identical to `gray`, so they are "on a deprecation path", and `spectral` was renamed to `nipy_spectral` to avoid conflicts with `Spectral`

https://github.com/matplotlib/matplotlib/pull/889
