### PR TITLE
copy all array_view members in copy constructor

### DIFF
--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -367,7 +367,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         }
     }
 
-    array_view(const array_view &other, bool contiguous = false) : m_arr(NULL), m_data(NULL)
+    array_view(const array_view &other) : m_arr(NULL), m_data(NULL)
     {
         m_arr = other.m_arr;
         Py_XINCREF(m_arr);


### PR DESCRIPTION
On my windows 7 32bit machine, the following script gives a traceback at the scatter call.  While I've determined that this code operates with-out traceback and seemingly correct on my linux machine, the proposed changes are OS independent (frankly, I'm baffled why it works on Linux).

The copy ctor as written before this patch seemingly ignores the other members of array_view.  This is not compatible with implementation of the operator[] returning a ND-1 dimension array but pointing to the same PyArray!

I suppose we'll need a comment from @mdboom since this was introduced in the removal of PyCXX.

```
import numpy
from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
from matplotlib.figure import Figure

POINTS = 500

figure = Figure(figsize=(6, 6), dpi=72)
ax = figure.add_subplot(1, 1, 1, projection=None)
scat = ax.scatter(numpy.arange(POINTS), numpy.sin(numpy.arange(POINTS)))
```

```
Traceback (most recent call last):
  File "C:\work\mpl_scatter_example.py", line 9, in <module>
    scat = ax.scatter(numpy.array([float(i) for i in range(POINTS)]), numpy.sin(numpy.arange(POINTS)))
  File "C:\Python27\lib\site-packages\matplotlib\axes\_axes.py", line 3690, in scatter
    self.add_collection(collection)
  File "C:\Python27\lib\site-packages\matplotlib\axes\_base.py", line 1459, in add_collection
    self.update_datalim(collection.get_datalim(self.transData))
  File "C:\Python27\lib\site-packages\matplotlib\collections.py", line 198, in get_datalim
    offsets, transOffset.frozen())
  File "C:\Python27\lib\site-packages\matplotlib\path.py", line 977, in get_path_collection_extents
    master_transform, paths, transforms, offsets, offset_transform))
ValueError: object too deep for desired array
```
