### PR TITLE
Make array_view::operator= non-const

### DIFF
--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -403,7 +403,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         Py_XDECREF(m_arr);
     }
 
-    const array_view& operator=(const array_view &other)
+    array_view& operator=(const array_view &other)
     {
         if (this != &other)
         {


### PR DESCRIPTION
Here's another C++ pedantry issue.

The `operator=` in `array_view` returned a `const` reference.  I _think_ this means that when the compiler needs a non-const reference it is free to use an auto-generated `operator=`, which of course would be wrong because it doesn't do the reference counting.

This is purely theoretical, of course, since I haven't seen a problem related to this, but I think this change makes things more correct.
