### PR TITLE
Mock backens when building doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -278,8 +278,12 @@ texinfo_documents = [
    1),
 ]
 
-from mock import MagicMock, patch
-import sys
+try:
+    from unittest.mock import MagicMock
+except:
+    from mock import MagicMock
+
+
 class MyWX(MagicMock):
     class Panel(object):
         pass
@@ -312,7 +316,6 @@ mockwxversion = MagicMock()
 mockwx = MyWX()
 mockpyqt4 = MyPyQt4()
 mocksip = MagicMock()
-patch.dict('sys.modules', {'wxversion': mockwxversion, 'wx': mockwx})
 sys.modules['wxversion'] = mockwxversion
 sys.modules['wx'] = mockwx
 sys.modules['sip'] = mocksip


### PR DESCRIPTION
Makes it possible to build the full docks without Wx and PyQT4. More specifically it allows travis to build these parts of the docs too.

We could take this one step further and replace the todo in the gtkagg backend docs with a similar mock

```
**TODO** We'll add this later, importing the gtk backends requires an active
X-session, which is not compatible with cron jobs.
```
