### PR TITLE
MEP22: Navigation by events

### DIFF
--- a/doc/api/backend_managers_api.rst
+++ b/doc/api/backend_managers_api.rst
@@ -1,0 +1,8 @@
+
+:mod:`matplotlib.backend_managers`
+===================================
+
+.. automodule:: matplotlib.backend_managers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/index_backend_api.rst
+++ b/doc/api/index_backend_api.rst
@@ -5,6 +5,7 @@ backends
 .. toctree::
 
    backend_bases_api.rst
+   backend_managers_api.rst
    backend_tools_api.rst
    backend_gtkagg_api.rst
    backend_qt4agg_api.rst

--- a/doc/users/whats_new/rcparams.rst
+++ b/doc/users/whats_new/rcparams.rst
@@ -15,9 +15,17 @@ Added "figure.titlesize" and "figure.titleweight" keys to rcParams
 Two new keys were added to rcParams to control the default font size and weight
 used by the figure title (as emitted by ``pyplot.suptitle()``).
 
+
 ``image.composite_image`` added to rcParams
 ```````````````````````````````````````````
 Controls whether vector graphics backends (i.e. PDF, PS, and SVG) combine
 multiple images on a set of axes into a single composite image.  Saving each
 image individually can be useful if you generate vector graphics files in
 matplotlib and then edit the files further in Inkscape or other programs.
+
+
+Added "toolmanager" to "toolbar" possible values
+````````````````````````````````````````````````
+
+The new value enables the use of ``ToolManager``
+

--- a/doc/users/whats_new/toolmanager.rst
+++ b/doc/users/whats_new/toolmanager.rst
@@ -1,0 +1,68 @@
+ToolManager
+-----------
+
+Federico Ariza wrote the new `matplotlib.backend_managers.ToolManager` that comes as replacement for `NavigationToolbar2`
+
+`ToolManager` offers a new way of looking at the user interactions with the figures.
+Before we had the `NavigationToolbar2` with its own tools like `zoom/pan/home/save/...` and also we had the shortcuts like
+`yscale/grid/quit/....`
+`Toolmanager` relocate all those actions as `Tools` (located in `matplotlib.backend_tools`), and defines a way to `access/trigger/reconfigure` them.
+
+The `Toolbars` are replaced for `ToolContainers` that are just GUI interfaces to `trigger` the tools. But don't worry the default backends include a `ToolContainer` called `toolbar`
+
+
+.. note::
+	For the moment the `ToolManager` is working only with `GTK3` and `Tk` backends.
+	Make sure you are using one of those.
+	Port for the rest of the backends is comming soon.
+	
+	To activate the `ToolManager` include the following at the top of your file:
+	
+	 >>> matplotlib.rcParams['toolbar'] = 'toolmanager'
+	
+
+Interact with the ToolContainer
+```````````````````````````````
+
+The most important feature is the ability to easily reconfigure the ToolContainer (aka toolbar).
+For example, if we want to remove the "forward" button we would just do.
+
+ >>> fig.canvas.manager.toolmanager.remove_tool('forward')
+
+Now if you want to programmatically trigger the "home" button
+
+ >>> fig.canvas.manager.toolmanager.trigger_tool('home')
+
+
+New Tools
+`````````
+
+It is possible to add new tools to the ToolManager
+
+A very simple tool that prints "You're awesome" would be::
+
+    from matplotlib.backend_tools import ToolBase
+    class AwesomeTool(ToolBase):
+        def trigger(self, *args, **kwargs):
+            print("You're awesome")
+
+
+To add this tool to `ToolManager`
+
+ >>> fig.canvas.manager.toolmanager.add_tool('Awesome', AwesomeTool)
+
+If we want to add a shortcut ("d") for the tool
+
+ >>> fig.canvas.manager.toolmanager.update_keymap('Awesome', 'd')
+
+
+To add it to the toolbar inside the group 'foo'
+
+ >>> fig.canvas.manager.toolbar.add_tool('Awesome', 'foo')
+
+
+There is a second class of tools, "Toggleable Tools", this are almost the same as our basic tools, just that belong to a group, and are mutually exclusive inside that group.
+For tools derived from `ToolToggleBase` there are two basic methods `enable` and `disable` that are called automatically whenever it is toggled.
+
+
+A full example is located in :ref:`user_interfaces-toolmanager`

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -6,54 +6,54 @@ import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
 
 
-# Create a simple tool to list all the tools
-class ListTools(ToolBase):
-    # keyboard shortcut
-    keymap = 'm'
-    description = 'List Tools'
-
-    def trigger(self, event):
-        tools = self.navigation.get_tools()
-
-        print ('_' * 80)
-        print ("{0:12} {1:45} {2}".format('Name (id)',
-                                          'Tool description',
-                                          'Keymap'))
-        print ('_' * 80)
-        for name in sorted(tools.keys()):
-            keys = ', '.join(sorted(tools[name]['keymap']))
-            print ("{0:12} {1:45} {2}".format(name,
-                                              tools[name]['description'],
-                                              keys))
-        print ('_' * 80)
-
-
-# A simple example of copy canvas
-# ref: at https://github.com/matplotlib/matplotlib/issues/1987
-class CopyToolGTK3(ToolBase):
-    keymap = 'ctrl+c'
-    description = 'Copy canvas'
-    # It is not added to the toolbar as a button
-    intoolbar = False
-
-    def trigger(self, event):
-        from gi.repository import Gtk, Gdk
-        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-        window = self.figure.canvas.get_window()
-        x, y, width, height = window.get_geometry()
-        pb = Gdk.pixbuf_get_from_window(window, x, y, width, height)
-        clipboard.set_image(pb)
+# # Create a simple tool to list all the tools
+# class ListTools(ToolBase):
+#     # keyboard shortcut
+#     keymap = 'm'
+#     description = 'List Tools'
+# 
+#     def trigger(self, event):
+#         tools = self.navigation.get_tools()
+# 
+#         print ('_' * 80)
+#         print ("{0:12} {1:45} {2}".format('Name (id)',
+#                                           'Tool description',
+#                                           'Keymap'))
+#         print ('_' * 80)
+#         for name in sorted(tools.keys()):
+#             keys = ', '.join(sorted(tools[name]['keymap']))
+#             print ("{0:12} {1:45} {2}".format(name,
+#                                               tools[name]['description'],
+#                                               keys))
+#         print ('_' * 80)
+# 
+# 
+# # A simple example of copy canvas
+# # ref: at https://github.com/matplotlib/matplotlib/issues/1987
+# class CopyToolGTK3(ToolBase):
+#     keymap = 'ctrl+c'
+#     description = 'Copy canvas'
+#     # It is not added to the toolbar as a button
+#     intoolbar = False
+# 
+#     def trigger(self, event):
+#         from gi.repository import Gtk, Gdk
+#         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+#         window = self.figure.canvas.get_window()
+#         x, y, width, height = window.get_geometry()
+#         pb = Gdk.pixbuf_get_from_window(window, x, y, width, height)
+#         clipboard.set_image(pb)
 
 
 fig = plt.figure()
 plt.plot([1, 2, 3])
 
 # Add the custom tools that we created
-fig.canvas.manager.navigation.add_tool('List', ListTools)
-if matplotlib.rcParams['backend'] == 'GTK3Cairo':
-    fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
- 
-# Just for fun, lets remove the forward button
-fig.canvas.manager.navigation.remove_tool('Forward')
+# fig.canvas.manager.navigation.add_tool('List', ListTools)
+# if matplotlib.rcParams['backend'] == 'GTK3Cairo':
+#     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
+#  
+# # Just for fun, lets remove the forward button
+# fig.canvas.manager.navigation.remove_tool('Forward')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -10,11 +10,11 @@ class ListTools(ToolBase):
     #keyboard shortcut
     keymap = 'm'
     #Name used as id, must be unique between tools of the same navigation
-    name = 'List' 
-    description = 'List Tools' 
+    name = 'List'
+    description = 'List Tools'
     #Where to put it in the toolbar, -1 = at the end, None = Not in toolbar
     position = -1
- 
+
     def trigger(self, event):
         #The most important attributes are navigation and figure
         self.navigation.list_tools()
@@ -29,7 +29,7 @@ class CopyTool(ToolBase):
     position = -1
 
     def trigger(self, event):
-        from gi.repository import Gtk, Gdk, GdkPixbuf
+        from gi.repository import Gtk, Gdk
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         window = self.figure.canvas.get_window()
         x, y, width, height = window.get_geometry()
@@ -46,7 +46,7 @@ if matplotlib.rcParams['toolbar'] in ('navigation', 'None'):
     fig.canvas.manager.navigation.add_tool(ListTools)
     fig.canvas.manager.navigation.add_tool(CopyTool)
 
-    ##Just for fun, lets remove the back button    
+    ##Just for fun, lets remove the back button
     fig.canvas.manager.navigation.remove_tool('Back')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -15,7 +15,7 @@ class ListTools(ToolBase):
     #Where to put it in the toolbar, -1 = at the end, None = Not in toolbar
     position = -1
  
-    def activate(self, event):
+    def trigger(self, event):
         #The most important attributes are navigation and figure
         self.navigation.list_tools()
 
@@ -28,7 +28,7 @@ class CopyTool(ToolBase):
     description = 'Copy canvas'
     position = -1
 
-    def activate(self, event):
+    def trigger(self, event):
         from gi.repository import Gtk, Gdk, GdkPixbuf
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         window = self.figure.canvas.get_window()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -6,54 +6,54 @@ import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
 
 
-# # Create a simple tool to list all the tools
-# class ListTools(ToolBase):
-#     # keyboard shortcut
-#     keymap = 'm'
-#     description = 'List Tools'
-# 
-#     def trigger(self, event):
-#         tools = self.navigation.get_tools()
-# 
-#         print ('_' * 80)
-#         print ("{0:12} {1:45} {2}".format('Name (id)',
-#                                           'Tool description',
-#                                           'Keymap'))
-#         print ('_' * 80)
-#         for name in sorted(tools.keys()):
-#             keys = ', '.join(sorted(tools[name]['keymap']))
-#             print ("{0:12} {1:45} {2}".format(name,
-#                                               tools[name]['description'],
-#                                               keys))
-#         print ('_' * 80)
-# 
-# 
-# # A simple example of copy canvas
-# # ref: at https://github.com/matplotlib/matplotlib/issues/1987
-# class CopyToolGTK3(ToolBase):
-#     keymap = 'ctrl+c'
-#     description = 'Copy canvas'
-#     # It is not added to the toolbar as a button
-#     intoolbar = False
-# 
-#     def trigger(self, event):
-#         from gi.repository import Gtk, Gdk
-#         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-#         window = self.figure.canvas.get_window()
-#         x, y, width, height = window.get_geometry()
-#         pb = Gdk.pixbuf_get_from_window(window, x, y, width, height)
-#         clipboard.set_image(pb)
+# Create a simple tool to list all the tools
+class ListTools(ToolBase):
+    # keyboard shortcut
+    keymap = 'm'
+    description = 'List Tools'
+ 
+    def trigger(self, event):
+        tools = self.navigation.get_tools()
+ 
+        print ('_' * 80)
+        print ("{0:12} {1:45} {2}".format('Name (id)',
+                                          'Tool description',
+                                          'Keymap'))
+        print ('_' * 80)
+        for name in sorted(tools.keys()):
+            keys = ', '.join(sorted(tools[name]['keymap']))
+            print ("{0:12} {1:45} {2}".format(name,
+                                              tools[name]['description'],
+                                              keys))
+        print ('_' * 80)
+ 
+ 
+# A simple example of copy canvas
+# ref: at https://github.com/matplotlib/matplotlib/issues/1987
+class CopyToolGTK3(ToolBase):
+    keymap = 'ctrl+c'
+    description = 'Copy canvas'
+    # It is not added to the toolbar as a button
+    intoolbar = False
+ 
+    def trigger(self, event):
+        from gi.repository import Gtk, Gdk
+        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        window = self.figure.canvas.get_window()
+        x, y, width, height = window.get_geometry()
+        pb = Gdk.pixbuf_get_from_window(window, x, y, width, height)
+        clipboard.set_image(pb)
 
 
 fig = plt.figure()
 plt.plot([1, 2, 3])
 
 # Add the custom tools that we created
-# fig.canvas.manager.navigation.add_tool('List', ListTools)
-# if matplotlib.rcParams['backend'] == 'GTK3Cairo':
-#     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
+fig.canvas.manager.navigation.add_tool('List', ListTools)
+if matplotlib.rcParams['backend'] == 'GTK3Cairo':
+    fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
 #  
-# # Just for fun, lets remove the forward button
-# fig.canvas.manager.navigation.remove_tool('Forward')
+# Just for fun, lets remove the forward button
+fig.canvas.manager.navigation.remove_tool('forward')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -1,5 +1,6 @@
 import matplotlib
-matplotlib.use('GTK3Cairo')
+# matplotlib.use('GTK3Cairo')
+matplotlib.use('TkAGG')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -4,7 +4,7 @@ matplotlib.use('GTK3Cairo')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
-
+from pydispatch import dispatcher
 
 # Create a simple tool to list all the tools
 class ListTools(ToolBase):
@@ -14,7 +14,7 @@ class ListTools(ToolBase):
  
     def trigger(self, event):
         tools = self.navigation.get_tools()
- 
+  
         print ('_' * 80)
         print ("{0:12} {1:45} {2}".format('Name (id)',
                                           'Tool description',
@@ -25,7 +25,7 @@ class ListTools(ToolBase):
             print ("{0:12} {1:45} {2}".format(name,
                                               tools[name]['description'],
                                               keys))
-        print ('_' * 80)
+        print ('_' * 80)  
  
  
 # A simple example of copy canvas
@@ -45,6 +45,9 @@ class CopyToolGTK3(ToolBase):
         clipboard.set_image(pb)
 
 
+
+
+
 fig = plt.figure()
 plt.plot([1, 2, 3])
 
@@ -52,8 +55,9 @@ plt.plot([1, 2, 3])
 fig.canvas.manager.navigation.add_tool('List', ListTools)
 if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
-#  
-# Just for fun, lets remove the forward button
-fig.canvas.manager.navigation.remove_tool('forward')
+ 
+# # Just for fun, lets remove the forward button
+# fig.canvas.manager.navigation.remove_tool('forward')
+
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -1,6 +1,6 @@
 import matplotlib
-matplotlib.use('GTK3Cairo')
-# matplotlib.use('TkAGG')
+# matplotlib.use('GTK3Cairo')
+matplotlib.use('TkAGG')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
@@ -54,6 +54,6 @@ if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
 
 # Just for fun, lets remove the back button
-fig.canvas.manager.navigation.remove_tool('Back')
+# fig.canvas.manager.navigation.remove_tool('Back')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -1,6 +1,6 @@
 import matplotlib
-# matplotlib.use('GTK3Cairo')
-matplotlib.use('TkAGG')
+matplotlib.use('GTK3Cairo')
+# matplotlib.use('TkAGG')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
@@ -53,7 +53,7 @@ fig.canvas.manager.navigation.add_tool('List', ListTools)
 if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
  
-# Just for fun, lets remove the back button
-# fig.canvas.manager.navigation.remove_tool('Back')
+# Just for fun, lets remove the forward button
+fig.canvas.manager.navigation.remove_tool('Forward')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -52,8 +52,8 @@ plt.plot([1, 2, 3])
 fig.canvas.manager.navigation.add_tool('List', ListTools)
 if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
-
+ 
 # Just for fun, lets remove the back button
-# fig.canvas.manager.navigation.remove_tool('Back')
+fig.canvas.manager.navigation.remove_tool('Back')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -54,6 +54,6 @@ if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
  
 # Just for fun, lets remove the back button
-fig.canvas.manager.navigation.remove_tool('Back')
+# fig.canvas.manager.navigation.remove_tool('Back')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -56,7 +56,7 @@ plt.plot([1, 2, 3])
 fig.canvas.manager.navigation.add_tool('List', ListTools)
 if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
-
+fig.canvas.manager.toolbar.add_tool('zoom', 'foo')
 # Uncomment to remove the forward button
 # fig.canvas.manager.navigation.remove_tool('forward')
 

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -1,33 +1,40 @@
 import matplotlib
-# matplotlib.use('GTK3Cairo')
-matplotlib.use('TkAGG')
+matplotlib.use('GTK3Cairo')
+# matplotlib.use('TkAGG')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
 
 
-#Create a simple tool to list all the tools
+# Create a simple tool to list all the tools
 class ListTools(ToolBase):
-    #keyboard shortcut
+    # keyboard shortcut
     keymap = 'm'
-    #Name used as id, must be unique between tools of the same navigation
-    name = 'List'
     description = 'List Tools'
-    #Where to put it in the toolbar, -1 = at the end, None = Not in toolbar
-    position = -1
 
     def trigger(self, event):
-        #The most important attributes are navigation and figure
-        self.navigation.list_tools()
+        tools = self.navigation.get_tools()
+
+        print ('_' * 80)
+        print ("{0:12} {1:45} {2}".format('Name (id)',
+                                          'Tool description',
+                                          'Keymap'))
+        print ('_' * 80)
+        for name in sorted(tools.keys()):
+            keys = ', '.join(sorted(tools[name]['keymap']))
+            print ("{0:12} {1:45} {2}".format(name,
+                                              tools[name]['description'],
+                                              keys))
+        print ('_' * 80)
 
 
-#A simple example of copy canvas
-#ref: at https://github.com/matplotlib/matplotlib/issues/1987
-class CopyTool(ToolBase):
+# A simple example of copy canvas
+# ref: at https://github.com/matplotlib/matplotlib/issues/1987
+class CopyToolGTK3(ToolBase):
     keymap = 'ctrl+c'
-    name = 'Copy'
     description = 'Copy canvas'
-    position = -1
+    # It is not added to the toolbar as a button
+    intoolbar = False
 
     def trigger(self, event):
         from gi.repository import Gtk, Gdk
@@ -41,13 +48,12 @@ class CopyTool(ToolBase):
 fig = plt.figure()
 plt.plot([1, 2, 3])
 
-#If we are in the old toolbar, don't try to modify it
-if matplotlib.rcParams['toolbar'] in ('navigation', 'None'):
-    ##Add the custom tools that we created
-    fig.canvas.manager.navigation.add_tool(ListTools)
-    fig.canvas.manager.navigation.add_tool(CopyTool)
+# Add the custom tools that we created
+fig.canvas.manager.navigation.add_tool('List', ListTools)
+if matplotlib.rcParams['backend'] == 'GTK3Cairo':
+    fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
 
-    ##Just for fun, lets remove the back button
-    fig.canvas.manager.navigation.remove_tool('Back')
+# Just for fun, lets remove the back button
+fig.canvas.manager.navigation.remove_tool('Back')
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -13,20 +13,25 @@ class ListTools(ToolBase):
     description = 'List Tools'
 
     def trigger(self, *args, **kwargs):
-        print ('_' * 80)
-        print ("{0:12} {1:45} {2}".format('Name (id)',
-                                          'Tool description',
-                                          'Keymap'))
-        print ('-' * 80)
+        print('_' * 80)
+        print("{0:12} {1:45} {2}".format('Name (id)',
+                                         'Tool description',
+                                         'Keymap'))
+        print('-' * 80)
         tools = self.navigation.tools
         for name in sorted(tools.keys()):
             if not tools[name].description:
                 continue
             keys = ', '.join(sorted(self.navigation.get_tool_keymap(name)))
-            print ("{0:12} {1:45} {2}".format(name,
-                                              tools[name].description,
-                                              keys))
-        print ('_' * 80)
+            print("{0:12} {1:45} {2}".format(name,
+                                             tools[name].description,
+                                             keys))
+        print('_' * 80)
+        print("Active Toggle tools")
+        print("{0:12} {1:45}").format("Group", "Active")
+        print('-' * 80)
+        for group, active in self.navigation.active_toggle.items():
+            print("{0:12} {1:45}").format(group, active)
 
 
 # A simple example of copy canvas

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -12,7 +12,7 @@ class ListTools(ToolBase):
     keymap = 'm'
     description = 'List Tools'
  
-    def trigger(self, event):
+    def trigger(self, *args, **kwargs):
         tools = self.navigation.get_tools()
   
         print ('_' * 80)
@@ -36,16 +36,13 @@ class CopyToolGTK3(ToolBase):
     # It is not added to the toolbar as a button
     intoolbar = False
  
-    def trigger(self, event):
+    def trigger(self, *args, **kwargs):
         from gi.repository import Gtk, Gdk
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         window = self.figure.canvas.get_window()
         x, y, width, height = window.get_geometry()
         pb = Gdk.pixbuf_get_from_window(window, x, y, width, height)
         clipboard.set_image(pb)
-
-
-
 
 
 fig = plt.figure()
@@ -56,8 +53,7 @@ fig.canvas.manager.navigation.add_tool('List', ListTools)
 if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
  
-# # Just for fun, lets remove the forward button
+# Uncomment to remove the forward button
 # fig.canvas.manager.navigation.remove_tool('forward')
-
 
 plt.show()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -4,30 +4,31 @@ matplotlib.use('GTK3Cairo')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
-from pydispatch import dispatcher
+
 
 # Create a simple tool to list all the tools
 class ListTools(ToolBase):
     # keyboard shortcut
     keymap = 'm'
     description = 'List Tools'
- 
+
     def trigger(self, *args, **kwargs):
-        tools = self.navigation.get_tools()
-  
         print ('_' * 80)
         print ("{0:12} {1:45} {2}".format('Name (id)',
                                           'Tool description',
                                           'Keymap'))
-        print ('_' * 80)
+        print ('-' * 80)
+        tools = self.navigation.tools
         for name in sorted(tools.keys()):
-            keys = ', '.join(sorted(tools[name]['keymap']))
+            if not tools[name].description:
+                continue
+            keys = ', '.join(sorted(self.navigation.get_tool_keymap(name)))
             print ("{0:12} {1:45} {2}".format(name,
-                                              tools[name]['description'],
+                                              tools[name].description,
                                               keys))
-        print ('_' * 80)  
- 
- 
+        print ('_' * 80)
+
+
 # A simple example of copy canvas
 # ref: at https://github.com/matplotlib/matplotlib/issues/1987
 class CopyToolGTK3(ToolBase):
@@ -35,7 +36,7 @@ class CopyToolGTK3(ToolBase):
     description = 'Copy canvas'
     # It is not added to the toolbar as a button
     intoolbar = False
- 
+
     def trigger(self, *args, **kwargs):
         from gi.repository import Gtk, Gdk
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
@@ -52,7 +53,7 @@ plt.plot([1, 2, 3])
 fig.canvas.manager.navigation.add_tool('List', ListTools)
 if matplotlib.rcParams['backend'] == 'GTK3Cairo':
     fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
- 
+
 # Uncomment to remove the forward button
 # fig.canvas.manager.navigation.remove_tool('forward')
 

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -39,8 +39,6 @@ class ListTools(ToolBase):
 class CopyToolGTK3(ToolBase):
     keymap = 'ctrl+c'
     description = 'Copy canvas'
-    # It is not added to the toolbar as a button
-    intoolbar = False
 
     def trigger(self, *args, **kwargs):
         from gi.repository import Gtk, Gdk

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -18,7 +18,7 @@ from gi.repository import Gtk, Gdk
 class ListTools(ToolBase):
     '''List all the tools controlled by `Navigation`'''
     # keyboard shortcut
-    keymap = 'm'
+    default_keymap = 'm'
     description = 'List Tools'
 
     def trigger(self, *args, **kwargs):
@@ -46,7 +46,7 @@ class ListTools(ToolBase):
 # ref: at https://github.com/matplotlib/matplotlib/issues/1987
 class CopyToolGTK3(ToolBase):
     '''Copy canvas to clipboard'''
-    keymap = 'ctrl+c'
+    default_keymap = 'ctrl+c'
     description = 'Copy canvas'
 
     def trigger(self, *args, **kwargs):

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -12,6 +12,7 @@ matplotlib.use('GTK3Cairo')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
+from gi.repository import Gtk, Gdk
 
 
 class ListTools(ToolBase):
@@ -36,10 +37,10 @@ class ListTools(ToolBase):
                                              keys))
         print('_' * 80)
         print("Active Toggle tools")
-        print("{0:12} {1:45}").format("Group", "Active")
+        print("{0:12} {1:45}".format("Group", "Active"))
         print('-' * 80)
         for group, active in self.navigation.active_toggle.items():
-            print("{0:12} {1:45}").format(group, active)
+            print("{0:12} {1:45}".format(group, active))
 
 
 # ref: at https://github.com/matplotlib/matplotlib/issues/1987
@@ -49,7 +50,6 @@ class CopyToolGTK3(ToolBase):
     description = 'Copy canvas'
 
     def trigger(self, *args, **kwargs):
-        from gi.repository import Gtk, Gdk
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         window = self.figure.canvas.get_window()
         x, y, width, height = window.get_geometry()

--- a/examples/user_interfaces/navigation.py
+++ b/examples/user_interfaces/navigation.py
@@ -1,13 +1,21 @@
+'''This example demonstrates how the `matplotlib.backend_bases.NavigationBase`
+class allows to:
+* Modify the Toolbar
+* Add tools
+* Remove tools
+'''
+
+
+from __future__ import print_function
 import matplotlib
 matplotlib.use('GTK3Cairo')
-# matplotlib.use('TkAGG')
 matplotlib.rcParams['toolbar'] = 'navigation'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
 
 
-# Create a simple tool to list all the tools
 class ListTools(ToolBase):
+    '''List all the tools controlled by `Navigation`'''
     # keyboard shortcut
     keymap = 'm'
     description = 'List Tools'
@@ -34,9 +42,9 @@ class ListTools(ToolBase):
             print("{0:12} {1:45}").format(group, active)
 
 
-# A simple example of copy canvas
 # ref: at https://github.com/matplotlib/matplotlib/issues/1987
 class CopyToolGTK3(ToolBase):
+    '''Copy canvas to clipboard'''
     keymap = 'ctrl+c'
     description = 'Copy canvas'
 
@@ -54,10 +62,16 @@ plt.plot([1, 2, 3])
 
 # Add the custom tools that we created
 fig.canvas.manager.navigation.add_tool('List', ListTools)
-if matplotlib.rcParams['backend'] == 'GTK3Cairo':
-    fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
+fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
+
+# Add an existing tool to new group `foo`.
+# It can be added as many times as we want
 fig.canvas.manager.toolbar.add_tool('zoom', 'foo')
-# Uncomment to remove the forward button
-# fig.canvas.manager.navigation.remove_tool('forward')
+
+# Remove the forward button
+fig.canvas.manager.navigation.remove_tool('forward')
+
+# To add a custom tool to the toolbar at specific location
+fig.canvas.manager.toolbar.add_tool('List', 'navigation', 1)
 
 plt.show()

--- a/examples/user_interfaces/toolmanager.py
+++ b/examples/user_interfaces/toolmanager.py
@@ -1,8 +1,9 @@
-'''This example demonstrates how the `matplotlib.backend_bases.NavigationBase`
-class allows to:
+'''This example demonstrates how to:
 * Modify the Toolbar
+* Create tools
 * Add tools
 * Remove tools
+Using `matplotlib.backend_managers.ToolManager`
 '''
 
 

--- a/examples/user_interfaces/toolmanager.py
+++ b/examples/user_interfaces/toolmanager.py
@@ -8,8 +8,7 @@ class allows to:
 
 from __future__ import print_function
 import matplotlib
-# matplotlib.use('GTK3Cairo')
-matplotlib.use('Tkagg')
+matplotlib.use('GTK3Cairo')
 matplotlib.rcParams['toolbar'] = 'toolmanager'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
@@ -63,7 +62,7 @@ plt.plot([1, 2, 3])
 
 # Add the custom tools that we created
 fig.canvas.manager.toolmanager.add_tool('List', ListTools)
-# fig.canvas.manager.toolmanager.add_tool('copy', CopyToolGTK3)
+fig.canvas.manager.toolmanager.add_tool('copy', CopyToolGTK3)
 
 # Add an existing tool to new group `foo`.
 # It can be added as many times as we want

--- a/examples/user_interfaces/toolmanager.py
+++ b/examples/user_interfaces/toolmanager.py
@@ -8,8 +8,9 @@ class allows to:
 
 from __future__ import print_function
 import matplotlib
-matplotlib.use('GTK3Cairo')
-matplotlib.rcParams['toolbar'] = 'navigation'
+# matplotlib.use('GTK3Cairo')
+matplotlib.use('Tkagg')
+matplotlib.rcParams['toolbar'] = 'toolmanager'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase
 from gi.repository import Gtk, Gdk
@@ -27,11 +28,11 @@ class ListTools(ToolBase):
                                          'Tool description',
                                          'Keymap'))
         print('-' * 80)
-        tools = self.navigation.tools
+        tools = self.toolmanager.tools
         for name in sorted(tools.keys()):
             if not tools[name].description:
                 continue
-            keys = ', '.join(sorted(self.navigation.get_tool_keymap(name)))
+            keys = ', '.join(sorted(self.toolmanager.get_tool_keymap(name)))
             print("{0:12} {1:45} {2}".format(name,
                                              tools[name].description,
                                              keys))
@@ -39,7 +40,7 @@ class ListTools(ToolBase):
         print("Active Toggle tools")
         print("{0:12} {1:45}".format("Group", "Active"))
         print('-' * 80)
-        for group, active in self.navigation.active_toggle.items():
+        for group, active in self.toolmanager.active_toggle.items():
             print("{0:12} {1:45}".format(group, active))
 
 
@@ -61,15 +62,15 @@ fig = plt.figure()
 plt.plot([1, 2, 3])
 
 # Add the custom tools that we created
-fig.canvas.manager.navigation.add_tool('List', ListTools)
-fig.canvas.manager.navigation.add_tool('copy', CopyToolGTK3)
+fig.canvas.manager.toolmanager.add_tool('List', ListTools)
+# fig.canvas.manager.toolmanager.add_tool('copy', CopyToolGTK3)
 
 # Add an existing tool to new group `foo`.
 # It can be added as many times as we want
 fig.canvas.manager.toolbar.add_tool('zoom', 'foo')
 
 # Remove the forward button
-fig.canvas.manager.navigation.remove_tool('forward')
+fig.canvas.manager.toolmanager.remove_tool('forward')
 
 # To add a custom tool to the toolbar at specific location
 fig.canvas.manager.toolbar.add_tool('List', 'navigation', 1)

--- a/examples/user_interfaces/toolmanager.py
+++ b/examples/user_interfaces/toolmanager.py
@@ -17,7 +17,7 @@ from gi.repository import Gtk, Gdk
 
 
 class ListTools(ToolBase):
-    '''List all the tools controlled by `Navigation`'''
+    '''List all the tools controlled by the `ToolManager`'''
     # keyboard shortcut
     default_keymap = 'm'
     description = 'List Tools'
@@ -72,7 +72,8 @@ fig.canvas.manager.toolbar.add_tool('zoom', 'foo')
 # Remove the forward button
 fig.canvas.manager.toolmanager.remove_tool('forward')
 
-# To add a custom tool to the toolbar at specific location
+# To add a custom tool to the toolbar at specific location inside
+# the navigation group
 fig.canvas.manager.toolbar.add_tool('List', 'navigation', 1)
 
 plt.show()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3450,8 +3450,7 @@ class NavigationBase(object):
     def trigger_tool(self, name):
         """Trigger on a tool
 
-        This is a convenient method to programatically "click" on
-        Tools
+        Method to programatically "click" on Tools
         """
         self._trigger_tool(name, None, False)
 
@@ -3475,6 +3474,8 @@ class NavigationBase(object):
             return
 
         name = self._keys.get(event.key, None)
+        if name is None:
+            return
         self._trigger_tool(name, event, False)
 
     def _get_instance(self, name):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3522,7 +3522,7 @@ class NavigationBase(object):
 
         self._trigger_tool(name, sender, canvasevent, data)
 
-        s = 'tool-trigger-%s' % name
+        s = 'tool_trigger_%s' % name
         event = ToolTriggerEvent(s, sender, self._tools[name], canvasevent,
                                  data)
         self._callbacks.process(s, event)
@@ -3611,7 +3611,7 @@ class ToolbarBase(object):
                           event.tool.description,
                           toggle)
         if toggle:
-            self.navigation.mpl_connect('tool-trigger-%s' % event.tool.name,
+            self.navigation.mpl_connect('tool_trigger_%s' % event.tool.name,
                                         self._tool_triggered_cbk)
 
     def _remove_tool_cbk(self, event):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3225,13 +3225,38 @@ class NavigationToolbar2(object):
         pass
 
 
+class NavigationEvent(object):
+    """"A Navigation Event ('tool_add_event',
+                   'tool_remove_event',
+                   'tool_trigger_event',
+                   'navigation_message_event').
+    Attributes
+    ----------
+    name: String
+        Name of the event
+    tool: ToolInstance
+    data: Extra data
+    source: String
+        Name of the object responsible for emiting the event
+        ('toolbar', 'navigation', 'keypress', etc...)
+    event: Event
+        Original event that causes navigation to emit this event
+    """
+
+    def __init__(self, name, tool, source, data=None, event=None):
+        self.name = name
+        self.tool = tool
+        self.data = data
+        self.source = source
+        self.event = event
+
+
 class NavigationBase(object):
     """ Helper class that groups all the user interactions for a FigureManager
 
      Attributes
     ----------
     manager : `FigureManager` instance
-    toolbar : `Toolbar` instance that is controlled by this `Navigation`
     keypresslock : `LockDraw` to know if the `canvas` key_press_event is
         locked
     messagelock : `LockDraw` to know if the message is available to write
@@ -3240,11 +3265,9 @@ class NavigationBase(object):
     _default_cursor = cursors.POINTER
 
     def __init__(self, manager):
-        """.. automethod:: _toolbar_callback"""
-
         self.manager = manager
         self.canvas = manager.canvas
-        self.toolbar = manager.toolbar
+        self.callbacks = cbook.CallbackRegistry()
 
         self._key_press_handler_id = self.canvas.mpl_connect(
             'key_press_event', self._key_press)
@@ -3258,10 +3281,76 @@ class NavigationBase(object):
 
         # to process keypress event
         self.keypresslock = widgets.LockDraw()
-        # to write into toolbar message
+        # To prevent the firing of 'navigation_message_event'
         self.messagelock = widgets.LockDraw()
 
         self._last_cursor = self._default_cursor
+
+    def mpl_connect(self, s, func):
+        return self.callbacks.connect(s, func)
+
+    def mpl_disconnect(self, cid):
+        return self.callbacks.disconnect(cid)
+
+    def tool_add_event(self, tool, group, position):
+        """
+        This method will call all functions connected to the
+        'tool_add_event' with a :class:`NavigationEvent`
+        """
+        s = 'tool_add_event'
+        data = {'group': group,
+                'position': position}
+        event = NavigationEvent(s, tool, 'navigation', data)
+        self.callbacks.process(s, event)
+
+    def tool_remove_event(self, tool):
+        """
+        This method will call all functions connected to the
+        'tool_remove_event' with a :class:`NavigationEvent`
+        """
+        s = 'tool_remove_event'
+        event = NavigationEvent(s, tool, 'navigation')
+        self.callbacks.process(s, event)
+
+    def tool_trigger_event(self, name, source, originalevent=None):
+        """
+        This method will call all functions connected to the
+        'tool_trigger_event' with a :class:`NavigationEvent`
+        """
+        if name not in self._tools:
+            raise AttributeError('%s not in Tools' % name)
+
+        tool = self._tools[name]
+
+        if isinstance(tool, tools.ToolToggleBase):
+            if self._toggled == name:
+                self._toggled = None
+            elif self._toggled is not None:
+                self.tool_trigger_event(self._toggled, 'navigation',
+                                        originalevent)
+                self._toggled = name
+            else:
+                self._toggled = name
+
+        tool.trigger(originalevent)
+
+        s = 'tool_trigger_event'
+        event = NavigationEvent(s, tool, source, originalevent)
+        self.callbacks.process(s, event)
+
+        for a in self.canvas.figure.get_axes():
+            a.set_navigate_mode(self._toggled)
+
+        self._set_cursor(originalevent)
+
+    def message_event(self, message, source='navigation'):
+        """
+        This method will call all functions connected to the
+        'navigation_message_event' with a :class:`NavigationEvent`
+        """
+        s = 'navigation_message_event'
+        event = NavigationEvent(s, None, source, data=message)
+        self.callbacks.process(s, event)
 
     @property
     def active_toggle(self):
@@ -3328,12 +3417,11 @@ class NavigationBase(object):
         tool.destroy()
 
         if self._toggled == name:
-            self._handle_toggle(name, from_toolbar=False)
+            self.tool_trigger_event(tool, 'navigation')
 
         self._remove_keys(name)
 
-        if self.toolbar and tool.intoolbar:
-            self.toolbar._remove_toolitem(name)
+        self.tool_remove_event(tool)
 
         del self._tools[name]
 
@@ -3346,14 +3434,12 @@ class NavigationBase(object):
         a either a reference to the tool Tool class itself, or None to
         insert a spacer.  See :func:`add_tool`.
         """
-        for name, tool in tools:
-            if tool is None:
-                if self.toolbar is not None:
-                    self.toolbar.add_separator(-1)
-            else:
-                self.add_tool(name, tool, None)
 
-    def add_tool(self, name, tool, position=None):
+        for group, grouptools in tools:
+            for position, tool in enumerate(grouptools):
+                self.add_tool(tool[1], tool[0], group, position)
+
+    def add_tool(self, name, tool, group=None, position=None):
         """Add tool to `Navigation`
 
         Parameters
@@ -3380,20 +3466,7 @@ class NavigationBase(object):
         if tool_cls.keymap is not None:
             self.set_tool_keymap(name, tool_cls.keymap)
 
-        if self.toolbar and tool_cls.intoolbar:
-            # TODO: better search for images, they are not always in the
-            # datapath
-            basedir = os.path.join(rcParams['datapath'], 'images')
-            if tool_cls.image is not None:
-                fname = os.path.join(basedir, tool_cls.image)
-            else:
-                fname = None
-            toggle = issubclass(tool_cls, tools.ToolToggleBase)
-            self.toolbar._add_toolitem(name,
-                                       tool_cls.description,
-                                       fname,
-                                       position,
-                                       toggle)
+        self.tool_add_event(self._tools[name], group, position)
 
     def _get_cls_to_instantiate(self, callback_class):
         if isinstance(callback_class, six.string_types):
@@ -3414,18 +3487,7 @@ class NavigationBase(object):
 
         Method to programatically "click" on Tools
         """
-
-        self._trigger_tool(name, event, False)
-
-    def _trigger_tool(self, name, event, from_toolbar):
-        if name not in self._tools:
-            raise AttributeError('%s not in Tools' % name)
-
-        tool = self._tools[name]
-        if isinstance(tool, tools.ToolToggleBase):
-            self._handle_toggle(name, event=event, from_toolbar=from_toolbar)
-        else:
-            tool.trigger(event)
+        self.tool_trigger_event(name, 'navigation', event)
 
     def _key_press(self, event):
         if event.key is None or self.keypresslock.locked():
@@ -3434,50 +3496,8 @@ class NavigationBase(object):
         name = self._keys.get(event.key, None)
         if name is None:
             return
-        self._trigger_tool(name, event, False)
 
-    def _toolbar_callback(self, name):
-        """Callback for the `Toolbar`
-
-        All Toolbar implementations have to call this method to signal that a
-        toolitem was clicked on
-
-        Parameters
-        ----------
-        name : string
-            Name of the tool that was activated (click) by the user using the
-            toolbar
-        """
-
-        self._trigger_tool(name, None, True)
-
-    def _handle_toggle(self, name, event=None, from_toolbar=False):
-        # toggle toolbar without callback
-        if not from_toolbar and self.toolbar:
-            self.toolbar._toggle(name, False)
-
-        tool = self._tools[name]
-        if self._toggled is None:
-            # first trigger of tool
-            self._toggled = name
-        elif self._toggled == name:
-            # second trigger of tool
-            self._toggled = None
-        else:
-            # other tool is triggered so trigger toggled tool
-            if self.toolbar:
-                # untoggle the previous toggled tool
-                self.toolbar._toggle(self._toggled, False)
-            self._tools[self._toggled].trigger(event)
-            self._toggled = name
-
-        tool.trigger(event)
-
-        for a in self.canvas.figure.get_axes():
-            a.set_navigate_mode(self._toggled)
-
-        # Change the cursor inmediately, don't wait for mouse move
-        self._set_cursor(event)
+        self.tool_trigger_event(name, 'keypress', event)
 
     def get_tools(self):
         """Return the tools controlled by `Navigation`"""
@@ -3495,6 +3515,9 @@ class NavigationBase(object):
         """Call the backend specific set_cursor method,
         if the pointer is inaxes
         """
+        if not event:
+            return
+
         if not event.inaxes or not self._toggled:
             if self._last_cursor != self._default_cursor:
                 self.set_cursor(self._default_cursor)
@@ -3509,8 +3532,10 @@ class NavigationBase(object):
     def _mouse_move(self, event):
         self._set_cursor(event)
 
-        if self.toolbar is None or self.messagelock.locked():
+        if self.messagelock.locked():
             return
+
+        message = ' '
 
         if event.inaxes and event.inaxes.get_navigate():
 
@@ -3520,15 +3545,13 @@ class NavigationBase(object):
                 pass
             else:
                 if self._toggled:
-                    self.toolbar.set_message('%s, %s' % (self._toggled, s))
+                    message = '%s, %s' % (self._toggled, s)
                 else:
-                    self.toolbar.set_message(s)
-        else:
-            self.toolbar.set_message('')
+                    message = s
+        self.message_event(message)
 
     def set_cursor(self, cursor):
-        """
-        Set the current cursor to one of the :class:`Cursors`
+        """Set the current cursor to one of the :class:`Cursors`
         enums values
         """
 
@@ -3575,33 +3598,92 @@ class ToolbarBase(object):
     """
 
     def __init__(self, manager):
-        """
-        .. automethod:: _add_toolitem
-        .. automethod:: _remove_toolitem
-        .. automethod:: _toggle
-        """
-
         self.manager = manager
+        self._tool_trigger_id = None
+        self._add_tool_id = None
+        self._remove_tool_id = None
+        self._navigation = None
 
-    def _add_toolitem(self, name, description, image_file, position,
-                      toggle):
+    def _get_image_filename(self, image):
+        # TODO: better search for images, they are not always in the
+        # datapath
+        basedir = os.path.join(rcParams['datapath'], 'images')
+        if image is not None:
+            fname = os.path.join(basedir, image)
+        else:
+            fname = None
+        return fname
+
+    def _add_tool_callback(self, event):
+        name = event.tool.name
+        group = event.data['group']
+        position = event.data['position']
+        image = self._get_image_filename(event.tool.image)
+        description = event.tool.description
+        toggle = isinstance(event.tool, tools.ToolToggleBase)
+        self.add_toolitem(name, group, position, image, description, toggle)
+
+    def _remove_tool_callback(self, event):
+        self.remove_toolitem(event.tool.name)
+
+    def _tool_trigger_callback(self, event):
+        if event.source == 'toolbar':
+            return
+
+        if isinstance(event.tool, tools.ToolToggleBase):
+            self.toggle_toolitem(event.tool.name)
+
+    def _message_event_callback(self, event):
+        self.set_message(event.data)
+
+    def trigger_tool(self, name):
+        """Inform navigation of a toolbar event
+
+        Uses the navigation method to emit a 'tool_trigger_event'
+        with 'navigation' as the source
+
+        Parameters
+        ----------
+        name : String
+            Name(id) of the tool that was triggered in the toolbar
+
+        """
+        self._navigation.tool_trigger_event(name, 'toolbar')
+
+    def set_navigation(self, navigation):
+        """Initialize the callbacks for navigation events"""
+        self._navigation = navigation
+        self._add_tool_id = self._navigation.mpl_connect(
+            'tool_add_event', self._add_tool_callback)
+
+        self._tool_trigger_id = self._navigation.mpl_connect(
+            'tool_trigger_event', self._tool_trigger_callback)
+
+        self._message_id = self._navigation.mpl_connect(
+            'navigation_message_event', self._message_event_callback)
+
+        self._remove_tool_id = self._navigation.mpl_connect(
+            'tool_remove_event', self._remove_tool_callback)
+
+    def add_toolitem(self, name, group, position, image, description, toggle):
         """Add a toolitem to the toolbar
 
         The callback associated with the button click event,
-        must be **EXACTLY** `self.manager.navigation._toolbar_callback(name)`
+        must be **EXACTLY** `self.trigger_tool(name)`
 
         Parameters
         ----------
         name : string
             Name of the tool to add, this is used as ID and as default label
             of the buttons
-        description : string
-            Description of the tool, used for the tooltips
+        group : String
+            Name of the group that the tool belongs to
+        position : Int
+            Position of the tool whthin its group if -1 at the End
         image_file : string
             Filename of the image for the button or `None`
-        position : integer
-            Position of the toolitem within the other toolitems
-            if -1 at the End
+        description : string
+            Description of the tool, used for the tooltips
         toggle : bool
             * `True` : The button is a toggle (change the pressed/unpressed
                 state between consecutive clicks)
@@ -3611,41 +3693,12 @@ class ToolbarBase(object):
 
         raise NotImplementedError
 
-    def add_separator(self, pos):
-        """Add a separator
-
-        Parameters
-        ----------
-        pos : integer
-            Position where to add the separator within the toolitems
-            if -1 at the end
-        """
-
-        pass
-
     def set_message(self, s):
         """Display a message on toolbar or in status bar"""
 
         pass
 
-    def _toggle(self, name, callback=False):
-        """Toogle a button
-
-        Parameters
-        ----------
-        name : string
-            Name of the button to toggle
-        callback : bool
-            * `True`: call the button callback during toggle
-            * `False`: toggle the button without calling the callback
-
-        """
-
-        # carefull, callback means to perform or not the callback while
-        # toggling
-        raise NotImplementedError
-
-    def _remove_toolitem(self, name):
+    def remove_toolitem(self, name):
         """Remove a toolitem from the `Toolbar`
 
         Parameters
@@ -3656,30 +3709,3 @@ class ToolbarBase(object):
         """
 
         raise NotImplementedError
-
-    def move_toolitem(self, pos_ini, pos_fin):
-        """Change the position of a toolitem
-
-        Parameters
-        ----------
-        pos_ini : integer
-            Initial position of the toolitem to move
-        pos_fin : integer
-            Final position of the toolitem
-        """
-
-        pass
-
-    def set_toolitem_visibility(self, name, visible):
-        """Change the visibility of a toolitem
-
-        Parameters
-        ----------
-        name : string
-            Name of the `Tool`
-        visible : bool
-            * `True`: set the toolitem visible
-            * `False`: set the toolitem invisible
-        """
-
-        pass

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3287,10 +3287,20 @@ class NavigationBase(object):
 
         self._last_cursor = self._default_cursor
 
+    @classmethod
+    def get_default_tools(cls):
+        """Get the default tools"""
+        return cls._default_tools
+
+    @classmethod
+    def set_default_tools(cls, tools):
+        """Set default tools"""
+        cls._default_tools = tools
+
     def _get_toolbar(self, toolbar, canvas):
         # must be inited after the window, drawingArea and figure
         # attrs are set
-        if rcParams['toolbar'] == 'navigation'  and toolbar is not None:
+        if rcParams['toolbar'] == 'navigation' and toolbar is not None:
             toolbar = toolbar(canvas.manager)
         else:
             toolbar = None
@@ -3324,7 +3334,7 @@ class NavigationBase(object):
         ----------
         list : list of keys associated with the Tool
         """
-        keys = [k for k, i in self._keys.items() if i == name]
+        keys = [k for k, i in six.iteritems(self._keys) if i == name]
         return keys
 
     def set_tool_keymap(self, name, *keys):
@@ -3340,7 +3350,7 @@ class NavigationBase(object):
         if name not in self._tools:
             raise AttributeError('%s not in Tools' % name)
 
-        active_keys = [k for k, i in self._keys.items() if i == name]
+        active_keys = [k for k, i in six.iteritems(self._keys) if i == name]
         for k in active_keys:
             del self._keys[k]
 
@@ -3385,7 +3395,7 @@ class NavigationBase(object):
         """
         self.unregister(name)
         del self._tools[name]
-        keys = [k for k, v in self._keys.items() if v == name]
+        keys = [k for k, v in six.iteritems(self._keys) if v == name]
         for k in keys:
             del self._keys[k]
 
@@ -3434,7 +3444,7 @@ class NavigationBase(object):
                                       toggle)
 
     def _get_cls_to_instantiate(self, callback_class):
-        if isinstance(callback_class, basestring):
+        if isinstance(callback_class, six.string_types):
             #FIXME: make more complete searching structure
             if callback_class in globals():
                 return globals()[callback_class]
@@ -3533,7 +3543,7 @@ class NavigationBase(object):
         print ('_' * 80)
         for name in sorted(self._tools.keys()):
             tool = self._tools[name]
-            keys = [k for k, i in self._keys.items() if i == name]
+            keys = [k for k, i in six.iteritems(self._keys) if i == name]
             print ("{0:20} {1:50} {2}".format(tool.name, tool.description,
                                               ', '.join(keys)))
         print ('_' * 80, '\n')

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3279,7 +3279,7 @@ class NavigationBase(object):
         self.keypresslock = widgets.LockDraw()
         self.messagelock = widgets.LockDraw()
 
-    def mpl_connect(self, s, func):
+    def nav_connect(self, s, func):
         """Connect event with string *s* to *func*.
 
         Parameters
@@ -3304,14 +3304,14 @@ class NavigationBase(object):
         """
         return self._callbacks.connect(s, func)
 
-    def mpl_disconnect(self, cid):
+    def nav_disconnect(self, cid):
         """Disconnect callback id cid
 
         Example usage::
 
-            cid = navigation.mpl_connect('tool_trigger_zoom', on_press)
+            cid = navigation.nav_connect('tool_trigger_zoom', on_press)
             #...later
-            navigation.mpl_disconnect(cid)
+            navigation.nav_disconnect(cid)
         """
         return self._callbacks.disconnect(cid)
 
@@ -3603,9 +3603,9 @@ class ToolbarBase(object):
         self.manager = manager
         self.navigation = manager.navigation
 
-        self.navigation.mpl_connect('tool_message_event', self._message_cbk)
-        self.navigation.mpl_connect('tool_added_event', self._add_tool_cbk)
-        self.navigation.mpl_connect('tool_removed_event',
+        self.navigation.nav_connect('tool_message_event', self._message_cbk)
+        self.navigation.nav_connect('tool_added_event', self._add_tool_cbk)
+        self.navigation.nav_connect('tool_removed_event',
                                     self._remove_tool_cbk)
 
     def _message_cbk(self, event):
@@ -3633,7 +3633,7 @@ class ToolbarBase(object):
                           event.tool.description,
                           toggle)
         if toggle:
-            self.navigation.mpl_connect('tool_trigger_%s' % event.tool.name,
+            self.navigation.nav_connect('tool_trigger_%s' % event.tool.name,
                                         self._tool_triggered_cbk)
 
     def _remove_tool_cbk(self, event):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3263,9 +3263,8 @@ class NavigationBase(object):
     messagelock: `LockDraw` to know if the message is available to write
     """
 
-    def __init__(self, manager):
-        self.manager = manager
-        self.canvas = manager.canvas
+    def __init__(self, canvas):
+        self.canvas = canvas
 
         self._key_press_handler_id = self.canvas.mpl_connect(
             'key_press_event', self._key_press)
@@ -3599,9 +3598,8 @@ class ToolbarBase(object):
         this `Toolbar` wants to communicate with
     """
 
-    def __init__(self, manager):
-        self.manager = manager
-        self.navigation = manager.navigation
+    def __init__(self, navigation):
+        self.navigation = navigation
 
         self.navigation.nav_connect('tool_message_event', self._message_cbk)
         self.navigation.nav_connect('tool_added_event', self._add_tool_cbk)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3421,6 +3421,9 @@ class NavigationBase(object):
         """
 
         tool_cls = self._get_cls_to_instantiate(tool)
+        if tool_cls is False:
+            warnings.warn('Impossible to find class for %s' % str(tool))
+            return
         name = tool_cls.name
 
         if name is None:
@@ -3442,9 +3445,11 @@ class NavigationBase(object):
                 self._keys[k] = name
 
         if self.toolbar and tool_cls.position is not None:
+            # TODO: better search for images, they are not always in the
+            # datapath
             basedir = os.path.join(rcParams['datapath'], 'images')
             if tool_cls.image is not None:
-                fname = os.path.join(basedir, tool_cls.image + '.png')
+                fname = os.path.join(basedir, tool_cls.image)
             else:
                 fname = None
             toggle = issubclass(tool_cls, tools.ToolToggleBase)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3252,10 +3252,6 @@ class NavigationBase(object):
         self._idDrag = self.canvas.mpl_connect(
             'motion_notify_event', self._mouse_move)
 
-        # a dict from axes index to a list of view limits
-        self.views = cbook.Stack()
-        self.positions = cbook.Stack()  # stack of subplot positions
-
         self._tools = {}
         self._keys = {}
         self._instances = {}
@@ -3522,12 +3518,6 @@ class NavigationBase(object):
                        'keymap': keys}
         return d
 
-    def update(self):
-        """Reset the axes stack"""
-
-        self.views.clear()
-        self.positions.clear()
-
     def _mouse_move(self, event):
         if not event.inaxes or not self._toggled:
             if self._last_cursor != self._default_cursor:
@@ -3557,28 +3547,6 @@ class NavigationBase(object):
         else:
             self.toolbar.set_message('')
 
-    def draw(self):
-        """Redraw the canvases, update the locators"""
-
-        for a in self.canvas.figure.get_axes():
-            xaxis = getattr(a, 'xaxis', None)
-            yaxis = getattr(a, 'yaxis', None)
-            zaxis = getattr(a, 'zaxis', None)
-            locators = []
-            if xaxis is not None:
-                locators.append(xaxis.get_major_locator())
-                locators.append(xaxis.get_minor_locator())
-            if yaxis is not None:
-                locators.append(yaxis.get_major_locator())
-                locators.append(yaxis.get_minor_locator())
-            if zaxis is not None:
-                locators.append(zaxis.get_major_locator())
-                locators.append(zaxis.get_minor_locator())
-
-            for loc in locators:
-                loc.refresh()
-        self.canvas.draw_idle()
-
     def set_cursor(self, cursor):
         """
         Set the current cursor to one of the :class:`Cursors`
@@ -3586,43 +3554,6 @@ class NavigationBase(object):
         """
 
         pass
-
-    def update_view(self):
-        """Update the viewlim and position from the view and
-        position stack for each axes
-        """
-
-        lims = self.views()
-        if lims is None:
-            return
-        pos = self.positions()
-        if pos is None:
-            return
-        for i, a in enumerate(self.canvas.figure.get_axes()):
-            xmin, xmax, ymin, ymax = lims[i]
-            a.set_xlim((xmin, xmax))
-            a.set_ylim((ymin, ymax))
-            # Restore both the original and modified positions
-            a.set_position(pos[i][0], 'original')
-            a.set_position(pos[i][1], 'active')
-
-        self.canvas.draw_idle()
-
-    def push_current(self):
-        """push the current view limits and position onto the stack"""
-
-        lims = []
-        pos = []
-        for a in self.canvas.figure.get_axes():
-            xmin, xmax = a.get_xlim()
-            ymin, ymax = a.get_ylim()
-            lims.append((xmin, xmax, ymin, ymax))
-            # Store both the original and modified positions
-            pos.append((
-                a.get_position(True).frozen(),
-                a.get_position().frozen()))
-        self.views.push(lims)
-        self.positions.push(pos)
 
     def draw_rubberband(self, event, caller, x0, y0, x1, y1):
         """Draw a rectangle rubberband to indicate zoom limits

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3230,7 +3230,7 @@ class NavigationBase(object):
 
      Attributes
     ----------
-    canvas : `FigureCanvas` instance
+    manager : `FigureManager` instance
     toolbar : `Toolbar` instance that is controlled by this `Navigation`
     keypresslock : `LockDraw` to know if the `canvas` key_press_event is
         locked
@@ -3238,33 +3238,19 @@ class NavigationBase(object):
     """
 
     _default_cursor = cursors.POINTER
-    _default_tools = [tools.ToolToggleGrid,
-             tools.ToolToggleFullScreen,
-             tools.ToolQuit,
-             tools.ToolEnableAllNavigation,
-             tools.ToolEnableNavigation,
-             tools.ToolToggleXScale,
-             tools.ToolToggleYScale,
-             tools.ToolHome, tools.ToolBack,
-             tools.ToolForward,
-             None,
-             tools.ToolZoom,
-             tools.ToolPan,
-             None,
-             'ConfigureSubplots',
-             'SaveFigure']
 
-    def __init__(self, canvas, toolbar=None):
+    def __init__(self, manager):
         """.. automethod:: _toolbar_callback"""
 
-        self.canvas = canvas
-        self.toolbar = self._get_toolbar(toolbar, canvas)
+        self.manager = manager
+        self.canvas = manager.canvas
+        self.toolbar = manager.toolbar
 
-        self._key_press_handler_id = self.canvas.mpl_connect('key_press_event',
-                                                            self._key_press)
+        self._key_press_handler_id = self.canvas.mpl_connect(
+            'key_press_event', self._key_press)
 
-        self._idDrag = self.canvas.mpl_connect('motion_notify_event',
-                                               self._mouse_move)
+        self._idDrag = self.canvas.mpl_connect(
+            'motion_notify_event', self._mouse_move)
 
         # a dict from axes index to a list of view limits
         self.views = cbook.Stack()
@@ -3280,35 +3266,14 @@ class NavigationBase(object):
         # to write into toolbar message
         self.messagelock = widgets.LockDraw()
 
-        for tool in self._default_tools:
+        for name, tool in tools.tools:
             if tool is None:
                 if self.toolbar is not None:
                     self.toolbar.add_separator(-1)
             else:
-                self.add_tool(tool)
+                self.add_tool(name, tool, None)
 
         self._last_cursor = self._default_cursor
-
-    @classmethod
-    def get_default_tools(cls):
-        """Get the default tools"""
-
-        return cls._default_tools
-
-    @classmethod
-    def set_default_tools(cls, tools):
-        """Set default tools"""
-
-        cls._default_tools = tools
-
-    def _get_toolbar(self, toolbar, canvas):
-        # must be inited after the window, drawingArea and figure
-        # attrs are set
-        if rcParams['toolbar'] == 'navigation' and toolbar is not None:
-            toolbar = toolbar(canvas.manager)
-        else:
-            toolbar = None
-        return toolbar
 
     @property
     def active_toggle(self):
@@ -3381,8 +3346,7 @@ class NavigationBase(object):
         This method is used by `PersistentTools` to remove the reference kept
         by `Navigation`.
 
-        It is usually called by the `deactivate` method or during
-        destroy if it is a graphical Tool.
+        It is usually called by the `unregister` method
 
         If called, next time the `Tool` is used it will be reinstantiated
         instead of using the existing instance.
@@ -3411,29 +3375,27 @@ class NavigationBase(object):
         if self.toolbar:
             self.toolbar._remove_toolitem(name)
 
-    def add_tool(self, tool):
+    def add_tool(self, name, tool, position=None):
         """Add tool to `Navigation`
 
         Parameters
         ----------
+        name : string
+            Name of the tool, treated as the ID, has to be unique
         tool : string or `Tool` class
             Reference to find the class of the Tool to be added
+        position : int or None (default)
+            Position in the toolbar, if None, is positioned at the end
         """
 
         tool_cls = self._get_cls_to_instantiate(tool)
         if tool_cls is False:
             warnings.warn('Impossible to find class for %s' % str(tool))
             return
-        name = tool_cls.name
 
-        if name is None:
-            warnings.warn('tool_clss need a name to be added, it is used '
-                          'as ID')
-            return
         if name in self._tools:
             warnings.warn('A tool_cls with the same name already exist, '
                           'not added')
-
             return
 
         self._tools[name] = tool_cls
@@ -3444,7 +3406,7 @@ class NavigationBase(object):
                                   (k, self._keys[k], name))
                 self._keys[k] = name
 
-        if self.toolbar and tool_cls.position is not None:
+        if self.toolbar and tool_cls.intoolbar:
             # TODO: better search for images, they are not always in the
             # datapath
             basedir = os.path.join(rcParams['datapath'], 'images')
@@ -3453,10 +3415,11 @@ class NavigationBase(object):
             else:
                 fname = None
             toggle = issubclass(tool_cls, tools.ToolToggleBase)
-            self.toolbar._add_toolitem(name, tool_cls.description,
-                                      fname,
-                                      tool_cls.position,
-                                      toggle)
+            self.toolbar._add_toolitem(name,
+                                       tool_cls.description,
+                                       fname,
+                                       position,
+                                       toggle)
 
     def _get_cls_to_instantiate(self, callback_class):
         if isinstance(callback_class, six.string_types):
@@ -3505,7 +3468,7 @@ class NavigationBase(object):
 
     def _get_instance(self, name):
         if name not in self._instances:
-            instance = self._tools[name](self.canvas.figure)
+            instance = self._tools[name](self.canvas.figure, name)
             # register instance
             self._instances[name] = instance
 
@@ -3551,26 +3514,23 @@ class NavigationBase(object):
         for a in self.canvas.figure.get_axes():
             a.set_navigate_mode(self._toggled)
 
-    def list_tools(self):
-        """Print the list the tools controlled by `Navigation`"""
+    def get_tools(self):
+        """Return the tools controlled by `Navigation`"""
 
-        print ('_' * 80)
-        print ("{0:20} {1:50} {2}".format('Name (id)', 'Tool description',
-                                          'Keymap'))
-        print ('_' * 80)
+        d = {}
         for name in sorted(self._tools.keys()):
             tool = self._tools[name]
             keys = [k for k, i in six.iteritems(self._keys) if i == name]
-            print ("{0:20} {1:50} {2}".format(tool.name, tool.description,
-                                              ', '.join(keys)))
-        print ('_' * 80, '\n')
+            d[name] = {'cls': tool,
+                       'description': tool.description,
+                       'keymap': keys}
+        return d
 
     def update(self):
         """Reset the axes stack"""
 
         self.views.clear()
         self.positions.clear()
-#        self.set_history_buttons()
 
     def _mouse_move(self, event):
         if not event.inaxes or not self._toggled:
@@ -3667,7 +3627,6 @@ class NavigationBase(object):
                 a.get_position().frozen()))
         self.views.push(lims)
         self.positions.push(pos)
-#        self.set_history_buttons()
 
     def draw_rubberband(self, event, caller, x0, y0, x1, y1):
         """Draw a rectangle rubberband to indicate zoom limits
@@ -3719,7 +3678,7 @@ class ToolbarBase(object):
         self.manager = manager
 
     def _add_toolitem(self, name, description, image_file, position,
-                     toggle):
+                      toggle):
         """Add a toolitem to the toolbar
 
         The callback associated with the button click event,
@@ -3776,7 +3735,8 @@ class ToolbarBase(object):
 
         """
 
-        # carefull, callback means to perform or not the callback while toggling
+        # carefull, callback means to perform or not the callback while
+        # toggling
         raise NotImplementedError
 
     def _remove_toolitem(self, name):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3244,7 +3244,8 @@ class ToolTriggerEvent(ToolEvent):
 
 
 class NavigationMessageEvent(object):
-    """Event carrying messages from navigation
+    """
+    Event carrying messages from navigation
 
     Messages usually get displayed to the user by the toolbar
     """
@@ -3255,7 +3256,8 @@ class NavigationMessageEvent(object):
 
 
 class NavigationBase(object):
-    """Helper class that groups all the user interactions for a FigureManager
+    """
+    Helper class that groups all the user interactions for a FigureManager
 
     Attributes
     ----------
@@ -3281,7 +3283,8 @@ class NavigationBase(object):
         self.messagelock = widgets.LockDraw()
 
     def nav_connect(self, s, func):
-        """Connect event with string *s* to *func*.
+        """
+        Connect event with string *s* to *func*.
 
         Parameters
         -----------
@@ -3306,7 +3309,8 @@ class NavigationBase(object):
         return self._callbacks.connect(s, func)
 
     def nav_disconnect(self, cid):
-        """Disconnect callback id cid
+        """
+        Disconnect callback id cid
 
         Example usage::
 
@@ -3317,7 +3321,7 @@ class NavigationBase(object):
         return self._callbacks.disconnect(cid)
 
     def message_event(self, message, sender=None):
-        """ Emit a tool_message_event event"""
+        """ Emit a `NavigationMessageEvent`"""
         if sender is None:
             sender = self
 
@@ -3327,7 +3331,8 @@ class NavigationBase(object):
 
     @property
     def active_toggle(self):
-        """Toggled Tool
+        """
+        Toggled Tool
 
         **dict** :  Currently toggled tools
         """
@@ -3335,7 +3340,8 @@ class NavigationBase(object):
         return self._toggled
 
     def get_tool_keymap(self, name):
-        """Get the keymap associated with the specified tool
+        """
+        Get the keymap associated with the specified tool
 
         Parameters
         ----------
@@ -3355,7 +3361,8 @@ class NavigationBase(object):
             del self._keys[k]
 
     def set_tool_keymap(self, name, *keys):
-        """Set the keymap to associate with the specified tool
+        """
+        Set the keymap to associate with the specified tool
 
         Parameters
         ----------
@@ -3365,7 +3372,7 @@ class NavigationBase(object):
         """
 
         if name not in self._tools:
-            raise AttributeError('%s not in Tools' % name)
+            raise KeyError('%s not in Tools' % name)
 
         self._remove_keys(name)
 
@@ -3377,7 +3384,8 @@ class NavigationBase(object):
                 self._keys[k] = name
 
     def remove_tool(self, name):
-        """Remove tool from `Navigation`
+        """
+        Remove tool from `Navigation`
 
         Parameters
         ----------
@@ -3401,7 +3409,8 @@ class NavigationBase(object):
         del self._tools[name]
 
     def add_tools(self, tools):
-        """ Add multiple tools to `NavigationBase`
+        """
+        Add multiple tools to `NavigationBase`
 
         Parameters
         ----------
@@ -3414,7 +3423,8 @@ class NavigationBase(object):
             self.add_tool(name, tool)
 
     def add_tool(self, name, tool, *args, **kwargs):
-        """Add tool to `NavigationBase`
+        """
+        Add tool to `NavigationBase`
 
         Add a tool to the tools controlled by Navigation
 
@@ -3440,11 +3450,10 @@ class NavigationBase(object):
 
         tool_cls = self._get_cls_to_instantiate(tool)
         if tool_cls is False:
-            warnings.warn('Impossible to find class for %s' % str(tool))
-            return
+            raise ValueError('Impossible to find class for %s' % str(tool))
 
         if name in self._tools:
-            warnings.warn('A tool_cls with the same name already exist, '
+            warnings.warn('A "Tool class" with the same name already exists, '
                           'not added')
             return self._tools[name]
 
@@ -3454,7 +3463,7 @@ class NavigationBase(object):
             self.set_tool_keymap(name, tool_cls.keymap)
 
         # For toggle tools init the radio_group in self._toggled
-        if getattr(tool_cls, 'toggled', False) is not False:
+        if isinstance(self._tools[name], tools.ToolToggleBase):
             # None group is not mutually exclusive, a set is used to keep track
             # of all toggled tools in this group
             if tool_cls.radio_group is None:
@@ -3471,8 +3480,10 @@ class NavigationBase(object):
         self._callbacks.process(s, event)
 
     def _handle_toggle(self, tool, sender, canvasevent, data):
-        # Toggle tools, need to untoggle prior to using other Toggle tool
-        # Called from tool_trigger_event
+        """
+        Toggle tools, need to untoggle prior to using other Toggle tool
+        Called from tool_trigger_event
+        """
 
         radio_group = tool.radio_group
         # radio_group None is not mutually exclusive
@@ -3522,7 +3533,8 @@ class NavigationBase(object):
 
     def tool_trigger_event(self, name, sender=None, canvasevent=None,
                            data=None):
-        """Trigger a tool and emit the tool-trigger-[name] event
+        """
+        Trigger a tool and emit the tool_trigger_[name] event
 
         Parameters
         ----------
@@ -3549,7 +3561,8 @@ class NavigationBase(object):
         self._callbacks.process(s, event)
 
     def _trigger_tool(self, name, sender=None, canvasevent=None, data=None):
-        """Trigger on a tool
+        """
+        Trigger on a tool
 
         Method to actually trigger the tool
         """
@@ -3578,7 +3591,8 @@ class NavigationBase(object):
         return self._tools
 
     def get_tool(self, name, warn=True):
-        """Return the tool object, also accepts the actual tool for convenience
+        """
+        Return the tool object, also accepts the actual tool for convenience
 
         Parameters
         -----------
@@ -3597,7 +3611,8 @@ class NavigationBase(object):
 
 
 class ToolContainerBase(object):
-    """Base class for all tool containers, e.g. toolbars.
+    """
+    Base class for all tool containers, e.g. toolbars.
 
      Attributes
     ----------
@@ -3611,14 +3626,16 @@ class ToolContainerBase(object):
                                     self._remove_tool_cbk)
 
     def _tool_toggled_cbk(self, event):
-        """Captures the 'tool-trigger-toolname
+        """
+        Captures the 'tool_trigger_[name]'
 
         This only gets used for toggled tools
         """
         self.toggle_toolitem(event.tool.name, event.tool.toggled)
 
     def add_tools(self, tools):
-        """ Add multiple tools to the container.
+        """
+        Add multiple tools to the container.
 
         Parameters
         ----------
@@ -3634,7 +3651,8 @@ class ToolContainerBase(object):
                 self.add_tool(tool, group, position)
 
     def add_tool(self, tool, group, position=-1):
-        """Adds a tool to this container
+        """
+        Adds a tool to this container
 
         Parameters
         ----------
@@ -3670,7 +3688,8 @@ class ToolContainerBase(object):
         return fname
 
     def trigger_tool(self, name):
-        """Trigger the tool
+        """
+        Trigger the tool
 
         Parameters
         ----------
@@ -3681,7 +3700,8 @@ class ToolContainerBase(object):
         self.navigation.tool_trigger_event(name, sender=self)
 
     def add_toolitem(self, name, group, position, image, description, toggle):
-        """Add a toolitem to the container
+        """
+        Add a toolitem to the container
 
         This method must get implemented per backend
 
@@ -3711,7 +3731,8 @@ class ToolContainerBase(object):
         raise NotImplementedError
 
     def toggle_toolitem(self, name, toggled):
-        """Toggle the toolitem without firing event
+        """
+        Toggle the toolitem without firing event
 
         Parameters
         ----------
@@ -3723,7 +3744,8 @@ class ToolContainerBase(object):
         raise NotImplementedError
 
     def remove_toolitem(self, name):
-        """Remove a toolitem from the `ToolContainer`
+        """
+        Remove a toolitem from the `ToolContainer`
 
         This method must get implemented per backend
 
@@ -3750,7 +3772,8 @@ class StatusbarBase(object):
         self.set_message(event.message)
 
     def set_message(self, s):
-        """Display a message on toolbar or in status bar
+        """
+        Display a message on toolbar or in status bar
 
         Parameters
         ----------

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3400,11 +3400,7 @@ class NavigationBase(object):
 
         self._tools[name] = tool_cls
         if tool_cls.keymap is not None:
-            for k in validate_stringlist(tool_cls.keymap):
-                if k in self._keys:
-                    warnings.warn('Key %s changed from %s to %s' %
-                                  (k, self._keys[k], name))
-                self._keys[k] = name
+            self.set_tool_keymap(name, tool_cls.keymap)
 
         if self.toolbar and tool_cls.intoolbar:
             # TODO: better search for images, they are not always in the

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -33,6 +33,8 @@ graphics contexts must implement to serve as a matplotlib backend
 :class:`ToolContainerBase`
      The base class for the Toolbar class of each interactive backend.
 
+:class:`StatusbarBase`
+    The base class for the messaging area.
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -3605,14 +3607,8 @@ class ToolContainerBase(object):
 
     def __init__(self, navigation):
         self.navigation = navigation
-
-        self.navigation.nav_connect('tool_message_event', self._message_cbk)
         self.navigation.nav_connect('tool_removed_event',
                                     self._remove_tool_cbk)
-
-    def _message_cbk(self, event):
-        """Captures the 'tool_message_event' to set the message on the toolbar"""
-        self.set_message(event.message)
 
     def _tool_toggled_cbk(self, event):
         """Captures the 'tool-trigger-toolname
@@ -3714,17 +3710,6 @@ class ToolContainerBase(object):
 
         raise NotImplementedError
 
-    def set_message(self, s):
-        """Display a message on toolbar or in status bar
-
-        Parameters
-        ----------
-        s : String
-            Message text
-        """
-
-        pass
-
     def toggle_toolitem(self, name, toggled):
         """Toggle the toolitem without firing event
 
@@ -3752,3 +3737,25 @@ class ToolContainerBase(object):
         """
 
         raise NotImplementedError
+
+
+class StatusbarBase(object):
+    """Base class for the statusbar"""
+    def __init__(self, navigation):
+        self.navigation = navigation
+        self.navigation.nav_connect('tool_message_event', self._message_cbk)
+
+    def _message_cbk(self, event):
+        """Captures the 'tool_message_event' and set the message"""
+        self.set_message(event.message)
+
+    def set_message(self, s):
+        """Display a message on toolbar or in status bar
+
+        Parameters
+        ----------
+        s : str
+            Message text
+        """
+
+        pass

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3273,8 +3273,9 @@ class NavigationBase(object):
         self._instances = {}
         self._toggled = None
 
-        #to communicate with tools and redirect events
+        #to process keypress event
         self.keypresslock = widgets.LockDraw()
+        #to write into toolbar message
         self.messagelock = widgets.LockDraw()
 
         for tool in self._default_tools:
@@ -3401,6 +3402,7 @@ class NavigationBase(object):
         """
         tool_cls = self._get_cls_to_instantiate(tool)
         name = tool_cls.name
+
         if name is None:
             warnings.warn('tool_clss need a name to be added, it is used '
                           'as ID')
@@ -3425,10 +3427,11 @@ class NavigationBase(object):
                 fname = os.path.join(basedir, tool_cls.image + '.png')
             else:
                 fname = None
+            toggle = issubclass(tool_cls, tools.ToolToggleBase)
             self.toolbar._add_toolitem(name, tool_cls.description,
                                       fname,
                                       tool_cls.position,
-                                      tool_cls.toggle)
+                                      toggle)
 
     def _get_cls_to_instantiate(self, callback_class):
         if isinstance(callback_class, basestring):
@@ -3457,9 +3460,9 @@ class NavigationBase(object):
             raise AttributeError('%s not in Tools' % name)
 
         tool = self._tools[name]
-        if tool.toggle:
+        if issubclass(tool, tools.ToolToggleBase):
             self._handle_toggle(name, event=event, from_toolbar=from_toolbar)
-        elif tool.persistent:
+        elif issubclass(tool, tools.ToolPersistentBase):
             instance = self._get_instance(name)
             instance.trigger(event)
         else:

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3383,7 +3383,7 @@ class NavigationBase(object):
             Name of the Tool
         """
 
-        tool = self._tools[name]
+        tool = self.get_tool(name)
         tool.destroy()
 
         # If is a toggle tool and toggled, untoggle
@@ -3534,8 +3534,8 @@ class NavigationBase(object):
         data : Object
             Extra data to pass to the tool when triggering
         """
-        if name not in self._tools:
-            warnings.warn("%s is not a tool controlled by Navigation" % name)
+        tool = self.get_tool(name)
+        if tool is None:
             return
 
         if sender is None:
@@ -3544,8 +3544,7 @@ class NavigationBase(object):
         self._trigger_tool(name, sender, canvasevent, data)
 
         s = 'tool_trigger_%s' % name
-        event = ToolTriggerEvent(s, sender, self._tools[name], canvasevent,
-                                 data)
+        event = ToolTriggerEvent(s, sender, tool, canvasevent, data)
         self._callbacks.process(s, event)
 
     def _trigger_tool(self, name, sender=None, canvasevent=None, data=None):
@@ -3553,7 +3552,7 @@ class NavigationBase(object):
 
         Method to actually trigger the tool
         """
-        tool = self._tools[name]
+        tool = self.get_tool(name)
 
         if isinstance(tool, tools.ToolToggleBase):
             self._handle_toggle(tool, sender, canvasevent, data)
@@ -3578,13 +3577,18 @@ class NavigationBase(object):
         return self._tools
 
     def get_tool(self, name):
-        """Return the tool object
+        """Return the tool object, also accepts the actual tool for convenience
 
         Parameters
         -----------
-        name : String
-            Name of the tool
+        name : String, ToolBase
+            Name of the tool, or the tool itself
         """
+        if isinstance(name, tools.ToolBase):
+            return name
+        if name not in self._tools:
+            warnings.warn("%s is not a tool controlled by Navigation" % name)
+            return None
         return self._tools[name]
 
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -24,6 +24,12 @@ graphics contexts must implement to serve as a matplotlib backend
     The base class for the Show class of each interactive backend;
     the 'show' callable is then set to Show.__call__, inherited from
     ShowBase.
+
+:class:`ToolContainerBase`
+     The base class for the Toolbar class of each interactive backend.
+
+:class:`StatusbarBase`
+    The base class for the messaging area.
 """
 
 from __future__ import (absolute_import, division, print_function,

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3292,9 +3292,12 @@ class NavigationBase(object):
             - 'tool_message_event'
             - 'tool_removed_event'
             - 'tool_added_event'
+
             For every tool added a new event is created
-            - 'tool_trigger_TOOLNAME
-            Where TOOLNAME is the id of the tool.
+
+            - 'tool_trigger_TOOLNAME`
+              Where TOOLNAME is the id of the tool.
+
         func : function
             Function to be called with signature
             def func(event)
