### PR TITLE
Remove the check on path length over 18980 in Cairo backend

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -150,8 +150,8 @@ class RendererCairo(RendererBase):
 
 
     def draw_path(self, gc, path, transform, rgbFace=None):
-        if len(path.vertices) > 18980:
-            raise ValueError("The Cairo backend can not draw paths longer than 18980 points.")
+#       if len(path.vertices) > 18980:
+#           raise ValueError("The Cairo backend can not draw paths longer than 18980 points.")
 
         ctx = gc.ctx
 


### PR DESCRIPTION
According to thread of http://comments.gmane.org/gmane.comp.python.matplotlib.general/33993 the check is not needed anymore.
This allows the rectangle selector example to display the curves.
(However it still stops with AttributeError: 'FigureCanvasGTK3Cairo' object has no attribute 'copy_from_bbox').
