### PR TITLE
add matplotlib.__bibtex__ attribute

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -109,6 +109,20 @@ from itertools import chain
 
 __version__ = str('1.5.x')
 __version__numpy__ = str('1.6')  # minimum required numpy version
+__bibtex__ = """@Article{Hunter:2007,
+  Author    = {Hunter, J. D.},
+  Title     = {Matplotlib: A 2D graphics environment},
+  Journal   = {Computing In Science \& Engineering},
+  Volume    = {9},
+  Number    = {3},
+  Pages     = {90--95},
+  abstract  = {Matplotlib is a 2D graphics package used for Python
+  for application development, interactive scripting, and
+  publication-quality image generation across user
+  interfaces and operating systems.},
+  publisher = {IEEE COMPUTER SOC},
+  year      = 2007
+}"""
 
 
 try:


### PR DESCRIPTION
Added a bibtex attribute for quick command-line access to the recommended citation info. Idea by @jakevdp: https://twitter.com/jakevdp/status/524329573580697600