### PR TITLE
Fix mathmpl images not showing in HTML Help (CHM)

### DIFF
--- a/lib/matplotlib/sphinxext/mathmpl.py
+++ b/lib/matplotlib/sphinxext/mathmpl.py
@@ -72,7 +72,7 @@ def latex2html(node, source):
     if not os.path.exists(destdir):
         os.makedirs(destdir)
     dest = os.path.join(destdir, '%s.png' % name)
-    path = os.path.join(setup.app.builder.imgpath, 'mathmpl')
+    path = '/'.join((setup.app.builder.imgpath, 'mathmpl'))
 
     depth = latex2png(latex, dest, node['fontset'])
 


### PR DESCRIPTION
Reported at http://matplotlib.1069221.n5.nabble.com/Thanks-for-the-HtmlHelp-file-td43735.html
