### PR TITLE
Pep8 fixes

### DIFF
--- a/examples/animation/double_pendulum_animated.py
+++ b/examples/animation/double_pendulum_animated.py
@@ -21,18 +21,18 @@ def derivs(state, t):
 
     del_ = state[2] - state[0]
     den1 = (M1 + M2)*L1 - M2*L1*cos(del_)*cos(del_)
-    dydx[1] = (M2*L1*state[1]*state[1]*sin(del_)*cos(del_)
-               + M2*G*sin(state[2])*cos(del_)
-               + M2*L2*state[3]*state[3]*sin(del_)
-               - (M1 + M2)*G*sin(state[0]))/den1
+    dydx[1] = (M2*L1*state[1]*state[1]*sin(del_)*cos(del_) +
+               M2*G*sin(state[2])*cos(del_) +
+               M2*L2*state[3]*state[3]*sin(del_) -
+               (M1 + M2)*G*sin(state[0]))/den1
 
     dydx[2] = state[3]
 
     den2 = (L2/L1)*den1
-    dydx[3] = (-M2*L2*state[3]*state[3]*sin(del_)*cos(del_)
-               + (M1 + M2)*G*sin(state[0])*cos(del_)
-               - (M1 + M2)*L1*state[1]*state[1]*sin(del_)
-               - (M1 + M2)*G*sin(state[2]))/den2
+    dydx[3] = (-M2*L2*state[3]*state[3]*sin(del_)*cos(del_) +
+               (M1 + M2)*G*sin(state[0])*cos(del_) -
+               (M1 + M2)*L1*state[1]*state[1]*sin(del_) -
+               (M1 + M2)*G*sin(state[2]))/den2
 
     return dydx
 

--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -33,7 +33,8 @@ PEP8_ADDITIONAL_IGNORE = ['E111',
                           'E129',
                           'E131',
                           'E265',
-                          'E266']
+                          'E266',
+                          'W503']
 
 EXTRA_EXCLUDE_FILE = os.path.join(os.path.dirname(__file__),
                                   '.pep8_test_exclude.txt')


### PR DESCRIPTION
pep8 version bumped to 1.6.2 which added a new warning W503.  This checks on patterns like

```python
c = (a  
     + b )
```

preferring 

```python
c = (a + 
     b )
```

This is a reasonable bit of code style to fix, but I don't have the patience to do this tonight.