### PR TITLE
BUG : fix  _reshape_2D bug with [(n, 1), ..] input

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2168,6 +2168,8 @@ def _reshape_2D(X):
 
     if not hasattr(X[0], '__len__'):
         X = [X]
+    else:
+        X = [np.ravel(x) for x in X]
 
     return X
 


### PR DESCRIPTION
`cbook._reshape_2D` the input can be _at most_ 2D, however if it
is passed a list of (n, 1) shaped ndarray this condition will
be violated and it fails to work (which is less than great, but
fine from a documentation stand point).  However, boxplot _used_
to work with a list of such ndarrays (and users might expect to
call a (n, 1) shaped array a 1D array).  The added `ravel` makes
sure that even if we get a list of any dimensional ndarrays in, the
output will be a list of (n, ) shaped arrays.

Closes #3220
