### PR TITLE
Consistent grid sizes in streamplot.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2013-12-30 Made streamplot grid size consistent for different types of density
+           argument. A 30x30 grid is now used for both density=1 and
+           density=(1, 1).
+
 2013-11-28 Added qhull extension module to perform Delaunay triangulation more
            robustly than before.  It is used by tri.Triangulation (and hence
            all pyplot.tri* methods) and mlab.griddata.  Deprecated

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -74,6 +74,13 @@ Added `FormatStrFormatterNewStyle` which does the same job as
 `FormatStrFormatter`, but accepts new-style formatting strings
 instead of printf-style formatting strings
 
+Consistent grid sizes in streamplots
+````````````````````````````````````
+:func:`~matplotlib.pyplot.streamplot` uses a base grid size of 30x30 for both
+`density=1` and `density=(1, 1)`. Previously a grid size of 30x30 was used for
+`density=1`, but a grid size of 25x25 was used for `density=(1, 1)`.
+
+
 Date handling
 -------------
 

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -31,7 +31,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         the number of columns should match x.
     *density* : float or 2-tuple
         Controls the closeness of streamlines. When `density = 1`, the domain
-        is divided into a 25x25 grid---*density* linearly scales this grid.
+        is divided into a 30x30 grid---*density* linearly scales this grid.
         Each cell in the grid can have, at most, one traversing streamline.
         For different densities in each direction, use [density_x, density_y].
     *linewidth* : numeric or 2d array
@@ -313,8 +313,8 @@ class StreamMask(object):
             self.nx = self.ny = int(30 * density)
         else:
             assert len(density) == 2
-            self.nx = int(25 * density[0])
-            self.ny = int(25 * density[1])
+            self.nx = int(30 * density[0])
+            self.ny = int(30 * density[1])
         self._mask = np.zeros((self.ny, self.nx))
         self.shape = self._mask.shape
 

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -28,7 +28,9 @@ def test_linewidth():
     X, Y, U, V = velocity_field()
     speed = np.sqrt(U*U + V*V)
     lw = 5*speed/speed.max()
-    plt.streamplot(X, Y, U, V, density=[0.5, 1], color='k', linewidth=lw)
+    df = 25. / 30.   # Compatibility factor for old test image
+    plt.streamplot(X, Y, U, V, density=[0.5 * df, 1. * df], color='k',
+                   linewidth=lw)
 
 
 @image_comparison(baseline_images=['streamplot_masks_and_nans_test_image'])

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -102,8 +102,9 @@ def test_pre_transform_plotting():
     u = 2*np.sin(x) + np.cos(y[:, np.newaxis])
     v = np.sin(x) - np.cos(y[:, np.newaxis])
 
+    df = 25. / 30.   # Compatibility factor for old test image
     ax.streamplot(x, y, u, v, transform=times10 + ax.transData,
-                  density=(1, 1), linewidth=u**2 + v**2)
+                  density=(df, df), linewidth=u**2 + v**2)
 
     # reduce the vector data down a bit for barb and quiver plotting
     x, y = x[::3], y[::3]


### PR DESCRIPTION
This PR addresses #2653. The grid size used by `streamplot()` for `density=1` was 30x30 (not 25x25 as stated in the docstring) but for `density=(1, 1)` it was 25x25. This PR changes the base grid size for both density specification types to 30x30, since this is the grid size currently used for the default value of the `density` argument.

I modified two tests that use a vector density specification so that the resulting test plots are the same. I saw no need for new test images taking up space in the repository.
