### PR TITLE
Fix deprecation warning in simple_linear_interpolation

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1746,7 +1746,7 @@ def simple_linear_interpolation(a, steps):
     result[0] = a[0]
     a0 = a[0:-1]
     a1 = a[1:]
-    delta = (a1 - a0) / float(steps)
+    delta = (a1 - a0) / steps
     for i in range(1, steps):
         result[i::steps] = delta * i + a0
     result[steps::steps] = a1


### PR DESCRIPTION
On master, when drawing polar plots:

```
cbook.py:1744: DeprecationWarning: using a non-integer number instead of an 
integer will result in an error in the future
    result = np.zeros(new_shape, a.dtype)
```

Ps: could I have pushed this on #2100 instead of creating another PR ?
