### PR TITLE
Connect the Resize Event for WebAgg

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -251,6 +251,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         # identical or within a pixel or so).
         self._png_is_old = True
         self.manager.resize(w, h)
+        self.resize_event()
 
     def handle_send_image_mode(self, event):
         # The client requests notification of what the current image mode is.


### PR DESCRIPTION
Add a simple call that enables the resize event.  To test:

```python
import matplotlib
import itertools
import numpy as np
matplotlib.use('webagg')
import matplotlib.pyplot as plt
plt.close('all')
fig, ax = plt.subplots()
x = np.linspace(0,10,100)
y = np.sin(x)
ln, = ax.plot(x,y, 'o', picker=5)
evt = []
colors = iter(itertools.cycle(['r', 'g', 'b', 'k', 'c']))
def on_event(event):
    evt.append(event)
    ln.set_color(next(colors))
    fig.canvas.draw()
    fig.canvas.draw_idle()
fig.canvas.mpl_connect('resize_event', on_event)
plt.show()
```
