### PR TITLE
remove print from test

### DIFF
--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -206,7 +206,6 @@ def test_mathtext_exceptions():
             parser.parse(math)
         except ValueError as e:
             exc = str(e).split('\n')
-            print(e)
             assert exc[3].startswith(msg)
         else:
             assert False, "Expected '%s', but didn't get it" % msg


### PR DESCRIPTION
This removes a print in test_mathtext_exceptions. This shows up in Travis output because of -s to nose even when the tests pass. Looks like a leftover debug statement which should be removed. 

The exception which this is inside is the expected outcome of the test. 