@@ -3347,8 +3350,7 @@ class NavigationBase(object):
         return keys
 
     def _remove_keys(self, name):
-        keys = [k for k, v in six.iteritems(self._keys) if v == name]
-        for k in keys:
+        for k in self.get_tool_keymap(name):
             del self._keys[k]
 
     def set_tool_keymap(self, name, *keys):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3546,6 +3546,16 @@ class NavigationBase(object):
                        'keymap': keys}
         return d
 
+    def get_tool(self, name):
+        """Return the tool object
+
+        Parameters:
+        -----------
+        name: String
+            Name of the tool
+        """
+        return self._tools[name]
+
     def _set_cursor(self, canvasevent):
         """Sets the current cursor in ToolSetCursor"""
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3232,11 +3232,9 @@ class NavigationBase(object):
     ----------
     canvas : `FigureCanvas` instance
     toolbar : `Toolbar` instance that is controlled by this `Navigation`
-    keypresslock : `LockDraw` to direct the `canvas` key_press_event
-    movelock : `LockDraw` to direct the `canvas` motion_notify_event
-    presslock : `LockDraw` to direct the `canvas` button_press_event
-    releaselock : `LockDraw` to direct the `canvas` button_release_event
-    canvaslock : shortcut to `canvas.widgetlock`
+    keypresslock : `LockDraw` to know if the `canvas` key_press_event is
+        locked
+    messagelock : `LockDraw` to know if the message is available to write
     """
     _default_cursor = cursors.POINTER
     _default_tools = [tools.ToolToggleGrid,
@@ -3266,11 +3264,6 @@ class NavigationBase(object):
         self._idDrag = self.canvas.mpl_connect('motion_notify_event',
                                                self._mouse_move)
 
-        self._idPress = self.canvas.mpl_connect('button_press_event',
-                                                self._press)
-        self._idRelease = self.canvas.mpl_connect('button_release_event',
-                                                  self._release)
-
         # a dict from axes index to a list of view limits
         self.views = cbook.Stack()
         self.positions = cbook.Stack()  # stack of subplot positions
@@ -3282,11 +3275,7 @@ class NavigationBase(object):
 
         #to communicate with tools and redirect events
         self.keypresslock = widgets.LockDraw()
-        self.movelock = widgets.LockDraw()
-        self.presslock = widgets.LockDraw()
-        self.releaselock = widgets.LockDraw()
-        #just to group all the locks in one place
-        self.canvaslock = self.canvas.widgetlock
+        self.messagelock = widgets.LockDraw()
 
         for tool in self._default_tools:
             if tool is None:
@@ -3479,15 +3468,8 @@ class NavigationBase(object):
             tool(self.canvas.figure, event)
 
     def _key_press(self, event):
-        if event.key is None:
+        if event.key is None or self.keypresslock.locked():
             return
-
-        #some tools may need to capture keypress, but they need to be toggle
-        if self._toggled:
-            instance = self._get_instance(self._toggled)
-            if self.keypresslock.isowner(instance):
-                instance.key_press(event)
-                return
 
         name = self._keys.get(event.key, None)
         self._trigger_tool(name, event, False)
@@ -3559,12 +3541,6 @@ class NavigationBase(object):
 #        self.set_history_buttons()
 
     def _mouse_move(self, event):
-        if self._toggled:
-            instance = self._instances[self._toggled]
-            if self.movelock.isowner(instance):
-                instance.mouse_move(event)
-                return
-
         if not event.inaxes or not self._toggled:
             if self._last_cursor != self._default_cursor:
                 self.set_cursor(self._default_cursor)
@@ -3576,7 +3552,7 @@ class NavigationBase(object):
                     self.set_cursor(cursor)
                     self._last_cursor = cursor
 
-        if self.toolbar is None:
+        if self.toolbar is None or self.messagelock.locked():
             return
 
         if event.inaxes and event.inaxes.get_navigate():
@@ -3592,30 +3568,6 @@ class NavigationBase(object):
                     self.toolbar.set_message(s)
         else:
             self.toolbar.set_message('')
-
-    def _release(self, event):
-        if self._toggled:
-            instance = self._instances[self._toggled]
-            if self.releaselock.isowner(instance):
-                instance.release(event)
-                return
-        self.release(event)
-
-    def release(self, event):
-        pass
-
-    def _press(self, event):
-        """Called whenver a mouse button is pressed."""
-        if self._toggled:
-            instance = self._instances[self._toggled]
-            if self.presslock.isowner(instance):
-                instance.press(event)
-                return
-        self.press(event)
-
-    def press(self, event):
-        """Called whenver a mouse button is pressed."""
-        pass
 
     def draw(self):
         """Redraw the canvases, update the locators"""
@@ -3681,9 +3633,34 @@ class NavigationBase(object):
         self.positions.push(pos)
 #        self.set_history_buttons()
 
-    def draw_rubberband(self, event, x0, y0, x1, y1):
-        """Draw a rectangle rubberband to indicate zoom limits"""
-        pass
+    def draw_rubberband(self, event, caller, x0, y0, x1, y1):
+        """Draw a rectangle rubberband to indicate zoom limits
+
+        Draw a rectanlge in the canvas, if
+        `self.canvas.widgetlock` is available to **caller**
+
+        Parameters
+        ----------
+        event : `FigureCanvas` event
+        caller : instance trying to draw the rubberband
+        x0, y0, x1, y1 : coordinates
+        """
+        if not self.canvas.widgetlock.available(caller):
+            warnings.warn("%s doesn't own the canvas widgetlock" % caller)
+
+    def remove_rubberband(self, event, caller):
+        """Remove the rubberband
+
+        Remove the rubberband if the `self.canvas.widgetlock` is
+        available to **caller**
+
+        Parameters
+        ----------
+        event : `FigureCanvas` event
+        caller : instance trying to remove the rubberband
+        """
+        if not self.canvas.widgetlock.available(caller):
+            warnings.warn("%s doesn't own the canvas widgetlock" % caller)
 
 
 class ToolbarBase(object):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3476,6 +3476,9 @@ class NavigationBase(object):
         for a in self.canvas.figure.get_axes():
             a.set_navigate_mode(self._toggled)
 
+        # Change the cursor inmediately, don't wait for mouse move
+        self._set_cursor(event)
+
     def get_tools(self):
         """Return the tools controlled by `Navigation`"""
 
@@ -3488,7 +3491,10 @@ class NavigationBase(object):
                        'keymap': keys}
         return d
 
-    def _mouse_move(self, event):
+    def _set_cursor(self, event):
+        """Call the backend specific set_cursor method,
+        if the pointer is inaxes
+        """
         if not event.inaxes or not self._toggled:
             if self._last_cursor != self._default_cursor:
                 self.set_cursor(self._default_cursor)
@@ -3499,6 +3505,9 @@ class NavigationBase(object):
                 if cursor and self._last_cursor != cursor:
                     self.set_cursor(cursor)
                     self._last_cursor = cursor
+
+    def _mouse_move(self, event):
+        self._set_cursor(event)
 
         if self.toolbar is None or self.messagelock.locked():
             return

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3254,7 +3254,6 @@ class NavigationBase(object):
 
         self._tools = {}
         self._keys = {}
-        self._instances = {}
         self._toggled = None
 
         # to process keypress event
@@ -3272,15 +3271,6 @@ class NavigationBase(object):
         """
 
         return self._toggled
