### PR TITLE
Fix for issue 4142: Let show() exit the run loop after all windows are closed in a non-interactive session

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5241,6 +5241,16 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
     return YES;
 }
 
+- (void)close
+{
+    [super close];
+    NSArray *windowsArray = [NSApp windows];
+    if([windowsArray count]==0) [NSApp stop: self];
+    /* This is needed for show(), which should exit from [NSApp run]
+     * after all windows are closed.
+     */
+}
+
 - (void)dealloc
 {
     PyGILState_STATE gstate;


### PR DESCRIPTION
See issue 4142. Currently show() does not exit after all windows have been closed. The relevant code was in src/_macosx.m, but was inadvertently lost in pull request 4006. This bug fix checks the number of windows remaining after closing one window, and calls [NSApp stop: self] if there are no more windows.
One open question is how Python show respond to keyboard interrupts (ctrl-c) while show() is running. Currently ctrl-c does nothing (other than printing ctrl-c to the screen). I guess it would make sense for ctrl-c to cause show() to exit.