### PR TITLE
BUG : fixes FontProperties memory leak

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -707,6 +707,12 @@ class FontProperties(object):
              self.get_file())
         return hash(l)
 
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __ne__(self, other):
+        return hash(self) != hash(other)
+
     def __str__(self):
         return self.get_fontconfig_pattern()
 


### PR DESCRIPTION
According to the data
model (https://docs.python.org/2/reference/datamodel.html#object.__hash__)
objects that define **hash** need to define **eq** or **cmp**.  By
default, all user defined classes have a **cmp** which evaluates to
False for all other objects.

Previously we do not define either **cmp** or **eq** on FontProperties,

This results in never finding the property
cached in the dict, hence the growth in the number of
FontProperties (and I assume the stuff in them).

By adding **eq** and **ne** we complete the data model and adding
FontProperties to dictionaries should work as expected.

This was not a problem before, but in #3077 the caching key was changed
from hash(prop) -> prop.

Closes #3264
