### PR TITLE
TST: __spec__ (an import-related variable for modules) was added in pyth...

### DIFF
--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -25,6 +25,7 @@ def test_override_builtins():
         '__doc__',
         '__package__',
         '__loader__',
+        '__spec__',
         'any',
         'all',
         'sum'


### PR DESCRIPTION
...on 3.4. Need to exclude in test_override_builtins. This addresses issue #2842
