### PR TITLE
Added called process error to __all__

### DIFF
--- a/lib/matplotlib/compat/subprocess.py
+++ b/lib/matplotlib/compat/subprocess.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 import subprocess
 
-__all__ = ['Popen', 'PIPE', 'STDOUT', 'check_output']
+__all__ = ['Popen', 'PIPE', 'STDOUT', 'check_output', 'CalledProcessError']
 
 
 if hasattr(subprocess, 'Popen'):


### PR DESCRIPTION
Fixes missed variable in compatibility layer which was causing importing subprocess to fail in some cases.
