### PR TITLE
add PySide to interactive_bk list

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -28,7 +28,7 @@ from matplotlib.colors import is_color_like
 # The capitalized forms are needed for ipython at present; this may
 # change for later versions.
 
-interactive_bk = ['GTK', 'GTKAgg', 'GTKCairo', 'MacOSX',
+interactive_bk = ['GTK', 'GTKAgg', 'GTKCairo', 'MacOSX', 'PySide', 
                   'Qt4Agg', 'Qt5Agg', 'TkAgg', 'WX', 'WXAgg', 'CocoaAgg',
                   'GTK3Cairo', 'GTK3Agg', 'WebAgg', 'nbAgg']
 


### PR DESCRIPTION
This fixes what seems to me to be a straight-forward omission of PySide in the list of valid back ends.  I discovered it while building in a context where PySide was the only available gui backend and "PySide" got written to the default rc file.
