### PR TITLE
Fix for issue #2872. Skip NaN's in draw_path_collection.

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1619,6 +1619,8 @@ GraphicsContext_draw_path_collection (GraphicsContext* self, PyObject* args)
                 translation.x = - (origin.x - translation.x);
                 translation.y = - (origin.y - translation.y);
             }
+            /* in case of missing values, translation may contain NaN's */
+            if (!isfinite(translation.x) || !isfinite(translation.y)) continue;
             CGContextTranslateCTM(cr, translation.x, translation.y);
         }
 


### PR DESCRIPTION
See issue #2872. In case of missing values (e.g., zeros when using a logarithmic scale), draw_path_collection may get offsets containing NaN's. In that case, using CGContextTranslateCTM once with translation and once with -translation will not restore the original CTM. This bugfix adds a check for NaN/inf.
