### PR TITLE
BUG : skip looking up expanduser if unicode error

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -510,6 +510,9 @@ def _get_home():
     except ImportError:
         # This happens on Google App Engine (pwd module is not present).
         pass
+    except UnicodeDecodeError:
+        # this happens on windows with py2k with non-ascii letters in the path
+        pass
     else:
         if os.path.isdir(path):
             return path


### PR DESCRIPTION
closes #3516 by ignoring the real problem.

The real problem seems to be in the core libary (
http://bugs.python.org/issue13207) to which the response was
'upgrade to python 3'.
