### PR TITLE
GTK3 backend: implemented FigureCanvasBase.resize_event()

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -200,6 +200,7 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         self.connect('motion_notify_event',  self.motion_notify_event)
         self.connect('leave_notify_event',   self.leave_notify_event)
         self.connect('enter_notify_event',   self.enter_notify_event)
+        self.connect('size_allocate',        self.size_allocate)
 
         self.set_events(self.__class__.event_mask)
 
@@ -274,6 +275,17 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
 
     def enter_notify_event(self, widget, event):
         FigureCanvasBase.enter_notify_event(self, event)
+
+    def size_allocate(self, widget, allocation):
+        if _debug:
+            print("FigureCanvasGTK3.%s" % fn_name())
+            print("size_allocate (%d x %d)" % (allocation.width, allocation.height))
+        dpival = self.figure.dpi
+        winch = allocation.width / dpival
+        hinch = allocation.height / dpival
+        self.figure.set_size_inches(winch, hinch)
+        FigureCanvasBase.resize_event(self)
+        self.draw_idle()
 
     def _get_key(self, event):
         if event.keyval in self.keyvald:


### PR DESCRIPTION
This pull request implements the FigureCanvasBase.resize_event() to the GTK3 backend, which will allow to connect to mpl_connect("resize_event", func).

Consider following animation example:

``` python
# Modified example from http://matplotlib.org/examples/animation/simple_anim.html
import numpy as np
import matplotlib as mpl
import matplotlib.animation as animation
from matplotlib.backends.backend_gtk3agg import FigureCanvasGTK3Agg as FigureCanvas

from gi.repository import Gtk

class TestWindow(Gtk.Window):
    def __init__(self):
        Gtk.Window.__init__(self)
        self.resize(600, 400)

        figure = mpl.figure.Figure()
        canvas = FigureCanvas(figure)
        self.add(canvas)
        self.show_all()

        x = np.arange(0, 2*np.pi, 0.01)

        ax1 = figure.add_subplot(121)
        line1, = ax1.plot(x, np.sin(x))

        ax2 = figure.add_subplot(122)
        line2, = ax2.plot(x, np.sin(x))

        def animate(i):
            line1.set_ydata(np.sin(x+i/10.0))
            line2.set_ydata(np.sin(x+i/10.0))
            return line1, line2

        def init():
            line1.set_ydata(np.ma.array(x, mask=True))
            line2.set_ydata(np.ma.array(x, mask=True))
            return line1, line2

        self.ani = animation.FuncAnimation(figure, animate, np.arange(1, 200), init_func=init,
                                           interval=25, blit=True)

if __name__ == "__main__":
    win = TestWindow()
    win.connect("delete-event", Gtk.main_quit)
    Gtk.main()
```

Without the patch, resize the window to see major redraw issues which makes the plot unusable. When using the blit option, the animation will connect to the resize_event signal to correctly redraw the plot when resized, which isn't available in the GTK3 backend. With the changes applied, resizing works without problems.

The patch is inspired by the Qt4 and wx backends, but comments from someone with more Matplotlib experience is greatly appreciated.
