### PR TITLE
_get_xdg_config_dir(), _get_xdg_cache_dir() - Restored for conformity to the standard.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -568,13 +568,16 @@ def _get_config_or_cache_dir(xdg_base):
 
     p = None
     h = get_home()
-    if h is not None:
+    if h:
         p = os.path.join(h, '.matplotlib')
-        if (sys.platform.startswith('linux') and
-            xdg_base is not None):
-            p = os.path.join(xdg_base, 'matplotlib')
+        if sys.platform.startswith('linux') and not os.path.exists(p):
+            # no old config exists
+            if xdg_base:
+                p = os.path.join(xdg_base, 'matplotlib')
+            else:
+                p = None
 
-    if p is not None:
+    if p:
         if os.path.exists(p):
             if _is_writable_dir(p):
                 return p


### PR DESCRIPTION
These commits result from making matplotlib running on a cluster system where no write access to the home directory exists from compute nodes. With these commits matplotlib can be used in that environment even without setting the environment variables XDG_*. The configuration and cache directory will then be created in the directory for temporary files.
1. The first commit restores standardconformity in the calculation of the configuration and cache directories. According to the freedesktop standard can the location of directories be specified independent from the existence of a home directory. This was not given in the implementation.

Compare http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables paragraphes 2 and 8.
1. The second commit restores the possibility to use an old configuration on Linux. That feature was lost in the last commit. 
