### PR TITLE
PGF backend: Fix vertical positioning of multi-line text

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-04-28 Fix multi-line text with the PGF backend. Previously all lines were
+           rendered in the same position.
+
 2014-04-22 Added an example showing the difference between 
 	   interpolation = 'none' and interpolation = 'nearest' in
 	   `imshow()` when saving vector graphics files.


### PR DESCRIPTION
This addresses issue #3000. The horizontal aligment is maintained, but for multi-line text the vertical alignment is applied manually in a similar way to the SVG backend.
