### PR TITLE
Travis: Commit docs on top of first_commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ after_success:
     git clone git@github.com:matplotlib/devdocs.git
     cd devdocs
     git checkout --orphan gh-pages
+    git reset --hard first_commit
     cp -R ../matplotlib/doc/build/html/. .
     touch .nojekyll
     git config --global user.email "MatplotlibTravisBot@nomail"


### PR DESCRIPTION
 I just discovered that the devdocs repository keeps growing. This was not the original intention since we don't really have any need for the diffs and the grow huge. This should stop docs repository from growing by always committing on top of a tag of the first commit.  