### PR TITLE
Fix PEP8 error.

### DIFF
--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -192,7 +192,6 @@ def test_given_colors_levels_and_extends():
         plt.colorbar()
 
 
-
 @image_comparison(baseline_images=['contour_datetime_axis'],
                   extensions=['png'], remove_text=False)
 def test_contour_datetime_axis():


### PR DESCRIPTION
Causing a bunch of Travis PRs to fail currently:

```
test_contour.py:196:1: E303 too many blank lines (3)
```