-
-    @property
-    def instances(self):
-        """Active tools instances
-
-        **dictionary** : Contains the active instances that are registered
-        """
-
-        return self._instances
 
     def get_tool_keymap(self, name):
         """Get the keymap associated with a tool
@@ -3323,28 +3313,19 @@ class NavigationBase(object):
                 self._keys[k] = name
 
     def unregister(self, name):
-        """Unregister the tool from the active instances
+        """Unregister the tool from Navigation
 
         Parameters
         ----------
         name : string
             Name of the tool to unregister
-
-        Notes
-        -----
-        This method is used by `PersistentTools` to remove the reference kept
-        by `Navigation`.
-
-        It is usually called by the `unregister` method
-
-        If called, next time the `Tool` is used it will be reinstantiated
-        instead of using the existing instance.
         """
 
         if self._toggled == name:
             self._handle_toggle(name, from_toolbar=False)
-        if name in self._instances:
-            del self._instances[name]
+        if name in self._tools:
+            self._tools[name].destroy()
+            del self._tools[name]
 
     def remove_tool(self, name):
         """Remove tool from the `Navigation`
@@ -3356,7 +3337,7 @@ class NavigationBase(object):
         """
 
         self.unregister(name)
-        del self._tools[name]
+
         keys = [k for k, v in six.iteritems(self._keys) if v == name]
         for k in keys:
             del self._keys[k]
@@ -3403,7 +3384,7 @@ class NavigationBase(object):
                           'not added')
             return
 
-        self._tools[name] = tool_cls
+        self._tools[name] = tool_cls(self.canvas.figure, name)
         if tool_cls.keymap is not None:
             self.set_tool_keymap(name, tool_cls.keymap)
 
@@ -3436,27 +3417,23 @@ class NavigationBase(object):
 
         return callback_class
 
-    def trigger_tool(self, name):
+    def trigger_tool(self, name, event=None):
         """Trigger on a tool
 
         Method to programatically "click" on Tools
         """
 
-        self._trigger_tool(name, None, False)
+        self._trigger_tool(name, event, False)
 
     def _trigger_tool(self, name, event, from_toolbar):
         if name not in self._tools:
             raise AttributeError('%s not in Tools' % name)
 
         tool = self._tools[name]
-        if issubclass(tool, tools.ToolToggleBase):
+        if isinstance(tool, tools.ToolToggleBase):
             self._handle_toggle(name, event=event, from_toolbar=from_toolbar)
-        elif issubclass(tool, tools.ToolPersistentBase):
-            instance = self._get_instance(name)
-            instance.trigger(event)
         else:
-            # Non persistent tools, are instantiated and forgotten
-            tool(self.canvas.figure, event)
+            tool.trigger(event)
 
     def _key_press(self, event):
         if event.key is None or self.keypresslock.locked():
@@ -3466,14 +3443,6 @@ class NavigationBase(object):
         if name is None:
             return
         self._trigger_tool(name, event, False)
-
-    def _get_instance(self, name):
-        if name not in self._instances:
-            instance = self._tools[name](self.canvas.figure, name)
-            # register instance
-            self._instances[name] = instance
-
-        return self._instances[name]
 
     def _toolbar_callback(self, name):
         """Callback for the `Toolbar`
@@ -3495,7 +3464,7 @@ class NavigationBase(object):
         if not from_toolbar and self.toolbar:
             self.toolbar._toggle(name, False)
 
-        instance = self._get_instance(name)
+        tool = self._tools[name]
         if self._toggled is None:
             # first trigger of tool
             self._toggled = name
@@ -3507,10 +3476,10 @@ class NavigationBase(object):
             if self.toolbar:
                 # untoggle the previous toggled tool
                 self.toolbar._toggle(self._toggled, False)
-            self._get_instance(self._toggled).trigger(event)
+            self._tools[self._toggled].trigger(event)
             self._toggled = name
 
-        instance.trigger(event)
+        tool.trigger(event)
 
         for a in self.canvas.figure.get_axes():
             a.set_navigate_mode(self._toggled)
@@ -3534,7 +3503,7 @@ class NavigationBase(object):
                 self._last_cursor = self._default_cursor
         else:
             if self._toggled:
-                cursor = self._instances[self._toggled].cursor
+                cursor = self._tools[self._toggled].cursor
                 if cursor and self._last_cursor != cursor:
                     self.set_cursor(cursor)
                     self._last_cursor = cursor

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3472,7 +3472,7 @@ class NavigationBase(object):
             self._handle_toggle(name, event=event, from_toolbar=from_toolbar)
         elif tool.persistent:
             instance = self._get_instance(name)
-            instance.activate(event)
+            instance.trigger(event)
         else:
             #Non persistent tools, are
             #instantiated and forgotten (reminds me an exgirlfriend?)
@@ -3521,7 +3521,7 @@ class NavigationBase(object):
 
         instance = self._get_instance(name)
         if self._toggled is None:
-            instance.activate(None)
+            instance.trigger(None)
             self._toggled = name
 
         elif self._toggled == name:
@@ -3533,7 +3533,7 @@ class NavigationBase(object):
                 self.toolbar._toggle(self._toggled, False)
 
             self._get_instance(self._toggled).deactivate(None)
-            instance.activate(None)
+            instance.trigger(None)
             self._toggled = name
 
         for a in self.canvas.figure.get_axes():

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2595,6 +2595,11 @@ class FigureManagerBase(object):
 
         """
 
+        self.toolbar = self._get_toolbar()
+        self.navigation = self._get_navigation()
+        if rcParams['toolbar'] == 'navigation':
+            self.navigation.add_tools(tools.tools)
+
     def show(self):
         """
         For GUI backends, show the figure window and redraw.
@@ -2642,6 +2647,11 @@ class FigureManagerBase(object):
         """
         pass
 
+    def _get_toolbar(self):
+        return None
+
+    def _get_navigation(self):
+        return None
 
 cursors = tools.cursors
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3521,21 +3521,20 @@ class NavigationBase(object):
 
         instance = self._get_instance(name)
         if self._toggled is None:
-            instance.trigger(None)
+            #first trigger of tool
             self._toggled = name
-
         elif self._toggled == name:
-            instance.trigger(None)
+            #second trigger of tool
             self._toggled = None
-
         else:
+            #other tool is triggered so trigger toggled tool
             if self.toolbar:
                 #untoggle the previous toggled tool
                 self.toolbar._toggle(self._toggled, False)
-
-            self._get_instance(self._toggled).trigger(None)
-            instance.trigger(None)
+            self._get_instance(self._toggled).trigger(event)
             self._toggled = name
+
+        instance.trigger(event)
 
         for a in self.canvas.figure.get_axes():
             a.set_navigate_mode(self._toggled)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3227,32 +3227,24 @@ class NavigationToolbar2(object):
 
 class ToolEvent(object):
     """Event for tool manipulation (add/remove)"""
-    def __init__(self, name, sender, tool):
+    def __init__(self, name, sender, tool, data=None):
         self.name = name
         self.sender = sender
         self.tool = tool
+        self.data = data
 
 
 class ToolTriggerEvent(ToolEvent):
     """Event to inform  that a tool has been triggered"""
     def __init__(self, name, sender, tool, canvasevent=None, data=None):
-        ToolEvent.__init__(self, name, sender, tool)
+        ToolEvent.__init__(self, name, sender, tool, data)
         self.canvasevent = canvasevent
-        self.data = data
-
-
-class ToolAddedEvent(ToolEvent):
-    """Event triggered when a tool is added"""
-    def __init__(self, name, sender, tool, group, position):
-        ToolEvent.__init__(self, name, sender, tool)
-        self.group = group
-        self.position = position
 
 
 class NavigationMessageEvent(object):
-    """Event carring messages from navigation
+    """Event carrying messages from navigation
 
-    Messages are generaly displayed to the user by the toolbar
+    Messages usually get displayed to the user by the toolbar
     """
     def __init__(self, name, sender, message):
         self.name = name
@@ -3339,7 +3331,7 @@ class NavigationBase(object):
         return self._toggled
 
     def get_tool_keymap(self, name):
-        """Get the keymap associated with a tool
+        """Get the keymap associated with the specified tool
 
         Parameters
         ----------
@@ -3360,13 +3352,13 @@ class NavigationBase(object):
             del self._keys[k]
 
     def set_tool_keymap(self, name, *keys):
-        """Set the keymap associated with a tool
+        """Set the keymap to associate with the specified tool
 
         Parameters
         ----------
         name : string
             Name of the Tool
-        keys : keys to associated with the Tool
+        keys : keys to associate with the Tool
         """
 
         if name not in self._tools:
@@ -3440,7 +3432,7 @@ class NavigationBase(object):
         group: String
             Group to position the tool in
         position : int or None (default)
-            Position within its group in the toolbar, if None, is positioned at the end
+            Position within its group in the toolbar, if None, it goes at the end
         """
 
         tool_cls = self._get_cls_to_instantiate(tool)
@@ -3457,7 +3449,7 @@ class NavigationBase(object):
         if tool_cls.keymap is not None:
             self.set_tool_keymap(name, tool_cls.keymap)
 
-        # For toggle tools init the radio_grop in self._toggled
+        # For toggle tools init the radio_group in self._toggled
         if getattr(tool_cls, 'toggled', False) is not False:
             # None group is not mutually exclusive, a set is used to keep track
             # of all toggled tools in this group
@@ -3470,15 +3462,15 @@ class NavigationBase(object):
 
     def _tool_added_event(self, tool, group, position):
         s = 'tool_added_event'
-        event = ToolAddedEvent(s, self,
-                               tool,
-                               group,
-                               position)
+        event = ToolEvent(s,
+                          self,
+                          tool,
+                          data={'group': group, 'position': position})
         self._callbacks.process(s, event)
 
     def _handle_toggle(self, tool, sender, canvasevent, data):
-        # Toggle tools, need to be untoggled before other Toggle tool is used
-        # This is called from tool_trigger_event
+        # Toggle tools, need to untoggle prior to using other Toggle tool
+        # Called from tool_trigger_event
 
         radio_group = tool.radio_group
         # radio_group None is not mutually exclusive
@@ -3490,8 +3482,7 @@ class NavigationBase(object):
                 self._toggled[None].add(tool.name)
             return
 
-        # If it is the same tool that is toggled in the radio_group
-        # untoggle it
+        # If the tool already has a toggled state, untoggle it
         if self._toggled[radio_group] == tool.name:
             toggled = None
         # If no tool was toggled in the radio_group
@@ -3536,7 +3527,7 @@ class NavigationBase(object):
         name : string
             Name of the tool
         sender: object
-            Object that wish to trigger the tool
+            Object that wishes to trigger the tool
         canvasevent : Event
             Original Canvas event or None
         data : Object
@@ -3567,7 +3558,7 @@ class NavigationBase(object):
             self._handle_toggle(tool, sender, canvasevent, data)
 
         # Important!!!
-        # This is where the Tool object is triggered
+        # This is where the Tool object gets triggered
         tool.trigger(sender, canvasevent, data)
 
     def _key_press(self, event):
@@ -3616,13 +3607,13 @@ class ToolbarBase(object):
                                     self._remove_tool_cbk)
 
     def _message_cbk(self, event):
-        """Captures the 'tool_message_event' to set message on the toolbar"""
+        """Captures the 'tool_message_event' to set the message on the toolbar"""
         self.set_message(event.message)
 
     def _tool_triggered_cbk(self, event):
         """Captures the 'tool-trigger-toolname
 
-        This is only used for toggled tools
+        This only gets used for toggled tools
         """
         if event.sender is self:
             return
@@ -3630,12 +3621,12 @@ class ToolbarBase(object):
         self.toggle_toolitem(event.tool.name)
 
     def _add_tool_cbk(self, event):
-        """Captures 'tool_added_event' and add the tool to the toolbar"""
+        """Captures 'tool_added_event' and adds the tool to the toolbar"""
         image = self._get_image_filename(event.tool.image)
         toggle = getattr(event.tool, 'toggled', None) is not None
         self.add_toolitem(event.tool.name,
-                          event.group,
-                          event.position,
+                          event.data['group'],
+                          event.data['position'],
                           image,
                           event.tool.description,
                           toggle)
@@ -3644,11 +3635,11 @@ class ToolbarBase(object):
                                         self._tool_triggered_cbk)
 
     def _remove_tool_cbk(self, event):
-        """Captures the 'tool_removed_event' signal and remove the tool"""
+        """Captures the 'tool_removed_event' signal and removes the tool"""
         self.remove_toolitem(event.tool.name)
 
     def _get_image_filename(self, image):
-        """"Base on the image name find the corresponding image"""
+        """Find the image based on its name"""
         # TODO: better search for images, they are not always in the
         # datapath
         basedir = os.path.join(rcParams['datapath'], 'images')
@@ -3664,7 +3655,7 @@ class ToolbarBase(object):
         Parameters
         ----------
         name : String
-            Name(id) of the tool that was triggered in the toolbar
+            Name(id) of the tool triggered from within the toolbar
 
         """
         self.navigation.tool_trigger_event(name, sender=self)
@@ -3672,7 +3663,7 @@ class ToolbarBase(object):
     def add_toolitem(self, name, group, position, image, description, toggle):
         """Add a toolitem to the toolbar
 
-        This method has to be implemented per backend
+        This method must get implemented per backend
 
         The callback associated with the button click event,
         must be **EXACTLY** `self.trigger_tool(name)`
@@ -3680,12 +3671,12 @@ class ToolbarBase(object):
         Parameters
         ----------
         name : string
-            Name of the tool to add, this is used as ID and as default label
-            of the buttons
+            Name of the tool to add, this gets used as the tool's ID and as the
+            default label of the buttons
         group : String
