### PR TITLE
Cairo: fix TypeError in figure.text() on Python3

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -215,7 +215,7 @@ class RendererCairo(RendererBase):
                 if isinstance(s, six.text_type):
                     s = s.encode("utf-8")
 
-            ctx.show_text(s)
+            ctx.show_text(s.decode())
             ctx.restore()
 
     def _draw_mathtext(self, gc, x, y, s, prop, angle):


### PR DESCRIPTION
Possible fix for https://github.com/matplotlib/matplotlib/issues/2903
