### PR TITLE
Add missing import of unichr from six.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -6,6 +6,7 @@ import os
 import re
 import signal
 import sys
+from six import unichr
 
 import matplotlib
 


### PR DESCRIPTION
Unichr is not defined in python3. This matches the usage in mathtext. The qt backend tests where failing for me with out this fix. I guess these don't run on travis. 
