### PR TITLE
Use metric identifiers to parse an AFM character metric line

### DIFF
--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -197,15 +197,15 @@ def _parse_char_metrics(fh):
         line = line.rstrip()
         if line.startswith(b'EndCharMetrics'):
             return ascii_d, name_d
-        vals = filter(lambda s: s != '', line.split(b';'))  # Split into a list of metrics
-        vals = dict(map(lambda s: tuple(s.strip().split(' ', 1)), vals))  # Split out the metric identifier and use as key for a dictionary
-        if 'C' not in vals.keys() or 'WX' not in vals.keys() or 'N' not in vals.keys() or 'B' not in vals.keys() :
+        vals = filter(lambda s: s != b'', line.split(b';'))  # Split into a list of metrics
+        vals = dict(map(lambda s: tuple(s.strip().split(b' ', 1)), vals))  # Split out the metric identifier and use as key for a dictionary
+        if b'C' not in vals.keys() or b'WX' not in vals.keys() or b'N' not in vals.keys() or b'B' not in vals.keys() :
             raise RuntimeError('Bad char metrics line: %s' % line)
-        num = _to_int(vals['C'])
-        wx = _to_float(vals['WX'])
-        name = vals['N']
+        num = _to_int(vals[b'C'])
+        wx = _to_float(vals[b'WX'])
+        name = vals[b'N']
         name = name.decode('ascii')
-        bbox = _to_list_of_floats(vals['B'])
+        bbox = _to_list_of_floats(vals[b'B'])
         bbox = map(int, bbox)
         # Workaround: If the character name is 'Euro', give it the
         # corresponding character code, according to WinAnsiEncoding (see PDF

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -197,15 +197,16 @@ def _parse_char_metrics(fh):
         line = line.rstrip()
         if line.startswith(b'EndCharMetrics'):
             return ascii_d, name_d
-        vals = line.split(b';')[:4]
-        if len(vals) != 4:
+        vals = filter(lambda s: s != '', line.split(b';'))  # Split into a list of metrics
+        vals = dict(map(lambda s: tuple(s.strip().split(' ', 1)), vals))  # Split out the metric identifier and use as key for a dictionary
+        if 'C' not in vals.keys() or 'WX' not in vals.keys() or 'N' not in vals.keys() or 'B' not in vals.keys() :
             raise RuntimeError('Bad char metrics line: %s' % line)
-        num = _to_int(vals[0].split()[1])
-        wx = _to_float(vals[1].split()[1])
-        name = vals[2].split()[1]
+        num = _to_int(vals['C'])
+        wx = _to_float(vals['WX'])
+        name = vals['N']
         name = name.decode('ascii')
-        bbox = _to_list_of_floats(vals[3][2:])
-        bbox = list(map(int, bbox))
+        bbox = _to_list_of_floats(vals['B'])
+        bbox = map(int, bbox)
         # Workaround: If the character name is 'Euro', give it the
         # corresponding character code, according to WinAnsiEncoding (see PDF
         # Reference).

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -197,9 +197,11 @@ def _parse_char_metrics(fh):
         line = line.rstrip()
         if line.startswith(b'EndCharMetrics'):
             return ascii_d, name_d
-        vals = filter(lambda s: s != b'', line.split(b';'))  # Split into a list of metrics
-        vals = dict(map(lambda s: tuple(s.strip().split(b' ', 1)), vals))  # Split out the metric identifier and use as key for a dictionary
-        if b'C' not in vals.keys() or b'WX' not in vals.keys() or b'N' not in vals.keys() or b'B' not in vals.keys() :
+        # Split metric line into dictonary keyed by the metric identifiers
+        vals = filter(lambda s: s != b'', line.split(b';'))
+        vals = dict(map(lambda s: tuple(s.strip().split(b' ', 1)), vals))
+        # check for the required metrics
+        if any([id not in vals.keys() for id in (b'C', b'WX', b'N', b'B')]) :
             raise RuntimeError('Bad char metrics line: %s' % line)
         num = _to_int(vals[b'C'])
         wx = _to_float(vals[b'WX'])

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -194,20 +194,19 @@ def _parse_char_metrics(fh):
         line = fh.readline()
         if not line:
             break
-        line = line.rstrip()
-        if line.startswith(b'EndCharMetrics'):
+        line = line.rstrip().decode('ascii')  # Convert from byte-literal
+        if line.startswith('EndCharMetrics'):
             return ascii_d, name_d
-        # Split metric line into dictonary keyed by the metric identifiers
-        vals = filter(lambda s: s != b'', line.split(b';'))
-        vals = dict(map(lambda s: tuple(s.strip().split(b' ', 1)), vals))
-        # check for the required metrics
-        if any([id not in vals.keys() for id in (b'C', b'WX', b'N', b'B')]):
+        # Split the metric line into a dictonary, keyed by metric identifiers
+        vals = filter(lambda s: len(s) > 0, line.split(';'))
+        vals = dict(map(lambda s: tuple(s.strip().split(' ', 1)), vals))
+        # There may be other metrics present, but only these are needed
+        if any([id not in vals.keys() for id in ('C', 'WX', 'N', 'B')]):
             raise RuntimeError('Bad char metrics line: %s' % line)
-        num = _to_int(vals[b'C'])
-        wx = _to_float(vals[b'WX'])
-        name = vals[b'N']
-        name = name.decode('ascii')
-        bbox = _to_list_of_floats(vals[b'B'])
+        num = _to_int(vals['C'])
+        wx = _to_float(vals['WX'])
+        name = vals['N']
+        bbox = _to_list_of_floats(vals['B'])
         bbox = list(map(int, bbox))
         # Workaround: If the character name is 'Euro', give it the
         # corresponding character code, according to WinAnsiEncoding (see PDF

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -206,7 +206,7 @@ def _parse_char_metrics(fh):
         name = vals[b'N']
         name = name.decode('ascii')
         bbox = _to_list_of_floats(vals[b'B'])
-        bbox = map(int, bbox)
+        bbox = list(map(int, bbox))
         # Workaround: If the character name is 'Euro', give it the
         # corresponding character code, according to WinAnsiEncoding (see PDF
         # Reference).

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -201,7 +201,7 @@ def _parse_char_metrics(fh):
         vals = filter(lambda s: s != b'', line.split(b';'))
         vals = dict(map(lambda s: tuple(s.strip().split(b' ', 1)), vals))
         # check for the required metrics
-        if any([id not in vals.keys() for id in (b'C', b'WX', b'N', b'B')]) :
+        if any([id not in vals.keys() for id in (b'C', b'WX', b'N', b'B')]):
             raise RuntimeError('Bad char metrics line: %s' % line)
         num = _to_int(vals[b'C'])
         wx = _to_float(vals[b'WX'])


### PR DESCRIPTION
An AFM Character Metric line contains key-value pairs, with some of these being mandatory and some optional. Matplotlib currently parses this using absolute positions, but there are no guarantees as to the order of keys on a line. For example, a Chinese font converted through FontForge results in an AFM with the following Character Metric:

C 0 ; WX 1000 ; WY 1377 ; N uni5200 ; B 73 -131 890 665 ;

The solution is to make use of the keys when parsing the metrics. Parsing a line out into a dictionary, as below, is one straightforward way.

Cheers,
Jw