### PR TITLE
Type of offset is int, not pointer.

### DIFF
--- a/extern/CXX/Python2/Objects.hxx
+++ b/extern/CXX/Python2/Objects.hxx
@@ -1130,7 +1130,7 @@ namespace Py
         // TMM: added this seqref ctor for use with STL algorithms
         seqref (Object& obj)
             : s(dynamic_cast< SeqBase<T>&>(obj))
-            , offset( NULL )
+            , offset( 0 )
             , the_item(s.getItem(offset))
         {}
         ~seqref()


### PR DESCRIPTION
Implicit NULL == 0 is less... desirable.
