### PR TITLE
1.4.0 RC1: --ftversion vs --version freetype version

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -937,7 +937,7 @@ class FreeType(SetupPackage):
 
         return self._check_for_pkg_config(
             'freetype2', 'ft2build.h',
-            min_version='2.4', version=version)
+            min_version='2.3', version=version)
 
     def add_flags(self, ext):
         pkg_config.setup_extension(


### PR DESCRIPTION
In RC1 of mpl 1.4.0 the freetype version is now determined correctly using `freetype-config --ftversion` (before `--version` which returned the libtool version `9.22.3` in my case). This however now leads to the case of matplotlib rc1 not installing on my machine as I have freetype 2.3.11.

My question is: Is freetype2 2.4 really required? Due to the setup bug in mpl 1.3.1 I used mpl with freetype 2.3.11 without any problems for several months now. It could be possible though that I didn't use all relevant features which would actually require 2.4 if that's really the case.
