### PR TITLE
Added missing warnings import

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+import warnings
 from textwrap import fill
 
 


### PR DESCRIPTION
There is a warnings call around line 732, but as warnings is not imported, this fails.
