### PR TITLE
Fixes legend.get_children() to actually return the real children of

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -754,13 +754,8 @@ class Legend(Artist):
         children = []
         if self._legend_box:
             children.append(self._legend_box)
-        children.extend(self.get_lines())
-        children.extend(self.get_patches())
-        children.extend(self.get_texts())
         children.append(self.get_frame())
 
-        if self._legend_title_box:
-            children.append(self.get_title())
         return children
 
     def get_frame(self):


### PR DESCRIPTION
legend while not including descendents who are children of other
objects (what would be grandchildren, great grandchildren, etc.)
