### PR TITLE
Fix use of a non-integer index in split_path_inout.

### DIFF
--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -256,7 +256,7 @@ def split_path_inout(path, inside, tolerence=0.01, reorder_inout=False):
 
     for ctl_points, command in path_iter:
         iold = i
-        i += len(ctl_points) / 2
+        i += len(ctl_points) // 2
         if inside(ctl_points[-2:]) != begin_inside:
             bezier_path = concat([ctl_points_old[-2:], ctl_points])
             break


### PR DESCRIPTION
This fixes warnings like:

```
/usr/lib64/python3.3/site-packages/matplotlib/bezier.py:294: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  path_out = Path(concat([verts_right, path.vertices[i:]]),
```

because `i += len(ctl_points) / 2` is a float. I assume that `ctl_points` is guaranteed to be divisible by two here.
