### PR TITLE
Replaced unicode() function by six.text_type

### DIFF
--- a/lib/matplotlib/backends/qt_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/formlayout.py
@@ -323,7 +323,7 @@ class FormWidget(QtWidgets.QWidget):
             elif tuple_to_qfont(value) is not None:
                 value = field.get_font()
             elif isinstance(value, six.string_types) or is_color_like(value):
-                value = unicode(field.text())
+                value = six.text_type(field.text())
             elif isinstance(value, (list, tuple)):
                 index = int(field.currentIndex())
                 if isinstance(value[0], (list, tuple)):


### PR DESCRIPTION
The Figure options dialog wasn' t working for me under Python3. Because ther is no unicode() function in Python3 I had to replace this by six.text_type.
