### PR TITLE
Restore compatibility with Python 3.2

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -381,7 +381,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
                 key = key.lower()
 
         mods.reverse()
-        return u'+'.join(mods + [key])
+        return six.u('+').join(mods + [key])
 
     def new_timer(self, *args, **kwargs):
         """


### PR DESCRIPTION
Fixes:

```
======================================================================
ERROR: Failure: SyntaxError (invalid syntax (backend_qt5.py, line 384))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python32\lib\site-packages\nose\failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "X:\Python32\lib\site-packages\nose\loader.py", line 403, in loadTestsFromName
    module = resolve_name(addr.module)
  File "X:\Python32\lib\site-packages\nose\util.py", line 311, in resolve_name
    module = __import__('.'.join(parts_copy))
  File "X:\Python32\lib\site-packages\matplotlib\tests\test_backend_qt4.py", line 20, in <module>
    from matplotlib.backends.backend_qt4 import (MODIFIER_KEYS,
  File "X:\Python32\lib\site-packages\matplotlib\backends\backend_qt4.py", line 35, in <module>
    from .backend_qt5 import (backend_version, SPECIAL_KEYS, SUPER, ALT, CTRL,
  File "X:\Python32\lib\site-packages\matplotlib\backends\backend_qt5.py", line 384
    return u'+'.join(mods + [key])
              ^
SyntaxError: invalid syntax
```

On Windows, Python 3.2 passes all tests with this patch.
