### PR TITLE
[WIP] Implement a scattertext plot method.

### DIFF
--- a/examples/pylab_examples/scattertext.py
+++ b/examples/pylab_examples/scattertext.py
@@ -1,0 +1,13 @@
+import matplotlib.pyplot as plt
+
+x = [0.5, -1.0, 1.0]
+y = [1.0, -2.0, 3.0]
+data = ['100.1', 'Hello!', '50']
+
+fig = plt.figure()
+ax = fig.add_subplot(1, 1, 1)
+ax.scattertext(x, y, data, loc=(-20, 20))
+ax.scattertext(x, y, data, color='red', loc=(20, -20))
+ax.scattertext(x, y, data, color='blue')
+
+plt.show()


### PR DESCRIPTION
Adds a TextCollection object that facilitates drawing a bunch of text
with common properties at different locations. scattertext() uses this
to plot text in data coordinates, with an optional offset.

This is a first cut in order to get design feedback. TextCollection inherits only from Text right now, just overriding the draw() method to do multiple calls to draw_text(). The implementation here started with Text.draw(), so there are some things like bbox and PathEffects that are inherited that may or may not make sense.

Questions:
1. How to refactor `Text` so that the hack for `get_layout()` isn't necessary
2. Any reason to also inherit `Collection`
3. Adding colormapping: using `cm.ScalarMappable`? 
4. Interface for `scattertext()`: Should it take an array of data values or an array of strings?

Any other issues?
