### PR TITLE
Don't use unicode_literals in backend_qt4

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 import six
 
 import os


### PR DESCRIPTION
This is an alternative to #3357. In short using unicode_lieterals with
six.u does not work and results in TypeErrors in python 2. This fixes
is by not using unicode_literals rather than getting rid of six.u

An alternative to #3357
This seems to work too but I am less confident that it will not introduce other issues. 
