### PR TITLE
ENH: speed-up mlab.contiguous_regions using numpy

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3874,23 +3874,17 @@ def contiguous_regions(mask):
     """
     return a list of (ind0, ind1) such that mask[ind0:ind1].all() is
     True and we cover all such regions
-
-    TODO: this is a pure python implementation which probably has a much
-    faster numpy impl
     """
+    mask = np.asarray(mask, dtype=bool)
 
-    in_region = None
-    boundaries = []
-    for i, val in enumerate(mask):
-        if in_region is None and val:
-            in_region = i
-        elif in_region is not None and not val:
-            boundaries.append((in_region, i))
-            in_region = None
+    if not mask.size:
+        return []
 
-    if in_region is not None:
-        boundaries.append((in_region, i+1))
-    return boundaries
+    idx, = np.nonzero(mask[:-1] != mask[1:])
+    idx = np.concatenate((([0],) if mask[0] else ()) + (idx + 1,) +
+                          (([len(mask)],) if mask[-1] else ()))
+
+    return list(zip(idx[::2], idx[1::2]))
 
 
 def cross_from_below(x, threshold):

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3880,9 +3880,18 @@ def contiguous_regions(mask):
     if not mask.size:
         return []
 
+    # Find the indices of region changes, and correct offset
     idx, = np.nonzero(mask[:-1] != mask[1:])
-    idx = np.concatenate((([0],) if mask[0] else ()) + (idx + 1,) +
-                          (([len(mask)],) if mask[-1] else ()))
+    idx += 1
+
+    # Add first and/or last index if needed
+    if mask[0] or mask[-1]:
+        idx = (idx,)
+        if mask[0]:
+            idx = ([0],) + idx
+        if mask[-1]:
+            idx = idx + ([len(mask)],)
+        idx = np.concatenate(idx)
 
     return list(zip(idx[::2], idx[1::2]))
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3884,14 +3884,14 @@ def contiguous_regions(mask):
     idx, = np.nonzero(mask[:-1] != mask[1:])
     idx += 1
 
+    # List operations are faster for moderately sized arrays
+    idx = idx.tolist()
+
     # Add first and/or last index if needed
-    if mask[0] or mask[-1]:
-        idx = (idx,)
-        if mask[0]:
-            idx = ([0],) + idx
-        if mask[-1]:
-            idx = idx + ([len(mask)],)
-        idx = np.concatenate(idx)
+    if mask[0]:
+        idx = [0] + idx
+    if mask[-1]:
+        idx.append(len(mask))
 
     return list(zip(idx[::2], idx[1::2]))
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -2963,6 +2963,30 @@ class gaussian_kde_evaluate_tests(object):
 
 
 #*****************************************************************
+
+def test_contiguous_regions():
+    a, b, c = 3, 4, 5
+    # Starts and ends with True
+    mask = [True]*a + [False]*b + [True]*c
+    expected = [(0, a), (a+b, a+b+c)]
+    assert_equal(mlab.contiguous_regions(mask), expected)
+    d, e = 6, 7
+    # Starts with True ends with False
+    mask = mask + [False]*e
+    assert_equal(mlab.contiguous_regions(mask), expected)
+    # Starts with False ends with True
+    mask = [False]*d + mask[:-e]
+    expected = [(d, d+a), (d+a+b, d+a+b+c)]
+    assert_equal(mlab.contiguous_regions(mask), expected)
+    # Starts and ends with False
+    mask = mask + [False]*e
+    assert_equal(mlab.contiguous_regions(mask), expected)
+    # No True in mask
+    assert_equal(mlab.contiguous_regions([False]*5), [])
+    # Empty mask
+    assert_equal(mlab.contiguous_regions([]), [])
+
+
 #*****************************************************************
 
 if __name__ == '__main__':


### PR DESCRIPTION
The docstring was asking for it, so here it goes. Added some tests as well.