### PR TITLE
extend #if to include both CLONGDOUBLE related definitions

### DIFF
--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -175,7 +175,6 @@ struct type_num_of<npy_clongdouble>
         value = NPY_CLONGDOUBLE
     };
 };
-#endif
 template <>
 struct type_num_of<std::complex<npy_longdouble> >
 {
@@ -183,6 +182,7 @@ struct type_num_of<std::complex<npy_longdouble> >
         value = NPY_CLONGDOUBLE
     };
 };
+#endif
 template <>
 struct type_num_of<PyObject *>
 {


### PR DESCRIPTION
This appears to me be an obvious correction to the logic of the #if which fixes an MSVC (2008 specific?) compiler pickiness.  With-out this I get 

```
c:\ext\matplotlib\src\numpy_cpp.h(185) : error C2766: explicit specialization; 'numpy::type_num_of<std::complex<double>>' has already been defined
```

The only thing that confuses me is what motivated the #if in the first place if that motivation didn't equally apply to the complex case.
