### PR TITLE
Axis Labels with offset Spines

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2154,8 +2154,8 @@ class YAxis(Axis):
         majt = self.majorTicks[0]
         mT = self.minorTicks[0]
 
-        majorRight = ((not majt.tick1On) and majt.tick2On
-                      and (not majt.label1On) and majt.label2On)
+        majorRight = ((not majt.tick1On) and majt.tick2On and
+                      (not majt.label1On) and majt.label2On)
         minorRight = ((not mT.tick1On) and mT.tick2On and
                       (not mT.label1On) and mT.label2On)
         if majorRight and minorRight:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1732,9 +1732,13 @@ class XAxis(Axis):
             return
         x, y = self.label.get_position()
         if self.label_position == 'bottom':
-            spine = self.axes.spines['bottom']
-            spinebbox = spine.get_transform().transform_path(
-                spine.get_path()).get_extents()
+            try:
+                spine = self.axes.spines['bottom']
+                spinebbox = spine.get_transform().transform_path(
+                    spine.get_path()).get_extents()
+            except KeyError:
+                # use axes if spine doesn't exist
+                spinebbox = self.axes.bbox
             bbox = mtransforms.Bbox.union(bboxes + [spinebbox])
             bottom = bbox.y0
 
@@ -1743,9 +1747,13 @@ class XAxis(Axis):
             )
 
         else:
-            spine = self.axes.spines['top']
-            spinebbox = spine.get_transform().transform_path(
-                spine.get_path()).get_extents()
+            try:
+                spine = self.axes.spines['top']
+                spinebbox = spine.get_transform().transform_path(
+                    spine.get_path()).get_extents()
+            except KeyError:
+                # use axes if spine doesn't exist
+                spinebbox = self.axes.bbox
             bbox = mtransforms.Bbox.union(bboxes2 + [spinebbox])
             top = bbox.y1
 
@@ -2040,9 +2048,13 @@ class YAxis(Axis):
             return
         x, y = self.label.get_position()
         if self.label_position == 'left':
-            spine = self.axes.spines['left']
-            spinebbox = spine.get_transform().transform_path(
-                spine.get_path()).get_extents()
+            try:
+                spine = self.axes.spines['left']
+                spinebbox = spine.get_transform().transform_path(
+                    spine.get_path()).get_extents()
+            except KeyError:
+                # use axes if spine doesn't exist
+                spinebbox = self.axes.bbox
             bbox = mtransforms.Bbox.union(bboxes + [spinebbox])
             left = bbox.x0
 
@@ -2051,9 +2063,13 @@ class YAxis(Axis):
             )
 
         else:
-            spine = self.axes.spines['right']
-            spinebbox = spine.get_transform().transform_path(
-                spine.get_path()).get_extents()
+            try:
+                spine = self.axes.spines['right']
+                spinebbox = spine.get_transform().transform_path(
+                    spine.get_path()).get_extents()
+            except KeyError:
+                # use axes if spine doesn't exist
+                spinebbox = self.axes.bbox
             bbox = mtransforms.Bbox.union(bboxes2 + [spinebbox])
             right = bbox.x1
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1569,9 +1569,8 @@ class Axis(artist.Artist):
 
     def _update_label_position(self, bboxes, bboxes2):
         """
-        Update the label position based on the sequence of bounding
-        boxes of all the ticklabels or using the axis spines if no
-        ticklabels are present
+        Update the label position based on the the bounding box enclosing
+        all the ticklabels and axis spine
         """
         raise NotImplementedError('Derived must override')
 
@@ -1726,33 +1725,30 @@ class XAxis(Axis):
 
     def _update_label_position(self, bboxes, bboxes2):
         """
-        Update the label position based on the sequence of bounding
-        boxes of all the ticklabels or using the axis spines if no
-        ticklabels are present
+        Update the label position based on the the bounding box enclosing
+        all the ticklabels and axis spine
         """
         if not self._autolabelpos:
             return
         x, y = self.label.get_position()
         if self.label_position == 'bottom':
-            if not len(bboxes):
-                bottom = (self.axes.spines['bottom'].get_transform().
-                          transform_path(self.axes.spines['bottom'].
-                                         get_path()).get_extents().ymin)
-            else:
-                bbox = mtransforms.Bbox.union(bboxes)
-                bottom = bbox.y0
+            spinebbox = (self.axes.spines['bottom'].get_transform().
+                         transform_path(self.axes.spines['bottom'].
+                                        get_path()).get_extents())
+            bbox = mtransforms.Bbox.union(bboxes + [spinebbox])
+            bottom = bbox.y0
+
             self.label.set_position(
                 (x, bottom - self.labelpad * self.figure.dpi / 72.0)
             )
 
         else:
