### PR TITLE
Path.contains_points() returns a uint8 array instead of a bool array

### DIFF
--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -36,8 +36,10 @@ def test_contains_points_negative_radius():
 
     points = [(0.0, 0.0), (1.25, 0.0), (0.9, 0.9)]
     expected = [True, False, False]
+    result = path.contains_points(points, radius=-0.5)
 
-    assert np.all(path.contains_points(points, radius=-0.5) == expected)
+    assert result.dtype == np.bool
+    assert np.all(result == expected)
 
 
 @image_comparison(baseline_images=['path_clipping'],

--- a/src/_path.h
+++ b/src/_path.h
@@ -67,7 +67,7 @@ struct XY
 template <class PathIterator, class PointArray, class ResultArray>
 void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &inside_flag)
 {
-    int yflag1;
+    bool yflag1;
     double vtx0, vty0, vtx1, vty1;
     double tx, ty;
     double sx, sy;
@@ -77,13 +77,13 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
 
     size_t n = points.size();
 
-    std::vector<int> yflag0(n);
-    std::vector<int> subpath_flag(n);
+    std::vector<bool> yflag0(n);
+    std::vector<bool> subpath_flag(n);
 
     path.rewind(0);
 
     for (i = 0; i < n; ++i) {
-        inside_flag[i] = 0;
+        inside_flag[i] = false;
     }
 
     unsigned code = 0;
@@ -106,7 +106,7 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
                 // get test bit for above/below X axis
                 yflag0[i] = (vty0 >= ty);
 
-                subpath_flag[i] = 0;
+                subpath_flag[i] = false;
             }
         }
 
@@ -152,7 +152,7 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
                     // Haigh-Hutchinson's different polygon inclusion
                     // tests.
                     if (((vty1 - ty) * (vtx0 - vtx1) >= (vtx1 - tx) * (vty0 - vty1)) == yflag1) {
-                        subpath_flag[i] ^= 1;
+                        subpath_flag[i] = subpath_flag[i] ^ true;
                     }
                 }
 
@@ -181,11 +181,11 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
             yflag1 = (vty1 >= ty);
             if (yflag0[i] != yflag1) {
                 if (((vty1 - ty) * (vtx0 - vtx1) >= (vtx1 - tx) * (vty0 - vty1)) == yflag1) {
-                    subpath_flag[i] ^= 1;
+                    subpath_flag[i] = subpath_flag[i] ^ true;
                 }
             }
-            inside_flag[i] |= subpath_flag[i];
-            if (inside_flag[i] == 0) {
+            inside_flag[i] = inside_flag[i] || subpath_flag[i];
+            if (inside_flag[i] == false) {
                 all_done = false;
             }
         }
@@ -210,7 +210,7 @@ inline void points_in_path(PointArray &points,
 
     size_t i;
     for (i = 0; i < result.size(); ++i) {
-        result[i] = 0;
+        result[i] = false;
     }
 
     if (path.total_vertices() < 3) {
@@ -236,8 +236,8 @@ inline bool point_in_path(
     point.push_back(y);
     points.push_back(point);
 
-    std::vector<uint8_t> result(1);
-    result[0] = 0;
+    std::vector<bool> result(1);
+    result[0] = false;
 
     points_in_path(points, r, path, trans, result);
 
@@ -258,7 +258,7 @@ void points_on_path(PointArray &points,
 
     size_t i;
     for (i = 0; i < result.size(); ++i) {
-        result[i] = 0;
+        result[i] = false;
     }
 
     transformed_path_t trans_path(path, trans);
@@ -279,8 +279,8 @@ inline bool point_on_path(
     point.push_back(y);
     points.push_back(point);
 
-    std::vector<uint8_t> result(1);
-    result[0] = 0;
+    std::vector<bool> result(1);
+    result[0] = false;
 
     points_on_path(points, r, path, trans, result);
 

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -80,7 +80,7 @@ static PyObject *Py_points_in_path(PyObject *self, PyObject *args, PyObject *kwd
     }
 
     npy_intp dims[] = { points.dim(0) };
-    numpy::array_view<uint8_t, 1> results(dims);
+    numpy::array_view<bool, 1> results(dims);
 
     CALL_CPP("points_in_path", (points_in_path(points, r, path, trans, results)));
 
@@ -139,7 +139,7 @@ static PyObject *Py_points_on_path(PyObject *self, PyObject *args, PyObject *kwd
     }
 
     npy_intp dims[] = { points.dim(0) };
-    numpy::array_view<uint8_t, 1> results(dims);
+    numpy::array_view<bool, 1> results(dims);
 
     CALL_CPP("points_on_path", (points_on_path(points, r, path, trans, results)));
 


### PR DESCRIPTION
According to the docs, `matplotlib.path.Path.contains_points()` ought to return a boolean array, but it currently returns a uint8 array. It looks like this API change was introduced in ba4016014cb4fb4927e36ce8ea429fed47dcb787. It caught me out when I tried to use the result of `contains_points()` as a boolean index to another array.
