### PR TITLE
BUG: use unittest.mock for Python 3.3+

### DIFF
--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -9,7 +9,11 @@ import warnings
 import tempfile
 
 import dateutil
-import mock
+try:
+    # mock in python 3.3+
+    from unittest import mock
+except ImportError:
+    import mock
 from nose.tools import assert_raises, assert_equal
 
 from matplotlib.testing.decorators import image_comparison, cleanup

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -3,8 +3,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 from six.moves import xrange
-
-import mock
+try:
+    # mock in python 3.3+
+    from unittest import mock
+except ImportError:
+    import mock
 from nose.tools import assert_equal
 import numpy as np
 

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -3,13 +3,18 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-import mock
-from nose.tools import assert_equal
 import numpy as np
 
 from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 import matplotlib.patheffects as path_effects
+
+try:
+    # mock in python 3.3+
+    from unittest import mock
+except ImportError:
+    import mock
+from nose.tools import assert_equal
 
 
 @image_comparison(baseline_images=['patheffect1'], remove_text=True)


### PR DESCRIPTION
Some tests had unguarded import of 'mock', but 'mock' package not installed
for Python 3.3+; change to use 'unittest.mock'.
