### PR TITLE
Avoid errors when switching scales on images

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2502,7 +2502,7 @@ def key_press_handler(event, canvas, toolbar=None):
         if scale == 'log':
             ax.set_yscale('linear')
             ax.figure.canvas.draw()
-        elif scale == 'linear':
+        elif scale == 'linear' and not ax.images:
             ax.set_yscale('log')
             ax.figure.canvas.draw()
     # toggle scaling of x-axes between 'log and 'linear' (default key 'k')
@@ -2512,7 +2512,7 @@ def key_press_handler(event, canvas, toolbar=None):
         if scalex == 'log':
             ax.set_xscale('linear')
             ax.figure.canvas.draw()
-        elif scalex == 'linear':
+        elif scalex == 'linear' and not ax.images:
             ax.set_xscale('log')
             ax.figure.canvas.draw()
 


### PR DESCRIPTION
If you accidentally hit the 'L' key while looking at an image, you get this error, and the image is not viewable.  I disabled those keys when an image is present.

``` python
Traceback (most recent call last):
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/backends/backend_qt5.py", line 282, in mouseMoveEvent
    FigureCanvasBase.motion_notify_event(self, x, y)
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 1939, in motion_notify_event
    guiEvent=guiEvent)
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 1531, in __init__
    LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 1432, in __init__
    axes_list = [a for a in self.canvas.figure.get_axes()
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 1433, in <listcomp>
    if a.in_axes(self)]
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/axes/_base.py", line 1716, in in_axes
    return self.patch.contains(mouseevent)[0]
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/patches.py", line 634, in contains
    x, y = self.get_transform().inverted().transform_point(
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/transforms.py", line 2323, in inverted
    return CompositeGenericTransform(self._b.inverted(), self._a.inverted())
  File "/home/silvester/workspace/matplotlib/lib/matplotlib/transforms.py", line 1728, in inverted
    self._inverted = Affine2D(inv(mtx), shorthand_name=shorthand_name)
  File "/home/silvester/anaconda/lib/python3.4/site-packages/numpy/linalg/linalg.py", line 520, in inv
    ainv = _umath_linalg.inv(a, signature=signature, extobj=extobj)
  File "/home/silvester/anaconda/lib/python3.4/site-packages/numpy/linalg/linalg.py", line 90, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
numpy.linalg.linalg.LinAlgError: Singular matrix
```
