### PR TITLE
Added parent `CallContainer` class and two subclassing objects.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5289,7 +5289,7 @@ class Axes(_AxesBase):
     def hist(self, x, bins=10, range=None, normed=False, weights=None,
              cumulative=False, bottom=None, histtype='bar', align='mid',
              orientation='vertical', rwidth=None, log=False,
-             color=None, label=None, stacked=False,
+             color=None, label=None, stacked=False, keep_call=False,
              **kwargs):
         """
         Plot a histogram.
@@ -5778,14 +5778,16 @@ class Axes(_AxesBase):
         else:
             n, patches = n, cbook.silent_list('Lists of Patches', patches)
 
-        call_container = HistCallContainer(patches, locals(), **kwargs)
-        self.add_container(call_container)
+        # keep_call = kwargs.pop('keep_call', None)
+        if keep_call:
+            call_container = HistCallContainer(patches, locals(), **kwargs)
+            self.add_container(call_container)
 
         return n, bins, patches
 
     @docstring.dedent_interpd
     def hist2d(self, x, y, bins=10, range=None, normed=False, weights=None,
-               cmin=None, cmax=None, **kwargs):
+               cmin=None, cmax=None, keep_call=False, **kwargs):
         """
         Make a 2D histogram plot.
 
@@ -5874,8 +5876,10 @@ class Axes(_AxesBase):
         self.set_xlim(xedges[0], xedges[-1])
         self.set_ylim(yedges[0], yedges[-1])
 
-        call_container = Hist2dCallContainer([pc], locals(), **kwargs)
-        self.add_container(call_container)
+        # keep_call = kwargs.pop('keep_call', None)
+        if keep_call:
+            call_container = Hist2dCallContainer([pc], locals(), **kwargs)
+            self.add_container(call_container)
 
         return h, xedges, yedges, pc
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5778,8 +5778,7 @@ class Axes(_AxesBase):
             n, patches = n, cbook.silent_list('Lists of Patches', patches)
 
         if keep_call:
-            call_container = CallContainer(patches, Axes.hist, locals(), **kwargs)
-            self.add_container(call_container)
+            self.add_container(CallContainer(patches, Axes.hist, locals(), **kwargs))
 
         return n, bins, patches
 
@@ -5875,8 +5874,7 @@ class Axes(_AxesBase):
         self.set_ylim(yedges[0], yedges[-1])
 
         if keep_call:
-            call_container = CallContainer([pc], Axes.hist2d, locals(), **kwargs)
-            self.add_container(call_container)
+            self.add_container(CallContainer([pc], Axes.hist2d, locals(), **kwargs))
 
         return h, xedges, yedges, pc
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5774,31 +5774,11 @@ class Axes(_AxesBase):
                     [(0, bins[0]), (0, bins[-1])], updatex=False)
 
         if nx == 1:
-            n, bins, patches = n[0], bins, cbook.silent_list('Patch', patches[0])
+            n, patches = n[0], cbook.silent_list('Patch', patches[0])
         else:
-            n, bins, patches = n, bins, cbook.silent_list('Lists of Patches', patches)
+            n, patches = n, cbook.silent_list('Lists of Patches', patches)
 
-        call_info = dict(type='hist',
-                         patches=patches,
-                         x=x,
-                         bins=bins,
-                         range=range,
-                         normed=normed,
-                         weights=weights,
-                         cumulative=cumulative,
-                         bottom=bottom,
-                         histtype=histtype,
-                         align=align,
-                         orientation=orientation,
-                         rwidth=rwidth,
-                         log=log,
-                         color=color,
-                         label=label,
-                         stacked=stacked,
-                         kwargs=kwargs
-                         )
-
-        call_container = HistCallContainer(patches, call_info, **kwargs)
+        call_container = HistCallContainer(patches, locals(), **kwargs)
         self.add_container(call_container)
 
         return n, bins, patches
@@ -5894,21 +5874,7 @@ class Axes(_AxesBase):
         self.set_xlim(xedges[0], xedges[-1])
         self.set_ylim(yedges[0], yedges[-1])
 
-        call_info = dict(x=x,
-                         y=y,
-                         bins=bins,
-                         range=range,
-                         normed=normed,
-                         weights=weights,
-                         cmin=cmin,
-                         cmax=cmax,
-                         pc=pc,
-                         xedges=xedges,
-                         yedges=yedges,
-                         h=h,
-                         kwargs=kwargs)
-
-        call_container = Hist2dCallContainer([pc], call_info, **kwargs)
+        call_container = Hist2dCallContainer([pc], locals(), **kwargs)
         self.add_container(call_container)
 
         return h, xedges, yedges, pc

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -40,8 +40,7 @@ import matplotlib.transforms as mtrans
 from matplotlib.container import (BarContainer,
                                   ErrorbarContainer,
                                   StemContainer,
-                                  HistCallContainer,
-                                  Hist2dCallContainer)
+                                  CallContainer)
 from matplotlib.axes._base import _AxesBase
 
 iterable = cbook.iterable
