### PR TITLE
Close a figure with a type long or uuid figure number

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -516,8 +516,12 @@ def close(*args):
         arg = args[0]
         if arg == 'all':
             _pylab_helpers.Gcf.destroy_all()
-        elif isinstance(arg, int):
+        elif isinstance(arg, six.integer_types):
             _pylab_helpers.Gcf.destroy(arg)
+        elif hasattr(arg, 'int'):
+            # if we are dealing with a type UUID, we
+            # can use its integer representation
+            _pylab_helpers.Gcf.destroy(arg.int)
         elif is_string_like(arg):
             allLabels = get_figlabels()
             if arg in allLabels:


### PR DESCRIPTION
If it is possible to create a figure using a figure number that is a type long or a type UUID, then it stands to reason that you should be able to close the figure using that same figure number.
