### PR TITLE
Better check for required dependency libpng

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1008,8 +1008,11 @@ class Png(SetupPackage):
                 'libpng', 'png.h',
                 min_version='1.2')
         except CheckFailed as e:
-            self.__class__.found_external = False
-            return str(e) + ' Using unknown version.'
+            include_dirs = [
+                os.path.join(dir, 'include') for dir in get_base_dirs()]
+            if has_include_file(include_dirs, 'png.h'):
+                return str(e) + ' Using unknown version found on system.'
+            raise
 
     def get_extension(self):
         sources = [


### PR DESCRIPTION
This fixes a bug where the setup incorrectly may state that libpng is present and continue building which will eventually error out.
## Current behavior
#### No libpng installed at all

```
REQUIRED DEPENDENCIES AND EXTENSIONS
...
...
                   png: yes [pkg-config information for 'libpng' could not
                        be found. Using unknown version.]
...
...
<builds until it eventually errors out>
```
## Updated behavior
#### libpng pkgconfig exists

```
REQUIRED DEPENDENCIES AND EXTENSIONS
...
...
                   png: yes [version x.y.z]
...
...
<builds>
```
#### no libpng pkgconfig bug png.h include exists

```
REQUIRED DEPENDENCIES AND EXTENSIONS
...
...
                   png: yes [pkg-config information for 'libpng' could not
                        be found. Using unknown version found on system.]
...
...
<builds>
```
#### no png.h include at all

```
REQUIRED DEPENDENCIES AND EXTENSIONS
...
...
                   png: no  [pkg-config information for 'libpng' could not
                        be found.]
...
...
============================================================================
                        * The following required packages can not be built:
                        * png
<does not build>
```
