### PR TITLE
 axes.locator_params fails with LogLocator (and most Locator subclasses) #3658 

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -11,6 +11,8 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 from matplotlib.testing.decorators import cleanup
 
+import warnings
+
 
 def test_MaxNLocator():
     loc = mticker.MaxNLocator(nbins=5)
@@ -63,6 +65,80 @@ def test_LogLocator():
     assert_almost_equal(loc.tick_values(1, 100), test_value)
 
 
+def test_LogLocator_set_params():
+    """ 
+    Create log locator with default value, base=10.0, subs=[1.0], numdecs=4, numticks=15
+     and change it to something else.
+    See if change was successful. 
+    Should not exception. 
+    """
+    loc = mticker.LogLocator()
+    loc.set_params(numticks = 8, numdecs = 8, subs = [2.0], base = 8)
+    nose.tools.assert_equal(loc.numticks, 8)
+    nose.tools.assert_equal(loc.numdecs, 8)
+    nose.tools.assert_equal(loc.base, 8)
+    nose.tools.assert_equal(loc.subs, [2.0])
+
+
+def test_NullLocator_set_params():
+    """ 
+    Create null locator, and attempt to call set_params() on it. 
+    Should not exception, and should raise a warning. 
+    """
+    loc = mticker.NullLocator()
+    with warnings.catch_warnings(True) as w:
+        loc.set_params()
+        nose.tools.assert_equal(len(w), 1)
+
+
+def test_MultipleLocator_set_params():
+    """ 
+    Create multiple locator with 0.7 base, and change it to something else.
+    See if change was successful. 
+    Should not exception. 
+    """
+    mult = mticker.MultipleLocator(base = 0.7)
+    mult.set_params(base = 1.7)
+    nose.tools.assert_equal(mult.base, 1.7)
+
+
+def test_FixedLocator_set_params():
+    """ 
+    Create fixed locator with 5 nbins, and change it to something else.
+    See if change was successful. 
+    Should not exception. 
+    """
+    fixed = mticker.FixedLocator(range (0,24),nbins=5)
+    fixed.set_params(nbins = 7)
+    nose.tools.assert_equal(fixed.nbins, 7)
+
+
+def test_IndexLocator_set_params():
+    """ 
+    Create index locator with 3 base, 4 offset. and change it to something else.
+    See if change was successful. 
+    Should not exception. 
+    """
+    index = mticker.IndexLocator(base = 3, offset = 4)
+    index.set_params(base = 7, offset = 7)
+    nose.tools.assert_equal(index.base, 7)
+    nose.tools.assert_equal(index.offset, 7)
+
+
+def test_SymmetricalLogLocator_set_params():
+    """ 
+    Create symmetrical log locator with default subs =[1.0] numticks = 15,
+    and change it to something else.
+    See if change was successful. 
+    Should not exception. 
+    """
+    #since we only test for the params change. I will pass empty transform
+    sym = mticker.SymmetricalLogLocator(None)
+    sym.set_params(subs = [2.0], numticks = 8)
+    nose.tools.assert_equal(sym._subs, [2.0])
+    nose.tools.assert_equal(sym.numticks, 8)
+
+
 def test_LogFormatterExponent():
     class FakeAxis(object):
         """Allow Formatter to be called without having a "full" plot set up."""
@@ -110,25 +186,6 @@ def test_formatstrformatter():
     # test str.format() style formatter
     tmp_form = mticker.StrMethodFormatter('{x:05d}')
     nose.tools.assert_equal('00002', tmp_form(2))
