### PR TITLE
Get rid of unused pre python 2.6 code in doc make.py

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -1,111 +1,11 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import fileinput
 import glob
 import os
 import shutil
 import sys
 import re
-
-### Begin compatibility block for pre-v2.6: ###
-#
-# ignore_patterns and copytree funtions are copies of what is included
-# in shutil.copytree of python v2.6 and later.
-#
-### When compatibility is no-longer needed, this block
-### can be replaced with:
-###
-###     from shutil import ignore_patterns, copytree
-###
-### or the "shutil." qualifier can be prepended to the function
-### names where they are used.
-
-try:
-    WindowsError
-except NameError:
-    WindowsError = None
-
-def ignore_patterns(*patterns):
-    """Function that can be used as copytree() ignore parameter.
-
-    Patterns is a sequence of glob-style patterns
-    that are used to exclude files"""
-    import fnmatch
-    def _ignore_patterns(path, names):
-        ignored_names = []
-        for pattern in patterns:
-            ignored_names.extend(fnmatch.filter(names, pattern))
-        return set(ignored_names)
-    return _ignore_patterns
-
-def copytree(src, dst, symlinks=False, ignore=None):
-    """Recursively copy a directory tree using copy2().
-
-    The destination directory must not already exist.
-    If exception(s) occur, an Error is raised with a list of reasons.
-
-    If the optional symlinks flag is true, symbolic links in the
-    source tree result in symbolic links in the destination tree; if
-    it is false, the contents of the files pointed to by symbolic
-    links are copied.
-
-    The optional ignore argument is a callable. If given, it
-    is called with the `src` parameter, which is the directory
-    being visited by copytree(), and `names` which is the list of
-    `src` contents, as returned by os.listdir():
-
-        callable(src, names) -> ignored_names
-
-    Since copytree() is called recursively, the callable will be
-    called once for each directory that is copied. It returns a
-    list of names relative to the `src` directory that should
-    not be copied.
-
-    XXX Consider this example code rather than the ultimate tool.
-
-    """
-    from shutil import copy2, Error, copystat
-    names = os.listdir(src)
-    if ignore is not None:
-        ignored_names = ignore(src, names)
-    else:
-        ignored_names = set()
-
-    os.makedirs(dst)
-    errors = []
-    for name in names:
-        if name in ignored_names:
-            continue
-        srcname = os.path.join(src, name)
-        dstname = os.path.join(dst, name)
-        try:
-            if symlinks and os.path.islink(srcname):
-                linkto = os.readlink(srcname)
-                os.symlink(linkto, dstname)
-            elif os.path.isdir(srcname):
-                copytree(srcname, dstname, symlinks, ignore)
-            else:
-                # Will raise a SpecialFileError for unsupported file types
-                copy2(srcname, dstname)
-        # catch the Error from the recursive copytree so that we can
-        # continue with other files
-        except Error as err:
-            errors.extend(err.args[0])
-        except EnvironmentError as why:
-            errors.append((srcname, dstname, str(why)))
-    try:
-        copystat(src, dst)
-    except OSError as why:
-        if WindowsError is not None and isinstance(why, WindowsError):
-            # Copying file access times may fail on Windows
-            pass
-        else:
-            errors.extend((src, dst, str(why)))
-    if errors:
-        raise Error(errors)
-
-### End compatibility block for pre-v2.6 ###
 
 
 def copy_if_out_of_date(original, derived):
@@ -151,7 +51,7 @@ def html(buildername='html'):
         os.remove(filename)
 
     shutil.copy('../CHANGELOG', 'build/%s/_static/CHANGELOG' % buildername)
-    
+
 def htmlhelp():
     html(buildername='htmlhelp')
     # remove scripts from index.html


### PR DESCRIPTION
Given that we don't support python pre 2.6 this code should no longer be needed.

fileinput is unused
