### PR TITLE
Make standardization of input optional in mlab.PCA

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1653,7 +1653,7 @@ def prepca(P, frac=0):
 
 
 class PCA:
-    def __init__(self, a):
+    def __init__(self, a, standardize=True):
         """
         compute the SVD of a and store data for PCA.  Use project to
         project the data onto a reduced set of dimensions
@@ -1661,6 +1661,8 @@ class PCA:
         Inputs:
 
           *a*: a numobservations x numdims array
+          *standardize*: True if input data are to be standardized. If False, only centering will be
+          carried out.
 
         Attrs:
 
@@ -1694,6 +1696,7 @@ class PCA:
         self.numrows, self.numcols = n, m
         self.mu = a.mean(axis=0)
         self.sigma = a.std(axis=0)
+        self.standardize = standardize
 
         a = self.center(a)
 
@@ -1745,8 +1748,11 @@ class PCA:
 
 
     def center(self, x):
-        'center the data using the mean and sigma from training set a'
-        return (x - self.mu)/self.sigma
+        'center and optionally standardize the data using the mean and sigma from training set a'
+        if self.standardize:
+            return (x - self.mu)/self.sigma
+        else:
+            return (x - self.mu)
 
 
 


### PR DESCRIPTION
In principal component analysis, standardization of input data should be a user choice, depending on the problem at hand. The current version always standardizes, without offering a choice to the user. Therefore, I added an option to the PCA class where the user can specify whether the input data are to be standardized before performing the PCA. When _standardize_ is set to False, only centering is performed, without dividing by sigma. The default is to standardize, to remain compatible with the current version.
