### PR TITLE
Get rid of warning about GTK3Agg with python3

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1711,9 +1711,6 @@ class BackendGtk3Agg(OptionalBackendPackage):
         if 'TRAVIS' in os.environ:
             raise CheckFailed("Can't build with Travis")
 
-        if PY3:
-            raise CheckFailed("gtk3agg backend does not work on Python 3")
-
         # This check needs to be performed out-of-process, because
         # importing gi and then importing regular old pygtk afterward
         # segfaults the interpreter.


### PR DESCRIPTION
According to #1227 this has been fixed by using cairocffi. 

I don't actually have a working gtk3 setup to test on at the moment so I haven't tested it. 
(Pygobject3 from homebrew segfaults for me with python3 on mac, but that is not a matplotlib issue)
