### PR TITLE
BUG: non integer overlap might lead to corrupt memory access in as_strided [backport 1.4.x]

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -590,6 +590,11 @@ def stride_windows(x, n, noverlap=None, axis=0):
     if n > x.size:
         raise ValueError('n cannot be greater than the length of x')
 
+    # np.lib.stride_tricks.as_strided easily leads to memory corruption for
+    # non integer shape and strides, i.e. noverlap or n. See #3845.
+    noverlap = int(noverlap)
+    n = int(n)
+
     step = n - noverlap
     if axis == 0:
         shape = (n, (x.shape[-1]-noverlap)//step)
@@ -641,6 +646,10 @@ def stride_repeat(x, n, axis=0):
             return np.atleast_2d(x).T
     if n < 1:
         raise ValueError('n cannot be less than 1')
+
+    # np.lib.stride_tricks.as_strided easily leads to memory corruption for
+    # non integer shape and strides, i.e. n. See #3845.
+    n = int(n)
 
     if axis == 0:
         shape = (n, x.size)

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -283,6 +283,24 @@ class stride_testcase(CleanupTestCase):
         assert_equal(y.shape, x1.shape)
         assert_array_equal(y, x1)
 
+    def test_stride_ensure_integer_type(self):
+        N = 100
+        x = np.empty(N + 20, dtype='>f4')
+        x.fill(np.NaN)
+        y = x[10:-10]
+        y.fill(0.3)
+        # previous to #3845 lead to corrupt access
+        y_strided = mlab.stride_windows(y, n=33, noverlap=0.6)
+        assert_array_equal(y_strided, 0.3)
+        # previous to #3845 lead to corrupt access
+        y_strided = mlab.stride_windows(y, n=33.3, noverlap=0)
+        assert_array_equal(y_strided, 0.3)
+        # even previous to #3845 could not find any problematic
+        # configuration however, let's be sure it's not accidentally
+        # introduced
+        y_strided = mlab.stride_repeat(y, n=33.815)
+        assert_array_equal(y_strided, 0.3)
+
 
 class csv_testcase(CleanupTestCase):
     def setUp(self):


### PR DESCRIPTION
Running mlab.psd with non integer `noverlap` might lead to corrupt memory access in the underlying `np.lib.stride_tricks.as_strides`. This is not obvious to debug, especially when `noverlap` is calculated programmatic.

Example:

``` python
from __future__ import division
import numpy as np
import matplotlib.pyplot as plt

N = 1000
n_sin_periods = 10

x = np.empty(3*N, dtype='f4')
x.fill(np.NaN)
y = x[N:2*N]
y[:] = np.sin(np.arange(N)/N * 2 * np.pi * n_sin_periods)

plt.psd(y, NFFT=330, noverlap=0.6)
plt.show()
```

This was not problematic with matplotlib 0.13, as the mlab.psd implementation was not using  `np.lib.stride_tricks.as_strides`  at that time.
