### PR TITLE
Simplify set_boxstyle Accepts section of FancyBboxPatch

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1739,8 +1739,10 @@ def _simpleprint_styles(_styles):
     (stylename : styleclass), return a string rep of the list of keys.
     Used to update the documentation.
     """
-
-    return str([i for i in list(_styles.keys())])
+    styles = "[ \'"
+    styles += "\' | \'".join(str(i) for i in sorted(_styles.keys()))
+    styles += "\' ]"
+    return styles
 
 
 class _Style(object):


### PR DESCRIPTION
Change it to something that can actually be passed by docscrape, correctly included in the and displayed in the setp docs.

Before setp would return something like: 

```
boxstyle: ==========   ==============   ==========================   Class        Name             Attrs                        ==========   ==============   ==========================   Circle       ``circle``       pad=0.3                      DArrow       ``darrow``       pad=0.3                      LArrow       ``larrow``       pad=0.3                      RArrow       ``rarrow``       pad=0.3                      Round        ``round``        pad=0.3,rounding_size=None   Round4       ``round4``       pad=0.3,rounding_size=None   Roundtooth   ``roundtooth``   pad=0.3,tooth_size=None      Sawtooth     ``sawtooth``     pad=0.3,tooth_size=None      Square       ``square``       pad=0.3                      ==========   ==============   ==========================
```

i.e. a list rendered as one line.

now it returns:

```
boxstyle: [u'square', u'sawtooth', u'roundtooth', u'darrow', u'round4', u'rarrow', u'larrow', u'circle', u'round']
```

The html docs used to render as 

http://matplotlib.org/api/patches_api.html (see set_boxstyle section)

now 

renders as 

http://jenshnielsen.github.io/mplddocs/api/patches_api.html

Edit: Correct link
