### PR TITLE
DOC: Fix order of parameters in ax.text docstring.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -523,11 +523,11 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        s : string
-            text
-
         x, y : scalars
             data coordinates
+
+        s : string
+            text
 
         fontdict : dictionary, optional, default: None
             A dictionary to override the default text properties. If fontdict


### PR DESCRIPTION
The parameters of text are described in the wrong order. A very minor fix, but it has tripped me up a few times.