-            if not len(bboxes2):
-                top = (self.axes.spines['top'].get_transform().
-                       transform_path(self.axes.spines['top'].
-                                      get_path()).get_extents().ymax)
-            else:
-                bbox = mtransforms.Bbox.union(bboxes2)
-                top = bbox.y1
+            spinebbox = (self.axes.spines['top'].get_transform().
+                         transform_path(self.axes.spines['top'].
+                                        get_path()).get_extents())
+            bbox = mtransforms.Bbox.union(bboxes2 + [spinebbox])
+            top = bbox.y1
+
             self.label.set_position(
                 (x, top + self.labelpad * self.figure.dpi / 72.0)
             )
@@ -2037,34 +2033,29 @@ class YAxis(Axis):
 
     def _update_label_position(self, bboxes, bboxes2):
         """
-        Update the label position based on the sequence of bounding
-        boxes of all the ticklabels or using the axis spines if no
-        ticklabels are present
+        Update the label position based on the the bounding box enclosing
+        all the ticklabels and axis spine
         """
         if not self._autolabelpos:
             return
         x, y = self.label.get_position()
         if self.label_position == 'left':
-            if not len(bboxes):
-                left = (self.axes.spines['left'].get_transform().
-                        transform_path(self.axes.spines['left'].
-                                       get_path()).get_extents().xmin)
-            else:
-                bbox = mtransforms.Bbox.union(bboxes)
-                left = bbox.x0
+            spinebbox = (self.axes.spines['left'].get_transform().
+                         transform_path(self.axes.spines['left'].
+                                        get_path()).get_extents())
+            bbox = mtransforms.Bbox.union(bboxes + [spinebbox])
+            left = bbox.x0
 
             self.label.set_position(
                 (left - self.labelpad * self.figure.dpi / 72.0, y)
             )
 
         else:
-            if not len(bboxes2):
-                right = (self.axes.spines['right'].get_transform().
+            spinebbox = (self.axes.spines['right'].get_transform().
                          transform_path(self.axes.spines['right'].
-                                        get_path()).get_extents().xmax)
-            else:
-                bbox = mtransforms.Bbox.union(bboxes2)
-                right = bbox.x1
+                                        get_path()).get_extents())
+            bbox = mtransforms.Bbox.union(bboxes2 + [spinebbox])
+            right = bbox.x1
 
             self.label.set_position(
                 (right + self.labelpad * self.figure.dpi / 72.0, y)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1733,7 +1733,9 @@ class XAxis(Axis):
         x, y = self.label.get_position()
         if self.label_position == 'bottom':
             if not len(bboxes):
-                bottom = self.axes.bbox.ymin
+                bottom = (self.axes.spines['bottom'].get_transform().
+                          transform_path(self.axes.spines['bottom'].
+                                         get_path()).get_extents().ymin)
             else:
                 bbox = mtransforms.Bbox.union(bboxes)
                 bottom = bbox.y0
@@ -1743,7 +1745,9 @@ class XAxis(Axis):
 
         else:
             if not len(bboxes2):
-                top = self.axes.bbox.ymax
+                top = (self.axes.spines['top'].get_transform().
+                       transform_path(self.axes.spines['top'].
+                                      get_path()).get_extents().ymax)
             else:
                 bbox = mtransforms.Bbox.union(bboxes2)
                 top = bbox.y1
@@ -2039,7 +2043,9 @@ class YAxis(Axis):
         x, y = self.label.get_position()
         if self.label_position == 'left':
             if not len(bboxes):
-                left = self.axes.bbox.xmin
+                left = (self.axes.spines['left'].get_transform().
+                        transform_path(self.axes.spines['left'].
+                                       get_path()).get_extents().xmin)
             else:
                 bbox = mtransforms.Bbox.union(bboxes)
                 left = bbox.x0
@@ -2050,7 +2056,9 @@ class YAxis(Axis):
 
         else:
             if not len(bboxes2):
-                right = self.axes.bbox.xmax
+                right = (self.axes.spines['right'].get_transform().
+                         transform_path(self.axes.spines['right'].
+                                        get_path()).get_extents().xmax)
             else:
                 bbox = mtransforms.Bbox.union(bboxes2)
                 right = bbox.x1

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1570,7 +1570,8 @@ class Axis(artist.Artist):
     def _update_label_position(self, bboxes, bboxes2):
         """
         Update the label position based on the sequence of bounding
-        boxes of all the ticklabels
+        boxes of all the ticklabels or using the axis spines if no
+        ticklabels are present
         """
         raise NotImplementedError('Derived must override')
 
@@ -1726,7 +1727,8 @@ class XAxis(Axis):
     def _update_label_position(self, bboxes, bboxes2):
         """
         Update the label position based on the sequence of bounding
-        boxes of all the ticklabels
+        boxes of all the ticklabels or using the axis spines if no
+        ticklabels are present
         """
         if not self._autolabelpos:
             return
@@ -2036,7 +2038,8 @@ class YAxis(Axis):
     def _update_label_position(self, bboxes, bboxes2):
         """
         Update the label position based on the sequence of bounding
-        boxes of all the ticklabels
+        boxes of all the ticklabels or using the axis spines if no
+        ticklabels are present
         """
         if not self._autolabelpos:
             return

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1732,9 +1732,9 @@ class XAxis(Axis):
             return
         x, y = self.label.get_position()
         if self.label_position == 'bottom':
-            spinebbox = (self.axes.spines['bottom'].get_transform().
-                         transform_path(self.axes.spines['bottom'].
-                                        get_path()).get_extents())
+            spine = self.axes.spines['bottom']
+            spinebbox = spine.get_transform().transform_path(
+                spine.get_path()).get_extents()
             bbox = mtransforms.Bbox.union(bboxes + [spinebbox])
             bottom = bbox.y0
 
@@ -1743,9 +1743,9 @@ class XAxis(Axis):
             )
 
         else:
