### PR TITLE
Fix axis.labelpad settings for 3D Graphs

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -633,7 +633,8 @@ defaultParams = {
     'polaraxes.grid': [True, validate_bool],  # display polar grid or
                                                      # not
     'axes3d.grid': [True, validate_bool],  # display 3d grid
-
+    'axes3d.labelpad': [0.0, validate_float], # 3D graph label padding
+    
     #legend properties
     'legend.fancybox': [False, validate_bool],
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1180,11 +1180,7 @@ class Axes3D(Axes):
         '''
         Set zlabel.  See doc for :meth:`set_ylabel` for description.
 
-        .. note::
-            Currently, *labelpad* does not have an effect on the labels.
         '''
-        # FIXME: With a rework of axis3d.py, the labelpad should work again
-        #        At that point, remove the above message in the docs.
         if labelpad is not None : self.zaxis.labelpad = labelpad
         return self.zaxis.set_label_text(zlabel, fontdict, **kwargs)
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -12,7 +12,7 @@ import math
 import copy
 
 from matplotlib import lines as mlines, axis as maxis, \
-        patches as mpatches
+        patches as mpatches, rcParams
 from . import art3d
 from . import proj3d
 
@@ -92,11 +92,11 @@ class Axis(maxis.XAxis):
                                        'linewidth': 1.0},
                             })
 
-
+        
         maxis.XAxis.__init__(self, axes, *args, **kwargs)
 
         self.set_rotate_label(kwargs.get('rotate_label', None))
-
+        self.labelpad = rcParams['axes3d.labelpad'] # 3D graph padding
 
     def init3d(self):
         self.line = mlines.Line2D(xdata=(0, 0), ydata=(0, 0),
@@ -264,13 +264,15 @@ class Axis(maxis.XAxis):
                   self.axes.transAxes.transform([peparray[0:2, 0]]))[0]
 
         lxyz = 0.5*(edgep1 + edgep2)
-
-        labeldeltas = info['label']['space_factor'] * deltas
+        
+        # Set label with padding while keeping backwords compatibility
+        labeldeltas = (self.labelpad + info['label']['space_factor']) * deltas
         axmask = [True, True, True]
         axmask[index] = False
         lxyz = move_from_center(lxyz, centers, labeldeltas, axmask)
         tlx, tly, tlz = proj3d.proj_transform(lxyz[0], lxyz[1], lxyz[2], \
                 renderer.M)
+                       
         self.label.set_position((tlx, tly))
         if self.get_rotate_label(self.label.get_text()):
             angle = art3d.norm_text_angle(math.degrees(math.atan2(dy, dx)))
@@ -281,7 +283,6 @@ class Axis(maxis.XAxis):
 
 
         # Draw Offset text
-
         # Which of the two edge points do we want to
         # use for locating the offset text?
         if juggled[2] == 2 :


### PR DESCRIPTION
Fix the 3DAxis label padding to interpret labelpad for 3D Graphs.
Adds an rCParam for 3D Graphs, initialized to 0 to prevent breaking
existing graphs.

Overview:
	- Add Labelpadding calculations for when label padding co-ords are
		initialized
	- Add an rcParam 'axes3d.labelpad'
        - Removed the Documentation lines in axes3d.py that reference labelpadding not working

Files Affected:
	- lib/mpl_toolkits/mplot3d/axis3d.py
	- lib/matplotlib/rcsetup.py
        - lib/matplotlib/rcsetup.py