### PR TITLE
add support for ttc font files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 install:
   - pip install -q --use-mirrors nose python-dateutil $NUMPY pep8 pyparsing pillow
-  - sudo apt-get update && sudo apt-get -qq install inkscape libav-tools gdb
+  - sudo apt-get update && sudo apt-get -qq install inkscape libav-tools gdb ttf-wqy-zenhei
   # We use --no-install-recommends to avoid pulling in additional large latex docs that we don't need
   - if [[ $BUILD_DOCS == true ]]; then sudo apt-get install -qq --no-install-recommends dvipng texlive-latex-base texlive-latex-extra texlive-fonts-recommended graphviz; fi
   - if [[ $BUILD_DOCS == true ]]; then pip install sphinx numpydoc linkchecker; fi

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -156,7 +156,7 @@ def get_fontext_synonyms(fontext):
     Return a list of file extensions extensions that are synonyms for
     the given file extension *fileext*.
     """
-    return {'ttf': ('ttf', 'otf'),
+    return {'ttf': ('ttf', 'ttc', 'otf'),
             'otf': ('ttf', 'otf'),
             'afm': ('afm',)}[fontext]
 

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -17,3 +17,13 @@ def test_font_priority():
         font = findfont(
             FontProperties(family=["sans-serif"]))
     assert_equal(os.path.basename(font), 'cmmi10.ttf')
+
+def test_font_ttc():
+# the font should be available(ttf-wqy-zenhei in ubuntu)
+    font = findfont(
+        FontProperties(family=["WenQuanYi Zen Hei"]))
+    assert_equal(os.path.basename(font), 'wqy-zenhei.ttc')
+
+if __name__=='__main__':
+    import nose
+    nose.runmodule(argv=['-s','--with-doctest'], exit=False)

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -18,12 +18,13 @@ def test_font_priority():
             FontProperties(family=["sans-serif"]))
     assert_equal(os.path.basename(font), 'cmmi10.ttf')
 
+
 def test_font_ttc():
-# the font should be available(ttf-wqy-zenhei in ubuntu)
+    # the font should be available(ttf-wqy-zenhei in ubuntu)
     font = findfont(
         FontProperties(family=["WenQuanYi Zen Hei"]))
     assert_equal(os.path.basename(font), 'wqy-zenhei.ttc')
 
-if __name__=='__main__':
+if __name__ == '__main__':
     import nose
-    nose.runmodule(argv=['-s','--with-doctest'], exit=False)
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
solve #3135

I found this solution in various web posts.

You may need to clean the cache in ~/.cache/matplotlib.
