### PR TITLE
Updating regex used to split sphinx version string.

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -147,7 +147,7 @@ import sphinx
 sphinx_version = sphinx.__version__.split(".")
 # The split is necessary for sphinx beta versions where the string is
 # '6b1'
-sphinx_version = tuple([int(re.split('[a-z]', x)[0])
+sphinx_version = tuple([int(re.split('[^0-9]', x)[0])
                         for x in sphinx_version[:2]])
 
 try:


### PR DESCRIPTION
The latest stable sphinx version string is '1.2+'.
The regex pattern '[a-z]' fails to match the '+' character
leading to a `ValueError` being raised when it attempts to
cast '2+' to an int. Replacing '[a-z]' with '[^0-9]' resolves this.
