### PR TITLE
WebAgg issue - Uncaught SyntaxError: Unexpected token & 

### DIFF
--- a/lib/matplotlib/backends/web_backend/all_figures.html
+++ b/lib/matplotlib/backends/web_backend/all_figures.html
@@ -8,60 +8,60 @@
 	<script src="{{ prefix }}/_static/jquery/js/jquery-ui.min.js"></script>
 	<script src="{{ prefix }}/_static/mpl.js"></script>
 	<script src="{{ prefix }}/{{ str(figures[0][0]) }}/mpl_interface.js"></script>
-	
+
 	<script>
 	var websocket_url_prefix = "{{ ws_uri }}";
 	var figures = new Array();
-	
+
     {% for (fig_id, _) in figures %}
         $(document).ready(
         function() {
-            fig = new figure({{ repr(str(fig_id)) }}, websocket_url_prefix);
+            fig = new figure("{{ fig_id }}", websocket_url_prefix);
             figures.push(fig);
-            
+
             fig.focus_on_mouseover = true;
-            
+
             var toolbar_prefix = '{{ str(fig_id).replace(' ', '') }}-toolbar';
             init_mpl_toolbar(fig, toolbar_prefix);
-            
+
             var statusbar_prefix = '{{ str(fig_id).replace(' ', '') }}-statusbar';
             var status_id = init_mpl_statusbar(toolbar_prefix, statusbar_prefix);
-            
+
             var canvas_prefix = '{{ str(fig_id).replace(' ', '') }}-canvas';
             init_mpl_canvas(fig, '{{ str(fig_id).replace(' ', '') }}-canvas-div', canvas_prefix);
-            
+
             fig.finalize(canvas_prefix, toolbar_prefix, statusbar_prefix);
-            
+
             $(fig.canvas).attr('tabindex', {{ fig_id }});
           }
         );
 
 	{% end %}
 	</script>
-	
-  <title>MPL | WebAgg current figures</title>	
+
+  <title>MPL | WebAgg current figures</title>
 
   </head>
   <body>
     <div id="mpl-warnings" class="mpl-warnings"></div>
     {% for (fig_id, fig_manager) in figures %}
         {% set fig_label='Figure: {}'.format(fig_manager.canvas.figure.get_label()) %}
-        
+
         {% if fig_label == 'Figure: ' %}
         {% set fig_label="Figure {}".format(fig_id) %}
         {% end %}
-        
+
     <div style="margin: 25px 100px;">
         <h2>
         <a href="{{ prefix }}/{{ str(fig_id) }}">
         {{ fig_label }}
-            
+
         </a>
         </h2>
        <div id="{{ str(fig_id).replace(' ', '') }}-canvas-div"></div>
        <div id="{{ str(fig_id).replace(' ', '') }}-toolbar" style="width: 700px;"></div>
     </div>
     {% end %}
-    
+
   </body>
 </html>


### PR DESCRIPTION
The following code (from http://matplotlib.org/users/pyplot_tutorial.html):

```
import matplotlib
matplotlib.use('webagg')

import matplotlib.pyplot as plt

plt.plot([1,2,3,4])
plt.ylabel('some numbers')
plt.show()
```

launches the Web server and browser pointing to http://127.0.0.1:8988/ OK, however there's an error in the Chrome's Console:

```
Uncaught SyntaxError: Unexpected token & 
```

The offending line is:

```
fig = new figure(&#39;1&#39;, websocket_url_prefix);
```

in the main HTML document, which seems to be from this template:

```
site-packages/matplotlib/backends/web_backend/all_figures.html 
```

which reads:

```
fig = new figure({{ repr(str(fig_id)) }}, websocket_url_prefix);
```

Removing the `repr` call above solves the issue - is there a reason behind it?

More info:
- Matplotlib

```
$ pip show matplotlib

---
Name: matplotlib
Version: 1.3.1
```
- Python 2.7.5+
- Chromium

```
Version 32.0.1700.107 Ubuntu 13.10 (32.0.1700.107-0ubuntu0.13.10.1~20140204.972.1)
```
