### PR TITLE
made idle_event() in backend_bases.py return True

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1974,6 +1974,7 @@ class FigureCanvasBase(object):
         s = 'idle_event'
         event = IdleEvent(s, self, guiEvent=guiEvent)
         self.callbacks.process(s, event)
+        return True
 
     def grab_mouse(self, ax):
         """


### PR DESCRIPTION
When using the GtkAgg backend I get the following message every time I close a figure in interactive mode:

```
/usr/lib/python2.7/site-packages/matplotlib/backends/backend_gtk.py:253: Warning: Source ID 31 was not found when attempting to remove it
    gobject.source_remove(self._idle_event_id)
```

This is because, as documented [here](http://www.pygtk.org/pygtk2reference/gobject-functions.html#function-gobject--idle-add), the idle event will be removed if the idle event callback returns false. In this case, the idle_event function had no return value (None) which was equivalent to false, so it was immediately removed. When the backend then tried to remove the event upon figure destruction there was a problem.  Making idle_event return True solves this problem for me.

Note that this means that previously callbacks attached to idle_event would not work, since `self.callbacks.process(s, event)` was not being called after the first idle event.

I am running gtk 2.24.25 and pyGtk 2.24.0-5.
