### PR TITLE
Package initialization made possible when executed in environments with...

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -531,11 +531,12 @@ def _get_xdg_config_dir():
     base directory spec
     <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
     """
-    home = get_home()
-    if home is None:
-        return None
-    else:
-        return os.environ.get('XDG_CONFIG_HOME', os.path.join(home, '.config'))
+    path = os.environ.get('XDG_CONFIG_HOME')
+    if path is None:
+        path = get_home()
+        if path is not None:
+            path = os.path.join(path, '.config')
+    return path
 
 
 def _get_xdg_cache_dir():
@@ -544,11 +545,12 @@ def _get_xdg_cache_dir():
     base directory spec
     <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
     """
-    home = get_home()
-    if home is None:
-        return None
-    else:
-        return os.environ.get('XDG_CACHE_HOME', os.path.join(home, '.cache'))
+    path = os.environ.get('XDG_CACHE_HOME')
+    if path is None:
+        path = get_home()
+        if path is not None:
+            path = os.path.join(path, '.cache')
+    return path
 
 
 def _get_config_or_cache_dir(xdg_base):
@@ -568,9 +570,8 @@ def _get_config_or_cache_dir(xdg_base):
     h = get_home()
     if h is not None:
         p = os.path.join(h, '.matplotlib')
-        if (sys.platform.startswith('linux') and
-            xdg_base is not None):
-            p = os.path.join(xdg_base, 'matplotlib')
+    if (sys.platform.startswith('linux') and xdg_base):
+        p = os.path.join(xdg_base, 'matplotlib')
 
     if p is not None:
         if os.path.exists(p):


### PR DESCRIPTION
...out access to the home directory.

Functions _get_xdg_config_dir(), _get_xdg_cache_dir(), _get_config_or_cache_dir() allow now the use of the environment variables XDG_CONFIG_HOME resp. XDG_CACHE_HOME without requiring access to the home directory (f.ex. in batch jobs on clusters).

Before, the definitions of the environment variables would not have been used when the home directory was not accessible. Nevertheless, the standard does not bind the variable definitions to the existence of home directories (only the default values are defined with respect to them).
