### PR TITLE
Ensure the gc module is available during interpreter exit

### DIFF
--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -84,6 +84,7 @@ class Gcf(object):
 
     @classmethod
     def destroy_all(cls):
+        import gc
         for manager in list(cls.figs.values()):
             manager.canvas.mpl_disconnect(manager._cidgcf)
             manager.destroy()


### PR DESCRIPTION
This is directly related to #4165.  Another side effect of `run_setup` is that any modules that are imported during the `run_setup` call are later removed from `sys.modules`.  If there are no other references to that module they will be garbage collected and any previous references to globals in that module will be replaced with `None`.

Because `destroy_all` is registered as an `atexit` function it will run even after all the module itself has been garbage collected (there are other contexts where this might happen as well).  This seems to otherwise work since it was changed to a `classmethod`, so now the `Gcf` class itself is still hanging around.  But it may be necessary to re-import the `gc` module if it's to be made use of.