### PR TITLE
Remove a redundant comparison that raises an exception in Python 3

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,8 +53,7 @@ except ImportError:
 
 autosummary_generate = True
 
-if sphinx.__version__ >= 1.1:
-    autodoc_docstring_signature = True
+autodoc_docstring_signature = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
sphinx.**version** is a string, 1.1 is a float: the comparison always
returns True in Python 2. In Python 3 however the

> <, <=, > and >= operators will raise a TypeError exception when
> comparing a complex number with another built-in numeric type, when
> the objects are of different types that cannot be compared, or in
> other cases where there is no defined ordering

[0]. str and float are such unorderable types.

[0] http://docs.python.org/3.3/library/stdtypes.html#comparisons
