### PR TITLE
add markerfacecolor to rcsetup.py

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -500,6 +500,7 @@ defaultParams = {
     'lines.linestyle':       ['-', six.text_type],             # solid line
     'lines.color':           ['b', validate_color],  # blue
     'lines.marker':          ['None', six.text_type],     # black
+    'lines.markerfacecolor':  ['b', validate_color],
     'lines.markeredgewidth': [0.5, validate_float],
     'lines.markersize':      [6, validate_float],    # markersize, in points
     'lines.antialiased':     [True, validate_bool],  # antialised (no jaggies)


### PR DESCRIPTION
closes #3293

This is the simplest fix, I didn't think to check to see if any other variables are missing from rcsetup.py