### PR TITLE
Use autolim kwarg in add_collection to prevent duplication of effort.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -965,7 +965,7 @@ class Axes(_AxesBase):
                  for thisxmin, thisxmax, thisy in zip(xmin, xmax, y)]
         coll = mcoll.LineCollection(verts, colors=colors,
                                     linestyles=linestyles, label=label)
-        self.add_collection(coll)
+        self.add_collection(coll, autolim=False)
         coll.update(kwargs)
 
         if len(y) > 0:
@@ -1045,7 +1045,7 @@ class Axes(_AxesBase):
         #print 'creating line collection'
         coll = mcoll.LineCollection(verts, colors=colors,
                                     linestyles=linestyles, label=label)
-        self.add_collection(coll)
+        self.add_collection(coll, autolim=False)
         coll.update(kwargs)
 
         if len(x) > 0:
@@ -1210,7 +1210,7 @@ class Axes(_AxesBase):
                                          linewidth=linewidth,
                                          color=color,
                                          linestyle=linestyle)
-            self.add_collection(coll)
+            self.add_collection(coll, autolim=False)
             coll.update(kwargs)
             colls.append(coll)
 
@@ -3937,7 +3937,7 @@ class Axes(_AxesBase):
         self.autoscale_view(tight=True)
 
         # add the collection last
-        self.add_collection(collection)
+        self.add_collection(collection, autolim=False)
         if not marginals:
             return collection
 
@@ -3983,7 +3983,7 @@ class Axes(_AxesBase):
         hbar.set_norm(norm)
         hbar.set_alpha(alpha)
         hbar.update(kwargs)
-        self.add_collection(hbar)
+        self.add_collection(hbar, autolim=False)
 
         coarse = np.linspace(ymin, ymax, gridsize)
         ycoarse = coarse_bin(yorig, C, coarse)
@@ -4011,7 +4011,7 @@ class Axes(_AxesBase):
         vbar.set_norm(norm)
         vbar.set_alpha(alpha)
         vbar.update(kwargs)
-        self.add_collection(vbar)
+        self.add_collection(vbar, autolim=False)
 
         collection.hbar = hbar
         collection.vbar = vbar
@@ -4073,7 +4073,7 @@ class Axes(_AxesBase):
             self.cla()
         q = mquiver.Quiver(self, *args, **kw)
 
-        self.add_collection(q, True)
+        self.add_collection(q, autolim=True)
         self.autoscale_view()
         return q
     quiver.__doc__ = mquiver.Quiver.quiver_doc
@@ -4113,7 +4113,7 @@ class Axes(_AxesBase):
         if not self._hold:
             self.cla()
         b = mquiver.Barbs(self, *args, **kw)
-        self.add_collection(b)
+        self.add_collection(b, autolim=True)
         self.autoscale_view()
         return b
 
@@ -4301,9 +4301,10 @@ class Axes(_AxesBase):
         XY2 = np.array([x[where], y2[where]]).T
         self.dataLim.update_from_data_xy(XY1, self.ignore_existing_data_limits,
                                          updatex=True, updatey=True)
+        self.ignore_existing_data_limits = False
         self.dataLim.update_from_data_xy(XY2, self.ignore_existing_data_limits,
                                          updatex=False, updatey=True)
-        self.add_collection(collection)
+        self.add_collection(collection, autolim=False)
         self.autoscale_view()
         return collection
 
@@ -4408,10 +4409,10 @@ class Axes(_AxesBase):
         X2Y = np.array([x2[where], y[where]]).T
         self.dataLim.update_from_data_xy(X1Y, self.ignore_existing_data_limits,
                                          updatex=True, updatey=True)
-
+        self.ignore_existing_data_limits = False
         self.dataLim.update_from_data_xy(X2Y, self.ignore_existing_data_limits,
-                                         updatex=False, updatey=True)
-        self.add_collection(collection)
+                                         updatex=True, updatey=False)
+        self.add_collection(collection, autolim=False)
         self.autoscale_view()
         return collection
 
@@ -4886,7 +4887,7 @@ class Axes(_AxesBase):
         corners = (minx, miny), (maxx, maxy)
         self.update_datalim(corners)
         self.autoscale_view()
-        self.add_collection(collection)
+        self.add_collection(collection, autolim=False)
         return collection
 
     @docstring.dedent_interpd
@@ -5032,7 +5033,7 @@ class Axes(_AxesBase):
         corners = (minx, miny), (maxx, maxy)
         self.update_datalim(corners)
         self.autoscale_view()
-        self.add_collection(collection)
+        self.add_collection(collection, autolim=False)
         return collection
 
     @docstring.dedent_interpd
@@ -5184,7 +5185,7 @@ class Axes(_AxesBase):
             collection.set_array(C)
             collection.set_cmap(cmap)
             collection.set_norm(norm)
-            self.add_collection(collection)
+            self.add_collection(collection, autolim=False)
             xl, xr, yb, yt = X.min(), X.max(), Y.min(), Y.max()
             ret = collection
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -939,7 +939,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                     alpha=self.alpha,
                     transform=self.get_transform(),
                     zorder=zorder)
-                self.ax.add_collection(col)
+                self.ax.add_collection(col, autolim=False)
                 self.collections.append(col)
         else:
             tlinewidths = self._process_linewidths()
@@ -961,7 +961,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                     transform=self.get_transform(),
                     zorder=zorder)
                 col.set_label('_nolegend_')
-                self.ax.add_collection(col, False)
+                self.ax.add_collection(col, autolim=False)
                 self.collections.append(col)
         self.changed()  # set the colors
 


### PR DESCRIPTION
This changeset cleans up several problems associated with updating
Axes.dataLim. The basic point is that when a method that creates
a collection also updates Axes.dataLim, Axes.add_collection() should be
called with autolim=False.  With autolim=True, add_collection will
use a very general method to update the dataLim, but in many cases
the method creating the collection can perform the update much more
efficiently.

Closes #3095, which reported a regression that appears to have been
introduced by 88b722f.
