### PR TITLE
MNT : fix typo in no-lint flag

### DIFF
--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -86,7 +86,7 @@ class Gcf(object):
     def destroy_all(cls):
         # this is need to ensure that gc is available in corner cases
         # where modules are being torn down after install with easy_install
-        import gc  # nnqa
+        import gc  # noqa
         for manager in list(cls.figs.values()):
             manager.canvas.mpl_disconnect(manager._cidgcf)
             manager.destroy()


### PR DESCRIPTION
Fixes a typo I introduced in 96d37e3