### PR TITLE
FIX: resizing a figure in webagg

### DIFF
--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -109,9 +109,6 @@ mpl.figure.prototype._init_canvas = function() {
     var fig = this;
 
     var canvas_div = $('<div/>');
-    canvas_div.resizable({ resize: mpl.debounce_resize(
-        function(event, ui) { fig.request_resize(ui.size.width, ui.size.height); }
-        , 50)});
 
     canvas_div.attr('style', 'position: relative; clear: both; outline: 0');
 
@@ -134,9 +131,27 @@ mpl.figure.prototype._init_canvas = function() {
 
     var rubberband = $('<canvas/>');
     rubberband.attr('style', "position: absolute; left: 0; top: 0; z-index: 1;")
+
+    var pass_mouse_events = true;
+
+    canvas_div.resizable({
+        start: function(event, ui) {
+            pass_mouse_events = false;
+        },
+        resize: function(event, ui) {
+            fig.request_resize(ui.size.width, ui.size.height);
+        },
+        stop: function(event, ui) {
+            pass_mouse_events = true;
+            fig.request_resize(ui.size.width, ui.size.height);
+        },
+    });
+
     function mouse_event_fn(event) {
-        return fig.mouse_event(event, event['data']);
+        if (pass_mouse_events)
+            return fig.mouse_event(event, event['data']);
     }
+
     rubberband.mousedown('button_press', mouse_event_fn);
     rubberband.mouseup('button_release', mouse_event_fn);
     // Throttle sequential mouse events to 1 every 20ms.
@@ -489,19 +504,3 @@ mpl.figure.prototype.toolbar_button_onclick = function(name) {
 mpl.figure.prototype.toolbar_button_onmouseover = function(tooltip) {
     this.message.textContent = tooltip;
 };
-
-mpl.debounce_event = function(func, time) {
-    var timer;
-    return function(event) {
-        clearTimeout(timer);
-        timer = setTimeout(function() { func(event); }, time);
-    };
-}
-
-mpl.debounce_resize = function(func, time) {
-    var timer;
-    return function(event, ui) {
-        clearTimeout(timer);
-        timer = setTimeout(function() { func(event, ui); }, time);
-    };
-}


### PR DESCRIPTION
Resizing in webagg doesn't work because the figure grabs mouse events (https://github.com/matplotlib/matplotlib/issues/3338).

This is an iteration over a previous pull request (https://github.com/matplotlib/matplotlib/pull/3341), including the minimal changes required to fix the problem.

I don't think that the debouncing is necessary anymore, so I removed it. I tested this with both a static plot and animations.

This addresses 90% of the problem. 

Resizing issues will reappear if working with multiple figures on the same page.
Refactoring would be necessary probably to introduce some "resizing manager" that will prevent mouse events from being passed to all figures while any figure is being resized.