### PR TITLE
double_pendulum_animated.py in 1.2.1 fails due to clear_temp kwarg

### DIFF
--- a/examples/animation/double_pendulum_animated.py
+++ b/examples/animation/double_pendulum_animated.py
@@ -84,5 +84,5 @@ def animate(i):
 ani = animation.FuncAnimation(fig, animate, np.arange(1, len(y)),
     interval=25, blit=True, init_func=init)
 
-#ani.save('double_pendulum.mp4', fps=15, clear_temp=True)
+#ani.save('double_pendulum.mp4', fps=15)
 plt.show()


### PR DESCRIPTION
I added these lines to the top of the file (http://matplotlib.org/1.2.1/examples/animation/double_pendulum_animated.html):

```
from matplotlib import __version__
print("matplotlib version: {}".format(__version__))
import os
os.system('ffmpeg')
```

```
Python 2.7.5+ (default, Sep 19 2013, 13:48:49) 
Type "copyright", "credits" or "license" for more information.

IPython 1.1.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: run double_pendulum_animated.py
matplotlib version: 1.2.1
ffmpeg version 0.8.9-6:0.8.9-0ubuntu0.13.10.1, Copyright (c) 2000-2013 the Libav developers
  built on Nov  9 2013 19:09:46 with gcc 4.8.1
*** THIS PROGRAM IS DEPRECATED ***
This program is only provided for compatibility and will be removed in a future release. Please use avconv instead.
Hyper fast Audio and Video encoder
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...

Use -h to get full help or, even better, run 'man ffmpeg'
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/usr/local/lib/python2.7/dist-packages/IPython/utils/py3compat.pyc in execfile(fname, *where)
    202             else:
    203                 filename = fname
--> 204             __builtin__.execfile(filename, *where)

/home/moorepants/Desktop/double_pendulum_animated.py in <module>()
     90     interval=25, blit=True, init_func=init)
     91 
---> 92 ani.save('double_pendulum.ogv', fps=15, clear_temp=True)
     93 plt.show()

TypeError: save() got an unexpected keyword argument 'clear_temp'
```
