### PR TITLE
Make _is_writable_dir more flexible to obscure failure modes

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -225,7 +225,7 @@ def _is_writable_dir(p):
             t.write(b'1')
         finally:
             t.close()
-    except OSError:
+    except:
         return False
 
     return True


### PR DESCRIPTION
This is pretty obscure, but is something I've observed in testing out some installation issues.

When setuptools installs a package downloaded from a package index using `easy_install`--in particular if that package is listed in the `setup_requires` list of build-time requirements for another package, it uses a function called [`run_setup`](https://bitbucket.org/pypa/setuptools/src/e50d57c3e4ed359316dc2ddce195ecfebe0784a9/setuptools/sandbox.py?at=default#cl-224) to run the `setup.py` script for the downloaded package.  It runs the `setup.py` in the context of a [`DirectorySandbox`](https://bitbucket.org/pypa/setuptools/src/e50d57c3e4ed359316dc2ddce195ecfebe0784a9/setuptools/sandbox.py?at=default#cl-361) which prevents the `setup.py` from writing files outside of the temporary directory set up for building the package.

If, in this case, the `setup_requires` package happens to import matplotlib and it goes down the right code path that his function is called, it will result in a `SandboxViolation` because matplotlib tried to write a file outside the sandbox.  Unfortunately this is *not* an `OSError`, so the exception is raised rather than simply returning `False` is it should (indeed, the directory is not writable, so no attempt should be made to write a matplotlibrc file).

I think that if matplotlib is going to attempt to write files to the filesystem during import time this function should be prepared for any kind of obscure error condition that could result :)