### PR TITLE
Fixed PEP8 coding style violations

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -35,6 +35,7 @@ plugins = [KnownFailure]
 from nose.plugins import multiprocess
 multiprocess._instantiate_plugins = plugins
 
+
 def run():
     try:
         import faulthandler


### PR DESCRIPTION
`pep8 tests.py --ignore=E501` tells us everything is ok.

As part of http://24pullrequests.com, and to test if I can actually
submit a PR for matplotlib.
