### PR TITLE
WebAgg: flush stdout after printing, redirect "stopped" message to stder... [backport to 1.4.x]

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -21,6 +21,7 @@ import io
 import json
 import os
 import random
+import sys
 import socket
 import threading
 
@@ -333,11 +334,13 @@ class WebAggApplication(tornado.web.Application):
         launched. We may end up with two concurrently running loops in that
         unlucky case with all the expected consequences.
         """
-        print("Press Ctrl+C to stop server")
+        print("Press Ctrl+C to stop WebAgg server")
+        sys.stdout.flush()
         try:
             tornado.ioloop.IOLoop.instance().start()
         except KeyboardInterrupt:
-            print("Server stopped")
+            print("Server is stopped")
+            sys.stdout.flush()
         finally:
             cls.started = False
 


### PR DESCRIPTION
...r

Without flushing, the message can be displayed too late. KeyboardInterrupt message should be printed to stderr.
