### PR TITLE
pyplot: Fix exception in `_backend_selection` during import [backport to 1.4.x]

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -91,8 +91,9 @@ def _backend_selection():
         if not PyQt5.QtWidgets.qApp.startingUp():
             # The mainloop is running.
             rcParams['backend'] = 'qt5Agg'
-    elif 'gtk' in sys.modules and not backend in ('GTK', 'GTKAgg',
-                                                            'GTKCairo'):
+    elif ('gtk' in sys.modules
+            and backend not in ('GTK', 'GTKAgg', 'GTKCairo')
+            and 'gi.repository.GObject' not in sys.modules):
         import gobject
         if gobject.MainLoop().is_running():
             rcParams['backend'] = 'gtk' + 'Agg' * is_agg_backend


### PR DESCRIPTION
if the new style introspection GObject python bindings are in use.  With pygobject >= 3.13.4 the following:

```
from gi.repository import GObject
from matplotlib import pyplot
```

causes an exception to be raised:

> AttributeError: When using gi.repository you must not import static modules
> like "gobject". Please change all occurrences of "import gobject" to "from
> gi.repository import GObject". See:
> https://bugzilla.gnome.org/show_bug.cgi?id=709183

It is not valid to use both non-introspection based and introspection based PyGObject in the same process.  Backend probing will `import gobject` (i.e. the non-introspection bindings) if it sees that the 'gtk' module is loaded.
Unfortunately it wouldn't check if this was the pygi or old-style gtk module. This commit adds this check avoiding the exception.

This check was added to PyGObject in [d704033](https://git.gnome.org/browse/pygobject/commit/?id=d704033)