@@ -5780,7 +5779,7 @@ class Axes(_AxesBase):
 
         # keep_call = kwargs.pop('keep_call', None)
         if keep_call:
-            call_container = HistCallContainer(patches, locals(), **kwargs)
+            call_container = CallContainer(patches, Axes.hist, locals(), **kwargs)
             self.add_container(call_container)
 
         return n, bins, patches
@@ -5878,7 +5877,7 @@ class Axes(_AxesBase):
 
         # keep_call = kwargs.pop('keep_call', None)
         if keep_call:
-            call_container = Hist2dCallContainer([pc], locals(), **kwargs)
+            call_container = CallContainer([pc], Axes.hist2d, locals(), **kwargs)
             self.add_container(call_container)
 
         return h, xedges, yedges, pc

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5288,8 +5288,7 @@ class Axes(_AxesBase):
     def hist(self, x, bins=10, range=None, normed=False, weights=None,
              cumulative=False, bottom=None, histtype='bar', align='mid',
              orientation='vertical', rwidth=None, log=False,
-             color=None, label=None, stacked=False, keep_call=False,
-             **kwargs):
+             color=None, label=None, stacked=False, **kwargs):
         """
         Plot a histogram.
 
@@ -5426,6 +5425,7 @@ class Axes(_AxesBase):
         .. plot:: mpl_examples/statistics/histogram_demo_features.py
 
         """
+        keep_call = kwargs.pop('keep_call', False)
         if not self._hold:
             self.cla()
 
@@ -5777,7 +5777,6 @@ class Axes(_AxesBase):
         else:
             n, patches = n, cbook.silent_list('Lists of Patches', patches)
 
-        # keep_call = kwargs.pop('keep_call', None)
         if keep_call:
             call_container = CallContainer(patches, Axes.hist, locals(), **kwargs)
             self.add_container(call_container)
@@ -5786,7 +5785,7 @@ class Axes(_AxesBase):
 
     @docstring.dedent_interpd
     def hist2d(self, x, y, bins=10, range=None, normed=False, weights=None,
-               cmin=None, cmax=None, keep_call=False, **kwargs):
+               cmin=None, cmax=None, **kwargs):
         """
         Make a 2D histogram plot.
 
@@ -5859,7 +5858,7 @@ class Axes(_AxesBase):
         --------
         .. plot:: mpl_examples/pylab_examples/hist2d_demo.py
         """
-
+        keep_call = kwargs.pop('keep_call', False)
         # xrange becomes range after 2to3
         bin_range = range
         range = __builtins__["range"]
@@ -5875,7 +5874,6 @@ class Axes(_AxesBase):
         self.set_xlim(xedges[0], xedges[-1])
         self.set_ylim(yedges[0], yedges[-1])
 
-        # keep_call = kwargs.pop('keep_call', None)
         if keep_call:
             call_container = CallContainer([pc], Axes.hist2d, locals(), **kwargs)
             self.add_container(call_container)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2629,7 +2629,7 @@ class Axes(_AxesBase):
         .. plot:: mpl_examples/statistics/errorbar_demo.py
 
         """
-
+        keep_call = kwargs.pop('keep_call', False)
         if errorevery < 1:
             raise ValueError(
                 'errorevery has to be a strictly positive integer')
@@ -2878,6 +2878,9 @@ class Axes(_AxesBase):
                                                label=label)
         self.containers.append(errorbar_container)
 
+        if keep_call:
+            self.add_container(CallContainer(l0, Axes.errorbar, locals(), **kwargs))
+
         return errorbar_container  # (l0, caplines, barcols)
 
     def boxplot(self, x, notch=False, sym='b+', vert=True, whis=1.5,
@@ -3031,6 +3034,7 @@ class Axes(_AxesBase):
 
         .. plot:: mpl_examples/statistics/boxplot_demo.py
         """
+        keep_call = kwargs.pop('keep_call', False)
         bxpstats = cbook.boxplot_stats(x, whis=whis, bootstrap=bootstrap,
                                        labels=labels)
         if sym == 'b+' and flierprops is None:
@@ -3073,6 +3077,9 @@ class Axes(_AxesBase):
                            medianprops=medianprops, meanprops=meanprops,
                            meanline=meanline, showfliers=showfliers,
                            manage_xticks=manage_xticks)
