### PR TITLE
Widget and animation improvements

### DIFF
--- a/examples/animation/animate_decay.py
+++ b/examples/animation/animate_decay.py
@@ -7,7 +7,7 @@ def data_gen(t=0):
     cnt = 0
     while cnt < 1000:
         cnt += 1
-        t += 0.05
+        t += 0.1
         yield t, np.sin(2*np.pi*t) * np.exp(-t/10.)
 
 fig, ax = plt.subplots()
@@ -32,6 +32,6 @@ def run(data):
 
     return line,
 
-ani = animation.FuncAnimation(fig, run, data_gen, blit=True, interval=10,
+ani = animation.FuncAnimation(fig, run, data_gen, blit=False, interval=10,
                               repeat=False)
 plt.show()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -698,17 +698,30 @@ class RadioButtons(AxesWidget):
             pcirc = np.array([p.center[0], p.center[1]])
             return dist(pclicked, pcirc) < p.radius
 
-        for p, t in zip(self.circles, self.labels):
+        for i, (p, t) in enumerate(zip(self.circles, self.labels)):
             if t.get_window_extent().contains(event.x, event.y) or inside(p):
-                inp = p
-                thist = t
-                self.value_selected = t.get_text()
+                index_match = i
                 break
         else:
             return
 
-        for p in self.circles:
-            if p == inp:
+        self.set_active(index_match)
+
+    def set_active(self, index):
+        """
+        Trigger which radio button to make active.
+
+        *index* is an index into the original label list
+            that this object was constructed with.
+
+        """
+        if 0 > index >= len(self.labels):
+            raise ValueError("Invalid RadioButton index: %d" % index)
+
+        self.value_selected = self.labels[index].get_text()
+
+        for i, p in enumerate(self.circles):
+            if i == index:
                 color = self.activecolor
             else:
                 color = self.ax.get_axis_bgcolor()
@@ -720,7 +733,7 @@ class RadioButtons(AxesWidget):
         if not self.eventson:
             return
         for cid, func in six.iteritems(self.observers):
-            func(thist.get_text())
+            func(self.labels[index].get_text())
 
     def on_clicked(self, func):
         """

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -569,16 +569,31 @@ class CheckButtons(AxesWidget):
         if event.inaxes != self.ax:
             return
 
-        for p, t, lines in zip(self.rectangles, self.labels, self.lines):
+        for i, (p, t) in enumerate(zip(self.rectangles, self.labels)):
             if (t.get_window_extent().contains(event.x, event.y) or
                     p.get_window_extent().contains(event.x, event.y)):
-                l1, l2 = lines
-                l1.set_visible(not l1.get_visible())
-                l2.set_visible(not l2.get_visible())
-                thist = t
+                self.set_active(i)
                 break
         else:
             return
+
+    def set_active(self, index):
+        """
+        Directly (de)activate a check button by index.
+
+        *index* is an index into the original label list
+            that this object was constructed with.
+            Raises ValueError if *index* is invalid.
+
+        Callbacks will be triggered if :attr:`eventson` is True.
+
+        """
+        if 0 > index >= len(self.labels):
+            raise ValueError("Invalid CheckButton index: %d" % index)
+
+        l1, l2 = self.lines[index]
+        l1.set_visible(not l1.get_visible())
+        l2.set_visible(not l2.get_visible())
 
         if self.drawon:
             self.ax.figure.canvas.draw()
@@ -586,7 +601,7 @@ class CheckButtons(AxesWidget):
         if not self.eventson:
             return
         for cid, func in six.iteritems(self.observers):
-            func(thist.get_text())
+            func(self.labels[index].get_text())
 
     def on_clicked(self, func):
         """
@@ -700,12 +715,10 @@ class RadioButtons(AxesWidget):
 
         for i, (p, t) in enumerate(zip(self.circles, self.labels)):
             if t.get_window_extent().contains(event.x, event.y) or inside(p):
-                index_match = i
+                self.set_active(i)
                 break
         else:
             return
-
-        self.set_active(index_match)
 
     def set_active(self, index):
         """
@@ -713,6 +726,9 @@ class RadioButtons(AxesWidget):
 
         *index* is an index into the original label list
             that this object was constructed with.
+            Raise ValueError if the index is invalid.
+
+        Callbacks will be triggered if :attr:`eventson` is True.
 
         """
         if 0 > index >= len(self.labels):


### PR DESCRIPTION
Add a method to RadioButtons and CheckButtons. Also fixed an animation example that needed its blitting turned off in order to show the changes in the x limits over time. Rescaled it to adjust for the performance penalty.

Probably the one questionable thing will be the use of index numbers for the `set_active()` methods. I decided on using index number for RadioButtons because that is what is used in the constructor for starting out. And I used index numbers for the CheckButtons' `set_active()` just for consistency. I would be open to turning the CheckButtons' set_active() from a strictly toggle method into an optional setter (so, have a `state=None`, which would toggle, while a `state=True` would turn it on and `state=False` would turn it off).