### PR TITLE
Typo in comment documentation for example timers.py

### DIFF
--- a/examples/event_handling/timers.py
+++ b/examples/event_handling/timers.py
@@ -13,13 +13,13 @@ fig, ax = plt.subplots()
 x = np.linspace(-3, 3)
 ax.plot(x, x*x)
 
-# Create a new timer object. Set the interval 500 milliseconds (1000 is default)
-# and tell the timer what function should be called.
+# Create a new timer object. Set the interval to 100 milliseconds
+# (1000 is default) and tell the timer what function should be called.
 timer = fig.canvas.new_timer(interval=100)
 timer.add_callback(update_title, ax)
 timer.start()
 
-#Or could start the timer on first figure draw
+# Or could start the timer on first figure draw
 #def start_timer(evt):
 #    timer.start()
 #    fig.canvas.mpl_disconnect(drawid)


### PR DESCRIPTION
Fixed documentation to match the code on timer interval set to 100 ms
