### PR TITLE
BUG : instantiate fall-back writer

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -702,7 +702,9 @@ class Animation(object):
                 warnings.warn("MovieWriter %s unavailable" % writer)
 
                 try:
-                    writer = writers.list()[0]
+                    writer = writers[writers.list()[0]](fps, codec, bitrate,
+                                                        extra_args=extra_args,
+                                                        metadata=metadata)
                 except IndexError:
                     raise ValueError("Cannot save animation: no writers are "
                                      "available. Please install mencoder or "


### PR DESCRIPTION
fixes #2651

If the a string is passed into save as `writer` the code tries to
look up a writer with that name and create it.  If a writer with that
name is not in the registry, it is replaced with the name of the first
writer that _is_ in the registry, but not an instance of that type.
