### PR TITLE
DOC : added inherited-members to Axes autodoc

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -9,3 +9,4 @@ axes
 .. autoclass:: matplotlib.axes.Axes
    :members:
    :undoc-members:
+   :inherited-members:


### PR DESCRIPTION
The re-factor of Axes split the class up into several
classes and the function from `_AxesBase` (such as
`set_aspect`) were not being included in the generated
documentation.
