### PR TITLE
Remove residual mention of TODO file, which no longer exists.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include CHANGELOG INSTALL
-include TODO CONTRIBUTING.md
+include CONTRIBUTING.md
 include Makefile MANIFEST.in
 include matplotlibrc.template setup.cfg.template
 include setupext.py setup.py distribute_setup.py

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PYTHON = `which python`
 VERSION = `${PYTHON} setup.py --version`
 
-DISTFILES = API_CHANGES KNOWN_BUGS INSTALL README TODO license	\
+DISTFILES = API_CHANGES KNOWN_BUGS INSTALL README license	\
 	CHANGELOG Makefile INTERACTIVE			\
 	MANIFEST.in lib lib/matplotlib lib/dateutil lib/pytz examples setup.py
 
@@ -49,6 +49,6 @@ test:
 
 
 test-coverage:
-	${PYTHON} tests.py --with-coverage --cover-package=matplotlib	
+	${PYTHON} tests.py --with-coverage --cover-package=matplotlib
 
 


### PR DESCRIPTION
This takes care of a warning; I should have found and removed these references to TODO when I removed the TODO file itself.
