### PR TITLE
backend_pgf: Error message for missing latex executable (fix #3051)

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -309,9 +309,13 @@ class LatexManager:
         self.texcommand = get_texcommand()
         self.latex_header = LatexManager._build_latex_header()
         latex_end = "\n\\makeatletter\n\\@@end\n"
-        latex = subprocess.Popen([self.texcommand, "-halt-on-error"],
-                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                 cwd=self.tmpdir)
+        try:
+            latex = subprocess.Popen([self.texcommand, "-halt-on-error"],
+                                     stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     cwd=self.tmpdir)
+        except OSError:
+            raise RuntimeError("Error starting process '%s'" % self.texcommand)
         test_input = self.latex_header + latex_end
         stdout, stderr = latex.communicate(test_input.encode("utf-8"))
         if latex.returncode != 0:


### PR DESCRIPTION
Raise RuntimeError with appropriate message when failing to start a latex subprocess (fix #3051).