-
-@cleanup
-def test_set_params():
-    loc = mticker.LogLocator(numticks = 2)
-
-    assert_raises(ValueError, loc.tick_values, 0, 1000)
-    #this should return number of ticks as 5
-    test_value = np.array([  1.0000000e-10,   1.0000000e-03,   1.0000000e+04,   1.0000000e+11,
-         1.0000000e+18])
-    assert_almost_equal(loc.tick_values(0.001, 1.1e5), test_value)
-    #after the set_params(numticks=8), it should have 7 extra which should have 7 extra
-    #numticks. Also it won't casue to thrown the exception for bugs # #3658
-    loc.set_params(numticks = 8)
-    test_value = np.array([ 1.0000000e-04,   1.0000000e-03,   1.0000000e-02,   1.0000000e-01,
-         1.0000000e+00,   1.0000000e+01,   1.0000000e+02,   1.0000000e+03,
-         1.0000000e+04,   1.0000000e+05,   1.0000000e+06,   1.0000000e+07])
-    assert_almost_equal(loc.tick_values(0.001, 1.1e5), test_value)
-
-
 
 if __name__ == '__main__':
     import nose

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -66,14 +66,14 @@ def test_LogLocator():
 
 
 def test_LogLocator_set_params():
-    """ 
-    Create log locator with default value, base=10.0, subs=[1.0], numdecs=4, numticks=15
-     and change it to something else.
-    See if change was successful. 
-    Should not exception. 
+    """
+    Create log locator with default value, base=10.0, subs=[1.0], numdecs=4,
+    numticks=15 and change it to something else.
+    See if change was successful.
+    Should not exception.
     """
     loc = mticker.LogLocator()
-    loc.set_params(numticks = 8, numdecs = 8, subs = [2.0], base = 8)
+    loc.set_params(numticks=8, numdecs=8, subs=[2.0], base=8)
     nose.tools.assert_equal(loc.numticks, 8)
     nose.tools.assert_equal(loc.numdecs, 8)
     nose.tools.assert_equal(loc.base, 8)
@@ -81,9 +81,9 @@ def test_LogLocator_set_params():
 
 
 def test_NullLocator_set_params():
-    """ 
-    Create null locator, and attempt to call set_params() on it. 
-    Should not exception, and should raise a warning. 
+    """
+    Create null locator, and attempt to call set_params() on it.
+    Should not exception, and should raise a warning.
     """
     loc = mticker.NullLocator()
     with warnings.catch_warnings(True) as w:
@@ -92,49 +92,49 @@ def test_NullLocator_set_params():
 
 
 def test_MultipleLocator_set_params():
-    """ 
-    Create multiple locator with 0.7 base, and change it to something else.
-    See if change was successful. 
-    Should not exception. 
     """
-    mult = mticker.MultipleLocator(base = 0.7)
-    mult.set_params(base = 1.7)
+    Create multiple locator with 0.7 base, and change it to something else.
+    See if change was successful.
+    Should not exception.
+    """
+    mult = mticker.MultipleLocator(base=0.7)
+    mult.set_params(base=1.7)
     nose.tools.assert_equal(mult.base, 1.7)
 
 
 def test_FixedLocator_set_params():
-    """ 
-    Create fixed locator with 5 nbins, and change it to something else.
-    See if change was successful. 
-    Should not exception. 
     """
-    fixed = mticker.FixedLocator(range (0,24),nbins=5)
-    fixed.set_params(nbins = 7)
+    Create fixed locator with 5 nbins, and change it to something else.
+    See if change was successful.
+    Should not exception.
+    """
+    fixed = mticker.FixedLocator(range(0, 24), nbins=5)
+    fixed.set_params(nbins=7)
     nose.tools.assert_equal(fixed.nbins, 7)
 
 
 def test_IndexLocator_set_params():
-    """ 
-    Create index locator with 3 base, 4 offset. and change it to something else.
-    See if change was successful. 
-    Should not exception. 
     """
-    index = mticker.IndexLocator(base = 3, offset = 4)
-    index.set_params(base = 7, offset = 7)
+    Create index locator with 3 base, 4 offset. and change it to something
+    else. See if change was successful.
+    Should not exception.
+    """
+    index = mticker.IndexLocator(base=3, offset=4)
+    index.set_params(base=7, offset=7)
     nose.tools.assert_equal(index.base, 7)
     nose.tools.assert_equal(index.offset, 7)
 
 
 def test_SymmetricalLogLocator_set_params():
-    """ 
+    """
     Create symmetrical log locator with default subs =[1.0] numticks = 15,
     and change it to something else.
-    See if change was successful. 
-    Should not exception. 
+    See if change was successful.
+    Should not exception.
     """
