### PR TITLE
ENH: add to_grayscale() method to color maps

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -665,6 +665,18 @@ class Colormap(object):
         return (np.alltrue(self._lut[:, 0] == self._lut[:, 1]) and
                 np.alltrue(self._lut[:, 0] == self._lut[:, 2]))
 
+    def to_grayscale(self):
+        """Return a grayscale version of the colormap"""
+        colors = self(np.arange(self.N))
+
+        # convert RGBA to perceived greyscale luminance
+        # cf. http://alienryderflex.com/hsp.html
+        RGB_weight = [0.299, 0.587, 0.114]
+        luminance = np.sqrt(np.dot(colors[:, :3] ** 2, RGB_weight))
+        colors[:, :3] = luminance[:, np.newaxis]
+
+        return self.from_list(self.name + "_gray", colors, self.N)
+
 
 class LinearSegmentedColormap(Colormap):
     """Colormap objects based on lookup tables using linear segments.


### PR DESCRIPTION
This PR adds a method to the `Colormap` base class which computes and returns a grayscale version of the map. This helps to quickly preview how various colormaps will appear when printed in grayscale.

This uses the same formula as photoshop's grayscale conversion; see http://alienryderflex.com/hsp.html for details.

As an example of the usage, we can quickly demonstrate one reason why everybody loves to rag on jet:

``` python
plt.figure(figsize=(8, 3))
im = np.random.rand(10, 10)

plt.subplot(121)
plt.imshow(im, cmap=plt.cm.jet)
plt.colorbar()

plt.subplot(122)
plt.imshow(im, cmap=plt.cm.jet.to_grayscale())
plt.colorbar()
```

![jet_example](https://cloud.githubusercontent.com/assets/781659/4436563/ab60dc6a-477a-11e4-828f-02a9dcd0c4cd.png)

I'm open to any suggestions or comments! I'm not sure if there are any complications with corner cases that I might be overlooking...
