### PR TITLE
Use libpng-config if available

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -976,10 +976,16 @@ class Png(SetupPackage):
     name = "png"
 
     def check(self):
+        status, output = getstatusoutput("libpng-config --version")
+        if status == 0:
+            version = output
+        else:
+            version = None
+
         try:
             return self._check_for_pkg_config(
                 'libpng', 'png.h',
-                min_version='1.2')
+                min_version='1.2', version=version)
         except CheckFailed as e:
             self.__class__.found_external = False
             return str(e) + ' Using unknown version.'
@@ -990,7 +996,8 @@ class Png(SetupPackage):
             ]
         ext = make_extension('matplotlib._png', sources)
         pkg_config.setup_extension(
-            ext, 'libpng', default_libraries=['png', 'z'])
+            ext, 'libpng', default_libraries=['png', 'z'],
+            alt_exec='libpng-config --ldflags')
         Numpy().add_flags(ext)
         CXX().add_flags(ext)
         return ext


### PR DESCRIPTION
Use alt_exec to pass libpng-config with ldflags argument.
Also duplicated versioning ability as freetype class performs it. This allows for pretty config summary.
