### PR TITLE
Bug: backend_pdf: UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1822,7 +1822,8 @@ class RendererPdf(RendererBase):
                 oldfont = dvifont
             # We need to convert the glyph numbers to bytes, and the easiest
             # way to do this on both Python 2 and 3 is .encode('latin-1')
-            seq += [['text', x1, y1, [chr(glyph).encode('latin-1')], x1+width]]
+            seq += [['text', x1, y1,
+                     [six.unichr(glyph).encode('latin-1')], x1+width]]
 
         # Find consecutive text strings with constant y coordinate and
         # combine into a sequence of strings and kerns, or just one


### PR DESCRIPTION
I tried this simple example on python 2.7.2:
(matplotlib 1.4.x)

```
import pandas as pd
import matplotlib as mpl
import matplotlib.pyplot as plt
from matplotlib import rc
#rc('font',**{'family':'serif'})
rc('text', usetex=True)
rc('text.latex',unicode=True)
rc('text.latex',preamble='\usepackage[utf8]{inputenc}')
rc('text.latex',preamble='\usepackage[russian]{babel}')

f = plt.figure()
ax = f.add_subplot(111)
ax.set_xlabel(u'время, с')
plt.show()
f.savefig('stepped_exp.pdf')
```

But I got:

```
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-2-74334d19869a> in <module>()
     14 ax.set_xlabel(u'время, с')
     15 plt.show()
---> 16 f.savefig('stepped_exp.pdf')
     17 

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/figure.pyc in savefig(self, *args, **kwargs)
   1468             self.set_frameon(frameon)
   1469 
-> 1470         self.canvas.print_figure(*args, **kwargs)
   1471 
   1472         if frameon:

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/backend_bases.pyc in print_figure(self, filename, dpi, facecolor, edgecolor, orientation, format, **kwargs)
   2190                 orientation=orientation,
   2191                 bbox_inches_restore=_bbox_inches_restore,
-> 2192                 **kwargs)
   2193         finally:
   2194             if bbox_inches and restore_bbox:

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/backends/backend_pdf.pyc in print_pdf(self, filename, **kwargs)
   2468                 RendererPdf(file, image_dpi),
   2469                 bbox_inches_restore=_bbox_inches_restore)
-> 2470             self.figure.draw(renderer)
   2471             renderer.finalize()
   2472         finally:

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/artist.pyc in draw_wrapper(artist, renderer, *args, **kwargs)
     57     def draw_wrapper(artist, renderer, *args, **kwargs):
     58         before(artist, renderer)
---> 59         draw(artist, renderer, *args, **kwargs)
     60         after(artist, renderer)
     61 

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/figure.pyc in draw(self, renderer)
   1077         dsu.sort(key=itemgetter(0))
   1078         for zorder, a, func, args in dsu:
-> 1079             func(*args)
   1080 
   1081         renderer.close_group('figure')

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/artist.pyc in draw_wrapper(artist, renderer, *args, **kwargs)
     57     def draw_wrapper(artist, renderer, *args, **kwargs):
     58         before(artist, renderer)
---> 59         draw(artist, renderer, *args, **kwargs)
     60         after(artist, renderer)
     61 

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/axes/_base.pyc in draw(self, renderer, inframe)
   2073 
   2074         for zorder, a in dsu:
-> 2075             a.draw(renderer)
   2076 
   2077         renderer.close_group('axes')

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/artist.pyc in draw_wrapper(artist, renderer, *args, **kwargs)
     57     def draw_wrapper(artist, renderer, *args, **kwargs):
     58         before(artist, renderer)
---> 59         draw(artist, renderer, *args, **kwargs)
     60         after(artist, renderer)
     61 

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/axis.pyc in draw(self, renderer, *args, **kwargs)
   1115         self._update_label_position(ticklabelBoxes, ticklabelBoxes2)
   1116 
-> 1117         self.label.draw(renderer)
   1118 
   1119         self._update_offset_text_position(ticklabelBoxes, ticklabelBoxes2)

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/artist.pyc in draw_wrapper(artist, renderer, *args, **kwargs)
     57     def draw_wrapper(artist, renderer, *args, **kwargs):
     58         before(artist, renderer)
---> 59         draw(artist, renderer, *args, **kwargs)
     60         after(artist, renderer)
     61 

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/text.pyc in draw(self, renderer)
    578             if rcParams['text.usetex']:
    579                 renderer.draw_tex(gc, x, y, clean_line,
--> 580                                   self._fontproperties, angle, mtext=self)
    581             else:
    582                 renderer.draw_text(gc, x, y, clean_line,

/Users/dmitry/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib-1.4.x-py2.7-macosx-10.6-x86_64.egg/matplotlib/backends/backend_pdf.pyc in draw_tex(self, gc, x, y, s, prop, angle, ismath, mtext)
   1823             # We need to convert the glyph numbers to bytes, and the easiest
   1824             # way to do this on both Python 2 and 3 is .encode('latin-1')
-> 1825             seq += [['text', x1, y1, [chr(glyph).encode('latin-1')], x1+width]]
   1826 
   1827         # Find consecutive text strings with constant y coordinate and

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)

```

It seems that this fix https://github.com/mdboom/matplotlib/commit/38d846baed9080b67f9fdf96a0f163d230ba9ffb

brakes the compatibility with cyrilic symbols.

The previous edition of backend_pdf.py with:

```
seq += [['text', x1, y1, [chr(glyph)], x1+width]]
```

Works just fine to me.

Or I'm doing something wrong?

Thanx! 
