### PR TITLE
Fix #3330 by changing weight into string [cherry-pick to master]

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -140,6 +140,11 @@ class RendererMac(RendererBase):
         else:
             family =  prop.get_family()
             weight = prop.get_weight()
+            # transform weight into string for the native backend
+            if weight >= 700:
+                weight = 'bold'
+            else:
+                weight = 'normal'
             style = prop.get_style()
             points = prop.get_size_in_points()
             size = self.points_to_pixels(points)
@@ -159,6 +164,11 @@ class RendererMac(RendererBase):
             return width, height, descent
         family =  prop.get_family()
         weight = prop.get_weight()
+        # transform weight into string for the native backend
+        if weight >= 700:
+            weight = 'bold'
+        else:
+            weight = 'normal'
         style = prop.get_style()
         points = prop.get_size_in_points()
         size = self.points_to_pixels(points)

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -864,6 +864,7 @@ class FontProperties(object):
         except ValueError:
             if weight not in weight_dict:
                 raise ValueError("weight is invalid")
+            weight = weight_dict[weight]
         self._weight = weight
 
     def set_stretch(self, stretch):


### PR DESCRIPTION
(see issue #3330).
The native part of the backend is actually checking whether the weight is `"bold"` (and the rest is normal) (see [_macosx.m:setfont] (https://github.com/matplotlib/matplotlib/blob/master/src/_macosx.m#L2345-L2362)).
So I'm checking `weight` against 700 and I'm putting bolder weights to `"bold"` (according to [`weight_dict`](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/font_manager.py#L91-L105)).