### PR TITLE
MNT : replace and deprecated qt4_compat

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -50,6 +50,11 @@ original location:
   - mstream -> `from matplotlib import stream as mstream`
   - mtable -> `from matplotlib import table as mtable`
 
+* As part of the refactoring to enable Qt5 support, the module
+  `matplotlib.backends.qt4_compat` was renamed to
+  `matplotlib.qt_compat`.  `qt4_compat` is deprecated in 1.4 and
+   will be removed in 1.5.
+
 * The :func:`~matplotlib.pyplot.errorbar` method has been changed such that
   the upper and lower limits (*lolims*, *uplims*, *xlolims*, *xuplims*) now
   point in the correct direction.

--- a/lib/matplotlib/backends/qt4_compat.py
+++ b/lib/matplotlib/backends/qt4_compat.py
@@ -1,0 +1,11 @@
+import warnings
+from matplotlib.cbook import mplDeprecation
+_warn_str = ("This module has been deprecated in 1.4 in favor "
+             "matplotlib.backends.qt_compat\n"
+             "This module will be removed in 1.5, please update "
+             "your imports.")
+# bulk-imports because we are pretending that file is this file
+from .qt_compat import *
+
+
+warnings.warn(_warn_str, mplDeprecation)


### PR DESCRIPTION
As part of the work to support qt5 qt4_compat got renamed to qt_compat.
Replaced the module for graceful deprecation.

Closes #3172
