### PR TITLE
Catch warning thrown in Mollweide projection.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1014,8 +1014,7 @@ class Axis(artist.Artist):
             # invalid numpy calculations that may be the result of out of
             # bounds on axis with finite allowed intervals such as geo
             # projections i.e. Mollweide.
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', category=RuntimeWarning)
+            with np.errstate(invalid='ignore'):
                 try:
                     ds1 = self._get_pixel_distance_along_axis(
                         interval_expanded[0], -0.5)


### PR DESCRIPTION
Yet another pull request to silence another warning in the test suite. 

A RuntimeWarning is thrown in the MollWeide grid tests since mpl tries to transform a point for tick calculation which is outside the allowed interval. This happens due to the code that expands the tick interval to not miss any ticks. The transform calculates np.arcsin(y/sqrt(2))
where y is larger that sqrt(2)

I also slightly improved the warnings message below to clarify that this is related to ticks only.

Also some PEP8 around the code that I changed.
