### PR TITLE
Changed pyplot.gca() and gcf() doc string 

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1226,7 +1226,7 @@ class Figure(Artist):
     @docstring.dedent_interpd
     def gca(self, **kwargs):
         """
-        Return the current axes, creating one if necessary
+        Get the current axes, creating one if necessary
 
         The following kwargs are supported for ensuring the returned axes
         adheres to the given projection etc., and for axes creation if

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -453,7 +453,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
 
 
 def gcf():
-    "Return a reference to the current figure."
+    "Get a reference to the current figure."
 
     figManager = _pylab_helpers.Gcf.get_active()
     if figManager is not None:
@@ -809,7 +809,7 @@ def sca(ax):
 
 def gca(**kwargs):
     """
-    Return the current :class:`~matplotlib.axes.Axes` instance on the
+    Get the current :class:`~matplotlib.axes.Axes` instance on the
     current figure matching the given keyword args, or create one.
 
     Examples


### PR DESCRIPTION
Doc strings now more closely relate to the name of the functions i.e. the "get" explains the "g" in the function names.
