### PR TITLE
AttributeError: 'module' object has no attribute 'next'

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -126,6 +126,11 @@ def compare_versions(a, b):
     else:
         return False
 
+if not compare_versions(six.__version__, '1.5'):
+    raise ImportError(
+        'six 1.5 or later is required; you have %s' % (
+            six.__version__))
+
 try:
     import pyparsing
 except ImportError:

--- a/setupext.py
+++ b/setupext.py
@@ -1090,6 +1090,7 @@ class Tri(SetupPackage):
 
 class Six(SetupPackage):
     name = "six"
+    min_version = "1.5"
 
     def check(self):
         try:
@@ -1098,10 +1099,15 @@ class Six(SetupPackage):
             return (
                 "six was not found.")
 
+        if not is_min_version(six.__version__, self.min_version):
+            raise CheckFailed(
+                "Requires six %s or later.  Found %s." %
+                (self.min_version, version))
+
         return "using six version %s" % six.__version__
 
     def get_install_requires(self):
-        return ['six']
+        return ['six>={0}'.format(self.min_version)]
 
 
 class Dateutil(SetupPackage):


### PR DESCRIPTION
Came across this error while testing on my Ubuntu 12.02 LTS machine with a system install of six (version 1.1.0)

```
Traceback (most recent call last):
  File "2dcollections3d_demo.py", line 10, in <module>
    ax.plot(x, y, zs=0, zdir='z', label='zs=0, zdir=z')
  File "/home/ben/Programs/matplotlib/lib/mpl_toolkits/mplot3d/axes3d.py", line 1518, in plot
    lines = Axes.plot(self, xs, ys, *args[argsi:], **kwargs)
  File "/home/ben/Programs/matplotlib/lib/matplotlib/axes/_axes.py", line 1394, in plot
    for line in self._get_lines(*args, **kwargs):
  File "/home/ben/Programs/matplotlib/lib/matplotlib/axes/_base.py", line 303, in _grab_next_args
    for seg in self._plot_args(remaining, kwargs):
  File "/home/ben/Programs/matplotlib/lib/matplotlib/axes/_base.py", line 291, in _plot_args
    seg = func(x[:, j % ncx], y[:, j % ncy], kw, kwargs)
  File "/home/ben/Programs/matplotlib/lib/matplotlib/axes/_base.py", line 236, in _makeline
    kw['color'] = six.next(self.color_cycle)
AttributeError: 'module' object has no attribute 'next'
```

Perhaps we need to set a minimum version of six?
