### PR TITLE
Remove the check on path length over 18980 in Cairo backend

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -150,9 +150,6 @@ class RendererCairo(RendererBase):
 
 
     def draw_path(self, gc, path, transform, rgbFace=None):
-        if len(path.vertices) > 18980:
-            raise ValueError("The Cairo backend can not draw paths longer than 18980 points.")
-
         ctx = gc.ctx
 
         transform = transform + \


### PR DESCRIPTION
Follow-up of PR #3119