+        if keep_call:
+            self.add_container(CallContainer(artists, Axes.boxplot, locals(), **kwargs))
+
         return artists
 
     def bxp(self, bxpstats, positions=None, widths=None, vert=True,
@@ -3490,7 +3497,7 @@ class Axes(_AxesBase):
         .. plot:: mpl_examples/shapes_and_collections/scatter_demo.py
 
         """
-
+        keep_call = kwargs.pop('keep_call', False)
         if not self._hold:
             self.cla()
 
@@ -3588,6 +3595,8 @@ class Axes(_AxesBase):
 
         self.add_collection(collection)
         self.autoscale_view()
+        if keep_call:
+            self.add_container(CallContainer(collection, Axes.scatter, locals(), **kwargs))
 
         return collection
 
@@ -4783,7 +4792,7 @@ class Axes(_AxesBase):
                 For an explanation of the differences between
                 pcolor and pcolormesh.
         """
-
+        keep_call = kwargs.pop('keep_call', False)
         if not self._hold:
             self.cla()
 
@@ -4904,6 +4913,7 @@ class Axes(_AxesBase):
         self.update_datalim(corners)
         self.autoscale_view()
         self.add_collection(collection, autolim=False)
+        self.add_container(CallContainer(collection, Axes.pcolor, locals(), **kwargs))
         return collection
 
     @docstring.dedent_interpd
@@ -4983,6 +4993,7 @@ class Axes(_AxesBase):
                 For an explanation of the grid orientation and the
                 expansion of 1-D *X* and/or *Y* to 2-D arrays.
         """
+        keep_call = kwargs.pop('keep_call', False)
         if not self._hold:
             self.cla()
 
@@ -5050,6 +5061,7 @@ class Axes(_AxesBase):
         self.update_datalim(corners)
         self.autoscale_view()
         self.add_collection(collection, autolim=False)
+        self.add_container(CallContainer(collection, Axes.pcolormesh, locals(), **kwargs))
         return collection
 
     @docstring.dedent_interpd
@@ -5135,7 +5147,7 @@ class Axes(_AxesBase):
         collection in the general quadrilateral case.
 
         """
-
+        keep_call = kwargs.pop('keep_call', False)
         if not self._hold:
             self.cla()
 
@@ -5235,20 +5247,29 @@ class Axes(_AxesBase):
             ret.autoscale_None()
         self.update_datalim(np.array([[xl, yb], [xr, yt]]))
         self.autoscale_view(tight=True)
+        self.add_container(CallContainer([ret], Axes.pcolorfast, locals(), **kwargs))
         return ret
 
     def contour(self, *args, **kwargs):
+        keep_call = kwargs.pop('keep_call', False)
         if not self._hold:
             self.cla()
         kwargs['filled'] = False
-        return mcontour.QuadContourSet(self, *args, **kwargs)
+        image = mcontour.QuadContourSet(self, *args, **kwargs)
+        if keep_call:
+            self.add_container(CallContainer([image], Axes.contour, locals(), **kwargs))
+        return image
     contour.__doc__ = mcontour.QuadContourSet.contour_doc
 
     def contourf(self, *args, **kwargs):
+        keep_call = kwargs.pop('keep_call', False)
         if not self._hold:
             self.cla()
         kwargs['filled'] = True
-        return mcontour.QuadContourSet(self, *args, **kwargs)
+        image = mcontour.QuadContourSet(self, *args, **kwargs)
+        if keep_call:
+            self.add_container(CallContainer([image], Axes.contourf, locals(), **kwargs))
+        return image
     contourf.__doc__ = mcontour.QuadContourSet.contour_doc
 
     def clabel(self, CS, *args, **kwargs):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -37,7 +37,11 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
 import matplotlib.transforms as mtrans
-from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
+from matplotlib.container import (BarContainer,
+                                  ErrorbarContainer,
+                                  StemContainer,
+                                  HistCallContainer,
+                                  Hist2dCallContainer)
 from matplotlib.axes._base import _AxesBase
 
 iterable = cbook.iterable
@@ -5770,9 +5774,34 @@ class Axes(_AxesBase):
                     [(0, bins[0]), (0, bins[-1])], updatex=False)
 
         if nx == 1:
-            return n[0], bins, cbook.silent_list('Patch', patches[0])
+            n, bins, patches = n[0], bins, cbook.silent_list('Patch', patches[0])
         else:
