### PR TITLE
Fix key modifier handling in Web backends [backport 1.4.x]

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Displays Agg images in the browser, with interactivity
 """

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Displays Agg images in the browser, with interactivity
 """
@@ -19,7 +18,6 @@ import six
 import io
 import json
 import os
-import re
 import time
 import warnings
 

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -49,52 +49,93 @@ def new_figure_manager_given_figure(num, figure):
     return manager
 
 
-_KEY_LUT = {'shift+À': '~',
-            'À': '`',
-            '\x1b': 'esc',
-            '\x08': 'backspace',
-            'shift+Ü': '|',
-            'Ü': '\\',
-            'shift+Ý': '}',
-            'Ý': ']',
-            'shift+Û': '{',
-            'Û': '[',
-            'shift+º': ':',
-            'º': ';',
-            'shift+Þ': '"',
-            'Þ': "'",
-            'shift+¼': '<',
-            '¼': ',',
-            'shift+¾': '>',
-            '¾': '.',
-            'shift+¿': '?',
-            '¿': '/',
-            'shift+»': '+',
-            '»': '=',
-            'shift+½': '_',
-            '½': '-',
-            '\x7f': 'del',
-            '\t': 'tab'}
+# http://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes
+_SHIFT_LUT = {59: ':',
+              61: '+',
+              173: '_',
+              186: ':',
+              187: '+',
+              188: '<',
+              189: '_',
+              190: '>',
+              191: '?',
+              192: '~',
+              219: '{',
+              220: '|',
+              221: '}',
+              222: '"'}
+
+_LUT = {8: 'backspace',
+        9: 'tab',
+        13: 'enter',
+        16: 'shift',
+        17: 'control',
+        18: 'alt',
+        19: 'pause',
+        20: 'caps',
+        27: 'escape',
+        32: ' ',
+        33: 'pageup',
+        34: 'pagedown',
+        35: 'end',
+        36: 'home',
+        37: 'left',
+        38: 'up',
+        39: 'right',
+        40: 'down',
+        45: 'insert',
+        46: 'delete',
+        91: 'super',
+        92: 'super',
+        93: 'select',
+        106: '*',
+        107: '+',
+        109: '-',
+        110: '.',
+        111: '/',
+        144: 'num_lock',
+        145: 'scroll_lock',
+        186: ':',
+        187: '=',
+        188: ',',
+        189: '-',
+        190: '.',
+        191: '/',
+        192: '`',
+        219: '[',
+        220: '\\',
+        221: ']',
+        222: "'"}
 
 
-def _get_key(key):
-    """Handle key codes with unicode characters"""
-    ind = key.index('u+')
-    char = chr(int(key[ind + 2:], 16))
-    if re.match('\d', char):
+def _handle_key(key):
+    """Handle key codes"""
+    code = int(key[key.index('k') + 1:])
+    value = chr(code)
+    # letter keys
+    if code >= 65 and code <= 90:
         if 'shift+' in key:
-            num = int(key[-1])
             key = key.replace('shift+', '')
-            char = ')!@#$%^&*('[num]
-    elif 'shift+' in key:
-        if 'shift+' + char in _KEY_LUT:
-            key = key.replace('shift+', '')
-            char = _KEY_LUT['shift+' + char]
         else:
-            char = _KEY_LUT[char]
-    else:
-        char = _KEY_LUT.get(char, char)
-    key = key[:key.index('u+')] + char
+            value = value.lower()
+    # number keys
+    elif code >= 48 and code <= 57:
+        if 'shift+' in key:
+            value = ')!@#$%^&*('[int(value)]
+            key = key.replace('shift+', '')
+    # function keys
+    elif code >= 112 and code <= 123:
+        value = 'f%s' % (code - 111)
+    # number pad keys
+    elif code >= 96 and code <= 105:
+        value = '%s' % (code - 96)
+    # keys with shift alternatives
+    elif code in _SHIFT_LUT and 'shift+' in key:
+        key = key.replace('shift+', '')
+        value = _SHIFT_LUT[code]
+    elif code in _LUT:
+        value = _LUT[code]
+    key = key[:key.index('k')] + value
     return key
 
 
@@ -272,9 +313,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             elif e_type == 'scroll':
                 self.scroll_event(x, y, event['step'])
         elif e_type in ('key_press', 'key_release'):
-            key = event['key']
-            if 'u+' in key:
-                key = _get_key(key)
+            key = _handle_key(event['key'])
             if e_type == 'key_press':
                 self.key_press_event(key)
             elif e_type == 'key_release':

