### PR TITLE
Fix units examples under python3

### DIFF
--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -123,11 +123,11 @@ class _TaggedValue(object):
                           {})
             if subcls not in units.registry:
                 units.registry[subcls] = basicConverter
-            return object.__new__(subcls, value, unit)
+            return object.__new__(subcls)
         except TypeError:
             if cls not in units.registry:
                 units.registry[cls] = basicConverter
-            return object.__new__(cls, value, unit)
+            return object.__new__(cls)
 
     def __init__(self, value, unit):
         self.value = value

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -311,7 +311,7 @@ def rad_fn(x, pos=None):
     elif n == 2:
         return r'$\pi$'
     elif n % 2 == 0:
-        return r'$%s\pi$' % (n/2,)
+        return r'$%s\pi$' % (n//2,)
     else:
         return r'$%s\pi/2$' % (n,)
 


### PR DESCRIPTION
Seems like passing additional arguments to object.__new__ is no longer supported. AFAIK these would previously just have been dropped anyway so I have removed them but I would like some input from someone who understands the python metaclasses better than me. 