### PR TITLE
WIP: Oo interactive; enable interactive mode with Axes and Figure methods

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -201,6 +201,31 @@ if not compare_versions(numpy.__version__, __version__numpy__):
         'numpy %s or later is required; you have %s' % (
             __version__numpy__, numpy.__version__))
 
+import functools
+def _interactive(func):
+    """
+    Decorator for Figure and Axes methods that will be wrapped in pyplot.
+
+    Methods so decorated no longer need a call to `draw_if_interactive`
+    in their pyplot wrappers, and are interactive when invoked as
+    methods with a gui backend in interactive mode.
+
+    Figure and Axes must define the methods `check_interactive`,
+    `draw_if_interactive`, and `clear_interactive` used in this
+    decorator.
+    """
+    @functools.wraps(func)
+    def inner(self, *args, **kw):
+        outer = self.check_interactive()
+        drawn = True  # default in "finally" clause is to clear.
+        try:
+            ret = func(self, *args, **kw)
+            drawn = self.draw_if_interactive(outer)
+        finally:
+            self.clear_interactive(drawn)
+        return ret
+    return inner
+
 
 def _is_writable_dir(p):
     """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -38,6 +38,7 @@ import matplotlib.transforms as mtrans
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
 from matplotlib.axes._base import _AxesBase
 from matplotlib.axes._base import _process_plot_format
+from matplotlib import _interactive  # decorator
 
 rcParams = matplotlib.rcParams
 
@@ -1235,6 +1236,7 @@ class Axes(_AxesBase):
         return colls
 
     #### Basic plotting
+    @_interactive
     @docstring.dedent_interpd
     def plot(self, *args, **kwargs):
         """
@@ -2530,6 +2532,7 @@ class Axes(_AxesBase):
         else:
             return slices, texts, autotexts
 
+    @_interactive
     @docstring.dedent_interpd
     def errorbar(self, x, y, yerr=None, xerr=None,
                  fmt='', ecolor=None, elinewidth=None, capsize=3,

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -30,9 +30,8 @@ import matplotlib.font_manager as font_manager
 import matplotlib.text as mtext
 import matplotlib.image as mimage
 from matplotlib.artist import allow_rasterization
-
-
 from matplotlib.cbook import iterable
+from matplotlib import is_interactive
 
 rcParams = matplotlib.rcParams
 
@@ -442,6 +441,7 @@ class _AxesBase(martist.Artist):
         self.set_cursor_props((1, 'k'))  # set the cursor properties for axes
 
         self._cachedRenderer = None
+        self._in_outer_method = False
         self.set_navigate(True)
         self.set_navigate_mode(None)
 
@@ -460,6 +460,40 @@ class _AxesBase(martist.Artist):
         if self.yaxis is not None:
             self._ycid = self.yaxis.callbacks.connect('units finalize',
                                                       self.relim)
+
+
+    def draw_if_interactive(self, outer=False):
+        print("entering draw_if_interactive in axes/_base, outer = ", outer)
+        # Not sure whether this should be public or private...
+        if not outer or not is_interactive():
+            return False
+        # Leave out the following check for now; it probably
+        # has to be modified so that it does not require importing
+        # all the available interactive backends just to make
+        # the list of canvases.  Instead, the check could be based
+        # on the str() or (repr) of self.canvas.
+        #if not isinstance(self.canvas, interactive_canvases):
+        #    return
+        self.figure.canvas.draw()
+        print("drawing complete in axes/_base")
+        return True
+
+    def check_interactive(self):
+        """
+        Return True upon entering an outer method, and set the
+        flag; return False if already in an outer method.
+        """
+        if not self._in_outer_method:
+            self._in_outer_method = True
+            print("checking: toggled _in_outer_method to True")
+            return True
+        print("checking: already _in_outer_method; returning False")
+        return False
+
+    def clear_interactive(self, drawn):
+        if drawn:
+            self._in_outer_method = False
+
 
     def __setstate__(self, state):
         self.__dict__ = state

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -24,7 +24,9 @@ import numpy as np
 from matplotlib import rcParams
 from matplotlib import docstring
 from matplotlib import __version__ as _mpl_version
+
 from matplotlib import is_interactive
+from matplotlib import _interactive  # decorator
 
 import matplotlib.artist as martist
 from matplotlib.artist import Artist, allow_rasterization
@@ -233,20 +235,6 @@ class SubplotParams(object):
                 val = rcParams[key]
 
         setattr(self, s, val)
-
-import functools
-def _interactive(func):
-    @functools.wraps(func)
-    def inner(self, *args, **kw):
-        outer = self.check_interactive()
-        drawn = True  # default in "finally" clause is to clear.
-        try:
-            ret = func(self, *args, **kw)
-            drawn = self.draw_if_interactive(outer)
-        finally:
-            self.clear_interactive(drawn)
-        return ret
-    return inner
 
 class Figure(Artist):
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -378,16 +378,19 @@ class Figure(Artist):
         #if not isinstance(self.canvas, interactive_canvases):
         #    return
         self.canvas.draw()
-        print("drawing complete")
-        #self._in_outer_method = False
+        # print("drawing complete")
         return True
 
     def check_interactive(self):
+        """
+        Return True upon entering an outer method, and set the
+        flag; return False if already in an outer method.
+        """
         if not self._in_outer_method:
             self._in_outer_method = True
-            print("checking: True")
+            print("checking: toggled _in_outer_method to True")
             return True
-        print("checking: False")
+        print("checking: already _in_outer_method; returning False")
         return False
 
     def clear_interactive(self, drawn):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2761,7 +2761,7 @@ def errorbar(x, y, yerr=None, xerr=None, fmt='', ecolor=None, elinewidth=None,
                           barsabove=barsabove, lolims=lolims, uplims=uplims,
                           xlolims=xlolims, xuplims=xuplims,
                           errorevery=errorevery, capthick=capthick, **kwargs)
-        draw_if_interactive()
+        #draw_if_interactive()
     finally:
         ax.hold(washold)
 
@@ -3095,7 +3095,7 @@ def plot(*args, **kwargs):
         ax.hold(hold)
     try:
         ret = ax.plot(*args, **kwargs)
-        draw_if_interactive()
+        #draw_if_interactive()
     finally:
         ax.hold(washold)
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -611,14 +611,12 @@ def waitforbuttonpress(*args, **kwargs):
 def figtext(*args, **kwargs):
 
     ret =  gcf().text(*args, **kwargs)
-    draw_if_interactive()
     return ret
 
 
 @docstring.copy_dedent(Figure.suptitle)
 def suptitle(*args, **kwargs):
     ret =  gcf().suptitle(*args, **kwargs)
-    draw_if_interactive()
     return ret
 
 


### PR DESCRIPTION
This is a sketch illustrating one method of allowing one to use the OO interface in interactive mode.  It involves adding three methods to the Figure and Axes classes, and then using a decorator for any method in those classes that should have a draw_if_interactive behavior.  Typically this would include all such methods that are wrapped in pyplot.  In the initial version of this PR, this is illustrated with `Figure.suptitle`, `Figure.text`, `Axes.plot`, and `Axes.errorbar`.  Print statements are presently left in to show how the system works; in particular, note that even though `errorbar` calls `plot`, the drawing operation is executed only once, so there is no significant loss of efficiency compared to the present pyplot function.  A simple illustration in ipython is:
```python
%matplotlib
import matplotlib.pyplot as plt
fig = plt.gcf()
fig.text(0.5, 0.5, 'testing')
ax = plt.gca()
ax.plot([1,2,3])
ax.errorbar([1,2.5, 3.5], [2, 3.5, 2], yerr=2)
```