### PR TITLE
DEP : removed levypdf from mlab

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -14,6 +14,9 @@ For new features that were added to matplotlib, please see
 Changes in 1.4.x
 ================
 
+Code changes
+------------
+
 * A major refactoring of the axes module was made. The axes module has been
 split into smaller modules:
 
@@ -148,6 +151,15 @@ original location:
   which can be created using the `skew` and `skew_deg` methods.
 
 * Added clockwise parameter to control sectors direction in `axes.pie`
+
+Code removal
+------------
+
+* Removed ``mlab.levypdf``.  The code raised a numpy error (and has for
+  a long time) and was not the standard form of the Levy distribution.
+  ``scipy.stats.levy`` should be used instead
+
+
 
 
 .. _changes_in_1_3:

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1557,28 +1557,6 @@ def normpdf(x, *args):
     return 1./(np.sqrt(2*np.pi)*sigma)*np.exp(-0.5 * (1./sigma*(x - mu))**2)
 
 
-def levypdf(x, gamma, alpha):
-    "Returm the levy pdf evaluated at *x* for params *gamma*, *alpha*"
-
-    N = len(x)
-
-    if N % 2 != 0:
-        raise ValueError('x must be an event length array; try\n' + \
-              'x = np.linspace(minx, maxx, N), where N is even')
-
-    dx = x[1] - x[0]
-
-    f = 1/(N*dx)*np.arange(-N / 2, N / 2, np.float_)
-
-    ind = np.concatenate([np.arange(N / 2, N, int),
-                          np.arange(0, N / 2, int)])
-    df = f[1] - f[0]
-    cfl = np.exp(-gamma * np.absolute(2 * np.pi * f) ** alpha)
-
-    px = np.fft.fft(np.take(cfl, ind) * df).astype(np.float_)
-    return np.take(px, ind)
-
-
 def find(condition):
     "Return the indices where ravel(condition) is true"
     res, = np.nonzero(np.ravel(condition))
@@ -1670,13 +1648,13 @@ class PCA:
 
           *numrows*, *numcols*: the dimensions of a
 
-          *mu* : a numdims array of means of a. This is the vector that points to the 
-          origin of PCA space. 
+          *mu* : a numdims array of means of a. This is the vector that points to the
+          origin of PCA space.
 
           *sigma* : a numdims array of standard deviation of a
 
           *fracs* : the proportion of variance of each of the principal components
-        
+
           *s* : the actual eigenvalues of the decomposition
 
           *Wt* : the weight vector for projecting a numdims point or array into PCA space
@@ -1705,23 +1683,23 @@ class PCA:
         U, s, Vh = np.linalg.svd(a, full_matrices=False)
 
         # Note: .H indicates the conjugate transposed / Hermitian.
-        
+
         # The SVD is commonly written as a = U s V.H.
         # If U is a unitary matrix, it means that it satisfies U.H = inv(U).
-        
+
         # The rows of Vh are the eigenvectors of a.H a.
-        # The columns of U are the eigenvectors of a a.H. 
+        # The columns of U are the eigenvectors of a a.H.
         # For row i in Vh and column i in U, the corresponding eigenvalue is s[i]**2.
-         
+
         self.Wt = Vh
-        
+
         # save the transposed coordinates
         Y = np.dot(Vh, a.T).T
         self.Y = Y
-        
+
         # save the eigenvalues
         self.s = s**2
-        
+
         # and now the contribution of the individual components
         vars = self.s/float(len(s))
         self.fracs = vars/vars.sum()

--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -156,7 +156,6 @@ _Matrix commands
 
 _Probability
 
-  levypdf   - The levy probability density function from the char. func.
   normpdf   - The Gaussian probability density function
   rand      - random numbers from the uniform distribution
   randn     - random numbers from the normal distribution
@@ -251,7 +250,7 @@ from matplotlib.mlab import griddata, stineman_interp, slopes, \
     is_closed_polygon, path_length, distances_along_curve, vector_lengths
 
 from matplotlib.mlab import window_hanning, window_none,  detrend, demean, \
-     detrend_mean, detrend_none, detrend_linear, entropy, normpdf, levypdf, \
+     detrend_mean, detrend_none, detrend_linear, entropy, normpdf, \
      find, longest_contiguous_ones, longest_ones, prepca, \
      prctile, prctile_rank, \
      center_matrix, rk4, bivariate_normal, get_xyz_where, \


### PR DESCRIPTION
This code raised exceptions and had the incorrect formula.  Given that
#3026 is the first we heard about this, it is unlikely anyone is

actually using so it can be safely removed.

As an alternative `scipy.stats.levy` should be used.

replaces #3026 and #3027

Going to hold off on getting rid of `normpdf` and `entorpy` for a more through check of what in mlab should stay.  My understanding is that many of those functions are there from before numpy/scipy matured and there are now better versions in those packages.
