### PR TITLE
BUGFIX:  This change fixes #2475

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -581,7 +581,7 @@ class ContourLabeler:
         # be a vertex in the path. So, if it isn't, add a vertex here
         paths = self.collections[conmin].get_paths()
         lc = paths[segmin].vertices
-        xcmin = self.ax.transData.inverted().transform([xmin, ymin])
+        xcmin = self.ax.transData.inverted().transform_point([xmin, ymin])
         if not np.allclose(xcmin, lc[imin]):
             lc = np.r_[lc[:imin], np.array(xcmin)[None, :], lc[imin:]]
             paths[segmin] = mpath.Path(lc)


### PR DESCRIPTION
Adding contour labels added manually produce ugly spikes in the contours.  The problem was that screen
coordinates were being passed as data coordinates when the contour was split to add room for the label.  xcmin in the add_label_near() method should contain data coordinates, and if transform=False was used (as it does in the BlockingContourLabeler), they were left in screen coordinates, causing the new vertices of the clipped contours to be in the wrong location.
