### PR TITLE
BUG : fix str vs bytes issue in py3 in ps backend

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -764,7 +764,7 @@ grestore
             except KeyError:
                 ps_name = sfnt[(3,1,0x0409,6)].decode(
                     'utf-16be')
-            ps_name = ps_name.encode('ascii', 'replace')
+            ps_name = ps_name.encode('ascii', 'replace').decode('ascii')
             self.set_font(ps_name, prop.get_size_in_points())
 
             cmap = font.get_charmap()


### PR DESCRIPTION
de-code the encoded ascii string so that it is a string, not
bytes, when it gets passed to the format function.  Having the
b'' from the bytes string appear in the eps file breaks the file.

closes #3494 

I really hope there is a better way to do this.
