### PR TITLE
Fix Travis building of docs with IPython 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ install:
   # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
   # version since is it basically just a .ttf file
 
-  # We install ipython to use the console highlighting. From IPython 3 this depends on jsonschema which is
-  # not installed as a dependency since it is not used by the IPython console.
+  # We install ipython to use the console highlighting. From IPython 3 this depends on jsonschema and misture.
+  # Neihter is installed as a dependency of IPython since they are not used by the IPython console.
   - |
     if [[ $BUILD_DOCS == true ]]; then
       sudo apt-get install -qq --no-install-recommends dvipng texlive-latex-base texlive-latex-extra texlive-fonts-recommended graphviz
-      pip install numpydoc linkchecker ipython jsonschema
+      pip install numpydoc linkchecker ipython jsonschema mistune
       wget http://mirrors.kernel.org/ubuntu/pool/universe/f/fonts-humor-sans/fonts-humor-sans_1.0-1_all.deb
       sudo dpkg -i fonts-humor-sans_1.0-1_all.deb
       wget https://googlefontdirectory.googlecode.com/hg/ofl/felipa/Felipa-Regular.ttf

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,13 @@ install:
   # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
   # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
   # version since is it basically just a .ttf file
+
+  # We install ipython to use the console highlighting. From IPython 3 this depends on jsonschema which is
+  # not installed as a dependency since it is not used by the IPython console.
   - |
     if [[ $BUILD_DOCS == true ]]; then
       sudo apt-get install -qq --no-install-recommends dvipng texlive-latex-base texlive-latex-extra texlive-fonts-recommended graphviz
-      pip install numpydoc linkchecker ipython
+      pip install numpydoc linkchecker ipython jsonschema
       wget http://mirrors.kernel.org/ubuntu/pool/universe/f/fonts-humor-sans/fonts-humor-sans_1.0-1_all.deb
       sudo dpkg -i fonts-humor-sans_1.0-1_all.deb
       wget https://googlefontdirectory.googlecode.com/hg/ofl/felipa/Felipa-Regular.ttf


### PR DESCRIPTION
IPython 3 depends on jsonschema to use the console highlighter. This is not stated as an explicit dependency of IPython since it is not needed for the console. 

An alternative solution would be:
```bash
pip install ipython[all] 
```
Which installs all IPython dependencies