### PR TITLE
Fix handling of getSaveFileName to be consistent [backport to 1.4.x]

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -22,7 +22,6 @@ from matplotlib.backend_bases import ShowBase
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.figure import Figure
 
-
 from matplotlib.widgets import SubplotTool
 try:
     import matplotlib.backends.qt_editor.figureoptions as figureoptions
@@ -184,6 +183,7 @@ class TimerQT(TimerBase):
         upon timer events. This list can be manipulated directly, or the
         functions add_callback and remove_callback can be used.
     '''
+
     def __init__(self, *args, **kwargs):
         TimerBase.__init__(self, *args, **kwargs)
 
@@ -331,8 +331,8 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('resize (%d x %d)' % (w, h))
             print("FigureCanvasQt.resizeEvent(%d, %d)" % (w, h))
         dpival = self.figure.dpi
-        winch = w/dpival
-        hinch = h/dpival
+        winch = w / dpival
+        hinch = h / dpival
         self.figure.set_size_inches(winch, hinch)
         FigureCanvasBase.resize_event(self)
         self.draw()
@@ -551,9 +551,9 @@ class FigureManagerQT(FigureManagerBase):
         self.window.destroyed.connect(self._widgetclosed)
 
         if self.toolbar:
-                self.toolbar.destroy()
+            self.toolbar.destroy()
         if DEBUG:
-                print("destroy figure manager")
+            print("destroy figure manager")
         self.window.close()
 
     def get_window_title(self):
@@ -750,7 +750,7 @@ class SubplotToolQt(SubplotTool, UiSubplotTool):
         self.slidertop.valueChanged.connect(self.sliderbottom.setMaximum)
 
         self.defaults = {}
-        for attr in ('left', 'bottom', 'right', 'top', 'wspace', 'hspace',):
+        for attr in ('left', 'bottom', 'right', 'top', 'wspace', 'hspace', ):
             self.defaults[attr] = getattr(self.targetfig.subplotpars, attr)
             slider = getattr(self, 'slider' + attr)
             slider.setMinimum(0)
@@ -761,7 +761,7 @@ class SubplotToolQt(SubplotTool, UiSubplotTool):
         self._setSliderPositions()
 
     def _setSliderPositions(self):
-        for attr in ('left', 'bottom', 'right', 'top', 'wspace', 'hspace',):
+        for attr in ('left', 'bottom', 'right', 'top', 'wspace', 'hspace', ):
             slider = getattr(self, 'slider' + attr)
             slider.setSliderPosition(int(self.defaults[attr] * 1000))
 
@@ -849,7 +849,6 @@ def exception_handler(type, value, tb):
 
     if len(msg):
         error_msg_qt(msg)
-
 
 FigureCanvas = FigureCanvasQT
 FigureManager = FigureManagerQT

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -15,7 +15,6 @@ QT_API_PYSIDE = 'PySide'    # only supports Version 2 API
 QT_API_PYQT5 = 'PyQt5'       # use PyQt5 API; Version 2 with module shim
 
 ETS = dict(pyqt=QT_API_PYQTv2, pyside=QT_API_PYSIDE, pyqt5=QT_API_PYQT5)
-
 # If the ETS QT_API environment variable is set, use it.  Note that
 # ETS requires the version 2 of PyQt4, which is not the platform
 # default for Python 2.x.
@@ -62,14 +61,14 @@ if _sip_imported:
             sip.setapi('QString', 2)
         except:
             res = 'QString API v2 specification failed. Defaulting to v1.'
-            verbose.report(cond+res, 'helpful')
+            verbose.report(cond + res, 'helpful')
             # condition has now been reported, no need to repeat it:
             cond = ""
         try:
             sip.setapi('QVariant', 2)
         except:
             res = 'QVariant API v2 specification failed. Defaulting to v1.'
-            verbose.report(cond+res, 'helpful')
+            verbose.report(cond + res, 'helpful')
 
     if QT_API in [QT_API_PYQT, QT_API_PYQTv2]:  # PyQt4 API
 
@@ -80,11 +79,15 @@ if _sip_imported:
                 # Use new getSaveFileNameAndFilter()
                 _getSaveFileName = QtGui.QFileDialog.getSaveFileNameAndFilter
             else:
+
+
                 # Use old getSaveFileName()
                 def _getSaveFileName(*args, **kwargs):
                     return QtGui.QFileDialog.getSaveFileName(*args, **kwargs), None
 
         except (AttributeError, KeyError):
+
+
             # call to getapi() can fail in older versions of sip
             def _getSaveFileName(*args, **kwargs):
                 return QtGui.QFileDialog.getSaveFileName(*args, **kwargs), None
@@ -123,4 +126,3 @@ if QT_API in (QT_API_PYQT, QT_API_PYQTv2, QT_API_PYSIDE):
 
     '''
     QtWidgets = QtGui
-


### PR DESCRIPTION
PyQt4 and PyQt5 handle getSaveFileName differently, returning either
a filename or a filename,filter tuple respectively. PySide behaves as
for PyQt5. This caused bug #3454 producing an 'format not supported'
error as the tuple did not match any of the string types.

This updates each API to return a tuple as per PyQt5 (following the
principle of using the latest API as a target). For recent PyQt4
this means using getSaveFileNameAndFilter instead, for older PyQt4
we wrap the function to output a tuple.

Figure saving has been tested on PySide, PyQt4 and PyQt5.
