### PR TITLE
MNT : delete unused Image

### DIFF
--- a/doc/api/api_changes/2014-11-07_remove_IMAGE.rst
+++ b/doc/api/api_changes/2014-11-07_remove_IMAGE.rst
@@ -1,0 +1,5 @@
+Removed `Image` from main namespace
+```````````````````````````````````
+
+`Image` was imported from PIL/pillow to test if PIL is available, but there is no
+reason to keep `Image` in the namespace once the availability has been determined.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -68,6 +68,7 @@ except:
 try:
     from PIL import Image
     _has_pil = True
+    del Image
 except ImportError:
     _has_pil = False
 


### PR DESCRIPTION
We only import Image to see if PIL/pillow is available to decide
if we should register jpg/tiff support for FigureCanvasBase.

Technically an API break, but anyone who was relying on this
probably deserves what they get.
