### PR TITLE
Can not import matplotlib when launching from non-ascii path 

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -745,7 +745,11 @@ def matplotlib_fname():
     - Lastly, it looks in `$MATPLOTLIBDATA/matplotlibrc` for a
       system-defined copy.
     """
-    fname = os.path.join(os.getcwd(), 'matplotlibrc')
+    if six.PY2:
+        cwd = os.getcwdu()
+    else:
+        cwd = os.getcwd()
+    fname = os.path.join(cwd, 'matplotlibrc')
     if os.path.exists(fname):
         return fname
 

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -447,8 +447,10 @@ def run_code(code, code_path, ns=None, function_name=None):
     # Change the working directory to the directory of the example, so
     # it can get at its data files, if any.  Add its path to sys.path
     # so it can import any helper modules sitting beside it.
-
-    pwd = os.getcwd()
+    if six.PY2:
+        pwd = os.getcwdu()
+    else:
+        pwd = os.getcwd()
     old_sys_path = list(sys.path)
     if setup.config.plot_working_directory is not None:
         try:


### PR DESCRIPTION
Can not import matplotlib when launching from non-ascii path. Matplotlib crashes with a UnicodeDecodeError. As far as I can see it is caused by calling os.getcwd and not os.getcwdu when building the path to matplotlibrc.

I could find 4 instances of getcwd in the code base:

```
__init__.py(748): fname = os.path.join(os.getcwd(), 'matplotlibrc')
backends\backend_gtk.py(820): if not path: path = os.getcwd() + os.sep
backends\backend_gtk3.py(645): if not path: path = os.getcwd() + os.sep
sphinxext\plot_directive.py(451): pwd = os.getcwd()
```

Example non-ascii path:

```
In [1]: pwd
Out[1]: u'C:\\python\\external\\\xe5\xe4\xf6'

In [2]: import matplotlib
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-2-82be63b7783c> in <module>()
----> 1 import matplotlib

C:\Python27-64\lib\site-packages\matplotlib\__init__.py in <module>()
   1046
   1047 # this is the instance used by the matplotlib classes
-> 1048 rcParams = rc_params()
   1049
   1050 if rcParams['examples.directory']:

C:\Python27-64\lib\site-packages\matplotlib\__init__.py in rc_params(fail_on_error)
    895     default matplotlib rc file.
    896     """
--> 897     fname = matplotlib_fname()
    898     if not os.path.exists(fname):
    899         # this should never happen, default in mpl-data should always be found

C:\Python27-64\lib\site-packages\matplotlib\__init__.py in matplotlib_fname()
    746       system-defined copy.
    747     """
--> 748     fname = os.path.join(os.getcwd(), 'matplotlibrc')
    749     if os.path.exists(fname):
    750         return fname

C:\Python27-64\lib\ntpath.pyc in join(a, *p)
    106                     path += b
    107                 else:
--> 108                     path += "\\" + b
    109             else:
    110                 # path is not empty and does not end with a backslash,

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 19: ordinal not in range(128)
```

Ex: ascii path:

```
In [1]: pwd
Out[1]: u'C:\\python\\external'

In [2]: import matplotlib

In [3]: matplotlib.v
matplotlib.validate_backend matplotlib.verbose

In [3]: matplotlib.__v
matplotlib.__version__        matplotlib.__version__numpy__

In [3]: matplotlib.__version__
Out[3]: u'1.4.0'
```
