### PR TITLE
Ticks on top axis disappear if tick size is too large (when using bbox_inches='tight')

### DIFF
--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -769,10 +769,10 @@ RendererAgg::draw_markers(const Py::Tuple& args)
         agg::serialized_scanlines_adaptor_aa8::embedded_scanline sl;
 
         agg::rect_d clipping_rect(
-            -(scanlines.min_x() + 1.0),
-            (scanlines.max_y() + 1.0),
-            width + scanlines.max_x() + 1.0,
-            height - scanlines.min_y() + 1.0);
+            -1.0 - scanlines.max_x(),
+            -1.0 - scanlines.max_y(),
+            1.0 + width - scanlines.min_x(),
+            1.0 + height - scanlines.min_y());
 
         if (has_clippath)
         {


### PR DESCRIPTION
This is a bug in Matplotlib 1.4 - the following script:

``` python
import matplotlib.pyplot as plt

fig = plt.figure()
ax = fig.add_subplot(1,1,1)
ax.plot([1,2,3])

for line in ax.xaxis.get_ticklines():
    line.set_markersize(17)

for line in ax.yaxis.get_ticklines():
    line.set_markersize(17)

fig.savefig('ticks.png', bbox_inches='tight')
```

produces the following output when using `bbox_inches='tight'`:

![ticks](https://cloud.githubusercontent.com/assets/314716/4264156/b005ecc4-3c17-11e4-9c2a-c0bdad25f1fe.png)

When not setting `bbox_inches='tight'`, the ticks are there:

![ticks](https://cloud.githubusercontent.com/assets/314716/4264157/c2b3a08c-3c17-11e4-820e-7b4970897089.png)

Addendum:  it turns out I noticed this because some of the image tests in my package were failing - however, this only caused an RMS difference of ~2 or so, so the tolerance has to be quite low to catch this!
