### PR TITLE
Fix unable to find Freefont on Ubuntu 14.04

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -906,6 +906,14 @@ class FreeType(SetupPackage):
             'freetype2', 'ft2build.h',
             min_version='2.4', version=version)
 
+    def get_extension(self):
+        ext = make_extension('test', [])
+        pkg_config.setup_extension(ext, 'freetype2')
+
+        self.add_flags(ext)
+
+        return ext
+
     def add_flags(self, ext):
         pkg_config.setup_extension(
             ext, 'freetype2',


### PR DESCRIPTION
Ensure that `.add_flags` is called for Freefont when building from source.

Otherwise we only look in `['/usr/local/include', '/usr/include', '.']`, and none of these contain Freefont on Ubuntu 14.04.

Solves https://github.com/matplotlib/matplotlib/issues/3029.
