### PR TITLE
Provide programmatic access valid interp options

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4672,6 +4672,12 @@ class Axes(_AxesBase):
         self.add_image(im)
         return im
 
+    imshow.interpolation = ['none', 'nearest', 'bilinear', 'bicubic',
+                            'spline16', 'spline36', 'hanning', 'hamming',
+                            'hermite', 'kaiser', 'quadric', 'catrom',
+                            'gaussian', 'bessel', 'mitchell', 'sinc',
+                            'lanczos']
+
     @staticmethod
     def _pcolorargs(funcname, *args, **kw):
         # This takes one kwarg, allmatch.


### PR DESCRIPTION
**Summary**
Added an attribute to the imshow function in _axes.py that is named the same as the keyword argument 'interpolation' so that the valid options for interpolation can be accessed programmatically.

**Purpose**
I spoke with @tacaswell offline and he was unaware of any place in mpl where the valid options for the `interpolation` kwarg in axes.imshow() were available, thus this PR (which is probably the first of many, but I thought I'd see how this goes over before I do this in other places in mpl source).  Such programmatic access to these kwargs is incredibly useful when constructing GUI widgets so that the valid options can be provided via a combo box.  

I can see a few different mechanisms by which these sorts of options can be provided programmatically, depending on how much you guys hate this change :smile:.

1. Functions can have attributes added to them whose variable name matches the kwarg for that function.
  1. The previous point doesn't work *that* well with classes, as classes can and do actually have attributes.
1. These options can be created in each module where they're useful with the template `_opts_funcname_kwarg`.
   1. So something like 
   ```python
_opts_imshow_interpolation = ['none', 'nearest', 'bilinear', 'bicubic',
                                  'spline16', 'spline36', 'hanning', 'hamming',
                                  'hermite', 'kaiser', 'quadric', 'catrom',
                                  'gaussian', 'bessel', 'mitchell', 'sinc',
                                  'lanczos']
   ````