### PR TITLE
missing mask for scroll event

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -178,7 +178,8 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
                   Gdk.EventMask.ENTER_NOTIFY_MASK   |
                   Gdk.EventMask.LEAVE_NOTIFY_MASK   |
                   Gdk.EventMask.POINTER_MOTION_MASK |
-                  Gdk.EventMask.POINTER_MOTION_HINT_MASK)
+                  Gdk.EventMask.POINTER_MOTION_HINT_MASK|
+                  Gdk.EventMask.SCROLL_MASK)
 
     def __init__(self, figure):
         if _debug: print('FigureCanvasGTK3.%s' % fn_name())


### PR DESCRIPTION
This fixes https://github.com/matplotlib/matplotlib/issues/2668 
Apparently it is a know bug http://stackoverflow.com/questions/11775161/gtk3-get-mouse-scroll-direction https://bugzilla.gnome.org/show_bug.cgi?id=671305

Tried with example `examples/pylab_examples/image_slices_viewer.py` and works
