### PR TITLE
Disable offset box clipping by default.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -149,6 +149,11 @@ class OffsetBox(martist.Artist):
 
         super(OffsetBox, self).__init__(*args, **kwargs)
 
+        # Clipping has not been implemented in the OffesetBox family, so
+        # disable the clip flag for consistency. It can always be turned back
+        # on to zero effect.
+        self.set_clip_on(False)
+
         self._children = []
         self._offset = (0, 0)
 


### PR DESCRIPTION
Closes #2530.
