### PR TITLE
Fix #4076. Change how result is stored in point_in_path/point_on_path.

### DIFF
--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -561,6 +561,7 @@ def test_regularpolycollection_scale():
     ax.axis([-1, 1, -1, 1])
 
 
+@cleanup
 def test_picking():
     fig, ax = plt.subplots()
     col = ax.scatter([0], [0], [1000])

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -6,6 +6,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
+import io
+
 from nose.tools import assert_equal
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -557,6 +559,22 @@ def test_regularpolycollection_scale():
                                transOffset=ax.transData)
     ax.add_collection(squares, autolim=True)
     ax.axis([-1, 1, -1, 1])
+
+
+def test_picking():
+    fig, ax = plt.subplots()
+    col = ax.scatter([0], [0], [1000])
+    fig.savefig(io.BytesIO(), dpi=fig.dpi)
+
+    class MouseEvent(object):
+        pass
+    event = MouseEvent()
+    event.x = 325
+    event.y = 240
+
+    found, indices = col.contains(event)
+    assert found
+    assert_array_equal(indices['ind'], [0])
 
 
 if __name__ == '__main__':

--- a/src/_path.h
+++ b/src/_path.h
@@ -209,7 +209,7 @@ inline void points_in_path(PointArray &points,
     typedef agg::conv_contour<curve_t> contour_t;
 
     size_t i;
-    for (i = 0; i < result.size(); ++i) {
+    for (i = 0; i < points.size(); ++i) {
         result[i] = false;
     }
 
@@ -236,8 +236,8 @@ inline bool point_in_path(
     point.push_back(y);
     points.push_back(point);
 
-    std::vector<bool> result(1);
-    result[0] = false;
+    int result[1];
+    result[0] = 0;
 
     points_in_path(points, r, path, trans, result);
 
@@ -257,7 +257,7 @@ void points_on_path(PointArray &points,
     typedef agg::conv_stroke<curve_t> stroke_t;
 
     size_t i;
-    for (i = 0; i < result.size(); ++i) {
+    for (i = 0; i < points.size(); ++i) {
         result[i] = false;
     }
 
@@ -279,8 +279,8 @@ inline bool point_on_path(
     point.push_back(y);
     points.push_back(point);
 
-    std::vector<bool> result(1);
-    result[0] = false;
+    int result[1];
+    result[0] = 0;
 
     points_on_path(points, r, path, trans, result);
 
@@ -406,7 +406,7 @@ void point_in_path_collection(double x,
                               agg::trans_affine &offset_trans,
                               bool filled,
                               e_offset_position offset_position,
-                              std::vector<size_t> &result)
+                              std::vector<int> &result)
 {
     size_t Npaths = paths.size();
 
@@ -432,6 +432,7 @@ void point_in_path_collection(double x,
                                       subtrans(1, 1),
                                       subtrans(0, 2),
                                       subtrans(1, 2));
+            trans *= master_transform;
         } else {
             trans = master_transform;
         }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -309,7 +309,7 @@ static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args, PyO
     agg::trans_affine offset_trans;
     int filled;
     e_offset_position offset_position;
-    std::vector<size_t> result;
+    std::vector<int> result;
 
     if (!PyArg_ParseTuple(args,
                           "dddO&OO&O&O&iO&:point_in_path_collection",
@@ -354,8 +354,8 @@ static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args, PyO
     }
 
     npy_intp dims[] = {(npy_intp)result.size() };
-    numpy::array_view<size_t, 1> pyresult(dims);
-    memcpy(pyresult.data(), &result[0], result.size() * sizeof(size_t));
+    numpy::array_view<int, 1> pyresult(dims);
+    memcpy(pyresult.data(), &result[0], result.size() * sizeof(int));
     return pyresult.pyobj();
 }
 


### PR DESCRIPTION
Return indices as signed integers (since that's what Numpy wants).