### PR TITLE
DOC: Organize colormap list and remove synonyms

### DIFF
--- a/doc/users/plotting/colormaps/grayscale.py
+++ b/doc/users/plotting/colormaps/grayscale.py
@@ -22,21 +22,23 @@ mpl.rcParams['mathtext.fallback_to_cm'] = 'True'
 
 # Have colormaps separated into categories: http://matplotlib.org/examples/color/colormaps_reference.html
 
-cmaps = [('Sequential',     ['binary', 'Blues', 'BuGn', 'BuPu', 'gist_yarg',
+cmaps = [('Sequential',     ['Blues', 'BuGn', 'BuPu',
                              'GnBu', 'Greens', 'Greys', 'Oranges', 'OrRd',
                              'PuBu', 'PuBuGn', 'PuRd', 'Purples', 'RdPu',
                              'Reds', 'YlGn', 'YlGnBu', 'YlOrBr', 'YlOrRd']),
-         ('Sequential2', ['afmhot', 'autumn', 'bone', 'cool', 'copper',
-                             'gist_gray', 'gist_heat', 'gray', 'hot', 'pink',
+         ('Sequential (2)', ['afmhot', 'autumn', 'bone', 'cool', 'copper',
+                             'gist_heat', 'gray', 'hot', 'pink',
                              'spring', 'summer', 'winter']),
          ('Diverging',      ['BrBG', 'bwr', 'coolwarm', 'PiYG', 'PRGn', 'PuOr',
-                             'RdBu', 'RdGy', 'RdYlBu', 'RdYlGn', 'seismic']),
-         ('Qualitative',    ['Accent', 'Dark2', 'hsv', 'Paired', 'Pastel1',
-                             'Pastel2', 'Set1', 'Set2', 'Set3', 'spectral']),
-         ('Miscellaneous',  ['gist_earth', 'gist_ncar', 'gist_rainbow',
-                             'gist_stern', 'jet', 'brg', 'CMRmap', 'cubehelix',
-                             'gnuplot', 'gnuplot2', 'ocean', 'rainbow',
-                             'terrain', 'flag', 'prism'])]
+                             'RdBu', 'RdGy', 'RdYlBu', 'RdYlGn', 'Spectral',
+                             'seismic']),
+         ('Qualitative',    ['Accent', 'Dark2', 'Paired', 'Pastel1',
+                             'Pastel2', 'Set1', 'Set2', 'Set3']),
+         ('Miscellaneous',  ['gist_earth', 'terrain', 'ocean', 'gist_stern',
+                             'brg', 'CMRmap', 'cubehelix',
+                             'gnuplot', 'gnuplot2', 'gist_ncar',
+                             'nipy_spectral', 'jet', 'rainbow',
+                             'gist_rainbow', 'hsv', 'flag', 'prism'])]
 
 # indices to step through colormap
 x = np.linspace(0.0, 1.0, 100)

--- a/doc/users/plotting/colormaps/lightness.py
+++ b/doc/users/plotting/colormaps/lightness.py
@@ -21,21 +21,23 @@ mpl.rcParams['mathtext.fallback_to_cm'] = 'True'
 
 # Have colormaps separated into categories: http://matplotlib.org/examples/color/colormaps_reference.html
 
-cmaps = [('Sequential',     ['binary', 'Blues', 'BuGn', 'BuPu', 'gist_yarg',
+cmaps = [('Sequential',     ['Blues', 'BuGn', 'BuPu',
                              'GnBu', 'Greens', 'Greys', 'Oranges', 'OrRd',
                              'PuBu', 'PuBuGn', 'PuRd', 'Purples', 'RdPu',
                              'Reds', 'YlGn', 'YlGnBu', 'YlOrBr', 'YlOrRd']),
-         ('Sequential2', ['afmhot', 'autumn', 'bone', 'cool', 'copper',
-                             'gist_gray', 'gist_heat', 'gray', 'hot', 'pink',
+         ('Sequential (2)', ['afmhot', 'autumn', 'bone', 'cool', 'copper',
+                             'gist_heat', 'gray', 'hot', 'pink',
                              'spring', 'summer', 'winter']),
          ('Diverging',      ['BrBG', 'bwr', 'coolwarm', 'PiYG', 'PRGn', 'PuOr',
-                             'RdBu', 'RdGy', 'RdYlBu', 'RdYlGn', 'seismic']),
-         ('Qualitative',    ['Accent', 'Dark2', 'hsv', 'Paired', 'Pastel1',
-                             'Pastel2', 'Set1', 'Set2', 'Set3', 'spectral']),
-         ('Miscellaneous',  ['gist_earth', 'gist_ncar', 'gist_rainbow',
-                             'gist_stern', 'jet', 'brg', 'CMRmap', 'cubehelix',
-                             'gnuplot', 'gnuplot2', 'ocean', 'rainbow',
-                             'terrain', 'flag', 'prism'])]
+                             'RdBu', 'RdGy', 'RdYlBu', 'RdYlGn', 'Spectral',
+                             'seismic']),
+         ('Qualitative',    ['Accent', 'Dark2', 'Paired', 'Pastel1',
+                             'Pastel2', 'Set1', 'Set2', 'Set3']),
+         ('Miscellaneous',  ['gist_earth', 'terrain', 'ocean', 'gist_stern',
+                             'brg', 'CMRmap', 'cubehelix',
+                             'gnuplot', 'gnuplot2', 'gist_ncar',
+                             'nipy_spectral', 'jet', 'rainbow',
+                             'gist_rainbow', 'hsv', 'flag', 'prism'])]
 
 # indices to step through colormap
 x = np.linspace(0.0, 1.0, 100)


### PR DESCRIPTION
I did this in colormaps_reference.py but didn't notice there were more
copies of the list.

https://github.com/endolith/matplotlib/commit/38690652137356b62e453fa82215f1cde8792890

Replaces #3975