### PR TITLE
ENH : improve error invalid error message for subplot

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -901,6 +901,10 @@ class Figure(Artist):
 
         if len(args) == 1 and isinstance(args[0], int):
             args = tuple([int(c) for c in str(args[0])])
+            if len(args) != 3:
+                raise ValueError("Integer subplot specification must " +
+                                 "be a three digit number.  " +
+                                 "Not {n:d}".format(n=len(args)))
 
         if isinstance(args[0], SubplotBase):
 


### PR DESCRIPTION
Closes #2098

If user passes in a not-three-digit integer, raise `ValueError`
instead of letting the error propagate up from much farther down
the stack
