### PR TITLE
matplotlib.__version__ is now unicode as of 1.4.0

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -106,8 +106,8 @@ import six
 import sys
 import distutils.version
 
-__version__  = '1.4.x'
-__version__numpy__ = '1.6' # minimum required numpy version
+__version__  = str('1.4.x')
+__version__numpy__ = str('1.6') # minimum required numpy version
 
 try:
     import dateutil


### PR DESCRIPTION
see here: https://github.com/pydata/pandas/issues/8502

this breaks `LooseVersion` (not sure why that is)

is this typical to make this unicode? (and not a plain string even in py2)?
