### PR TITLE
Clean up matplotlib.colors

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -457,7 +457,7 @@ def makeMappingArray(N, data, gamma=1.0):
     except:
         raise TypeError("data must be convertable to an array")
     shape = adata.shape
-    if len(shape) != 2 and shape[1] != 3:
+    if len(shape) != 2 or shape[1] != 3:
         raise ValueError("data must be nx3 format")
 
     x = adata[:, 0]
@@ -476,13 +476,12 @@ def makeMappingArray(N, data, gamma=1.0):
     xind = (N - 1) * np.linspace(0, 1, N) ** gamma
     ind = np.searchsorted(x, xind)[1:-1]
 
-    lut[1:-1] = (((xind[1:-1] - x[ind - 1]) / (x[ind] - x[ind - 1])) *
-                 (y0[ind] - y1[ind - 1]) + y1[ind - 1])
+    distance = (xind[1:-1] - x[ind - 1]) / (x[ind] - x[ind - 1])
+    lut[1:-1] = distance * (y0[ind] - y1[ind - 1]) + y1[ind - 1]
     lut[0] = y1[0]
     lut[-1] = y0[-1]
     # ensure that the lut is confined to values between 0 and 1 by clipping it
-    np.clip(lut, 0.0, 1.0)
-    return lut
+    return np.clip(lut, 0.0, 1.0)
 
 
 class Colormap(object):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1195,7 +1195,7 @@ class PowerNorm(Normalize):
 
         if cbook.iterable(value):
             val = ma.asarray(value)
-            return ma.power(value, 1. / gamma) * (vmax - vmin) + vmin
+            return ma.power(val, 1. / gamma) * (vmax - vmin) + vmin
         else:
             return pow(value, 1. / gamma) * (vmax - vmin) + vmin
 
@@ -1550,8 +1550,7 @@ class LightSource(object):
         aspect = np.arctan2(-dy, -dx)
         slope = 0.5 * np.pi - np.arctan(np.hypot(dx, dy))
         intensity = (np.sin(alt) * np.sin(slope) +
-                     np.cos(alt) * np.cos(slope) *
-                     np.cos(az - aspect))
+                     np.cos(alt) * np.cos(slope) * np.cos(az - aspect))
 
         # Apply contrast stretch
         imin, imax = intensity.min(), intensity.max()


### PR DESCRIPTION
Various code cleanups to matplotlib.colors. There are a couple places where the logic is changed, although I'm reasonably sure the old logic was wrong:

* Original line 484 (return `np.clip(lut, 0, 1)` instead of just `lut`)
* Original line 460 `and` to `or`
* Original line 1204 `value` to `val` (which is `ma.asarray(value)`).