### PR TITLE
BUG : don't use mutable objects as dictionary keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2014-06-07 Fixed bug so radial plots can be saved as ps in py3k.
+
 2014-06-01 Changed the fmt kwarg of errorbar to support the
            the mpl convention that "none" means "don't draw it",
            and to default to the empty string, so that plotting

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -554,15 +554,16 @@ grestore
         return ps
 
     def _get_clip_path(self, clippath, clippath_transform):
-        id = self._clip_paths.get((clippath, clippath_transform))
-        if id is None:
-            id = 'c%x' % len(self._clip_paths)
-            ps_cmd = ['/%s {' % id]
+        key = (clippath, id(clippath_transform))
+        pid = self._clip_paths.get(key)
+        if pid is None:
+            pid = 'c%x' % len(self._clip_paths)
+            ps_cmd = ['/%s {' % pid]
             ps_cmd.append(self._convert_path(clippath, clippath_transform,
                                              simplify=False))
             ps_cmd.extend(['clip', 'newpath', '} bind def\n'])
             self._pswriter.write('\n'.join(ps_cmd))
-            self._clip_paths[(clippath, clippath_transform)] = id
+            self._clip_paths[key] = pid
         return id
 
     def draw_path(self, gc, path, transform, rgbFace=None):


### PR DESCRIPTION
Base key on the string version of the transform matrix

This addresses the core issue (we are trying to use a mutable object as a key) instead of breaking the data-model in one of two ways.

Closes #2828

Alternate to #2909
