### PR TITLE
Fix 'version version not identified' message.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1284,7 +1284,7 @@ class BackendTkAgg(OptionalBackendPackage):
             tk_v = Tkinter.__version__.split()[-2]
         except (AttributeError, IndexError):
             # Tkinter.__version__ has been removed in python 3
-            tk_v = 'version not identified'
+            tk_v = 'not identified'
 
         BackendAgg.force = True
 


### PR DESCRIPTION
An utterly trivial PR--just something I noticed recently when installing on Python 3.4.  The message read "version version not identified" when detecting tkinter.
