### PR TITLE
Fixes issue #2525

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -529,6 +529,7 @@ class Figure(Artist):
             self._suptitle.set_text(t)
             self._suptitle.set_position((x, y))
             self._suptitle.update_from(sup)
+            sup.remove()
         else:
             self._suptitle = sup
         return self._suptitle
@@ -960,6 +961,7 @@ class Figure(Artist):
         self.legends = []
         if not keep_observers:
             self._axobservers = []
+        self._suptitle = None
 
     def clear(self):
         """


### PR DESCRIPTION
Clears _suptitle instance on clf() and fixes a bugwhere suptitle endlessly adds text artists to the figure