-            Name of the group that the tool belongs to
+            Name of the group that this tool belongs to
         position : Int
-            Position of the tool whthin its group if -1 at the End
+            Position of the tool within its group, if -1 it goes at the End
         image_file : String
             Filename of the image for the button or `None`
         description : String
@@ -3723,9 +3714,9 @@ class ToolbarBase(object):
     def remove_toolitem(self, name):
         """Remove a toolitem from the `Toolbar`
 
-        This method has to be implemented per backend
+        This method must get implemented per backend
 
-        Called when `tool_removed_event` is emited by `NavigationBase`
+        Called when `NavigationBase` emits a `tool_removed_event`
 
         Parameters
         ----------

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3227,7 +3227,7 @@ class ToolContainerBase(object):
     """
     Base class for all tool containers, e.g. toolbars.
 
-     Attributes
+    Attributes
     ----------
     toolmanager : `ToolManager` object that holds the tools that
         this `ToolContainer` wants to communicate with.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3618,9 +3618,6 @@ class NavigationBase(object):
                 loc.refresh()
         self.canvas.draw_idle()
 
-    def dynamic_update(self):
-        pass
-
     def set_cursor(self, cursor):
         """
         Set the current cursor to one of the :class:`Cursors`

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3288,6 +3288,11 @@ class NavigationBase(object):
         keys = [k for k, i in six.iteritems(self._keys) if i == name]
         return keys
 
+    def _remove_keys(self, name):
+        keys = [k for k, v in six.iteritems(self._keys) if v == name]
+        for k in keys:
+            del self._keys[k]
+
     def set_tool_keymap(self, name, *keys):
         """Set the keymap associated with a tool
 
@@ -3301,9 +3306,7 @@ class NavigationBase(object):
         if name not in self._tools:
             raise AttributeError('%s not in Tools' % name)
 
-        active_keys = [k for k, i in six.iteritems(self._keys) if i == name]
-        for k in active_keys:
-            del self._keys[k]
+        self._remove_keys(name)
 
         for key in keys:
             for k in validate_stringlist(key):
@@ -3311,21 +3314,6 @@ class NavigationBase(object):
                     warnings.warn('Key %s changed from %s to %s' %
                                   (k, self._keys[k], name))
                 self._keys[k] = name
-
-    def unregister(self, name):
-        """Unregister the tool from Navigation
-
-        Parameters
-        ----------
-        name : string
-            Name of the tool to unregister
-        """
-
-        if self._toggled == name:
-            self._handle_toggle(name, from_toolbar=False)
-        if name in self._tools:
-            self._tools[name].destroy()
-            del self._tools[name]
 
     def remove_tool(self, name):
         """Remove tool from the `Navigation`
@@ -3336,14 +3324,18 @@ class NavigationBase(object):
             Name of the Tool
         """
 
-        self.unregister(name)
+        tool = self._tools[name]
+        tool.destroy()
 
-        keys = [k for k, v in six.iteritems(self._keys) if v == name]
-        for k in keys:
-            del self._keys[k]
+        if self._toggled == name:
+            self._handle_toggle(name, from_toolbar=False)
 
-        if self.toolbar:
+        self._remove_keys(name)
+
+        if self.toolbar and tool.intoolbar:
             self.toolbar._remove_toolitem(name)
+
+        del self._tools[name]
 
     def add_tools(self, tools):
         """ Add multiple tools to `Navigation`
@@ -3491,7 +3483,7 @@ class NavigationBase(object):
         for name in sorted(self._tools.keys()):
             tool = self._tools[name]
             keys = [k for k, i in six.iteritems(self._keys) if i == name]
-            d[name] = {'cls': tool,
+            d[name] = {'obj': tool,
                        'description': tool.description,
                        'keymap': keys}
         return d

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3455,15 +3455,15 @@ class NavigationBase(object):
 
         return callback_class
 
-    def click_tool(self, name):
-        """Simulate a click on a tool
+    def trigger_tool(self, name):
+        """Trigger on a tool
 
-        This is a convenient method to programatically click on
+        This is a convenient method to programatically "click" on
         Tools
         """
-        self._tool_activate(name, None, False)
+        self._trigger_tool(name, None, False)
 
-    def _tool_activate(self, name, event, from_toolbar):
+    def _trigger_tool(self, name, event, from_toolbar):
         if name not in self._tools:
             raise AttributeError('%s not in Tools' % name)
 
@@ -3490,7 +3490,7 @@ class NavigationBase(object):
                 return
 
         name = self._keys.get(event.key, None)
-        self._tool_activate(name, event, False)
+        self._trigger_tool(name, event, False)
 
     def _get_instance(self, name):
         if name not in self._instances:
@@ -3512,7 +3512,7 @@ class NavigationBase(object):
             Name of the tool that was activated (click) by the user using the
             toolbar
         """
-        self._tool_activate(name, None, True)
+        self._trigger_tool(name, None, True)
 
     def _handle_toggle(self, name, event=None, from_toolbar=False):
         #toggle toolbar without callback
@@ -3525,14 +3525,15 @@ class NavigationBase(object):
             self._toggled = name
 
         elif self._toggled == name:
-            instance.deactivate(None)
+            instance.trigger(None)
             self._toggled = None
 
         else:
             if self.toolbar:
+                #untoggle the previous toggled tool
                 self.toolbar._toggle(self._toggled, False)
 
-            self._get_instance(self._toggled).deactivate(None)
+            self._get_instance(self._toggled).trigger(None)
             instance.trigger(None)
             self._toggled = name
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2595,11 +2595,6 @@ class FigureManagerBase(object):
 
         """
 
-        self.toolbar = self._get_toolbar()
-        self.navigation = self._get_navigation()
-        if rcParams['toolbar'] == 'navigation':
-            self.navigation.add_tools(tools.tools)
-
     def show(self):
         """
         For GUI backends, show the figure window and redraw.
@@ -2647,11 +2642,6 @@ class FigureManagerBase(object):
         """
         pass
 
-    def _get_toolbar(self):
-        return None
-
-    def _get_navigation(self):
-        return None
 
 cursors = tools.cursors
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -46,6 +46,7 @@ import sys
 import warnings
 import time
 import io
+from pydispatch import dispatcher
 
 import numpy as np
 import matplotlib.cbook as cbook
@@ -3225,32 +3226,6 @@ class NavigationToolbar2(object):
         pass
 
 
-class NavigationEvent(object):
-    """"A Navigation Event ('tool_add_event',
-                   'tool_remove_event',
-                   'tool_trigger_event',
-                   'navigation_message_event').
-    Attributes
-    ----------
-    name: String
-        Name of the event
-    tool: ToolInstance
-    data: Extra data
-    source: String
-        Name of the object responsible for emiting the event
-        ('toolbar', 'navigation', 'keypress', etc...)
-    event: Event
-        Original event that causes navigation to emit this event
-    """
-
-    def __init__(self, name, tool, source, data=None, event=None):
-        self.name = name
-        self.tool = tool
-        self.data = data
-        self.source = source
-        self.event = event
-
-
 class NavigationBase(object):
     """ Helper class that groups all the user interactions for a FigureManager
 
@@ -3262,18 +3237,12 @@ class NavigationBase(object):
     messagelock : `LockDraw` to know if the message is available to write
     """
 
-    _default_cursor = cursors.POINTER
-
     def __init__(self, manager):
         self.manager = manager
         self.canvas = manager.canvas
-        self.callbacks = cbook.CallbackRegistry()
 
         self._key_press_handler_id = self.canvas.mpl_connect(
             'key_press_event', self._key_press)
-
-        self._idDrag = self.canvas.mpl_connect(
-            'motion_notify_event', self._mouse_move)
 
         self._tools = {}
         self._keys = {}
@@ -3281,76 +3250,15 @@ class NavigationBase(object):
 
         # to process keypress event
         self.keypresslock = widgets.LockDraw()
-        # To prevent the firing of 'navigation_message_event'
         self.messagelock = widgets.LockDraw()
 
-        self._last_cursor = self._default_cursor
-
-    def mpl_connect(self, s, func):
-        return self.callbacks.connect(s, func)
-
-    def mpl_disconnect(self, cid):
-        return self.callbacks.disconnect(cid)
-
-    def tool_add_event(self, tool, group, position):
-        """
-        This method will call all functions connected to the
-        'tool_add_event' with a :class:`NavigationEvent`
-        """
-        s = 'tool_add_event'
-        data = {'group': group,
-                'position': position}
-        event = NavigationEvent(s, tool, 'navigation', data)
-        self.callbacks.process(s, event)
-
-    def tool_remove_event(self, tool):
-        """
-        This method will call all functions connected to the
-        'tool_remove_event' with a :class:`NavigationEvent`
-        """
-        s = 'tool_remove_event'
-        event = NavigationEvent(s, tool, 'navigation')
-        self.callbacks.process(s, event)
-
-    def tool_trigger_event(self, name, source, originalevent=None):
-        """
-        This method will call all functions connected to the
-        'tool_trigger_event' with a :class:`NavigationEvent`
-        """
-        if name not in self._tools:
-            raise AttributeError('%s not in Tools' % name)
-
-        tool = self._tools[name]
-
-        if isinstance(tool, tools.ToolToggleBase):
-            if self._toggled == name:
-                self._toggled = None
-            elif self._toggled is not None:
-                self.tool_trigger_event(self._toggled, 'navigation',
-                                        originalevent)
-                self._toggled = name
-            else:
-                self._toggled = name
-
-        tool.trigger(originalevent)
-
-        s = 'tool_trigger_event'
-        event = NavigationEvent(s, tool, source, originalevent)
-        self.callbacks.process(s, event)
-
-        for a in self.canvas.figure.get_axes():
-            a.set_navigate_mode(self._toggled)
-
-        self._set_cursor(originalevent)
-
-    def message_event(self, message, source='navigation'):
-        """
-        This method will call all functions connected to the
-        'navigation_message_event' with a :class:`NavigationEvent`
-        """
-        s = 'navigation_message_event'
-        event = NavigationEvent(s, None, source, data=message)
-        self.callbacks.process(s, event)
+    def send_message(self, message, sender=None):
+        """ Send a navigation-message event"""
+        if sender is None:
+            sender = self
+        dispatcher.send(signal='navigation-message',
+                        sender=sender,
+                        message=message)
 
     @property
     def active_toggle(self):
@@ -3421,7 +3329,9 @@ class NavigationBase(object):
 
         self._remove_keys(name)
 
-        self.tool_remove_event(tool)
+        dispatcher.send(signal='navigation-tool-removed',
+                        sender=self,
+                        tool=tool)
 
         del self._tools[name]
 
@@ -3448,6 +3358,8 @@ class NavigationBase(object):
             Name of the tool, treated as the ID, has to be unique
         tool : string or `Tool` class
             Reference to find the class of the Tool to be added
+        group: String
+            Group to position the tool in
         position : int or None (default)
             Position in the toolbar, if None, is positioned at the end
         """
@@ -3466,9 +3378,39 @@ class NavigationBase(object):
         if tool_cls.keymap is not None:
             self.set_tool_keymap(name, tool_cls.keymap)
 
-        self.tool_add_event(self._tools[name], group, position)
+        dispatcher.send(signal='navigation-tool-added',
+                        sender=self,
+                        tool=self._tools[name],
+                        group=group,
+                        position=position)
+
+        if isinstance(self._tools[name], tools.ToolToggleBase):
+            dispatcher.connect(self._handle_toggle,
+                               'tool-pre-trigger-%s' % name,
+                               sender=dispatcher.Any)
+
+    def _handle_toggle(self, signal, sender, event=None):
+        # Toggle tools, need to be untoggled before other Toggle tool is used
+        # This is connected to the 'tool-pre-trigger-toolname' signal
+        name = '-'.join(signal.split('-')[3:])
+        if self._toggled == name:
+            toggled = None
+        elif self._toggled is None:
+            toggled = name
+        else:
+            # untoggle currently toggled tool
+            dispatcher.send(signal='tool-trigger-%s' % self._toggled,
+                            sender=self)
+            toggled = name
+
+        self._toggled = toggled
+        for a in self.canvas.figure.get_axes():
+            a.set_navigate_mode(self._toggled)
+
+        self._set_cursor(event)
 
     def _get_cls_to_instantiate(self, callback_class):
+        # Find the class that corresponds to the tool
         if isinstance(callback_class, six.string_types):
             # FIXME: make more complete searching structure
             if callback_class in globals():
@@ -3487,7 +3429,9 @@ class NavigationBase(object):
 
         Method to programatically "click" on Tools
         """
-        self.tool_trigger_event(name, 'navigation', event)
+        dispatcher.send(signal='tool-trigger-%s' % name,
+                        sender=self,
+                        event=event)
 
     def _key_press(self, event):
         if event.key is None or self.keypresslock.locked():
@@ -3496,8 +3440,7 @@ class NavigationBase(object):
         name = self._keys.get(event.key, None)
         if name is None:
             return
-
-        self.tool_trigger_event(name, 'keypress', event)
+        self.trigger_tool(name, event)
 
     def get_tools(self):
         """Return the tools controlled by `Navigation`"""
@@ -3512,43 +3455,24 @@ class NavigationBase(object):
         return d
 
     def _set_cursor(self, event):
-        """Call the backend specific set_cursor method,
-        if the pointer is inaxes
+        """Fire the tool-trigger-cursor event,
+
+        This event set the current cursor
+        in the tool ToolSetCursor
         """
-        if not event:
-            return
-
-        if not event.inaxes or not self._toggled:
-            if self._last_cursor != self._default_cursor:
-                self.set_cursor(self._default_cursor)
-                self._last_cursor = self._default_cursor
+        if event is None:
+            class dummy(object):
+                cursor = None
+            event = dummy()
+        if self._toggled:
+            cursor = self._tools[self._toggled].cursor
         else:
-            if self._toggled:
-                cursor = self._tools[self._toggled].cursor
-                if cursor and self._last_cursor != cursor:
-                    self.set_cursor(cursor)
-                    self._last_cursor = cursor
-
-    def _mouse_move(self, event):
-        self._set_cursor(event)
-
-        if self.messagelock.locked():
-            return
-
-        message = ' '
-
-        if event.inaxes and event.inaxes.get_navigate():
-
-            try:
-                s = event.inaxes.format_coord(event.xdata, event.ydata)
-            except (ValueError, OverflowError):
-                pass
-            else:
-                if self._toggled:
-                    message = '%s, %s' % (self._toggled, s)
-                else:
-                    message = s
-        self.message_event(message)
+            cursor = None
+        setattr(event, 'cursor', cursor)
+#         event.cursor = cursor
+        dispatcher.send(signal='tool-trigger-cursor',
+                        sender=self,
+                        event=event)
 
     def set_cursor(self, cursor):
         """Set the current cursor to one of the :class:`Cursors`
@@ -3599,12 +3523,53 @@ class ToolbarBase(object):
 
     def __init__(self, manager):
         self.manager = manager
-        self._tool_trigger_id = None
-        self._add_tool_id = None
-        self._remove_tool_id = None
-        self._navigation = None
+
+        dispatcher.connect(self._add_tool_cbk,
+                           signal='navigation-tool-added',
+                           sender=dispatcher.Any)
+
+        dispatcher.connect(self._remove_tool_cbk,
+                           signal='navigation-tool-removed',
+                           sender=dispatcher.Any)
+
+        dispatcher.connect(self._message_cbk,
+                           signal='navigation-message',
+                           sender=dispatcher.Any)
+
+    def _message_cbk(self, signal, sender, message):
+        """Captures the 'navigation-message to set message on the toolbar"""
+        self.set_message(message)
+
+    def _tool_triggered_cbk(self, signal, sender):
+        """Captures the 'tool-trigger-toolname
+
+        This is only used for toggled tools
+        If the sender is not the toolbar itself, just untoggle the toggled tool
+        """
+        if sender is self:
+            return
+
+        name = '-'.join(signal.split('-')[2:])
+        self.toggle_toolitem(name)
+
+    def _add_tool_cbk(self, tool, group, position, signal, sender):
+        """Captures 'navigation-tool-added' and add the tool to the toolbar"""
+        name = tool.name
+        image = self._get_image_filename(tool.image)
+        description = tool.description
+        toggle = isinstance(tool, tools.ToolToggleBase)
+        self.add_toolitem(name, group, position, image, description, toggle)
+        if toggle:
+            dispatcher.connect(self._tool_triggered_cbk,
+                               signal='tool-trigger-%s' % name,
+                               sender=dispatcher.Any)
+
+    def _remove_tool_cbk(self, tool, signal, sender):
+        """Captures the 'navigation-tool-removed' signal and remove the tool"""
+        self.remove_toolitem(tool.name)
 
     def _get_image_filename(self, image):
+        """"Base on the image name find the corresponding image"""
         # TODO: better search for images, they are not always in the
         # datapath
         basedir = os.path.join(rcParams['datapath'], 'images')
@@ -3614,33 +3579,11 @@ class ToolbarBase(object):
             fname = None
         return fname
 
-    def _add_tool_callback(self, event):
-        name = event.tool.name
-        group = event.data['group']
-        position = event.data['position']
-        image = self._get_image_filename(event.tool.image)
-        description = event.tool.description
-        toggle = isinstance(event.tool, tools.ToolToggleBase)
-        self.add_toolitem(name, group, position, image, description, toggle)
-
-    def _remove_tool_callback(self, event):
-        self.remove_toolitem(event.tool.name)
-
-    def _tool_trigger_callback(self, event):
-        if event.source == 'toolbar':
-            return
-
-        if isinstance(event.tool, tools.ToolToggleBase):
-            self.toggle_toolitem(event.tool.name)
-
-    def _message_event_callback(self, event):
-        self.set_message(event.data)
+#     def _message_event_callback(self, event):
+#         self.set_message(event.data)
 
     def trigger_tool(self, name):
-        """Inform navigation of a toolbar event
-
-        Uses the navigation method to emit a 'tool_trigger_event'
-        with 'navigation' as the source
+        """fire the 'tool-trigger-toolname' signal
 
         Parameters
         ----------
@@ -3648,22 +3591,8 @@ class ToolbarBase(object):
             Name(id) of the tool that was triggered in the toolbar
 
         """
-        self._navigation.tool_trigger_event(name, 'toolbar')
-
-    def set_navigation(self, navigation):
-        """Initialize the callbacks for navigation events"""
-        self._navigation = navigation
-        self._add_tool_id = self._navigation.mpl_connect(
-            'tool_add_event', self._add_tool_callback)
-
-        self._tool_trigger_id = self._navigation.mpl_connect(
-            'tool_trigger_event', self._tool_trigger_callback)
-
-        self._message_id = self._navigation.mpl_connect(
-            'navigation_message_event', self._message_event_callback)
-
-        self._remove_tool_id = self._navigation.mpl_connect(
-            'tool_remove_event', self._remove_tool_callback)
+        dispatcher.send(signal='tool-trigger-%s' % name,
+                        sender=self)
 
     def add_toolitem(self, name, group, position, image, description, toggle):
         """Add a toolitem to the toolbar

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3262,13 +3262,6 @@ class NavigationBase(object):
         # to write into toolbar message
         self.messagelock = widgets.LockDraw()
 
-        for name, tool in tools.tools:
-            if tool is None:
-                if self.toolbar is not None:
-                    self.toolbar.add_separator(-1)
-            else:
-                self.add_tool(name, tool, None)
-
         self._last_cursor = self._default_cursor
 
     @property
@@ -3370,6 +3363,22 @@ class NavigationBase(object):
 
         if self.toolbar:
             self.toolbar._remove_toolitem(name)
+
+    def add_tools(self, tools):
+        """ Add multiple tools to `Navigation`
+
+        Parameters
+        ----------
+        tools : a list of tuples which contains the id of the tool and
+        a either a reference to the tool Tool class itself, or None to
+        insert a spacer.  See :func:`add_tool`.
+        """
+        for name, tool in tools:
+            if tool is None:
+                if self.toolbar is not None:
+                    self.toolbar.add_separator(-1)
+            else:
+                self.add_tool(name, tool, None)
 
     def add_tool(self, name, tool, position=None):
         """Add tool to `Navigation`

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3406,20 +3406,6 @@ class NavigationBase(object):
 
         del self._tools[name]
 
-    def add_tools(self, tools):
-        """
-        Add multiple tools to `NavigationBase`
-
-        Parameters
-        ----------
-        tools : {str: class_like}
-            The tools to add in a {name: tool} dict, see `add_tool` for more
-            info.
-        """
-
-        for name, tool in six.iteritems(tools):
-            self.add_tool(name, tool)
-
     def add_tool(self, name, tool, *args, **kwargs):
         """
         Add tool to `NavigationBase`
@@ -3515,9 +3501,9 @@ class NavigationBase(object):
         else:
             # Untoggle previously toggled tool
             self.trigger_tool(self._toggled[radio_group],
-                                    self,
-                                    canvasevent,
-                                    data)
+                              self,
+                              canvasevent,
+                              data)
             toggled = tool.name
 
         # Keep track of the toggled tool in the radio_group
@@ -3644,23 +3630,6 @@ class ToolContainerBase(object):
         This only gets used for toggled tools
         """
         self.toggle_toolitem(event.tool.name, event.tool.toggled)
-
-    def add_tools(self, tools):
-        """
-        Add multiple tools to the container.
-
-        Parameters
-        ----------
-        tools : list
-            List in the form
-            [[group1, [tool1, tool2 ...]], [group2, [...]]]
-            Where the tools given by tool1, and tool2 will display in group1.
-            See `add_tool` for details.
-        """
-
-        for group, grouptools in tools:
-            for position, tool in enumerate(grouptools):
-                self.add_tool(tool, group, position)
 
     def add_tool(self, tool, group, position=-1):
         """

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3236,6 +3236,7 @@ class NavigationBase(object):
         locked
     messagelock : `LockDraw` to know if the message is available to write
     """
+
     _default_cursor = cursors.POINTER
     _default_tools = [tools.ToolToggleGrid,
              tools.ToolToggleFullScreen,
@@ -3255,6 +3256,7 @@ class NavigationBase(object):
 
     def __init__(self, canvas, toolbar=None):
         """.. automethod:: _toolbar_callback"""
+
         self.canvas = canvas
         self.toolbar = self._get_toolbar(toolbar, canvas)
 
@@ -3273,9 +3275,9 @@ class NavigationBase(object):
         self._instances = {}
         self._toggled = None
 
-        #to process keypress event
+        # to process keypress event
         self.keypresslock = widgets.LockDraw()
-        #to write into toolbar message
+        # to write into toolbar message
         self.messagelock = widgets.LockDraw()
 
         for tool in self._default_tools:
@@ -3290,11 +3292,13 @@ class NavigationBase(object):
     @classmethod
     def get_default_tools(cls):
         """Get the default tools"""
+
         return cls._default_tools
 
     @classmethod
     def set_default_tools(cls, tools):
         """Set default tools"""
+
         cls._default_tools = tools
 
     def _get_toolbar(self, toolbar, canvas):
@@ -3312,6 +3316,7 @@ class NavigationBase(object):
 
         **string** :  Currently toggled tool, or None
         """
+
         return self._toggled
 
     @property
@@ -3320,6 +3325,7 @@ class NavigationBase(object):
 
         **dictionary** : Contains the active instances that are registered
         """
+
         return self._instances
 
     def get_tool_keymap(self, name):
@@ -3334,6 +3340,7 @@ class NavigationBase(object):
         ----------
         list : list of keys associated with the Tool
         """
+
         keys = [k for k, i in six.iteritems(self._keys) if i == name]
         return keys
 
@@ -3380,6 +3387,7 @@ class NavigationBase(object):
         If called, next time the `Tool` is used it will be reinstantiated
         instead of using the existing instance.
         """
+
         if self._toggled == name:
             self._handle_toggle(name, from_toolbar=False)
         if name in self._instances:
@@ -3393,6 +3401,7 @@ class NavigationBase(object):
         name : string
             Name of the Tool
         """
+
         self.unregister(name)
         del self._tools[name]
         keys = [k for k, v in six.iteritems(self._keys) if v == name]
@@ -3410,6 +3419,7 @@ class NavigationBase(object):
         tool : string or `Tool` class
             Reference to find the class of the Tool to be added
         """
+
         tool_cls = self._get_cls_to_instantiate(tool)
         name = tool_cls.name
 
@@ -3445,7 +3455,7 @@ class NavigationBase(object):
 
     def _get_cls_to_instantiate(self, callback_class):
         if isinstance(callback_class, six.string_types):
-            #FIXME: make more complete searching structure
+            # FIXME: make more complete searching structure
             if callback_class in globals():
                 return globals()[callback_class]
 
@@ -3462,6 +3472,7 @@ class NavigationBase(object):
 
         Method to programatically "click" on Tools
         """
+
         self._trigger_tool(name, None, False)
 
     def _trigger_tool(self, name, event, from_toolbar):
@@ -3475,8 +3486,7 @@ class NavigationBase(object):
             instance = self._get_instance(name)
             instance.trigger(event)
         else:
-            #Non persistent tools, are
-            #instantiated and forgotten (reminds me an exgirlfriend?)
+            # Non persistent tools, are instantiated and forgotten
             tool(self.canvas.figure, event)
 
     def _key_press(self, event):
@@ -3491,7 +3501,7 @@ class NavigationBase(object):
     def _get_instance(self, name):
         if name not in self._instances:
             instance = self._tools[name](self.canvas.figure)
-            #register instance
+            # register instance
             self._instances[name] = instance
 
         return self._instances[name]
@@ -3508,24 +3518,25 @@ class NavigationBase(object):
             Name of the tool that was activated (click) by the user using the
             toolbar
         """
+
         self._trigger_tool(name, None, True)
 
     def _handle_toggle(self, name, event=None, from_toolbar=False):
-        #toggle toolbar without callback
+        # toggle toolbar without callback
         if not from_toolbar and self.toolbar:
             self.toolbar._toggle(name, False)
 
         instance = self._get_instance(name)
         if self._toggled is None:
-            #first trigger of tool
+            # first trigger of tool
             self._toggled = name
         elif self._toggled == name:
-            #second trigger of tool
+            # second trigger of tool
             self._toggled = None
         else:
-            #other tool is triggered so trigger toggled tool
+            # other tool is triggered so trigger toggled tool
             if self.toolbar:
-                #untoggle the previous toggled tool
+                # untoggle the previous toggled tool
                 self.toolbar._toggle(self._toggled, False)
             self._get_instance(self._toggled).trigger(event)
             self._toggled = name
@@ -3537,6 +3548,7 @@ class NavigationBase(object):
 
     def list_tools(self):
         """Print the list the tools controlled by `Navigation`"""
+
         print ('_' * 80)
         print ("{0:20} {1:50} {2}".format('Name (id)', 'Tool description',
                                           'Keymap'))
@@ -3550,6 +3562,7 @@ class NavigationBase(object):
 
     def update(self):
         """Reset the axes stack"""
+
         self.views.clear()
         self.positions.clear()
 #        self.set_history_buttons()
@@ -3585,9 +3598,11 @@ class NavigationBase(object):
 
     def draw(self):
         """Redraw the canvases, update the locators"""
+
         for a in self.canvas.figure.get_axes():
             xaxis = getattr(a, 'xaxis', None)
             yaxis = getattr(a, 'yaxis', None)
+            zaxis = getattr(a, 'zaxis', None)
             locators = []
             if xaxis is not None:
                 locators.append(xaxis.get_major_locator())
@@ -3595,6 +3610,9 @@ class NavigationBase(object):
             if yaxis is not None:
                 locators.append(yaxis.get_major_locator())
                 locators.append(yaxis.get_minor_locator())
+            if zaxis is not None:
+                locators.append(zaxis.get_major_locator())
+                locators.append(zaxis.get_minor_locator())
 
             for loc in locators:
                 loc.refresh()
@@ -3608,6 +3626,7 @@ class NavigationBase(object):
         Set the current cursor to one of the :class:`Cursors`
         enums values
         """
+
         pass
 
     def update_view(self):
@@ -3633,6 +3652,7 @@ class NavigationBase(object):
 
     def push_current(self):
         """push the current view limits and position onto the stack"""
+
         lims = []
         pos = []
         for a in self.canvas.figure.get_axes():
@@ -3659,6 +3679,7 @@ class NavigationBase(object):
         caller : instance trying to draw the rubberband
         x0, y0, x1, y1 : coordinates
         """
+
         if not self.canvas.widgetlock.available(caller):
             warnings.warn("%s doesn't own the canvas widgetlock" % caller)
 
@@ -3673,6 +3694,7 @@ class NavigationBase(object):
         event : `FigureCanvas` event
         caller : instance trying to remove the rubberband
         """
+
         if not self.canvas.widgetlock.available(caller):
             warnings.warn("%s doesn't own the canvas widgetlock" % caller)
 
@@ -3684,12 +3706,14 @@ class ToolbarBase(object):
     ----------
     manager : `FigureManager` instance that integrates this `Toolbar`
     """
+
     def __init__(self, manager):
         """
         .. automethod:: _add_toolitem
         .. automethod:: _remove_toolitem
         .. automethod:: _toggle
         """
+
         self.manager = manager
 
     def _add_toolitem(self, name, description, image_file, position,
@@ -3717,6 +3741,7 @@ class ToolbarBase(object):
             * `False` : The button is a normal button (returns to unpressed
                 state after release)
         """
+
         raise NotImplementedError
 
     def add_separator(self, pos):
@@ -3728,10 +3753,12 @@ class ToolbarBase(object):
             Position where to add the separator within the toolitems
             if -1 at the end
         """
+
         pass
 
     def set_message(self, s):
         """Display a message on toolbar or in status bar"""
+
         pass
 
     def _toggle(self, name, callback=False):
@@ -3746,7 +3773,8 @@ class ToolbarBase(object):
             * `False`: toggle the button without calling the callback
 
         """
-        #carefull, callback means to perform or not the callback while toggling
+
+        # carefull, callback means to perform or not the callback while toggling
         raise NotImplementedError
 
     def _remove_toolitem(self, name):
@@ -3758,6 +3786,7 @@ class ToolbarBase(object):
             Name of the tool to remove
 
         """
+
         raise NotImplementedError
 
     def move_toolitem(self, pos_ini, pos_fin):
@@ -3770,6 +3799,7 @@ class ToolbarBase(object):
         pos_fin : integer
             Final position of the toolitem
         """
+
         pass
 
     def set_toolitem_visibility(self, name, visible):
@@ -3783,4 +3813,5 @@ class ToolbarBase(object):
             * `True`: set the toolitem visible
             * `False`: set the toolitem invisible
         """
+
         pass

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3396,7 +3396,7 @@ class NavigationBase(object):
 
         # If is a toggle tool and toggled, untoggle
         if getattr(tool, 'toggled', False):
-            self.tool_trigger_event(tool, 'navigation')
+            self.trigger_tool(tool, 'navigation')
 
         self._remove_keys(name)
 
@@ -3481,7 +3481,7 @@ class NavigationBase(object):
     def _handle_toggle(self, tool, sender, canvasevent, data):
         """
         Toggle tools, need to untoggle prior to using other Toggle tool
-        Called from tool_trigger_event
+        Called from trigger_tool
 
         Parameters
         ----------
@@ -3514,7 +3514,7 @@ class NavigationBase(object):
         # Other tool in the radio_group is toggled
         else:
             # Untoggle previously toggled tool
