### PR TITLE
DOC: instructions on installing matplotlib for dev

### DIFF
--- a/doc/devel/gitwash/index.rst
+++ b/doc/devel/gitwash/index.rst
@@ -11,6 +11,6 @@ Contents:
    git_intro
    git_install
    following_latest
-   git_development
+   setting_up_for_development
    git_resources
    patching

--- a/doc/devel/gitwash/matplotlib_for_dev.rst
+++ b/doc/devel/gitwash/matplotlib_for_dev.rst
@@ -1,0 +1,17 @@
+.. _matplotlib-for-dev:
+
+===================================================
+    Install for matplotlib source for development
+===================================================
+
+After obtaining a local copy of the matpotlib source code (:ref:`set-up-fork`),
+navigate to the matplotlib directory and run the following in the shell:
+
+::
+    
+    python setup.py develop
+
+This installs matplotlib for development (i.e., builds everything and places the
+symbolic links back to the source code).
+
+You may want to consider setting up a `virtual environment <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_.

--- a/doc/devel/gitwash/setting_up_for_development.rst
+++ b/doc/devel/gitwash/setting_up_for_development.rst
@@ -1,7 +1,7 @@
-.. _git-development:
+.. _setting_up_for_development:
 
 =====================
- Git for development
+ Setting up for development
 =====================
 
 Contents:
@@ -11,5 +11,6 @@ Contents:
 
    forking_hell
    set_up_fork
+   matplotlib_for_dev
    configure_git
    development_workflow


### PR DESCRIPTION
Added instructions on installing matplotlib for dev for issue (https://github.com/matplotlib/matplotlib/issues/3959)

NOTE: I renamed one of the URLs. git_development -> setting_up_for_development 

let me know if this is a problem.