### PR TITLE
Add animation.convert_path setting to matplotlibrc.template

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -483,3 +483,6 @@ backend      : %(backend)s
                                    # Path to mencoder binary. Without full path
                                    # $PATH is searched
 #animation.mencoder_args: ''       # Additional arguments to pass to mencoder
+#animation.convert_path: 'convert' # Path to ImageMagick's convert binary.
+                                   # On Windows use the full path since convert 
+                                   # is also the name of a system tool.


### PR DESCRIPTION
Added a note that on Windows the full path to ImageMagicks convert.exe needs to be specified since convert.exe is also the name of a Windows system tool. 
See http://matplotlib.1069221.n5.nabble.com/Couldn-t-save-animation-as-gif-td42260.html
