### PR TITLE
Add Figure Enter/Leave Events to Webagg

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -190,7 +190,8 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             pass
         elif e_type == 'draw':
             self.draw()
-        elif e_type in ('button_press', 'button_release', 'motion_notify'):
+        elif e_type in ('button_press', 'button_release', 'motion_notify',
+                        'figure_enter', 'figure_leave'):
             x = event['x']
             y = event['y']
             y = self.get_renderer().height - y
@@ -212,6 +213,10 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 self.button_release_event(x, y, button)
             elif e_type == 'motion_notify':
                 self.motion_notify_event(x, y)
+            elif e_type == 'figure_enter':
+                self.enter_notify_event(xy=(x, y))
+            elif e_type == 'figure_leave':
+                self.leave_notify_event()
         elif e_type in ('key_press', 'key_release'):
             key = event['key']
 

--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -125,6 +125,9 @@ mpl.figure.prototype._init_canvas = function() {
     // Throttle sequential mouse events to 1 every 20ms.
     rubberband.mousemove('motion_notify', mouse_event_fn);
 
+    rubberband.mouseenter('figure_enter', mouse_event_fn);
+    rubberband.mouseleave('figure_leave', mouse_event_fn);
+
     canvas_div.append(canvas);
     canvas_div.append(rubberband);
 


### PR DESCRIPTION
To test:

```python
import matplotlib
import itertools
import numpy as np
matplotlib.use('webagg')
import matplotlib.pyplot as plt
plt.close('all')
fig, ax = plt.subplots()
x = np.linspace(0,10,100)
y = np.sin(x)
ln, = ax.plot(x,y, 'o', picker=5)
evt = []
colors = iter(itertools.cycle(['r', 'g', 'b', 'k', 'c']))
def on_event(event):
    evt.append(event)
    ln.set_color(next(colors))
    fig.canvas.draw()
    fig.canvas.draw_idle()
fig.canvas.mpl_connect('figure_enter_event', on_event)
fig.canvas.mpl_connect('figure_leave_event', on_event)
plt.show()
```