### PR TITLE
Remove deprecated nonorm and normalize

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1308,14 +1308,6 @@ class NoNorm(Normalize):
     def inverse(self, value):
         return value
 
-# compatibility with earlier class names that violated convention:
-normalize = cbook.deprecated('1.3', alternative='Normalize',
-                             name='normalize',
-                             obj_type='class alias')(Normalize)
-no_norm = cbook.deprecated('1.3', alternative='NoNorm',
-                           name='no_norm',
-                           obj_type='class alias')(NoNorm)
-
 
 def rgb_to_hsv(arr):
     """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -52,7 +52,6 @@ import numpy as np
 
 # We may not need the following imports here:
 from matplotlib.colors import Normalize
-from matplotlib.colors import normalize  # for backwards compat.
 from matplotlib.lines import Line2D
 from matplotlib.text import Text, Annotation
 from matplotlib.patches import Polygon, Rectangle, Circle, Arrow


### PR DESCRIPTION
They were deprecated in 1.3.0 so I think that it should be safe to remove them now. 
