### PR TITLE
Python 3 METH_VARARGS with METH_KEYWORDS

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -3784,7 +3784,7 @@ static PyMethodDef FigureCanvas_methods[] = {
     },
     {"stop_event_loop",
      (PyCFunction)FigureCanvas_stop_event_loop,
-     METH_KEYWORDS | METH_VARARGS,
+     METH_NOARGS,
      "Stops the event loop that was started by start_event_loop.\n",
     },
     {NULL}  /* Sentinel */


### PR DESCRIPTION
Added `METH_VARARGS` to the method definition flags in __macosx.m_ as Python 3 requires `METH_VARARGS` to be set when `METH_KEYWORDS` is set. This is already the case where `METH_KEYWORDS` is used elsewhere, namely __ttconv.cpp_ and _cntr.c_.

Without this and executing within Python3 one will get the error
`SystemError: Bad call flags in PyCFunction_Call. METH_OLDARGS is no longer supported!`
