### PR TITLE
DOC : fix main-page tags

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -63,9 +63,9 @@ function getSnippet(id, url) {
   For a sampling, see the <a href="{{ pathto('users/screenshots') }}">screenshots</a>, <a href="{{ pathto('gallery') }}">thumbnail</a> gallery,  and
     <a href="examples/index.html">examples</a> directory</p>
 
-<p>For simple plotting the <pre>pyplot</pre> interface provides a
+<p>For simple plotting the <tt>pyplot</tt> interface provides a
   MATLAB-like interface, particularly when combined
-  with <pre>IPython</pre>.  For the power user, you have full control
+  with <tt>IPython</tt>.  For the power user, you have full control
   of line styles, font properties, axes properties, etc, via an object
   oriented interface or via a set of functions familiar to MATLAB
   users.</p>


### PR DESCRIPTION
```
<pre> -> <tt> for inline markup.
```

[edit as the markup was getting marked up]
