### PR TITLE
Check for freetype header in freetype2 dir

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -957,7 +957,7 @@ class FreeType(SetupPackage):
             version = self.version_from_header()
 
         return self._check_for_pkg_config(
-            'freetype2', 'ft2build.h',
+            'freetype2', 'freetype2/ft2build.h',
             min_version='2.3', version=version)
 
     def version_from_header(self):


### PR DESCRIPTION
This fixes building agains Xquartz freetype on OSX without pkg-config. The headers are inside the freetype2 dir so we need to look there. 

Closes part of #3694

We need to test that this does not break the build on other platforms. Perhaps we should check both places? 