### PR TITLE
Rectangle Selector Upgrade

### DIFF
--- a/examples/widgets/rectangle_selector.py
+++ b/examples/widgets/rectangle_selector.py
@@ -46,6 +46,7 @@ toggle_selector.RS = RectangleSelector(current_ax, line_select_callback,
                                        drawtype='box', useblit=True,
                                        button=[1, 3],  # don't use middle button
                                        minspanx=5, minspany=5,
-                                       spancoords='pixels')
+                                       spancoords='pixels',
+                                       interactive=True)
 plt.connect('key_press_event', toggle_selector)
 plt.show()

--- a/examples/widgets/rectangle_selector.py
+++ b/examples/widgets/rectangle_selector.py
@@ -43,7 +43,7 @@ print("\n      click  -->  release")
 
 # drawtype is 'box' or 'line' or 'none'
 toggle_selector.RS = RectangleSelector(current_ax, line_select_callback,
-                                       drawtype='line', useblit=True,
+                                       drawtype='box', useblit=True,
                                        button=[1, 3],  # don't use middle button
                                        minspanx=5, minspany=5,
                                        spancoords='pixels',

--- a/examples/widgets/rectangle_selector.py
+++ b/examples/widgets/rectangle_selector.py
@@ -43,7 +43,7 @@ print("\n      click  -->  release")
 
 # drawtype is 'box' or 'line' or 'none'
 toggle_selector.RS = RectangleSelector(current_ax, line_select_callback,
-                                       drawtype='box', useblit=True,
+                                       drawtype='line', useblit=True,
                                        button=[1, 3],  # don't use middle button
                                        minspanx=5, minspany=5,
                                        spancoords='pixels',

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -16,6 +16,7 @@ from matplotlib.testing.decorators import cleanup
 def get_ax():
     fig, ax = plt.subplots(1, 1)
     ax.plot([0, 200], [0, 200])
+    ax.set_aspect(1.0)
     ax.figure.canvas.draw()
     return ax
 
@@ -105,9 +106,54 @@ def test_rectangle_selector():
     check_rectangle(rectprops=dict(fill=True))
 
 
-def test_rectangle_modifiers():
-    # TODO: add tests for center, square, center, shift+drag
-    pass
+def test_ellipse():
+    """For ellipse, test out the key modifiers"""
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.EllipseSelector(ax, onselect=onselect,
+                                     maxdist=10)
+    tool.extents = (100, 150, 100, 150)
+
+    # drag the rectangle
+    event = get_event(ax, xdata=10, ydata=10, button=1,
+                    key='alt')
+    tool.press(event)
+    event = get_event(ax, xdata=30, ydata=30, button=1)
+    tool.onmove(event)
+    tool.release(event)
+    assert tool.extents == (120, 170, 120, 170)
+
+    # create from center
+    event = get_event(ax, xdata=100, ydata=100, button=1,
+                    key='control')
+    tool.press(event)
+    event = get_event(ax, xdata=125, ydata=125, button=1)
+    tool.onmove(event)
+    tool.release(event)
+    assert tool.extents == (75, 125, 75, 125)
+
+    # create a square
+    event = get_event(ax, xdata=10, ydata=10, button=1,
+                    key='shift')
+    tool.press(event)
+    event = get_event(ax, xdata=35, ydata=30, button=1)
+    tool.onmove(event)
+    tool.release(event)
+    extents = [int(e) for e in tool.extents]
+    assert extents == [10, 35, 10, 35]
+
+    # create a square from center
+    event = get_event(ax, xdata=100, ydata=100, button=1,
+                      key='ctrl+shift')
+    tool.press(event)
+    event = get_event(ax, xdata=125, ydata=130, button=1)
+    tool.onmove(event)
+    tool.release(event)
+    extents = [int(e) for e in tool.extents]
+    assert extents == [70, 130, 70, 130], extents
 
 
 def test_rectangle_handles():
@@ -118,9 +164,6 @@ def test_rectangle_handles():
 
     tool = widgets.RectangleSelector(ax, onselect=onselect,
                                      maxdist=10)
-    event = get_event(ax, xdata=100, ydata=100, button=1)
-    tool.press(event)
-
     tool.extents = (100, 150, 100, 150)
 
     assert tool.corners == (
@@ -137,6 +180,14 @@ def test_rectangle_handles():
     tool.onmove(event)
     tool.release(event)
     assert tool.extents ==  (120, 150, 120, 150)
+
+    # grab the center and move it
+    event = get_event(ax, xdata=132, ydata=132)
+    tool.press(event)
+    event = get_event(ax, xdata=120, ydata=120)
+    tool.onmove(event)
+    tool.release(event)
+    assert tool.extents ==  (108, 138, 108, 138)
 
     # create a new rectangle
     event = get_event(ax, xdata=10, ydata=10)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -125,10 +125,10 @@ def test_ellipse():
 
     # drag the rectangle
     do_event(tool, 'press', xdata=10, ydata=10, button=1,
-                    key='alt')
+                    key=' ')
     do_event(tool, 'onmove', xdata=30, ydata=30, button=1)
     do_event(tool, 'release', xdata=30, ydata=30, button=1)
-    assert tool.extents == (120, 170, 120, 170)
+    assert tool.extents == (120, 170, 120, 170), tool.extents
 
     # create from center
     do_event(tool, 'on_key_press', xdata=100, ydata=100, button=1,

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -173,7 +173,7 @@ def test_rectangle_handles():
         pass
 
     tool = widgets.RectangleSelector(ax, onselect=onselect,
-                                     maxdist=10)
+                                     maxdist=10, interactive=True)
     tool.extents = (100, 150, 100, 150)
 
     assert tool.corners == (

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -119,7 +119,7 @@ def test_ellipse():
         pass
 
     tool = widgets.EllipseSelector(ax, onselect=onselect,
-                                     maxdist=10)
+                                   maxdist=10, interactive=True)
     tool.extents = (100, 150, 100, 150)
 
     # drag the rectangle
@@ -193,7 +193,7 @@ def test_rectangle_handles():
     do_event(tool, 'press', xdata=132, ydata=132)
     do_event(tool, 'onmove', xdata=120, ydata=120)
     do_event(tool, 'release', xdata=120, ydata=120)
-    assert tool.extents == (108, 138, 108, 138)
+    assert tool.extents == (108, 138, 108, 138), tool.extents
 
     # create a new rectangle
     do_event(tool, 'press', xdata=10, ydata=10)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -11,6 +11,7 @@ import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
 
+from numpy.testing import assert_allclose
 
 
 def get_ax():
@@ -94,6 +95,10 @@ def check_rectangle(**kwargs):
     event = get_event(ax, xdata=250, ydata=250, button=1)
     tool.release(event)
 
+    assert_allclose(tool.geometry,
+        [[100., 100, 199, 199, 100], [100, 199, 199, 100, 100]],
+        err_msg=tool.geometry)
+
     assert ax._got_onselect
 
 
@@ -155,6 +160,8 @@ def test_ellipse():
     extents = [int(e) for e in tool.extents]
     assert extents == [70, 130, 70, 130], extents
 
+    assert tool.geometry.shape == (2, 74)
+    assert_allclose(tool.geometry[:, 0], [70., 100])
 
 def test_rectangle_handles():
     ax = get_ax()

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -12,6 +12,14 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
 
 
+
+def get_ax():
+    fig, ax = plt.subplots(1, 1)
+    ax.plot([0, 200], [0, 200])
+    ax.figure.canvas.draw()
+    return ax
+
+
 def get_event(ax, button=1, xdata=0, ydata=0, key=None, step=1):
     """
      *name*
@@ -65,9 +73,7 @@ def get_event(ax, button=1, xdata=0, ydata=0, key=None, step=1):
 
 @cleanup
 def check_rectangle(**kwargs):
-    fig, ax = plt.subplots(1, 1)
-    ax.plot([0, 200], [0, 200])
-    ax.figure.canvas.draw()
+    ax = get_ax()
 
     def onselect(epress, erelease):
         ax._got_onselect = True
@@ -105,9 +111,7 @@ def test_rectangle_modifiers():
 
 
 def test_rectangle_handles():
-    fig, ax = plt.subplots(1, 1)
-    ax.plot([0, 200], [0, 200])
-    ax.figure.canvas.draw()
+    ax = get_ax()
 
     def onselect(epress, erelease):
         pass
@@ -145,9 +149,7 @@ def test_rectangle_handles():
 
 @cleanup
 def check_span(*args, **kwargs):
-    fig, ax = plt.subplots(1, 1)
-    ax.plot([0, 200], [0, 200])
-    ax.figure.canvas.draw()
+    ax = get_ax()
 
     def onselect(vmin, vmax):
         ax._got_onselect = True
@@ -186,10 +188,7 @@ def test_span_selector():
 
 @cleanup
 def check_lasso_selector(**kwargs):
-    fig, ax = plt.subplots(1, 1)
-    ax = plt.gca()
-    ax.plot([0, 200], [0, 200])
-    ax.figure.canvas.draw()
+    ax = get_ax()
 
     def onselect(verts):
         ax._got_onselect = True

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -73,14 +73,14 @@ def check_rectangle(**kwargs):
         ax._got_onselect = True
         assert epress.xdata == 100
         assert epress.ydata == 100
-        assert erelease.xdata == 200
-        assert erelease.ydata == 200
+        assert erelease.xdata == 199
+        assert erelease.ydata == 199
 
     tool = widgets.RectangleSelector(ax, onselect, **kwargs)
     event = get_event(ax, xdata=100, ydata=100, button=1)
     tool.press(event)
 
-    event = get_event(ax, xdata=125, ydata=125, button=1)
+    event = get_event(ax, xdata=199, ydata=199, button=1)
     tool.onmove(event)
 
     # purposely drag outside of axis for release
@@ -97,6 +97,50 @@ def test_rectangle_selector():
     check_rectangle(drawtype='none', minspanx=10, minspany=10)
     check_rectangle(minspanx=10, minspany=10, spancoords='pixels')
     check_rectangle(rectprops=dict(fill=True))
+
+
+def test_rectangle_modifiers():
+    # TODO: add tests for center, square, center, shift+drag
+    pass
+
+
+def test_rectangle_handles():
+    fig, ax = plt.subplots(1, 1)
+    ax.plot([0, 200], [0, 200])
+    ax.figure.canvas.draw()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect=onselect,
+                                     maxdist=10)
+    event = get_event(ax, xdata=100, ydata=100, button=1)
+    tool.press(event)
+
+    tool.extents = (100, 150, 100, 150)
+
+    assert tool.corners == (
+        (100, 150, 150, 100), (100, 100, 150, 150))
+    assert tool.extents == (100, 150, 100, 150)
+    assert tool.edge_centers == (
+        (100, 125.0, 150, 125.0), (125.0, 100, 125.0, 150))
+    assert tool.extents == (100, 150, 100, 150)
+
+    # grab a corner and move it
+    event = get_event(ax, xdata=100, ydata=100)
+    tool.press(event)
+    event = get_event(ax, xdata=120, ydata=120)
+    tool.onmove(event)
+    tool.release(event)
+    assert tool.extents ==  (120, 150, 120, 150)
+
+    # create a new rectangle
+    event = get_event(ax, xdata=10, ydata=10)
+    tool.press(event)
+    event = get_event(ax, xdata=100, ydata=100)
+    tool.onmove(event)
+    tool.release(event)
+    assert tool.extents == (10, 100, 10, 100)
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -110,6 +110,7 @@ def test_rectangle_selector():
     check_rectangle(rectprops=dict(fill=True))
 
 
+@cleanup
 def test_ellipse():
     """For ellipse, test out the key modifiers"""
     ax = get_ax()
@@ -163,6 +164,8 @@ def test_ellipse():
     assert tool.geometry.shape == (2, 74)
     assert_allclose(tool.geometry[:, 0], [70., 100])
 
+
+@cleanup
 def test_rectangle_handles():
     ax = get_ax()
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -193,7 +193,7 @@ def test_rectangle_handles():
     do_event(tool, 'press', xdata=132, ydata=132)
     do_event(tool, 'onmove', xdata=120, ydata=120)
     do_event(tool, 'release', xdata=120, ydata=120)
-    assert tool.extents == (108, 138, 108, 138), tool.extents
+    assert tool.extents == (108, 138, 108, 138)
 
     # create a new rectangle
     do_event(tool, 'press', xdata=10, ydata=10)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -72,7 +72,7 @@ def do_event(tool, etype, button=1, xdata=0, ydata=0, key=None, step=1):
     event.guiEvent = None
     event.name = 'Custom'
 
-    func = getattr(tool, '_%s' % etype)
+    func = getattr(tool, etype)
     func(event)
 
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -94,9 +94,10 @@ def check_rectangle(**kwargs):
     # purposely drag outside of axis for release
     do_event(tool, 'release', xdata=250, ydata=250, button=1)
 
-    assert_allclose(tool.geometry,
-        [[100., 100, 199, 199, 100], [100, 199, 199, 100, 100]],
-        err_msg=tool.geometry)
+    if kwargs.get('drawtype', None) not in ['line', 'none']:
+        assert_allclose(tool.geometry,
+            [[100., 100, 199, 199, 100], [100, 199, 199, 100, 100]],
+            err_msg=tool.geometry)
 
     assert ax._got_onselect
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -187,13 +187,13 @@ def test_rectangle_handles():
     do_event(tool, 'press', xdata=100, ydata=100)
     do_event(tool, 'onmove', xdata=120, ydata=120)
     do_event(tool, 'release', xdata=120, ydata=120)
-    assert tool.extents ==  (120, 150, 120, 150)
+    assert tool.extents == (120, 150, 120, 150)
 
     # grab the center and move it
     do_event(tool, 'press', xdata=132, ydata=132)
     do_event(tool, 'onmove', xdata=120, ydata=120)
     do_event(tool, 'release', xdata=120, ydata=120)
-    assert tool.extents ==  (108, 138, 108, 138)
+    assert tool.extents == (108, 138, 108, 138)
 
     # create a new rectangle
     do_event(tool, 'press', xdata=10, ydata=10)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1145,7 +1145,7 @@ class _SelectorWidget(AxesWidget):
         self.connect_default_events()
 
         self.state_modifier_keys = dict(move=' ', clear='escape',
-                                        square='shift', center='ctrl')
+                                        square='shift', center='control')
         self.state_modifier_keys.update(state_modifier_keys or {})
 
         self.background = None
@@ -1273,7 +1273,8 @@ class _SelectorWidget(AxesWidget):
             self.eventpress = event
             self._prev_event = event
             key = event.key or ''
-            key = key.replace('control', 'ctrl')
+            key = key.replace('ctrl', 'control')
+            # move state is locked in on a button press
             if key == self.state_modifier_keys['move']:
                 self.state.add('move')
             self._press(event)
@@ -1322,10 +1323,10 @@ class _SelectorWidget(AxesWidget):
         pass
 
     def on_key_press(self, event):
-        """Key press event handler and validator"""
+        """Key press event handler and validator for all selection widgets"""
         if self.active:
             key = event.key or ''
-            key = key.replace('control', 'ctrl')
+            key = key.replace('ctrl', 'control')
             if key == self.state_modifier_keys['clear']:
                 for artist in self.artists:
                     artist.set_visible(False)
@@ -1337,7 +1338,8 @@ class _SelectorWidget(AxesWidget):
             self._on_key_press(event)
 
     def _on_key_press(self, event):
-        """Key press event handler"""
+        """Key press event handler - use for widget-specific key press actions.
+        """
         pass
 
     def on_key_release(self, event):
@@ -1424,7 +1426,7 @@ class SpanSelector(_SelectorWidget):
         if rectprops is None:
             rectprops = dict(facecolor='red', alpha=0.5)
 
-        rectprops['animated'] = useblit
+        rectprops['animated'] = self.useblit
 
         if direction not in ['horizontal', 'vertical']:
             msg = "direction must be in [ 'horizontal' | 'vertical' ]"
@@ -1567,7 +1569,6 @@ class SpanSelector(_SelectorWidget):
 
 
 class ToolHandles(object):
-
     """Control handles for canvas tools.
 
     Parameters

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1140,11 +1140,11 @@ class _SelectorWidget(AxesWidget):
 
         self.visible = True
         self.onselect = onselect
+        self.useblit = useblit and self.canvas.supports_blit
         self.connect_default_events()
 
         self.background = None
         self.artists = []
-        self.useblit = useblit and self.canvas.supports_blit
 
         if isinstance(button, int):
             self.validButtons = [button]
@@ -1172,13 +1172,13 @@ class _SelectorWidget(AxesWidget):
 
     def connect_default_events(self):
         """Connect the major canvas events to methods."""
-        self.connect_event('motion_notify_event', self._onmove)
-        self.connect_event('button_press_event', self._press)
-        self.connect_event('button_release_event', self._release)
+        self.connect_event('motion_notify_event', self.onmove)
+        self.connect_event('button_press_event', self.press)
+        self.connect_event('button_release_event', self.release)
         self.connect_event('draw_event', self.update_background)
-        self.connect_event('key_press_event', self._on_key_press)
-        self.connect_event('key_release_event', self._on_key_release)
-        self.connect_event('scroll_event', self._on_scroll)
+        self.connect_event('key_press_event', self.on_key_press)
+        self.connect_event('key_release_event', self.on_key_release)
+        self.connect_event('scroll_event', self.on_scroll)
 
     def ignore(self, event):
         """return *True* if *event* should be ignored"""
@@ -1258,7 +1258,7 @@ class _SelectorWidget(AxesWidget):
         self._prev_event = event
         return event
 
-    def _press(self, event):
+    def press(self, event):
         """Button press handler and validator"""
         if not self.ignore(event):
             event = self._clean_event(event)
@@ -1267,44 +1267,44 @@ class _SelectorWidget(AxesWidget):
             key = event.key or ''
             if 'alt' in key or key == ' ':
                 self.state.add('move')
-            self.press(event)
+            self._press(event)
 
-    def press(self, event):
+    def _press(self, event):
         """Button press handler"""
         pass
 
-    def _release(self, event):
+    def release(self, event):
         """Button release event handler and validator"""
         if not self.ignore(event) and self.eventpress:
             event = self._clean_event(event)
             self.eventrelease = event
-            self.release(event)
+            self._release(event)
             self.state.discard('move')
 
-    def release(self, event):
+    def _release(self, event):
         """Button release event handler"""
         pass
             
-    def _onmove(self, event):
+    def onmove(self, event):
         """Cursor move event handler and validator"""
         if not self.ignore(event) and self.eventpress:
             event = self._clean_event(event)
-            self.onmove(event)
+            self._onmove(event)
 
-    def onmove(self, event):
+    def _onmove(self, event):
         """Cursor move event handler"""
         pass
 
-    def _on_scroll(self, event):
+    def on_scroll(self, event):
         """Mouse scroll event handler and validator"""
         if not self.ignore(event):
-            self.on_scroll(event)
+            self._on_scroll(event)
 
-    def on_scroll(self, event):
+    def _on_scroll(self, event):
         """Mouse scroll event handler"""
         pass
 
-    def _on_key_press(self, event):
+    def on_key_press(self, event):
         """Key press event handler and validator"""
         if self.active:
             key = event.key or ''
@@ -1312,13 +1312,13 @@ class _SelectorWidget(AxesWidget):
                 self.state.add('square')
             if 'ctrl' in key or 'control' in key:
                 self.state.add('center')
-            self.on_key_press(event)
+            self._on_key_press(event)
 
-    def on_key_press(self, event):
+    def _on_key_press(self, event):
         """Key press event handler"""
         pass
 
-    def _on_key_release(self, event):
+    def on_key_release(self, event):
         """Key release event handler and validator"""
         if self.active:
             key = event.key or ''
@@ -1326,9 +1326,9 @@ class _SelectorWidget(AxesWidget):
                 self.state.discard('square')
             if 'ctrl' in key or 'control' in key:
                 self.state.discard('center')
-            self.on_key_release(event)
+            self._on_key_release(event)
 
-    def on_key_release(self, event):
+    def _on_key_release(self, event):
         """Key release event handler"""
         pass
 
@@ -1458,7 +1458,7 @@ class SpanSelector(_SelectorWidget):
         """return *True* if *event* should be ignored"""
         return _SelectorWidget.ignore(self, event) or not self.visible
 
-    def press(self, event):
+    def _press(self, event):
         """on button press event"""
         self.rect.set_visible(self.visible)
         if self.span_stays:
@@ -1471,7 +1471,7 @@ class SpanSelector(_SelectorWidget):
             self.pressv = ydata
         return False
 
-    def release(self, event):
+    def _release(self, event):
         """on button release event"""
         if self.pressv is None:
             return
@@ -1503,7 +1503,7 @@ class SpanSelector(_SelectorWidget):
         self.pressv = None
         return False
 
-    def onmove(self, event):
+    def _onmove(self, event):
         """on motion notify event"""
         if self.pressv is None:
             return
@@ -1752,7 +1752,7 @@ class RectangleSelector(_SelectorWidget):
                         self._corner_handles.artist,
                         self._edge_handles.artist]
 
-    def press(self, event):
+    def _press(self, event):
         """on button press event"""
         # make the drawed box/line visible get the click-coordinates,
         # button, ...
@@ -1765,7 +1765,7 @@ class RectangleSelector(_SelectorWidget):
 
         self.set_visible(self.visible)
 
-    def release(self, event):
+    def _release(self, event):
         """on button release event"""
         if self.spancoords == 'data':
             xmin, ymin = self.eventpress.xdata, self.eventpress.ydata
@@ -1812,7 +1812,7 @@ class RectangleSelector(_SelectorWidget):
 
         return False
 
-    def onmove(self, event):
+    def _onmove(self, event):
         """on motion notify event if box/line is wanted"""     
         # resize an existing shape
         if self.active_handle and not self.active_handle == 'C':
@@ -2084,14 +2084,14 @@ class LassoSelector(_SelectorWidget):
     def onpress(self, event):
         self.press(event)
 
-    def press(self, event):
+    def _press(self, event):
         self.verts = [self._get_data(event)]
         self.line.set_visible(True)
 
     def onrelease(self, event):
         self.release(event)
 
-    def release(self, event):
+    def _release(self, event):
         if self.verts is not None:
             self.verts.append(self._get_data(event))
             self.onselect(self.verts)
@@ -2099,7 +2099,7 @@ class LassoSelector(_SelectorWidget):
         self.line.set_visible(False)
         self.verts = None
 
-    def onmove(self, event):
+    def _onmove(self, event):
         if self.verts is None:
             return
         self.verts.append(self._get_data(event))

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1945,7 +1945,6 @@ class RectangleSelector(_SelectorWidget):
             return np.array(self.to_draw.get_data())
 
 
-
 class EllipseSelector(RectangleSelector):
 
     _shape_klass = Ellipse

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1218,6 +1218,9 @@ class _SelectorWidget(AxesWidget):
         useblit
 
         """
+        if not self.ax.get_visible():
+            return False
+
         if self.useblit:
             if self.background is not None:
                 self.canvas.restore_region(self.background)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -83,7 +83,7 @@ class Widget(object):
     # set_active is overriden by SelectorWidgets.
     active = property(get_active, lambda self, active: self.set_active(active),
                       doc="Is the widget active?")
-                      
+
     def ignore(self, event):
         """Return True if event should be ignored.
 
@@ -642,7 +642,7 @@ class RadioButtons(AxesWidget):
 
      *circles*
         A list of :class:`matplotlib.patches.Circle` instances
-        
+
      *value_selected*
         A string listing the current value selected
 
@@ -1091,7 +1091,7 @@ class MultiCursor(Widget):
     def clear(self, event):
         """clear the cursor"""
         if self.ignore(event):
-            return        
+            return
         if self.useblit:
             self.background = (
                 self.canvas.copy_from_bbox(self.canvas.figure.bbox))
@@ -1100,7 +1100,7 @@ class MultiCursor(Widget):
 
     def onmove(self, event):
         if self.ignore(event):
-            return        
+            return
         if event.inaxes is None:
             return
         if not self.canvas.widgetlock.available(self):
@@ -1257,7 +1257,7 @@ class _SelectorWidget(AxesWidget):
         else:
             event = copy.copy(event)
         event.xdata, event.ydata = self._get_data(event)
-        
+
         self._prev_event = event
         return event
 
@@ -1293,7 +1293,7 @@ class _SelectorWidget(AxesWidget):
     def _release(self, event):
         """Button release event handler"""
         pass
-            
+
     def onmove(self, event):
         """Cursor move event handler and validator"""
         if not self.ignore(event) and self.eventpress:
@@ -1392,7 +1392,7 @@ class SpanSelector(_SelectorWidget):
         If *minspan* is not *None*, ignore events smaller than *minspan*
 
         The span rectangle is drawn with *rectprops*; default::
-        
+
           rectprops = dict(facecolor='red', alpha=0.5)
 
         Set the visible attribute to *False* if you want to turn off
@@ -1413,7 +1413,7 @@ class SpanSelector(_SelectorWidget):
 
         """
         _SelectorWidget.__init__(self, ax, onselect, useblit=useblit,
-            button=button)
+                                 button=button)
 
         if rectprops is None:
             rectprops = dict(facecolor='red', alpha=0.5)
@@ -1845,7 +1845,7 @@ class RectangleSelector(_SelectorWidget):
         return False
 
     def _onmove(self, event):
-        """on motion notify event if box/line is wanted"""     
+        """on motion notify event if box/line is wanted"""
         # resize an existing shape
         if self.active_handle and not self.active_handle == 'C':
             x1, x2, y1, y2 = self._extents_on_press
@@ -1985,10 +1985,10 @@ class RectangleSelector(_SelectorWidget):
         c_idx, c_dist = self._corner_handles.closest(event.x, event.y)
         e_idx, e_dist = self._edge_handles.closest(event.x, event.y)
         m_idx, m_dist = self._center_handle.closest(event.x, event.y)
-        
+
         if 'move' in self.state:
             self.active_handle = 'C'
-            self._extents_on_press = self.extents    
+            self._extents_on_press = self.extents
 
         # Set active handle as closest handle, if mouse click is close enough.
         elif m_dist < self.maxdist * 2:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1796,7 +1796,6 @@ class RectangleSelector(_SelectorWidget):
         if self.interactive and self.to_draw.get_visible():
             self._set_active_handle(event)
 
-        self.set_visible(self.visible)
         if self.active_handle is None or not self.interactive:
             # Clear previous rectangle before drawing new rectangle.
             self.update()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1886,6 +1886,13 @@ class RectangleSelector(_SelectorWidget):
         x0, x1, y0, y1 = extents
         xmin, xmax = sorted([x0, x1])
         ymin, ymax = sorted([y0, y1])
+        xlim = self.ax.get_xlim()
+        ylim = self.ax.get_ylim()
+
+        xmin = max(xlim[0], xmin)
+        ymin = max(ylim[0], ymin)
+        xmax = min(xmax, xlim[1])
+        ymax = min(ymax, ylim[1])
 
         if self.drawtype == 'patch':
             self.to_draw.set_x(xmin)
@@ -1927,6 +1934,10 @@ class RectangleSelector(_SelectorWidget):
         if self.active_handle in ['N', 'NW', 'NE']:
             y1, y2 = y2, event.ydata
         self._extents_on_press = x1, x2, y1, y2
+
+    @property
+    def path(self):
+        return self.to_draw.get_path()
 
 
 class EllipseSelector(RectangleSelector):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1156,7 +1156,7 @@ class _SelectorWidget(AxesWidget):
         # will save the data (pos. at mouserelease)
         self.eventrelease = None
         self._prev_event = None
-        self.state = []
+        self.state = set()
 
     def set_active(self, active):
         AxesWidget.set_active(self, active)
@@ -1177,6 +1177,7 @@ class _SelectorWidget(AxesWidget):
         self.connect_event('button_release_event', self._release)
         self.connect_event('draw_event', self.update_background)
         self.connect_event('key_press_event', self._on_key_press)
+        self.connect_event('key_release_event', self._on_key_release)
         self.connect_event('scroll_event', self._on_scroll)
 
     def ignore(self, event):
@@ -1257,15 +1258,9 @@ class _SelectorWidget(AxesWidget):
             event = self._clean_event(event)
             self.eventpress = event
             self._prev_event = event
-
-            self.state = []
             key = event.key or ''
             if 'alt' in key or key == ' ':
-                self.state.append('move')
-            if 'shift' in key:
-                self.state.append('square')
-            if 'ctrl' in key or 'control' in key:
-                self.state.append('center')
+                self.state.add('move')
             self.press(event)
 
     def press(self, event):
@@ -1287,16 +1282,6 @@ class _SelectorWidget(AxesWidget):
         """Cursor move event handler and validator"""
         if not self.ignore(event) and self.eventpress:
             event = self._clean_event(event)
-            # update the state
-            if 'move' in self.state:
-                self.state = ['move']
-            else:
-                self.state = []
-            key = event.key or ''
-            if 'shift' in key:
-                self.state.append('square')
-            if 'ctrl' in key or 'control' in key:
-                self.state.append('center')
             self.onmove(event)
 
     def onmove(self, event):
@@ -1314,11 +1299,30 @@ class _SelectorWidget(AxesWidget):
 
     def _on_key_press(self, event):
         """Key press event handler and validator"""
-        if not self.ignore(event):
+        if self.active:
+            key = event.key or ''
+            if 'shift' in key:
+                self.state.add('square')
+            if 'ctrl' in key or 'control' in key:
+                self.state.add('center')
             self.on_key_press(event)
 
     def on_key_press(self, event):
         """Key press event handler"""
+        pass
+
+    def _on_key_release(self, event):
+        """Key release event handler and validator"""
+        if self.active:
+            key = event.key or ''
+            if 'shift' in key:
+                self.state.discard('square')
+            if 'ctrl' in key or 'control' in key:
+                self.state.discard('center')
+            self.on_key_release(event)
+
+    def on_key_release(self, event):
+        """Key release event handler"""
         pass
 
     def set_visible(self, visible):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1778,6 +1778,8 @@ class RectangleSelector(_SelectorWidget):
         if not self.interactive:
             self.artists = [self.to_draw]
 
+        self._extents_on_press = None
+
     def _press(self, event):
         """on button press event"""
         # make the drawed box/line visible get the click-coordinates,
@@ -1853,7 +1855,8 @@ class RectangleSelector(_SelectorWidget):
                 y2 = event.ydata
 
         # move existing shape
-        elif 'move' in self.state:
+        elif (('move' in self.state or self.active_handle == 'C')
+              and self._extents_on_press is not None):
             x1, x2, y1, y2 = self._extents_on_press
             dx = event.xdata - self.eventpress.xdata
             dy = event.ydata - self.eventpress.ydata

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1660,7 +1660,7 @@ class RectangleSelector(_SelectorWidget):
 
     _shape_klass = Rectangle
 
-    def __init__(self, ax, onselect, drawtype='patch',
+    def __init__(self, ax, onselect, drawtype='box',
                  minspanx=None, minspany=None, useblit=False,
                  lineprops=None, rectprops=None, spancoords='data',
                  button=None, maxdist=10, marker_props=None,
@@ -1691,7 +1691,7 @@ class RectangleSelector(_SelectorWidget):
         Use *drawtype* if you want the mouse to draw a line,
         a box or nothing between click and actual position by setting
 
-        ``drawtype = 'line'``, ``drawtype='patch'`` or ``drawtype = 'none'``.
+        ``drawtype = 'line'``, ``drawtype='box'`` or ``drawtype = 'none'``.
 
         *spancoords* is one of 'data' or 'pixels'.  If 'data', *minspanx*
         and *minspanx* will be interpreted in the same coordinates as
@@ -1708,7 +1708,15 @@ class RectangleSelector(_SelectorWidget):
          3 = right mouse button
 
         *interactive* will draw a set of handles and allow you interact
-        with the widget after it is drawn.
+        with the widget after it is drawn.  Holding the 'space' while dragging
+        the mouse will move the object.
+
+        Modifier keys
+        -------------
+        One can use modifier keys to affect the way the shape is drawn.
+        Hold the 'Ctrl' key to center the rectangle on the initial position.
+        Hold the 'Shift' key to force the shape to be square.
+        These can be combined.
         """
         _SelectorWidget.__init__(self, ax, onselect, useblit=useblit,
                                  button=button)
@@ -1717,14 +1725,11 @@ class RectangleSelector(_SelectorWidget):
         self.visible = True
         self.interactive = interactive
 
-        if drawtype == 'box':  # backwards compatibility
-            drawtype = 'patch'
-
         if drawtype == 'none':
             drawtype = 'line'                        # draw a line but make it
             self.visible = False                     # invisible
 
-        if drawtype == 'patch':
+        if drawtype == 'box':
             if rectprops is None:
                 rectprops = dict(facecolor='red', edgecolor='black',
                                  alpha=0.2, fill=True)
@@ -1739,7 +1744,7 @@ class RectangleSelector(_SelectorWidget):
                                  linewidth=2, alpha=0.5)
             lineprops['animated'] = useblit
             self.lineprops = lineprops
