### PR TITLE
Add per-page pdf notes in PdfFile and PdfPages.

### DIFF
--- a/doc/users/whats_new/pdfpages_notes.rst
+++ b/doc/users/whats_new/pdfpages_notes.rst
@@ -1,0 +1,12 @@
+Per-page pdf notes in multi-page pdfs (PdfPages)
+------------------------------------------------
+
+Add a new method attach_note to the PdfPages class, allowing the
+attachment of simple text notes to pages in a multi-page pdf of
+figures. The new note is visible in the list of pdf annotations in a
+viewer that has this facility (Adobe Reader, OSX Preview, Skim,
+etc.). Per default the note itself is kept off-page to prevent it to
+appear in print-outs.
+
+PdfPages.attach_note needs to be called before savefig in order to be
+added to the correct figure.

--- a/examples/pylab_examples/multipage_pdf.py
+++ b/examples/pylab_examples/multipage_pdf.py
@@ -20,6 +20,8 @@ with PdfPages('multipage_pdf.pdf') as pdf:
     x = np.arange(0, 5, 0.1)
     plt.plot(x, np.sin(x), 'b-')
     plt.title('Page Two')
+    pdf.attach_note("plot of sin(x)")  # you can add a pdf note to
+                                       # attach metadata to a page
     pdf.savefig()
     plt.close()
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -480,8 +480,8 @@ class PdfFile(object):
 
         self.paths = []
 
-        self.pageAnnotations = [] # A list of annotations for the
-                                  # current page
+        self.pageAnnotations = []  # A list of annotations for the
+                                   # current page
 
         # The PDF spec recommends to include every procset
         procsets = [Name(x)
@@ -526,7 +526,7 @@ class PdfFile(object):
         # Clear the list of annotations for the next page
         self.pageAnnotations = []
 
-    def newTextnote(self, text, positionRect = [-100, -100, 0, 0]):
+    def newTextnote(self, text, positionRect=[-100, -100, 0, 0]):
         # Create a new annotation of type text
         theNote = {'Type': Name('Annot'),
                    'Subtype': Name('Text'),
@@ -2468,6 +2468,7 @@ class PdfPages(object):
         Add a new text note to the page to be saved next.
         """
         self._file.newTextnote(text)
+
 
 class FigureCanvasPdf(FigureCanvasBase):
     """

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2463,11 +2463,14 @@ class PdfPages(object):
         """
         return len(self._file.pageList)
 
-    def attach_note(self, text):
+    def attach_note(self, text, positionRect=[-100, -100, 0, 0]):
         """
-        Add a new text note to the page to be saved next.
+        Add a new text note to the page to be saved next. The optional
+        positionRect specifies the position of the new note on the
+        page. It is outside the page per default to make sure it is
+        invisible on printouts.
         """
-        self._file.newTextnote(text)
+        self._file.newTextnote(text, positionRect)
 
 
 class FigureCanvasPdf(FigureCanvasBase):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -480,6 +480,9 @@ class PdfFile(object):
 
         self.paths = []
 
+        self.pageAnnotations = [] # A list of annotations for the
+                                  # current page
+
         # The PDF spec recommends to include every procset
         procsets = [Name(x)
                     for x in "PDF Text ImageB ImageC ImageI".split()]
@@ -507,7 +510,8 @@ class PdfFile(object):
                    'Contents': contentObject,
                    'Group': {'Type': Name('Group'),
                              'S': Name('Transparency'),
-                             'CS': Name('DeviceRGB')}
+                             'CS': Name('DeviceRGB')},
+                   'Annots': self.pageAnnotations,
                    }
         pageObject = self.reserveObject('page')
         self.writeObject(pageObject, thePage)
@@ -518,6 +522,20 @@ class PdfFile(object):
         # Initialize the pdf graphics state to match the default mpl
         # graphics context: currently only the join style needs to be set
         self.output(GraphicsContextPdf.joinstyles['round'], Op.setlinejoin)
+
+        # Clear the list of annotations for the next page
+        self.pageAnnotations = []
+
+    def newTextnote(self, text, positionRect = [-100, -100, 0, 0]):
+        # Create a new annotation of type text
+        theNote = {'Type': Name('Annot'),
+                   'Subtype': Name('Text'),
+                   'Contents': text,
+                   'Rect': positionRect,
+                   }
+        annotObject = self.reserveObject('annotation')
+        self.writeObject(annotObject, theNote)
+        self.pageAnnotations.append(annotObject)
 
     def close(self):
         self.endStream()
@@ -2445,6 +2463,11 @@ class PdfPages(object):
         """
         return len(self._file.pageList)
 
+    def attach_note(self, text):
+        """
+        Add a new text note to the page to be saved next.
+        """
+        self._file.newTextnote(text)
 
 class FigureCanvasPdf(FigureCanvasBase):
     """


### PR DESCRIPTION
I was looking for the possibility to add per-figure metadata to a PdfPages output file. This patch enables this and adds a new method attach_note to the PdfPages class. This methods needs to be called with an arbitrary piece of text that is added as a note to the following page (hence attach_note needs to be called before savefig). The logic for creating the underlying pdf annotation object sits in the newNote method of the PdfFile class. The note is visible in any pdf reader that is able to display a list of annotations.
