### PR TITLE
Fix wx._core.PyAssertionError ... wxGetStockLabel(): invalid stock item ID

### DIFF
--- a/examples/user_interfaces/mathtext_wx.py
+++ b/examples/user_interfaces/mathtext_wx.py
@@ -65,7 +65,7 @@ class CanvasFrame(wx.Frame):
             menu = wx.Menu()
             for i, (mt, func) in enumerate(functions):
                 bm = mathtext_to_wxbitmap(mt)
-                item = wx.MenuItem(menu, 1000 + i, "")
+                item = wx.MenuItem(menu, 1000 + i, " ")
                 item.SetBitmap(bm)
                 menu.AppendItem(item)
                 self.Bind(wx.EVT_MENU, self.OnChangePlot, item)


### PR DESCRIPTION
Using wxPython 3.0.2 on Windows, the `mathtext_wx.py` example fails:
```
  File "mathtext_wx.py", line 122, in <module>
    app = MyApp()
  File "X:\Python27-x64\lib\site-packages\wx-3.0-msw\wx\_core.py", line 8628, in __init__
    self._BootstrapApp()
  File "X:\Python27-x64\lib\site-packages\wx-3.0-msw\wx\_core.py", line 8196, in _BootstrapApp
    return _core_.PyApp__BootstrapApp(*args, **kwargs)
  File "mathtext_wx.py", line 117, in OnInit
    frame = CanvasFrame(None, "wxPython mathtext demo app")
  File "mathtext_wx.py", line 65, in __init__
    item = wx.MenuItem(menu, 1000 + i, "")
  File "X:\Python27-x64\lib\site-packages\wx-3.0-msw\wx\_core.py", line 12435, in __init__
    _core_.MenuItem_swiginit(self,_core_.new_MenuItem(*args, **kwargs))
wx._core.PyAssertionError: C++ assertion "Assert failure" failed at ..\..\src\common\stockitem.cpp(213) in wxGetStockLabel(): invalid stock item ID
```
Apparently, if no or an empty label is given to wx.MenuItem it assumes to use a stock item.