### PR TITLE
Bug: Empty sym string for boxplots still displays fliers.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3048,6 +3048,10 @@ class Axes(_AxesBase):
         else:
             flierprops['sym'] = sym
 
+        # do not show fliers if sym is empty string
+        if sym == '':
+            showfliers = False
+
         # replace medians if necessary:
         if usermedians is not None:
             if (len(np.ravel(usermedians)) != len(bxpstats) or


### PR DESCRIPTION
As per documentation, specifying empty string for sym argument should prevent drawing fliers for boxplots.

As an example, the following script displays fliers in the boxplot when it shouldn't.

```
import matplotlib.pyplot as plt

data = list(range(0,100)) + [200,-200,250,-250]
bp = plt.boxplot(data,sym='',widths=.3)
plt.show()
```

Added logic to ensure empty sym string does not display fliers.