-            self.to_draw = Line2D([0, 0, 0, 0, 0], [0, 0, 0, 0, 0], visible=False,
+            self.to_draw = Line2D([0, 0], [0, 0], visible=False,
                                   **self.lineprops)
             self.ax.add_line(self.to_draw)
 
@@ -1905,7 +1910,7 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def _rect_bbox(self):
-        if self.drawtype == 'patch':
+        if self.drawtype == 'box':
             x0 = self.to_draw.get_x()
             y0 = self.to_draw.get_y()
             width = self.to_draw.get_width()
@@ -1972,15 +1977,14 @@ class RectangleSelector(_SelectorWidget):
         xmax = min(xmax, xlim[1])
         ymax = min(ymax, ylim[1])
 
-        if self.drawtype == 'patch':
+        if self.drawtype == 'box':
             self.to_draw.set_x(xmin)
             self.to_draw.set_y(ymin)
             self.to_draw.set_width(xmax - xmin)
             self.to_draw.set_height(ymax - ymin)
 
         elif self.drawtype == 'line':
-            self.to_draw.set_data([xmin,  xmin, xmax, xmax, xmin],
-                                  [ymin, ymax, ymax, ymin, ymin])
+            self.to_draw.set_data([xmin, xmax], [ymin, ymax])
 
     def _set_active_handle(self, event):
         """Set active handle based on the location of the mouse event"""
@@ -2070,7 +2074,7 @@ class EllipseSelector(RectangleSelector):
         a = (xmax - xmin) / 2.
         b = (ymax - ymin) / 2.
 
-        if self.drawtype == 'patch':
+        if self.drawtype == 'box':
             self.to_draw.center = center
             self.to_draw.width = 2 * a
             self.to_draw.height = 2 * b
@@ -2082,7 +2086,7 @@ class EllipseSelector(RectangleSelector):
 
     @property
     def _rect_bbox(self):
-        if self.drawtype == 'patch':
+        if self.drawtype == 'box':
             x, y = self.to_draw.center
             width = self.to_draw.width
             height = self.to_draw.height

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1634,17 +1634,17 @@ class RectangleSelector(_SelectorWidget):
 
         def onselect(eclick, erelease):
           'eclick and erelease are matplotlib events at press and release'
-          print ' startposition : (%f, %f)' % (eclick.xdata, eclick.ydata)
-          print ' endposition   : (%f, %f)' % (erelease.xdata, erelease.ydata)
-          print ' used button   : ', eclick.button
+          print(' startposition : (%f, %f)' % (eclick.xdata, eclick.ydata))
+          print(' endposition   : (%f, %f)' % (erelease.xdata, erelease.ydata))
+          print(' used button   : ', eclick.button)
 
         def toggle_selector(event):
-            print ' Key pressed.'
+            print(' Key pressed.')
             if event.key in ['Q', 'q'] and toggle_selector.RS.active:
-                print ' RectangleSelector deactivated.'
+                print(' RectangleSelector deactivated.')
                 toggle_selector.RS.set_active(False)
             if event.key in ['A', 'a'] and not toggle_selector.RS.active:
-                print ' RectangleSelector activated.'
+                print(' RectangleSelector activated.')
                 toggle_selector.RS.set_active(True)
 
         x = arange(100)/(99.0)
@@ -2024,7 +2024,42 @@ class RectangleSelector(_SelectorWidget):
 
 
 class EllipseSelector(RectangleSelector):
+    """
+    Select an elliptical region of an axes.
 
+    For the cursor to remain responsive you much keep a reference to
+    it.
+
+    Example usage::
+
+        from matplotlib.widgets import  EllipseSelector
+        from pylab import *
+
+        def onselect(eclick, erelease):
+          'eclick and erelease are matplotlib events at press and release'
+          print(' startposition : (%f, %f)' % (eclick.xdata, eclick.ydata))
+          print(' endposition   : (%f, %f)' % (erelease.xdata, erelease.ydata))
+          print(' used button   : ', eclick.button)
+
+        def toggle_selector(event):
+            print(' Key pressed.')
+            if event.key in ['Q', 'q'] and toggle_selector.ES.active:
+                print(' EllipseSelector deactivated.')
+                toggle_selector.RS.set_active(False)
+            if event.key in ['A', 'a'] and not toggle_selector.ES.active:
+                print(' EllipseSelector activated.')
+                toggle_selector.ES.set_active(True)
+
+        x = arange(100)/(99.0)
+        y = sin(x)
+        fig = figure
+        ax = subplot(111)
+        ax.plot(x,y)
+
+        toggle_selector.ES = EllipseSelector(ax, onselect, drawtype='line')
+        connect('key_press_event', toggle_selector)
+        show()
+    """
     _shape_klass = Ellipse
 
     def draw_shape(self, extents):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1456,9 +1456,8 @@ class SpanSelector(_SelectorWidget):
                                        **self.rectprops)
             self.ax.add_patch(self.stay_rect)
 
