### PR TITLE
TST: Fix test_animation RuntimeErrors on Windows

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
+import os
 import tempfile
 import sys
 import numpy as np
@@ -55,6 +56,7 @@ def check_save_animation(writer, extension='mp4'):
 
     # Use NamedTemporaryFile: will be automatically deleted
     F = tempfile.NamedTemporaryFile(suffix='.' + extension)
+    F.close()
     anim = animation.FuncAnimation(fig, animate, init_func=init, frames=5)
     try:
         anim.save(F.name, fps=30, writer=writer)
@@ -63,7 +65,10 @@ def check_save_animation(writer, extension='mp4'):
                                "import stack, " +
                                "see issues #1891 and #2679")
     finally:
-        F.close()
+        try:
+            os.remove(F.name)
+        except Exception:
+            pass
 
 
 @cleanup


### PR DESCRIPTION
Fixes the following test errors:

```
======================================================================
ERROR: matplotlib.tests.test_animation.test_save_animation_smoketest('imagemagick_file', u'gif')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_animation.py", line 60, in check_save_animation
    anim.save(F.name, fps=30, writer=writer)
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 752, in save
    writer.grab_frame(**savefig_kwargs)
  File "X:\Python27-x64\lib\contextlib.py", line 24, in __exit__
    self.gen.next()
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 177, in saving
    self.finish()
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 365, in finish
    + ' Try running with --verbose-debug')
RuntimeError: Error creating movie, return code: 1 Try running with --verbose-debug

======================================================================
ERROR: matplotlib.tests.test_animation.test_save_animation_smoketest('ffmpeg', u'mp4')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_animation.py", line 60, in check_save_animation
    anim.save(F.name, fps=30, writer=writer)
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 752, in save
    writer.grab_frame(**savefig_kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 210, in grab_frame
    dpi=self.dpi, **savefig_kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\figure.py", line 1470, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\backend_bases.py", line 2192, in print_figure
    **kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\backends\backend_agg.py", line 505, in print_raw
    renderer._renderer.write_rgba(filename_or_obj)
RuntimeError: Error writing to file

======================================================================
ERROR: matplotlib.tests.test_animation.test_save_animation_smoketest('ffmpeg_file', u'mp4')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_animation.py", line 60, in check_save_animation
    anim.save(F.name, fps=30, writer=writer)
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 752, in save
    writer.grab_frame(**savefig_kwargs)
  File "X:\Python27-x64\lib\contextlib.py", line 24, in __exit__
    self.gen.next()
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 177, in saving
    self.finish()
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 365, in finish
    + ' Try running with --verbose-debug')
RuntimeError: Error creating movie, return code: 1 Try running with --verbose-debug

======================================================================
ERROR: matplotlib.tests.test_animation.test_save_animation_smoketest('avconv', u'mp4')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_animation.py", line 60, in check_save_animation
    anim.save(F.name, fps=30, writer=writer)
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 752, in save
    writer.grab_frame(**savefig_kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 210, in grab_frame
    dpi=self.dpi, **savefig_kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\figure.py", line 1470, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\backend_bases.py", line 2192, in print_figure
    **kwargs)
  File "X:\Python27-x64\lib\site-packages\matplotlib\backends\backend_agg.py", line 505, in print_raw
    renderer._renderer.write_rgba(filename_or_obj)
RuntimeError: Error writing to file

======================================================================
ERROR: matplotlib.tests.test_animation.test_save_animation_smoketest('avconv_file', u'mp4')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\matplotlib\tests\test_animation.py", line 60, in check_save_animation
    anim.save(F.name, fps=30, writer=writer)
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 752, in save
    writer.grab_frame(**savefig_kwargs)
  File "X:\Python27-x64\lib\contextlib.py", line 24, in __exit__
    self.gen.next()
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 177, in saving
    self.finish()
  File "X:\Python27-x64\lib\site-packages\matplotlib\animation.py", line 365, in finish
    + ' Try running with --verbose-debug')
RuntimeError: Error creating movie, return code: 1 Try running with --verbose-debug
```
