### PR TITLE
Image: handle images with zero columns or rows.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -327,6 +327,8 @@ class _AxesImageBase(martist.Artist, cm.ScalarMappable):
         im.reset_matrix()
         numrows, numcols = im.get_size()
 
+        if numrows <= 0 or numcols <= 0:
+            return
         im.resize(numcols, numrows)  # just to create im.bufOut that
                                      # is required by backends. There
                                      # may be better solution -JJL

--- a/src/_image.cpp
+++ b/src/_image.cpp
@@ -374,10 +374,10 @@ Image::resize(const Py::Tuple& args, const Py::Dict& kwargs)
     int numcols = Py::Int(args[0]);
     int numrows = Py::Int(args[1]);
 
-    if (numcols < 0 || numrows < 0)
+    if (numcols <= 0 || numrows <= 0)
     {
-	throw Py::RuntimeError(
-	    "Width and height must have non-negative values");
+        throw Py::RuntimeError(
+        "Width and height must have positive values");
     }
 
     colsOut = numcols;

--- a/src/_image.h
+++ b/src/_image.h
@@ -45,6 +45,12 @@ public:
     inline Py::Object flipud_out(const Py::Tuple& args)
     {
         args.verify_length(0);
+        if (colsOut <= 0 || rowsOut <= 0)
+        {
+            throw Py::RuntimeError(
+            "Width and height must have positive values");
+        }
+
         int stride = rbufOut->stride();
         //std::cout << "flip before: " << rbufOut->stride() << std::endl;
         rbufOut->attach(bufferOut, colsOut, rowsOut, -stride);


### PR DESCRIPTION
Two methods in the _image extension module now raise an
exception if the number of rows or columns is zero;
previously they could segfault.  A particular
circumstance that can cause this (setting xlim completely
outside the image extent) is handled directly in the
image module without raising an exception.

Closes #3091.
