### PR TITLE
Allow for null-strides in wireframe plot

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1741,8 +1741,14 @@ class Axes3D(Axes):
         # This transpose will make it easy to obtain the columns.
         tX, tY, tZ = np.transpose(X), np.transpose(Y), np.transpose(Z)
 
-        rii = list(xrange(0, rows, rstride))
-        cii = list(xrange(0, cols, cstride))
+        if rii:
+            rii = list(xrange(0, rows, rstride))
+        else:
+            rii = []
+        if cii:                
+            cii = list(xrange(0, cols, cstride))
+        else:
+            cii = []
 
         # Add the last index only if needed
         if rows > 0 and rii[-1] != (rows - 1) :

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1741,11 +1741,11 @@ class Axes3D(Axes):
         # This transpose will make it easy to obtain the columns.
         tX, tY, tZ = np.transpose(X), np.transpose(Y), np.transpose(Z)
 
-        if rii:
+        if rstride:
             rii = list(xrange(0, rows, rstride))
         else:
             rii = []
-        if cii:                
+        if cstride:                
             cii = list(xrange(0, cols, cstride))
         else:
             cii = []


### PR DESCRIPTION
When making a wireframe plot, we've found that it's often nice to have just rowstrides or just column strides.  Currently, a value of 0 for the stride distance will result in an error.

This small change seems all that is needed.  Is there a reason for not wanting this to be allowed?  

One issue I foresee is that if users pass rstride=None, cstride=None, they will get blank plot.  I hope it would be obvious to them as to what is occurring in this case.  

I've attached  a screenshot of a wireframe plot with no column stride.
![no_stride_plot](https://cloud.githubusercontent.com/assets/1972276/4363657/0d38f45a-4298-11e4-9854-fc16cb91e6fa.png)
