### PR TITLE
Unicode fixes

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -371,7 +371,7 @@ class FigureCanvasQT(QtGui.QWidget, FigureCanvasBase):
                 key = key.lower()
 
         mods.reverse()
-        return u'+'.join(mods + [key])
+        return '+'.join(mods + [key])
 
     def new_timer(self, *args, **kwargs):
         """


### PR DESCRIPTION
@jkseppan Can you confirm that I did not mess up your name?

The only place left we have `u'...'` is in `test_rcparams.py` which has py3k logic guards and in a comment in `test_mathtext.py`
