### PR TITLE
Change name of dev version

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -107,7 +107,7 @@ import sys
 import distutils.version
 from itertools import chain
 
-__version__ = str('1.5.x')
+__version__ = str('1.5.dev1')
 __version__numpy__ = str('1.6')  # minimum required numpy version
 
 try:


### PR DESCRIPTION
Needed to conform with pep440, change 1.5.x to 1.5.dev1

Without this change I get warnings about the version not conforming with pep 440 https://www.python.org/dev/peps/pep-0440/

With the newly released version of pip (6.0) 1.5.x is being regarded as smaller that all releases (1.4.2 etc.) 
1.5.devN are allowed names and correctly handled as > 1.4.N and < 1.5.0, 1.5.0rcN etc. 
