### PR TITLE
Fix install: find correct freetype libs

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -930,7 +930,13 @@ class FreeType(SetupPackage):
                 'lib/freetype2/include/freetype2'],
             default_library_dirs=[
                 'freetype2/lib'],
-            default_libraries=['freetype', 'z'])
+            default_libraries=['freetype', 'z'],
+            alt_exec='freetype-config --libs')
+
+    def get_extension(self):
+        ext = make_extension('matplotlib.freetype2', [])
+        self.add_flags(ext)
+        return ext
 
 
 class FT2Font(SetupPackage):


### PR DESCRIPTION
Caveat: I really don't have a good grasp of how the build system works, so this PR should be looked over with some suspicion.

I have freetype installed through Canopy, and I didn't want to add yet-another install of it. Currently, the freetype search looks only in a few predefined directories. (In fact, the pre-install check looks in the barest of defaults, even though `add_flags` adds some better default search directories. Even when adding a call to `add_flags`, the directory lists don't seem to be used; only the result of the `freetype-config` call seems to matter. This is why I say I don't have a grasp on the build system.)

There's not anything Canopy-specific here, per se: This just uses `freetype-config` to find include paths (and Canopy installs into a virtual environment, so hard-coded default paths won't work).
