### PR TITLE
WebAgg: Fix IPython detection.  Fix encoding error on Python 3

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -40,15 +40,6 @@ from matplotlib.figure import Figure
 from matplotlib._pylab_helpers import Gcf
 from . import backend_webagg_core as core
 
-# TODO: This should really only be set for the IPython notebook, but
-# I'm not sure how to detect that.
-try:
-    __IPYTHON__
-except:
-    _in_ipython = False
-else:
-    _in_ipython = True
-
 
 def new_figure_manager(num, *args, **kwargs):
     """


### PR DESCRIPTION
This is an alternative to #2832.

This fixes an error on Python 3 where byte strings can not be serialized to JSON.

This also removes `show()` as a way to display all figures inline in the IPython notebook.  This causes problems because:

1) In a regular IPython console, you want to start the plotting server blocking

2) In an IPython notebook, you don't

There is no way to detect which frontend you have for IPython -- in some cases, you may actually be using both.

So the solution here is to make `show()` always start a blocking server (and thus, it's only useful outside of the IPython notebook), and use the `Figure` repr to display an inline figure.
