### PR TITLE
Build failure on MacOS X 10.5.8 (PowerPC G5) with Python 3.3.3

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2824,7 +2824,7 @@ GraphicsContext_draw_text (GraphicsContext* self, PyObject* args)
                                 &italic,
                                 &angle)) return NULL;
 
-    if (!(atsfont = setfont(cr, family, size, weight, italic))
+    if (!(atsfont = setfont(cr, family, size, weight, italic)))
     {
         return NULL;
     }


### PR DESCRIPTION
La Défense, le 20/12/2013

Hi

Using commit 8c16c614ecf71f9268afbc741a75541af82c2b5b .

I get a build failure on MacOS X 10.5.8 (PowerPC G5 - still have to use it) with Python 3.3.3 and powerpc-apple-darwin9-gcc-4.2.1 (GCC) 4.2.1 (Apple Inc. build 5566):

src/_macosx.m: In function ‘GraphicsContext_draw_text’:
src/_macosx.m:2828: error: expected ‘)’ before ‘{’ token
src/_macosx.m:2892: error: expected expression before ‘}’ token
error: command 'gcc' failed with exit status 1

The same code compiles fine under MacOS X 10.9.1 (Intel) with Python 3.3.3 and clang.

Thanks

Hubert Holin