-    #since we only test for the params change. I will pass empty transform
+    # since we only test for the params change. I will pass empty transform
     sym = mticker.SymmetricalLogLocator(None)
-    sym.set_params(subs = [2.0], numticks = 8)
+    sym.set_params(subs=[2.0], numticks=8)
     nose.tools.assert_equal(sym._subs, [2.0])
     nose.tools.assert_equal(sym.numticks, 8)
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -111,6 +111,15 @@ def test_MultipleLocator_set_params():
     mult.set_params(base=1.7)
     nose.tools.assert_equal(mult._base, 1.7)
 
+def test_LogitLocator_set_params():
+    """
+    Create logit locator with default minor=False, and change it to something
+    else. See if change was successful. Should not exception.
+    """
+    loc = mticker.LogitLocator()  # Defaults to false.
+    loc.set_params(minor=True)
+    nose.tools.assert_true(loc.minor)
+
 
 def test_FixedLocator_set_params():
     """

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -111,6 +111,24 @@ def test_formatstrformatter():
     tmp_form = mticker.StrMethodFormatter('{x:05d}')
     nose.tools.assert_equal('00002', tmp_form(2))
 
+@cleanup
+def test_set_params():
+    loc = mticker.LogLocator(numticks = 2)
+
+    assert_raises(ValueError, loc.tick_values, 0, 1000)
+    #this should return number of ticks as 5
+    test_value = np.array([  1.0000000e-10,   1.0000000e-03,   1.0000000e+04,   1.0000000e+11,
+         1.0000000e+18])
+    assert_almost_equal(loc.tick_values(0.001, 1.1e5), test_value)
+    #after the set_params(numticks=8), it should have 7 extra which should have 7 extra
+    #numticks. Also it won't casue to thrown the exception for bugs # #3658
+    loc.set_params(numticks = 8)
+    test_value = np.array([ 1.0000000e-04,   1.0000000e-03,   1.0000000e-02,   1.0000000e-01,
+         1.0000000e+00,   1.0000000e+01,   1.0000000e+02,   1.0000000e+03,
+         1.0000000e+04,   1.0000000e+05,   1.0000000e+06,   1.0000000e+07])
+    assert_almost_equal(loc.tick_values(0.001, 1.1e5), test_value)
+
+
 
 if __name__ == '__main__':
     import nose

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -111,6 +111,7 @@ def test_MultipleLocator_set_params():
     mult.set_params(base=1.7)
     nose.tools.assert_equal(mult._base, 1.7)
 
+
 def test_LogitLocator_set_params():
     """
     Create logit locator with default minor=False, and change it to something

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -52,7 +52,6 @@ def test_AutoMinorLocator():
 
 def test_LogLocator():
     loc = mticker.LogLocator(numticks=5)
