### PR TITLE
Does the gtk3agg backend work on python3?

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -149,6 +149,19 @@ added. Furthermore, the the subplottool is now implemented as a modal
 dialog. It was previously a QMainWindow, leaving the SPT open if one closed the
 plotwindow.
 
+Cairo backends
+``````````````
+
+The Cairo backends are now able to use the `cairocffi bindings
+<https://github.com/SimonSapin/cairocffi>`__ which are more actively
+maintained than the `pycairo bindings
+<http://cairographics.org/pycairo/>`__.
+
+Gtk3Agg backend
+```````````````
+
+The Gtk3Agg backend now works on Python 3.x, if the `cairocffi
+bindings <https://github.com/SimonSapin/cairocffi>`__ are installed.
 
 Text
 ----

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -5,10 +5,18 @@ import six
 
 from . import backend_gtk3
 from . import backend_cairo
+from .backend_cairo import cairo, HAS_CAIRO_CFFI
 from matplotlib.figure import Figure
 
 class RendererGTK3Cairo(backend_cairo.RendererCairo):
     def set_context(self, ctx):
+        if HAS_CAIRO_CFFI:
+            ctx = cairo.Context._from_pointer(
+                cairo.ffi.cast(
+                    'cairo_t **',
+                    id(ctx) + object.__basicsize__)[0],
+                incref=True)
+
         self.gc.ctx = ctx
 
 

--- a/setupext.py
+++ b/setupext.py
@@ -1679,9 +1679,12 @@ class BackendGtk3Agg(OptionalBackendPackage):
 
 def backend_gtk3cairo_internal_check(x):
     try:
-        import cairo
+        import cairocffi
     except ImportError:
-        return (False, "Requires cairo to be installed.")
+        try:
+            import cairo
+        except ImportError:
+            return (False, "Requires cairocffi or pycairo to be installed.")
 
     try:
         import gi
@@ -1871,11 +1874,16 @@ class BackendCairo(OptionalBackendPackage):
 
     def check_requirements(self):
         try:
-            import cairo
+            import cairocffi
         except ImportError:
-            raise CheckFailed("cairo not found")
+            try:
+                import cairo
+            except ImportError:
+                raise CheckFailed("cairocffi or pycairo not found")
+            else:
+                return "pycairo version %s" % cairo.version
         else:
-            return "version %s" % cairo.version
+            return "cairocffi version %s" % cairocffi.version
 
 
 class DviPng(SetupPackage):


### PR DESCRIPTION
Whatsnew indicates that the gtk3agg backend works on python3. However 
backend_gtk3agg.py still contains a warning about in not working:

``` python
warnings.warn("The Gtk3Agg backend is not known to work on Python 3.x.")
```

and I'm still seeing the error given in the original pull request (#590) when using this backend on python3
on ubuntu 12.04. 

``` python
NotImplementedError: Surface.create_for_data: Not Implemented yet.
```

Does it work with more resent versions of the gtk3 bindings for python3?

Edit: Ubuntu 12.04 ships with python3-gi 3.2.2