-            self.tool_trigger_event(self._toggled[radio_group],
+            self.trigger_tool(self._toggled[radio_group],
                                     self,
                                     canvasevent,
                                     data)
@@ -3543,8 +3543,8 @@ class NavigationBase(object):
         else:
             return None
 
-    def tool_trigger_event(self, name, sender=None, canvasevent=None,
-                           data=None):
+    def trigger_tool(self, name, sender=None, canvasevent=None,
+                     data=None):
         """
         Trigger a tool and emit the tool_trigger_[name] event
 
@@ -3594,7 +3594,7 @@ class NavigationBase(object):
         name = self._keys.get(event.key, None)
         if name is None:
             return
-        self.tool_trigger_event(name, canvasevent=event)
+        self.trigger_tool(name, canvasevent=event)
 
     @property
     def tools(self):
@@ -3709,7 +3709,7 @@ class ToolContainerBase(object):
             Name(id) of the tool triggered from within the container
 
         """
-        self.navigation.tool_trigger_event(name, sender=self)
+        self.navigation.trigger_tool(name, sender=self)
 
     def add_toolitem(self, name, group, position, image, description, toggle):
         """

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3233,17 +3233,10 @@ class NavigationBase(object):
     canvas : `FigureCanvas` instance
     toolbar : `Toolbar` instance that is controlled by this `Navigation`
     keypresslock : `LockDraw` to direct the `canvas` key_press_event
-    movelock: `LockDraw` to direct the `canvas` motion_notify_event
-    presslock: `LockDraw` to direct the `canvas` button_press_event
-    releaselock: `LockDraw` to direct the `canvas` button_release_event
-    canvaslock: shortcut to `canvas.widgetlock`
-
-    Notes
-    --------_
-    The following methos are for implementation pourposes and not for user use
-    For these reason they are defined as **_methodname** (private)
-
-    .. automethod:: _toolbar_callback
+    movelock : `LockDraw` to direct the `canvas` motion_notify_event
+    presslock : `LockDraw` to direct the `canvas` button_press_event
+    releaselock : `LockDraw` to direct the `canvas` button_release_event
+    canvaslock : shortcut to `canvas.widgetlock`
     """
     _default_cursor = cursors.POINTER
     _default_tools = [tools.ToolToggleGrid,
@@ -3263,6 +3256,7 @@ class NavigationBase(object):
              'SaveFigure']
 
     def __init__(self, canvas, toolbar=None):
+        """.. automethod:: _toolbar_callback"""
         self.canvas = canvas
         self.toolbar = self._get_toolbar(toolbar, canvas)
 
@@ -3312,18 +3306,20 @@ class NavigationBase(object):
             toolbar = None
         return toolbar
 
-    def get_active(self):
-        """Get the active tools
+    @property
+    def active_toggle(self):
+        """Get the tooggled Tool"""
+        return self._toggled
+
+    def get_instances(self):
+        """Get the active tools instgances
 
         Returns
         ----------
-         A dictionary with the following elements
-          * `toggled`: The currently toggled Tool or None
-          * `instances`: List of the currently active tool instances
-            that are registered with Navigation
-
+         A dictionary with the active instances that are registered with
+         Navigation
         """
-        return {'toggled': self._toggled, 'instances': self._instances.keys()}
+        return self._instances
 
     def get_tool_keymap(self, name):
         """Get the keymap associated with a tool
@@ -3375,7 +3371,8 @@ class NavigationBase(object):
         It is usually called by the `deactivate` method or during
         destroy if it is a graphical Tool.
 
-        If called, next time the `Tool` is used it will be reinstantiated instead
+        If called, next time the `Tool` is used it will be reinstantiated
+        instead
         of using the existing instance.
         """
         if self._toggled == name:
@@ -3686,17 +3683,13 @@ class ToolbarBase(object):
      Attributes
     ----------
     manager : `FigureManager` instance that integrates this `Toolbar`
-
-    Notes
-    -----
-    The following methos are for implementation pourposes and not for user use.
-    For these reason they are defined as **_methodname** (private)
-
-    .. automethod:: _toggle
-    .. automethod:: _add_toolitem
-    .. automethod:: _remove_toolitem
     """
     def __init__(self, manager):
+        """
+        .. automethod:: _add_toolitem
+        .. automethod:: _remove_toolitem
+        .. automethod:: _toggle
+        """
         self.manager = manager
 
     def _add_toolitem(self, name, description, image_file, position,

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -99,7 +99,7 @@ class ToolManager(object):
 
     def toolmanager_disconnect(self, cid):
         """
-        Disconnect callback id cid
+        Disconnect callback id *cid*
 
         Example usage::
 
@@ -196,9 +196,7 @@ class ToolManager(object):
 
     def add_tool(self, name, tool, *args, **kwargs):
         """
-        Add tool to `ToolManager`
-
-        Add a tool to the tools controlled by ToolManager
+        Add *tool* to `ToolManager`
 
         If successful adds a new event `tool_trigger_name` where **name** is
         the **name** of the tool, this event is fired everytime

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -1,0 +1,411 @@
+"""
+:class:`NavigationBase`
+    The base class for the Navigation class that makes the bridge between
+    user interaction (key press, toolbar clicks, ..) and the actions in
+    response to the user inputs.
+
+:class:`ToolContainerBase`
+     The base class for the Toolbar class of each interactive backend.
+
+:class:`StatusbarBase`
+    The base class for the messaging area.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import six
+import warnings
+import sys
+
+import matplotlib.cbook as cbook
+import matplotlib.widgets as widgets
+from matplotlib.rcsetup import validate_stringlist
+import matplotlib.backend_tools as tools
+
+try:
+    from importlib import import_module
+except:
+    # simple python 2.6 implementation (no relative imports)
+    def import_module(name):
+        __import__(name)
+        return sys.modules[name]
+
+
+class ToolEvent(object):
+    """Event for tool manipulation (add/remove)"""
+    def __init__(self, name, sender, tool, data=None):
+        self.name = name
+        self.sender = sender
+        self.tool = tool
+        self.data = data
+
+
+class ToolTriggerEvent(ToolEvent):
+    """Event to inform  that a tool has been triggered"""
+    def __init__(self, name, sender, tool, canvasevent=None, data=None):
+        ToolEvent.__init__(self, name, sender, tool, data)
+        self.canvasevent = canvasevent
+
+
+class ToolManagerMessageEvent(object):
+    """
+    Event carrying messages from toolmanager
+
+    Messages usually get displayed to the user by the toolbar
+    """
+    def __init__(self, name, sender, message):
+        self.name = name
+        self.sender = sender
+        self.message = message
+
+
+class ToolManager(object):
+    """
+    Helper class that groups all the user interactions for a FigureManager
+
+    Attributes
+    ----------
+    manager: `FigureManager`
+    keypresslock: `widgets.LockDraw`
+        `LockDraw` object to know if the `canvas` key_press_event is locked
+    messagelock: `widgets.LockDraw`
+        `LockDraw` object to know if the message is available to write
+    """
+
+    def __init__(self, canvas):
+        self.canvas = canvas
+
+        self._key_press_handler_id = self.canvas.mpl_connect(
+            'key_press_event', self._key_press)
+
+        self._tools = {}
+        self._keys = {}
+        self._toggled = {}
+        self._callbacks = cbook.CallbackRegistry()
+
+        # to process keypress event
+        self.keypresslock = widgets.LockDraw()
+        self.messagelock = widgets.LockDraw()
+
+    def toolmanager_connect(self, s, func):
+        """
+        Connect event with string *s* to *func*.
+
+        Parameters
+        -----------
+        s : String
+            Name of the event
+
+            The following events are recognized
+
+            - 'tool_message_event'
+            - 'tool_removed_event'
+            - 'tool_added_event'
+
+            For every tool added a new event is created
+
+            - 'tool_trigger_TOOLNAME`
+              Where TOOLNAME is the id of the tool.
+
+        func : function
+            Function to be called with signature
+            def func(event)
+        """
+        return self._callbacks.connect(s, func)
+
+    def toolmanager_disconnect(self, cid):
+        """
+        Disconnect callback id cid
+
+        Example usage::
+
+            cid = toolmanager.toolmanager_connect('tool_trigger_zoom',
+                                                  on_press)
+            #...later
+            toolmanager.toolmanager_disconnect(cid)
+        """
+        return self._callbacks.disconnect(cid)
+
+    def message_event(self, message, sender=None):
+        """ Emit a `ToolManagerMessageEvent`"""
+        if sender is None:
+            sender = self
+
+        s = 'tool_message_event'
+        event = ToolManagerMessageEvent(s, sender, message)
+        self._callbacks.process(s, event)
+
+    @property
+    def active_toggle(self):
+        """Currently toggled tools"""
+
+        return self._toggled
+
+    def get_tool_keymap(self, name):
+        """
+        Get the keymap associated with the specified tool
+
+        Parameters
+        ----------
+        name : string
+            Name of the Tool
+
+        Returns
+        ----------
+        list : list of keys associated with the Tool
+        """
+
+        keys = [k for k, i in six.iteritems(self._keys) if i == name]
+        return keys
+
+    def _remove_keys(self, name):
+        for k in self.get_tool_keymap(name):
+            del self._keys[k]
+
+    def update_keymap(self, name, *keys):
+        """
+        Set the keymap to associate with the specified tool
+
+        Parameters
+        ----------
+        name : string
+            Name of the Tool
+        keys : keys to associate with the Tool
+        """
+
+        if name not in self._tools:
+            raise KeyError('%s not in Tools' % name)
+
+        self._remove_keys(name)
+
+        for key in keys:
+            for k in validate_stringlist(key):
+                if k in self._keys:
+                    warnings.warn('Key %s changed from %s to %s' %
+                                  (k, self._keys[k], name))
+                self._keys[k] = name
+
+    def remove_tool(self, name):
+        """
+        Remove tool from `ToolManager`
+
+        Parameters
+        ----------
+        name : string
+            Name of the Tool
+        """
+
+        tool = self.get_tool(name)
+        tool.destroy()
+
+        # If is a toggle tool and toggled, untoggle
+        if getattr(tool, 'toggled', False):
+            self.trigger_tool(tool, 'toolmanager')
+
+        self._remove_keys(name)
+
+        s = 'tool_removed_event'
+        event = ToolEvent(s, self, tool)
+        self._callbacks.process(s, event)
+
+        del self._tools[name]
+
+    def add_tool(self, name, tool, *args, **kwargs):
+        """
+        Add tool to `ToolManager`
+
+        Add a tool to the tools controlled by ToolManager
+
+        If successful adds a new event `tool_trigger_name` where **name** is
+        the **name** of the tool, this event is fired everytime
+        the tool is triggered.
+
+        Parameters
+        ----------
+        name : str
+            Name of the tool, treated as the ID, has to be unique
+        tool : class_like, i.e. str or type
+            Reference to find the class of the Tool to added.
+
+        Notes
+        -----
+        args and kwargs get passed directly to the tools constructor.
+
+        See Also
+        --------
+        matplotlib.backend_tools.ToolBase : The base class for tools.
+        """
+
+        tool_cls = self._get_cls_to_instantiate(tool)
+        if not tool_cls:
+            raise ValueError('Impossible to find class for %s' % str(tool))
+
+        if name in self._tools:
+            warnings.warn('A "Tool class" with the same name already exists, '
+                          'not added')
+            return self._tools[name]
+
+        tool_obj = tool_cls(self, name, *args, **kwargs)
+        self._tools[name] = tool_obj
+
+        if tool_cls.default_keymap is not None:
+            self.update_keymap(name, tool_cls.default_keymap)
+
+        # For toggle tools init the radio_group in self._toggled
+        if isinstance(tool_obj, tools.ToolToggleBase):
+            # None group is not mutually exclusive, a set is used to keep track
+            # of all toggled tools in this group
+            if tool_obj.radio_group is None:
+                self._toggled.setdefault(None, set())
+            else:
+                self._toggled.setdefault(tool_obj.radio_group, None)
+
+        self._tool_added_event(tool_obj)
+        return tool_obj
+
+    def _tool_added_event(self, tool):
+        s = 'tool_added_event'
+        event = ToolEvent(s, self, tool)
+        self._callbacks.process(s, event)
+
+    def _handle_toggle(self, tool, sender, canvasevent, data):
+        """
+        Toggle tools, need to untoggle prior to using other Toggle tool
+        Called from trigger_tool
+
+        Parameters
+        ----------
+        tool: Tool object
+        sender: object
+            Object that wishes to trigger the tool
+        canvasevent : Event
+            Original Canvas event or None
+        data : Object
+            Extra data to pass to the tool when triggering
+        """
+
+        radio_group = tool.radio_group
+        # radio_group None is not mutually exclusive
+        # just keep track of toggled tools in this group
+        if radio_group is None:
+            if tool.toggled:
+                self._toggled[None].remove(tool.name)
+            else:
+                self._toggled[None].add(tool.name)
+            return
+
+        # If the tool already has a toggled state, untoggle it
+        if self._toggled[radio_group] == tool.name:
+            toggled = None
+        # If no tool was toggled in the radio_group
+        # toggle it
+        elif self._toggled[radio_group] is None:
+            toggled = tool.name
+        # Other tool in the radio_group is toggled
+        else:
+            # Untoggle previously toggled tool
+            self.trigger_tool(self._toggled[radio_group],
+                              self,
+                              canvasevent,
+                              data)
+            toggled = tool.name
+
+        # Keep track of the toggled tool in the radio_group
+        self._toggled[radio_group] = toggled
+#         for a in self.canvas.figure.get_axes():
+#             a.set_navigate_mode(self._toggled)
+
+    def _get_cls_to_instantiate(self, callback_class):
+        # Find the class that corresponds to the tool
+        if isinstance(callback_class, six.string_types):
+            # FIXME: make more complete searching structure
+            if callback_class in globals():
+                callback_class = globals()[callback_class]
+            else:
+                mod = 'backend_tools'
+                current_module = __import__(mod,
+                                            globals(), locals(), [mod], -1)
+
+                callback_class = getattr(current_module, callback_class, False)
+        if callable(callback_class):
+            return callback_class
+        else:
+            return None
+
+    def trigger_tool(self, name, sender=None, canvasevent=None,
+                     data=None):
+        """
+        Trigger a tool and emit the tool_trigger_[name] event
+
+        Parameters
+        ----------
+        name : string
+            Name of the tool
+        sender: object
+            Object that wishes to trigger the tool
+        canvasevent : Event
+            Original Canvas event or None
+        data : Object
+            Extra data to pass to the tool when triggering
+        """
+        tool = self.get_tool(name)
+        if tool is None:
+            return
+
+        if sender is None:
+            sender = self
+
+        self._trigger_tool(name, sender, canvasevent, data)
+
+        s = 'tool_trigger_%s' % name
+        event = ToolTriggerEvent(s, sender, tool, canvasevent, data)
+        self._callbacks.process(s, event)
+
+    def _trigger_tool(self, name, sender=None, canvasevent=None, data=None):
+        """
+        Trigger on a tool
+
+        Method to actually trigger the tool
+        """
+        tool = self.get_tool(name)
+
+        if isinstance(tool, tools.ToolToggleBase):
+            self._handle_toggle(tool, sender, canvasevent, data)
+
+        # Important!!!
+        # This is where the Tool object gets triggered
+        tool.trigger(sender, canvasevent, data)
+
+    def _key_press(self, event):
+        if event.key is None or self.keypresslock.locked():
+            return
+
+        name = self._keys.get(event.key, None)
+        if name is None:
+            return
+        self.trigger_tool(name, canvasevent=event)
+
+    @property
+    def tools(self):
+        """Return the tools controlled by `ToolManager`"""
+
+        return self._tools
+
+    def get_tool(self, name, warn=True):
+        """
+        Return the tool object, also accepts the actual tool for convenience
+
+        Parameters
+        -----------
+        name : str, ToolBase
+            Name of the tool, or the tool itself
+        warn : bool, optional
+            If this method should give warnings.
+        """
+        if isinstance(name, tools.ToolBase) and name.name in self._tools:
+            return name
+        if name not in self._tools:
+            if warn:
+                warnings.warn("ToolManager does not control tool %s" % name)
+            return None
+        return self._tools[name]

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -1,34 +1,18 @@
 """
-:class:`NavigationBase`
-    The base class for the Navigation class that makes the bridge between
-    user interaction (key press, toolbar clicks, ..) and the actions in
-    response to the user inputs.
-
-:class:`ToolContainerBase`
-     The base class for the Toolbar class of each interactive backend.
-
-:class:`StatusbarBase`
-    The base class for the messaging area.
+`ToolManager`
+    Class that makes the bridge between user interaction (key press,
+    toolbar clicks, ..) and the actions in response to the user inputs.
 """
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import warnings
-import sys
 
 import matplotlib.cbook as cbook
 import matplotlib.widgets as widgets
 from matplotlib.rcsetup import validate_stringlist
 import matplotlib.backend_tools as tools
-
-try:
-    from importlib import import_module
-except:
-    # simple python 2.6 implementation (no relative imports)
-    def import_module(name):
-        __import__(name)
-        return sys.modules[name]
 
 
 class ToolEvent(object):

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -294,8 +294,6 @@ class ToolManager(object):
 
         # Keep track of the toggled tool in the radio_group
         self._toggled[radio_group] = toggled
-#         for a in self.canvas.figure.get_axes():
-#             a.set_navigate_mode(self._toggled)
 
     def _get_cls_to_instantiate(self, callback_class):
         # Find the class that corresponds to the tool

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -56,9 +56,6 @@ class ToolBase(object):
     `name` is used as a label in the toolbar button
     """
 
-    intoolbar = True
-    """Add the tool to the toolbar"""
-
     cursor = None
     """Cursor to use when the tool is active"""
 
@@ -143,7 +140,6 @@ class ToolToggleBase(ToolBase):
 class ToolQuit(ToolBase):
     """Tool to call the figure manager destroy method"""
 
-    intoolbar = False
     description = 'Quit the figure'
     keymap = rcParams['keymap.quit']
 
@@ -154,7 +150,6 @@ class ToolQuit(ToolBase):
 class ToolEnableAllNavigation(ToolBase):
     """Tool to enable all axes for navigation interaction"""
 
-    intoolbar = False
     description = 'Enables all axes navigation'
     keymap = rcParams['keymap.all_axes']
 
@@ -171,7 +166,6 @@ class ToolEnableAllNavigation(ToolBase):
 class ToolEnableNavigation(ToolBase):
     """Tool to enable a specific axes for navigation interaction"""
 
-    intoolbar = False
     description = 'Enables one axes navigation'
     keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
 
@@ -191,7 +185,6 @@ class ToolEnableNavigation(ToolBase):
 class ToolToggleGrid(ToolBase):
     """Tool to toggle the grid of the figure"""
 
-    intoolbar = False
     description = 'Toogle Grid'
     keymap = rcParams['keymap.grid']
 
@@ -205,7 +198,6 @@ class ToolToggleGrid(ToolBase):
 class ToolToggleFullScreen(ToolBase):
     """Tool to toggle full screen"""
 
-    intoolbar = False
     description = 'Toogle Fullscreen mode'
     keymap = rcParams['keymap.fullscreen']
 
@@ -218,7 +210,6 @@ class ToolToggleYScale(ToolBase):
 
     description = 'Toogle Scale Y axis'
     keymap = rcParams['keymap.yscale']
-    intoolbar = False
 
     def trigger(self, event):
         ax = event.inaxes
@@ -239,7 +230,6 @@ class ToolToggleXScale(ToolBase):
 
     description = 'Toogle Scale X axis'
     keymap = rcParams['keymap.xscale']
-    intoolbar = False
 
     def trigger(self, event):
         ax = event.inaxes
@@ -720,20 +710,12 @@ class ToolPan(ZoomPanBase):
         self.navigation.canvas.draw_idle()
 
 
-tools = (('Grid', ToolToggleGrid),
-         ('Fullscreen', ToolToggleFullScreen),
-         ('Quit', ToolQuit),
-         ('EnableAll', ToolEnableAllNavigation),
-         ('EnableOne', ToolEnableNavigation),
-         ('XScale', ToolToggleXScale),
-         ('YScale', ToolToggleYScale),
-         ('Home', ToolHome),
-         ('Back', ToolBack),
-         ('Forward', ToolForward),
-         ('Spacer1', None),
-         ('Zoom', ToolZoom),
-         ('Pan', ToolPan),
-         ('Spacer2', None),
-         ('Subplots', 'ConfigureSubplots'),
-         ('Save', 'SaveFigure'))
+tools = {'navigation': [ToolHome, ToolBack, ToolForward],
+         'zoompan': [ToolZoom, ToolPan],
+         'layout': ['ConfigureSubplots', ],
+         'io': ['SaveFigure', ],
+         None: [ToolToggleGrid, ToolToggleFullScreen, ToolQuit,
+                ToolEnableAllNavigation, ToolEnableNavigation,
+                ToolToggleXScale, ToolToggleYScale]}
+
 """Default tools"""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -319,9 +319,7 @@ class ViewsPositionsMixin(object):
     @classmethod
     def clear(cls, figure):
         """Reset the axes stack"""
-        print('clear')
         if figure in cls.views:
-            print('done clear')
             cls.views[figure].clear()
             cls.positions[figure].clear()
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -182,7 +182,7 @@ class ToolEnableNavigation(ToolBase):
                     a.set_navigate(i == n)
 
 
-class ToolToggleGrid(ToolBase):
+class ToolGrid(ToolBase):
     """Tool to toggle the grid of the figure"""
 
     description = 'Toogle Grid'
@@ -195,7 +195,7 @@ class ToolToggleGrid(ToolBase):
         self.figure.canvas.draw()
 
 
-class ToolToggleFullScreen(ToolBase):
+class ToolFullScreen(ToolBase):
     """Tool to toggle full screen"""
 
     description = 'Toogle Fullscreen mode'
@@ -205,7 +205,7 @@ class ToolToggleFullScreen(ToolBase):
         self.figure.canvas.manager.full_screen_toggle()
 
 
-class ToolToggleYScale(ToolBase):
+class ToolYScale(ToolBase):
     """Tool to toggle between linear and logarithmic the Y axis"""
 
     description = 'Toogle Scale Y axis'
@@ -225,7 +225,7 @@ class ToolToggleYScale(ToolBase):
             ax.figure.canvas.draw()
 
 
-class ToolToggleXScale(ToolBase):
+class ToolXScale(ToolBase):
     """Tool to toggle between linear and logarithmic the X axis"""
 
     description = 'Toogle Scale X axis'
@@ -710,12 +710,42 @@ class ToolPan(ZoomPanBase):
         self.navigation.canvas.draw_idle()
 
 
-tools = {'navigation': [ToolHome, ToolBack, ToolForward],
-         'zoompan': [ToolZoom, ToolPan],
-         'layout': ['ConfigureSubplots', ],
-         'io': ['SaveFigure', ],
-         None: [ToolToggleGrid, ToolToggleFullScreen, ToolQuit,
-                ToolEnableAllNavigation, ToolEnableNavigation,
-                ToolToggleXScale, ToolToggleYScale]}
+# Not so nice, extra order need for groups
+# tools = {'home': {'cls': ToolHome, 'group': 'navigation', 'pos': 0},
+#          'back': {'cls': ToolBack, 'group': 'navigation', 'pos': 1},
+#          'forward': {'cls': ToolForward,  'group': 'navigation', 'pos': 2},
+#          'zoom': {'cls': ToolZoom, 'group': 'zoompan', 'pos': 0},
+#          'pan': {'cls': ToolPan, 'group': 'zoompan', 'pos': 1},
+#          'subplots': {'cls': 'ConfigureSubplots', 'group': 'layout'},
+#          'save': {'cls': 'SaveFigure', 'group': 'io'},
+#          'grid': {'cls': ToolGrid},
+#          'fullscreen': {'cls': ToolFullScreen},
+#          'quit': {'cls': ToolQuit},
+#          'allnavigation': {'cls': ToolEnableAllNavigation},
+#          'navigation': {'cls': ToolEnableNavigation},
+#          'xscale': {'cls': ToolXScale},
+#          'yscale': {'cls': ToolYScale}
+#          }
+
+# Horrible with implicit order
+tools = [['navigation', [(ToolHome, 'home'),
+                         (ToolBack, 'back'),
+                         (ToolForward, 'forward')]],
+
+         ['zoompan', [(ToolZoom, 'zoom'),
+                      (ToolPan, 'pan')]],
+
+         ['layout', [('ConfigureSubplots', 'subplots'), ]],
+
+         ['io', [('SaveFigure', 'save'), ]],
+
+         [None, [(ToolGrid, 'grid'),
+                 (ToolFullScreen, 'fullscreen'),
+                 (ToolQuit, 'quit'),
+                 (ToolEnableAllNavigation, 'allnav'),
+                 (ToolEnableNavigation, 'nav'),
+                 (ToolXScale, 'xscale'),
+                 (ToolYScale, 'yscale')]]]
+
 
 """Default tools"""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -97,9 +97,9 @@ class ToolBase(object):
     def __init__(self, figure, event=None):
         self.figure = figure
         self.navigation = figure.canvas.manager.navigation
-        self.activate(event)
+        self.trigger(event)
 
-    def activate(self, event):
+    def trigger(self, event):
         """Called when tool is used
 
         Parameters
@@ -118,7 +118,7 @@ class ToolPersistentBase(ToolBase):
 
     Notes
     -----
-    The difference with `ToolBase` is that `activate` method
+    The difference with `ToolBase` is that `trigger` method
     is not called automatically at initialization
     """
     persistent = True
@@ -126,7 +126,7 @@ class ToolPersistentBase(ToolBase):
     def __init__(self, figure, event=None):
         self.figure = figure
         self.navigation = figure.canvas.manager.navigation
-        #persistent tools don't call activate a at instantiation
+        #persistent tools don't call trigger a at instantiation
 
     def unregister(self, *args):
         """Unregister the tool from the instances of Navigation
@@ -196,7 +196,7 @@ class ToolQuit(ToolBase):
     description = 'Quit the figure'
     keymap = rcParams['keymap.quit']
 
-    def activate(self, event):
+    def trigger(self, event):
         Gcf.destroy_fig(self.figure)
 
 
@@ -207,7 +207,7 @@ class ToolEnableAllNavigation(ToolBase):
     description = 'Enables all axes navigation'
     keymap = rcParams['keymap.all_axes']
 
-    def activate(self, event):
+    def trigger(self, event):
         if event.inaxes is None:
             return
 
@@ -225,7 +225,7 @@ class ToolEnableNavigation(ToolBase):
     description = 'Enables one axes navigation'
     keymap = range(1, 10)
 
-    def activate(self, event):
+    def trigger(self, event):
         if event.inaxes is None:
             return
 
@@ -244,7 +244,7 @@ class ToolToggleGrid(ToolBase):
     description = 'Toogle Grid'
     keymap = rcParams['keymap.grid']
 
-    def activate(self, event):
+    def trigger(self, event):
         if event.inaxes is None:
             return
         event.inaxes.grid()
@@ -257,7 +257,7 @@ class ToolToggleFullScreen(ToolBase):
     description = 'Toogle Fullscreen mode'
     keymap = rcParams['keymap.fullscreen']
 
-    def activate(self, event):
+    def trigger(self, event):
         self.figure.canvas.manager.full_screen_toggle()
 
 
@@ -267,7 +267,7 @@ class ToolToggleYScale(ToolBase):
     description = 'Toogle Scale Y axis'
     keymap = rcParams['keymap.yscale']
 
-    def activate(self, event):
+    def trigger(self, event):
         ax = event.inaxes
         if ax is None:
             return
@@ -287,7 +287,7 @@ class ToolToggleXScale(ToolBase):
     description = 'Toogle Scale X axis'
     keymap = rcParams['keymap.xscale']
 
-    def activate(self, event):
+    def trigger(self, event):
         ax = event.inaxes
         if ax is None:
             return
@@ -309,7 +309,7 @@ class ToolHome(ToolBase):
     keymap = rcParams['keymap.home']
     position = -1
 
-    def activate(self, *args):
+    def trigger(self, *args):
         self.navigation.views.home()
         self.navigation.positions.home()
         self.navigation.update_view()
@@ -324,7 +324,7 @@ class ToolBack(ToolBase):
     keymap = rcParams['keymap.back']
     position = -1
 
-    def activate(self, *args):
+    def trigger(self, *args):
         self.navigation.views.back()
         self.navigation.positions.back()
 #        self.set_history_buttons()
@@ -339,7 +339,7 @@ class ToolForward(ToolBase):
     keymap = rcParams['keymap.forward']
     position = -1
 
-    def activate(self, *args):
+    def trigger(self, *args):
         self.navigation.views.forward()
         self.navigation.positions.forward()
 #        self.set_history_buttons()
@@ -378,7 +378,7 @@ class ToolZoom(ToolToggleBase):
         self._button_pressed = None
         self._xypress = None
 
-    def activate(self, event):
+    def trigger(self, event):
         self.navigation.canvaslock(self)
         self.navigation.presslock(self)
         self.navigation.releaselock(self)
@@ -607,7 +607,7 @@ class ToolPan(ToolToggleBase):
         self._button_pressed = None
         self._xypress = None
 
-    def activate(self, event):
+    def trigger(self, event):
         self.navigation.canvaslock(self)
         self.navigation.presslock(self)
         self.navigation.releaselock(self)

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -205,7 +205,7 @@ class ToolEnableNavigation(ToolBase):
     """
     name = 'EnableOne'
     description = 'Enables one axes navigation'
-    keymap = range(1, 10)
+    keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
 
     def trigger(self, event):
         if event.inaxes is None:

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -175,8 +175,8 @@ class ToolToggleBase(ToolPersistentBase):
         """Deactivate the toggle tool
 
         This method is called when the tool is deactivated (second click on the
-        toolbar button) or when another toogle tool from the same `navigation` is
-        activated
+        toolbar button) or when another toogle tool from the same `navigation`
+        is activated
         """
         pass
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -3,10 +3,10 @@ Abstract base classes define the primitives for Tools.
 These tools are used by `NavigationBase`
 
 :class:`ToolBase`
-    Simple tool that is instantiated every time it is used
+    Simple tool that gets instantiated every time it is used
 
 :class:`ToolPersistentBase`
-    Tool which instance is registered within `Navigation`
+    Tool whose instance gets registered within `Navigation`
 
 :class:`ToolToggleBase`
     PersistentTool that has two states, only one Toggle tool can be
@@ -37,7 +37,7 @@ class ToolBase(object):
     """
 
     keymap = None
-    """Keymap to associate this tool
+    """Keymap to associate with this tool
 
     **string**: List of comma separated keys that will be used to call this
     tool when the keypress event of *self.figure.canvas* is emited
@@ -47,14 +47,14 @@ class ToolBase(object):
     """Description of the Tool
 
     **string**: If the Tool is included in the Toolbar this text is used
-    as Tooltip
+    as a Tooltip
     """
 
     image = None
     """Filename of the image
 
     **string**: Filename of the image to use in the toolbar. If None, the
-    `name` is used as label in the toolbar button
+    `name` is used as a label in the toolbar button
     """
 
     intoolbar = True
@@ -70,12 +70,12 @@ class ToolBase(object):
         self.trigger(event)
 
     def trigger(self, event):
-        """Called when tool is used
+        """Called when this tool gets used
 
         Parameters
         ----------
         event : `Event`
-            Event that caused this tool to be called
+            The event that caused this tool to be called
         """
 
         pass

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -49,7 +49,6 @@ class ToolBase(object):
      * **integer** : Position within the Toolbar
      * **None** : Do not put in the Toolbar
      * **-1**: At the end of the Toolbar
-
     """
 
     description = None
@@ -73,8 +72,7 @@ class ToolBase(object):
     """
 
     cursor = None
-    """Cursor to use when the tool is active
-    """
+    """Cursor to use when the tool is active"""
 
     def __init__(self, figure, event=None):
         self.figure = None
@@ -90,6 +88,7 @@ class ToolBase(object):
         event : `Event`
             Event that caused this tool to be called
         """
+
         pass
 
     def set_figure(self, figure):
@@ -101,6 +100,7 @@ class ToolBase(object):
         ----------
         figure : `Figure`
         """
+
         self.figure = figure
         self.navigation = figure.canvas.manager.navigation
 
@@ -121,8 +121,8 @@ class ToolPersistentBase(ToolBase):
         self.figure = None
         self.navigation = None
         self.set_figure(figure)
-        #persistent tools don't call trigger a at instantiation
-        #it will be called by Navigation
+        # persistent tools don't call trigger a at instantiation
+        # it will be called by Navigation
 
     def unregister(self, *args):
         """Unregister the tool from the instances of Navigation
@@ -130,7 +130,8 @@ class ToolPersistentBase(ToolBase):
         If the reference in navigation was the last reference
         to the instance of the tool, it will be garbage collected
         """
-        #call this to unregister from navigation
+
+        # call this to unregister from navigation
         self.navigation.unregister(self.name)
 
 
@@ -139,8 +140,8 @@ class ToolToggleBase(ToolPersistentBase):
 
     This tool is a Persistent Tool that has a toggled state.
     Every time it is triggered, it switches between enable and disable
-
     """
+
     _toggled = False
 
     def trigger(self, event):
@@ -155,6 +156,7 @@ class ToolToggleBase(ToolPersistentBase):
 
         This method is called when the tool is triggered and not toggled
         """
+
         pass
 
     def disable(self, event=None):
@@ -164,17 +166,19 @@ class ToolToggleBase(ToolPersistentBase):
          * Second click on the toolbar tool button
          * Another toogle tool is triggered (from the same `navigation`)
         """
+
         pass
 
     @property
     def toggled(self):
         """State of the toggled tool"""
+
         return self._toggled
 
 
 class ToolQuit(ToolBase):
-    """Tool to call the figure manager destroy method
-    """
+    """Tool to call the figure manager destroy method"""
+
     name = 'Quit'
     description = 'Quit the figure'
     keymap = rcParams['keymap.quit']
@@ -184,8 +188,8 @@ class ToolQuit(ToolBase):
 
 
 class ToolEnableAllNavigation(ToolBase):
-    """Tool to enable all axes for navigation interaction
-    """
+    """Tool to enable all axes for navigation interaction"""
+
     name = 'EnableAll'
     description = 'Enables all axes navigation'
     keymap = rcParams['keymap.all_axes']
@@ -201,8 +205,8 @@ class ToolEnableAllNavigation(ToolBase):
 
 
 class ToolEnableNavigation(ToolBase):
-    """Tool to enable a specific axes for navigation interaction
-    """
+    """Tool to enable a specific axes for navigation interaction"""
+
     name = 'EnableOne'
     description = 'Enables one axes navigation'
     keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
@@ -222,6 +226,7 @@ class ToolEnableNavigation(ToolBase):
 
 class ToolToggleGrid(ToolBase):
     """Tool to toggle the grid of the figure"""
+
     name = 'Grid'
     description = 'Toogle Grid'
     keymap = rcParams['keymap.grid']
@@ -235,6 +240,7 @@ class ToolToggleGrid(ToolBase):
 
 class ToolToggleFullScreen(ToolBase):
     """Tool to toggle full screen"""
+
     name = 'Fullscreen'
     description = 'Toogle Fullscreen mode'
     keymap = rcParams['keymap.fullscreen']
@@ -245,6 +251,7 @@ class ToolToggleFullScreen(ToolBase):
 
 class ToolToggleYScale(ToolBase):
     """Tool to toggle between linear and logarithmic the Y axis"""
+
     name = 'YScale'
     description = 'Toogle Scale Y axis'
     keymap = rcParams['keymap.yscale']
@@ -265,6 +272,7 @@ class ToolToggleYScale(ToolBase):
 
 class ToolToggleXScale(ToolBase):
     """Tool to toggle between linear and logarithmic the X axis"""
+
     name = 'XScale'
     description = 'Toogle Scale X axis'
     keymap = rcParams['keymap.xscale']
@@ -285,6 +293,7 @@ class ToolToggleXScale(ToolBase):
 
 class ToolHome(ToolBase):
     """Restore the original view"""
+
     description = 'Reset original view'
     name = 'Home'
     image = 'home'
@@ -300,6 +309,7 @@ class ToolHome(ToolBase):
 
 class ToolBack(ToolBase):
     """move back up the view lim stack"""
+
     description = 'Back to  previous view'
     name = 'Back'
     image = 'back'
@@ -315,6 +325,7 @@ class ToolBack(ToolBase):
 
 class ToolForward(ToolBase):
     """Move forward in the view lim stack"""
+
     description = 'Forward to next view'
     name = 'Forward'
     image = 'forward'
@@ -330,6 +341,7 @@ class ToolForward(ToolBase):
 
 class ConfigureSubplotsBase(ToolPersistentBase):
     """Base tool for the configuration of subplots"""
+
     description = 'Configure subplots'
     name = 'Subplots'
     image = 'subplots'
@@ -338,6 +350,7 @@ class ConfigureSubplotsBase(ToolPersistentBase):
 
 class SaveFigureBase(ToolBase):
     """Base tool for figure saving"""
+
     description = 'Save the figure'
     name = 'Save'
     image = 'filesave'
@@ -347,6 +360,7 @@ class SaveFigureBase(ToolBase):
 
 class ToolZoom(ToolToggleBase):
     """Zoom to rectangle"""
+
     description = 'Zoom to rectangle'
     name = 'Zoom'
     image = 'zoom_to_rect'
@@ -387,6 +401,7 @@ class ToolZoom(ToolToggleBase):
 
     def _press(self, event):
         """the _press mouse button in zoom to rect mode callback"""
+
         # If we're already in the middle of a zoom, pressing another
         # button works to "cancel"
         if self._ids_zoom != []:
@@ -434,6 +449,7 @@ class ToolZoom(ToolToggleBase):
 
     def _mouse_move(self, event):
         """the drag callback in zoom mode"""
+
         if self._xypress:
             x, y = event.x, event.y
             lastx, lasty, a, _ind, _lim, _trans = self._xypress[0]
@@ -454,6 +470,7 @@ class ToolZoom(ToolToggleBase):
 
     def _release(self, event):
         """the release mouse button callback in zoom to rect mode"""
+
         for zoom_id in self._ids_zoom:
             self.figure.canvas.mpl_disconnect(zoom_id)
         self._ids_zoom = []
@@ -576,6 +593,7 @@ class ToolZoom(ToolToggleBase):
 
 class ToolPan(ToolToggleBase):
     """Pan axes with left mouse, zoom with right"""
+
     keymap = rcParams['keymap.pan']
     name = 'Pan'
     description = 'Pan axes with left mouse, zoom with right'
@@ -623,7 +641,7 @@ class ToolPan(ToolToggleBase):
         x, y = event.x, event.y
 
         # push the current view to define home if stack is empty
-        #TODO: add define_home in navigation
+        # TODO: add define_home in navigation
         if self.navigation.views.empty():
             self.navigation.push_current()
 
@@ -656,7 +674,7 @@ class ToolPan(ToolToggleBase):
 
     def _mouse_move(self, event):
         for a, _ind in self._xypress:
-            #safer to use the recorded button at the _press than current
-            #button: #multiple button can get pressed during motion...
+            # safer to use the recorded button at the _press than current
+            # button: # multiple button can get pressed during motion...
             a.drag_pan(self._button_pressed, event.key, event.x, event.y)
         self.navigation.dynamic_update()

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -146,6 +146,7 @@ class ToolToggleBase(ToolPersistentBase):
     to use the same events at the same time
     """
     toggle = True
+    _toggled = False
 
     def mouse_move(self, event):
         """Mouse move event
@@ -171,12 +172,26 @@ class ToolToggleBase(ToolPersistentBase):
         """
         pass
 
-    def deactivate(self, event=None):
-        """Deactivate the toggle tool
+    def trigger(self, event):
+        if self._toggled:
+            self.disable(event)
+        else:
+            self.enable(event)
+        self._toggled = not self._toggled
 
-        This method is called when the tool is deactivated (second click on the
-        toolbar button) or when another toogle tool from the same `navigation`
-        is activated
+    def enable(self, event=None):
+        """Enable the toggle tool
+
+        This method is called when the tool is triggered and not active
+        """
+        pass
+
+    def disable(self, event=None):
+        """Disable the toggle tool
+
+        This method is called when the tool is triggered and active.
+         * Second click on the toolbar button
+         * Another toogle tool is triggered (from the same `navigation`)
         """
         pass
 
@@ -217,7 +232,6 @@ class ToolEnableAllNavigation(ToolBase):
                 a.set_navigate(True)
 
 
-#FIXME: use a function instead of string for enable navigation
 class ToolEnableNavigation(ToolBase):
     """Tool to enable a specific axes for navigation interaction
     """
@@ -378,12 +392,12 @@ class ToolZoom(ToolToggleBase):
         self._button_pressed = None
         self._xypress = None
 
-    def trigger(self, event):
+    def enable(self, event):
         self.navigation.canvaslock(self)
         self.navigation.presslock(self)
         self.navigation.releaselock(self)
 
-    def deactivate(self, event):
+    def disable(self, event):
         self.navigation.canvaslock.release(self)
         self.navigation.presslock.release(self)
         self.navigation.releaselock.release(self)
@@ -607,12 +621,12 @@ class ToolPan(ToolToggleBase):
         self._button_pressed = None
         self._xypress = None
 
-    def trigger(self, event):
+    def enable(self, event):
         self.navigation.canvaslock(self)
         self.navigation.presslock(self)
         self.navigation.releaselock(self)
 
-    def deactivate(self, event):
+    def disable(self, event):
         self.navigation.canvaslock.release(self)
         self.navigation.presslock.release(self)
         self.navigation.releaselock.release(self)

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -97,9 +97,9 @@ class ToolBase(object):
 
 
 class ToolPersistentBase(ToolBase):
-    """Persisten tool
+    """Persistent tool
 
-    Persistent Tools are keept alive after their initialization,
+    Persistent Tools are kept alive after their initialization,
     a reference of the instance is kept by `navigation`.
 
     Notes
@@ -287,20 +287,41 @@ class ToolToggleXScale(ToolBase):
 
 
 class ViewsPositionsMixin(object):
+    """Mixin to handle changes in views and positions
+
+    Tools that change the views and positions, use this mixin to
+    keep track of the changes.
+    """
+
     views = WeakKeyDictionary()
+    """Record of views with Figure objects as keys"""
+
     positions = WeakKeyDictionary()
+    """Record of positions with Figure objects as keys"""
 
     def init_vp(self):
+        """Add a figure to the list of figures handled by this mixin
+
+        To handle the views and positions for a given figure, this method
+        has to be called at least once before any other method.
+
+        The best way to call it is during the set_figure method of the tools
+        """
         if self.figure not in self.views:
             self.views[self.figure] = cbook.Stack()
             self.positions[self.figure] = cbook.Stack()
             # Define Home
             self.push_current()
+            # Adding the clear method as axobserver, removes this burden from
+            # the backend
+            self.figure.add_axobserver(self.clear)
 
     @classmethod
     def clear(cls, figure):
         """Reset the axes stack"""
+        print('clear')
         if figure in cls.views:
+            print('done clear')
             cls.views[figure].clear()
             cls.positions[figure].clear()
 
@@ -375,12 +396,9 @@ class ViewsPositionsMixin(object):
         self.positions[self.figure].forward()
 
 
-def clear_views_positions(figure):
-    ViewsPositionsMixin.clear(figure)
-
-
 class ViewsPositionsBase(ViewsPositionsMixin, ToolBase):
     # Simple base to avoid repeating code on Home, Back and Forward
+    # Not of much use for other tools, so not documented
     _on_trigger = None
 
     def set_figure(self, *args):
@@ -435,6 +453,8 @@ class SaveFigureBase(ToolBase):
 
 
 class ZoomPanBase(ViewsPositionsMixin, ToolToggleBase):
+    # Base class to group common functionality between zoom and pan
+    # Not of much use for other tools, so not documented
     def __init__(self, *args):
         ToolToggleBase.__init__(self, *args)
         self.init_vp()

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -92,19 +92,6 @@ class ToolBase(object):
         self.figure = figure
         self.navigation = figure.canvas.manager.navigation
 
-    def unregister(self, *args):
-        """Unregister the tool from the instances of Navigation
-
-        It is usually called by during destroy if it is a
-        graphical Tool.
-
-        If the reference in navigation was the last reference
-        to the instance of the tool, it will be garbage collected
-        """
-
-        # call this to unregister from navigation
-        self.navigation.unregister(self._name)
-
     @property
     def name(self):
         return self._name

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -677,4 +677,4 @@ class ToolPan(ToolToggleBase):
             # safer to use the recorded button at the _press than current
             # button: # multiple button can get pressed during motion...
             a.drag_pan(self._button_pressed, event.key, event.x, event.y)
-        self.navigation.dynamic_update()
+        self.navigation.canvas.draw_idle()

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -296,7 +296,7 @@ class ToolHome(ToolBase):
 
     description = 'Reset original view'
     name = 'Home'
-    image = 'home'
+    image = 'home.png'
     keymap = rcParams['keymap.home']
     position = -1
 
@@ -312,7 +312,7 @@ class ToolBack(ToolBase):
 
     description = 'Back to  previous view'
     name = 'Back'
-    image = 'back'
+    image = 'back.png'
     keymap = rcParams['keymap.back']
     position = -1
 
@@ -328,7 +328,7 @@ class ToolForward(ToolBase):
 
     description = 'Forward to next view'
     name = 'Forward'
-    image = 'forward'
+    image = 'forward.png'
     keymap = rcParams['keymap.forward']
     position = -1
 
@@ -344,7 +344,7 @@ class ConfigureSubplotsBase(ToolPersistentBase):
 
     description = 'Configure subplots'
     name = 'Subplots'
-    image = 'subplots'
+    image = 'subplots.png'
     position = -1
 
 
@@ -353,7 +353,7 @@ class SaveFigureBase(ToolBase):
 
     description = 'Save the figure'
     name = 'Save'
-    image = 'filesave'
+    image = 'filesave.png'
     position = -1
     keymap = rcParams['keymap.save']
 
@@ -363,7 +363,7 @@ class ToolZoom(ToolToggleBase):
 
     description = 'Zoom to rectangle'
     name = 'Zoom'
-    image = 'zoom_to_rect'
+    image = 'zoom_to_rect.png'
     position = -1
     keymap = rcParams['keymap.zoom']
     cursor = cursors.SELECT_REGION
@@ -597,7 +597,7 @@ class ToolPan(ToolToggleBase):
     keymap = rcParams['keymap.pan']
     name = 'Pan'
     description = 'Pan axes with left mouse, zoom with right'
-    image = 'move'
+    image = 'move.png'
     position = -1
     cursor = cursors.MOVE
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -72,31 +72,14 @@ class ToolBase(object):
     `name` is used as label in the toolbar button
     """
 
-    toggle = False  # Change the status (take control of the events)
-    """Is toggleable tool
-
-    **bool**:
-
-     * **True**: The tool is a toogleable tool
-     * **False**: The tool is not toggleable
-
-    """
-
-    persistent = False
-    """Is persistent tool
-
-    **bool**:
-     * `True`: The tool is persistent
-     * `False`: The tool is not persistent
-    """
-
     cursor = None
     """Cursor to use when the tool is active
     """
 
     def __init__(self, figure, event=None):
-        self.figure = figure
-        self.navigation = figure.canvas.manager.navigation
+        self.figure = None
+        self.navigation = None
+        self.set_figure(figure)
         self.trigger(event)
 
     def trigger(self, event):
@@ -108,6 +91,18 @@ class ToolBase(object):
             Event that caused this tool to be called
         """
         pass
+
+    def set_figure(self, figure):
+        """Set the figure and navigation
+
+        Set the figure to be affected by this tool
+
+        Parameters
+        ----------
+        figure : `Figure`
+        """
+        self.figure = figure
+        self.navigation = figure.canvas.manager.navigation
 
 
 class ToolPersistentBase(ToolBase):
@@ -121,12 +116,13 @@ class ToolPersistentBase(ToolBase):
     The difference with `ToolBase` is that `trigger` method
     is not called automatically at initialization
     """
-    persistent = True
 
     def __init__(self, figure, event=None):
-        self.figure = figure
-        self.navigation = figure.canvas.manager.navigation
+        self.figure = None
+        self.navigation = None
+        self.set_figure(figure)
         #persistent tools don't call trigger a at instantiation
+        #it will be called by Navigation
 
     def unregister(self, *args):
         """Unregister the tool from the instances of Navigation
@@ -145,7 +141,6 @@ class ToolToggleBase(ToolPersistentBase):
     Every time it is triggered, it switches between enable and disable
 
     """
-    toggle = True
     _toggled = False
 
     def trigger(self, event):

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -65,6 +65,9 @@ class ToolBase(object):
     def __init__(self, navigation, name):
         self._name = name
         self.figure = None
+        self.set_navigation(navigation)
+
+    def set_navigation(self, navigation):
         self.navigation = navigation
         self.set_figure(navigation.canvas.figure)
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -903,26 +903,23 @@ class ToolPan(ZoomPanBase):
         self.navigation.canvas.draw_idle()
 
 
-tools = [['navigation', [(ToolHome, 'home'),
-                         (ToolBack, 'back'),
-                         (ToolForward, 'forward')]],
-
-         ['zoompan', [(ToolZoom, 'zoom'),
-                      (ToolPan, 'pan')]],
-
-         ['layout', [('ToolConfigureSubplots', 'subplots'), ]],
-
-         ['io', [('ToolSaveFigure', 'save'), ]],
-
-         [None, [(ToolGrid, 'grid'),
-                 (ToolFullScreen, 'fullscreen'),
-                 (ToolQuit, 'quit'),
-                 (ToolEnableAllNavigation, 'allnav'),
-                 (ToolEnableNavigation, 'nav'),
-                 (ToolXScale, 'xscale'),
-                 (ToolYScale, 'yscale'),
-                 (ToolCursorPosition, 'position'),
-                 (ToolViewsPositions, 'viewpos'),
-                 ('ToolSetCursor', 'cursor'),
-                 ('ToolRubberband', 'rubberband')]]]
+tools = [(ToolHome, 'home'), (ToolBack, 'back'), (ToolForward, 'forward'),
+         (ToolZoom, 'zoom'), (ToolPan, 'pan'),
+         ('ToolConfigureSubplots', 'subplots'),
+         ('ToolSaveFigure', 'save'),
+         (ToolGrid, 'grid'),
+         (ToolFullScreen, 'fullscreen'),
+         (ToolQuit, 'quit'),
+         (ToolEnableAllNavigation, 'allnav'),
+         (ToolEnableNavigation, 'nav'),
+         (ToolXScale, 'xscale'),
+         (ToolYScale, 'yscale'),
+         (ToolCursorPosition, 'position'),
+         (ToolViewsPositions, 'viewpos'),
+         ('ToolSetCursor', 'cursor'),
+         ('ToolRubberband', 'rubberband')]
+toolbar_tools = [['navigation', ['home', 'back', 'forward']],
+                  ['zoompan', ['zoom', 'pan']],
+                  ['layout', ['subplots']],
+                  ['io', ['save']]]
 """Default tools"""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -65,9 +65,6 @@ class ToolBase(object):
     def __init__(self, navigation, name):
         self._name = name
         self.figure = None
-        self.set_navigation(navigation)
-
-    def set_navigation(self, navigation):
         self.navigation = navigation
         self.set_figure(navigation.canvas.figure)
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -921,7 +921,7 @@ tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
 """Default tools"""
 
 toolbar_tools = [['navigation', ['home', 'back', 'forward']],
-                  ['zoompan', ['zoom', 'pan']],
-                  ['layout', ['subplots']],
-                  ['io', ['save']]]
+                 ['zoompan', ['zoom', 'pan']],
+                 ['layout', ['subplots']],
+                 ['io', ['save']]]
 """Default tools in the toolbar"""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -344,11 +344,11 @@ class ToolGrid(ToolToggleBase):
 
     def enable(self, event):
         event.inaxes.grid(True)
-        self.figure.canvas.draw()
+        self.figure.canvas.draw_idle()
 
     def disable(self, event):
         event.inaxes.grid(False)
-        self.figure.canvas.draw()
+        self.figure.canvas.draw_idle()
 
 
 class ToolFullScreen(ToolToggleBase):
@@ -374,11 +374,11 @@ class AxisScaleBase(ToolToggleBase):
 
     def enable(self, event):
         self.set_scale(event.inaxes, 'log')
-        self.figure.canvas.draw()
+        self.figure.canvas.draw_idle()
 
     def disable(self, event):
         self.set_scale(event.inaxes, 'linear')
-        self.figure.canvas.draw()
+        self.figure.canvas.draw_idle()
 
 
 class ToolYScale(AxisScaleBase):
@@ -622,7 +622,7 @@ class ZoomPanBase(ToolToggleBase):
                      xdata + cur_xrange*scale_factor])
         ax.set_ylim([ydata - cur_yrange*scale_factor,
                      ydata + cur_yrange*scale_factor])
