### PR TITLE
clip_on documentation note/warning

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -644,8 +644,8 @@ class Artist(object):
         """
         Set whether artist uses clipping.
 
-        When False, If figure range and data range don't line up
-        the Artist it might run off and produce unexpected results.
+        When False artists will be visible out side of the axes which 
+        can lead to unexpected results.
 
         ACCEPTS: [True | False]
         """


### PR DESCRIPTION
This try to fix the comment on PR https://github.com/matplotlib/matplotlib/pull/2837

Warning:
I didn't even knew the `clip_on` existence and I'm not sure I am describing the results correctly. 
I am just paraphrasing @tacaswell from https://stackoverflow.com/questions/21615285/how-to-not-cut-flatten-lines-when-moving-the-spines-in-matplotlib/21617349#21617349
