### PR TITLE
add 'buttons' parameter in LassoSelector and SpanSelector

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -528,7 +528,12 @@ class CallbackRegistry:
             for cid, proxy in list(six.iteritems(self.callbacks[s])):
                 # Clean out dead references
                 if proxy.inst is not None and proxy.inst() is None:
-                    del self.callbacks[s][cid]
+                    try:
+                        del self.callbacks[s][cid]
+                    except KeyError:
+                        # Perhaps other handlers have disconnected peer
+                        # callbacks.  Let KeyError's pass silently.
+                        pass
                 else:
                     proxy(*args, **kwargs)
 


### PR DESCRIPTION
It seems to me that the RectangleSelector, LassoSelector and SpanSelector are similar and could expose a more similar API.  This PR moves in this direction by adding a 'buttons' parameter in LassoSelector and SpanSelector with semantics identical to the RectangleSelector.

The purpose of this PR is to request feedback on the philosophy of the design and the changes.  Currently, I think the changes here don't maintain the backwards compatibility quite as much as it could.  Further actions in this philosophy would be default the line and rect styles in a consistent way for all of them.
