### PR TITLE
BUG : fix eps corruption when using clipping

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -568,7 +568,7 @@ grestore
             ps_cmd.extend(['clip', 'newpath', '} bind def\n'])
             self._pswriter.write('\n'.join(ps_cmd))
             self._clip_paths[key] = pid
-        return id
+        return pid
 
     def draw_path(self, gc, path, transform, rgbFace=None):
         """


### PR DESCRIPTION
_get_clip_path was returning '<built-in function id>' instead
of the ps-function name like it should have been.  This was introduced
in 9b9c0c6fbdd53ec42e2a1edecc9c6895b6f7a3ef in PR #2927.

Closes #3523
