### PR TITLE
Remove duplicate import_array() call

### DIFF
--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -764,8 +764,6 @@ PyMODINIT_FUNC init_image(void)
         INITERROR;
     }
 
-    import_array();
-
     if (!PyImage_init_type(m, &PyImageType)) {
         INITERROR;
     }


### PR DESCRIPTION
There are two calls to `import_array()` in `src/_image_wrapper.cpp`, lines 767 and 798.  It doesn't seem to cause a problem, but only one is needed.  I've removed the first.
