### PR TITLE
Supress some warnings in examples

### DIFF
--- a/examples/pylab_examples/demo_tight_layout.py
+++ b/examples/pylab_examples/demo_tight_layout.py
@@ -94,8 +94,8 @@ gs2 = gridspec.GridSpec(2, 1)
 ax4 = fig.add_subplot(gs2[0])
 ax5 = fig.add_subplot(gs2[1])
 
-#example_plot(ax4)
-#example_plot(ax5)
+example_plot(ax4)
+example_plot(ax5)
 
 with warnings.catch_warnings():
     # This raises warnings since tight layout cannot

--- a/examples/pylab_examples/demo_tight_layout.py
+++ b/examples/pylab_examples/demo_tight_layout.py
@@ -1,6 +1,6 @@
 
 import matplotlib.pyplot as plt
-
+import warnings
 
 import random
 fontsizes = [8, 16, 24, 32]
@@ -83,7 +83,12 @@ example_plot(ax1)
 example_plot(ax2)
 example_plot(ax3)
 
-gs1.tight_layout(fig, rect=[None, None, 0.45, None])
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", UserWarning)
+    # This raises warnings since tight layout cannot
+    # handle gridspec automatically. We are going to
+    # do that manually so we can filter the warning.
+    gs1.tight_layout(fig, rect=[None, None, 0.45, None])
 
 gs2 = gridspec.GridSpec(2, 1)
 ax4 = fig.add_subplot(gs2[0])
@@ -92,7 +97,12 @@ ax5 = fig.add_subplot(gs2[1])
 #example_plot(ax4)
 #example_plot(ax5)
 
-gs2.tight_layout(fig, rect=[0.45, None, None, None])
+with warnings.catch_warnings():
+    # This raises warnings since tight layout cannot
+    # handle gridspec automatically. We are going to
+    # do that manually so we can filter the warning.
+    warnings.simplefilter("ignore", UserWarning)
+    gs2.tight_layout(fig, rect=[0.45, None, None, None])
 
 # now match the top and bottom of two gridspecs.
 top = min(gs1.top, gs2.top)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4065,7 +4065,11 @@ class Axes(_AxesBase):
             ind = coarse.searchsorted(x).clip(0, len(coarse) - 1)
             mus = np.zeros(len(coarse))
             for i in range(len(coarse)):
-                mu = reduce_C_function(y[ind == i])
+                yi = y[ind == i]
+                if len(yi) > 0:
+                    mu = reduce_C_function(yi)
+                else:
+                    mu = np.nan
                 mus[i] = mu
             return mus
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -146,7 +146,13 @@ class InvertedPolarTransform(Transform):
         x = xy[:, 0:1]
         y = xy[:, 1:]
         r = np.sqrt(x*x + y*y)
-        theta = np.arccos(x / r)
+        with np.errstate(invalid='ignore'):
+            # At x=y=r=0 this will raise an
+            # invalid value warning when doing 0/0
+            # Divide by zero warnings are only raised when
+            # the numerator is different from 0. That
+            # should not happen here.
+            theta = np.arccos(x / r)
         theta = np.where(y < 0, 2 * np.pi - theta, theta)
 
         theta -= theta_offset

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -386,12 +386,13 @@ class ExtremeFinderCycle(ExtremeFinderSimple):
 
         # iron out jumps, but algorithm should be improved.
         # Tis is just naive way of doing and my fail for some cases.
-        if self.lon_cycle is not None:
-            lon0 = np.nanmin(lon)
-            lon -= 360. * ((lon - lon0) > 180.)
-        if self.lat_cycle is not None:
-            lat0 = np.nanmin(lat)
-            lat -= 360. * ((lat - lat0) > 180.)
+        with np.errstate(invalid='ignore'):
+            if self.lon_cycle is not None:
+                lon0 = np.nanmin(lon)
+                lon -= 360. * ((lon - lon0) > 180.)
+            if self.lat_cycle is not None:
+                lat0 = np.nanmin(lat)
+                lat -= 360. * ((lat - lat0) > 180.)
 
         lon_min, lon_max = np.nanmin(lon), np.nanmax(lon)
         lat_min, lat_max = np.nanmin(lat), np.nanmax(lat)

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -385,7 +385,11 @@ class ExtremeFinderCycle(ExtremeFinderSimple):
         lon, lat = transform_xy(np.ravel(x), np.ravel(y))
 
         # iron out jumps, but algorithm should be improved.
-        # Tis is just naive way of doing and my fail for some cases.
+        # This is just naive way of doing and my fail for some cases.
+        # Consider replacing this with numpy.unwrap
+        # We are ignoring invalid warnings. They are triggered when
+        # comparing arrays with NaNs using > We are already handling
+        # that correctly using np.nanmin and np.nanmax
         with np.errstate(invalid='ignore'):
             if self.lon_cycle is not None:
                 lon0 = np.nanmin(lon)


### PR DESCRIPTION
This filters a number of warnings from the examples. 

*  Numpy invalid values which are already handled correctly. 
*  Warnings about tight layout which is handled manually in the example
*  Explicitly handle mean of empty slices to avoid warnings. 

I have done this for 2 reasons

1.  I don't think that end users should be seeing warnings when running examples. That will lead to confusion for end users. 
2.  The warnings are raised when building the documentation. Any real issues might be concealed by these warnings. 