### PR TITLE
DOC : added DOI link to citing.html

### DIFF
--- a/doc/_templates/citing.html
+++ b/doc/_templates/citing.html
@@ -24,4 +24,11 @@ BibTeX entry:
   year      = 2007
 }
 </pre>
+
+
+<h2>DOIs</h2>
+<dl>
+  <dt>v1.4.0</dt><dd><a href="http://dx.doi.org/10.5281/zenodo.11451"><img src="https://zenodo.org/badge/doi/10.5281/zenodo.11451.png" alt="10.5281/zenodo.11451"></a></dd>
+</dl>
+
 {% endblock %}


### PR DESCRIPTION
Closes #3417

This is how it renders:

![full_us2](https://cloud.githubusercontent.com/assets/199813/4070559/90d6b048-2e5e-11e4-8d30-ab92b5f1f8b3.jpeg)
