### PR TITLE
Link fix in external ressources + 1 addition

### DIFF
--- a/doc/resources/index.rst
+++ b/doc/resources/index.rst
@@ -5,34 +5,38 @@
 *******************
 
 
-===================
- Books and Chapters
-===================
+=============================
+ Books, Chapters and Articles
+=============================
 
-* `Matplotlib for Python Developers 
-  <http://www.packtpub.com/matplotlib-python-development/book?mid/171109cna1h>`_ 
+* `Matplotlib for Python Developers
+  <http://www.packtpub.com/matplotlib-python-development/book?mid/171109cna1h>`_
   by Sandro Tosi
 
-* `Matplotlib chapter <http://www.aosabook.org/en/matplotlib.html>`_ 
-  by John Hunter and Michael Droettboom in The Architecture of Open Source 
+* `Matplotlib chapter <http://www.aosabook.org/en/matplotlib.html>`_
+  by John Hunter and Michael Droettboom in The Architecture of Open Source
   Applications
 
-* `Graphics with Matplotlib 
-  <http://physics.nmt.edu/~raymond/software/python_notes/paper004.html>`_ 
+* `Graphics with Matplotlib
+  <http://physics.nmt.edu/~raymond/software/python_notes/paper004.html>`_
   by David J. Raymond
+
+* `Ten Simple Rules for Better Figures
+   <http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003833>`_
+   by Nicolas P. Rougier, Michael Droettboom and Philip E. Bourne
 
 =======
  Videos
 =======
 
-* `Getting started with Matplotlib 
-  <http://showmedo.com/videotutorials/video?name=7200090&fromSeriesID=720>`_ 
+* `Getting started with Matplotlib
+  <http://showmedo.com/videotutorials/video?name=7200090&fromSeriesID=720>`_
   by `unpingco <http://showmedo.com/videotutorials/?author=6237>`_
 
-* `Plotting with matplotlib <http://www.youtube.com/watch?v=P7SVi0YTIuE>`_ 
-  by Mike Müller 
+* `Plotting with matplotlib <http://www.youtube.com/watch?v=P7SVi0YTIuE>`_
+  by Mike Müller
 
-* `Introduction to NumPy and Matplotlib 
+* `Introduction to NumPy and Matplotlib
   <http://www.youtube.com/watch?v=3Fp1zn5ao2M&feature=plcp>`_ by Eric Jones
 
 * `Anatomy of Matplotlib
@@ -43,10 +47,9 @@
  Tutorials
 ==========
 
-* `Matplotlib tutorial <http://www.loria.fr/~rougier/teaching/matplotlib/>`_ 
+* `Matplotlib tutorial <http://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_
   by Nicolas P. Rougier
 
 * `Anatomy of Matplotlib - IPython Notebooks
   <https://github.com/WeatherGod/AnatomyOfMatplotlib>`_
   by Benjamin Root
-

--- a/doc/resources/index.rst
+++ b/doc/resources/index.rst
@@ -22,8 +22,8 @@
   by David J. Raymond
 
 * `Ten Simple Rules for Better Figures
-   <http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003833>`_
-   by Nicolas P. Rougier, Michael Droettboom and Philip E. Bourne
+  <http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003833>`_
+  by Nicolas P. Rougier, Michael Droettboom and Philip E. Bourne
 
 =======
  Videos


### PR DESCRIPTION
I fixed the link for my tutorial and added a reference for the "Ten Simple Rules for Better Figures" article (all figures have been made using matplotlib, sources are available from https://github.com/rougier/ten-rules).

I did some mess with trailing whitespaces (removing them) but I can put them back if necessary.