### PR TITLE
Correct FA 4 name of Download icon

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -92,7 +92,7 @@ _FONT_AWESOME_CLASSES = {
     'forward': 'fa fa-arrow-right icon-arrow-right',
     'zoom_to_rect': 'fa fa-square-o icon-check-empty',
     'move': 'fa fa-arrows icon-move',
-    'download': 'fa fa-icon-save icon-save',
+    'download': 'fa fa-floppy-o icon-save',
     None: None
 }
 


### PR DESCRIPTION
See http://fortawesome.github.io/Font-Awesome/icon/floppy-o/ 
There is as far as I can see no fa-icon-save in in FA 4.x it has been renamed to fa-floppy-o
Resolves an issue with a missing icon in IPython3