### PR TITLE
Fix for #4071

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3426,6 +3426,10 @@ class Axes(_AxesBase):
             box_right = pos + width * 0.5
             med_y = [stats['med'], stats['med']]
 
+            #There's no data to plot; skip plotting.
+            if np.isnan(stats['mean']):
+                continue
+
             # notched boxes
             if shownotches:
                 box_x = [box_left, box_right, box_right, cap_right, box_right,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3510,6 +3510,13 @@ def test_numerical_hist_label():
     fig, ax = plt.subplots()
     ax.hist([range(15)] * 5, label=range(5))
 
+
+@cleanup
+def test_emptydata_boxplot():
+    #issue 4071
+    fix, ax = plt.subplots()
+    ax.boxplot([[0], [], [0, 0]], notch=True)
+
 if __name__ == '__main__':
     import nose
     import sys


### PR DESCRIPTION
`Axes.bxp` skips plotting boxplots when there is missing data.