-        self.figure.canvas.draw()  # force re-draw
+        self.figure.canvas.draw_idle()  # force re-draw
 
 
 class ToolZoom(ZoomPanBase):

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -244,7 +244,7 @@ class ToolCursorPosition(ToolBase):
             'motion_notify_event', self.send_message)
 
     def send_message(self, event):
-        """Call `matplotlib.backend_bases.NavigationBase.message_event"""
+        """Call `matplotlib.backend_bases.NavigationBase.message_event`"""
         if self.navigation.messagelock.locked():
             return
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -954,7 +954,7 @@ default_toolbar_tools = [['navigation', ['home', 'back', 'forward']],
 """Default tools in the toolbar"""
 
 
-def add_tools_2_toolmanager(toolmanager, tools=default_tools):
+def add_tools_to_manager(toolmanager, tools=default_tools):
     """
     Add multiple tools to `ToolManager`
 
@@ -971,7 +971,7 @@ def add_tools_2_toolmanager(toolmanager, tools=default_tools):
         toolmanager.add_tool(name, tool)
 
 
-def add_tools_2_container(container, tools=default_toolbar_tools):
+def add_tools_to_container(container, tools=default_toolbar_tools):
     """
     Add multiple tools to the container.
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -926,31 +926,31 @@ class ToolPan(ZoomPanBase):
         self.navigation.canvas.draw_idle()
 
 
-tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
-         'zoom': ToolZoom, 'pan': ToolPan,
-         'subplots': 'ToolConfigureSubplots',
-         'save': 'ToolSaveFigure',
-         'grid': ToolGrid,
-         'fullscreen': ToolFullScreen,
-         'quit': ToolQuit,
-         'allnav': ToolEnableAllNavigation,
-         'nav': ToolEnableNavigation,
-         'xscale': ToolXScale,
-         'yscale': ToolYScale,
-         'position': ToolCursorPosition,
-         _views_positions: ToolViewsPositions,
-         'cursor': 'ToolSetCursor',
-         'rubberband': 'ToolRubberband'}
+default_tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
+                 'zoom': ToolZoom, 'pan': ToolPan,
+                 'subplots': 'ToolConfigureSubplots',
+                 'save': 'ToolSaveFigure',
+                 'grid': ToolGrid,
+                 'fullscreen': ToolFullScreen,
+                 'quit': ToolQuit,
+                 'allnav': ToolEnableAllNavigation,
+                 'nav': ToolEnableNavigation,
+                 'xscale': ToolXScale,
+                 'yscale': ToolYScale,
+                 'position': ToolCursorPosition,
+                 _views_positions: ToolViewsPositions,
+                 'cursor': 'ToolSetCursor',
+                 'rubberband': 'ToolRubberband'}
 """Default tools"""
 
-toolbar_tools = [['navigation', ['home', 'back', 'forward']],
-                 ['zoompan', ['zoom', 'pan']],
-                 ['layout', ['subplots']],
-                 ['io', ['save']]]
+default_toolbar_tools = [['navigation', ['home', 'back', 'forward']],
+                         ['zoompan', ['zoom', 'pan']],
+                         ['layout', ['subplots']],
+                         ['io', ['save']]]
 """Default tools in the toolbar"""
 
 
-def add_tools_2_navigation(navigation, tools=tools):
+def add_tools_2_navigation(navigation, tools=default_tools):
     """
     Add multiple tools to `Navigation`
 
@@ -965,7 +965,7 @@ def add_tools_2_navigation(navigation, tools=tools):
         navigation.add_tool(name, tool)
 
 
-def add_tools_2_container(container, tools=toolbar_tools):
+def add_tools_2_container(container, tools=default_toolbar_tools):
     """
     Add multiple tools to the container.
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -16,6 +16,7 @@ from matplotlib._pylab_helpers import Gcf
 import matplotlib.cbook as cbook
 from weakref import WeakKeyDictionary
 import numpy as np
+import six
 
 
 class Cursors(object):
@@ -946,3 +947,36 @@ toolbar_tools = [['navigation', ['home', 'back', 'forward']],
                  ['layout', ['subplots']],
                  ['io', ['save']]]
 """Default tools in the toolbar"""
+
+
+def add_tools_2_navigation(navigation, tools=tools):
+    """
+    Add multiple tools to `Navigation`
+
+    Parameters
+    ----------
+    tools : {str: class_like}
+        The tools to add in a {name: tool} dict, see `add_tool` for more
+        info.
+    """
+
+    for name, tool in six.iteritems(tools):
+        navigation.add_tool(name, tool)
+
+
+def add_tools_2_container(container, tools=toolbar_tools):
+    """
+    Add multiple tools to the container.
+
+    Parameters
+    ----------
+    tools : list
+        List in the form
+        [[group1, [tool1, tool2 ...]], [group2, [...]]]
+        Where the tools given by tool1, and tool2 will display in group1.
+        See `add_tool` for details.
+    """
+
+    for group, grouptools in tools:
+        for position, tool in enumerate(grouptools):
+            container.add_tool(tool, group, position)

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -956,7 +956,9 @@ def add_tools_2_navigation(navigation, tools=default_tools):
 
     Parameters
     ----------
-    tools : {str: class_like}
+    navigation: Navigation
+        `backend_bases.NavigationBase` object that will get the tools added
+    tools : {str: class_like}, optional
         The tools to add in a {name: tool} dict, see `add_tool` for more
         info.
     """
@@ -971,7 +973,9 @@ def add_tools_2_container(container, tools=default_toolbar_tools):
 
     Parameters
     ----------
-    tools : list
+    container: Container
+        `backend_bases.ToolContainerBase` object that will get the tools added
+    tools : list, optional
         List in the form
         [[group1, [tool1, tool2 ...]], [group2, [...]]]
         Where the tools given by tool1, and tool2 will display in group1.

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -84,7 +84,7 @@ class ToolBase(object):
         Called when this tool gets used
 
         This method is called by
-        `matplotlib.backend_bases.NavigationBase.tool_trigger_event`
+        `matplotlib.backend_bases.NavigationBase.trigger_tool`
 
         Parameters
         ----------
@@ -173,7 +173,7 @@ class ToolToggleBase(ToolBase):
         This can happen in different circumstances
 
         * Click on the toolbar tool button
-        * Call to `matplotlib.backend_bases.NavigationBase.tool_trigger_event`
+        * Call to `matplotlib.backend_bases.NavigationBase.trigger_tool`
         * Another `ToolToggleBase` derived tool is triggered
           (from the same `Navigation`)
         """
@@ -662,7 +662,7 @@ class ToolZoom(ZoomPanBase):
     def _cancel_action(self):
         for zoom_id in self._ids_zoom:
             self.figure.canvas.mpl_disconnect(zoom_id)
-        self.navigation.tool_trigger_event('rubberband', self)
+        self.navigation.trigger_tool('rubberband', self)
         self.navigation.get_tool(_views_positions).refresh_locators()
         self._xypress = None
         self._button_pressed = None
@@ -731,9 +731,9 @@ class ToolZoom(ZoomPanBase):
                 x1, y1, x2, y2 = a.bbox.extents
                 x, lastx = x1, x2
 
-            self.navigation.tool_trigger_event('rubberband',
-                                               self,
-                                               data=(x, y, lastx, lasty))
+            self.navigation.trigger_tool('rubberband',
+                                         self,
+                                         data=(x, y, lastx, lasty))
 
     def _release(self, event):
         """the release mouse button callback in zoom to rect mode"""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -196,7 +196,7 @@ class SetCursorBase(ToolBase):
     # If the tool is toggleable, set the cursor when the tool is triggered
     def _add_tool(self, tool):
         if getattr(tool, 'cursor', None) is not None:
