### PR TITLE
Don't close GzipFile before it is used

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -475,17 +475,10 @@ class FigureCanvasCairo (FigureCanvasBase):
                 raise RuntimeError ('cairo has not been compiled with SVG '
                                     'support enabled')
             if format == 'svgz':
-                filename = fo
                 if is_string_like(fo):
-                    fo = open(fo, 'wb')
-                    close = True
+                    fo = gzip.GzipFile(fo, 'wb')
                 else:
-                    close = False
-                try:
                     fo = gzip.GzipFile(None, 'wb', fileobj=fo)
-                finally:
-                    if close:
-                        fo.close()
             surface = cairo.SVGSurface (fo, width_in_points, height_in_points)
         else:
             warnings.warn ("unknown format: %s" % format)
@@ -523,6 +516,8 @@ class FigureCanvasCairo (FigureCanvasBase):
 
         ctx.show_page()
         surface.finish()
+        if format == 'svgz':
+            fo.close()
 
 
 FigureCanvas = FigureCanvasCairo


### PR DESCRIPTION
Fixes issue #1883 for me on Windows.

Consider the code at https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/backends/backend_cairo.py#L478:

``` Python
            if format == 'svgz':
                filename = fo
                if is_string_like(fo):
                    fo = open(fo, 'wb')
                    close = True
                else:
                    close = False
                try:
                    fo = gzip.GzipFile(None, 'wb', fileobj=fo)
                finally:
                    if close:
                        fo.close()
```

In case the GzipFile is created from the open file created with `fo = open(fo, 'wb')`:
1) The GzipFile is always closed in the finally clause. Even though the GzipFile is closed, the open file passed to GzipFile as fileobj stays open. Later writes will be uncompressed (see https://docs.python.org/2/library/gzip.html#gzip.GzipFile). Does this produce valid svgz files?
2)  When the GzipFile is closed there is no reference to the open file left. Python can/will close the file at any time. Maybe that is the reason why on Windows the file is closed while on Linux it is still open.

The proposed changes should close all GzipFile and open file instances when/if necessary.
