### PR TITLE
avoid np.nan values in colors array returned by axes3d._shade_colors

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1678,10 +1678,10 @@ class Axes3D(Axes):
                           if proj3d.mod(n) else np.nan
                           for n in normals])
         mask = ~np.isnan(shade)
-        shade[~mask] = 0
 
         if len(shade[mask]) > 0:
             norm = Normalize(min(shade[mask]), max(shade[mask]))
+            shade[~mask] = min(shade[mask])
             color = colorConverter.to_rgba_array(color)
             # shape of color should be (M, 4) (where M is number of faces)
             # shape of shade should be (M,)


### PR DESCRIPTION
Fix bug in Axes3D._shade_colors 

There is a problem with handling NaN values in the shade array in on line 1677 in axes3d.py. If proj3d.mod(n) the corresponding value in shade is nan, and it is masked out from the shade array using `mask` on lines 1681 - 1682 but not line 1688. As a result the colors array will include nan values, and the following warnings are displayed when for example calling the `bar3d` function

```
.../lib/python3.4/site-packages/matplotlib-1.4.x-py3.4-linux-x86_64.egg/mpl_toolkits/mplot3d/axes3d.py:1679: RuntimeWarning: invalid value encountered in true_divide
    for n in normals])
.../lib/python3.4/site-packages/matplotlib-1.4.x-py3.4-linux-x86_64.egg/matplotlib/colors.py:401: RuntimeWarning: invalid value encountered in greater
    if (c.ravel() > 1).any() or (c.ravel() < 0).any():
.../python3.4/site-packages/matplotlib-1.4.x-py3.4-linux-x86_64.egg/matplotlib/colors.py:401: RuntimeWarning: invalid value encountered in less
    if (c.ravel() > 1).any() or (c.ravel() < 0).any():
```

(because here the array c includes nan values and the comparison operations fail).

This PR fixes this by avoiding nan in the shades array in Axes3D._shade_colors.
