### PR TITLE
BUG : improved input clean up in Axes.{h|v}line

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
-2014-04-22 Added an example showing the difference between 
+2014-04-27 Improved input clean up in Axes.{h|v}lines
+	   Coerce input into a 1D ndarrays (after dealing with units).
+
+2014-04-22 Added an example showing the difference between
 	   interpolation = 'none' and interpolation = 'nearest' in
 	   `imshow()` when saving vector graphics files.
 
@@ -7,7 +10,7 @@
 
 2014-04-08 Fixed a bug in parasite_axes.py by making a list out
            of a generator at line 263.
-	   
+
 2014-02-25 In backend_qt4agg changed from using update -> repaint under
 	   windows.  See comment in source near `self._priv_update` for
 	   longer explaination.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -955,19 +955,10 @@ class Axes(_AxesBase):
         if not iterable(xmax):
             xmax = [xmax]
 
-        y = np.asarray(y)
-        xmin = np.asarray(xmin)
-        xmax = np.asarray(xmax)
+        y = np.ravel(y)
 
-        if len(xmin) == 1:
-            xmin = np.resize(xmin, y.shape)
-        if len(xmax) == 1:
-            xmax = np.resize(xmax, y.shape)
-
-        if len(xmin) != len(y):
-            raise ValueError('xmin and y are unequal sized sequences')
-        if len(xmax) != len(y):
-            raise ValueError('xmax and y are unequal sized sequences')
+        xmin = np.resize(xmin, y.shape)
+        xmax = np.resize(xmax, y.shape)
 
         verts = [((thisxmin, thisy), (thisxmax, thisy))
                  for thisxmin, thisxmax, thisy in zip(xmin, xmax, y)]
@@ -1044,23 +1035,12 @@ class Axes(_AxesBase):
         if not iterable(ymax):
             ymax = [ymax]
 
-        x = np.asarray(x)
-        ymin = np.asarray(ymin)
-        ymax = np.asarray(ymax)
-        if len(ymin) == 1:
-            ymin = np.resize(ymin, x.shape)
-        if len(ymax) == 1:
-            ymax = np.resize(ymax, x.shape)
-
-        if len(ymin) != len(x):
-            raise ValueError('ymin and x are unequal sized sequences')
-        if len(ymax) != len(x):
-            raise ValueError('ymax and x are unequal sized sequences')
-
-        Y = np.array([ymin, ymax]).T
+        x = np.ravel(x)
+        ymin = np.resize(ymin, x.shape)
+        ymax = np.resize(ymax, x.shape)
 
         verts = [((thisx, thisymin), (thisx, thisymax))
-                 for thisx, (thisymin, thisymax) in zip(x, Y)]
+                 for thisx, thisymin, thisymax in zip(x, ymin, ymax)]
         #print 'creating line collection'
         coll = mcoll.LineCollection(verts, colors=colors,
                                     linestyles=linestyles, label=label)


### PR DESCRIPTION
- passing in a (N, 1) shaped array as input causes the zipping to
  generate an extra dimension
- use squeeze to get rid of useless dimensions
- use atleast_1d to make sure scalars remain 1D ((1, ) vs () shape)
- closes #2197

@efiring I suspect there is a better way to do this.
