### PR TITLE
Reenable shading tests for numpy 1.9.1 and later

### DIFF
--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -313,7 +313,8 @@ def test_light_source_shading_default():
     assert_array_almost_equal(rgb, expect, decimal=2)
 
 
-@knownfailureif(V(np.__version__) <= V('1.9.0'))
+@knownfailureif((V(np.__version__) <= V('1.9.0')
+                and V(np.__version__) >= V('1.7.0')))
 # Numpy 1.9.1 fixed a bug in masked arrays which resulted in
 # additional elements being masked when calculating the gradient thus
 # the output is different with earlier numpy versions.


### PR DESCRIPTION
This fixes #3598 now the numpy 1.9.1 is released which changes the default gradient on the edge back to first order and fixes an issue with sharing of masks for masked arrays calculated from other masked arrays. 

The non masked test passed for all versions of numpy different from 1.9.0. To get the tests passing with 1.9.0 the arrays are modified to cut out the edges which is the only differences. 

The masked test is different for all versions due to the long standing mask bug. The numpy 1.9.1 version is the most correct so I chose to raise a knowfailure for all older versions. 

See attached illustration (the corners where previously masked but are now calculated correctly) :

![numpy19shadebug](https://cloud.githubusercontent.com/assets/548266/4907915/86d2b294-6465-11e4-97f0-b25482baf4cc.png)
