### PR TITLE
ENH: use fewer points for 3d quiver plot

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2544,8 +2544,7 @@ class Axes3D(Axes):
         # must all in same shape
         assert len(set([k.shape for k in input_args])) == 1
 
-        # TODO: num should probably get parameterized
-        shaft_dt = np.linspace(0, length, num=20)
+        shaft_dt = np.linspace(0, length, num=2)
         arrow_dt = shaft_dt * arrow_length_ratio
 
         if pivot == 'tail':


### PR DESCRIPTION
This doesn't appear to change any visual behavior, and it reduces memory usage significantly for large 3d quiver plots.

Previously: each quiver line, left head, and right head was defined by 20 points each. Now, they're defined by 2 points each.  
