### PR TITLE
More helpful error message for pgf backend

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -319,7 +319,7 @@ class LatexManager(object):
                                      cwd=self.tmpdir)
         except OSError as e:
             if e.errno == errno.ENOENT:
-                raise OSError(errno.ENOENT, "Latex command not found. "
+                raise RuntimeError("Latex command not found. "
                     "Install '%s' or change pgf.texsystem to the desired command."
                     % self.texcommand
                 )

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -6,6 +6,7 @@ import six
 import math
 import os
 import sys
+import errno
 import re
 import shutil
 import tempfile
@@ -316,8 +317,14 @@ class LatexManager(object):
                                      stdin=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
                                      cwd=self.tmpdir)
-        except OSError:
-            raise RuntimeError("Error starting process '%s'" % self.texcommand)
+        except OSError, e:
+            if e.errno == errno.ENOENT:
+                raise OSError(errno.ENOENT, "Latex command not found. "
+                    "Install '%s' or change pgf.texsystem to the desired command."
+                    % self.texcommand
+                )
+            else:
+                raise RuntimeError("Error starting process '%s'" % self.texcommand)
         test_input = self.latex_header + latex_end
         stdout, stderr = latex.communicate(test_input.encode("utf-8"))
         if latex.returncode != 0:

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -317,7 +317,7 @@ class LatexManager(object):
                                      stdin=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
                                      cwd=self.tmpdir)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 raise OSError(errno.ENOENT, "Latex command not found. "
                     "Install '%s' or change pgf.texsystem to the desired command."


### PR DESCRIPTION
Makes the error message more helpful if subprocess fails with a file-not-found-error.