### PR TITLE
fix deprecation warning in simple linear interpolation

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1737,7 +1737,7 @@ def simple_linear_interpolation(a, steps):
     if steps == 1:
         return a
 
-    steps = np.floor(steps)
+    steps = int(np.floor(steps))
     new_length = ((len(a) - 1) * steps) + 1
     new_shape = list(a.shape)
     new_shape[0] = new_length


### PR DESCRIPTION
Using floats as a shape argument to np.zeros or other numpy functions prints a deprecation warning ("using a non-integer number instead of an integer will result in an error in the future") as of numpy 1.8.
