### PR TITLE
Gtk.main_iteration takes no arguments

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -362,7 +362,7 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
     def flush_events(self):
         Gdk.threads_enter()
         while Gtk.events_pending():
-            Gtk.main_iteration(True)
+            Gtk.main_iteration()
         Gdk.flush()
         Gdk.threads_leave()
 


### PR DESCRIPTION
the older sig is gtk.main_iteration(block=True) anyways. http://lazka.github.io/pgi-docs/#Gtk-3.0/functions.html#Gtk.main_iteration