### PR TITLE
BUG : fix fetch of freetype version during build

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -896,7 +896,7 @@ class FreeType(SetupPackage):
         if sys.platform == 'win32':
             return "Unknown version"
 
-        status, output = getstatusoutput("freetype-config --version")
+        status, output = getstatusoutput("freetype-config --ftversion")
         if status == 0:
             version = output
         else:


### PR DESCRIPTION
Use freetype-config --ftversion flag to get freetype version (previously using
freetype-config --version which returns libtool version).
