### PR TITLE
fix find_output_cell for IPython >= 3.0 [backport to 1.4.x]

### DIFF
--- a/lib/matplotlib/backends/web_backend/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/nbagg_mpl.js
@@ -160,12 +160,15 @@ mpl.find_output_cell = function(html_output) {
     var ncells = cells.length;
     for (var i=0; i<ncells; i++) {
         var cell = cells[i];
-        if (cell.cell_type == 'code'){
+        if (cell.cell_type === 'code'){
             for (var j=0; j<cell.output_area.outputs.length; j++) {
                 var data = cell.output_area.outputs[j];
-                if (cell.output_area.outputs[j]['text/html'] == html_output) {
-                    var output = cell.output_area.outputs[j];
-                    return [cell, output, j];
+                if (data.data) {
+                    // IPython >= 3 moved mimebundle to data attribute of output
+                    data = data.data;
+                }
+                if (data['text/html'] == html_output) {
+                    return [cell, data, j];
                 }
             }
         }

--- a/lib/matplotlib/backends/web_backend/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/nbagg_mpl.js
@@ -44,6 +44,10 @@ mpl.mpl_figure_comm = function(comm, msg) {
 
     fig.parent_element = element.get(0);
     fig.cell_info = mpl.find_output_cell("<div id='" + id + "'></div>");
+    if (!fig.cell_info) {
+        console.error("Failed to find cell for figure", id, fig);
+        return;
+    }
 
     var output_index = fig.cell_info[2]
     var cell = fig.cell_info[0];


### PR DESCRIPTION
output mime-type keys moved from top-level to a `data` attribute.

Added an error-log for the case where output is not found, which should make similar bugs a bit easier to find in the future.

closes ipython/ipython#7351