### PR TITLE
use _fast_from_codes_and_verts in transform code

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1380,8 +1380,9 @@ class Transform(TransformNode):
         ``transform_path(path)`` is equivalent to
         ``transform_path_affine(transform_path_non_affine(values))``.
         """
-        return Path(self.transform_non_affine(path.vertices), path.codes,
-                    path._interpolation_steps)
+        x = self.transform_non_affine(path.vertices)
+        return Path._fast_from_codes_and_verts(x, path.codes,
+                {'interpolation_steps': path._interpolation_steps})
 
     def transform_angles(self, angles, pts, radians=False, pushoff=1e-5):
         """
@@ -2587,8 +2588,8 @@ class TransformedPath(TransformNode):
             self._transformed_path = \
                 self._transform.transform_path_non_affine(self._path)
             self._transformed_points = \
-                Path(self._transform.transform_non_affine(self._path.vertices),
-                     None, self._path._interpolation_steps)
+                Path._fast_from_codes_and_verts(self._transform.transform_non_affine(self._path.vertices),
+                        None, {'interpolation_steps': self._path._interpolation_steps})
         self._invalid = 0
 
     def get_transformed_points_and_affine(self):


### PR DESCRIPTION
This commit uses the internal constructor for Path objects.  This results in a 4% speedup during plot drawing.
