### PR TITLE
Minor fixes in _macosx.m

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -203,6 +203,7 @@ static int wait_for_stdin(void)
         if (interrupted) raise(SIGINT);
     }
     CFReadStreamClose(stream);
+    CFRelease(stream);
     return 1;
 }
 
@@ -2103,6 +2104,7 @@ _shade_one_color(CGContextRef cr, CGFloat colors[3], CGPoint points[3], int icol
                                                     function,
                                                     true,
                                                     true);
+        CGColorSpaceRelease(colorspace);
         CGFunctionRelease(function);
         if (shading)
         {
@@ -2236,6 +2238,7 @@ _shade_alpha(CGContextRef cr, CGFloat alphas[3], CGPoint points[3])
     CGImageRef mask = CGBitmapContextCreateImage(bitmap);
     CGContextClipToMask(cr, rect, mask);
     CGImageRelease(mask);
+    CGContextRelease(bitmap);
     free(data);
     return 0;
 }
@@ -3990,9 +3993,9 @@ FigureManager_set_window_title(FigureManager* self,
     if(window)
     {
         NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-        NSString* ns_title = [[NSString alloc]
-                              initWithCString: title
-                              encoding: NSUTF8StringEncoding];
+        NSString* ns_title = [[[NSString alloc]
+                               initWithCString: title
+                               encoding: NSUTF8StringEncoding] autorelease];
         [window setTitle: ns_title];
         [pool release];
     }


### PR DESCRIPTION
A couple warnings from clang: in one place it thinks an array is uninitialized, and a few resources don't get released. There are also a few warnings about missing [(super or self) init...] but I don't understand Cocoa sufficiently to know what to do about them.

Perhaps @mdehoon could review this?
