### PR TITLE
Fix regression in pcolormesh: don't generate a path list.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1451,7 +1451,10 @@ class _AxesBase(martist.Artist):
         if collection.get_clip_path() is None:
             collection.set_clip_path(self.patch)
 
-        if autolim:
+        if (autolim and
+            collection._paths is not None and
+            len(collection._paths) and
+            len(collection._offsets)):
             self.update_datalim(collection.get_datalim(self.transData))
 
         collection._remove_method = lambda h: self.collections.remove(h)


### PR DESCRIPTION
Restores part of f39c3af9 that was lost in the axes refactoring,
5e65bbe5.
Closes #3095.
