### PR TITLE
WIP : major Axes refactor

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -138,6 +138,10 @@ class Artist(object):
         # protected attribute if Python supported that sort of thing.  The
         # callback has one parameter, which is the child to be removed.
         if self._remove_method is not None:
+            # set the current axes to None
+            self._axes = None
+            # use the call back registered by the axes when the artist
+            # was added to remove it the artist from the axes
             self._remove_method(self)
         else:
             raise NotImplementedError('cannot remove artist')

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -701,6 +701,9 @@ class Artist(object):
         "return True if the artist is to be rasterized"
         return self._rasterized
 
+    def set_remove_method(self, f):
+        self._remove_method = f
+
     def set_rasterized(self, rasterized):
         """
         Force rasterized (bitmap) drawing in vector backend output.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2805,7 +2805,7 @@ class Axes(_AxesBase):
                 else:
                     marker = mlines.CARETLEFT
                 caplines.extend(
-                    self.plot(leftlo,  ylo, ls='None', marker=marker,
+                    self.plot(leftlo, ylo, ls='None', marker=marker,
                               **plot_kw))
                 if capsize > 0:
                     xup, yup = xywhere(x, y, xuplims & everymask)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -13,7 +13,7 @@ from numpy import ma
 import matplotlib
 
 import matplotlib.cbook as cbook
-from matplotlib.cbook import _string_to_bool, mplDeprecation
+from matplotlib.cbook import mplDeprecation
 import matplotlib.collections as mcoll
 import matplotlib.colors as mcolors
 import matplotlib.contour as mcontour

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2667,6 +2667,8 @@ class Axes(_AxesBase):
 
         label = kwargs.pop("label", None)
 
+        zorder = kwargs.pop('zorder', 0)
+
         # make sure all the args are iterable; use lists not arrays to
         # preserve units
         if not iterable(x):
@@ -2898,6 +2900,7 @@ class Axes(_AxesBase):
                                                has_xerr=(xerr is not None),
                                                has_yerr=(yerr is not None),
                                                label=label)
+        errorbar_container.set_zorder(zorder)
         return self.add_container(errorbar_container)
 
     def boxplot(self, x, notch=False, sym=None, vert=True, whis=1.5,

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1605,13 +1605,19 @@ class _AxesBase(martist.Artist):
         Add a :class:`~matplotlib.container.Container` instance
         to the axes.
 
-        Returns the collection.
+        Returns the container.
         """
+        container.set_axes(self)
+        self._set_artist_props(container)
+        self.containers.append(container)
+
+        container.set_clip_path(self.patch)
+        container.set_remove_method(lambda h: self.containers.remove(h))
+
         label = container.get_label()
         if not label:
             container.set_label('_container%d' % len(self.containers))
-        self.containers.append(container)
-        container.set_remove_method(lambda h: self.containers.remove(h))
+
         return container
 
     def relim(self, visible_only=False):
@@ -1998,6 +2004,7 @@ class _AxesBase(martist.Artist):
         artists.extend(self.lines)
         artists.extend(self.texts)
         artists.extend(self.artists)
+        artists.extend(self.containers)
 
         # the frame draws the edges around the axes patch -- we
         # decouple these so the patch can be in the background and the

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -10,7 +10,8 @@ class Container(tuple, Artist):
     """
     Base class for containers.
     """
-    _no_broadcast = ['label', ]
+    _no_broadcast = ['label', 'visible', 'zorder', 'animated',
+                     'agg_filter']
 
     def __repr__(self):
         return "<Container object of %d artists>" % (len(self))
@@ -22,7 +23,7 @@ class Container(tuple, Artist):
         # set up the artist details
         Artist.__init__(self, **kwargs)
         # for some reason we special case label
-        self.set_label(label=label)
+        self.set_label(label)
 
     def remove(self):
         # remove the children

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from matplotlib.artist import Artist
+from matplotlib.artist import Artist, allow_rasterization
 import matplotlib.cbook as cbook
 
 
@@ -51,6 +51,7 @@ class Container(tuple, Artist):
         else:
             return super(Container, self).__getattribute__(key)
 
+    @allow_rasterization
     def draw(self, renderer, *args, **kwargs):
         # just broadcast the draw down to children
         for a in self:


### PR DESCRIPTION
This branch is the start of work to unify the storage of the artists in the Axes into a single tree.   I think this will simplify the serialization and export code we want to add.  I also think this will make it easier to implement logic to check if a canvas needs to re-drawn.  In all cases, the benefit comes from having a single Artist tree to walk.

The first step of this is to promote `Containers` to be full-class `Artists` and use them for drawing (not just sorting out legend handles and returning).  This will fix the z-order overlap issues with error bar (#409). 

There is some magic in how the broadcasting of the `{set,get}_*` methods works which should probably have some discussion around it.

The sub-class of `list` is so that we can maintain back-compatibility for users that are removing artists by mucking with the internal data structures.
- [ ] intra-container zorder
- [ ] update all usage of `Container` sub-classes (only ~5)
- [ ] unify draw logic to a single tree
- [ ] make sure all the back compatibility works 
- [ ] make remove fully clean up after `add_*`
- [ ] deprecate all of the `add_*` methods
- [ ] add visitor-pattern API
