### PR TITLE
Fixed the differencing of images for the webagg/nbagg backends.

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -35,12 +35,20 @@ class Show(ShowBase):
         if not managers:
             return
 
+        interactive = is_interactive()
+
         for manager in managers:
             manager.show()
 
-            if not is_interactive() and manager in Gcf._activeQue:
-                Gcf._activeQue.remove(manager)
+            # plt.figure adds an event which puts the figure in focus
+            # in the activeQue. Disable this behaviour, as it results in
+            # figures being put as the active figure after they have been
+            # shown, even in non-interactive mode.
+            if hasattr(manager, '_cidgcf'):
+                manager.canvas.mpl_disconnect(manager._cidgcf)
 
+            if not interactive and manager in Gcf._activeQue:
+                Gcf._activeQue.remove(manager)
 
 show = Show()
 

--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -41,6 +41,7 @@ mpl.figure = function(figure_id, websocket, ondownload, parent_element) {
     this.format_dropdown = undefined;
 
     this.focus_on_mousover = false;
+    this.image_mode = 'full';
 
     this.root = $('<div/>');
     this.root.attr('style', 'display: inline-block');
@@ -56,11 +57,17 @@ mpl.figure = function(figure_id, websocket, ondownload, parent_element) {
 
     this.ws.onopen =  function () {
             fig.send_message("supports_binary", {value: fig.supports_binary});
+            fig.send_message("send_image_mode", {});
             fig.send_message("refresh", {});
         }
 
     this.imageObj.onload = function() {
-            fig.context.clearRect(0, 0, fig.canvas.width, fig.canvas.height);
+            if (fig.image_mode == 'full') {
+                // Full images could contain transparency (where diff images
+                // almost always do), so we need to clear the canvas so that
+                // there is no ghosting.
+                fig.context.clearRect(0, 0, fig.canvas.width, fig.canvas.height);
+            }
             fig.context.drawImage(fig.imageObj, 0, 0);
             fig.waiting = false;
         };
@@ -300,6 +307,10 @@ mpl.figure.prototype.handle_message = function(fig, msg) {
 mpl.figure.prototype.handle_draw = function(fig, msg) {
     // Request the server to send over a new figure.
     fig.send_draw_message();
+}
+
+mpl.figure.prototype.handle_image_mode = function(fig, msg) {
+    fig.image_mode = msg['mode'];
 }
 
 mpl.figure.prototype.updated_canvas_event = function() {


### PR DESCRIPTION
In #3552 I improved the ability to handle images with transparency in the webagg/nbagg backends. Unfortunately, in doing so, I managed to break the differencing mode by always clearing the existing image on the javascript side. This change fixes the issue by keeping track of the image mode in the backend and notifying the client of any changes (as a result of transparency appearing).
