### PR TITLE
backend_qt5.py Don't use six.u

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -381,7 +381,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
                 key = key.lower()
 
         mods.reverse()
-        return six.u('+').join(mods + [key])
+        return '+'.join(mods + [key])
 
     def new_timer(self, *args, **kwargs):
         """


### PR DESCRIPTION
This code already does from `__future__ import unicode_literal`.
Thus '+' will be a unicode string even in python 2 and there is no
need for converting it into a unicode string. In fact this results in
a TypeError because six.u assumes the input string to be ASCII only.
See http://pythonhosted.org/six/#six.u

This fixes test failures with rc3 on python 2 

```
ERROR: matplotlib.tests.test_backend_qt4.test_shift
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python2.7/site-packages/matplotlib/testing/decorators.py", line 110, in wrapped_function
    func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/matplotlib/testing/decorators.py", line 51, in failer
    result = f(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/matplotlib/tests/test_backend_qt4.py", line 80, in test_shift
    'A')
  File "/usr/local/lib/python2.7/site-packages/matplotlib/tests/test_backend_qt4.py", line 72, in assert_correct_key
    qt_canvas.keyPressEvent(event)
  File "/usr/local/lib/python2.7/site-packages/matplotlib/backends/backend_qt5.py", line 312, in keyPressEvent
    key = self._get_key(event)
  File "/usr/local/lib/python2.7/site-packages/matplotlib/backends/backend_qt5.py", line 384, in _get_key
    return six.u('+').join(mods + [key])
  File "/usr/local/lib/python2.7/site-packages/six.py", line 589, in u
    return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
TypeError: decoding Unicode is not supported
```

An alternative solution would be to get rid of the use of `from __future__ import unicode_literal` but this seems less intrusive at this late stage. 

@cgohlke you changed this code the last time to ensure python 3.2 compatibility. Can you please check that you are ok with this change.  
