### PR TITLE
setup.py creates a zombie C extension called "freetype2"

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -253,6 +253,11 @@ class PkgConfig(object):
             self.set_pkgconfig_path()
             status, output = getstatusoutput("pkg-config --help")
             self.has_pkgconfig = (status == 0)
+            if not self.has_pkgconfig:
+                print("IMPORTANT WARNING:")
+                print(
+                    "    pkg-config is not installed.\n"
+                    "    matplotlib may not be able to find some of its dependencies")
 
     def set_pkgconfig_path(self):
         pkgconfig_path = sysconfig.get_config_var('LIBDIR')
@@ -981,19 +986,13 @@ class FreeType(SetupPackage):
         pkg_config.setup_extension(
             ext, 'freetype2',
             default_include_dirs=[
-                'freetype2', 'lib/freetype2/include',
+                'include/freetype2', 'freetype2',
+                'lib/freetype2/include',
                 'lib/freetype2/include/freetype2'],
             default_library_dirs=[
                 'freetype2/lib'],
-            default_libraries=['freetype', 'z'],
-            alt_exec='freetype-config')
+            default_libraries=['freetype', 'z'])
 
-    def get_extension(self):
-        if sys.platform == 'win32':
-            return None
-        ext = make_extension('freetype2', [])
-        self.add_flags(ext)
-        return ext
 
 
 class FT2Font(SetupPackage):


### PR DESCRIPTION
Since #3067, there has been a useless and unimportable extension created as part of the matplotlib install.  We need to remove it.

However, it reportedly fixes a real bug for some, but it's not quite clear how.  I'll poke around and see if I can break/fix it in the same way as the original reports and then find a better solution that doesn't install a broken `.so` file.

```
>>> import freetype2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: dynamic module does not define init function (initfreetype2)
```

The name of matplotlib's freetype wrapper is ft2font, not freetype2.