-            self.navigation.mpl_connect('tool-trigger-%s' % tool.name,
+            self.navigation.mpl_connect('tool_trigger_%s' % tool.name,
                                         self._tool_trigger_cbk)
 
     # If tool is added, process it

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -1,13 +1,14 @@
 """
 Abstract base classes define the primitives for Tools.
-These tools are used by `ToolManager`
+These tools are used by `matplotlib.backend_managers.ToolManager`
 
 :class:`ToolBase`
     Simple stateless tool
 
 :class:`ToolToggleBase`
     Tool that has two states, only one Toggle tool can be
-    active at any given time for the same `ToolManager`
+    active at any given time for the same
+    `matplotlib.backend_managers.ToolManager`
 """
 
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -143,7 +143,7 @@ class ToolToggleBase(ToolBase):
     def enable(self, event=None):
         """Enable the toggle tool
 
-        This method is called dby `trigger` when the `toggled` is False
+        `trigger` calls this method when `toggled` is False
         """
 
         pass
@@ -151,7 +151,7 @@ class ToolToggleBase(ToolBase):
     def disable(self, event=None):
         """Disable the toggle tool
 
-        This method is called by `trigger` when the `toggled` is True.
+        `trigger` call this methond when `toggled` is True.
 
         This can happen in different circumstances
 
@@ -174,7 +174,7 @@ class SetCursorBase(ToolBase):
     """Change to the current cursor while inaxes
 
     This tool, keeps track of all `ToolToggleBase` derived tools, and calls
-    set_cursor when one of these tools is triggered
+    set_cursor when a tool gets triggered
     """
     def __init__(self, *args, **kwargs):
         ToolBase.__init__(self, *args, **kwargs)
@@ -251,7 +251,6 @@ class ToolCursorPosition(ToolBase):
         message = ' '
 
         if event.inaxes and event.inaxes.get_navigate():
-
             try:
                 s = event.inaxes.format_coord(event.xdata, event.ydata)
             except (ValueError, OverflowError):
@@ -275,14 +274,14 @@ class RubberbandBase(ToolBase):
     def draw_rubberband(self, *data):
         """Draw rubberband
 
-        This method has to be implemented per backend
+        This method must get implemented per backend
         """
         pass
 
     def remove_rubberband(self):
         """Remove rubberband
 
-        This method has to be implemented per backend
+        This method must get implemented per backend
         """
         pass
 
@@ -383,7 +382,7 @@ class AxisScaleBase(ToolToggleBase):
 
 
 class ToolYScale(AxisScaleBase):
-    """Tool to toggle between linear and logarithmic the Y axis"""
+    """Tool to toggle between linear and logarithmic scales on the Y axis"""
 
     description = 'Toogle Scale Y axis'
     keymap = rcParams['keymap.yscale']
@@ -393,7 +392,7 @@ class ToolYScale(AxisScaleBase):
 
 
 class ToolXScale(AxisScaleBase):
-    """Tool to toggle between linear and logarithmic the X axis"""
+    """Tool to toggle between linear and logarithmic scales on the X axis"""
 
     description = 'Toogle Scale X axis'
     keymap = rcParams['keymap.xscale']
@@ -405,8 +404,8 @@ class ToolXScale(AxisScaleBase):
 class ToolViewsPositions(ToolBase):
     """Auxiliary Tool to handle changes in views and positions
 
-    Runs in the background and is used by all the tools that
-    need to access the record of views and positions of the figure
+    Runs in the background and should get used by all the tools that
+    need to access the figure's history of views and positions, e.g.
 
     * `ToolZoom`
     * `ToolPan`

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -183,7 +183,7 @@ class SetCursorBase(ToolBase):
         self._cursor = None
         self._default_cursor = cursors.POINTER
         self._last_cursor = self._default_cursor
-        self.navigation.mpl_connect('tool_added_event', self._add_tool_cbk)
+        self.navigation.nav_connect('tool_added_event', self._add_tool_cbk)
 
         # process current tools
         for tool in self.navigation.tools.values():
@@ -200,7 +200,7 @@ class SetCursorBase(ToolBase):
     # If the tool is toggleable, set the cursor when the tool is triggered
     def _add_tool(self, tool):
         if getattr(tool, 'cursor', None) is not None:
-            self.navigation.mpl_connect('tool_trigger_%s' % tool.name,
+            self.navigation.nav_connect('tool_trigger_%s' % tool.name,
                                         self._tool_trigger_cbk)
 
     # If tool is added, process it

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -18,7 +18,7 @@ from weakref import WeakKeyDictionary
 import numpy as np
 
 
-class Cursors:
+class Cursors(object):
     """Simple namespace for cursor reference"""
     HAND, POINTER, SELECT_REGION, MOVE = list(range(4))
 cursors = Cursors()
@@ -118,6 +118,9 @@ class ToolToggleBase(ToolBase):
     Every time it is triggered, it switches between enable and disable
     """
 
+    radio_group = None
+    """Attribute to group 'radio' like tools"""
+
     cursor = None
     """Cursor to use when the tool is active"""
 
@@ -192,7 +195,7 @@ class SetCursorBase(ToolBase):
 
     # If the tool is toggleable, set the cursor when the tool is triggered
     def _add_tool(self, tool):
-        if getattr(tool, 'toggled', None) is not None:
+        if getattr(tool, 'cursor', None) is not None:
             self.navigation.mpl_connect('tool-trigger-%s' % tool.name,
                                         self._tool_trigger_cbk)
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -141,36 +141,12 @@ class ToolPersistentBase(ToolBase):
 class ToolToggleBase(ToolPersistentBase):
     """Toggleable tool
 
-    This tool is a Persistent Tool, that has the ability to capture
-    the keypress, press and release events, preventing other tools
-    to use the same events at the same time
+    This tool is a Persistent Tool that has a toggled state.
+    Every time it is triggered, it switches between enable and disable
+
     """
     toggle = True
     _toggled = False
-
-    def mouse_move(self, event):
-        """Mouse move event
-
-        Called when a motion_notify_event is emited by the `FigureCanvas` if
-        `navigation.movelock(self)` was setted
-        """
-        pass
-
-    def press(self, event):
-        """Mouse press event
-
-        Called when a button_press_event is emited by the `FigureCanvas` if
-        `navigation.presslock(self)` was setted
-        """
-        pass
-
-    def release(self, event):
-        """Mouse release event
-
-        Called when a button_release_event is emited by the `FigureCanvas` if
-        `navigation.releaselock(self)` was setted
-        """
-        pass
 
     def trigger(self, event):
         if self._toggled:
@@ -182,26 +158,23 @@ class ToolToggleBase(ToolPersistentBase):
     def enable(self, event=None):
         """Enable the toggle tool
 
-        This method is called when the tool is triggered and not active
+        This method is called when the tool is triggered and not toggled
         """
         pass
 
     def disable(self, event=None):
         """Disable the toggle tool
 
-        This method is called when the tool is triggered and active.
-         * Second click on the toolbar button
+        This method is called when the tool is triggered and toggled.
+         * Second click on the toolbar tool button
          * Another toogle tool is triggered (from the same `navigation`)
         """
         pass
 
-    def key_press(self, event):
-        """Key press event
-
-        Called when a key_press_event is emited by the `FigureCanvas` if
-        `navigation.keypresslock(self)` was setted
-        """
-        pass
+    @property
+    def toggled(self):
+        """State of the toggled tool"""
+        return self._toggled
 
 
 class ToolQuit(ToolBase):
@@ -391,26 +364,29 @@ class ToolZoom(ToolToggleBase):
         self._ids_zoom = []
         self._button_pressed = None
         self._xypress = None
+        self._idPress = None
+        self._idRelease = None
 
     def enable(self, event):
-        self.navigation.canvaslock(self)
-        self.navigation.presslock(self)
-        self.navigation.releaselock(self)
+        self.figure.canvas.widgetlock(self)
+        self._idPress = self.figure.canvas.mpl_connect(
+                        'button_press_event', self._press)
+        self._idRelease = self.figure.canvas.mpl_connect(
+                        'button_release_event', self._release)
 
     def disable(self, event):
-        self.navigation.canvaslock.release(self)
-        self.navigation.presslock.release(self)
-        self.navigation.releaselock.release(self)
+        self.figure.canvas.widgetlock.release(self)
+        self.figure.canvas.mpl_disconnect(self._idPress)
+        self.figure.canvas.mpl_disconnect(self._idRelease)
 
-    def press(self, event):
-        """the press mouse button in zoom to rect mode callback"""
+    def _press(self, event):
+        """the _press mouse button in zoom to rect mode callback"""
         # If we're already in the middle of a zoom, pressing another
         # button works to "cancel"
         if self._ids_zoom != []:
-            self.navigation.movelock.release(self)
             for zoom_id in self._ids_zoom:
                 self.figure.canvas.mpl_disconnect(zoom_id)
-            self.navigation.release(event)
+            self.navigation.remove_rubberband(event, self)
             self.navigation.draw()
             self._xypress = None
             self._button_pressed = None
@@ -439,26 +415,25 @@ class ToolZoom(ToolToggleBase):
                 self._xypress.append((x, y, a, i, a.viewLim.frozen(),
                                       a.transData.frozen()))
 
-        self.navigation.movelock(self)
+        id1 = self.figure.canvas.mpl_connect(
+                        'motion_notify_event', self._mouse_move)
         id2 = self.figure.canvas.mpl_connect('key_press_event',
                                       self._switch_on_zoom_mode)
         id3 = self.figure.canvas.mpl_connect('key_release_event',
                                       self._switch_off_zoom_mode)
 
-        self._ids_zoom = id2, id3
+        self._ids_zoom = id1, id2, id3
         self._zoom_mode = event.key
-
-        self.navigation.press(event)
 
     def _switch_on_zoom_mode(self, event):
         self._zoom_mode = event.key
-        self.mouse_move(event)
+        self._mouse_move(event)
 
     def _switch_off_zoom_mode(self, event):
         self._zoom_mode = None
-        self.mouse_move(event)
+        self._mouse_move(event)
 
-    def mouse_move(self, event):
+    def _mouse_move(self, event):
         """the drag callback in zoom mode"""
         if self._xypress:
             x, y = event.x, event.y
@@ -476,11 +451,10 @@ class ToolZoom(ToolToggleBase):
                 x1, y1, x2, y2 = a.bbox.extents
                 x, lastx = x1, x2
 
-            self.navigation.draw_rubberband(event, x, y, lastx, lasty)
+            self.navigation.draw_rubberband(event, self, x, y, lastx, lasty)
 
-    def release(self, event):
+    def _release(self, event):
         """the release mouse button callback in zoom to rect mode"""
-        self.navigation.movelock.release(self)
         for zoom_id in self._ids_zoom:
             self.figure.canvas.mpl_disconnect(zoom_id)
         self._ids_zoom = []
@@ -496,7 +470,7 @@ class ToolZoom(ToolToggleBase):
             # ignore singular clicks - 5 pixels is a threshold
             if abs(x - lastx) < 5 or abs(y - lasty) < 5:
                 self._xypress = None
-                self.navigation.release(event)
+                self.navigation.remove_rubberband(event, self)
                 self.navigation.draw()
                 return
 
@@ -604,7 +578,7 @@ class ToolZoom(ToolToggleBase):
         self._zoom_mode = None
 
         self.navigation.push_current()
-        self.navigation.release(event)
+        self.navigation.remove_rubberband(event, self)
 
 
 class ToolPan(ToolToggleBase):
@@ -620,18 +594,23 @@ class ToolPan(ToolToggleBase):
         ToolToggleBase.__init__(self, *args)
         self._button_pressed = None
         self._xypress = None
+        self._idPress = None
+        self._idRelease = None
+        self._idDrag = None
 
     def enable(self, event):
-        self.navigation.canvaslock(self)
-        self.navigation.presslock(self)
-        self.navigation.releaselock(self)
+        self.figure.canvas.widgetlock(self)
+        self._idPress = self.figure.canvas.mpl_connect(
+                        'button_press_event', self._press)
+        self._idRelease = self.figure.canvas.mpl_connect(
+                        'button_release_event', self._release)
 
     def disable(self, event):
-        self.navigation.canvaslock.release(self)
-        self.navigation.presslock.release(self)
-        self.navigation.releaselock.release(self)
+        self.figure.canvas.widgetlock.release(self)
+        self.figure.canvas.mpl_disconnect(self._idPress)
+        self.figure.canvas.mpl_disconnect(self._idRelease)
 
-    def press(self, event):
+    def _press(self, event):
         if event.button == 1:
             self._button_pressed = 1
         elif event.button == 3:
@@ -653,14 +632,16 @@ class ToolPan(ToolToggleBase):
                     a.get_navigate() and a.can_pan()):
                 a.start_pan(x, y, event.button)
                 self._xypress.append((a, i))
-                self.navigation.movelock(self)
-        self.navigation.press(event)
+                self.navigation.messagelock(self)
+                self._idDrag = self.figure.canvas.mpl_connect(
+                                'motion_notify_event', self._mouse_move)
 
-    def release(self, event):
+    def _release(self, event):
         if self._button_pressed is None:
             return
 
-        self.navigation.movelock.release(self)
+        self.figure.canvas.mpl_disconnect(self._idDrag)
+        self.navigation.messagelock.release(self)
 
         for a, _ind in self._xypress:
             a.end_pan()
@@ -669,12 +650,11 @@ class ToolPan(ToolToggleBase):
         self._xypress = []
         self._button_pressed = None
         self.navigation.push_current()
-        self.navigation.release(event)
         self.navigation.draw()
 
-    def mouse_move(self, event):
+    def _mouse_move(self, event):
         for a, _ind in self._xypress:
-            #safer to use the recorded button at the press than current button:
-            #multiple button can get pressed during motion...
+            #safer to use the recorded button at the _press than current
+            #button: #multiple button can get pressed during motion...
             a.drag_pan(self._button_pressed, event.key, event.x, event.y)
         self.navigation.dynamic_update()

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -948,7 +948,7 @@ default_tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
 """Default tools"""
 
 default_toolbar_tools = [['navigation', ['home', 'back', 'forward']],
-                         ['zoompan', ['zoom', 'pan']],
+                         ['zoompan', ['pan', 'zoom']],
                          ['layout', ['subplots']],
                          ['io', ['save']]]
 """Default tools in the toolbar"""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -45,7 +45,7 @@ class ToolBase(object):
         Navigation
     """
 
-    keymap = None
+    default_keymap = None
     """
     Keymap to associate with this tool
 
@@ -311,7 +311,7 @@ class ToolQuit(ToolBase):
     """Tool to call the figure manager destroy method"""
 
     description = 'Quit the figure'
-    keymap = rcParams['keymap.quit']
+    default_keymap = rcParams['keymap.quit']
 
     def trigger(self, sender, event, data=None):
         Gcf.destroy_fig(self.figure)
@@ -321,7 +321,7 @@ class ToolEnableAllNavigation(ToolBase):
     """Tool to enable all axes for navigation interaction"""
 
     description = 'Enables all axes navigation'
-    keymap = rcParams['keymap.all_axes']
+    default_keymap = rcParams['keymap.all_axes']
 
     def trigger(self, sender, event, data=None):
         if event.inaxes is None:
@@ -337,7 +337,7 @@ class ToolEnableNavigation(ToolBase):
     """Tool to enable a specific axes for navigation interaction"""
 
     description = 'Enables one axes navigation'
-    keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
+    default_keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
 
     def trigger(self, sender, event, data=None):
         if event.inaxes is None:
@@ -354,7 +354,7 @@ class ToolGrid(ToolToggleBase):
     """Tool to toggle the grid of the figure"""
 
     description = 'Toogle Grid'
-    keymap = rcParams['keymap.grid']
+    default_keymap = rcParams['keymap.grid']
 
     def trigger(self, sender, event, data=None):
         if event.inaxes is None:
@@ -374,7 +374,7 @@ class ToolFullScreen(ToolToggleBase):
     """Tool to toggle full screen"""
 
     description = 'Toogle Fullscreen mode'
-    keymap = rcParams['keymap.fullscreen']
+    default_keymap = rcParams['keymap.fullscreen']
 
     def enable(self, event):
         self.figure.canvas.manager.full_screen_toggle()
@@ -404,7 +404,7 @@ class ToolYScale(AxisScaleBase):
     """Tool to toggle between linear and logarithmic scales on the Y axis"""
 
     description = 'Toogle Scale Y axis'
-    keymap = rcParams['keymap.yscale']
+    default_keymap = rcParams['keymap.yscale']
 
     def set_scale(self, ax, scale):
         ax.set_yscale(scale)
@@ -414,7 +414,7 @@ class ToolXScale(AxisScaleBase):
     """Tool to toggle between linear and logarithmic scales on the X axis"""
 
     description = 'Toogle Scale X axis'
-    keymap = rcParams['keymap.xscale']
+    default_keymap = rcParams['keymap.xscale']
 
     def set_scale(self, ax, scale):
         ax.set_xscale(scale)
@@ -547,7 +547,7 @@ class ToolHome(ViewsPositionsBase):
 
     description = 'Reset original view'
     image = 'home.png'
-    keymap = rcParams['keymap.home']
+    default_keymap = rcParams['keymap.home']
     _on_trigger = 'home'
 
 
@@ -556,7 +556,7 @@ class ToolBack(ViewsPositionsBase):
 
     description = 'Back to  previous view'
     image = 'back.png'
-    keymap = rcParams['keymap.back']
+    default_keymap = rcParams['keymap.back']
     _on_trigger = 'back'
 
 
@@ -565,7 +565,7 @@ class ToolForward(ViewsPositionsBase):
 
     description = 'Forward to next view'
     image = 'forward.png'
-    keymap = rcParams['keymap.forward']
+    default_keymap = rcParams['keymap.forward']
     _on_trigger = 'forward'
 
 
@@ -581,7 +581,7 @@ class SaveFigureBase(ToolBase):
 
     description = 'Save the figure'
     image = 'filesave.png'
-    keymap = rcParams['keymap.save']
+    default_keymap = rcParams['keymap.save']
 
 
 class ZoomPanBase(ToolToggleBase):
@@ -651,7 +651,7 @@ class ToolZoom(ZoomPanBase):
 
     description = 'Zoom to rectangle'
     image = 'zoom_to_rect.png'
-    keymap = rcParams['keymap.zoom']
+    default_keymap = rcParams['keymap.zoom']
     cursor = cursors.SELECT_REGION
     radio_group = 'default'
 
@@ -861,7 +861,7 @@ class ToolZoom(ZoomPanBase):
 class ToolPan(ZoomPanBase):
     """Pan axes with left mouse, zoom with right"""
 
-    keymap = rcParams['keymap.pan']
+    default_keymap = rcParams['keymap.pan']
     description = 'Pan axes with left mouse, zoom with right'
     image = 'move.png'
     cursor = cursors.MOVE

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -903,23 +903,25 @@ class ToolPan(ZoomPanBase):
         self.navigation.canvas.draw_idle()
 
 
-tools = [(ToolHome, 'home'), (ToolBack, 'back'), (ToolForward, 'forward'),
-         (ToolZoom, 'zoom'), (ToolPan, 'pan'),
-         ('ToolConfigureSubplots', 'subplots'),
-         ('ToolSaveFigure', 'save'),
-         (ToolGrid, 'grid'),
-         (ToolFullScreen, 'fullscreen'),
-         (ToolQuit, 'quit'),
-         (ToolEnableAllNavigation, 'allnav'),
-         (ToolEnableNavigation, 'nav'),
-         (ToolXScale, 'xscale'),
-         (ToolYScale, 'yscale'),
-         (ToolCursorPosition, 'position'),
-         (ToolViewsPositions, 'viewpos'),
-         ('ToolSetCursor', 'cursor'),
-         ('ToolRubberband', 'rubberband')]
+tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
+         'zoom': ToolZoom, 'pan': ToolPan,
+         'subplots': 'ToolConfigureSubplots',
+         'save': 'ToolSaveFigure',
+         'grid': ToolGrid,
+         'fullscreen': ToolFullScreen,
+         'quit': ToolQuit,
+         'allnav': ToolEnableAllNavigation,
+         'nav': ToolEnableNavigation,
+         'xscale': ToolXScale,
+         'yscale': ToolYScale,
+         'position': ToolCursorPosition,
+         'viewpos': ToolViewsPositions,
+         'cursor': 'ToolSetCursor',
+         'rubberband': 'ToolRubberband'}
+"""Default tools"""
+
 toolbar_tools = [['navigation', ['home', 'back', 'forward']],
                   ['zoompan', ['zoom', 'pan']],
                   ['layout', ['subplots']],
                   ['io', ['save']]]
-"""Default tools"""
+"""Default tools in the toolbar"""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -74,7 +74,7 @@ class ToolBase(object):
         self._name = name
         self._figure = None
         self.navigation = navigation
-        self.set_figure(navigation.canvas.figure)
+        self.figure = navigation.canvas.figure
 
     @property
     def figure(self):
@@ -99,7 +99,8 @@ class ToolBase(object):
 
         pass
 
-    def set_figure(self, figure):
+    @figure.setter
+    def figure(self, figure):
         """
         Set the figure
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -416,9 +416,6 @@ class FigureManagerGTK3(FigureManagerBase):
 
         self.vbox.pack_start(self.canvas, True, True, 0)
 
-        self.toolbar = self._get_toolbar()
-        self.navigation = self._get_navigation()
-
         # calculate size for window
         w = int (self.canvas.figure.bbox.width)
         h = int (self.canvas.figure.bbox.height)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -33,7 +33,7 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
 from matplotlib.backend_bases import (ShowBase, ToolContainerBase,
                                       StatusbarBase)
 from matplotlib.backend_managers import ToolManager
-import matplotlib.backend_tools as tools
+from matplotlib import backend_tools
 
 from matplotlib.cbook import is_string_like, is_writable_file_like
 from matplotlib.colors import colorConverter
@@ -432,8 +432,8 @@ class FigureManagerGTK3(FigureManagerBase):
             return size_request.height
 
         if matplotlib.rcParams['toolbar'] == 'toolmanager':
-            tools.add_tools_2_toolmanager(self.toolmanager)
-            tools.add_tools_2_container(self.toolbar)
+            backend_tools.add_tools_2_toolmanager(self.toolmanager)
+            backend_tools.add_tools_2_container(self.toolbar)
             self.statusbar = StatusbarGTK3(self.toolmanager)
             h += add_widget(self.statusbar, False, False, 0)
             h += add_widget(Gtk.HSeparator(), False, False, 0)
@@ -731,9 +731,9 @@ class FileChooserDialog(Gtk.FileChooserDialog):
         return filename, self.ext
 
 
-class RubberbandGTK3(tools.RubberbandBase):
+class RubberbandGTK3(backend_tools.RubberbandBase):
     def __init__(self, *args, **kwargs):
-        tools.RubberbandBase.__init__(self, *args, **kwargs)
+        backend_tools.RubberbandBase.__init__(self, *args, **kwargs)
         self.ctx = None
 
     def draw_rubberband(self, x0, y0, x1, y1):
@@ -846,7 +846,7 @@ class StatusbarGTK3(StatusbarBase, Gtk.Statusbar):
         self.push(self._context, s)
 
 
-class SaveFigureGTK3(tools.SaveFigureBase):
+class SaveFigureGTK3(backend_tools.SaveFigureBase):
 
     def get_filechooser(self):
         fc = FileChooserDialog(
@@ -878,14 +878,14 @@ class SaveFigureGTK3(tools.SaveFigureBase):
                 error_msg_gtk(str(e), parent=self)
 
 
-class SetCursorGTK3(tools.SetCursorBase):
+class SetCursorGTK3(backend_tools.SetCursorBase):
     def set_cursor(self, cursor):
         self.figure.canvas.get_property("window").set_cursor(cursord[cursor])
 
 
-class ConfigureSubplotsGTK3(tools.ConfigureSubplotsBase, Gtk.Window):
+class ConfigureSubplotsGTK3(backend_tools.ConfigureSubplotsBase, Gtk.Window):
     def __init__(self, *args, **kwargs):
-        tools.ConfigureSubplotsBase.__init__(self, *args, **kwargs)
+        backend_tools.ConfigureSubplotsBase.__init__(self, *args, **kwargs)
         self.window = None
 
     def init_window(self):
@@ -1122,10 +1122,10 @@ def error_msg_gtk(msg, parent=None):
     dialog.destroy()
 
 
-tools.ToolSaveFigure = SaveFigureGTK3
-tools.ToolConfigureSubplots = ConfigureSubplotsGTK3
-tools.ToolSetCursor = SetCursorGTK3
-tools.ToolRubberband = RubberbandGTK3
+backend_tools.ToolSaveFigure = SaveFigureGTK3
+backend_tools.ToolConfigureSubplots = ConfigureSubplotsGTK3
+backend_tools.ToolSetCursor = SetCursorGTK3
+backend_tools.ToolRubberband = RubberbandGTK3
 
 Toolbar = ToolbarGTK3
 FigureCanvas = FigureCanvasGTK3

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -431,12 +431,13 @@ class FigureManagerGTK3(FigureManagerBase):
             size_request = child.size_request()
             return size_request.height
 
-        if matplotlib.rcParams['toolbar'] == 'toolmanager':
+        if self.toolmanager:
             backend_tools.add_tools_to_manager(self.toolmanager)
-            backend_tools.add_tools_to_container(self.toolbar)
-            self.statusbar = StatusbarGTK3(self.toolmanager)
-            h += add_widget(self.statusbar, False, False, 0)
-            h += add_widget(Gtk.HSeparator(), False, False, 0)
+            if self.toolbar:
+                backend_tools.add_tools_to_container(self.toolbar)
+                self.statusbar = StatusbarGTK3(self.toolmanager)
+                h += add_widget(self.statusbar, False, False, 0)
+                h += add_widget(Gtk.HSeparator(), False, False, 0)
 
         if self.toolbar is not None:
             self.toolbar.show()

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -488,6 +488,8 @@ class FigureManagerGTK3(FigureManagerBase):
         # must be initialised after toolbar has been setted
         if rcParams['toolbar'] != 'toolbar2':
             navigation = NavigationGTK3(self)
+        else:
+            navigation = None
         return navigation
 
     def get_window_title(self):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -758,8 +758,6 @@ class RubberbandGTK3(tools.RubberbandBase):
         self.ctx.set_source_rgb(0, 0, 0)
         self.ctx.stroke()
 
-tools.ToolRubberband = RubberbandGTK3
-
 
 class ToolbarGTK3(ToolContainerBase, Gtk.Box):
     def __init__(self, toolmanager):
@@ -879,14 +877,10 @@ class SaveFigureGTK3(tools.SaveFigureBase):
             except Exception as e:
                 error_msg_gtk(str(e), parent=self)
 
-tools.ToolSaveFigure = SaveFigureGTK3
-
 
 class SetCursorGTK3(tools.SetCursorBase):
     def set_cursor(self, cursor):
         self.figure.canvas.get_property("window").set_cursor(cursord[cursor])
-
-tools.ToolSetCursor = SetCursorGTK3
 
 
 class ConfigureSubplotsGTK3(tools.ConfigureSubplotsBase, Gtk.Window):
@@ -940,9 +934,6 @@ class ConfigureSubplotsGTK3(tools.ConfigureSubplotsBase, Gtk.Window):
     def trigger(self, sender, event, data=None):
         self.init_window()
         self.window.present()
-
-
-tools.ToolConfigureSubplots = ConfigureSubplotsGTK3
 
 
 class DialogLineprops:
@@ -1129,6 +1120,12 @@ def error_msg_gtk(msg, parent=None):
         message_format = msg)
     dialog.run()
     dialog.destroy()
+
+
+tools.ToolSaveFigure = SaveFigureGTK3
+tools.ToolConfigureSubplots = ConfigureSubplotsGTK3
+tools.ToolSetCursor = SetCursorGTK3
+tools.ToolRubberband = RubberbandGTK3
 
 Toolbar = ToolbarGTK3
 FigureCanvas = FigureCanvasGTK3

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -30,7 +30,7 @@ import matplotlib
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
      FigureManagerBase, FigureCanvasBase, NavigationToolbar2, cursors, TimerBase
-from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
+from matplotlib.backend_bases import ShowBase, ToolContainerBase, NavigationBase
 from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, \
     tools, toolbar_tools, SetCursorBase, RubberbandBase
 
@@ -756,9 +756,9 @@ class RubberbandGTK3(RubberbandBase):
 ToolRubberband = RubberbandGTK3
 
 
-class ToolbarGTK3(ToolbarBase, Gtk.Box):
+class ToolbarGTK3(ToolContainerBase, Gtk.Box):
     def __init__(self, navigation):
-        ToolbarBase.__init__(self, navigation)
+        ToolContainerBase.__init__(self, navigation)
         Gtk.Box.__init__(self)
         self.set_property("orientation", Gtk.Orientation.VERTICAL)
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -31,7 +31,7 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
      FigureManagerBase, FigureCanvasBase, NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
-from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase
+from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, tools
 
 from matplotlib.cbook import is_string_like, is_writable_file_like
 from matplotlib.colors import colorConverter
@@ -415,6 +415,11 @@ class FigureManagerGTK3(FigureManagerBase):
         self.canvas.show()
 
         self.vbox.pack_start(self.canvas, True, True, 0)
+
+        self.toolbar = self._get_toolbar()
+        self.navigation = self._get_navigation()
+        if matplotlib.rcParams['toolbar'] == 'navigation':
+            self.navigation.add_tools(tools)
 
         # calculate size for window
         w = int (self.canvas.figure.bbox.width)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -415,8 +415,9 @@ class FigureManagerGTK3(FigureManagerBase):
         self.canvas.show()
 
         self.vbox.pack_start(self.canvas, True, True, 0)
-        self.navigation = None
-        self.toolbar = self._get_toolbar(canvas)
+
+        self.toolbar = self._get_toolbar()
+        self.navigation = self._get_navigation()
 
         # calculate size for window
         w = int (self.canvas.figure.bbox.width)
@@ -472,18 +473,22 @@ class FigureManagerGTK3(FigureManagerBase):
     _full_screen_flag = False
 
 
-    def _get_toolbar(self, canvas):
+    def _get_toolbar(self):
         # must be inited after the window, drawingArea and figure
         # attrs are set
         if rcParams['toolbar'] == 'toolbar2':
-            toolbar = NavigationToolbar2GTK3 (canvas, self.window)
+            toolbar = NavigationToolbar2GTK3 (self.canvas, self.window)
         elif rcParams['toolbar'] == 'navigation':
-            self.navigation = NavigationGTK3(canvas, ToolbarGTK3)
-            toolbar = self.navigation.toolbar
+            toolbar = ToolbarGTK3(self)
         else:
-            self.navigation = NavigationGTK3(canvas, None)
             toolbar = None
         return toolbar
+
+    def _get_navigation(self):
+        # must be inited after toolbar is setted
+        if rcParams['toolbar'] != 'toolbar2':
+            navigation = NavigationGTK3(self)
+        return navigation
 
     def get_window_title(self):
         return self.window.get_title()
@@ -722,8 +727,8 @@ class NavigationGTK3(NavigationBase):
         if not self.canvas.widgetlock.available(caller):
             return
 
-        #'adapted from http://aspn.activestate.com/ASPN/Cookbook/Python/
-        #Recipe/189744'
+        # 'adapted from http://aspn.activestate.com/ASPN/Cookbook/Python/
+        # Recipe/189744'
         self.ctx = self.canvas.get_property("window").cairo_create()
 
         # todo: instead of redrawing the entire figure, copy the part of
@@ -775,7 +780,7 @@ class ToolbarGTK3(ToolbarBase, Gtk.Box,):
         sep.show_all()
 
     def _add_toolitem(self, name, tooltip_text, image_file, position,
-                     toggle):
+                      toggle):
         if toggle:
             tbutton = Gtk.ToggleToolButton()
         else:
@@ -787,6 +792,8 @@ class ToolbarGTK3(ToolbarBase, Gtk.Box,):
             image.set_from_file(image_file)
             tbutton.set_icon_widget(image)
 
+        if position is None:
+            position = -1
         self._toolbar.insert(tbutton, position)
         signal = tbutton.connect('clicked', self._call_tool, name)
         tbutton.set_tooltip_text(tooltip_text)
@@ -860,14 +867,14 @@ class SaveFigureGTK3(SaveFigureBase):
         chooser.destroy()
         if fname:
             startpath = os.path.expanduser(
-                            rcParams.get('savefig.directory', ''))
+                rcParams.get('savefig.directory', ''))
             if startpath == '':
                 # explicitly missing key or empty str signals to use cwd
                 rcParams['savefig.directory'] = startpath
             else:
                 # save dir for next time
                 rcParams['savefig.directory'] = os.path.dirname(
-                                                    six.text_type(fname))
+                    six.text_type(fname))
             try:
                 self.figure.canvas.print_figure(fname, format=format_)
             except Exception as e:
@@ -1107,6 +1114,7 @@ def error_msg_gtk(msg, parent=None):
     dialog.run()
     dialog.destroy()
 
-
+Toolbar = ToolbarGTK3
+Navigation = NavigationGTK3
 FigureCanvas = FigureCanvasGTK3
 FigureManager = FigureManagerGTK3

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -32,8 +32,12 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
      FigureManagerBase, FigureCanvasBase, NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import (ShowBase, ToolContainerBase,
                                       NavigationBase, StatusbarBase)
-from matplotlib.backend_tools import (SaveFigureBase, ConfigureSubplotsBase,
-    tools, toolbar_tools, SetCursorBase, RubberbandBase)
+from matplotlib.backend_tools import (SaveFigureBase,
+                                      ConfigureSubplotsBase,
+                                      add_tools_2_navigation,
+                                      add_tools_2_container,
+                                      SetCursorBase,
+                                      RubberbandBase)
 
 from matplotlib.cbook import is_string_like, is_writable_file_like
 from matplotlib.colors import colorConverter
@@ -432,8 +436,10 @@ class FigureManagerGTK3(FigureManagerBase):
             return size_request.height
 
         if matplotlib.rcParams['toolbar'] == 'navigation':
-            self.navigation.add_tools(tools)
-            self.toolbar.add_tools(toolbar_tools)
+            add_tools_2_navigation(self.navigation)
+#             self.navigation.add_tools(tools)
+#             self.toolbar.add_tools(toolbar_tools)
+            add_tools_2_container(self.toolbar)
             self.statusbar = StatusbarGTK3(self.navigation)
             h += add_widget(self.statusbar, False, False, 0)
             h += add_widget(Gtk.HSeparator(), False, False, 0)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -890,10 +890,15 @@ SaveFigure = SaveFigureGTK3
 class ConfigureSubplotsGTK3(ConfigureSubplotsBase, Gtk.Window):
     def __init__(self, *args, **kwargs):
         ConfigureSubplotsBase.__init__(self, *args, **kwargs)
-        Gtk.Window.__init__(self)
+        self.window = None
+
+    def init_window(self):
+        if self.window:
+            return
+        self.window = Gtk.Window(title="Subplot Configuration Tool")
 
         try:
-            self.window.set_icon_from_file(window_icon)
+            self.window.window.set_icon_from_file(window_icon)
         except (SystemExit, KeyboardInterrupt):
             # re-raise exit type Exceptions
             raise
@@ -901,12 +906,12 @@ class ConfigureSubplotsGTK3(ConfigureSubplotsBase, Gtk.Window):
             # we presumably already logged a message on the
             # failure of the main plot, don't keep reporting
             pass
-        self.set_title("Subplot Configuration Tool")
+
         self.vbox = Gtk.Box()
         self.vbox.set_property("orientation", Gtk.Orientation.VERTICAL)
-        self.add(self.vbox)
+        self.window.add(self.vbox)
         self.vbox.show()
-        self.connect('destroy', self.unregister)
+        self.window.connect('destroy', self.destroy)
 
         toolfig = Figure(figsize=(6, 3))
         canvas = self.figure.canvas.__class__(toolfig)
@@ -917,17 +922,22 @@ class ConfigureSubplotsGTK3(ConfigureSubplotsBase, Gtk.Window):
         w = int(toolfig.bbox.width)
         h = int(toolfig.bbox.height)
 
-        self.set_default_size(w, h)
+        self.window.set_default_size(w, h)
 
         canvas.show()
         self.vbox.pack_start(canvas, True, True, 0)
-        self.show()
+        self.window.show()
+
+    def destroy(self, *args):
+        self.window.destroy()
+        self.window = None
 
     def _get_canvas(self, fig):
         return self.canvas.__class__(fig)
 
     def trigger(self, event):
-        self.present()
+        self.init_window()
+        self.window.present()
 
 
 ConfigureSubplots = ConfigureSubplotsGTK3

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -803,6 +803,7 @@ class ToolbarGTK3(ToolbarBase, Gtk.Box):
 
         if position is None:
             position = -1
+        # TODO implement groups positions
         self._toolbar.insert(tbutton, -1)
         signal = tbutton.connect('clicked', self._call_tool, name)
         tbutton.set_tooltip_text(description)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -859,7 +859,7 @@ class SaveFigureGTK3(SaveFigureBase):
         fc.set_current_name(self.figure.canvas.get_default_filename())
         return fc
 
-    def activate(self, *args):
+    def trigger(self, *args):
         chooser = self.get_filechooser()
         fname, format_ = chooser.get_filename_from_user()
         chooser.destroy()
@@ -920,7 +920,7 @@ class ConfigureSubplotsGTK3(ConfigureSubplotsBase, Gtk.Window):
     def _get_canvas(self, fig):
         return self.canvas.__class__(fig)
 
-    def activate(self, event):
+    def trigger(self, event):
         self.present()
 
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -936,7 +936,7 @@ class ConfigureSubplotsGTK3(tools.ConfigureSubplotsBase, Gtk.Window):
         self.window.present()
 
 
-class DialogLineprops:
+class DialogLineprops(object):
     """
     A GUI dialog for controlling lineprops
     """

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -31,8 +31,7 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
      FigureManagerBase, FigureCanvasBase, NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
-from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, \
-    clear_views_positions
+from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase
 
 from matplotlib.cbook import is_string_like, is_writable_file_like
 from matplotlib.colors import colorConverter
@@ -442,7 +441,7 @@ class FigureManagerGTK3(FigureManagerBase):
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
             if self.navigation is not None:
-                clear_views_positions(fig)
+                pass
             elif self.toolbar is not None: self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -483,7 +483,7 @@ class FigureManagerGTK3(FigureManagerBase):
         if rcParams['toolbar'] == 'toolbar2':
             toolbar = NavigationToolbar2GTK3 (self.canvas, self.window)
         elif rcParams['toolbar'] == 'navigation':
-            toolbar = ToolbarGTK3(self)
+            toolbar = ToolbarGTK3(self.navigation)
         else:
             toolbar = None
         return toolbar
@@ -491,7 +491,7 @@ class FigureManagerGTK3(FigureManagerBase):
     def _get_navigation(self):
         # must be initialised after toolbar has been setted
         if rcParams['toolbar'] != 'toolbar2':
-            navigation = NavigationGTK3(self)
+            navigation = NavigationGTK3(self.canvas)
         else:
             navigation = None
         return navigation
@@ -756,8 +756,8 @@ ToolRubberband = RubberbandGTK3
 
 
 class ToolbarGTK3(ToolbarBase, Gtk.Box):
-    def __init__(self, manager):
-        ToolbarBase.__init__(self, manager)
+    def __init__(self, navigation):
+        ToolbarBase.__init__(self, navigation)
         Gtk.Box.__init__(self)
         self.set_property("orientation", Gtk.Orientation.VERTICAL)
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -31,7 +31,8 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
      FigureManagerBase, FigureCanvasBase, NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
-from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase
+from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, \
+    clear_views_positions
 
 from matplotlib.cbook import is_string_like, is_writable_file_like
 from matplotlib.colors import colorConverter
@@ -441,7 +442,7 @@ class FigureManagerGTK3(FigureManagerBase):
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
             if self.navigation is not None:
-                self.navigation.update()
+                clear_views_positions(fig)
             elif self.toolbar is not None: self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 
