### PR TITLE
Python3 pep8 fixes

### DIFF
--- a/examples/api/date_index_formatter.py
+++ b/examples/api/date_index_formatter.py
@@ -11,7 +11,7 @@ import matplotlib.cbook as cbook
 import matplotlib.ticker as ticker
 
 datafile = cbook.get_sample_data('aapl.csv', asfileobj=False)
-print ('loading %s' % datafile)
+print('loading %s' % datafile)
 r = mlab.csv2rec(datafile)
 
 r.sort()

--- a/examples/api/watermark_image.py
+++ b/examples/api/watermark_image.py
@@ -8,7 +8,7 @@ import matplotlib.image as image
 import matplotlib.pyplot as plt
 
 datafile = cbook.get_sample_data('logo2.png', asfileobj=False)
-print ('loading %s' % datafile)
+print('loading %s' % datafile)
 im = image.imread(datafile)
 im[:, :, -1] = 0.5  # set the alpha channel
 


### PR DESCRIPTION
I am seeing these pep8 failures in the test suite only with python3. Because print isn't a function in python2? Travis does not run pep8 on python3 so I only see this failures locally. 
