### PR TITLE
let KeyErrors pass silently on callback removal

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -528,7 +528,12 @@ class CallbackRegistry:
             for cid, proxy in list(six.iteritems(self.callbacks[s])):
                 # Clean out dead references
                 if proxy.inst is not None and proxy.inst() is None:
-                    del self.callbacks[s][cid]
+                    try:
+                        del self.callbacks[s][cid]
+                    except KeyError:
+                        # Perhaps other handlers have disconnected peer
+                        # callbacks.  Let KeyError's pass silently.
+                        pass
                 else:
                     proxy(*args, **kwargs)
 


### PR DESCRIPTION
I've run into a spurious KeyError when I remove an event connection during another event.  This patch fixes that by letting it pass silently.  I don't have a failing test written as the contribution guidelines request; I'm hoping this commit can be accepted despite that as it is pretty innocent & writing such a test seems to be breaking very new ground -- there is only one test containing "mpl_connect" and simulating events with-out picking a backend is unknown to me.
