### PR TITLE
DOC/ENH : get/set_size_inches

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -669,7 +669,7 @@ class Figure(Artist):
         size : ndarray
            The size of the figure in inches
 
-        Also See
+        See Also
         --------
 
         :func:`~matplotlib.Figure.set_size_inches`


### PR DESCRIPTION
Added links between `get_size_inches` and `set_size_inches`

Added an `np.array` call to `get_size_inches` to return a copy of
the size, instead of a reference to the internal np.array.

Closes #2303
