### PR TITLE
OSX backend. 2D histograms are flipped vertically

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -3222,8 +3222,14 @@ GraphicsContext_draw_image(GraphicsContext* self, PyObject* args)
 
     CGFloat deviceScale = _get_device_scale(cr);
 
-    CGContextDrawImage(cr, CGRectMake(x, y, ncols/deviceScale, nrows/deviceScale), bitmap);
+    CGContextSaveGState(cr);
+    CGContextTranslateCTM(cr, 0, y + nrows/deviceScale);
+    CGContextScaleCTM(cr, 1.0, -1.0);
+
+    CGContextDrawImage(cr, CGRectMake(x, 0, ncols/deviceScale, nrows/deviceScale), bitmap);
     CGImageRelease(bitmap);
+
+    CGContextRestoreGState(cr);
 
     Py_INCREF(Py_None);
     return Py_None;


### PR DESCRIPTION
This bug only exists on master but not in 1.4.2. Moreover this only happens on screen but is correct when saving the figure. I guess this relates to how the y-axis is inverted in images. 

This can be seen by running api/power_norm_demo.py where the covariance is inverted. 

The qt4/5 gtk3Agg and tkAgg are not affected.

OS x (screenshot)

![screen shot 2014-11-16 at 17 55 25](https://cloud.githubusercontent.com/assets/548266/5062430/c576e2e2-6db9-11e4-8206-390ee1113c7a.png)

OSX result (saved fig)
![figure_1](https://cloud.githubusercontent.com/assets/548266/5062423/5be6d9f4-6db9-11e4-9e59-02724f111eee.png)

In the docs:

![power_norm_demo](https://cloud.githubusercontent.com/assets/548266/5062426/82750e06-6db9-11e4-9458-e9a64fea9c22.png)
