### PR TITLE
Default rstride and cstride for plot_surface changed to 1 from 10.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-06-19 Changed default plot_surface rstride and cstride to 1
+	   instead of 10.
+ 
 2014-06-10 Added Colorbar.remove()
 
 2014-06-07 Fixed bug so radial plots can be saved as ps in py3k.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1558,8 +1558,8 @@ class Axes3D(Axes):
         X, Y, Z = np.broadcast_arrays(X, Y, Z)
         rows, cols = Z.shape
 
-        rstride = kwargs.pop('rstride', 10)
-        cstride = kwargs.pop('cstride', 10)
+        rstride = kwargs.pop('rstride', 1)
+        cstride = kwargs.pop('cstride', 1)
 
         if 'facecolors' in kwargs:
             fcolors = kwargs.pop('facecolors')


### PR DESCRIPTION
It doesn't seem like a sensible default to throw away 90% of the data.