### PR TITLE
BUG : expand x/y range in hexbin if singular

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -36,6 +36,7 @@ import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
+import matplotlib.transforms as mtrans
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
 from matplotlib.axes._base import _AxesBase
 
@@ -3762,6 +3763,10 @@ class Axes(_AxesBase):
             xmax = np.amax(x)
             ymin = np.amin(y)
             ymax = np.amax(y)
+            # to avoid issues with singular data, expand the min/max pairs
+            xmin, xmax = mtrans.nonsingular(xmin, xmax, expander=0.1)
+            ymin, ymax = mtrans.nonsingular(ymin, ymax, expander=0.1)
+
         # In the x-direction, the hexagons exactly cover the region from
         # xmin to xmax. Need some padding to avoid roundoff errors.
         padding = 1.e-9 * (xmax - xmin)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -14,6 +14,8 @@ import matplotlib
 from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 from numpy.testing import assert_array_equal
+import warnings
+
 
 @image_comparison(baseline_images=['formatter_ticker_001',
                                    'formatter_ticker_002',
@@ -2988,6 +2990,17 @@ def test_pie_ccw_true():
             counterclock=True)
     # Set aspect ratio to be equal so that pie is drawn as a circle.
     plt.axis('equal')
+
+
+@cleanup
+def test_pathological_hexbin():
+    # issue #2863
+    with warnings.catch_warnings(record=True) as w:
+        mylist = [10] * 100
+        fig, ax = plt.subplots(1, 1)
+        ax.hexbin(mylist, mylist)
+        plt.show()
+        assert_equal(len(w), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- ensures sensible behavior if a list of identical values is passed
  to hexbin

Closes #2863
