### PR TITLE
symlog-scale: Remove asssert linscale >= 1.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-05-14 Allow the linscale keyword parameter of symlog scale to be
+           smaller one.
+
 2014-05-02 Added colorblind-friendly colormap, named 'Wistia'.
 
 2014-04-27 Improved input clean up in Axes.{h|v}lines

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -449,7 +449,7 @@ class SymmetricalLogScale(ScaleBase):
 
         assert base > 1.0
         assert linthresh > 0.0
-        assert linscale >= 1.0
+        assert linscale > 0.0
 
         self._transform = self.SymmetricalLogTransform(base,
                                                        linthresh,


### PR DESCRIPTION
I can't see why the assert was needed and it does excatly what i would expect from it.