@@ -761,9 +762,9 @@ class ToolbarGTK3(ToolbarBase, Gtk.Box):
         self._toolbar.show_all()
         self._toolitems = {}
         self._signals = {}
-        self._add_message()
+        self._setup_message_area()
 
-    def _add_message(self):
+    def _setup_message_area(self):
         box = Gtk.Box()
         box.set_property("orientation", Gtk.Orientation.HORIZONTAL)
         sep = Gtk.Separator()

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -432,8 +432,8 @@ class FigureManagerGTK3(FigureManagerBase):
             return size_request.height
 
         if matplotlib.rcParams['toolbar'] == 'toolmanager':
-            backend_tools.add_tools_2_toolmanager(self.toolmanager)
-            backend_tools.add_tools_2_container(self.toolbar)
+            backend_tools.add_tools_to_manager(self.toolmanager)
+            backend_tools.add_tools_to_container(self.toolbar)
             self.statusbar = StatusbarGTK3(self.toolmanager)
             h += add_widget(self.statusbar, False, False, 0)
             h += add_widget(Gtk.HSeparator(), False, False, 0)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -485,7 +485,7 @@ class FigureManagerGTK3(FigureManagerBase):
         return toolbar
 
     def _get_navigation(self):
-        # must be inited after toolbar is setted
+        # must be initialised after toolbar has been setted
         if rcParams['toolbar'] != 'toolbar2':
             navigation = NavigationGTK3(self)
         return navigation
@@ -749,7 +749,7 @@ class NavigationGTK3(NavigationBase):
         self.ctx.stroke()
 
 
-class ToolbarGTK3(ToolbarBase, Gtk.Box,):
+class ToolbarGTK3(ToolbarBase, Gtk.Box):
     def __init__(self, manager):
         ToolbarBase.__init__(self, manager)
         Gtk.Box.__init__(self)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -32,7 +32,7 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
      FigureManagerBase, FigureCanvasBase, NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
 from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, \
-    tools, SetCursorBase, RubberbandBase
+    tools, toolbar_tools, SetCursorBase, RubberbandBase
 
 from matplotlib.cbook import is_string_like, is_writable_file_like
 from matplotlib.colors import colorConverter
@@ -421,6 +421,7 @@ class FigureManagerGTK3(FigureManagerBase):
         self.toolbar = self._get_toolbar()
         if matplotlib.rcParams['toolbar'] == 'navigation':
             self.navigation.add_tools(tools)
+            self.toolbar.add_tools(toolbar_tools)
 
         # calculate size for window
         w = int (self.canvas.figure.bbox.width)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -718,7 +718,10 @@ class NavigationGTK3(NavigationBase):
     def set_cursor(self, cursor):
         self.canvas.get_property("window").set_cursor(cursord[cursor])
 
-    def draw_rubberband(self, event, x0, y0, x1, y1):
+    def draw_rubberband(self, event, caller, x0, y0, x1, y1):
+        if not self.canvas.widgetlock.available(caller):
+            return
+
         #'adapted from http://aspn.activestate.com/ASPN/Cookbook/Python/
         #Recipe/189744'
         self.ctx = self.canvas.get_property("window").cairo_create()
@@ -743,10 +746,6 @@ class NavigationGTK3(NavigationBase):
     def dynamic_update(self):
         # legacy method; new method is canvas.draw_idle
         self.canvas.draw_idle()
-
-#    def release(self, event):
-#        try: del self._pixmapBack
-#        except AttributeError: pass
 
 
 class ToolbarGTK3(ToolbarBase, Gtk.Box,):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -743,10 +743,6 @@ class NavigationGTK3(NavigationBase):
         self.ctx.set_source_rgb(0, 0, 0)
         self.ctx.stroke()
 
-    def dynamic_update(self):
-        # legacy method; new method is canvas.draw_idle
-        self.canvas.draw_idle()
-
 
 class ToolbarGTK3(ToolbarBase, Gtk.Box,):
     def __init__(self, manager):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -419,6 +419,7 @@ class FigureManagerGTK3(FigureManagerBase):
         self.toolbar = self._get_toolbar()
         self.navigation = self._get_navigation()
         if matplotlib.rcParams['toolbar'] == 'navigation':
+            self.toolbar.set_navigation(self.navigation)
             self.navigation.add_tools(tools)
 
         # calculate size for window
@@ -783,8 +784,11 @@ class ToolbarGTK3(ToolbarBase, Gtk.Box):
         self.pack_end(sep, False, True, 0)
         sep.show_all()
 
-    def _add_toolitem(self, name, tooltip_text, image_file, position,
-                      toggle):
+    def add_toolitem(self, name, group, position, image_file, description,
+                     toggle):
+        if group is None:
+            return
+
         if toggle:
             tbutton = Gtk.ToggleToolButton()
         else:
@@ -798,34 +802,29 @@ class ToolbarGTK3(ToolbarBase, Gtk.Box):
 
         if position is None:
             position = -1
-        self._toolbar.insert(tbutton, position)
+        self._toolbar.insert(tbutton, -1)
         signal = tbutton.connect('clicked', self._call_tool, name)
-        tbutton.set_tooltip_text(tooltip_text)
+        tbutton.set_tooltip_text(description)
         tbutton.show_all()
         self._toolitems[name] = tbutton
         self._signals[name] = signal
 
     def _call_tool(self, btn, name):
-        self.manager.navigation._toolbar_callback(name)
+        self.trigger_tool(name)
 
     def set_message(self, s):
         self.message.set_label(s)
 
-    def _toggle(self, name, callback=False):
+    def toggle_toolitem(self, name):
         if name not in self._toolitems:
-            self.set_message('%s Not in toolbar' % name)
             return
 
         status = self._toolitems[name].get_active()
-        if not callback:
-            self._toolitems[name].handler_block(self._signals[name])
-
+        self._toolitems[name].handler_block(self._signals[name])
         self._toolitems[name].set_active(not status)
+        self._toolitems[name].handler_unblock(self._signals[name])
 
-        if not callback:
-            self._toolitems[name].handler_unblock(self._signals[name])
-
-    def _remove_toolitem(self, name):
+    def remove_toolitem(self, name):
         if name not in self._toolitems:
             self.set_message('%s Not in toolbar' % name)
             return
@@ -837,20 +836,6 @@ class ToolbarGTK3(ToolbarBase, Gtk.Box):
         self._toolbar.insert(toolitem, pos)
         toolitem.show()
         return toolitem
-
-    def move_toolitem(self, pos_ini, pos_fin):
-        widget = self._toolbar.get_nth_item(pos_ini)
-        if not widget:
-            self.set_message('Impossible to remove tool %d' % pos_ini)
-            return
-        self._toolbar.remove(widget)
-        self._toolbar.insert(widget, pos_fin)
-
-    def set_toolitem_visibility(self, name, visible):
-        if name not in self._toolitems:
-            self.set_message('%s Not in toolbar' % name)
-            return
-        self._toolitems[name].set_visible(visible)
 
 
 class SaveFigureGTK3(SaveFigureBase):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -419,7 +419,6 @@ class FigureManagerGTK3(FigureManagerBase):
         self.toolbar = self._get_toolbar()
         self.navigation = self._get_navigation()
         if matplotlib.rcParams['toolbar'] == 'navigation':
-            self.toolbar.set_navigation(self.navigation)
             self.navigation.add_tools(tools)
 
         # calculate size for window

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -21,7 +21,7 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase
 from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
 from matplotlib.backend_bases import NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
-from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase
+from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, tools
 from matplotlib._pylab_helpers import Gcf
 
 from matplotlib.figure import Figure
@@ -525,10 +525,11 @@ class FigureManagerTkAgg(FigureManagerBase):
     window      : The tk.Window
     """
     def __init__(self, canvas, num, window):
-        self.window = window
         FigureManagerBase.__init__(self, canvas, num)
+        self.window = window
         self.window.withdraw()
         self.set_window_title("Figure %d" % num)
+        self.canvas = canvas
         self._num =  num
         if matplotlib.rcParams['toolbar']=='toolbar2':
             self.toolbar = NavigationToolbar2TkAgg( canvas, self.window )

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -20,7 +20,8 @@ from matplotlib.cbook import is_string_like
 from matplotlib.backend_bases import RendererBase, GraphicsContextBase
 from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
 from matplotlib.backend_bases import NavigationToolbar2, cursors, TimerBase
-from matplotlib.backend_bases import ShowBase
+from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
+from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase
 from matplotlib._pylab_helpers import Gcf
 
 from matplotlib.figure import Figure
@@ -541,8 +542,22 @@ class FigureManagerTkAgg(FigureManagerBase):
 
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
-            if self.toolbar != None: self.toolbar.update()
+            if self.navigation is not None:
+                self.navigation.update()
+            elif self.toolbar is not None:
+                self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
+
+    def _get_toolbar(self, canvas):
+        if matplotlib.rcParams['toolbar'] == 'toolbar2':
+            toolbar = NavigationToolbar2TkAgg(canvas, self.window)
+        elif matplotlib.rcParams['toolbar'] == 'navigation':
+            self.navigation = NavigationTk(canvas, ToolbarTk)
+            toolbar = self.navigation.toolbar
+        else:
+            self.navigation = NavigationTk(canvas, None)
+            toolbar = None
+        return toolbar
 
     def resize(self, width, height=None):
         # before 09-12-22, the resize method takes a single *event*
@@ -870,6 +885,181 @@ class ToolTip(object):
         self.tipwindow = None
         if tw:
             tw.destroy()
+
+
+class NavigationTk(NavigationBase):
+    def __init__(self, *args, **kwargs):
+        NavigationBase.__init__(self, *args, **kwargs)
+
+    def set_cursor(self, cursor):
+        self.canvas.manager.window.configure(cursor=cursord[cursor])
+
+    def draw_rubberband(self, event, caller, x0, y0, x1, y1):
+        if not self.canvas.widgetlock.available(caller):
+            return
+        height = self.canvas.figure.bbox.height
+        y0 = height - y0
+        y1 = height - y1
+        try:
+            self.lastrect
+        except AttributeError:
+            pass
+        else:
+            self.canvas._tkcanvas.delete(self.lastrect)
+        self.lastrect = self.canvas._tkcanvas.create_rectangle(x0, y0, x1, y1)
+
+    def remove_rubberband(self, event, caller):
+        try:
+            self.lastrect
+        except AttributeError:
+            pass
+        else:
+            self.canvas._tkcanvas.delete(self.lastrect)
+            del self.lastrect
+
+
+class ToolbarTk(ToolbarBase, Tk.Frame):
+    def __init__(self, manager):
+        ToolbarBase.__init__(self, manager)
+        xmin, xmax = self.manager.canvas.figure.bbox.intervalx
+        height, width = 50, xmax - xmin
+        Tk.Frame.__init__(self, master=self.manager.window,
+                          width=int(width), height=int(height),
+                          borderwidth=2)
+        self._toolitems = {}
+        self._add_message()
+
+    def _add_toolitem(self, name, tooltip_text, image_file, position,
+                     toggle):
+
+        button = self._Button(name, image_file, toggle)
+        if tooltip_text is not None:
+            ToolTip.createToolTip(button, tooltip_text)
+        self._toolitems[name] = button
+
+    def _Button(self, text, file, toggle):
+        if file is not None:
+            img_file = os.path.join(rcParams['datapath'], 'images', file)
+            im = Tk.PhotoImage(master=self, file=img_file)
+        else:
+            im = None
+
+        if not toggle:
+            b = Tk.Button(
+                          master=self, text=text, padx=2, pady=2, image=im,
+                          command=lambda: self._button_click(text))
+        else:
+            b = Tk.Checkbutton(master=self, text=text, padx=2, pady=2,
+                               image=im, indicatoron=False,
+                               command=lambda: self._button_click(text))
+        b._ntimage = im
+        b.pack(side=Tk.LEFT)
+        return b
+
+    def _button_click(self, name):
+        self.manager.navigation._toolbar_callback(name)
+
+    def _toggle(self, name, callback=False):
+        if name not in self._toolitems:
+            self.set_message('%s Not in toolbar' % name)
+            return
+        self._toolitems[name].toggle()
+        if callback:
+            self._button_click(name)
+
+    def _add_message(self):
+        self.message = Tk.StringVar(master=self)
+        self._message_label = Tk.Label(master=self, textvariable=self.message)
+        self._message_label.pack(side=Tk.RIGHT)
+        self.pack(side=Tk.BOTTOM, fill=Tk.X)
+
+    def set_message(self, s):
+        self.message.set(s)
+
+    def _remove_toolitem(self, name):
+        self._toolitems[name].pack_forget()
+        del self._toolitems[name]
+
+    def set_toolitem_visibility(self, name, visible):
+        pass
+
+
+class SaveFigureTk(SaveFigureBase):
+    def trigger(self, *args):
+        from six.moves import tkinter_tkfiledialog, tkinter_messagebox
+        filetypes = self.figure.canvas.get_supported_filetypes().copy()
+        default_filetype = self.figure.canvas.get_default_filetype()
+
+        # Tk doesn't provide a way to choose a default filetype,
+        # so we just have to put it first
+        default_filetype_name = filetypes[default_filetype]
+        del filetypes[default_filetype]
+
+        sorted_filetypes = list(six.iteritems(filetypes))
+        sorted_filetypes.sort()
+        sorted_filetypes.insert(0, (default_filetype, default_filetype_name))
+
+        tk_filetypes = [
+            (name, '*.%s' % ext) for (ext, name) in sorted_filetypes]
+
+        # adding a default extension seems to break the
+        # asksaveasfilename dialog when you choose various save types
+        # from the dropdown.  Passing in the empty string seems to
+        # work - JDH!
+        #defaultextension = self.figure.canvas.get_default_filetype()
+        defaultextension = ''
+        initialdir = rcParams.get('savefig.directory', '')
+        initialdir = os.path.expanduser(initialdir)
+        initialfile = self.figure.canvas.get_default_filename()
+        fname = tkinter_tkfiledialog.asksaveasfilename(
+            master=self.figure.canvas.manager.window,
+            title='Save the figure',
+            filetypes=tk_filetypes,
+            defaultextension=defaultextension,
+            initialdir=initialdir,
+            initialfile=initialfile,
+            )
+
+        if fname == "" or fname == ():
+            return
+        else:
+            if initialdir == '':
+                # explicitly missing key or empty str signals to use cwd
+                rcParams['savefig.directory'] = initialdir
+            else:
+                # save dir for next time
+                rcParams['savefig.directory'] = os.path.dirname(
+                    six.text_type(fname))
+            try:
+                # This method will handle the delegation to the correct type
+                self.figure.canvas.print_figure(fname)
+            except Exception as e:
+                tkinter_messagebox.showerror("Error saving file", str(e))
+
+
+class ConfigureSubplotsTk(ConfigureSubplotsBase):
+    def __init__(self, *args, **kwargs):
+        ConfigureSubplotsBase.__init__(self, *args, **kwargs)
+        toolfig = Figure(figsize=(6, 3))
+        self.window = Tk.Tk()
+
+        canvas = FigureCanvasTkAgg(toolfig, master=self.window)
+        toolfig.subplots_adjust(top=0.9)
+        _tool = SubplotTool(self.figure, toolfig)
+        canvas.show()
+        canvas.get_tk_widget().pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
+        self.window.protocol("WM_DELETE_WINDOW", self.destroy)
+
+    def trigger(self, event):
+        self.window.lift()
+
+    def destroy(self, *args, **kwargs):
+        self.unregister()
+        self.window.destroy()
+
+
+SaveFigure = SaveFigureTk
+ConfigureSubplots = ConfigureSubplotsTk
 
 FigureCanvas = FigureCanvasTkAgg
 FigureManager = FigureManagerTkAgg

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -540,8 +540,8 @@ class FigureManagerTkAgg(FigureManagerBase):
         self.statusbar = None
 
         if matplotlib.rcParams['toolbar'] == 'toolmanager':
-            backend_tools.add_tools_2_toolmanager(self.toolmanager)
-            backend_tools.add_tools_2_container(self.toolbar)
+            backend_tools.add_tools_to_manager(self.toolmanager)
+            backend_tools.add_tools_to_container(self.toolbar)
             self.statusbar = StatusbarTk(self.window, self.toolmanager)
 
         self._shown = False

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -525,11 +525,10 @@ class FigureManagerTkAgg(FigureManagerBase):
     window      : The tk.Window
     """
     def __init__(self, canvas, num, window):
-        FigureManagerBase.__init__(self, canvas, num)
         self.window = window
+        FigureManagerBase.__init__(self, canvas, num)
         self.window.withdraw()
         self.set_window_title("Figure %d" % num)
-        self.canvas = canvas
         self._num =  num
         if matplotlib.rcParams['toolbar']=='toolbar2':
             self.toolbar = NavigationToolbar2TkAgg( canvas, self.window )

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -939,25 +939,41 @@ class ToolbarTk(ToolContainerBase, Tk.Frame):
                           borderwidth=2)
         self._toolitems = {}
         self.pack(side=Tk.TOP, fill=Tk.X)
+        self._groups = {}
 
     def add_toolitem(self, name, group, position, image_file, description,
                      toggle):
-        button = self._Button(name, image_file, toggle)
+        frame = self._get_groupframe(group)
+        button = self._Button(name, image_file, toggle, frame)
         if description is not None:
             ToolTip.createToolTip(button, description)
-        self._toolitems[name] = button
+        self._toolitems.setdefault(name, [])
+        self._toolitems[name].append(button)
 
-    def _Button(self, text, image_file, toggle):
+    def _get_groupframe(self, group):
+        if group not in self._groups:
+            if self._groups:
+                self._add_separator()
+            frame = Tk.Frame(master=self, borderwidth=0)
+            frame.pack(side=Tk.LEFT, fill=Tk.Y)
+            self._groups[group] = frame
+        return self._groups[group]
+
+    def _add_separator(self):
+        separator = Tk.Frame(master=self, bd=5, width=1, bg='black')
+        separator.pack(side=Tk.LEFT, fill=Tk.Y, padx=2)
+
+    def _Button(self, text, image_file, toggle, frame):
         if image_file is not None:
             im = Tk.PhotoImage(master=self, file=image_file)
         else:
             im = None
 
         if not toggle:
-            b = Tk.Button(master=self, text=text, padx=2, pady=2, image=im,
+            b = Tk.Button(master=frame, text=text, padx=2, pady=2, image=im,
                           command=lambda: self._button_click(text))
         else:
-            b = Tk.Checkbutton(master=self, text=text, padx=2, pady=2,
+            b = Tk.Checkbutton(master=frame, text=text, padx=2, pady=2,
                                image=im, indicatoron=False,
                                command=lambda: self._button_click(text))
         b._ntimage = im
@@ -970,13 +986,15 @@ class ToolbarTk(ToolContainerBase, Tk.Frame):
     def toggle_toolitem(self, name, toggled):
         if name not in self._toolitems:
             return
-        if toggled:
-            self._toolitems[name].select()
-        else:
-            self._toolitems[name].deselect()
+        for toolitem in self._toolitems[name]:
+            if toggled:
+                toolitem.select()
+            else:
+                toolitem.deselect()
 
     def remove_toolitem(self, name):
-        self._toolitems[name].pack_forget()
+        for toolitem in self._toolitems[name]:
+            toolitem.pack_forget()
         del self._toolitems[name]
 
 

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -21,8 +21,7 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase
 from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
 from matplotlib.backend_bases import NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
-from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, \
-    clear_views_positions
+from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase
 from matplotlib._pylab_helpers import Gcf
 
 from matplotlib.figure import Figure
@@ -544,7 +543,7 @@ class FigureManagerTkAgg(FigureManagerBase):
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
             if self.navigation is not None:
-                clear_views_positions(fig)
+                pass
             elif self.toolbar is not None:
                 self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -539,10 +539,11 @@ class FigureManagerTkAgg(FigureManagerBase):
         self.toolbar = self._get_toolbar()
         self.statusbar = None
 
-        if matplotlib.rcParams['toolbar'] == 'toolmanager':
+        if self.toolmanager:
             backend_tools.add_tools_to_manager(self.toolmanager)
-            backend_tools.add_tools_to_container(self.toolbar)
-            self.statusbar = StatusbarTk(self.window, self.toolmanager)
+            if self.toolbar:
+                backend_tools.add_tools_to_container(self.toolbar)
+                self.statusbar = StatusbarTk(self.window, self.toolmanager)
 
         self._shown = False
 

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -548,16 +548,20 @@ class FigureManagerTkAgg(FigureManagerBase):
                 self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
 
-    def _get_toolbar(self, canvas):
+    def _get_toolbar(self):
         if matplotlib.rcParams['toolbar'] == 'toolbar2':
-            toolbar = NavigationToolbar2TkAgg(canvas, self.window)
+            toolbar = NavigationToolbar2TkAgg(self.canvas, self.window)
         elif matplotlib.rcParams['toolbar'] == 'navigation':
-            self.navigation = NavigationTk(canvas, ToolbarTk)
-            toolbar = self.navigation.toolbar
+            toolbar = ToolbarTk(self)
         else:
-            self.navigation = NavigationTk(canvas, None)
             toolbar = None
         return toolbar
+
+    def _get_navigation(self):
+        # must be inited after toolbar is setted
+        if rcParams['toolbar'] != 'toolbar2':
+            navigation = NavigationTk(self)
+        return navigation
 
     def resize(self, width, height=None):
         # before 09-12-22, the resize method takes a single *event*
@@ -930,23 +934,21 @@ class ToolbarTk(ToolbarBase, Tk.Frame):
         self._add_message()
 
     def _add_toolitem(self, name, tooltip_text, image_file, position,
-                     toggle):
+                      toggle):
 
         button = self._Button(name, image_file, toggle)
         if tooltip_text is not None:
             ToolTip.createToolTip(button, tooltip_text)
         self._toolitems[name] = button
 
-    def _Button(self, text, file, toggle):
-        if file is not None:
-            img_file = os.path.join(rcParams['datapath'], 'images', file)
-            im = Tk.PhotoImage(master=self, file=img_file)
+    def _Button(self, text, image_file, toggle):
+        if image_file is not None:
+            im = Tk.PhotoImage(master=self, file=image_file)
         else:
             im = None
 
         if not toggle:
-            b = Tk.Button(
-                          master=self, text=text, padx=2, pady=2, image=im,
+            b = Tk.Button(master=self, text=text, padx=2, pady=2, image=im,
                           command=lambda: self._button_click(text))
         else:
             b = Tk.Checkbutton(master=self, text=text, padx=2, pady=2,
@@ -1006,7 +1008,7 @@ class SaveFigureTk(SaveFigureBase):
         # asksaveasfilename dialog when you choose various save types
         # from the dropdown.  Passing in the empty string seems to
         # work - JDH!
-        #defaultextension = self.figure.canvas.get_default_filetype()
+        # defaultextension = self.figure.canvas.get_default_filetype()
         defaultextension = ''
         initialdir = rcParams.get('savefig.directory', '')
         initialdir = os.path.expanduser(initialdir)
@@ -1060,6 +1062,7 @@ class ConfigureSubplotsTk(ConfigureSubplotsBase):
 
 SaveFigure = SaveFigureTk
 ConfigureSubplots = ConfigureSubplotsTk
-
+Toolbar = ToolbarTk
+Navigation = NavigationTk
 FigureCanvas = FigureCanvasTkAgg
 FigureManager = FigureManagerTkAgg

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -23,7 +23,7 @@ from matplotlib.backend_bases import NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import (ShowBase, ToolContainerBase,
                                       StatusbarBase)
 from matplotlib.backend_managers import ToolManager
-import matplotlib.backend_tools as tools
+from matplotlib import backend_tools
 from matplotlib._pylab_helpers import Gcf
 
 from matplotlib.figure import Figure
@@ -540,8 +540,8 @@ class FigureManagerTkAgg(FigureManagerBase):
         self.statusbar = None
 
         if matplotlib.rcParams['toolbar'] == 'toolmanager':
-            tools.add_tools_2_toolmanager(self.toolmanager)
-            tools.add_tools_2_container(self.toolbar)
+            backend_tools.add_tools_2_toolmanager(self.toolmanager)
+            backend_tools.add_tools_2_container(self.toolbar)
             self.statusbar = StatusbarTk(self.window, self.toolmanager)
 
         self._shown = False
@@ -898,9 +898,9 @@ class ToolTip(object):
             tw.destroy()
 
 
-class RubberbandTk(tools.RubberbandBase):
+class RubberbandTk(backend_tools.RubberbandBase):
     def __init__(self, *args, **kwargs):
-        tools.RubberbandBase.__init__(self, *args, **kwargs)
+        backend_tools.RubberbandBase.__init__(self, *args, **kwargs)
 
     def draw_rubberband(self, x0, y0, x1, y1):
         height = self.figure.canvas.figure.bbox.height
@@ -924,7 +924,7 @@ class RubberbandTk(tools.RubberbandBase):
             del self.lastrect
 
 
-class SetCursorTk(tools.SetCursorBase):
+class SetCursorTk(backend_tools.SetCursorBase):
     def set_cursor(self, cursor):
         self.figure.canvas.manager.window.configure(cursor=cursord[cursor])
 
@@ -1015,7 +1015,7 @@ class StatusbarTk(StatusbarBase, Tk.Frame):
         self._message.set(s)
 
 
-class SaveFigureTk(tools.SaveFigureBase):
+class SaveFigureTk(backend_tools.SaveFigureBase):
     def trigger(self, *args):
         from six.moves import tkinter_tkfiledialog, tkinter_messagebox
         filetypes = self.figure.canvas.get_supported_filetypes().copy()
@@ -1068,9 +1068,9 @@ class SaveFigureTk(tools.SaveFigureBase):
                 tkinter_messagebox.showerror("Error saving file", str(e))
 
 
-class ConfigureSubplotsTk(tools.ConfigureSubplotsBase):
+class ConfigureSubplotsTk(backend_tools.ConfigureSubplotsBase):
     def __init__(self, *args, **kwargs):
-        tools.ConfigureSubplotsBase.__init__(self, *args, **kwargs)
+        backend_tools.ConfigureSubplotsBase.__init__(self, *args, **kwargs)
         self.window = None
 
     def trigger(self, *args):
@@ -1096,10 +1096,10 @@ class ConfigureSubplotsTk(tools.ConfigureSubplotsBase):
         self.window = None
 
 
-tools.ToolSaveFigure = SaveFigureTk
-tools.ToolConfigureSubplots = ConfigureSubplotsTk
-tools.ToolSetCursor = SetCursorTk
-tools.ToolRubberband = RubberbandTk
+backend_tools.ToolSaveFigure = SaveFigureTk
+backend_tools.ToolConfigureSubplots = ConfigureSubplotsTk
+backend_tools.ToolSetCursor = SetCursorTk
+backend_tools.ToolRubberband = RubberbandTk
 Toolbar = ToolbarTk
 FigureCanvas = FigureCanvasTkAgg
 FigureManager = FigureManagerTkAgg

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -22,8 +22,12 @@ from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
 from matplotlib.backend_bases import NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import (ShowBase, ToolContainerBase,
                                       NavigationBase, StatusbarBase)
-from matplotlib.backend_tools import (SaveFigureBase, ConfigureSubplotsBase,
-    tools, toolbar_tools, SetCursorBase, RubberbandBase)
+from matplotlib.backend_tools import (SaveFigureBase,
+                                      ConfigureSubplotsBase,
+                                      add_tools_2_navigation,
+                                      add_tools_2_container,
+                                      SetCursorBase,
+                                      RubberbandBase)
 from matplotlib._pylab_helpers import Gcf
 
 from matplotlib.figure import Figure
@@ -540,11 +544,10 @@ class FigureManagerTkAgg(FigureManagerBase):
         self.statusbar = None
 
         if matplotlib.rcParams['toolbar'] == 'navigation':
-            self.navigation.add_tools(tools)
-            self.toolbar.add_tools(toolbar_tools)
+            add_tools_2_navigation(self.navigation)
+            add_tools_2_container(self.toolbar)
             self.statusbar = StatusbarTk(self.window, self.navigation)
 
-        
         self._shown = False
 
         def notify_axes_change(fig):

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -561,6 +561,8 @@ class FigureManagerTkAgg(FigureManagerBase):
         # must be inited after toolbar is setted
         if rcParams['toolbar'] != 'toolbar2':
             navigation = NavigationTk(self)
+        else:
+            navigation = None
         return navigation
 
     def resize(self, width, height=None):

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -930,8 +930,8 @@ class SetCursorTk(tools.SetCursorBase):
 
 
 class ToolbarTk(ToolContainerBase, Tk.Frame):
-    def __init__(self, navigation, window):
-        ToolContainerBase.__init__(self, navigation)
+    def __init__(self, toolmanager, window):
+        ToolContainerBase.__init__(self, toolmanager)
         xmin, xmax = self.toolmanager.canvas.figure.bbox.intervalx
         height, width = 50, xmax - xmin
         Tk.Frame.__init__(self, master=window,

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -1044,6 +1044,16 @@ class SaveFigureTk(SaveFigureBase):
 class ConfigureSubplotsTk(ConfigureSubplotsBase):
     def __init__(self, *args, **kwargs):
         ConfigureSubplotsBase.__init__(self, *args, **kwargs)
+        self.window = None
+
+    def trigger(self, event):
+        self.init_window()
+        self.window.lift()
+
+    def init_window(self):
+        if self.window:
+            return
+
         toolfig = Figure(figsize=(6, 3))
         self.window = Tk.Tk()
 
@@ -1054,12 +1064,9 @@ class ConfigureSubplotsTk(ConfigureSubplotsBase):
         canvas.get_tk_widget().pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
         self.window.protocol("WM_DELETE_WINDOW", self.destroy)
 
-    def trigger(self, event):
-        self.window.lift()
-
     def destroy(self, *args, **kwargs):
-        self.unregister()
         self.window.destroy()
+        self.window = None
 
 
 SaveFigure = SaveFigureTk

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -21,7 +21,8 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase
 from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
 from matplotlib.backend_bases import NavigationToolbar2, cursors, TimerBase
 from matplotlib.backend_bases import ShowBase, ToolbarBase, NavigationBase
-from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase
+from matplotlib.backend_tools import SaveFigureBase, ConfigureSubplotsBase, \
+    clear_views_positions
 from matplotlib._pylab_helpers import Gcf
 
 from matplotlib.figure import Figure
@@ -543,7 +544,7 @@ class FigureManagerTkAgg(FigureManagerBase):
         def notify_axes_change(fig):
             'this will be called whenever the current axes is changed'
             if self.navigation is not None:
-                self.navigation.update()
+                clear_views_positions(fig)
             elif self.toolbar is not None:
                 self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -31,6 +31,7 @@ from matplotlib.cbook import dedent, silent_list, is_string_like, is_numlike
 from matplotlib.cbook import _string_to_bool
 from matplotlib import docstring
 from matplotlib.backend_bases import FigureCanvasBase
+from matplotlib.backend_tools import tools as default_tools
 from matplotlib.figure import Figure, figaspect
 from matplotlib.gridspec import GridSpec
 from matplotlib.image import imread as _imread
@@ -432,6 +433,9 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
                                         frameon=frameon,
                                         FigureClass=FigureClass,
                                         **kwargs)
+
+        if rcParams['toolbar'] == 'navigation':
+            figManager.navigation.add_tools(default_tools)
 
         if figLabel:
             figManager.set_window_title(figLabel)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -31,7 +31,6 @@ from matplotlib.cbook import dedent, silent_list, is_string_like, is_numlike
 from matplotlib.cbook import _string_to_bool
 from matplotlib import docstring
 from matplotlib.backend_bases import FigureCanvasBase
-from matplotlib.backend_tools import tools as default_tools
 from matplotlib.figure import Figure, figaspect
 from matplotlib.gridspec import GridSpec
 from matplotlib.image import imread as _imread
@@ -433,9 +432,6 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
                                         frameon=frameon,
                                         FigureClass=FigureClass,
                                         **kwargs)
-
-        if rcParams['toolbar'] == 'navigation':
-            figManager.navigation.add_tools(default_tools)
 
         if figLabel:
             figManager.set_window_title(figLabel)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -168,7 +168,7 @@ validate_qt5 = ValidateInStrings('backend.qt5', ['PyQt5'])
 def validate_toolbar(s):
     validator = ValidateInStrings(
                 'toolbar',
-                ['None', 'toolbar2', 'navigation'],
+                ['None', 'toolbar2', 'toolmanager'],
                 ignorecase=True)
     return validator(s)
 


### PR DESCRIPTION
This PR is the implementation of MEP22, https://github.com/matplotlib/matplotlib/wiki/Mep22#implementation 

This it supersedes the https://github.com/matplotlib/matplotlib/pull/2759

`Toolbar` has been relegated as `listener/emiter` of events that get dispatched to the `Tools` by `Navigation`.

The `toolbar` is easily reconfigurable at running time. new tools can be `created/added/removed` without modificaion of the backend code.


**Example**
` examples/user_interfaces/navigation.py`
