### PR TITLE
Make ScalarMappable a new-style class.

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -163,7 +163,7 @@ def get_cmap(name=None, lut=None):
             % (name, ', '.join(cmap_d.keys())))
 
 
-class ScalarMappable:
+class ScalarMappable(object):
     """
     This is a mixin class to support scalar data to RGBA mapping.
     The ScalarMappable makes use of data normalization before returning


### PR DESCRIPTION
(In `cm.py`:) `class ScalarMappable:` ==> `class ScalarMappable(object):`

There are no other old-style classes in `cm.py`, but, _e.g._,

```
$ grep '^class' *.py |grep -v '('
__init__.py:class Verbose:
animation.py:class FFMpegBase:
animation.py:class MencoderBase:
animation.py:class ImageMagickBase:
artist.py:class ArtistInspector:
axis.py:class Ticker:
backend_bases.py:class GraphicsContextBase:
backend_bases.py:class Event:
backend_bases.py:class Cursors:
cbook.py:class CallbackRegistry:
cbook.py:class Bunch:
cbook.py:class Sorter:
cbook.py:class Null:
cbook.py:class GetRealpathAndStat:
cbook.py:class RingBuffer:
cbook.py:class MemoryMonitor:
contour.py:class ContourLabeler:
dates.py:class strpdate2num:
dates.py:class rrulewrapper:
figure.py:class SubplotParams:
fontconfig_pattern.py:class FontconfigPatternParser:
hatch.py:class HatchPatternBase:
lines.py:class VertexSelector:
mlab.py:class PCA:
mlab.py:class FIFOBuffer:
mlab.py:class FormatObj:
rcsetup.py:class ValidateInStrings:
rcsetup.py:class validate_nseq_float:
rcsetup.py:class validate_nseq_int:
rcsetup.py:class ValidateInterval:
sankey.py:class Sankey:
texmanager.py:class TexManager:
ticker.py:class Base:
units.py:class AxisInfo:
units.py:class ConversionInterface:
widgets.py:class LockDraw:
$
```
