### PR TITLE
set `fig.waiting = false` when image data is received [backport to color_overhaul]

### DIFF
--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -70,7 +70,6 @@ mpl.figure = function(figure_id, websocket, ondownload, parent_element) {
                 fig.context.clearRect(0, 0, fig.canvas.width, fig.canvas.height);
             }
             fig.context.drawImage(fig.imageObj, 0, 0);
-            fig.waiting = false;
         };
 
     this.imageObj.onunload = function() {
@@ -401,11 +400,13 @@ mpl.figure.prototype._make_on_message_function = function(fig) {
             fig.imageObj.src = (window.URL || window.webkitURL).createObjectURL(
                 evt.data);
             fig.updated_canvas_event();
+            fig.waiting = false;
             return;
         }
         else if (typeof evt.data === 'string' && evt.data.slice(0, 21) == "data:image/png;base64") {
             fig.imageObj.src = evt.data;
             fig.updated_canvas_event();
+            fig.waiting = false;
             return;
         }
 


### PR DESCRIPTION
instead of image.onload, which only fires if the value changes.

might close #4168, but I'm not sure this was the only issue.