### PR TITLE
Use is to compare with None in backend_pdf

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2273,7 +2273,10 @@ class GraphicsContextPdf(GraphicsContextBase):
                 ours = getattr(self, p)
                 theirs = getattr(other, p)
                 try:
-                    different = bool(ours != theirs)
+                    if (ours is None or theirs is None):
+                        different = bool(not(ours is theirs))
+                    else:
+                        different = bool(ours != theirs)
                 except ValueError:
                     ours = np.asarray(ours)
                     theirs = np.asarray(theirs)


### PR DESCRIPTION
Fixes some of the Numpy future warnings raised with numpy 1.9 

The remaining ones are thrown from the Capi inside _tri.cpp and are likely related to the use of PyCXX. I don't think that there is much point in fixing them if the plan is to replace the use of PyCXX with the pure Python Capi
