### PR TITLE
test_text Modify filter warning regex

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -22,8 +22,8 @@ def test_font_styles():
         return FontProperties(fname=path)
 
     from matplotlib.font_manager import FontProperties, findfont
-    warnings.filterwarnings('ignore', 'findfont: Font family \[\'Foo\'\] '+ \
-                            'not found. Falling back to .',
+    warnings.filterwarnings('ignore', ('findfont: Font family \[u?\'Foo\'\] '+
+                            'not found. Falling back to .'),
                             UserWarning,
                             module='matplotlib.font_manager')
     fig = plt.figure()


### PR DESCRIPTION
The regex will not match in python 2 since this is a unicode literal.
Fix that by adding an optional 'u' to the regex. 

This removes another warning from the test suite that i missed because it is python 2 only
