### PR TITLE
Fix for #3789, segfault in _tri

### DIFF
--- a/lib/matplotlib/tri/_tri.cpp
+++ b/lib/matplotlib/tri/_tri.cpp
@@ -530,7 +530,8 @@ int Triangulation::get_triangle_point(const TriEdge& tri_edge) const
 bool Triangulation::is_masked(int tri) const
 {
     assert(tri >= 0 && tri < get_ntri() && "Triangle index out of bounds.");
-    return !_mask.empty() && _mask(tri);
+    const npy_bool* mask_ptr = reinterpret_cast<const npy_bool*>(_mask.data());
+    return !_mask.empty() && mask_ptr[tri];
 }
 
 void Triangulation::set_mask(const MaskArray& mask)

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -480,6 +480,12 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
     }
 
     // Do not use this for array_view<bool, ND>.  See comment near top of file.
+    const T *data() const
+    {
+        return (const T *)m_data;
+    }
+
+    // Do not use this for array_view<bool, ND>.  See comment near top of file.
     T *data()
     {
         return (T *)m_data;


### PR DESCRIPTION
Candidate fix for issue #3789.  Segfaults were occurring when travis was running `test_tritools`, but only under python 3.  This is an esoteric one - my local tests all ran fine under python 3 with both old and new gcc and numpy, so I could only debug by pushing candidate fixes to my github mpl repository and running travis on them there.  That's a new form of remote debugging for me.

The problem occurs accessing const/non-const boolean arrays wrapped in the new numpy::array_view classes.  It shouldn't occur, but evidently some combination of hardware, gcc and python versions behave differently.

I will need to go through the travis logs with a fine toothcomb before this is merged.

@jenshnielsen: Thanks for reporting this.
