### PR TITLE
bugfix for tooltips reappearing in macosx backend

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5888,7 +5888,9 @@ show(PyObject* self)
         NSEnumerator *enumerator = [windowsArray objectEnumerator];
         NSWindow *window;
         while ((window = [enumerator nextObject])) {
-            [window orderFront:nil];
+            if ([window isVisible]) {
+                [window orderFront:nil];
+            }
         }
         [pool release];
         [NSApp run];


### PR DESCRIPTION
Addresses issue #3746 by bringing to the front of the display only windows which were already visible when `show` is called. This eliminates the possibility of accidentally raising other hidden windows like `NSToolTipPanel`.