### PR TITLE
Xdg message repr

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -750,7 +750,7 @@ def matplotlib_fname():
                     "Found matplotlib configuration in ~/.matplotlib/. "
                     "To conform with the XDG base directory standard, "
                     "this configuration location has been deprecated "
-                    "on Linux, and the new location is now %r/matplotlib/. "
+                    "on Linux, and the new location is now %s/matplotlib/. "
                     "Please move your configuration there to ensure that "
                     "matplotlib will continue to find it in the future." %
                     _get_xdg_config_dir())


### PR DESCRIPTION
As it stands, I get quotes around the config directory when issued with the XDG warning - this PR fixes it. e.g.

```
..the new location is now '/home/pelson/.config'/matplotlib/. Please move your configuration there to ensure that...
```

Becomes

```
..the new location is now /home/pelson/.config/matplotlib/. Please move your configuration there to ensure that...
```
