### PR TITLE
added guiEvent to PickEvent

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1848,7 +1848,9 @@ class FigureCanvasBase(object):
         fire off :class:`PickEvent` callbacks registered listeners
         """
         s = 'pick_event'
-        event = PickEvent(s, self, mouseevent, artist, **kwargs)
+        event = PickEvent(s, self, mouseevent, artist,
+                          guiEvent=mouseevent.guiEvent,
+                          **kwargs)
         self.callbacks.process(s, event)
 
     def scroll_event(self, x, y, step, guiEvent=None):


### PR DESCRIPTION
PickEvent.guiEvent is currenly set to None. However, the guiEvent is available within PickEvent.mouseevent.guiEvent. This looks like it was done by design, but I feel like it's somewhat of an API inconsistency.

Example of what I was trying to do that didn't work:

```python

import matplotlib
import numpy as np
import matplotlib.pyplot as plt

def onpick(event):
    print event.mouseevent.guiEvent # <-- available
    print event.guiEvent # <--  no available, but this is what I expect to be able to use

x = [1, 2, 3]
y = [1, 2, 3]

fig, ax = plt.subplots()
ax.scatter(x, y, picker=True)
fig.canvas.mpl_connect('pick_event',  onpick)
plt.show()
```