### PR TITLE
Ignore doc generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,10 +53,12 @@ doc/examples
 doc/_templates/gallery.html
 doc/users/installing.rst
 doc/_static/matplotlibrc
+doc/pyplots/tex_demo.png
 lib/dateutil
 examples/*/*.pdf
 examples/*/*.png
 examples/tests/*
 !examples/tests/backend_driver.py
 texput.log
+texput.aux
 result_images


### PR DESCRIPTION
These two files are generated when running the tests from the source dir and building the docs so ignore them in git
