### PR TITLE
Fix for bug #3029.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -917,6 +917,10 @@ class FreeType(SetupPackage):
             default_libraries=['freetype', 'z'],
             alt_exec='freetype-config')
 
+    def get_extension(self):
+        ext = make_extension('freetype2', [])
+        self.add_flags(ext)
+        return ext
 
 class FT2Font(SetupPackage):
     name = 'ft2font'


### PR DESCRIPTION
The FreeType class does not override the `get_extension` method, by default this method will return None.

https://github.com/matplotlib/matplotlib/blob/6cf6063c7a3037d52545b2b7268623d33da0ecdd/setupext.py#L387

When calling the `_check_for_pkg_config` method a new extension will be created that what won't contain the original flags added by the `add_flags` method.

https://github.com/matplotlib/matplotlib/blob/6cf6063c7a3037d52545b2b7268623d33da0ecdd/setupext.py#L438