-            spinebbox = (self.axes.spines['top'].get_transform().
-                         transform_path(self.axes.spines['top'].
-                                        get_path()).get_extents())
+            spine = self.axes.spines['top']
+            spinebbox = spine.get_transform().transform_path(
+                spine.get_path()).get_extents()
             bbox = mtransforms.Bbox.union(bboxes2 + [spinebbox])
             top = bbox.y1
 
@@ -2040,9 +2040,9 @@ class YAxis(Axis):
             return
         x, y = self.label.get_position()
         if self.label_position == 'left':
-            spinebbox = (self.axes.spines['left'].get_transform().
-                         transform_path(self.axes.spines['left'].
-                                        get_path()).get_extents())
+            spine = self.axes.spines['left']
+            spinebbox = spine.get_transform().transform_path(
+                spine.get_path()).get_extents()
             bbox = mtransforms.Bbox.union(bboxes + [spinebbox])
             left = bbox.x0
 
@@ -2051,9 +2051,9 @@ class YAxis(Axis):
             )
 
         else:
-            spinebbox = (self.axes.spines['right'].get_transform().
-                         transform_path(self.axes.spines['right'].
-                                        get_path()).get_extents())
+            spine = self.axes.spines['right']
+            spinebbox = spine.get_transform().transform_path(
+                spine.get_path()).get_extents()
             bbox = mtransforms.Bbox.union(bboxes2 + [spinebbox])
             right = bbox.x1
 

--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -213,7 +213,6 @@ def test_pep8_conformance_installed_files():
                           'tests/test_mathtext.py',
                           'tests/test_rcparams.py',
                           'tests/test_simplification.py',
-                          'tests/test_spines.py',
                           'tests/test_streamplot.py',
                           'tests/test_subplots.py',
                           'tests/test_tightlayout.py',

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from nose.tools import assert_less
+from nose.tools import assert_true
 import six
 
 import matplotlib
@@ -71,11 +71,13 @@ def test_label_without_ticks():
     spine = ax.spines['left']
     spinebbox = spine.get_transform().transform_path(
         spine.get_path()).get_extents()
