### PR TITLE
py3k fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-04-08 Fixed a bug in parasite_axes.py by making a list out
+           of a generator at line 263.
+	   
 2014-02-25 In backend_qt4agg changed from using update -> repaint under
 	   windows.  See comment in source near `self._priv_update` for
 	   longer explaination.

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -260,7 +260,7 @@ class HostAxesBase:
 
     def _get_legend_handles(self, legend_handler_map=None):
         Axes_get_legend_handles = self._get_base_axes_attr("_get_legend_handles")
-        all_handles = Axes_get_legend_handles(self, legend_handler_map)
+        all_handles = list(Axes_get_legend_handles(self, legend_handler_map))
 
         for ax in self.parasites:
             all_handles.extend(ax._get_legend_handles(legend_handler_map))


### PR DESCRIPTION
Hi,

This is probably not the right way to fix this issue, but I would like to draw attention to this bug when using parasite_axes.py on python3.3.

The legend handler was returning an

``` python
AttributeError: 'generator' object has no attribute 'extend'
```

Thanks for matplotlib!

-Filipe
