### PR TITLE
Use the interpolation parameter in make_thumbnail

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1439,6 +1439,6 @@ def thumbnail(infile, thumbfile, scale=0.1, interpolation='bilinear',
                       frameon=False, xticks=[], yticks=[])
 
     basename, ext = os.path.splitext(basename)
-    ax.imshow(im, aspect='auto', resample=True, interpolation='bilinear')
+    ax.imshow(im, aspect='auto', resample=True, interpolation=interpolation)
     fig.savefig(thumbfile, dpi=dpi)
     return fig


### PR DESCRIPTION
Just happened to notice that the interpolation parameter in make_thumbnail never actually gets used.
