### PR TITLE
MNT : add guard to not look up HOME env on windows

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -142,7 +142,7 @@ OSXFontDirectories = [
     ""
 ]
 
-if not USE_FONTCONFIG:
+if not USE_FONTCONFIG and sys.platform != 'win32':
     home = os.environ.get('HOME')
     if home is not None:
         # user fonts on OSX


### PR DESCRIPTION
This variable should not be defined on windows so don't
even bother looking at it.

addresses #3804 

Suggested by @jbmohler
