### PR TITLE
Unicode decode error [backport to 1.4.x]

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -523,7 +523,10 @@ def _get_home():
         http://mail.python.org/pipermail/python-list/2005-February/325395.html
     """
     try:
-        path = os.path.expanduser(b"~").decode(sys.getfilesystemencoding())
+        if six.PY2 and sys.platform == 'win32':
+            path = os.path.expanduser(b"~").decode(sys.getfilesystemencoding())
+        else:
+            path = os.path.expanduser("~")
     except ImportError:
         # This happens on Google App Engine (pwd module is not present).
         pass


### PR DESCRIPTION
Correct the following exception on Windows with Py2.x and user having e.g. Umlaute in his home folder name.
twcbsrc.app_base - ERROR - app_base.pyo - 292 - Traceback (most recent call last):
  File "twcbsrc\controllers\app_cb.pyo", line 403, in onTBStats
  File "importlib__init__.pyo", line 37, in import_module
  File "zipextimporter.pyo", line 82, in load_module
  File "twcbsrc\controllers\app_stats.pyo", line 29, in <module>
  File "zipextimporter.pyo", line 82, in load_module
  File "twcbsrc\views\statistics.pyo", line 19, in <module>
  File "zipextimporter.pyo", line 82, in load_module
  File "matplotlib__init__.pyo", line 1048, in <module>
  File "matplotlib__init__.pyo", line 897, in rc_params
  File "matplotlib__init__.pyo", line 759, in matplotlib_fname
  File "matplotlib__init__.pyo", line 630, in _get_configdir
  File "matplotlib__init__.pyo", line 555, in _get_xdg_config_dir
  File "matplotlib__init__.pyo", line 323, in wrapper
  File "matplotlib__init__.pyo", line 509, in _get_home
  File "ntpath.pyo", line 310, in expanduser
UnicodeDecodeError: 'utf8' codec can't decode byte 0xf6 in position 10: invalid start byte 

See also:  #3532
