### PR TITLE
Change documented "Optional" ScaleBase method to "Required"

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -25,9 +25,9 @@ class ScaleBase(object):
 
       - :attr:`name`
       - :meth:`get_transform`
+      - :meth:`set_default_locators_and_formatters`
 
     And optionally:
-      - :meth:`set_default_locators_and_formatters`
       - :meth:`limit_range_for_scale`
     """
     def get_transform(self):


### PR DESCRIPTION
The `matplotlib.scale.ScaleBase.set_default_locators_and_formatters` method is documented as optional in subclasses, but throws a `NotImplementedError` - and is actually called on subclass instances, so is not optional. 

This fixes the documentation to reflect this fact.