### PR TITLE
Fix plot directive when used with multiple options.

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -421,7 +421,7 @@ TEMPLATE = """
 
    {% for img in images %}
    .. figure:: {{ build_dir }}/{{ img.basename }}.png
-      {%- for option in options %}
+      {% for option in options -%}
       {{ option }}
       {% endfor %}
 
@@ -447,7 +447,7 @@ TEMPLATE = """
 
    {% for img in images %}
    .. image:: {{ build_dir }}/{{ img.basename }}.png
-      {%- for option in options %}
+      {% for option in options -%}
       {{ option }}
       {% endfor %}
 


### PR DESCRIPTION
The existing template produces newlines between options, which were confusing
the reST parser. By fiddling with whitespace control, the template can
be made to put things together correctly.

See #2928.
