### PR TITLE
Prevent Windows from opening command prompt (#4021) [backport to 1.4.x]

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -23,6 +23,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import xrange, zip
 
+import platform
 import sys
 import itertools
 import contextlib
@@ -34,7 +35,12 @@ from matplotlib import rcParams
 # Process creation flag for subprocess to prevent it raising a terminal
 # window. See for example:
 # https://stackoverflow.com/questions/24130623/using-python-subprocess-popen-cant-prevent-exe-stopped-working-prompt
-CREATE_NO_WINDOW = 0x08000000
+if platform.system() == 'Windows':
+    CREATE_NO_WINDOW = 0x08000000
+    subprocess_creation_flags = CREATE_NO_WINDOW
+else:
+    # Apparently None won't work here
+    subprocess_creation_flags = 0
 
 # Other potential writing methods:
 # * http://pymedia.org/
@@ -195,7 +201,7 @@ class MovieWriter(object):
         self._proc = subprocess.Popen(command, shell=False,
                                       stdout=output, stderr=output,
                                       stdin=subprocess.PIPE,
-                                      creationflags=CREATE_NO_WINDOW)
+                                      creationflags=subprocess_creation_flags)
 
     def finish(self):
         'Finish any processing for writing the movie.'
@@ -258,7 +264,7 @@ class MovieWriter(object):
                              shell=False,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,
-                             creationflags=CREATE_NO_WINDOW)
+                             creationflags=subprocess_creation_flags)
             p.communicate()
             return True
         except OSError:

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -31,6 +31,11 @@ from matplotlib.compat import subprocess
 from matplotlib import verbose
 from matplotlib import rcParams
 
+# Process creation flag for subprocess to prevent it raising a terminal
+# window. See for example:
+# https://stackoverflow.com/questions/24130623/using-python-subprocess-popen-cant-prevent-exe-stopped-working-prompt
+CREATE_NO_WINDOW = 0x08000000
+
 # Other potential writing methods:
 # * http://pymedia.org/
 # * libmng (produces swf) python wrappers: https://github.com/libming/libming
@@ -189,7 +194,8 @@ class MovieWriter(object):
                        ' '.join(command))
         self._proc = subprocess.Popen(command, shell=False,
                                       stdout=output, stderr=output,
-                                      stdin=subprocess.PIPE)
+                                      stdin=subprocess.PIPE,
+                                      creationflags=CREATE_NO_WINDOW)
 
     def finish(self):
         'Finish any processing for writing the movie.'
@@ -251,7 +257,8 @@ class MovieWriter(object):
             p = subprocess.Popen(cls.bin_path(),
                              shell=False,
                              stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+                             stderr=subprocess.PIPE,
+                             creationflags=CREATE_NO_WINDOW)
             p.communicate()
             return True
         except OSError:


### PR DESCRIPTION
This tells Windows not to create a new window when using Subprocess to
save an animation.