### PR TITLE
mpl issue: #2974 - documentation corrected

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2558,7 +2558,7 @@ class Axes(_AxesBase):
 
           *ecolor*: [ *None* | mpl color ]
             A matplotlib color arg which gives the color the errorbar lines;
-            if *None*, use the marker color.
+            if *None*, use the color of the line connecting the markers.
 
           *elinewidth*: scalar
             The linewidth of the errorbar lines. If *None*, use the linewidth.


### PR DESCRIPTION
A minor change to the documentation to reflect the color of the errorbar edges in case the parameter supplied is 'None'.
