### PR TITLE
BUG : patches.Wedge.set_radius set wrong attribute

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -955,7 +955,7 @@ class Wedge(Patch):
 
     def set_radius(self, radius):
         self._path = None
-        self.radius = radius
+        self.r = radius
 
     def set_theta1(self, theta1):
         self._path = None

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -8,6 +8,7 @@ import six
 
 import numpy as np
 from numpy.testing import assert_array_equal
+from numpy.testing import assert_equal
 from numpy.testing import assert_almost_equal
 
 from matplotlib.patches import Polygon
@@ -201,6 +202,21 @@ def test_patch_custom_linestyle():
     ax.set_xlim([-1, 2])
     ax.set_ylim([-1, 2])
 
+
+def test_wedge_movement():
+    param_dict = {'center': ((0, 0), (1, 1), 'set_center'),
+                  'r': (5, 8, 'set_radius'),
+                  'width': (2, 3, 'set_width'),
+                  'theta1': (0, 30, 'set_theta1'),
+                  'theta2': (45, 50, 'set_theta2')}
+
+    init_args = dict((k, v[0]) for (k, v) in six.iteritems(param_dict))
+
+    w = mpatches.Wedge(**init_args)
+    for attr, (old_v, new_v, func) in six.iteritems(param_dict):
+        assert_equal(getattr(w, attr), old_v)
+        getattr(w, func)(new_v)
+        assert_equal(getattr(w, attr), new_v)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
set_radius set the attribute `radius` which is not
used to compute the path.  Change to set `self.r` which
is used.
