### PR TITLE
Fixes #3219 by ignoring pep8 noncomplicant auto-generated file.

### DIFF
--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -35,7 +35,8 @@ EXCLUDE_FILES = ['_delaunay.py',
                  '_gtkagg.py',
                  '_backend_gdk.py',
                  'pyparsing*',
-                 '_qhull.py']
+                 '_qhull.py',
+                 '_macosx.py']
 
 PEP8_ADDITIONAL_IGNORE = ['E111',
                           'E112',


### PR DESCRIPTION
at the suggestion of @tacaswell, I'm just adding this auto-generated macosx.py file to the ignore list with it's compadres.

Fixes #3219 on my machine. 
