### PR TITLE
Stop make.py removing generated documentation figs

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -145,13 +145,6 @@ def html():
     if os.system('sphinx-build %s -b html -d build/doctrees . build/html' % options):
         raise SystemExit("Building HTML failed.")
 
-    figures_dest_path = 'build/html/pyplots'
-    if os.path.exists(figures_dest_path):
-        shutil.rmtree(figures_dest_path)
-    copytree(
-        'pyplots', figures_dest_path,
-        ignore=ignore_patterns("*.pyc"))
-
     # Clean out PDF files from the _images directory
     for filename in glob.glob('build/html/_images/*.pdf'):
         os.remove(filename)

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -575,7 +575,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
                    function_name, config, context_reset=False):
     """
     Run a pyplot script and save the low and high res PNGs and a PDF
-    in outdir.
+    in *output_dir*.
 
     Save the images under *output_dir* with file names derived from
     *output_base*
@@ -598,7 +598,6 @@ def render_figures(code, code_path, output_dir, output_base, context,
 
     code_pieces = split_code_at_show(code)
 
-    # Look for single-figure output files first
     # Look for single-figure output files first
     all_exists = True
     img = ImageFile(output_base, output_dir)


### PR DESCRIPTION
I think this fixes #2908.  Links seem to work locally now.
