### PR TITLE
remove _orig_color which is duplicate of _rgb

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -783,7 +783,6 @@ class GraphicsContextBase(object):
         self._linestyle = 'solid'
         self._linewidth = 1
         self._rgb = (0.0, 0.0, 0.0, 1.0)
-        self._orig_color = (0.0, 0.0, 0.0, 1.0)
         self._hatch = None
         self._url = None
         self._gid = None
@@ -803,7 +802,6 @@ class GraphicsContextBase(object):
         self._linestyle = gc._linestyle
         self._linewidth = gc._linewidth
         self._rgb = gc._rgb
-        self._orig_color = gc._orig_color
         self._hatch = gc._hatch
         self._url = gc._url
         self._gid = gc._gid
@@ -937,7 +935,7 @@ class GraphicsContextBase(object):
         else:
             self._alpha = 1.0
             self._forced_alpha = False
-        self.set_foreground(self._orig_color)
+        self.set_foreground(self._rgb, isRGBA=True)
 
     def set_antialiased(self, b):
         """
@@ -999,8 +997,9 @@ class GraphicsContextBase(object):
 
         If you know fg is rgba, set ``isRGBA=True`` for efficiency.
         """
-        self._orig_color = fg
-        if self._forced_alpha:
+        if self._forced_alpha and isRGBA:
+            self._rgb = fg[:3] + (self._alpha,)
+        elif self._forced_alpha:
             self._rgb = colors.colorConverter.to_rgba(fg, self._alpha)
         elif isRGBA:
             self._rgb = fg
@@ -1011,7 +1010,6 @@ class GraphicsContextBase(object):
         """
         Set the foreground color to be a gray level with *frac*
         """
-        self._orig_color = frac
         self._rgb = (frac, frac, frac, self._alpha)
 
     def set_joinstyle(self, js):


### PR DESCRIPTION
The GraphicsContextBase._orig_color member was introduced by https://github.com/matplotlib/matplotlib/commit/6cc8aaa3e2a493a8df72cc10a08c2422ecb37ae2 , but I don't believe it is necessary.  This patch removes that member and goes a small step further to put related special case in set_foreground.

This is a spin-off of https://github.com/matplotlib/matplotlib/issues/3393 where test coverage is a legit concern.  A default tests.py run on my linux box covers all paths touched by this code with the exception of set_greylevel.
