### PR TITLE
fix a bug introduced in c998561d6cc1236

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -335,7 +335,7 @@ def compare_images(expected, actual, tol, in_decorator=False):
     save_diff_image(expected, actual, diff_image)
 
     results = dict(rms=rms, expected=str(expected),
-                   actual=str(actual), diff=str(diff_image))
+                   actual=str(actual), diff=str(diff_image), tol=tol)
 
     if not in_decorator:
         # Then the results should be a string suitable for stdout.


### PR DESCRIPTION
changing the message formatting to use previously assembled results
dictionary broke due to the tolerance not being included in the results
dictionary.
