### PR TITLE
BUG : Qt repaint workaround on windows

### DIFF
--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -73,6 +73,22 @@ class FigureCanvasQTAgg( FigureCanvasQT, FigureCanvasAgg ):
         self.rect = []
         self.blitbox = None
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
+        # it has been reported that Qt is semi-broken in a windows
+        # environment.  If `self.draw()` uses `update` to trigger a
+        # system-level window repaint (as is explicitly advised in the
+        # Qt documentation) the figure responds very slowly to mouse
+        # input.  The work around is to directly use `repaint`
+        # (against the advice of the Qt documentation).  The
+        # difference between `update` and repaint is that `update`
+        # schedules a `repaint` for the next time the system is idle,
+        # where as `repaint` repaints the window immediately.  The
+        # risk is if `self.draw` gets called with in another `repaint`
+        # method there will be an infinite recursion.  Thus, we only
+        # expose windows users to this risk.
+        if sys.platform.startswith('win'):
+            self._priv_update = self.repaint
+        else:
+            self._priv_update = self.update
 
     def drawRectangle( self, rect ):
         self.rect = rect
@@ -152,7 +168,7 @@ class FigureCanvasQTAgg( FigureCanvasQT, FigureCanvasAgg ):
         # causes problems with code that uses the result of the
         # draw() to update plot elements.
         FigureCanvasAgg.draw(self)
-        self.update()
+        self._priv_update()
 
     def blit(self, bbox=None):
         """


### PR DESCRIPTION
Added platform specific replacement of `update` with `repaint` in
`FigureCanvasQtAgg.draw` for windows.
