### PR TITLE
BUG: Fix 'TypeError: expected bytes, str found' on Python 3

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3452,8 +3452,8 @@ def griddata(x, y, z, xi, yi, interp='nn'):
             yi = yi[:, 0]
 
         # Override default natgrid internal parameters.
-        _natgrid.seti('ext', 0)
-        _natgrid.setr('nul', np.nan)
+        _natgrid.seti(b'ext', 0)
+        _natgrid.setr(b'nul', np.nan)
 
         if np.min(np.diff(xi)) < 0 or np.min(np.diff(yi)) < 0:
             raise ValueError("Output grid defined by xi,yi must be monotone "


### PR DESCRIPTION
[natgrid\test.py](https://github.com/matplotlib/natgrid/blob/master/test.py) fails on Python 3 because [`_natgrid.seti`](https://github.com/matplotlib/natgrid/blob/master/src/_natgrid.pyx#L32) and [`_natgrid.setr`](https://github.com/matplotlib/natgrid/blob/master/src/_natgrid.pyx#L38) expect byte strings:

```
Traceback (most recent call last):
  File "test.py", line 15, in <module>
    zi = griddata(x,y,z,xi,yi)
  File "X:\Python34\lib\site-packages\matplotlib\mlab.py", line 2586, in griddata
    _natgrid.seti('ext',0)
  File "_natgrid.pyx", line 35, in _natgrid.seti (src\_natgrid.c:875)
TypeError: expected bytes, str found
```
