### PR TITLE
BLD : improve how six dependency is handled

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1170,12 +1170,17 @@ class Six(SetupPackage):
             import six
         except ImportError:
             return (
-                "six was not found.")
+                "six was not found."
+                "pip will attempt to install it "
+                "after matplotlib.")
 
         if not is_min_version(six.__version__, self.min_version):
-            raise CheckFailed(
-                "Requires six %s or later.  Found %s." %
-                (self.min_version, six.__version__))
+            return ("The installed version of six is {inst_ver} but "
+                    "a the minimum required version is {min_ver}. "
+                    "pip/easy install will attempt to install a "
+                    "newer version."
+                    ).format(min_ver=self.min_version,
+                             inst_ver=six.__version__)
 
         return "using six version %s" % six.__version__
 


### PR DESCRIPTION
if an old version of six is installed try to update it rather than fail.

This change seems to only work with pip, not with easy-install

If you have an old version of six installed and you use pip to install matplotlib (either via making a tar-ball with sdist and `pip install path/to/tar` or `pip -e ./matplotlib`) this works correctly.  

If you do `python setup.py install` with this patch it successfully updates six, but then falls over saying the version of six is too low.  If you then start up python and import six, it finds the newly installed version and if you re-run `python setup.py install` it will find the new version and work correctly.

I suspect that this may be due to pip vs easy install vs distutils vs setuptools vs black magic issues that is probably a bug in _some_ external code, but I have no idea which.

I did this testing in a venv with `pip install six==1.0` on an ubuntu box.