### PR TITLE
Added center and frame arguments for pie-charts

### DIFF
--- a/examples/pie_and_polar_charts/pie_demo_features.py
+++ b/examples/pie_and_polar_charts/pie_demo_features.py
@@ -18,7 +18,6 @@ positive y-axis.
 """
 import matplotlib.pyplot as plt
 
-
 # The slices will be ordered and plotted counter-clockwise.
 labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
 sizes = [15, 30, 45, 10]
@@ -29,4 +28,35 @@ plt.pie(sizes, explode=explode, labels=labels, colors=colors,
         autopct='%1.1f%%', shadow=True, startangle=90)
 # Set aspect ratio to be equal so that pie is drawn as a circle.
 plt.axis('equal')
+
+fig = plt.figure()
+ax = fig.gca()
+import numpy as np
+
+ax.pie(np.random.random(4), explode=explode, labels=labels, colors=colors,
+        autopct='%1.1f%%', shadow=True, startangle=90, 
+       radius=0.25, center=(0,0),frame=True)
+ax.pie(np.random.random(4), explode=explode, labels=labels, colors=colors,
+        autopct='%1.1f%%', shadow=True, startangle=90, 
+       radius=0.25, center=(1,1),frame=True)
+ax.pie(np.random.random(4), explode=explode, labels=labels, colors=colors,
+        autopct='%1.1f%%', shadow=True, startangle=90, 
+       radius=0.25, center=(0,1),frame=True)
+ax.pie(np.random.random(4), explode=explode, labels=labels, colors=colors,
+        autopct='%1.1f%%', shadow=True, startangle=90, 
+       radius=0.25, center=(1,0),frame=True)
+
+ax.set_xticks([0,1])
+ax.set_yticks([0,1])
+ax.set_xticklabels(["Sunny","Cloudy"])
+ax.set_yticklabels(["Dry","Rainy"])
+ax.set_xlim((-0.5,1.5))
+ax.set_ylim((-0.5,1.5))
+
+# Set aspect ratio to be equal so that pie is drawn as a circle.
+ax.set_aspect('equal')
+
+
+
+
 plt.show()

--- a/lib/matplotlib/axes.py
+++ b/lib/matplotlib/axes.py
@@ -5312,7 +5312,8 @@ class Axes(martist.Artist):
 
     def pie(self, x, explode=None, labels=None, colors=None,
             autopct=None, pctdistance=0.6, shadow=False,
-            labeldistance=1.1, startangle=None, radius=None):
+            labeldistance=1.1, startangle=None, radius=None,
+            center = (0, 0), frame=False ):
         r"""
         Plot a pie chart.
 
@@ -5321,7 +5322,8 @@ class Axes(martist.Artist):
           pie(x, explode=None, labels=None,
               colors=('b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'),
               autopct=None, pctdistance=0.6, shadow=False,
-              labeldistance=1.1, startangle=None, radius=None)
+              labeldistance=1.1, startangle=None, radius=None, 
+              center = (0, 0) )
 
         Make a pie chart of array *x*.  The fractional area of each
         wedge is given by x/sum(x).  If sum(x) <= 1, then the values
@@ -5366,6 +5368,12 @@ class Axes(martist.Artist):
           *radius*: [ *None* | scalar ]
           The radius of the pie, if *radius* is *None* it will be set to 1.
 
+          *center*: [ (0,0) | sequence of 2 scalars ]
+          Center position of the chart.
+
+          *frame*: [ *False* | *True* ]
+            Plot axes frame with the chart.
+
         The pie chart will probably look best if the figure and axes are
         square, or the Axes aspect is equal.  e.g.::
 
@@ -5391,7 +5399,6 @@ class Axes(martist.Artist):
           :class:`~matplotlib.text.Text` instances for the numeric
           labels.
         """
-        self.set_frame_on(False)
 
         x = np.asarray(x).astype(np.float32)
 
@@ -5408,7 +5415,7 @@ class Axes(martist.Artist):
         if colors is None:
             colors = ('b', 'g', 'r', 'c', 'm', 'y', 'k', 'w')
 
-        center = 0, 0
+        
         if radius is None:
             radius = 1
 
@@ -5477,10 +5484,12 @@ class Axes(martist.Artist):
             theta1 = theta2
             i += 1
 
-        self.set_xlim((-1.25, 1.25))
-        self.set_ylim((-1.25, 1.25))
-        self.set_xticks([])
-        self.set_yticks([])
+        if not frame:
+            self.set_frame_on(False)
+            self.set_xlim((-1.25, 1.25))
+            self.set_ylim((-1.25, 1.25))
+            self.set_xticks([])
+            self.set_yticks([])
 
         if autopct is None:
             return slices, texts

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2955,7 +2955,7 @@ def pcolormesh(*args, **kwargs):
 @_autogen_docstring(Axes.pie)
 def pie(x, explode=None, labels=None, colors=None, autopct=None,
         pctdistance=0.6, shadow=False, labeldistance=1.1, startangle=None,
-        radius=None, hold=None):
+        radius=None, hold=None,center=(0,0),frame=False):
     ax = gca()
     # allow callers to override the hold state by passing hold=True|False
     washold = ax.ishold()
@@ -2966,7 +2966,7 @@ def pie(x, explode=None, labels=None, colors=None, autopct=None,
         ret = ax.pie(x, explode=explode, labels=labels, colors=colors,
                      autopct=autopct, pctdistance=pctdistance, shadow=shadow,
                      labeldistance=labeldistance, startangle=startangle,
-                     radius=radius)
+                     radius=radius,center=center,frame=frame)
         draw_if_interactive()
     finally:
         ax.hold(washold)


### PR DESCRIPTION
Simple UI extension to make ax.pie more generally applicable. Allow definition of center coordinate of the pie and allow retaining the axes frame.  The default behavior is not changed.
