### PR TITLE
Fix scale factor label issue #4043

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2114,11 +2114,11 @@ class YAxis(Axis):
         if position == 'right':
             self.set_tick_params(which='both', right=True, labelright=True,
                                  left=False, labelleft=False)
-            self.set_offset_position(position)                     
+            self.set_offset_position(position)
         elif position == 'left':
             self.set_tick_params(which='both', right=False, labelright=False,
                                  left=True, labelleft=True)
-            self.set_offset_position(position)                    
+            self.set_offset_position(position)
         elif position == 'both':
             self.set_tick_params(which='both', right=True,
                                  left=True)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2023,7 +2023,6 @@ class YAxis(Axis):
         assert position == 'left' or position == 'right'
         self.label.set_rotation_mode('anchor')
         self.label.set_horizontalalignment('center')
-        self.set_offset_position(position)
         if position == 'left':
             self.label.set_verticalalignment('bottom')
         else:
@@ -2115,9 +2114,11 @@ class YAxis(Axis):
         if position == 'right':
             self.set_tick_params(which='both', right=True, labelright=True,
                                  left=False, labelleft=False)
+            self.set_offset_position(position)                     
         elif position == 'left':
             self.set_tick_params(which='both', right=False, labelright=False,
                                  left=True, labelleft=True)
+            self.set_offset_position(position)                    
         elif position == 'both':
             self.set_tick_params(which='both', right=True,
                                  left=True)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2023,6 +2023,7 @@ class YAxis(Axis):
         assert position == 'left' or position == 'right'
         self.label.set_rotation_mode('anchor')
         self.label.set_horizontalalignment('center')
+        self.set_offset_position(position)
         if position == 'left':
             self.label.set_verticalalignment('bottom')
         else:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3514,7 +3514,6 @@ def test_move_offsetlabel():
     data = np.random.random(10) * 1e-22
     fig, ax = plt.subplots()
     ax.plot(data)
-    ax.yaxis.set_label_position('right')
     ax.yaxis.tick_right()
     assert_equal((1, 0.5), ax.yaxis.offsetText.get_position())
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3508,6 +3508,15 @@ def test_color_None():
 def test_numerical_hist_label():
     fig, ax = plt.subplots()
     ax.hist([range(15)] * 5, label=range(5))
+    
+@cleanup
+def test_move_offsetlabel():
+    data = np.random.random(10) * 1e-22
+    fig, ax = plt.subplots()
+    ax.plot(data)
+    ax.yaxis.set_label_position('right')
+    ax.yaxis.tick_right()
+    assert_equal((1, 0.5), ax.yaxis.offsetText.get_position())
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
Added the line, self.set_offset_position(position) in the YAxis class (line 2026) and it appears to fix the issue of the scale factor label not moving to the right with the tick labels.