### PR TITLE
BUG : modified logic on starting qApp

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -125,13 +125,13 @@ def _create_qApp():
     """
     Only one qApp can exist at a time, so check before creating one.
     """
-    if QtWidgets.QApplication.startingUp():
+
+    if qApp is None:
         if DEBUG:
             print("Starting up QApplication")
         global qApp
         app = QtWidgets.QApplication.instance()
         if app is None:
-
             # check for DISPLAY env variable on X11 build of Qt
             if hasattr(QtGui, "QX11Info"):
                 display = os.environ.get('DISPLAY')


### PR DESCRIPTION
when working in ipython, it seems that _create_qApp is not called
until the first time that a figure is made, but ipython has already
started up the QApplication for us (I think) so that we never set
backend_qt5.qApp to be non-None.  This seems to mostly be ok, but breaks
`plt.pause`.

I don't have time right now to track down the when this bug came in and if this is something we changed or something Ipython changed.
