### PR TITLE
Fix Cairo text on Python3 with pycairo

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -242,7 +242,7 @@ class RendererCairo(RendererBase):
 
             size = fontsize * self.dpi / 72.0
             ctx.set_font_size(size)
-            if isinstance(s, six.text_type):
+            if not six.PY3 and isinstance(s, six.text_type):
                 s = s.encode("utf-8")
             ctx.show_text(s)
             ctx.restore()


### PR DESCRIPTION
See #2906 for explanation.

Fixes
```
testing cairo
        driving ..\pylab_examples\accented_text.py
Traceback (most recent call last):
  File "_tmp_accented_text.py", line 33, in <module>
    savefig(r"cairo\accented_text", dpi=150)
  File "X:\Python34\lib\site-packages\matplotlib\pyplot.py", line 577, in savefig
    res = fig.savefig(*args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\figure.py", line 1476, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\backend_bases.py", line 2211, in print_figure
    **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\backends\backend_cairo.py", line 442, in print_png
    self.figure.draw (renderer)
  File "X:\Python34\lib\site-packages\matplotlib\artist.py", line 59, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\figure.py", line 1085, in draw
    func(*args)
  File "X:\Python34\lib\site-packages\matplotlib\artist.py", line 59, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\axes\_base.py", line 2110, in draw
    a.draw(renderer)
  File "X:\Python34\lib\site-packages\matplotlib\artist.py", line 59, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\axis.py", line 1128, in draw
    self.label.draw(renderer)
  File "X:\Python34\lib\site-packages\matplotlib\artist.py", line 59, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\text.py", line 642, in draw
    ismath=ismath, mtext=mtext)
  File "X:\Python34\lib\site-packages\matplotlib\backends\backend_cairo.py", line 194, in draw_text
    self._draw_mathtext(gc, x, y, s, prop, angle)
  File "X:\Python34\lib\site-packages\matplotlib\backends\backend_cairo.py", line 247, in _draw_mathtext
    ctx.show_text(s)
TypeError: Can't convert 'bytes' object to str implicitly
```