### PR TITLE
The FreeType extension defines add_flags, but is never called.  This

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -386,6 +386,12 @@ class SetupPackage(object):
         """
         return None
 
+    def add_flags(self, ext):
+        """
+        Add any extension specific flags.
+        """
+        return
+
     def get_install_requires(self):
         """
         Get a list of Python packages that we require.
@@ -438,6 +444,7 @@ class SetupPackage(object):
         ext = self.get_extension()
         if ext is None:
             ext = make_extension('test', [])
+            self.add_flags(ext)
             pkg_config.setup_extension(ext, package)
 
         check_include_file(ext.include_dirs, include_file, package)


### PR DESCRIPTION
On MacOSX using Macports with the freetype package installed setup fails to find the freetype headers.

The bug is a failure to call add_flags when creating the FreeType extension.  This small patch fixes it.

I've attached the output of setup before the fix, as you can see freetype2 is installed in /opt/local/include, but fails to be found.

(wst)haku-2:matplotlib kirat$ uname -a
Darwin haku-2.local 13.1.0 Darwin Kernel Version 13.1.0: Wed Apr  2 23:52:02 PDT 2014; root:xnu-2422.92.1~2/RELEASE_X86_64 x86_64
(wst)haku-2:matplotlib kirat$ python --version
Python 3.4.0
(wst)haku-2:matplotlib kirat$ ls /opt/local/include/freetype2/
config                    ftautoh.h ftbzip2.h   ftcid.h     ftglyph.h   ftincrem.h  ftmac.h     ftotval.h ftsizes.h ftsystem.h ftwinfnt.h tttables.h
freetype.h            ftbbox.h  ftcache.h   fterrdef.h  ftgxval.h   ftlcdfil.h  ftmm.h            ftoutln.h ftsnames.h fttrigon.h ftxf86.h tttags.h
ft2build.h            ftbdf.h           ftcffdrv.h  fterrors.h  ftgzip.h    ftlist.h          ftmodapi.h           ftpfr.h         ftstroke.h ftttdrv.h t1tables.h ttunpat.h
ftadvanc.h            ftbitmap.h        ftchapters.h    ftgasp.h    ftimage.h   ftlzw.h                        ftmoderr.h      ftrender.h ftsynth.h fttypes.h  ttnameid.h
# (wst)haku-2:matplotlib kirat$ python setup.py

Edit setup.cfg to change the build options

BUILDING MATPLOTLIB
            matplotlib: yes [1.4.x]
                python: yes [3.4.0 (default, Mar 25 2014, 11:07:05)  [GCC
                        4.2.1 Compatible Apple LLVM 5.1 (clang-503.0.38)]]
              platform: yes [darwin]

REQUIRED DEPENDENCIES AND EXTENSIONS
                 numpy: yes [version 1.8.1]
                   six: yes [using six version 1.6.1]
              dateutil: yes [dateutil was not found. It is required for date
                        axis support. pip/easy_install may attempt to
                        install it after matplotlib.]
               tornado: yes [tornado was not found. It is required for the
                        WebAgg backend. pip/easy_install may attempt to
                        install it after matplotlib.]
             pyparsing: yes [pyparsing was not found. It is required for
                        mathtext support. pip/easy_install may attempt to
                        install it after matplotlib.]
                 pycxx: yes [Official versions of PyCXX are not compatible
                        with Python 3.x.  Using local copy]
                libagg: yes [pkg-config information for 'libagg' could not
                        be found. Using local copy.]
              freetype: no  [The C/C++ header for freetype2 (ft2build.h)
                        could not be found.  You may need to install the
                        development package.]
                   png: yes [pkg-config information for 'libpng' could not
                        be found. Using unknown version.]
                 qhull: yes [pkg-config information for 'qhull' could not be
                        found. Using local copy.]

OPTIONAL SUBPACKAGES
           sample_data: yes [installing]
              toolkits: yes [installing]
                 tests: yes [nose 0.11.1 or later is required to run the
                        matplotlib test suite.  pip/easy_install may attempt
                        to install it after matplotlib. / using
                        unittest.mock]

OPTIONAL BACKEND EXTENSIONS
                macosx: yes [installing, darwin]
                qt4agg: no  [PyQt4 not found]
               gtk3agg: no  [gtk3agg backend does not work on Python 3]
             gtk3cairo: no  [Requires cairocffi or pycairo to be installed.]
                gtkagg: no  [Requires pygtk]
                 tkagg: no  [TKAgg requires Tkinter.]
                 wxagg: no  [requires wxPython]
                   gtk: no  [Requires pygtk]
                   agg: yes [installing]
                 cairo: no  [cairocffi or pycairo not found]
             windowing: no  [Microsoft Windows only]

OPTIONAL LATEX DEPENDENCIES
                dvipng: no
           ghostscript: no
                 latex: no
               pdftops: no
# 

```
                    * The following required packages can not be built:
                    * freetype
```

(wst)haku-2:matplotlib kirat$ 
