### PR TITLE
Fix Gtk3 Backend Source ID was not found

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -208,11 +208,14 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         self.set_can_focus(True)
         self._renderer_init()
         self._idle_event_id = GLib.idle_add(self.idle_event)
+        default_context = GLib.main_context_get_thread_default() or GLib.main_context_default()
+        self._idle_event_source = default_context.find_source_by_id(self._idle_event_id)
 
     def destroy(self):
         #Gtk.DrawingArea.destroy(self)
         self.close_event()
-        GLib.source_remove(self._idle_event_id)
+        if not self._idle_event_source.is_destroyed():
+            GLib.source_remove(self._idle_event_id)
         if self._idle_draw_id != 0:
             GLib.source_remove(self._idle_draw_id)
 


### PR DESCRIPTION
I'm using matplotlib in a GTK3 application (backend is set to GTK3Cairo) and when my application exits I consistently get the following warning:
```
/usr/lib64/python2.7/site-packages/matplotlib/backends/backend_gtk3.py:215: Warning: Source ID 45 was not found when attempting to remove it
  GLib.source_remove(self._idle_event_id)
```

Looking into the issue it looks like the idle_event is removed and thus when ```GLib.source_remove``` is called, the event id no longer exists. It would be great if a check could take place before the event source is removed to determine if it is still valid.

This PR adds a reference to the Gtk3 source created by GLib.idle_add so it can be checked to see if it was destroyed later to avoid removing an invalid source id and causing the aforementioned warning messages to be displayed.

