### PR TITLE
Build failure on Launchpad

### DIFF
--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -11,10 +11,6 @@
 */
 
 
-#include "numpy_cpp.h"
-#include "mplutils.h"
-#include "file_compat.h"
-
 extern "C" {
 #   include <png.h>
 #   ifdef _POSIX_C_SOURCE
@@ -24,6 +20,11 @@ extern "C" {
 #       undef _XOPEN_SOURCE
 #   endif
 }
+
+#include "numpy_cpp.h"
+#include "mplutils.h"
+#include "file_compat.h"
+
 #   include <vector>
 #   include "Python.h"
 


### PR DESCRIPTION
This started a few days ago (on the 18th, I think), and has been consistent since then.

```
building 'matplotlib._png' extension
i686-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__png_ARRAY_API -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/libpng12 -I/usr/include -I. -I/usr/include/python2.7 -c src/_png.cpp -o build/temp.linux-i686-2.7/src/_png.o
In file included from /usr/include/libpng12/png.h:540:0,
                 from src/_png.cpp:21:
/usr/include/libpng12/pngconf.h:371:12: error: '__pngconf' does not name a type
            __pngconf.h__ in libpng already includes setjmp.h;
            ^
/usr/include/libpng12/pngconf.h:372:12: error: '__dont__' does not name a type
            __dont__ include it again.;
            ^
```