-            return n, bins, cbook.silent_list('Lists of Patches', patches)
+            n, bins, patches = n, bins, cbook.silent_list('Lists of Patches', patches)
+
+        call_info = dict(type='hist',
+                         patches=patches,
+                         x=x,
+                         bins=bins,
+                         range=range,
+                         normed=normed,
+                         weights=weights,
+                         cumulative=cumulative,
+                         bottom=bottom,
+                         histtype=histtype,
+                         align=align,
+                         orientation=orientation,
+                         rwidth=rwidth,
+                         log=log,
+                         color=color,
+                         label=label,
+                         stacked=stacked,
+                         kwargs=kwargs
+                         )
+
+        call_container = HistCallContainer(patches, call_info, **kwargs)
+        self.add_container(call_container)
+
+        return n, bins, patches
 
     @docstring.dedent_interpd
     def hist2d(self, x, y, bins=10, range=None, normed=False, weights=None,
@@ -5864,6 +5893,23 @@ class Axes(_AxesBase):
         pc = self.pcolorfast(xedges, yedges, h.T, **kwargs)
         self.set_xlim(xedges[0], xedges[-1])
         self.set_ylim(yedges[0], yedges[-1])
+
+        call_info = dict(x=x,
+                         y=y,
+                         bins=bins,
+                         range=range,
+                         normed=normed,
+                         weights=weights,
+                         cmin=cmin,
+                         cmax=cmax,
+                         pc=pc,
+                         xedges=xedges,
+                         yedges=yedges,
+                         h=h,
+                         kwargs=kwargs)
+
+        call_container = Hist2dCallContainer([pc], call_info, **kwargs)
+        self.add_container(call_container)
 
         return h, xedges, yedges, pc
 

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -127,3 +127,25 @@ class StemContainer(Container):
         self.stemlines = stemlines
         self.baseline = baseline
         Container.__init__(self, markerline_stemlines_baseline, **kwargs)
+
+
+class CallContainer(Container):
+
+    def __repr__(self):
+        return "<CallContainer object of %d artists>" % (len(self))
+
+
+class HistCallContainer(CallContainer):
+
+    def __init__(self, patches, call_info, **kwargs):
+        for key in call_info:
+            setattr(self, key, call_info[key])
+        CallContainer.__init__(self, patches, **kwargs)
+
+
+class Hist2dCallContainer(CallContainer):
+
+    def __init__(self, pc, call_info, **kwargs):
+        for key in call_info:
+            setattr(self, key, call_info[key])
+        CallContainer.__init__(self, pc, **kwargs)

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -135,7 +135,7 @@ class CallContainer(Container):
         self.call_func = call_func
         for key in call_info:
             setattr(self, key, call_info[key])
-        Container.__init__(self, artist_list, **kwargs)
+        Container.__init__(self, artist_list, label=kwargs.pop('label', None))
 
     def __repr__(self):
         return ("<CallContainer object of {} artists for '{}' call>"

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -131,21 +131,13 @@ class StemContainer(Container):
 
 class CallContainer(Container):
 
+    def __init__(self, artist_list, call_func, call_info, **kwargs):
+        self.call_func = call_func
+        for key in call_info:
+            setattr(self, key, call_info[key])
+        Container.__init__(self, artist_list, **kwargs)
+
     def __repr__(self):
-        return "<CallContainer object of %d artists>" % (len(self))
-
-
-class HistCallContainer(CallContainer):
-
-    def __init__(self, patches, call_info, **kwargs):
-        for key in call_info:
-            setattr(self, key, call_info[key])
-        CallContainer.__init__(self, patches, **kwargs)
-
-
-class Hist2dCallContainer(CallContainer):
-
-    def __init__(self, pc, call_info, **kwargs):
-        for key in call_info:
-            setattr(self, key, call_info[key])
-        CallContainer.__init__(self, pc, **kwargs)
+        return ("<CallContainer object of {} artists for '{}' call>"
+                "".format(len(self), self.call_func.__name__)
+        )


### PR DESCRIPTION
Calls to plot functions like `hist`, forget about the user input.
However, this information is useful for re-binning, re-analyzing, etc.
If this information is preserved, the standard matplotlib `Figure`
object reference could be passed around queried instead of needing to
rerun python scripts.

New Containers:

`CallContainer`:

Meant to hold both user-call information (`x`, `y`, `label`, etc.) and
information generated during the plot call (`xedges`, `yedges`, `h`,
`patches`, etc.). This class is a parent class, which will be useful for
inheritance testing.

`HistCallContainer`:

A `CallContainer` meant to hold information about calls to `hist`.

`Hist2dCallContainer`:

A `CallContainer` meant to hold information about calls to `hist2d`. The
container in this instance is very useful. Though we get an `h` matrix
and a colormap, we lose the actual heights of matrix image. Again,
re-binning, seeing the number of elements in each bin, etc.

The impetus for this is having a unique figure description held in the
`Figure` object. If we have an unambiguous figure representation, we the
visualizations and the data created in matplotlib can be exported
elsewhere.
