### PR TITLE
Fix warning in docs causing Travis error

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -481,7 +481,7 @@ though we have made significant progress towards supporting blocking events.
 .. _howto-boxplot_violinplot:
 
 Interpreting box plots and violin plots
------------------------------------
+---------------------------------------
 
 Tukey's `box plots <http://matplotlib.org/examples/pylab_examples/boxplot_demo.html>`_ (Robert McGill, John W. Tukey and Wayne A. Larsen: "The American Statistician" Vol. 32, No. 1, Feb., 1978, pp. 12-16) are statistical plots that provide useful information about the data distribution such as skewness. However, bar plots with error bars are still the common standard in most scientific literature, and thus, the interpretation of box plots can be challenging for the unfamiliar reader. The figure below illustrates the different visual features of a box plot.
 


### PR DESCRIPTION
Following the cross merge of #3770 which made Travis fall hard on doc warnings and #3736 which introduced a small warning in the docs the doc build in failing on Travis. This pr fixes that. 

The tests for the pull request was not being run with warnings as errors since it was branched before #3770 was merged. Future pull requests should not have this issue. 
