### PR TITLE
Fixed large pcolormesh rendering with bbox_inches='tight'.

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1705,6 +1705,9 @@ class QuadMesh(Collection):
         self._paths = self.convert_mesh_to_paths(
             self._meshWidth, self._meshHeight, self._coordinates)
 
+    def get_datalim(self, transData):
+        return (self.get_transform() - transData).transform_bbox(self._bbox)
+
     @staticmethod
     def convert_mesh_to_paths(meshWidth, meshHeight, coordinates):
         """

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1344,6 +1344,15 @@ class Transform(TransformNode):
         """
         return values
 
+    def transform_bbox(self, bbox):
+        """
+        Transform the given bounding box.
+
+        Note, for smarter transforms including caching (a common
+        requirement for matplotlib figures), see :class:`TransformedBbox`.
+        """
+        return Bbox(self._transform.transform(bbox.get_points()))
+
     def get_affine(self):
         """
         Get the affine part of this transform.


### PR DESCRIPTION
Replaces #4017.
Closes #3095.