### PR TITLE
Fix problem with legend if data has NaN's [backport to 1.4.x]

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -648,10 +648,11 @@ class BboxBase(TransformNode):
             return 0
         vertices = np.asarray(vertices)
         x0, y0, x1, y1 = self._get_extents()
-        dx0 = np.sign(vertices[:, 0] - x0)
-        dy0 = np.sign(vertices[:, 1] - y0)
-        dx1 = np.sign(vertices[:, 0] - x1)
-        dy1 = np.sign(vertices[:, 1] - y1)
+        with np.errstate(invalid='ignore'):
+            dx0 = np.sign(vertices[:, 0] - x0)
+            dy0 = np.sign(vertices[:, 1] - y0)
+            dx1 = np.sign(vertices[:, 0] - x1)
+            dy1 = np.sign(vertices[:, 1] - y1)
         inside = ((abs(dx0 + dx1) + abs(dy0 + dy1)) == 0)
         return np.sum(inside)
 


### PR DESCRIPTION
If data has NaN's and the plot a legend with parameter 'best', matplotlib throws the following RuntimeWarning:

...\matplotlib\transforms.py:651: RuntimeWarning: invalid value encountered in sign
  dx0 = np.sign(vertices[:, 0] - x0)
...\matplotlib\transforms.py:652: RuntimeWarning: invalid value encountered in sign
  dy0 = np.sign(vertices[:, 1] - y0)
...\matplotlib\transforms.py:653: RuntimeWarning: invalid value encountered in sign
  dx1 = np.sign(vertices[:, 0] - x1)
...\matplotlib\transforms.py:654: RuntimeWarning: invalid value encountered in sign
  dy1 = np.sign(vertices[:, 1] - y1)

The following code reproduces this RuntimeWarning:
plt.plot([1,2,np.nan,4,5], label='test')
plt.legend(loc='best')

The solution is to check for NaN's in data and delete those rows, as suggested.
