### PR TITLE
DEP : bump min numpy to 1.6

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -111,7 +111,7 @@ import sys
 import distutils.version
 
 __version__  = '1.4.x'
-__version__numpy__ = '1.5' # minimum required numpy version
+__version__numpy__ = '1.6' # minimum required numpy version
 
 try:
     import dateutil


### PR DESCRIPTION
Closes #3226, discussed in #3191

Closes #3191 as we no longer need to worry if the tests pass with 1.5
