### PR TITLE
ENH: Updated inset locator axes to return a HostAxes by default

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -7,8 +7,7 @@ from matplotlib.offsetbox import AnchoredOffsetbox
  #from matplotlib.transforms import IdentityTransform
 
 import matplotlib.transforms as mtrans
- #from matplotlib.axes import Axes
-from .mpl_axes import Axes
+from .parasite_axes import HostAxes  # subclasses mpl_axes
 
 from matplotlib.transforms import Bbox, TransformedBbox, IdentityTransform
 
@@ -261,7 +260,7 @@ def inset_axes(parent_axes, width, height, loc=1,
                 **kwargs):
 
     if axes_class is None:
-        axes_class = Axes
+        axes_class = HostAxes
 
     if axes_kwargs is None:
         inset_axes = axes_class(parent_axes.figure, parent_axes.get_position())
@@ -292,7 +291,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc=1,
                        **kwargs):
 
     if axes_class is None:
-        axes_class = Axes
+        axes_class = HostAxes
 
     if axes_kwargs is None:
         inset_axes = axes_class(parent_axes.figure, parent_axes.get_position())


### PR DESCRIPTION
This is better than mpl_axes as a default axes class to return for inset locator since the axes the inset functions return are located at plot time. The HostAxes subclasses mpl_axes so you still get the features of the mpl_axes (namely the AxisDict).
