### PR TITLE
Fix FancyBboxPatch Typo

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2236,7 +2236,8 @@ class FancyBboxPatch(Patch):
     """
 
     def __str__(self):
-        return "FancyBboxPatch(%g,%g;%gx%g)" % (self._x, self._y,
+        return self.__class__.__name__ \
+                           + "(%g,%g;%gx%g)" % (self._x, self._y,
                                                 self._width, self._height)
 
     @docstring.dedent_interpd


### PR DESCRIPTION
A tiny cosmetic fix.  Previous behavior was

``` python
>>> from matplotlib.patches import FancyBboxPatch
>>> print FancyBboxPatch((0, 0), 1, 1)
FancyBboxPatchFancyBboxPatch(0,0;1x1)
```

After this PR it is

``` python
>>> print FancyBboxPatch((0, 0), 1, 1)
FancyBboxPatch(0,0;1x1)
```
