### PR TITLE
fix for figure resizing in webagg

### DIFF
--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -40,7 +40,7 @@ mpl.figure = function(figure_id, websocket, ondownload, parent_element) {
     this.rubberband_context = undefined;
     this.format_dropdown = undefined;
 
-    this.focus_on_mousover = false;
+    this.focus_on_mouseover = false;
 
     this.root = $('<div/>');
     this.root.attr('style', 'display: inline-block');
@@ -89,9 +89,6 @@ mpl.figure.prototype._init_canvas = function() {
     var fig = this;
 
     var canvas_div = $('<div/>');
-    canvas_div.resizable({ resize: mpl.debounce_resize(
-        function(event, ui) { fig.request_resize(ui.size.width, ui.size.height); }
-        , 50)});
 
     canvas_div.attr('style', 'position: relative; clear: both;');
     this.root.append(canvas_div);
@@ -109,8 +106,44 @@ mpl.figure.prototype._init_canvas = function() {
 
     var rubberband = $('<canvas/>');
     rubberband.attr('style', "position: absolute; left: 0; top: 0; z-index: 1;")
+
+    var ignore_mouse_events = false;
+
+    // The if statement below should just be implemented directly in CSS...
+    if (!$("head").hasClass("boxme"))
+    {
+        $("<style type='text/css'> .boxme { background-color: lightgray; border: 1px solid gray;} </style>").appendTo("head");
+    }
+
+    canvas_div.resizable({ 
+        start: function(event, ui) {
+            ignore_mouse_events = true;
+            ctx = fig.context;
+            var canvas = ctx.canvas;
+            canvas.blur(); // removes focus if focused (may need more work?)
+            canvas_div.addClass("boxme");
+           
+            /// Clearing the canvas
+            // Store the current transformation matrix
+            ctx.save();
+            // Use the identity matrix while clearing the canvas
+            ctx.setTransform(1, 0, 0, 1, 0, 0);
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            // Restore the transform
+            ctx.restore();
+        },
+        stop: function(event, ui) { 
+            ignore_mouse_events = false;
+            fig.request_resize(ui.size.width, ui.size.height); 
+            canvas_div.removeClass("boxme");
+        },
+    });
+
     function mouse_event_fn(event) {
-        return fig.mouse_event(event, event['data']);
+        if (ignore_mouse_events == false)
+        {
+            return fig.mouse_event(event, event['data']);
+        }
     }
     rubberband.mousedown('button_press', mouse_event_fn);
     rubberband.mouseup('button_release', mouse_event_fn);
@@ -379,7 +412,7 @@ mpl.findpos = function(e) {
 };
 
 mpl.figure.prototype.mouse_event = function(event, name) {
-    var canvas_pos = mpl.findpos(event)
+    var canvas_pos = mpl.findpos(event);
 
     if (this.focus_on_mouseover && name === 'motion_notify')
     {


### PR DESCRIPTION
This is a fix for this issue: https://github.com/matplotlib/matplotlib/issues/3338

Currently, resizing does not work well in the webagg backend because mouse events are not ignored during the resize, which makes it both difficult and slow to do.

The code below ignores mouse events while resizing, but the fix is only for the figure in question. (So resizing figure 1 over figure 2 won't stop figure 2 from responding to mouse events.)

I also included some cosmetic changes: while resizing the figure, the figure is not rendered continuously but is replaced by a light gray box. This makes the resizing look a lot smoother in my opinion.

I have (very) little experience with javascript/html/css, so I wasn't sure where to place the CSS code for the "boxme" class. (It's directly in the javascript below, which probably isn't the best idea.)
