### PR TITLE
Started simple reorganization of the gallery examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -118,7 +118,7 @@ plot_formats = [('png', 80), ('hires.png', 200), ('pdf', 50)]
 # Subdirectories in 'examples/' directory of package and titles for gallery
 mpl_example_sections = (
     ('lines_bars_and_markers', 'Lines, bars, and markers'),
-    ('shapes_and_collections', 'Shapes and collections'),
+    ('shapes_and_collections', 'Shapes, collections and paths'),
     ('statistics', 'Statistical plots'),
     ('images_contours_and_fields', 'Images, contours, and fields'),
     ('pie_and_polar_charts', 'Pie and polar charts'),

--- a/examples/lines_bars_and_markers/barchart_vertical.py
+++ b/examples/lines_bars_and_markers/barchart_vertical.py
@@ -1,0 +1,39 @@
+
+#!/usr/bin/env python
+# a bar plot with errorbars
+import numpy as np
+import matplotlib.pyplot as plt
+
+N = 5
+menMeans = (20, 35, 30, 35, 27)
+menStd =   (2, 3, 4, 1, 2)
+
+ind = np.arange(N)  # the x locations for the groups
+width = 0.35       # the width of the bars
+
+fig, ax = plt.subplots()
+rects1 = ax.bar(ind, menMeans, width, color='r', yerr=menStd)
+
+womenMeans = (25, 32, 34, 20, 25)
+womenStd =   (3, 5, 2, 3, 3)
+rects2 = ax.bar(ind+width, womenMeans, width, color='y', yerr=womenStd)
+
+# add some text for labels, title and axes ticks
+ax.set_ylabel('Scores')
+ax.set_title('Scores by group and gender')
+ax.set_xticks(ind+width)
+ax.set_xticklabels( ('G1', 'G2', 'G3', 'G4', 'G5') )
+
+ax.legend( (rects1[0], rects2[0]), ('Men', 'Women') )
+
+def autolabel(rects):
+    # attach some text labels
+    for rect in rects:
+        height = rect.get_height()
+        ax.text(rect.get_x()+rect.get_width()/2., 1.05*height, '%d'%int(height),
+                ha='center', va='bottom')
+
+autolabel(rects1)
+autolabel(rects2)
+
+plt.show()

--- a/examples/shapes_and_collections/bbox_intersect.py
+++ b/examples/shapes_and_collections/bbox_intersect.py
@@ -1,0 +1,19 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.transforms import Bbox
+from matplotlib.path import Path
+
+rect = plt.Rectangle((-1, -1), 2, 2, facecolor="#aaaaaa")
+plt.gca().add_patch(rect)
+bbox = Bbox.from_bounds(-1, -1, 2, 2)
+
+for i in range(12):
+    vertices = (np.random.random((2, 2)) - 0.5) * 6.0
+    path = Path(vertices)
+    if path.intersects_bbox(bbox):
+        color = 'r'
+    else:
+        color = 'b'
+    plt.plot(vertices[:,0], vertices[:,1], color=color)
+
+plt.show()

--- a/examples/shapes_and_collections/collections_demo.py
+++ b/examples/shapes_and_collections/collections_demo.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+'''Demonstration of LineCollection, PolyCollection, and
+RegularPolyCollection with autoscaling.
+
+For the first two subplots, we will use spirals.  Their
+size will be set in plot units, not data units.  Their positions
+will be set in data units by using the "offsets" and "transOffset"
+kwargs of the LineCollection and PolyCollection.
+
+The third subplot will make regular polygons, with the same
+type of scaling and positioning as in the first two.
+
+The last subplot illustrates the use of "offsets=(xo,yo)",
+that is, a single tuple instead of a list of tuples, to generate
+successively offset curves, with the offset given in data
+units.  This behavior is available only for the LineCollection.
+
+'''
+
+import matplotlib.pyplot as plt
+from matplotlib import collections, transforms
+from matplotlib.colors import colorConverter
+import numpy as np
+
+nverts = 50
+npts = 100
+
+# Make some spirals
+r = np.array(range(nverts))
+theta = np.array(range(nverts)) * (2*np.pi)/(nverts-1)
+xx = r * np.sin(theta)
+yy = r * np.cos(theta)
+spiral = list(zip(xx,yy))
+
+# Make some offsets
+rs = np.random.RandomState([12345678])
+xo = rs.randn(npts)
+yo = rs.randn(npts)
+xyo = list(zip(xo, yo))
+
+# Make a list of colors cycling through the rgbcmyk series.
+colors = [colorConverter.to_rgba(c) for c in ('r','g','b','c','y','m','k')]
+
+fig, axes = plt.subplots(2,2)
+((ax1, ax2), (ax3, ax4)) = axes # unpack the axes
+
+
+col = collections.LineCollection([spiral], offsets=xyo,
+                                transOffset=ax1.transData)
+trans = fig.dpi_scale_trans + transforms.Affine2D().scale(1.0/72.0)
+col.set_transform(trans)  # the points to pixels transform
+    # Note: the first argument to the collection initializer
+    # must be a list of sequences of x,y tuples; we have only
+    # one sequence, but we still have to put it in a list.
+ax1.add_collection(col, autolim=True)
+    # autolim=True enables autoscaling.  For collections with
+    # offsets like this, it is neither efficient nor accurate,
+    # but it is good enough to generate a plot that you can use
+    # as a starting point.  If you know beforehand the range of
+    # x and y that you want to show, it is better to set them
+    # explicitly, leave out the autolim kwarg (or set it to False),
+    # and omit the 'ax1.autoscale_view()' call below.
+
+# Make a transform for the line segments such that their size is
+# given in points:
+col.set_color(colors)
+
+ax1.autoscale_view()  # See comment above, after ax1.add_collection.
+ax1.set_title('LineCollection using offsets')
+
+
+# The same data as above, but fill the curves.
+col = collections.PolyCollection([spiral], offsets=xyo,
+                                transOffset=ax2.transData)
+trans = transforms.Affine2D().scale(fig.dpi/72.0)
+col.set_transform(trans)  # the points to pixels transform
+ax2.add_collection(col, autolim=True)
+col.set_color(colors)
+
+
+ax2.autoscale_view()
+ax2.set_title('PolyCollection using offsets')
+
+# 7-sided regular polygons
+
+col = collections.RegularPolyCollection(7,
+                                        sizes = np.fabs(xx)*10.0, offsets=xyo,
+                                        transOffset=ax3.transData)
+trans = transforms.Affine2D().scale(fig.dpi/72.0)
+col.set_transform(trans)  # the points to pixels transform
+ax3.add_collection(col, autolim=True)
+col.set_color(colors)
+ax3.autoscale_view()
+ax3.set_title('RegularPolyCollection using offsets')
+
+
+# Simulate a series of ocean current profiles, successively
+# offset by 0.1 m/s so that they form what is sometimes called
+# a "waterfall" plot or a "stagger" plot.
+
+nverts = 60
+ncurves = 20
+offs = (0.1, 0.0)
+
+yy = np.linspace(0, 2*np.pi, nverts)
+ym = np.amax(yy)
+xx = (0.2 + (ym-yy)/ym)**2 * np.cos(yy-0.4) * 0.5
+segs = []
+for i in range(ncurves):
+    xxx = xx + 0.02*rs.randn(nverts)
+    curve = list(zip(xxx, yy*100))
+    segs.append(curve)
+
+col = collections.LineCollection(segs, offsets=offs)
+ax4.add_collection(col, autolim=True)
+col.set_color(colors)
+ax4.autoscale_view()
+ax4.set_title('Successive data offsets')
+ax4.set_xlabel('Zonal velocity component (m/s)')
+ax4.set_ylabel('Depth (m)')
+# Reverse the y-axis so depth increases downward
+ax4.set_ylim(ax4.get_ylim()[::-1])
+
+
+plt.show()
+
+


### PR DESCRIPTION
Together with Hamid at the SciPy sprint, we are starting to reorganize the huge blocks of examples in the gallery to relevant directories.

At the moment, we are _not_ modifying the examples, just moving the current ones into more suitable directories.