--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -472,44 +472,15 @@ mpl.figure.prototype.key_event = function(event, name) {
         this._key = null;
 
     var value = '';
-    if (event.ctrlKey && !(event.which == 17))
+    if (event.ctrlKey && event.which != 17)
         value += "ctrl+";
-    if (event.altKey && !(event.which == 18))
+    if (event.altKey && event.which != 18)
         value += "alt+";
+    if (event.shiftKey && event.which != 16)
+        value += "shift+";
 
-    if (event.which == 17) {
-        value += "control";
-        if (event.shiftKey) 
-            value += "+shift"
-    }
-    else if (event.which == 18) {
-        value += "alt";
-        if (event.shiftKey) 
-            value += "+shift"
-    }
-    else if (event.which == 16)
-        value += "shift";
-    else {
-        if (event.which >= 65 && event.which <= 90) {
-            if (event.shiftKey)
-                value += String.fromCharCode(event.which);
-            else
-                value += String.fromCharCode(event.which).toLowerCase();
-        }
-        else if (event.key) {
-            if (event.shiftKey && (event.which <= 46 || 
-                    (event.key >= 91 && event.key <= 145)))
-                value += "shift+"
-            value += event.key.toLowerCase();
-        }
-        else if (event.originalEvent.keyIdentifier) {
-            if (event.shiftKey)
-                value += "shift+"
-            value += event.originalEvent.keyIdentifier.toLowerCase();
-        }
-        else
-            value += String.fromCharCode(event.which);
-    }
+    value += 'k';
+    value += event.which.toString();
 
     this.send_message(name, {key: value});
     return false;

--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -458,6 +458,10 @@ mpl.figure.prototype.mouse_event = function(event, name) {
     return false;
 }
 
+mpl.figure.prototype._key_event_extra = function(event, name) { 
+
+}
+
 mpl.figure.prototype.key_event = function(event, name) {
 
     // Prevent repeat events
@@ -481,6 +485,8 @@ mpl.figure.prototype.key_event = function(event, name) {
 
     value += 'k';
     value += event.which.toString();
+
+    this._key_event_extra(event, name);
 
     this.send_message(name, {key: value});
     return false;

--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -120,7 +120,7 @@ mpl.figure.prototype._init_canvas = function() {
     }
 
     canvas_div.keydown('key_press', canvas_keyboard_event);
-    canvas_div.keydown('key_release', canvas_keyboard_event);
+    canvas_div.keyup('key_release', canvas_keyboard_event);
     this.canvas_div = canvas_div
     this._canvas_extra_style(canvas_div)
     this.root.append(canvas_div);
@@ -459,20 +459,33 @@ mpl.figure.prototype.mouse_event = function(event, name) {
 }
 
 mpl.figure.prototype.key_event = function(event, name) {
-    /* Don't fire events just when a modifier is changed.  Modifiers are
-       sent along with other keys. */
-    if (event.keyCode >= 16 && event.keyCode <= 20) {
-        return;
-    }
 
+    // Ignore pause/break and caps lock
+    if (event.keyCode === 19 || event.keyCode === 20) 
+        return;
     var value = '';
-    if (event.ctrlKey) {
+    if (event.ctrlKey && !(event.keyCode == 17)) {
         value += "ctrl+";
     }
-    if (event.altKey) {
+    if (event.altKey && !(event.keyCode == 18)) {
         value += "alt+";
     }
-    value += String.fromCharCode(event.keyCode).toLowerCase();
+    if (event.shiftKey && !(event.keyCode == 16)) {
+        value += "shift+";
+    }
+
+    if (event.keyCode == 17) {
+        value += "control";
+    }
+    else if (event.keyCode == 18) {
+        value += "alt";
+    }
+    else if (event.keyCode == 16) {
+        value += "shift";
+    }
+    else {
+        value += String.fromCharCode(event.keyCode).toLowerCase();
+    }
 
     this.send_message(name, {key: value});
     return false;

--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -458,14 +458,14 @@ mpl.figure.prototype.mouse_event = function(event, name) {
     return false;
 }
 
-mpl.figure.prototype._key_event_extra = function(event, name) { 
-
+mpl.figure.prototype._key_event_extra = function(event, name) {
+    // Handle any extra behaviour associated with a key event
 }
 
 mpl.figure.prototype.key_event = function(event, name) {
 
     // Prevent repeat events
-    if (name == 'key_press') 
+    if (name == 'key_press')
     {
         if (event.which === this._key)
             return;

--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -460,31 +460,55 @@ mpl.figure.prototype.mouse_event = function(event, name) {
 
 mpl.figure.prototype.key_event = function(event, name) {
 
-    // Ignore pause/break and caps lock
-    if (event.keyCode === 19 || event.keyCode === 20) 
-        return;
-    var value = '';
-    if (event.ctrlKey && !(event.keyCode == 17)) {
-        value += "ctrl+";
+    // Prevent repeat events
+    if (name == 'key_press') 
+    {
+        if (event.which === this._key)
+            return;
+        else
+            this._key = event.which;
     }
-    if (event.altKey && !(event.keyCode == 18)) {
-        value += "alt+";
-    }
-    if (event.shiftKey && !(event.keyCode == 16)) {
-        value += "shift+";
-    }
+    if (name == 'key_release')
+        this._key = null;
 
-    if (event.keyCode == 17) {
+    var value = '';
+    if (event.ctrlKey && !(event.which == 17))
+        value += "ctrl+";
+    if (event.altKey && !(event.which == 18))
+        value += "alt+";
+
+    if (event.which == 17) {
         value += "control";
+        if (event.shiftKey) 
+            value += "+shift"
     }
-    else if (event.keyCode == 18) {
+    else if (event.which == 18) {
         value += "alt";
+        if (event.shiftKey) 
+            value += "+shift"
     }
-    else if (event.keyCode == 16) {
+    else if (event.which == 16)
         value += "shift";
-    }
     else {
-        value += String.fromCharCode(event.keyCode).toLowerCase();
+        if (event.which >= 65 && event.which <= 90) {
+            if (event.shiftKey)
+                value += String.fromCharCode(event.which);
+            else
+                value += String.fromCharCode(event.which).toLowerCase();
+        }
+        else if (event.key) {
+            if (event.shiftKey && (event.which <= 46 || 
+                    (event.key >= 91 && event.key <= 145)))
+                value += "shift+"
+            value += event.key.toLowerCase();
+        }
+        else if (event.originalEvent.keyIdentifier) {
+            if (event.shiftKey)
+                value += "shift+"
+            value += event.originalEvent.keyIdentifier.toLowerCase();
+        }
+        else
+            value += String.fromCharCode(event.which);
     }
 
     this.send_message(name, {key: value});

--- a/lib/matplotlib/backends/web_backend/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/nbagg_mpl.js
@@ -149,6 +149,22 @@ mpl.figure.prototype._canvas_extra_style = function(el){
 
 }
 
+mpl.figure.prototype._key_event_extra = function(event, name) { 
+    var manager = IPython.notebook.keyboard_manager;
+    if (!manager)
+        IPython.keyboard_manager;
+
+    // Check for shift+enter
+    if (event.shiftKey && event.which == 13) {
+        this.canvas_div.blur();
+        event.shiftKey = false;
+        // Send a "J" for go to next cell
+        event.which = 74;
+        event.keyCode = 74;
+        manager.command_mode();
+        manager.handle_keydown(event);
+    }
+}
 
 mpl.figure.prototype.handle_save = function(fig, msg) {
     fig.ondownload(fig, null);

--- a/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
+++ b/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:7f7ec6a6e2a63837a45a88a501ba3c5b1eb88e744925456a9bfeb0d6faa896a5"
+  "signature": "sha256:a1ac68aba163c75eab3d1fc91aa4d9a8ca66b09159619563827a19967d96814b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -417,13 +417,23 @@
       "evt = []\n",
       "colors = iter(itertools.cycle(['r', 'g', 'b', 'k', 'c']))\n",
       "def on_event(event):\n",
+      "    if event.name.startswith('key'):\n",
+      "        fig.suptitle('%s: %s' % (event.name, event.key))\n",
+      "    elif event.name == 'scroll_event':\n",
+      "        fig.suptitle('%s: %s' % (event.name, event.step))\n",
+      "    else:\n",
+      "        fig.suptitle('%s: %s' % (event.name, event.button))\n",
       "    evt.append(event)\n",
       "    ln.set_color(next(colors))\n",
       "    fig.canvas.draw()\n",
       "    fig.canvas.draw_idle()\n",
+      "\n",
       "fig.canvas.mpl_connect('button_press_event', on_event)\n",
-      "fig.canvas.mpl_connect('key_press_event', on_event)\n",
+      "fig.canvas.mpl_connect('button_release_event', on_event)\n",
       "fig.canvas.mpl_connect('scroll_event', on_event)\n",
+      "fig.canvas.mpl_connect('key_press_event', on_event)\n",
+      "fig.canvas.mpl_connect('key_release_event', on_event)\n",
+      "\n",
       "plt.show()"
      ],
      "language": "python",


### PR DESCRIPTION
Addresses #4028.
Fixes an earlier mishandling of the `key_release` event.
Handles all of the standard keys, including `shift` modifiers.
Also properly handles `shift+enter` event in `nbagg`, moving to the next cell.

Test script:

```python
import matplotlib
matplotlib.use('webagg')
import numpy as np
import matplotlib.pyplot as plt

fig = plt.figure()
ax = fig.add_subplot(111)
ax.plot(np.random.rand(10))


def onkeyevent(event):
    fig.suptitle('%s: %s' % (event.name, event.key))
    fig.canvas.draw()

cid = fig.canvas.mpl_connect('key_press_event', onkeyevent)
cid = fig.canvas.mpl_connect('key_release_event', onkeyevent)
plt.show()
```