-
     assert_raises(ValueError, loc.tick_values, 0, 1000)
 
     test_value = np.array([1.00000000e-05, 1.00000000e-03, 1.00000000e-01,
@@ -63,6 +62,17 @@ def test_LogLocator():
     loc = mticker.LogLocator(base=2)
     test_value = np.array([0.5, 1., 2., 4., 8., 16., 32., 64., 128., 256.])
     assert_almost_equal(loc.tick_values(1, 100), test_value)
+
+
+def test_LinearLocator_set_params():
+    """
+    Create linear locator with presets={}, numticks=2 and change it to
+    something else. See if change was successful. Should not exception.
+    """
+    loc = mticker.LinearLocator(numticks=2)
+    loc.set_params(numticks=8, presets={(0, 1): []})
+    nose.tools.assert_equal(loc.numticks, 8)
+    nose.tools.assert_equal(loc.presets, {(0, 1): []})
 
 
 def test_LogLocator_set_params():
@@ -86,7 +96,7 @@ def test_NullLocator_set_params():
     Should not exception, and should raise a warning.
     """
     loc = mticker.NullLocator()
-    with warnings.catch_warnings(True) as w:
+    with warnings.catch_warnings(record=True) as w:
         loc.set_params()
         nose.tools.assert_equal(len(w), 1)
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -109,7 +109,7 @@ def test_MultipleLocator_set_params():
     """
     mult = mticker.MultipleLocator(base=0.7)
     mult.set_params(base=1.7)
-    nose.tools.assert_equal(mult.base, 1.7)
+    nose.tools.assert_equal(mult._base, 1.7)
 
 
 def test_FixedLocator_set_params():
@@ -131,7 +131,7 @@ def test_IndexLocator_set_params():
     """
     index = mticker.IndexLocator(base=3, offset=4)
     index.set_params(base=7, offset=7)
-    nose.tools.assert_equal(index.base, 7)
+    nose.tools.assert_equal(index._base, 7)
     nose.tools.assert_equal(index.offset, 7)
 
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -956,7 +956,8 @@ class Locator(TickHelper):
         raise NotImplementedError('Derived must override')
 
     def set_params(self, **kwargs):
-        warnings.warn("'set_params()' not defined for locator of type " + str(type(self)))
+        warnings.warn("'set_params()' not defined for locator of type " +
+                      str(type(self)))
 
     def __call__(self):
         """Return the locations of the ticks"""

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1031,11 +1031,11 @@ class IndexLocator(Locator):
         self._base = base
         self.offset = offset
 
-    def set_params(self, **kwargs):
-        if 'base' in kwargs:
-            self.base = kwargs['base']
-        if 'offset' in kwargs:
-            self.offset = kwargs['offset']
+    def set_params(self, base=None, offset=None):
+        if base is not None:
+            self.base = base
+        if offset is not None:
+            self.offset = offset
 
     def __call__(self):
         """Return the locations of the ticks"""
@@ -1064,9 +1064,9 @@ class FixedLocator(Locator):
         if self.nbins is not None:
             self.nbins = max(self.nbins, 2)
 
-    def set_params(self, **kwargs):
-        if 'nbins' in kwargs:
-            self.nbins = kwargs['nbins']
+    def set_params(self, nbins=None):
+        if nbins is not None:
+            self.nbins=nbins
 
     def __call__(self):
         return self.tick_values(None, None)
@@ -1132,11 +1132,15 @@ class LinearLocator(Locator):
         else:
             self.presets = presets
 
-    def set_params(self, **kwargs):
-        if 'presets' in kwargs:
-            self.presets = kwargs['presets']
-        if 'numticks' in kwargs:
-            self.numticks = kwargs['numticks']
+    def set_params(self, numticks=None, presets=None):
+        """
+        [numticks : Int,present : dict] ->None
+        
+        """
+        if presets is not None:
+            self.presets = presents
+        if numticks is not None:
+            self.numticks = numticks
 
     def __call__(self):
         'Return the locations of the ticks'
@@ -1240,9 +1244,12 @@ class MultipleLocator(Locator):
     def __init__(self, base=1.0):
         self._base = Base(base)
 
-    def set_params(self, **kwargs):
-        if 'base' in kwargs:
-            self.base = kwargs['base']
+    def set_params(self, base):
+        """
+
+        """
+        if base is not None :
+            self.base = base
 
     def __call__(self):
         'Return the locations of the ticks'
@@ -1479,15 +1486,15 @@ class LogLocator(Locator):
         self.numticks = numticks
         self.numdecs = numdecs
 
-    def set_params(self, **kwargs):
-        if 'base' in kwargs:
-            self.base = kwargs['base']
-        if 'subs' in kwargs:
-            self.subs = kwargs['subs']
-        if 'numdecs' in kwargs:
-            self.numdecs = kwargs['numdecs']
-        if 'numticks' in kwargs:
-            self.numticks = kwargs['numticks']
+    def set_params(self, base=None, subs=None, numdecs=None, numticks=None):
+        if base is not None:
+            self.base = base
+        if subs is not None:
+            self.subs = subs
+        if numdecs is not None:
+            self.numdecs = numdecs
+        if numticks is not None:
+            self.numticks = numticks
 
     def base(self, base):
         """
@@ -1616,11 +1623,14 @@ class SymmetricalLogLocator(Locator):
             self._subs = subs
         self.numticks = 15
 
-    def set_params(self, **kwargs):
-        if 'numticks' in kwargs:
-            self.numticks = kwargs['numticks']
-        if 'subs' in kwargs:
-            self._subs = kwargs['subs']
+    def set_params(self, subs=None, numticks=None):
+        """
+
+        """
+        if numticks is not None:
+            self.numticks = numticks
+        if subs is not None:
+            self._subs = subs
 
     def __call__(self):
         'Return the locations of the ticks'

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1038,7 +1038,7 @@ class IndexLocator(Locator):
     def set_params(self, base=None, offset=None):
         """Set parameters within this locator"""
         if base is not None:
-            self.base = base
+            self._base = base
         if offset is not None:
             self.offset = offset
 
@@ -1250,7 +1250,7 @@ class MultipleLocator(Locator):
     def set_params(self, base):
         """Set parameters within this locator."""
         if base is not None:
-            self.base = base
+            self._base = base
 
     def __call__(self):
         'Return the locations of the ticks'

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1781,6 +1781,11 @@ class LogitLocator(Locator):
         """
         self.minor = minor
 
+    def set_params(self, minor=None):
+        """Set parameters within this locator."""
+        if minor is not None:
+            self.minor = minor
+
     def __call__(self):
         'Return the locations of the ticks'
         vmin, vmax = self.axis.get_view_interval()

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -155,6 +155,8 @@ from matplotlib import rcParams
 from matplotlib import cbook
 from matplotlib import transforms as mtransforms
 
+import warnings
+
 if six.PY3:
     long = int
 
@@ -953,6 +955,9 @@ class Locator(TickHelper):
         """
         raise NotImplementedError('Derived must override')
 
+    def set_params(self, **kwargs):
+        warnings.warn("'set_params()' not defined for locator of type " + str(type(self)))
+
     def __call__(self):
         """Return the locations of the ticks"""
         # note: some locators return data limits, other return view limits,
@@ -1609,6 +1614,12 @@ class SymmetricalLogLocator(Locator):
         else:
             self._subs = subs
         self.numticks = 15
+
+    def set_params(self, **kwargs):
+        if 'numticks' in kwargs:
+            self.numticks = kwargs['numticks']
+        if 'subs' in kwargs:
+            self._subs = kwargs['subs']
 
     def __call__(self):
         'Return the locations of the ticks'

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1025,6 +1025,12 @@ class IndexLocator(Locator):
         self._base = base
         self.offset = offset
 
+    def set_params(self, **kwargs):
+        if 'base' in kwargs:
+            self.base = kwargs['base']
+        if 'offset' in kwargs:
+            self.offset = kwargs['offset']
+
     def __call__(self):
         """Return the locations of the ticks"""
         dmin, dmax = self.axis.get_data_interval()
@@ -1051,6 +1057,10 @@ class FixedLocator(Locator):
         self.nbins = nbins
         if self.nbins is not None:
             self.nbins = max(self.nbins, 2)
+
+    def set_params(self, **kwargs):
+        if 'nbins' in kwargs:
+            self.nbins = kwargs['nbins']
 
     def __call__(self):
         return self.tick_values(None, None)
@@ -1115,6 +1125,12 @@ class LinearLocator(Locator):
             self.presets = {}
         else:
             self.presets = presets
+
+    def set_params(self, **kwargs):
+        if 'presets' in kwargs:
+            self.presets = kwargs['presets']
+        if 'numticks' in kwargs:
+            self.numticks = kwargs['numticks']
 
     def __call__(self):
         'Return the locations of the ticks'
@@ -1217,6 +1233,10 @@ class MultipleLocator(Locator):
 
     def __init__(self, base=1.0):
         self._base = Base(base)
+
+    def set_params(self, **kwargs):
+        if 'base' in kwargs:
+            self.base = kwargs['base']
 
     def __call__(self):
         'Return the locations of the ticks'
@@ -1452,6 +1472,16 @@ class LogLocator(Locator):
         self.subs(subs)
         self.numticks = numticks
         self.numdecs = numdecs
+
+    def set_params(self, **kwargs):
+        if 'base' in kwargs:
+            self.base = kwargs['base']
+        if 'subs' in kwargs:
+            self.subs = kwargs['subs']
+        if 'numdecs' in kwargs:
+            self.numdecs = kwargs['numdecs']
+        if 'numticks' in kwargs:
+            self.numticks = kwargs['numticks']
 
     def base(self, base):
         """

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -956,6 +956,10 @@ class Locator(TickHelper):
         raise NotImplementedError('Derived must override')
 
     def set_params(self, **kwargs):
+        """
+        Do nothing, and rase a warning. Any locator class not supporting the
+        set_params() function will call this.
+        """
         warnings.warn("'set_params()' not defined for locator of type " +
                       str(type(self)))
 
@@ -1032,6 +1036,7 @@ class IndexLocator(Locator):
         self.offset = offset
 
     def set_params(self, base=None, offset=None):
+        """Set parameters within this locator"""
         if base is not None:
             self.base = base
         if offset is not None:
@@ -1065,8 +1070,9 @@ class FixedLocator(Locator):
             self.nbins = max(self.nbins, 2)
 
     def set_params(self, nbins=None):
+        """Set parameters within this locator."""
         if nbins is not None:
-            self.nbins=nbins
+            self.nbins = nbins
 
     def __call__(self):
         return self.tick_values(None, None)
@@ -1133,12 +1139,9 @@ class LinearLocator(Locator):
             self.presets = presets
 
     def set_params(self, numticks=None, presets=None):
-        """
-        [numticks : Int,present : dict] ->None
-        
-        """
+        """Set parameters within this locator."""
         if presets is not None:
-            self.presets = presents
+            self.presets = presets
         if numticks is not None:
             self.numticks = numticks
 
@@ -1245,10 +1248,8 @@ class MultipleLocator(Locator):
         self._base = Base(base)
 
     def set_params(self, base):
-        """
-
-        """
-        if base is not None :
+        """Set parameters within this locator."""
+        if base is not None:
             self.base = base
 
     def __call__(self):
@@ -1352,6 +1353,7 @@ class MaxNLocator(Locator):
         self.set_params(**kwargs)
 
     def set_params(self, **kwargs):
+        """Set parameters within this locator."""
         if 'nbins' in kwargs:
             self._nbins = int(kwargs['nbins'])
         if 'trim' in kwargs:
@@ -1487,6 +1489,7 @@ class LogLocator(Locator):
         self.numdecs = numdecs
 
     def set_params(self, base=None, subs=None, numdecs=None, numticks=None):
+        """Set parameters within this locator."""
         if base is not None:
             self.base = base
         if subs is not None:
@@ -1624,9 +1627,7 @@ class SymmetricalLogLocator(Locator):
         self.numticks = 15
 
     def set_params(self, subs=None, numticks=None):
-        """
-
-        """
+        """Set parameters within this locator."""
         if numticks is not None:
             self.numticks = numticks
         if subs is not None:


### PR DESCRIPTION
set_param() function is now implemented in both Locator and its subtypes, following the suggestions of @tacaswell.  
Test cases were implemented for all Locator classes where a set_param() function is added. Raised warnings are also accounted for in Locators that do not implement set_param() (i.e. NullLocator). 