### PR TITLE
TST: Fix test_backend_ps failures on Windows

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -39,7 +39,7 @@ def _test_savefig_to_stringio(format='ps'):
     values = [re.sub(b'%%.*?\n', b'', x) for x in values]
 
     assert values[0] == values[1]
-    assert values[1] == values[2].replace('\r\n', '\n')
+    assert values[1] == values[2].replace(b'\r\n', b'\n')
 
 
 @cleanup


### PR DESCRIPTION
```
======================================================================
FAIL: matplotlib.tests.test_backend_ps.test_savefig_to_stringio
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\testing\decorators.py", line 110, in wrapped_function
    func(*args, **kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_backend_ps.py", line 47, in test_savefig_to_stringio
    _test_savefig_to_stringio()
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_backend_ps.py", line 42, in _test_savefig_to_stringio
    assert values[1] == values[2]
AssertionError

======================================================================
FAIL: matplotlib.tests.test_backend_ps.test_savefig_to_stringio_eps
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\testing\decorators.py", line 110, in wrapped_function
    func(*args, **kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_backend_ps.py", line 68, in test_savefig_to_stringio_eps
    _test_savefig_to_stringio(format='eps')
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_backend_ps.py", line 42, in _test_savefig_to_stringio
    assert values[1] == values[2]
AssertionError
```
