### PR TITLE
scale: little API change in linear scale

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -60,11 +60,7 @@ class LinearScale(ScaleBase):
     """
     The default linear scale.
     """
-
     name = 'linear'
-
-    def __init__(self, axis, **kwargs):
-        pass
 
     def set_default_locators_and_formatters(self, axis):
         """


### PR DESCRIPTION
Follow-up of PR #3753. The linear scale, LinearScale, has an empty constructor that swallows **kwargs. I propose to dump it.

(LogScale and its symmetric twin are a different case, because they use **kwargs to discriminate x axes from y axes.)