### PR TITLE
Fix for invalid check of freetype version when no freetype library exists [backport to 1.4.x]

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -932,13 +932,13 @@ class FreeType(SetupPackage):
         status, output = getstatusoutput("freetype-config --ftversion")
         if status == 0:
             version = output
+            # Early versions of freetype grep badly inside freetype-config,
+            # so catch those cases. (tested with 2.5.3).
+            if 'No such file or directory\ngrep:' in version:
+                version = self.version_from_header()
         else:
             version = None
 
-        # Early versions of freetype grep badly inside freetype-config,
-        # so catch those cases. (tested with 2.5.3).
-        if 'No such file or directory\ngrep:' in version:
-            version = self.version_from_header()
 
         return self._check_for_pkg_config(
             'freetype2', 'ft2build.h',


### PR DESCRIPTION
Fixes an invalid check for freetype version when freetype-config does not exist or there was an error. Specifically, only performs `version_from_header` on version when freetype-config returns a value and `version` is set.
