### PR TITLE
Fixed Annotation draw method

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import zip
 
+import copy
 import math
 import warnings
 
@@ -2092,7 +2093,9 @@ class Annotation(Text, _AnnotationBase):
                 self.arrow_patch.figure = self.figure
             self.arrow_patch.draw(renderer)
 
-        Text.draw(self, renderer)
+        astext = copy.copy(self)
+        astext.__class__ = Text
+        Text.draw(astext, renderer)
 
     def get_window_extent(self, renderer=None):
         '''


### PR DESCRIPTION
Fix for issue #4139 

This correctly draws the text portion of the annotation after incorporation of PR #4023. 

### Before
![image](https://cloud.githubusercontent.com/assets/1505899/6319918/888cf098-ba84-11e4-90e9-16c1cf864b7b.png)
### After
![image](https://cloud.githubusercontent.com/assets/1505899/6319932/e81f9b14-ba84-11e4-9886-807cefd2b809.png)

