### PR TITLE
Example of embedding a figure into an existing Tk canvas

### DIFF
--- a/examples/user_interfaces/embedding_in_tk_canvas.py
+++ b/examples/user_interfaces/embedding_in_tk_canvas.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- noplot -*-
+
+import matplotlib as mpl
+import numpy as np
+import Tkinter as tk
+import matplotlib.backends.tkagg as tkagg
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+def draw_figure(canvas, figure, loc=[0,0]):
+    """ Draw a matplotlib figure onto a Tk canvas
+    
+    loc: location of top-left corner of figure on canvas in pixels.
+
+    Inspired by matplotlib source: lib/matplotlib/backends/backend_tkagg.py
+    """
+    figure_canvas_agg = FigureCanvasAgg(figure)
+    figure_canvas_agg.draw()
+    figure_x, figure_y, figure_w, figure_h = figure.bbox.bounds
+    figure_w, figure_h  = int(figure_w), int(figure_h)
+    photo = tk.PhotoImage(master=canvas, width=figure_w, height=figure_h)
+
+    # Position: convert from top-left anchor to center anchor
+    canvas.create_image(loc[0] + figure_w/2, loc[1] + figure_h/2, image=photo)
+
+    # Unfortunatly, there's no accessor for the pointer to the native renderer
+    tkagg.blit(photo, figure_canvas_agg.get_renderer()._renderer, colormode=2)
+
+    # Return a handle which contains a reference to the photo object
+    # which must be kept live or else the picture disappears
+    return photo
+
+# Create a canvas
+w, h = 300, 200
+window = tk.Tk()
+window.title("A figure in a canvas")
+canvas = tk.Canvas(window, width=w, height=h)
+canvas.pack()
+
+# Generate some example data
+X = np.linspace(0, 2.0*3.14, 50)
+Y = np.sin(X)
+
+# Create the figure we desire to add to an existing canvas
+fig = mpl.figure.Figure(figsize=(2, 1))
+ax = fig.add_axes([0,0,1,1])
+ax.plot(X, Y)
+
+# Keep this handle alive, or else figure will disappear
+fig_x, fig_y = 100, 100
+fig_photo = draw_figure(canvas, fig, loc=[fig_x, fig_y])
+fig_w, fig_h = fig_photo.width(), fig_photo.height()
+
+# Add more elements to the canvas, potentially on top of the figure
+canvas.create_line(200, 50, fig_x + fig_w / 2, fig_y + fig_h / 2)
+canvas.create_text(200, 50, text="Zero-crossing", anchor="s")
+
+# Let Tk take over
+tk.mainloop()


### PR DESCRIPTION
A new example that shows how to embed a matplotlib figure into an existing canvas at an arbitrary location. This is useful for integrating matplotlib output with graphical output that is already created using Tk drawing and not subject to be ported into matplotlib.

This example complements `embedding_in_tk.py` and `embedding_in_tk2.py` both of which use the FigureCanvasTkAgg function which creates a new Tk canvas.

![embedding_in_tk_canvas](https://cloud.githubusercontent.com/assets/1269002/4346755/71561724-4112-11e4-9ba9-b95684997d91.png)
