### PR TITLE
Cairo backend ignores alpha in imshow. 

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -468,17 +468,17 @@ class FigureCanvasCairo (FigureCanvasBase):
                                                  width_in_points)
 
         if format == 'ps':
-            if not cairo.HAS_PS_SURFACE:
+            if not hasattr(cairo, 'PSSurface'):
                 raise RuntimeError ('cairo has not been compiled with PS '
                                     'support enabled')
             surface = cairo.PSSurface (fo, width_in_points, height_in_points)
         elif format == 'pdf':
-            if not cairo.HAS_PDF_SURFACE:
+            if not hasattr(cairo, 'PDFSurface'):
                 raise RuntimeError ('cairo has not been compiled with PDF '
                                     'support enabled')
             surface = cairo.PDFSurface (fo, width_in_points, height_in_points)
         elif format in ('svg', 'svgz'):
-            if not cairo.HAS_SVG_SURFACE:
+            if not hasattr(cairo, 'SVGSurface'):
                 raise RuntimeError ('cairo has not been compiled with SVG '
                                     'support enabled')
             if format == 'svgz':


### PR DESCRIPTION
As indicated in #1188 there is a problem with rendering images with alpha != 1 in the cairo backend. 
The following code produces an image with alpha = 1 using the cairo backend
but the right alpha on the colorbar.

``` python
import matplotlib
matplotlib.use('cairo')
import numpy as np
import matplotlib.pyplot as plt

z = np.arange(150)
z.shape = (10,15)

fig, axs = plt.subplots(1,1)

ax = axs
im = ax.imshow(z, interpolation='nearest', alpha=0.3)
cbar = fig.colorbar(im, ax=ax)

plt.savefig("test2.png")
plt.savefig("test2.pdf")
plt.savefig("test2.svg")
plt.show()
```
