### PR TITLE
added some fixes in order to use the result obtained from `mpl._get_configdir()` [backport to 1.4.2-doc]

### DIFF
--- a/doc/users/style_sheets.rst
+++ b/doc/users/style_sheets.rst
@@ -26,14 +26,14 @@ Defining your own style
 
 You can create custom styles and use them by calling ``style.use`` with the
 path or URL to the style sheet. Alternatively, if you add your
-``<style-name>.mplstyle`` file to ``~/.matplotlib/stylelib`` (you may need to
+``<style-name>.mplstyle`` file to ``~/.config/matplotlib/stylelib`` (you may need to
 create this directory), you can reuse your custom style sheet with a call to
 ``style.use(<style-name>)``. Note that a custom style sheet in
-``~/.matplotlib/stylelib`` will override a style sheet defined by matplotlib if
+``~/.config/matplotlib/stylelib`` will override a style sheet defined by matplotlib if
 the styles have the same name.
 
 For example, you might want to create
-``~/.matplotlib/stylelib/presentation.mplstyle`` with the following::
+``~/.config/matplotlib/stylelib/presentation.mplstyle`` with the following::
 
    axes.titlesize : 24
    axes.labelsize : 20

--- a/doc/users/style_sheets.rst
+++ b/doc/users/style_sheets.rst
@@ -25,15 +25,15 @@ Defining your own style
 =======================
 
 You can create custom styles and use them by calling ``style.use`` with the
-path or URL to the style sheet. Alternatively, if you add your
-``<style-name>.mplstyle`` file to ``~/.config/matplotlib/stylelib`` (you may need to
-create this directory), you can reuse your custom style sheet with a call to
-``style.use(<style-name>)``. Note that a custom style sheet in
-``~/.config/matplotlib/stylelib`` will override a style sheet defined by matplotlib if
-the styles have the same name.
+path or URL to the style sheet. Alternatively, if you add your ``<style-name>.mplstyle`` 
+file to ``mpl_configdir/stylelib`, you can reuse your custom style sheet with a call to 
+``style.use(<style-name>)``. By default ``mpl_configdir`` should be ``~/.config/matplotlib``, 
+but you can check where yours is with ``matplotlib.get_configdir()``, you may need to 
+create this directory. Note that a custom style sheet in ``mpl_configdir/stylelib`` 
+will override a style sheet defined by matplotlib if the styles have the same name.
 
 For example, you might want to create
-``~/.config/matplotlib/stylelib/presentation.mplstyle`` with the following::
+``mpl_configdir/stylelib/presentation.mplstyle`` with the following::
 
    axes.titlesize : 24
    axes.labelsize : 20


### PR DESCRIPTION
The docs show the folder `~/.matplotlib/stylelib` as the folder to find user defined style sheets but the result from:
```python
import matplotlib as mpl
print(mpl._get_configdir())
```
indicates that the folder should be:
`~/.config/matplotlib/stylelib`
(https://github.com/matplotlib/matplotlib/blob/980e4cd6f10a0af28b28c9a93d2564d6b5d67608/lib/matplotlib/style/core.py#L32)

This PR just fix this in the docs (http://matplotlib.org/users/style_sheets.html)

I followed the process of the docs to make this PR but it is the first time so if there is somethiing wrong, please, let me know.

If I am wrong about the PR just discard it and sorry for the noise.