### PR TITLE
TST : force re-building of font-cache

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -6,7 +6,7 @@ import six
 
 import os
 
-from matplotlib.font_manager import findfont, FontProperties
+from matplotlib.font_manager import findfont, FontProperties, _rebuild
 from matplotlib import rc_context
 
 
@@ -14,6 +14,10 @@ def test_font_priority():
     with rc_context(rc={
             'font.sans-serif':
             ['cmmi10', 'Bitstream Vera Sans']}):
+        # force the font manager to rebuild it self
+        _rebuild()
         font = findfont(
             FontProperties(family=["sans-serif"]))
     assert_equal(os.path.basename(font), 'cmmi10.ttf')
+    # force it again
+    _rebuild()


### PR DESCRIPTION
- there should be a better way to do this, this will get the
  tests passing again.

as suggested by @efiring in #3073

closes #3065
