### PR TITLE
Add legend.framealpha to matplotlibrc

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -367,8 +367,9 @@ class Legend(Artist):
         # init with null renderer
         self._init_legend_box(handles, labels)
 
-        if framealpha is not None:
-            self.get_frame().set_alpha(framealpha)
+        if framealpha is None:
+            framealpha = rcParams["legend.framealpha"]
+        self.get_frame().set_alpha(framealpha)
 
         self._loc = loc
         self.set_title(title)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -632,6 +632,8 @@ defaultParams = {
     'legend.shadow': [False, validate_bool],
      # whether or not to draw a frame around legend
     'legend.frameon': [True, validate_bool],
+    # the alpha channel for the frame
+    'legend.framealpha': [1.0, validate_float],
 
 
     ## the following dimensions are in fraction of the font size

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -317,6 +317,7 @@ backend      : %(backend)s
 #legend.shadow        : False
 #legend.frameon       : True   # whether or not to draw a frame around legend
 #legend.scatterpoints : 3 # number of scatter points
+#legend.framealpha    : 1.0    # the alpha channel of the frame
 
 ### FIGURE
 # See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure


### PR DESCRIPTION
So far it is only referenced in lib/matplotlib/axes/_axes.py:legend()
and this commit finally adds it to matplotlibrc.

My graphs suddently had legends, where the grid from behind was shining through. This commit fixes that for me.
