### PR TITLE
Check for GhostScript in this test which needs it

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -51,6 +51,8 @@ def test_savefig_to_stringio():
 
 @cleanup
 def test_savefig_to_stringio_with_distiller():
+    if not matplotlib.checkdep_ghostscript():
+        raise SkipTest("This test requires a GhostScript installation")
     matplotlib.rcParams['ps.usedistiller'] = 'ghostscript'
     _test_savefig_to_stringio()
 


### PR DESCRIPTION
This should fix #3259 by only running the test that needs ghostscript when it is available. 
