### PR TITLE
Fix invalid symbol if numpy 1.6

### DIFF
--- a/src/_backend_gdk.c
+++ b/src/_backend_gdk.c
@@ -7,6 +7,11 @@
 
 #include <pygtk/pygtk.h>
 
+// support numpy 1.6 - this macro was renamed and deprecated at once in 1.7
+#ifndef NPY_ARRAY_WRITEABLE
+#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
+#endif
+
 static PyTypeObject *_PyGdkPixbuf_Type;
 #define PyGdkPixbuf_Type (*_PyGdkPixbuf_Type)
 


### PR DESCRIPTION
Fix for issue #3712, similar to that used at the top of `lib/matplotlib/delaunay/_delaunay.cpp`.  Tested using numpy 1.6 and 1.8.
