### PR TITLE
Update to doc/conf.py to allow for building docs without qt installed

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -312,13 +312,14 @@ class MyPyQt4(MagicMock):
             pass
 
 
-class mocksip(MagicMock):
+class MySip(MagicMock):
     def getapi(*args):
         return 1
 
 
 mockwxversion = MagicMock()
 mockwx = MyWX()
+mocksip = MySip()
 mockpyqt4 = MyPyQt4()
 sys.modules['wxversion'] = mockwxversion
 sys.modules['wx'] = mockwx


### PR DESCRIPTION
Had to modify `mocksip` in `conf.py` from a simple MagicMock object to one with a `getapi` function to avoid the following type error:

```
Exception occurred:
  File "/Users/cimarron/github/matplotlib/lib/matplotlib/backends/qt_compat.py", line 94, in <module>
    if sip.getapi("QString") > 1:
TypeError: unorderable types: MagicMock() > int()
```
