### PR TITLE
BUG: in Spine.set_position(), preserve most Axis info.

### DIFF
--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -379,7 +379,7 @@ class Spine(mpatches.Patch):
         self.set_transform(self.get_spine_transform())
 
         if self.axis is not None:
-            self.axis.cla()
+            self.axis.reset_ticks()
 
     def get_position(self):
         """get the spine position"""


### PR DESCRIPTION
Clearing the axis is excessive; calling axis.reset_ticks()
seems to be both necessary and sufficient.

Closes #2941
