### PR TITLE
Fix Cairo text on Python3 with pycairo

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -212,7 +212,7 @@ class RendererCairo(RendererBase):
                 if not isinstance(s, six.text_type):
                     s = six.text_type(s)
             else:
-                if isinstance(s, six.text_type):
+                if not six.PY3 and isinstance(s, six.text_type):
                     s = s.encode("utf-8")
 
             ctx.show_text(s)


### PR DESCRIPTION
There are three possible cairo wrappers that we support: `py2cairo` on Python 2.x, `pycairo` on Python 3.x and `cairocffi` on both.  Unfortunately, they want to receive strings differently.  `py2cairo` expects them as utf-8-encoding byte strings.  The other two expect Python unicode strings.

This fixes the one case we missed in the recent changes to support cairocffi: when on Python 3.x with pycairo, we need to give the wrapper unicode strings.

Replaces #2905.  Fixes #2903.
