### PR TITLE
Nbagg icons

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -89,7 +89,7 @@ def connection_info():
 _FONT_AWESOME_CLASSES = {
     'home': 'fa fa-home icon-home',
     'back': 'fa fa-arrow-left icon-arrow-left',
-    'forward': 'fa fa--arrow-right icon-arrow-right',
+    'forward': 'fa fa-arrow-right icon-arrow-right',
     'zoom_to_rect': 'fa fa-square-o icon-check-empty',
     'move': 'fa fa-arrows icon-move',
     None: None

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -315,7 +315,7 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
             "rubberband", x0=x0, y0=y0, x1=x1, y1=y1)
 
     def release_zoom(self, event):
-        super(NavigationToolbar2WebAgg, self).release_zoom(event)
+        backend_bases.NavigationToolbar2.release_zoom(self, event)
         self.canvas.send_event(
             "rubberband", x0=-1, y0=-1, x1=-1, y1=-1)
 

--- a/lib/matplotlib/backends/web_backend/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/nbagg_mpl.js
@@ -115,7 +115,7 @@ mpl.figure.prototype._init_toolbar = function() {
 
     // Add the close button to the window.
     var buttongrp = $('<div class="btn-group inline pull-right"></div>');
-    var button = $('<button class="btn btn-mini btn-danger" href="#" title="Close figure"><i class="fa icon-remove icon-large"></i></button>');
+    var button = $('<button class="btn btn-mini btn-danger" href="#" title="Close figure"><i class="fa fa-times icon-remove icon-large"></i></button>');
     button.click(function (evt) { fig.handle_close(fig, {}); } );
     button.mouseover('Close figure', toolbar_mouse_event);
     buttongrp.append(button);


### PR DESCRIPTION
Closes #3607 and #3606 and fixes the broken zoom to rect (which I haven't figured out why it broke in the first place - perhaps something changed with the Nav toolbar recently?).

Tested with IPython 2.1 and master (~3.0.0) with Python 2.
