### PR TITLE
Propose removing minimum window size limit in tkAgg backend

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -530,13 +530,6 @@ class FigureManagerTkAgg(FigureManagerBase):
         self.set_window_title("Figure %d" % num)
         self.canvas = canvas
         self._num =  num
-        # Minimum size limit on window unnecessary (doesn't crash, just 
-        # opens up the possibility of making really tiny windows), but 
-        # if desired should be set to a hard minimum value rather than a 
-        # sizable percentage of the original dimensions (as implemented 
-        # in v1.4.2 and prior) to allow initially large windows to 
-        # shrink
-        # self.window.minsize(10, 10)
         if matplotlib.rcParams['toolbar']=='toolbar2':
             self.toolbar = NavigationToolbar2TkAgg( canvas, self.window )
         else:

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -530,9 +530,13 @@ class FigureManagerTkAgg(FigureManagerBase):
         self.set_window_title("Figure %d" % num)
         self.canvas = canvas
         self._num =  num
-        _, _, w, h = canvas.figure.bbox.bounds
-        w, h = int(w), int(h)
-        self.window.minsize(int(w*3/4),int(h*3/4))
+        # Minimum size limit on window unnecessary (doesn't crash, just 
+        # opens up the possibility of making really tiny windows), but 
+        # if desired should be set to a hard minimum value rather than a 
+        # sizable percentage of the original dimensions (as implemented 
+        # in v1.4.2 and prior) to allow initially large windows to 
+        # shrink
+        # self.window.minsize(10, 10)
         if matplotlib.rcParams['toolbar']=='toolbar2':
             self.toolbar = NavigationToolbar2TkAgg( canvas, self.window )
         else:


### PR DESCRIPTION
I like to dynamically resize my plot windows and was having problems when starting large and going small. Problem is a min size limit that is set to 3/4 of original size. Limited testing shows no crash problems with removing the size limit altogether and going super small. As long as the window manager uses a border it won't be too small to see. But if a limit must be present, I suggest a hard coded limit rather than a percentage of original size that can limit valid resize requests.