### PR TITLE
Fixes for File Saving in Webagg

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -197,7 +197,13 @@ class WebAggApplication(tornado.web.Application):
 
             self.set_header('Content-Type', mimetypes.get(fmt, 'binary'))
 
-            buff = io.BytesIO()
+            # override fileno to raise AttributeError so PIL doesn't error
+            class BytesIO(io.BytesIO):
+                @property
+                def fileno(self):
+                    raise AttributeError
+
+            buff = BytesIO()
             manager.canvas.print_figure(buff, format=fmt)
             self.write(buff.getvalue())
 

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -17,7 +17,6 @@ import six
 
 import datetime
 import errno
-import io
 import json
 import os
 import random
@@ -197,13 +196,7 @@ class WebAggApplication(tornado.web.Application):
 
             self.set_header('Content-Type', mimetypes.get(fmt, 'binary'))
 
-            # override fileno to raise AttributeError to prevent PIL error
-            class BytesIO(io.BytesIO):
-                @property
-                def fileno(self):
-                    raise AttributeError
-
-            buff = BytesIO()
+            buff = six.BytesIO()
             manager.canvas.print_figure(buff, format=fmt)
             self.write(buff.getvalue())
 

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -197,7 +197,7 @@ class WebAggApplication(tornado.web.Application):
 
             self.set_header('Content-Type', mimetypes.get(fmt, 'binary'))
 
-            # override fileno to raise AttributeError so PIL doesn't error
+            # override fileno to raise AttributeError to prevent PIL error
             class BytesIO(io.BytesIO):
                 @property
                 def fileno(self):

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -403,7 +403,8 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
         for filetype, ext in sorted(FigureCanvasWebAggCore.
                                     get_supported_filetypes_grouped().
                                     items()):
-            extensions.append(ext[0])
+            if not ext[0] == 'pgf':  # pgf does not support BytesIO
+                extensions.append(ext[0])
         output.write("mpl.extensions = {0};\n\n".format(
             json.dumps(extensions)))
 


### PR DESCRIPTION
Closes #3979.  Uses `six.BytesIO` for compatibility, which prevents a bug when using `PIL` (not `Pillow`) related to `io.BytesIO`.  Also, the `pgf` backend relies on writing encoded text to a file, which is incompatible with `BytesIO`.