-        if not self.useblit:
-            self.ax.add_patch(self.rect)
-            self.artists = [self.rect]
+        self.ax.add_patch(self.rect)
+        self.artists = [self.rect]
 
     def ignore(self, event):
         """return *True* if *event* should be ignored"""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1548,6 +1548,7 @@ class ToolHandles(object):
         else:
             return 0, np.sqrt(np.sum(diff ** 2))
 
+
 class RectangleSelector(_SelectorWidget):
     """
     Select a rectangular region of an axes.
@@ -1679,7 +1680,7 @@ class RectangleSelector(_SelectorWidget):
         if rectprops is None:
             props = dict(mec='r')
         else:
-            props = dict(mec=rectprops['edgecolor'])
+            props = dict(mec=rectprops.get('edgecolor', 'k'))
         self._corner_order = ['NW', 'NE', 'SE', 'SW']
         xc, yc = self.corners
         self._corner_handles = ToolHandles(self.ax, xc, yc, marker_props=props,
@@ -1962,12 +1963,6 @@ class EllipseSelector(RectangleSelector):
             x0, x1 = min(x), max(x)
             y0, y1 = min(y), max(y)
             return x0, y0, x1 - x0, y1 - y0
-
-    @property
-    def geometry(self):
-        x0, y0, width, height = self._rect_bbox
-        return x0 + width / 2., y0 + width / 2., width, height
-
 
 
 class LassoSelector(_SelectorWidget):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1418,6 +1418,8 @@ class SpanSelector(_SelectorWidget):
         if rectprops is None:
             rectprops = dict(facecolor='red', alpha=0.5)
 
+        rectprops['animated'] = useblit
+
         if direction not in ['horizontal', 'vertical']:
             msg = "direction must be in [ 'horizontal' | 'vertical' ]"
             raise ValueError(msg)
@@ -1726,6 +1728,7 @@ class RectangleSelector(_SelectorWidget):
             if rectprops is None:
                 rectprops = dict(facecolor='red', edgecolor='black',
                                  alpha=0.2, fill=True)
+            rectprops['animated'] = useblit
             self.rectprops = rectprops
             self.to_draw = self._shape_klass((0, 0),
                                      0, 1, visible=False, **self.rectprops)
@@ -1734,6 +1737,7 @@ class RectangleSelector(_SelectorWidget):
             if lineprops is None:
                 lineprops = dict(color='black', linestyle='-',
                                  linewidth=2, alpha=0.5)
+            lineprops['animated'] = useblit
             self.lineprops = lineprops
             self.to_draw = Line2D([0, 0, 0, 0, 0], [0, 0, 0, 0, 0], visible=False,
                                   **self.lineprops)
@@ -1954,8 +1958,7 @@ class RectangleSelector(_SelectorWidget):
         self._edge_handles.set_data(*self.edge_centers)
         self._center_handle.set_data(*self.center)
         self.set_visible(self.visible)
-
-        self.canvas.draw_idle()
+        self.update()
 
     def draw_shape(self, extents):
         x0, x1, y0, y1 = extents

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1853,7 +1853,7 @@ class RectangleSelector(_SelectorWidget):
                 y2 = event.ydata
 
         # move existing shape
-        elif self.active_handle == 'C' or 'move' in self.state:
+        elif 'move' in self.state:
             x1, x2, y1, y2 = self._extents_on_press
             dx = event.xdata - self.eventpress.xdata
             dy = event.ydata - self.eventpress.ydata

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1807,6 +1807,8 @@ class RectangleSelector(_SelectorWidget):
         # button, ...
         if self.interactive and self.to_draw.get_visible():
             self._set_active_handle(event)
+        else:
+            self.active_handle = None
 
         if self.active_handle is None or not self.interactive:
             # Clear previous rectangle before drawing new rectangle.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1281,6 +1281,8 @@ class _SelectorWidget(AxesWidget):
             event = self._clean_event(event)
             self.eventrelease = event
             self._release(event)
+            self.eventpress = None
+            self.eventrelease = None
             self.state.discard('move')
             return True
         return False

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1489,6 +1489,65 @@ class SpanSelector(_SelectorWidget):
         return False
 
 
+class ToolHandles(object):
+
+    """Control handles for canvas tools.
+
+    Parameters
+    ----------
+    ax : :class:`matplotlib.axes.Axes`
+        Matplotlib axes where tool handles are displayed.
+    x, y : 1D arrays
+        Coordinates of control handles.
+    marker : str
+        Shape of marker used to display handle. See `matplotlib.pyplot.plot`.
+    marker_props : dict
+        Additional marker properties. See :class:`matplotlib.lines.Line2D`.
+    """
+
+    def __init__(self, ax, x, y, marker='o', marker_props=None, useblit=True):
+        self.ax = ax
+
+        props = dict(marker=marker, markersize=7, mfc='w', ls='none',
+                     alpha=0.5, visible=False)
+        props.update(marker_props if marker_props is not None else {})
+        self._markers = Line2D(x, y, animated=useblit, **props)
+        self.ax.add_line(self._markers)
+        self.artist = self._markers
+
+    @property
+    def x(self):
+        return self._markers.get_xdata()
+
+    @property
+    def y(self):
+        return self._markers.get_ydata()
+
+    def set_data(self, pts, y=None):
+        """Set x and y positions of handles"""
+        if y is not None:
+            x = pts
+            pts = np.array([x, y])
+        self._markers.set_data(pts)
+
+    def set_visible(self, val):
+        self._markers.set_visible(val)
+
+    def set_animated(self, val):
+        self._markers.set_animated(val)
+
+    def closest(self, x, y):
+        """Return index and pixel distance to closest index."""
+        pts = np.transpose((self.x, self.y))
+        # Transform data coordinates to pixel coordinates.
+        pts = self.ax.transData.transform(pts)
+        diff = pts - ((x, y))
+        if diff.ndim == 2:
+            dist = np.sqrt(np.sum(diff ** 2, axis=1))
+            return np.argmin(dist), np.min(dist)
+        else:
+            return 0, np.sqrt(np.sum(diff ** 2))
+
 class RectangleSelector(_SelectorWidget):
     """
     Select a rectangular region of an axes.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1268,6 +1268,8 @@ class _SelectorWidget(AxesWidget):
             if 'alt' in key or key == ' ':
                 self.state.add('move')
             self._press(event)
