### PR TITLE
Fixes TypeError when installing without freetype

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -937,7 +937,7 @@ class FreeType(SetupPackage):
 
         # Early versions of freetype grep badly inside freetype-config,
         # so catch those cases. (tested with 2.5.3).
-        if 'No such file or directory\ngrep:' in version:
+        if version is None or 'No such file or directory\ngrep:' in version:
             version = self.version_from_header()
 
         return self._check_for_pkg_config(


### PR DESCRIPTION
When `freetype-config` is missing, setup.py crashes with TypeError. This fixes it and allows the "required packages" info to be printed.

Log of the error installing 1.4.0:

```
(venv-mpl)remram@vebian:~$ pip install -U matplotlib
Downloading/unpacking matplotlib
  Downloading matplotlib-1.4.0.tar.gz (51.2MB): 51.2MB downloaded
  Running setup.py (path:/tmp/venv-mpl/build/matplotlib/setup.py) egg_info for package matplotlib
    ============================================================================
    Edit setup.cfg to change the build options

    BUILDING MATPLOTLIB
                matplotlib: yes [1.4.0]
                    python: yes [2.7.8 (default, Aug 10 2014, 16:19:34)  [GCC
                            4.9.1]]
                  platform: yes [linux2]

    REQUIRED DEPENDENCIES AND EXTENSIONS
                     numpy: yes [not found. pip may install it below.]
                       six: yes [six was not found.]
                  dateutil: yes [dateutil was not found. It is required for date
                            axis support. pip/easy_install may attempt to
                            install it after matplotlib.]
                   tornado: yes [tornado was not found. It is required for the
                            WebAgg backend. pip/easy_install may attempt to
                            install it after matplotlib.]
                 pyparsing: yes [pyparsing was not found. It is required for
                            mathtext support. pip/easy_install may attempt to
                            install it after matplotlib.]
                     pycxx: yes [Couldn't import.  Using local copy.]
                    libagg: yes [pkg-config information for 'libagg' could not
                            be found. Using local copy.]
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/venv-mpl/build/matplotlib/setup.py", line 154, in <module>
        result = package.check()
      File "setupext.py", line 940, in check
        if 'No such file or directory\ngrep:' in version:
    TypeError: argument of type 'NoneType' is not iterable
    Complete output from command python setup.py egg_info:
    ============================================================================

Edit setup.cfg to change the build options



BUILDING MATPLOTLIB

            matplotlib: yes [1.4.0]

                python: yes [2.7.8 (default, Aug 10 2014, 16:19:34)  [GCC

                        4.9.1]]

              platform: yes [linux2]



REQUIRED DEPENDENCIES AND EXTENSIONS

                 numpy: yes [not found. pip may install it below.]

                   six: yes [six was not found.]

              dateutil: yes [dateutil was not found. It is required for date

                        axis support. pip/easy_install may attempt to

                        install it after matplotlib.]

               tornado: yes [tornado was not found. It is required for the

                        WebAgg backend. pip/easy_install may attempt to

                        install it after matplotlib.]

             pyparsing: yes [pyparsing was not found. It is required for

                        mathtext support. pip/easy_install may attempt to

                        install it after matplotlib.]

                 pycxx: yes [Couldn't import.  Using local copy.]

                libagg: yes [pkg-config information for 'libagg' could not

                        be found. Using local copy.]

Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/venv-mpl/build/matplotlib/setup.py", line 154, in <module>

    result = package.check()

  File "setupext.py", line 940, in check

    if 'No such file or directory\ngrep:' in version:

TypeError: argument of type 'NoneType' is not iterable

----------------------------------------
Cleaning up...
```
