### PR TITLE
BUG : make qApp global before using it

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -125,11 +125,11 @@ def _create_qApp():
     """
     Only one qApp can exist at a time, so check before creating one.
     """
+    global qApp
 
     if qApp is None:
         if DEBUG:
             print("Starting up QApplication")
-        global qApp
         app = QtWidgets.QApplication.instance()
         if app is None:
             # check for DISPLAY env variable on X11 build of Qt


### PR DESCRIPTION
Make qApp global in backend_qt5.py before using it.

This silences a warning.

I don't think this change requires a new RC.

closes #3379
