### PR TITLE
WIP : draft of replacement for pyplot

### DIFF
--- a/lib/matplotlib/pyplot_nng.py
+++ b/lib/matplotlib/pyplot_nng.py
@@ -1,0 +1,48 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import six
+import matplotlib.pyplot as plt  # to grab figure management stuff
+from matplotlib.axes import Axes
+import functools
+
+
+# apparently, raw object objects use slots.
+class Dummy(object):
+    pass
+
+pyplot_nng = Dummy()
+interactive = Dummy()
+
+
+def interactive_wrapper(func):
+    @functools.wraps(func)
+    def inner(ax, *args, **kwargs):
+        ret_list = func(ax, *args, **kwargs)
+        ax.figure.canvas.draw()
+        return ret_list
+
+    return inner
+
+
+def wrap_for_pyplot(func):
+    def inner(*args, **kwargs):
+        ax = plt.gca()
+        art_list = func(ax, *args, **kwargs)
+        ax.figure.canvas.draw()
+        return art_list
+
+    inner.__name__ = func.__name__
+    # This should be modified to strip the docs
+    # if the axes as the first argument is documented
+    inner.__doc__ = func.__doc__
+    return inner
+
+funcs_to_wrap = [atr for atr in
+                 (getattr(Axes, atr_name) for atr_name in dir(Axes)
+                  if not atr_name.startswith('_'))
+                 if callable(atr)]
+
+for f in funcs_to_wrap:
+    setattr(pyplot_nng, f.__name__, wrap_for_pyplot(f))
+    setattr(interactive, f.__name__, interactive_wrapper(f))


### PR DESCRIPTION
pyplot_nng replaces most of pyplot plotting functions, a few
things (like plt.subplots and the other axes/figure generation
functions) need to be

interactive gives a auto-redraw wrapper for explicitly using axes, but
forces you through a functional interface rather than the OO interface.

This a result of  http://thread.gmane.org/gmane.comp.python.matplotlib.devel/12999

On one hand, this is a huge API change (but it can be done breaking back-compatibility as slowly as we want), but I think this will greatly simplify things going forward and solve the pyplot vs OO issues replacing both with a more functional approach (we still need to work out where the edges are, is it `set_yscale(ax, 'log')`, `ax.yscale('log')`, `ax.set_yscale('log')` or `ax.yscale = 'log'`).   The pyplot/interactive repl interface is an automatic wrapping of the functions to handle the global state and automatic re-drawing and the functions take the place of the OO in scripts and user developed functions.

This would also let us sort the plotting functions in to modules which might help with the documentation issues.

cc @efiring 
