### PR TITLE
Imsave AssertionError (empty bboxes)

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1610,6 +1610,9 @@ class Figure(Artist):
             if ax.get_visible():
                 bb.append(ax.get_tightbbox(renderer))
 
+        if len(bb) == 0:
+            return self.bbox_inches
+
         _bbox = Bbox.union([b for b in bb if b.width != 0 or b.height != 0])
 
         bbox_inches = TransformedBbox(_bbox,


### PR DESCRIPTION
Pyplot.imsave does not seem to work.  The matplotlibrc file that I'm using: https://raw.githubusercontent.com/byuimpact/numerical_computing/develop/matplotlibrc

``` python
import matplotlib
matplotlib.rcParams = matplotlib.rc_params_from_file("./matplotlibrc")

import numpy as np
import matplotlib.pyplot as plt
f = np.random.randint(0, 255, shape=(92,92))
plt.imsave("test.png", f)
```

results in an AssertionError

```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-23-02f5f5fccdfa> in <module>()
----> 1 plt.imsave("test.pdf", f)

/usr/lib/python2.7/site-packages/matplotlib/pyplot.pyc in imsave(*args, **kwargs)
   2218 @docstring.copy_dedent(_imsave)
   2219 def imsave(*args, **kwargs):
-> 2220     return _imsave(*args, **kwargs)
   2221 
   2222 

/usr/lib/python2.7/site-packages/matplotlib/image.pyc in imsave(fname, arr, vmin, vmax, cmap, format, origin, dpi)
   1312     canvas = FigureCanvas(fig)
   1313     im = fig.figimage(arr, cmap=cmap, vmin=vmin, vmax=vmax, origin=origin)
-> 1314     fig.savefig(fname, dpi=dpi, format=format, transparent=True)
   1315 
   1316 

/usr/lib/python2.7/site-packages/matplotlib/figure.pyc in savefig(self, *args, **kwargs)
   1468             self.set_frameon(frameon)
   1469 
-> 1470         self.canvas.print_figure(*args, **kwargs)
   1471 
   1472         if frameon:

/usr/lib/python2.7/site-packages/matplotlib/backend_bases.pyc in print_figure(self, filename, dpi, facecolor, edgecolor, orientation, format, **kwargs)
   2141                     **kwargs)
   2142                 renderer = self.figure._cachedRenderer
-> 2143                 bbox_inches = self.figure.get_tightbbox(renderer)
   2144 
   2145                 bbox_artists = kwargs.pop("bbox_extra_artists", None)

/usr/lib/python2.7/site-packages/matplotlib/figure.pyc in get_tightbbox(self, renderer)
   1611                 bb.append(ax.get_tightbbox(renderer))
   1612 
-> 1613         _bbox = Bbox.union([b for b in bb if b.width != 0 or b.height != 0])
   1614 
   1615         bbox_inches = TransformedBbox(_bbox,

/usr/lib/python2.7/site-packages/matplotlib/transforms.pyc in union(bboxes)
    720         Return a :class:`Bbox` that contains all of the given bboxes.
    721         """
--> 722         assert(len(bboxes))
    723 
    724         if len(bboxes) == 1:

AssertionError: 
```

It appears that the `Bbox.union()` results in an empty list.

EDIT: Gave the correct sample that code that produces the error.
