### PR TITLE
Bug-fix for issue 3106

### DIFF
--- a/lib/matplotlib/docstring.py
+++ b/lib/matplotlib/docstring.py
@@ -87,7 +87,7 @@ class Appender(object):
 
     def __call__(self, func):
         docitems = [func.__doc__, self.addendum]
-        func.__doc__ = func.__doc__ and ''.join(docitems)
+        func.__doc__ = func.__doc__ and self.join.join(docitems)
         return func
 
 


### PR DESCRIPTION
Former Bug was that all strings will be append directly after old
docstring independent of self.join
Can be tested with matplotlib.pyplot.figimage.**doc** where Appender
class has been used.
