### PR TITLE
Added missing cleanup decorator import.

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -10,6 +10,7 @@ from nose import with_setup
 from matplotlib import pyplot as plt
 from matplotlib import animation
 from matplotlib.testing.noseclasses import KnownFailureTest
+from matplotlib.testing.decorators import cleanup
 from matplotlib.testing.decorators import CleanupTest
 
 


### PR DESCRIPTION
I'm seeing a test error because the `@cleanup` decorator is used in test_animation.py but is not imported. The combination of these two commits looks to be the problem: 61bce5ddc20cdef650a6cf2c5ff05898a665ea04 and 03c71f53cd8d1d39f4ef16687800ce07a3bea06b.