-    assert_less(ax.yaxis.label.get_position()[0], spinebbox.xmin,
+    # replace with assert_less if >python2.6
+    assert_true(ax.yaxis.label.get_position()[0] < spinebbox.xmin,
                 "Y-Axis label not left of the spine")
 
     spine = ax.spines['bottom']
     spinebbox = spine.get_transform().transform_path(
         spine.get_path()).get_extents()
-    assert_less(ax.xaxis.label.get_position()[1], spinebbox.ymin,
+    # replace with assert_less if >python2.6
+    assert_true(ax.xaxis.label.get_position()[1] < spinebbox.ymin,
                 "X-Axis label not below the spine")

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -15,35 +15,37 @@ from matplotlib.testing.decorators import image_comparison, cleanup
 def test_spines_axes_positions():
     # SF bug 2852168
     fig = plt.figure()
-    x = np.linspace(0,2*np.pi,100)
+    x = np.linspace(0, 2*np.pi, 100)
     y = 2*np.sin(x)
-    ax = fig.add_subplot(1,1,1)
+    ax = fig.add_subplot(1, 1, 1)
     ax.set_title('centered spines')
-    ax.plot(x,y)
-    ax.spines['right'].set_position(('axes',0.1))
+    ax.plot(x, y)
+    ax.spines['right'].set_position(('axes', 0.1))
     ax.yaxis.set_ticks_position('right')
-    ax.spines['top'].set_position(('axes',0.25))
+    ax.spines['top'].set_position(('axes', 0.25))
     ax.xaxis.set_ticks_position('top')
     ax.spines['left'].set_color('none')
     ax.spines['bottom'].set_color('none')
 
+
 @image_comparison(baseline_images=['spines_data_positions'])
 def test_spines_data_positions():
     fig = plt.figure()
-    ax = fig.add_subplot(1,1,1)
+    ax = fig.add_subplot(1, 1, 1)
     ax.spines['left'].set_position(('data', -1.5))
     ax.spines['top'].set_position(('data', 0.5))
     ax.spines['right'].set_position(('data', -0.5))
     ax.spines['bottom'].set_position('zero')
-    ax.set_xlim([-2,2])
-    ax.set_ylim([-2,2])
+    ax.set_xlim([-2, 2])
+    ax.set_ylim([-2, 2])
+
 
 @image_comparison(baseline_images=['spines_capstyle'])
 def test_spines_capstyle():
     # issue 2542
     plt.rc('axes', linewidth=20)
     fig = plt.figure()
-    ax = fig.add_subplot(1,1,1)
+    ax = fig.add_subplot(1, 1, 1)
     ax.set_xticks([])
     ax.set_yticks([])
 

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -1,12 +1,15 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import numpy as np
+from nose.tools import assert_less
 import six
 
-import numpy as np
 import matplotlib
-from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
+import matplotlib.transforms as mtransforms
+from matplotlib.testing.decorators import image_comparison, cleanup
+
 
 @image_comparison(baseline_images=['spines_axes_positions'])
 def test_spines_axes_positions():
@@ -43,3 +46,34 @@ def test_spines_capstyle():
     ax = fig.add_subplot(1,1,1)
     ax.set_xticks([])
     ax.set_yticks([])
+
+
+@cleanup
+def test_label_without_ticks():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    plt.subplots_adjust(left=0.3, bottom=0.3)
+    ax.plot(np.arange(10))
+    ax.yaxis.set_ticks_position('left')
+    ax.spines['left'].set_position(('outward', 30))
+    ax.spines['right'].set_visible(False)
+    ax.set_ylabel('y label')
+    ax.xaxis.set_ticks_position('bottom')
+    ax.spines['bottom'].set_position(('outward', 30))
+    ax.spines['top'].set_visible(False)
+    ax.set_xlabel('x label')
+    ax.xaxis.set_ticks([])
+    ax.yaxis.set_ticks([])
+    plt.draw()
+
+    spine = ax.spines['left']
+    spinebbox = spine.get_transform().transform_path(
+        spine.get_path()).get_extents()
+    assert_less(ax.yaxis.label.get_position()[0], spinebbox.xmin,
+                "Y-Axis label not left of the spine")
+
+    spine = ax.spines['bottom']
+    spinebbox = spine.get_transform().transform_path(
+        spine.get_path()).get_extents()
+    assert_less(ax.xaxis.label.get_position()[1], spinebbox.ymin,
+                "X-Axis label not below the spine")


### PR DESCRIPTION
An attempt to fix the issue #3715. This takes into account the location of the axis spines when locating the axis label if there are no tick labels present.

Examples in #3715
###  Before patch
![image](https://cloud.githubusercontent.com/assets/1505899/6282055/00d02dbc-b883-11e4-923f-e8092eb92d65.png)

### After patch
![image](https://cloud.githubusercontent.com/assets/1505899/6282027/b86dbb7a-b882-11e4-8a02-815684e94f6b.png)
