### PR TITLE
Use tempfile.mkdtemp for animation.FileMovieWriter.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -163,7 +163,7 @@ class MovieWriter(object):
                       mplDeprecation)
         self._setup(*args, **kwargs)
 
-    def _setup(self, outfile, dpi):
+    def _setup(self, fig, outfile, dpi):
         self.outfile = outfile
         self.fig = fig
         self.dpi = dpi
@@ -204,8 +204,9 @@ class MovieWriter(object):
 
     def finish(self):
         'Finish any processing for writing the movie.'
-        warnings.warn('finish interacts poorly with the saving context-manager',
-                      mplDeprecation)
+        warnings.warn(
+            'finish interacts poorly with the saving context-manager',
+            mplDeprecation)
         self.cleanup()
 
     def _finish(self):
@@ -241,8 +242,9 @@ class MovieWriter(object):
 
     def cleanup(self):
         'Clean-up and collect the process used to write the movie file.'
-        warnings.warn('cleanup interacts poorly with the saving context-manager',
-                      mplDeprecation)
+        warnings.warn(
+            'cleanup interacts poorly with the saving context-manager',
+            mplDeprecation)
         self._cleanup()
 
     def _cleanup(self):
@@ -287,7 +289,7 @@ class FileMovieWriter(MovieWriter):
         self.frame_format = rcParams['animation.frame_format']
 
     def _setup(self, fig, outfile, dpi, frame_prefix='_tmp', clear_temp=True,
-                tmpdir=None):
+               tmpdir=None):
         '''
         Perform setup for writing the movie file.
 
@@ -400,9 +402,9 @@ class FileMovieWriter(MovieWriter):
     def _cleanup(self):
         MovieWriter._cleanup(self)
 
-        #Delete temporary files
+        # Delete temporary files
         if self.clear_temp:
-            if self._temp_names is None: # tmpdir created with mkdtemp
+            if self._temp_names is None:  # tmpdir created with mkdtemp
                 verbose.report(
                     'MovieWriter: clearing temporary fnames=%s' % self._tmpdir,
                 level='debug')

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -76,6 +76,12 @@ class MovieWriterRegistry(object):
 writers = MovieWriterRegistry()
 
 
+def _deprecation_message(name):
+    return ('MovieWriter.%s interacts poorly with the saving context-manager '
+            'and has been deprecated in 1.5.  This method will be removed in '
+            '1.6, please use `with writer.saving(...):` instead' % name)
+
+
 class MovieWriter(object):
     '''
     Base class for writing movies. Fundamentally, what a MovieWriter does is
@@ -159,8 +165,7 @@ class MovieWriter(object):
             The DPI (or resolution) for the file.  This controls the size
             in pixels of the resulting movie file.
         '''
-        warnings.warn('setup interacts poorly with the saving context-manager',
-                      mplDeprecation)
+        warnings.warn(_deprecation_message('setup'), mplDeprecation)
         self._setup(*args, **kwargs)
 
     def _setup(self, fig, outfile, dpi):
@@ -204,9 +209,7 @@ class MovieWriter(object):
 
     def finish(self):
         'Finish any processing for writing the movie.'
-        warnings.warn(
-            'finish interacts poorly with the saving context-manager',
-            mplDeprecation)
+        warnings.warn(_deprecation_message('finish'), mplDeprecation)
         self.cleanup()
 
     def _finish(self):
@@ -242,9 +245,7 @@ class MovieWriter(object):
 
     def cleanup(self):
         'Clean-up and collect the process used to write the movie file.'
-        warnings.warn(
-            'cleanup interacts poorly with the saving context-manager',
-            mplDeprecation)
+        warnings.warn(_deprecation_message('cleanup'), mplDeprecation)
         self._cleanup()
 
     def _cleanup(self):
@@ -285,7 +286,7 @@ class MovieWriter(object):
 class FileMovieWriter(MovieWriter):
     '`MovieWriter` subclass that handles writing to a file.'
     def __init__(self, *args, **kwargs):
-        MovieWriter.__init__(self, *args, **kwargs)
+        super(FileMovieWriter, self).__init__(*args, **kwargs)
         self.frame_format = rcParams['animation.frame_format']
 
     def _setup(self, fig, outfile, dpi, frame_prefix='_tmp', clear_temp=True,
@@ -390,7 +391,7 @@ class FileMovieWriter(MovieWriter):
         # Call run here now that all frame grabbing is done. All temp files
         # are available to be assembled.
         self._run()
-        MovieWriter._finish(self)
+        super(FileMovieWriter, self)._finish()
 
         # Check error code for creating file here, since we just run
         # the process here, rather than having an open pipe.
@@ -400,7 +401,7 @@ class FileMovieWriter(MovieWriter):
                                + ' Try running with --verbose-debug')
 
     def _cleanup(self):
-        MovieWriter._cleanup(self)
+        super(FileMovieWriter, self)._cleanup()
 
         # Delete temporary files
         if self.clear_temp:


### PR DESCRIPTION
Currently, `animation.FileMovieWriter` (e.g. `FFMpegFileWriter`)
creates temporaries in the current folder, without even checking
whether the file existed before.  This is obviously risky (e.g., create
a file named `_tmp0000000.png` in the current folder before running
`moviewriter.py` from the docs examples and it will be overwritten.
Moveover, temporaries are not cleaned up if an exception is raised
(e.g., KeyboardInterrupt).

This is relatively easy to fix using `tempfile.mkdtemp`, although I
had to modify `finish` so that it doesn't call `cleanup` by itself
(obviously, this can be fixed by keeping a `cleaned_up` attribute
but it feels like a minor API change is preferable; moreover the
context-manager API stays the same).

Only basic, manual testing done.
