### PR TITLE
ENH: passing colors (and other optional keyword arguments) to violinplot()

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6870,7 +6870,7 @@ class Axes(_AxesBase):
 
     def violinplot(self, dataset, positions=None, vert=True, widths=0.5,
                    showmeans=False, showextrema=True, showmedians=False,
-                   points=100, bw_method=None, color='y', line_kw={},
+                   points=100, bw_method=None, color='y', line_kw=None,
                    **fill_kw):
         """Make a violin plot.
 
@@ -6878,7 +6878,7 @@ class Axes(_AxesBase):
 
           violinplot(dataset, positions=None, vert=True, widths=0.5,
                      showmeans=False, showextrema=True, showmedians=False,
-                     points=100, bw_method=None, color='y', line_kw={},
+                     points=100, bw_method=None, color='y', line_kw=None,
                      **fill_kw):
 
         Make a violin plot for each column of *dataset* or each vector in
@@ -6986,14 +6986,14 @@ class Axes(_AxesBase):
 
     def violin(self, vpstats, positions=None, vert=True, widths=0.5,
                showmeans=False, showextrema=True, showmedians=False,
-               color='y', line_kw={}, **fill_kw):
+               color='y', line_kw=None, **fill_kw):
         """Drawing function for violin plots.
 
         Call signature::
 
           violin(vpstats, positions=None, vert=True, widths=0.5,
                  showmeans=False, showextrema=True, showmedians=False,
-                 color='y', line_kw={}, **fill_kw):
+                 color='y', line_kw=None, **fill_kw):
 
         Draw a violin plot for each column of `vpstats`. Each filled area
         extends to represent the entire data range, with optional lines at the
@@ -7123,6 +7123,9 @@ class Axes(_AxesBase):
             color = [color] * N
         elif len(color) != N:
             raise ValueError(datashape_message.format("color"))
+
+        if line_kw is None:
+            line_kw = {}
 
         # original default values for line color and alpha
         line_color = line_kw.pop('colors', 'r')

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3420,7 +3420,7 @@ def triplot(*args, **kwargs):
 @_autogen_docstring(Axes.violinplot)
 def violinplot(dataset, positions=None, vert=True, widths=0.5, showmeans=False,
                showextrema=True, showmedians=False, points=100, bw_method=None,
-               hold=None):
+               color='y', line_kw={}, hold=None, **fill_kw):
     ax = gca()
     # allow callers to override the hold state by passing hold=True|False
     washold = ax.ishold()
@@ -3431,7 +3431,8 @@ def violinplot(dataset, positions=None, vert=True, widths=0.5, showmeans=False,
         ret = ax.violinplot(dataset, positions=positions, vert=vert,
                             widths=widths, showmeans=showmeans,
                             showextrema=showextrema, showmedians=showmedians,
-                            points=points, bw_method=bw_method)
+                            points=points, bw_method=bw_method, color=color,
+                            line_kw=line_kw, **fill_kw)
         draw_if_interactive()
     finally:
         ax.hold(washold)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3420,7 +3420,7 @@ def triplot(*args, **kwargs):
 @_autogen_docstring(Axes.violinplot)
 def violinplot(dataset, positions=None, vert=True, widths=0.5, showmeans=False,
                showextrema=True, showmedians=False, points=100, bw_method=None,
-               color='y', line_kw={}, hold=None, **fill_kw):
+               color='y', line_kw=None, hold=None, **fill_kw):
     ax = gca()
     # allow callers to override the hold state by passing hold=True|False
     washold = ax.ishold()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1797,6 +1797,52 @@ def test_horiz_violinplot_custompoints_200():
                   showextrema=0, showmedians=0, points=200)
 
 
+@image_comparison(baseline_images=['violinplot_custom_color'],
+                  extensions=['png'])
+def test_violinplot_custom_color():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(42))
+    np.random.seed(480740698)
+    data = [np.random.normal(size=100) for i in range(4)]
+    ax.violinplot(data, positions=range(4), vert=True, showmeans=0,
+                  showextrema=0, showmedians=0, color='c')
+
+
+@image_comparison(baseline_images=['violinplot_custom_multicolor'],
+                  extensions=['png'])
+def test_violinplot_custom_multicolor():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(44))
+    np.random.seed(633249580)
+    data = [np.random.normal(size=100) for i in range(4)]
+    ax.violinplot(data, positions=range(4), vert=True, showmeans=0,
+                  showextrema=0, showmedians=0, color=['r', 'g', 'b', 'c'])
+
+
+@image_comparison(baseline_images=['violinplot_line_kw'],
+                  extensions=['png'])
+def test_violinplot_line_kw():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(45))
+    np.random.seed(708203932)
+    data = [np.random.normal(size=100) for i in range(4)]
+    ax.violinplot(data, positions=range(4), vert=True, showmeans=1,
+                  showextrema=1, showmedians=1,
+                  line_kw=dict(colors='g', linestyles='dashed', alpha=0.5))
+
+
+@image_comparison(baseline_images=['violinplot_fill_kw'],
+                  extensions=['png'])
+def test_violinplot_fill_kw():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(46))
+    np.random.seed(782329983)
+    data = [np.random.normal(size=100) for i in range(4)]
+    ax.violinplot(data, positions=range(4), vert=True, showmeans=0,
+                  showextrema=0, showmedians=0, alpha=1, edgecolor='r',
+                  linewidths=2, linestyles='dashed')
+
+
 @cleanup
 def test_violinplot_bad_positions():
     ax = plt.axes()


### PR DESCRIPTION
I'm really glad that matplotlib now has a `violinplot()` function, but I find the current implementation a bit annoying to customize, since the only way to change the colors, alpha values etc. is to modify each artist after creating the plot. One would ideally want to be able to pass in any arbitrary keyword arguments for the `PolyCollection` and `LineCollection` artists in each individual 'violin', but there's a trade-off between flexibility and simplicity.

I think a reasonable compromise is to have the option to specify individual fill colors for each violin (like the `color` kwarg for `hist()`), but to have only a single dict for all the other optional kwargs for the fills and lines. For the time being I've stuck to the default colors/alpha values in the original implementation, but it might make more sense to leave these defaults unspecified so that they can be set according to `rcParams`.