+            return True
+        return False
 
     def _press(self, event):
         """Button press handler"""
@@ -1280,6 +1282,8 @@ class _SelectorWidget(AxesWidget):
             self.eventrelease = event
             self._release(event)
             self.state.discard('move')
+            return True
+        return False
 
     def _release(self, event):
         """Button release event handler"""
@@ -1290,6 +1294,8 @@ class _SelectorWidget(AxesWidget):
         if not self.ignore(event) and self.eventpress:
             event = self._clean_event(event)
             self._onmove(event)
+            return True
+        return False
 
     def _onmove(self, event):
         """Cursor move event handler"""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1268,7 +1268,7 @@ class _SelectorWidget(AxesWidget):
             self.eventpress = event
             self._prev_event = event
             key = event.key or ''
-            if 'alt' in key or key == ' ':
+            if key == ' ':
                 self.state.add('move')
             self._press(event)
             return True
@@ -1681,7 +1681,7 @@ class RectangleSelector(_SelectorWidget):
         The rectangle is drawn with *rectprops*; default::
 
           rectprops = dict(facecolor='red', edgecolor = 'black',
-                           alpha=0.5, fill=False)
+                           alpha=0.2, fill=True)
 
         The line is drawn with *lineprops*; default::
 
@@ -1731,7 +1731,7 @@ class RectangleSelector(_SelectorWidget):
             if rectprops is None:
                 rectprops = dict(facecolor='red', edgecolor='black',
                                  alpha=0.2, fill=True)
