### PR TITLE
ENH : make sure configdir is absolute path

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -582,8 +582,8 @@ def _get_config_or_cache_dir(xdg_base):
 
     configdir = os.environ.get('MPLCONFIGDIR')
     if configdir is not None:
+        configdir = os.path.abspath(configdir)
         if not os.path.exists(configdir):
-            from matplotlib.cbook import mkdirs
             mkdirs(configdir)
 
         if not _is_writable_dir(configdir):


### PR DESCRIPTION
When reading the configuration path from an the MPLCONFIGDIR env convert
to an absolute path.

Fixes #3823