### PR TITLE
Line 2256 of patches.py should be removed 

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2253,7 +2253,6 @@ class BoxStyle(_Style):
             codes = ([Path.MOVETO] +
                  [Path.CURVE3, Path.CURVE3] * ((len(saw_vertices)-1) // 2) +
                  [Path.CLOSEPOLY])
-            print(len(codes), saw_vertices.shape)
             return Path(saw_vertices, codes)
 
     _style_list["roundtooth"] = Roundtooth


### PR DESCRIPTION
This line is probably there for debug purpose. 

print(len(codes), saw_vertices.shape)
