### PR TITLE
Suppress invalid argument warnings in inverse Mollweide projection

### DIFF
--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -484,11 +484,12 @@ class MollweideAxes(GeoAxes):
             x = xy[:, 0:1]
             y = xy[:, 1:2]
 
-            # from Equations (7, 8) of
-            # http://mathworld.wolfram.com/MollweideProjection.html
-            theta = np.arcsin(y / np.sqrt(2))
-            lon = (np.pi / (2 * np.sqrt(2))) * x / np.cos(theta)
-            lat = np.arcsin((2 * theta + np.sin(2 * theta)) / np.pi)
+            with np.errstate(invalid='ignore'):
+                # from Equations (7, 8) of
+                # http://mathworld.wolfram.com/MollweideProjection.html
+                theta = np.arcsin(y / np.sqrt(2))
+                lon = (np.pi / (2 * np.sqrt(2))) * x / np.cos(theta)
+                lat = np.arcsin((2 * theta + np.sin(2 * theta)) / np.pi)
 
             return np.concatenate((lon, lat), 1)
         transform_non_affine.__doc__ = Transform.transform_non_affine.__doc__


### PR DESCRIPTION
The Mollweide inverse projection generates Numpy invalid value warnings for pixels outside of the projection. For example, the following code:

```
from matplotlib import pyplot as plt
plt.subplot(111, projection='mollweide')
plt.savefig('test.png')
```

produces this warning:

```
.../matplotlib/projections/geo.py:489:
RuntimeWarning: invalid value encountered in arcsin
  theta = np.arcsin(y / np.sqrt(2))
```

This patch silences the warning by wrapping the inverse transformation in a `np.errstate` context.
