### PR TITLE
CallbackRegistry fix

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -361,6 +361,7 @@ class _BoundMethodProxy(object):
     Minor bugfixes by Michael Droettboom
     '''
     def __init__(self, cb):
+        self._hash = hash(cb)
         try:
             try:
                 self.inst = ref(cb.im_self)
@@ -433,6 +434,9 @@ class _BoundMethodProxy(object):
         '''
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return self._hash
+
 
 class CallbackRegistry(object):
     """
@@ -492,14 +496,14 @@ class CallbackRegistry(object):
         func will be called
         """
         self._func_cid_map.setdefault(s, WeakKeyDictionary())
-        if func in self._func_cid_map[s]:
-            return self._func_cid_map[s][func]
+        proxy = _BoundMethodProxy(func)
+        if proxy in self._func_cid_map[s]:
+            return self._func_cid_map[s][proxy]
 
         self._cid += 1
         cid = self._cid
-        self._func_cid_map[s][func] = cid
+        self._func_cid_map[s][proxy] = cid
         self.callbacks.setdefault(s, dict())
-        proxy = _BoundMethodProxy(func)
         self.callbacks[s][cid] = proxy
         return cid
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -520,11 +520,16 @@ class CallbackRegistry(object):
         return cid
 
     def _remove_proxy(self, proxy):
-        for category, proxies in list(six.iteritems(self._func_cid_map)):
+        for signal, proxies in list(six.iteritems(self._func_cid_map)):
             try:
-                del self.callbacks[category][proxies[proxy]]
+                del self.callbacks[signal][proxies[proxy]]
             except KeyError:
                 pass
+
+            if len(self.callbacks[signal]) == 0:
+                del self.callbacks[signal]
+                del self._func_cid_map[signal]
+
 
     def disconnect(self, cid):
         """
@@ -536,7 +541,7 @@ class CallbackRegistry(object):
             except KeyError:
                 continue
             else:
-                for category, functions in list(
+                for signal, functions in list(
                         six.iteritems(self._func_cid_map)):
                     for function, value in list(six.iteritems(functions)):
                         if value == cid:

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import numpy as np
 from numpy.testing.utils import (assert_array_equal, assert_approx_equal,
                                  assert_array_almost_equal)
-from nose.tools import assert_equal, raises, assert_true
+from nose.tools import assert_equal, assert_not_equal, raises, assert_true
 
 import matplotlib.cbook as cbook
 import matplotlib.colors as mcolors
@@ -243,3 +243,47 @@ class Test_boxplot_stats(object):
     def test_bad_dims(self):
         data = np.random.normal(size=(34, 34, 34))
         results = cbook.boxplot_stats(data)
+
+
+class Test_callback_registry(object):
+    def setup(self):
+        self.signal = 'test'
+        self.callbacks = cbook.CallbackRegistry()
+
+    def connect(self, s, func):
+        return self.callbacks.connect(s, func)
+
+    def is_empty(self):
+        assert_equal(self.callbacks._func_cid_map, {})
+        assert_equal(self.callbacks.callbacks, {})
+
+    def is_not_empty(self):
+        assert_not_equal(self.callbacks._func_cid_map, {})
+        assert_not_equal(self.callbacks.callbacks, {})
+
+    def test_callback_complete(self):
+        # ensure we start with an empty registry
+        self.is_empty()
+
+        # create a class for testing
+        mini_me = Test_callback_registry()
+
+        # test that we can add a callback
+        cid1 = self.connect(self.signal, mini_me.dummy)
+        assert_equal(type(cid1), int)
+        self.is_not_empty()
+
+        # test that we don't add a second callback
+        cid2 = self.connect(self.signal, mini_me.dummy)
+        assert_equal(cid1, cid2)
+        self.is_not_empty()
+        assert_equal(len(self.callbacks._func_cid_map), 1)
+        assert_equal(len(self.callbacks.callbacks), 1)
+
+        del mini_me
+
+        # check we now have no callbacks registered
+        self.is_empty()
+
+    def dummy(self):
+        pass


### PR DESCRIPTION
As ``weakref.ref()`` does not accept bound or unbound functions, this means that the current ``if func in self._func_cid_map[s]:`` fails in these cases, and allows (s, func) pairs to get added many times.  ``_BoundMethodProxy`` fixed this problem for the ``CallbackRegistry.callbacks`` dict, but not for the ``CallbackRegistry._func_cid_map``, here we correct this.

While researching the bug (and how to fix it), I discovered that ``weakref.ref()`` also supports a callback for when the weakref dies.  This seems like a much better way to do garbage collection then at present as ``CallbackRegistry`` only does GC only on the specific signal as it gets processed, so potentially quite late, this I fixed in the second commit.