### PR TITLE
bytes2pdatenum

### DIFF
--- a/examples/pylab_examples/load_converter.py
+++ b/examples/pylab_examples/load_converter.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from matplotlib.dates import strpdate2num
+from matplotlib.dates import bytespdate2num
 #from matplotlib.mlab import load
 import numpy as np
 from pylab import figure, show
@@ -10,7 +10,7 @@ print('loading', datafile)
 
 dates, closes = np.loadtxt(
     datafile, delimiter=',',
-    converters={0: strpdate2num('%d-%b-%y')},
+    converters={0: bytespdate2num('%d-%b-%y')},
     skiprows=1, usecols=(0, 2), unpack=True)
 
 fig = figure()

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -261,6 +261,32 @@ class strpdate2num(object):
         return date2num(datetime.datetime(*time.strptime(s, self.fmt)[:6]))
 
 
+class bytespdate2num(strpdate2num):
+    """
+    Use this class to parse date strings to matplotlib datenums when
+    you know the date format string of the date you are parsing.  See
+    :file:`examples/load_demo.py`.
+    """
+    def __init__(self, fmt, encoding='utf-8'):
+        """
+        Args:
+            fmt: any valid strptime format is supported
+            encoding: encoding to use on byte input (default: 'utf-8')
+        """
+        super(bytespdate2num, self).__init__(fmt)
+        self.encoding = encoding
+
+    def __call__(self, b):
+        """
+        Args:
+            b: byte input to be converted
+        Returns:
+            A date2num float
+        """
+        s = b.decode(self.encoding)
+        return super(bytespdate2num, self).__call__(s)
+
+
 # a version of dateutil.parser.parse that can operate on nump0y arrays
 _dateutil_parser_parse_np_vectorized = np.vectorize(dateutil.parser.parse)
 


### PR DESCRIPTION
Possible fix for issue #4126. This extends the `strpdate2num` converter class to add a `bytespdate2num` converter which could be used in numpy's converter argument for `loadtxt`, `genfromtxt`, etc.

I have my doubts on how useful this or `strpdate2num` converters really are, however. The functionality seems orthogonal to matplotlib's core and better suited for a different library but maybe there is enough usage that it warrants being there.