-            rectprops['animated'] = useblit
+            rectprops['animated'] = self.useblit
             self.rectprops = rectprops
             self.to_draw = self._shape_klass((0, 0),
                                      0, 1, visible=False, **self.rectprops)
@@ -1740,7 +1740,7 @@ class RectangleSelector(_SelectorWidget):
             if lineprops is None:
                 lineprops = dict(color='black', linestyle='-',
                                  linewidth=2, alpha=0.5)
-            lineprops['animated'] = useblit
+            lineprops['animated'] = self.useblit
             self.lineprops = lineprops
             self.to_draw = Line2D([0, 0], [0, 0], visible=False,
                                   **self.lineprops)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1182,7 +1182,7 @@ class _SelectorWidget(AxesWidget):
 
     def ignore(self, event):
         """return *True* if *event* should be ignored"""
-        if not self.active:
+        if not self.active or not self.ax.get_visible():
             return True
 
         # If canvas was locked

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1737,7 +1737,7 @@ class RectangleSelector(_SelectorWidget):
         if rectprops is None:
             props = dict(mec='r')
         else:
-            props = dict(mec=rectprops.get('edgecolor', 'k'))
+            props = dict(mec=rectprops.get('edgecolor', 'r'))
         self._corner_order = ['NW', 'NE', 'SE', 'SW']
         xc, yc = self.corners
         self._corner_handles = ToolHandles(self.ax, xc, yc, marker_props=props,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1919,7 +1919,7 @@ class RectangleSelector(_SelectorWidget):
         e_idx, e_dist = self._edge_handles.closest(event.x, event.y)
         m_idx, m_dist = self._center_handle.closest(event.x, event.y)
 
-        if event.key in ['alt', ' ']:
+        if self._moving:
             self.active_handle = 'C'
             self._extents_on_press = self.extents
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1708,8 +1708,7 @@ class RectangleSelector(_SelectorWidget):
          3 = right mouse button
 
         *interactive* will draw a set of handles and allow you interact
-        with the widget after it is drawn.  Holding the 'space' while dragging
-        the mouse will move the object.
+        with the widget after it is drawn.
 
         Keyboard modifiers:
         Alt or Space moves the existing shape.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1346,10 +1346,9 @@ class _SelectorWidget(AxesWidget):
         """Key release event handler and validator"""
         if self.active:
             key = event.key or ''
-            if 'shift' in key:
-                self.state.discard('square')
-            if 'ctrl' in key or 'control' in key:
-                self.state.discard('center')
+            for (state, modifier) in self.state_modifier_keys.items():
+                if modifier in key:
+                    self.state.discard(state)
             self._on_key_release(event)
 
     def _on_key_release(self, event):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1518,6 +1518,9 @@ class SpanSelector(_SelectorWidget):
         if self.pressv is None:
             return
         x, y = self._get_data(event)
+        if x is None:
+            return
+
         self.prev = x, y
         if self.direction == 'horizontal':
             v = x

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1936,8 +1936,14 @@ class RectangleSelector(_SelectorWidget):
         self._extents_on_press = x1, x2, y1, y2
 
     @property
-    def path(self):
-        return self.to_draw.get_path()
+    def geometry(self):
+        if hasattr(self.to_draw, 'get_verts'):
+            xfm = self.ax.transData.inverted()
+            y, x = xfm.transform(self.to_draw.get_verts()).T
+            return np.array([x[:-1], y[:-1]])
+        else:
+            return np.array(self.to_draw.get_data())
+
 
 
 class EllipseSelector(RectangleSelector):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1155,6 +1155,7 @@ class _SelectorWidget(AxesWidget):
         self.eventpress = None
         # will save the data (pos. at mouserelease)
         self.eventrelease = None
+        self._prev_event = None
 
     def set_active(self, active):
         AxesWidget.set_active(self, active)
@@ -1241,6 +1242,7 @@ class _SelectorWidget(AxesWidget):
         """Button press handler"""
         if not self.ignore(event):
             self.eventpress = copy.copy(event)
+            self._prev_event = copy.copy(event)
             self.eventpress.xdata, self.eventpress.ydata = (
                 self._get_data(event))
             return True
@@ -1249,16 +1251,25 @@ class _SelectorWidget(AxesWidget):
     def release(self, event):
         """Button release event"""
         if not self.ignore(event) and self.eventpress is not None:
+            if event.xdata is None:
+                event = copy.copy(self._prev_event)
             self.eventrelease = copy.copy(event)
             self.eventrelease.xdata, self.eventrelease.ydata = (
                 self._get_data(event))
-            return True
+            return event
         else:
-            return False
+            return None
 
     def onmove(self, event):
         """Cursor move event"""
-        pass
+        if not self.ignore(event) and self.eventpress is not None:
+            if event.xdata is None:
+                event = copy.copy(self._prev_event)
+            else:
+                self._prev_event = copy.copy(event)
+            return event
+        else:
+            return False
 
     def on_scroll(self, event):
         """Mouse scroll event"""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1846,6 +1846,7 @@ class RectangleSelector(_SelectorWidget):
                 (xproblems or yproblems)):
             # check if drawn distance (if it exists) is not too small in
             # neither x nor y-direction
