### PR TITLE
Add spines and ticks in rcParams

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -574,6 +574,12 @@ defaultParams = {
     'axes.facecolor':        ['w', validate_color],  # background color; white
     'axes.edgecolor':        ['k', validate_color],  # edge color; black
     'axes.linewidth':        [1.0, validate_float],  # edge linewidth
+
+    'axes.spines.left':      [True, validate_bool],  # Set visibility of axes
+    'axes.spines.right':     [True, validate_bool],  # 'spines', the lines
+    'axes.spines.bottom':    [True, validate_bool],  # around the chart
+    'axes.spines.top':       [True, validate_bool],  # denoting data boundary
+
     'axes.titlesize':        ['large', validate_fontsize],  # fontsize of the
                                                             # axes title
     'axes.titleweight':      ['normal', six.text_type],  # font weight of axes title

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -429,6 +429,13 @@ def validate_bbox(s):
             return None
         raise ValueError("bbox should be 'tight' or 'standard'")
 
+validate_xtick_position = ValidateInStrings('xtick.position',
+                                            ['both', 'bottom', 'top'])
+
+validate_ytick_position = ValidateInStrings('ytick.position',
+                                            ['both', 'left', 'right'])
+
+
 def validate_sketch(s):
     if s == 'None' or s is None:
         return None
@@ -665,6 +672,7 @@ defaultParams = {
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
     'xtick.direction':   ['in', six.text_type],            # direction of xticks
+    'xtick.position':    ['both', validate_xtick_position],
 
     'ytick.major.size':  [4, validate_float],     # major ytick size in points
     'ytick.minor.size':  [2, validate_float],     # minor ytick size in points
@@ -676,6 +684,7 @@ defaultParams = {
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],
     'ytick.direction':   ['in', six.text_type],            # direction of yticks
+    'ytick.position':    ['both', validate_ytick_position],
 
     'grid.color':        ['k', validate_color],       # grid color
     'grid.linestyle':    [':', six.text_type],       # dotted

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -430,10 +430,10 @@ def validate_bbox(s):
         raise ValueError("bbox should be 'tight' or 'standard'")
 
 validate_xtick_position = ValidateInStrings('xtick.position',
-                                            ['both', 'bottom', 'top'])
+                                            ['both', 'bottom', 'top', 'none'])
 
 validate_ytick_position = ValidateInStrings('ytick.position',
-                                            ['both', 'left', 'right'])
+                                            ['both', 'left', 'right', 'none'])
 
 
 def validate_sketch(s):

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -458,6 +458,9 @@ class Spine(mpatches.Patch):
         else:
             raise ValueError('unable to make path for spine "%s"' % spine_type)
         result = cls(axes, spine_type, path, **kwargs)
+        if not rcParams['axes.spines.{}'.format(spine_type)]:
+            result.set_visible(False)
+
         return result
 
     @classmethod

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -458,7 +458,7 @@ class Spine(mpatches.Patch):
         else:
             raise ValueError('unable to make path for spine "%s"' % spine_type)
         result = cls(axes, spine_type, path, **kwargs)
-        if not rcParams['axes.spines.{}'.format(spine_type)]:
+        if not rcParams['axes.spines.{0}'.format(spine_type)]:
             result.set_visible(False)
 
         return result


### PR DESCRIPTION
Hello there,
I started working on this PR to make my [`prettyplotlib`](https://github.com/olgabot/prettyplotlib) library obsolete by allowing you to do everything via rcParams.

So far I've only gotten the `spines` to work: http://nbviewer.ipython.org/gist/olgabot/8260601

Current todos are:

1. `set_ticks_location` via rcParams
2. Tell `scatter` to `get_current_color_cycle` for the `facecolor`. Ditto for `fill_between` and `fill_betweenx`
3. Set `boxplot` colors and lines: https://github.com/olgabot/prettyplotlib/wiki/Examples-with-code#boxplot
4. Add `image.cmap_divergent` for data with both negative and positive values in a heatmap
5. (maybe) allow for only y- or x-axis grids, e.g. for bar plots and histograms https://github.com/olgabot/prettyplotlib/wiki/Examples-with-code#bar-with-a-white-grid-to-erase-and-yet-add-information

Thoughts? Does this look like it's going in the right direction?