### PR TITLE
WebAgg: _png.write_png raises TypeError

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -143,7 +143,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             # TODO: We should write a new version of write_png that
             # handles the differencing inline
             _png.write_png(
-                output,
+                output.view(dtype=np.uint8).reshape(output.shape + (4,)),
                 self._png_buffer)
 
             # Swap the renderer frames


### PR DESCRIPTION
This looks like a regression after 1.4.x.
Trying to view the plots results in

``` python
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/tornado/websocket.py", line 303, in wrapper
    return callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_webagg.py", line 229, in on_message
    manager.handle_json(message)
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_webagg_core.py", line 361, in handle_json
    self.canvas.handle_event(content)
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_webagg_core.py", line 192, in handle_event
    self.draw()
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_webagg_core.py", line 90, in draw
    self.manager.refresh_all()
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_webagg_core.py", line 365, in refresh_all
    diff = self.canvas.get_diff_image()
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_webagg_core.py", line 147, in get_diff_image
    self._png_buffer)
TypeError: Cannot cast array data from dtype('uint32') to dtype('uint8') according to the rule 'safe'
```

looks like this happened after write_png() API changed.
