### PR TITLE
Fix mathtext image bounding box

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -178,7 +178,7 @@ class MathtextBackendAgg(MathtextBackend):
     def set_canvas_size(self, w, h, d):
         MathtextBackend.set_canvas_size(self, w, h, d)
         if self.mode != 'bbox':
-            self.image = FT2Image(ceil(w), ceil(h + d))
+            self.image = FT2Image(ceil(w), ceil(h + max(d, 0)))
 
     def render_glyph(self, ox, oy, info):
         if self.mode == 'bbox':

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -3,9 +3,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
+import io
+
 import numpy as np
 import matplotlib
-from matplotlib.testing.decorators import image_comparison, knownfailureif
+from matplotlib.testing.decorators import image_comparison, knownfailureif, cleanup
 import matplotlib.pyplot as plt
 from matplotlib import mathtext
 
@@ -209,6 +211,22 @@ def test_mathtext_exceptions():
             assert exc[3].startswith(msg)
         else:
             assert False, "Expected '%s', but didn't get it" % msg
+
+@cleanup
+def test_single_minus_sign():
+    plt.figure(figsize=(0.3, 0.3))
+    plt.text(0.5, 0.5, '$-$')
+    for spine in plt.gca().spines.values():
+        spine.set_visible(False)
+    plt.gca().set_xticks([])
+    plt.gca().set_yticks([])
+
+    buff = io.BytesIO()
+    plt.savefig(buff, format="rgba", dpi=1000)
+    array = np.fromstring(buff.getvalue(), dtype=np.uint8)
+
+    # If this fails, it would be all white
+    assert not np.all(array == 0xff)
 
 
 if __name__ == '__main__':

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -146,11 +146,11 @@ FT2Image::draw_rect_filled(unsigned long x0, unsigned long y0, unsigned long x1,
 {
     x0 = std::min(x0, m_width);
     y0 = std::min(y0, m_height);
-    x1 = std::min(x1, m_width);
-    y1 = std::min(y1, m_height);
+    x1 = std::min(x1 + 1, m_width);
+    y1 = std::min(y1 + 1, m_height);
 
-    for (size_t j = y0; j < y1 + 1; j++) {
-        for (size_t i = x0; i < x1 + 1; i++) {
+    for (size_t j = y0; j < y1; j++) {
+        for (size_t i = x0; i < x1; i++) {
             m_buffer[i + j * m_width] = 255;
         }
     }

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -55,10 +55,10 @@ FT2Image::~FT2Image()
 
 void FT2Image::resize(long width, long height)
 {
-    if (width < 0) {
+    if (width <= 0) {
         width = 1;
     }
-    if (height < 0) {
+    if (height <= 0) {
         height = 1;
     }
     size_t numBytes = width * height;


### PR DESCRIPTION
This fixes #4147, so that characters with a negative depth (such as the minus sign) are not arbitrarily clipped.

Going down that rabbit hole, discovered two other bugs related to text buffers, including a buffer overrun.

Fix #4147.