### PR TITLE
BUG: Fix to the macosx backend to only raise windows which were visible ...

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5888,7 +5888,9 @@ show(PyObject* self)
         NSEnumerator *enumerator = [windowsArray objectEnumerator];
         NSWindow *window;
         while ((window = [enumerator nextObject])) {
-            [window orderFront:nil];
+            if ([window isVisible]) {
+                [window orderFront:nil];
+            }
         }
         [pool release];
         [NSApp run];


### PR DESCRIPTION
...when show is called. This eliminates the possibility of accidently raising other hidden windows like NSToolTipPanel.

Replaces #3798 