### PR TITLE
Only insert links to pdfs if we are actually generating these.

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -383,7 +383,9 @@ TEMPLATE = """
 {{ only_latex }}
 
    {% for img in images %}
+   {% if 'pdf' in img.formats -%}
    .. image:: {{ build_dir }}/{{ img.basename }}.pdf
+   {% endif -%}
    {% endfor %}
 
 {{ only_texinfo }}


### PR DESCRIPTION
 This should silence most warnings in the html only small build on Travis. Waiting for Travis to confirm
