### PR TITLE
Data limits in scatter function

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3657,7 +3657,8 @@ class Axes(_AxesBase):
         if self._ymargin < 0.05 and x.size > 0:
             self.set_ymargin(0.05)
 
-        self.add_collection(collection)
+        self.add_collection(collection, autolim=False)
+        self.update_datalim(offsets)
         self.autoscale_view()
 
         return collection


### PR DESCRIPTION
Updates the data limits in a scatter plot with just the (x,y) input points. Currently, the `scatter` function creates a collection of markers which then are allowed to update the data limits. This has unintended consequences as seen in issue #3059.
