### PR TITLE
Fix animation errors

### DIFF
--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -2168,6 +2168,7 @@ RendererAgg::write_rgba(const Py::Tuple& args)
     }
     else
     {
+        PyErr_Clear();
         PyObject* write_method = PyObject_GetAttrString(py_fileobj.ptr(),
                                                         "write");
         if (!(write_method && PyCallable_Check(write_method)))


### PR DESCRIPTION
Three changes: use 'y#' in python 3, ignore errors from AsFileDescriptor (to allow use of BytesIO and similarly brain-dead objects as the target), and don't require setting of the position of the file handle to succeed (so that we can use streams).

Fixes #1891 
