### PR TITLE
clip_on = False does not work for x-axis

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -457,7 +457,8 @@ class Line2D(Artist):
         if (self.axes and len(x) > 100 and self._is_sorted(x) and
                 self.axes.name == 'rectilinear' and
                 self.axes.get_xscale() == 'linear' and
-                self._markevery is None):
+                self._markevery is None and
+                self.get_clip_on() is True):
             self._subslice = True
         if hasattr(self, '_path'):
             interpolation_steps = self._path._interpolation_steps


### PR DESCRIPTION
When I set clip_on = False the curve extends beyond the y-limits, but it does not extend beyond the x-limits. Am I doing something wrong, or is this a bug?

For example, the following code:

```
import matplotlib.pyplot as plt
import numpy as np
x1 = np.arange(-10, 10, 0.01)
y1 = x1
ax = plt.subplot()
ax.set_xlim(-2,2)
ax.set_ylim(-1,1)
ax.plot(x1, y1, clip_on = False)
```

produces the plot I would expect:

![good](http://s8.postimg.org/tc0csa3p1/wtf1.jpg)

However, all I have to do is change the y-limits,

```
fig = plt.figure()
ax = plt.subplot()
ax.set_xlim(-2,2)
ax.set_ylim(-3,3)
ax.plot(x1, y1, clip_on = False)
```

and I get the following plot:

![bad](http://s11.postimg.org/g81ef6r2b/wtf2.jpg)

Why does the first plot extend beyond the y-limits, while the second one does not extend beyond the x-limits?  In case it matters, I am using matplotlib 1.3.0 with the TkAgg backend, but apparently (http://stackoverflow.com/questions/20523752/matplotlib-clip-on-false-does-not-work-on-x-axis) it also happens with the MacOSX backend.
