### PR TITLE
Fix documentation of entropy function

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1525,11 +1525,11 @@ def cohere_pairs( X, ij, NFFT=256, Fs=2, detrend=detrend_none,
 
 def entropy(y, bins):
     r"""
-    Return the entropy of the data in *y*.
+    Return the entropy of the data in *y* in units of nat.
 
     .. math::
 
-      \sum p_i \log_2(p_i)
+      -\sum p_i \ln(p_i)
 
     where :math:`p_i` is the probability of observing *y* in the
     :math:`i^{th}` bin of *bins*.  *bins* can be a number of bins or a


### PR DESCRIPTION
Fix the documentation of the entropy function to correct the formula so
it reflects the calculation used in the code. Also mention the unit of
the value returned,

See also this stackoverflow question: [Matplotlib mlab entropy calculation incorrect?](http://stackoverflow.com/questions/23291576/matplotlib-mlab-entropy-calculation-incorrect)
