### PR TITLE
fix for #3669 Font issue without PyCXX

### DIFF
--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1309,9 +1309,15 @@ static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args, PyObj
                              t->maxMemType1);
     }
     case 6: {
+        #if PY3K
+        char pclt_dict[] =
+            "{s:(h,h), s:k, s:H, s:H, s:H, s:H, s:H, s:H, s:s, s:y, s:b, s:b, "
+            "s:b}";
+        #else
         char pclt_dict[] =
             "{s:(h,h), s:k, s:H, s:H, s:H, s:H, s:H, s:H, s:s, s:s, s:b, s:b, "
             "s:b}";
+        #endif
         TT_PCLT *t = (TT_PCLT *)table;
         return Py_BuildValue(pclt_dict,
                              "version",


### PR DESCRIPTION
This fixes #3669 for me. It looks like CharacterComplement doesn't return a valid unicode string so make it a bytestring in python3

This happens to me for the standard matplotlib font matplotlib/mpl-data/fonts/ttf/Vera.ttf 
not sure why it doesn't happen on travis. 

In any case 'characterComplement' is '\xff\xff\xff\xff6\xff\xff\xfe628R00' for this font on both python2 and python3 which looks rather strange to me. I expected this to be a string of all chars that this font contains so perhaps there is a deeper issue? 