+            self.extents = [0, 0, 0, 0]
             return
 
         # update the eventpress and eventrelease with the resulting extents

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1285,6 +1285,15 @@ class _SelectorWidget(AxesWidget):
         """Cursor move event handler and validator"""
         if not self.ignore(event):
             event = self._clean_event(event)
+            # update the state
+            if 'move' in self.state:
+                self.state = ['move']
+            else:
+                self.state = []
+            if 'shift' in event.key:
+                self.state.append('square')
+            if 'ctrl' in event.key or 'control' in event.key:
+                self.state.append('center')
             self.onmove(event)
 
     def onmove(self, event):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1711,12 +1711,11 @@ class RectangleSelector(_SelectorWidget):
         with the widget after it is drawn.  Holding the 'space' while dragging
         the mouse will move the object.
 
-        Modifier keys
-        -------------
-        One can use modifier keys to affect the way the shape is drawn.
-        Hold the 'Ctrl' key to center the rectangle on the initial position.
-        Hold the 'Shift' key to force the shape to be square.
-        These can be combined.
+        Keyboard modifiers:
+        Alt or Space moves the existing shape.
+        Shift makes the shape square.
+        Ctrl makes the initial point the center of the shape.
+        Ctrl and shift can be combined.
         """
         _SelectorWidget.__init__(self, ax, onselect, useblit=useblit,
                                  button=button)


### PR DESCRIPTION
This builds on #3486 and #3502.

This improves the `RectangleSelector` and adds an `EllipseSelector` with minimal code differences.
Improvements:

- Visible handles for manipulating the shape after it has been drawn
-  Keyboard modifiers:
  - Alt or Space moves the existing shape (as does dragging the center handle)
  - Shift makes the shape square (or circular)
  - Ctrl makes the initial point the center of the shape (helpful for ellipses)
   - Ctrl and shift can be combined

The API is the same (unless using the modifier keys), but we add the `interactive` keyword arg to enable the new behavior.

![ellipse](https://cloud.githubusercontent.com/assets/2096628/5513625/bd9910ba-87c5-11e4-982f-b8cb0a487e13.png)
![rectangle](https://cloud.githubusercontent.com/assets/2096628/5513626/bf51f5e8-87c5-11e4-88c8-f9327521d7c8.png)
