### PR TITLE
Use mailmap in github stats

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,3 +5,32 @@ Ben Root <ben.v.root@gmail.com> Benjamin Root <ben.v.root@gmail.com>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@michiel-de-hoons-computer.local>
 Kevin Davies <kdavies4@gmail.com> Kevin Davies <daviesk24@yahoo.com>
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
+Christoph Gohlke <cgohlke@uci.edu> C. Gohlke <cgohlke@uci.edu>
+anykraus <kraus@mpip-mainz.mpg.de> anykraus <anykraus@users.noreply.github.com>
+Daniel Hyams <dhyams@gmail.com> Daniel Hyams <dhyams@gitdev.(none)>
+Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>
+Francesco Montesano <franz.bergesund@gmail.com> montefra <franz.bergesund@gmail.com>
+James R. Evans <jrevans1@earthlink.net> James Evans <jrevans1@earthlink.net>
+Jeffrey Bingham <bingjeff@gmail.com> Jeff Bingham <bingjeff@gmail.com>
+Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H Nielsen <jenshnielsen@gmail.com>
+Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H. Nielsen <jenshnielsen@gmail.com>
+Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H. Nielsen <jens.nielsen@ucl.ac.uk>
+Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens Hedegaard Nielsen <jens.nielsen@ucl.ac.uk>
+Julien Schueller <julien.schueller@gmail.com> jschueller <schueller@porsche-l64.phimeca.lan>
+Julien Schueller <julien.schueller@gmail.com> Julien Schueller <schueller@bx-l64.phimeca.lan>
+Julien Schueller <julien.schueller@gmail.com> Julien Schueller <schueller@porsche-l64.phimeca.lan>
+Matthias Bussonnier <bussonniermatthias@gmail.com> Matthias BUSSONNIER <bussonniermatthias@gmail.com>
+Matthias Bussonnier <bussonniermatthias@gmail.com> Bussonnier Matthias <bussonniermatthias@gmail.com>
+MinRK <benjaminrk@gmail.com> Min RK <minrk@kerbin.local>
+Nelle Varoquaux <nelle.varoquaux@gmail.com> Varoquaux <nelle.varoquaux@gmail.com>
+Nicolas P. Rougier <Nicolas.Rougier@inria.fr> Nicolas Rougier <Nicolas.Rougier@inria.fr>
+Per Parker <wisalam@live.com> Per <wisalam@live.com>
+Per Parker <wisalam@live.com> solvents <wisalam@live.com>
+Peter Würtz <pwuertz@gmail.com> pwuertz <pwuertz@gmail.com>
+Peter Würtz <pwuertz@gmail.com> pwuertz <pwuertz@googlemail.com>
+Peter Würtz <pwuertz@gmail.com> Peter Würtz <pwuertz@googlemail.com>
+Phil Elson <pelson.pub@gmail.com> Phil Elson <philipelson@gmail.com>
+Phil Elson <pelson.pub@gmail.com> Phil Elson <philipelson@hotmail.com>
+Phil Elson <pelson.pub@gmail.com> pelson <philipelson@hotmail.com>
+Phil Elson <pelson.pub@gmail.com> pelson <pelson.pub@gmail.com>
+Scott Lasley <selasley@me.com> selasley <selasley@me.com>


### PR DESCRIPTION
In the 1.4.0 release notes I manages to get my name in using 3 different variations http://matplotlib.org/users/github_stats.html. I thought that looked rather silly so this is an attempt to deduplicate this.

IPython deduplicates various spellings by using the .mailmap file so I have just copied this to our repository and added the relevant variations of my name to the mailmap

I think that at least @pelson  and @pwuertz  also appear more than once in the log so we might want to add them. This could be back ported to the 1.4.0  documentation branch. 
