### PR TITLE
BUGFIX: contour.py - add_label_near()

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -582,7 +582,7 @@ class ContourLabeler:
         paths = self.collections[conmin].get_paths()
         lc = paths[segmin].vertices
         if transform:
-            xcmin = transform.inverted().transform([xmin, ymin])
+            xcmin = transform.inverted().transform_point([xmin, ymin])
         else:
             xcmin = np.array([xmin, ymin])
         if not np.allclose(xcmin, lc[imin]):


### PR DESCRIPTION
`transform.inverted().transform([])` evoked an IndexError error:

```
/usr/local/lib/python2.7/dist-packages/matplotlib/transforms.pyc in transform_non_affine(self, points)
   2002             x_points = x.transform_non_affine(points)[:, 0:1]
   2003         else:
-> 2004             x_points = x.transform_non_affine(points[:, 0])
   2005             x_points = x_points.reshape((len(x_points), 1))
   2006 

IndexError: too many indices

```

calling `transform_point()` fixes the intended inverted transformation
