### PR TITLE
Annotation: always use FancyBboxPatch instead of bbox_artist

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3119,14 +3119,14 @@ class ArrowStyle(_Style):
     %(AvailableArrowstyles)s
 
 
-    An instance of any arrow style class is an callable object,
+    An instance of any arrow style class is a callable object,
     whose call signature is::
 
         __call__(self, path, mutation_size, linewidth, aspect_ratio=1.)
 
     and it returns a tuple of a :class:`Path` instance and a boolean
-    value. *path* is a :class:`Path` instance along witch the arrow
-    will be drawn. *mutation_size* and *aspect_ratio* has a same
+    value. *path* is a :class:`Path` instance along which the arrow
+    will be drawn. *mutation_size* and *aspect_ratio* have the same
     meaning as in :class:`BoxStyle`. *linewidth* is a line width to be
     stroked. This is meant to be used to correct the location of the
     head so that it does not overshoot the destination point, but not all
@@ -3175,11 +3175,11 @@ class ArrowStyle(_Style):
 
         def transmute(self, path, mutation_size, linewidth):
             """
-            The transmute method is a very core of the ArrowStyle
+            The transmute method is the very core of the ArrowStyle
             class and must be overriden in the subclasses. It receives
             the path object along which the arrow will be drawn, and
-            the mutation_size, with which the amount arrow head and
-            etc. will be scaled. The linewidth may be used to adjust
+            the mutation_size, with which the arrow head etc.
+            will be scaled. The linewidth may be used to adjust
             the path so that it does not pass beyond the given
             points. It returns a tuple of a Path instance and a
             boolean. The boolean value indicate whether the path can
@@ -4077,7 +4077,7 @@ class FancyArrowPatch(Patch):
 
         *connectionstyle* can be a string with connectionstyle name with
          optional comma-separated attributes. Alternatively, the attrs can be
-         probided as keywords.
+         provided as keywords.
 
          set_connectionstyle("arc,angleA=0,armA=30,rad=10")
          set_connectionstyle("arc", angleA=0,armA=30,rad=10)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2738,15 +2738,15 @@ class ConnectionStyle(_Style):
                      shrinkA=2., shrinkB=2., patchA=None, patchB=None):
             """
             Calls the *connect* method to create a path between *posA*
-             and *posB*. The path is clipped and shrinked.
+             and *posB*. The path is clipped and shrunken.
             """
 
             path = self.connect(posA, posB)
 
             clipped_path = self._clip(path, patchA, patchB)
-            shrinked_path = self._shrink(clipped_path, shrinkA, shrinkB)
+            shrunk_path = self._shrink(clipped_path, shrinkA, shrinkB)
 
-            return shrinked_path
+            return shrunk_path
 
         def __reduce__(self):
             # because we have decided to nest these classes, we need to
@@ -3204,9 +3204,9 @@ class ArrowStyle(_Style):
                 vertices, codes = path.vertices[:], path.codes[:]
                 # Squeeze the height
                 vertices[:, 1] = vertices[:, 1] / aspect_ratio
-                path_shrinked = Path(vertices, codes)
+                path_shrunk = Path(vertices, codes)
                 # call transmute method with squeezed height.
-                path_mutated, fillable = self.transmute(path_shrinked,
+                path_mutated, fillable = self.transmute(path_shrunk,
                                                         linewidth,
                                                         mutation_size)
                 if cbook.iterable(fillable):
@@ -3261,7 +3261,7 @@ class ArrowStyle(_Style):
             Return the paths for arrow heads. Since arrow lines are
             drawn with capstyle=projected, The arrow goes beyond the
             desired point. This method also returns the amount of the path
-            to be shrinked so that it does not overshoot.
+            to be shrunken so that it does not overshoot.
             """
 
             # arrow from x0, y0 to x1, y1
@@ -3968,7 +3968,7 @@ class FancyArrowPatch(Patch):
         """
         If *posA* and *posB* is given, a path connecting two point are
         created according to the connectionstyle. The path will be
-        clipped with *patchA* and *patchB* and further shrinked by
+        clipped with *patchA* and *patchB* and further shrunken by
         *shrinkA* and *shrinkB*. An arrow is drawn along this
         resulting path using the *arrowstyle* parameter. If *path*
         provided, an arrow is drawn along this path and *patchA*,

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2658,14 +2658,14 @@ class ConnectionStyle(_Style):
 
     class _Base(object):
         """
-        A base class for connectionstyle classes. The dervided needs
-        to implement a *connect* methods whose call signature is::
+        A base class for connectionstyle classes. The subclass needs
+        to implement a *connect* method whose call signature is::
 
           connect(posA, posB)
 
         where posA and posB are tuples of x, y coordinates to be
-        connected.  The methods needs to return a path connecting two
-        points. This base class defines a __call__ method, and few
+        connected.  The method needs to return a path connecting two
+        points. This base class defines a __call__ method, and a few
         helper methods.
         """
 
@@ -2749,7 +2749,7 @@ class ConnectionStyle(_Style):
             return shrinked_path
 
         def __reduce__(self):
-            # because we have decided to nest thes classes, we need to
+            # because we have decided to nest these classes, we need to
             # add some more information to allow instance pickling.
             import matplotlib.cbook as cbook
             return (cbook._NestedClassGetter(),
@@ -2994,7 +2994,7 @@ class ConnectionStyle(_Style):
     class Bar(_Base):
         """
         A line with *angle* between A and B with *armA* and
-        *armB*. One of the arm is extend so that they are connected in
+        *armB*. One of the arms is extended so that they are connected in
         a right angle. The length of armA is determined by (*armA*
         + *fraction* x AB distance). Same for armB.
         """
@@ -3968,7 +3968,7 @@ class FancyArrowPatch(Patch):
         """
         If *posA* and *posB* is given, a path connecting two point are
         created according to the connectionstyle. The path will be
-        clipped with *patchA* and *patchB* and further shirnked by
+        clipped with *patchA* and *patchB* and further shrinked by
         *shrinkA* and *shrinkB*. An arrow is drawn along this
         resulting path using the *arrowstyle* parameter. If *path*
         provided, an arrow is drawn along this path and *patchA*,

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -382,11 +382,11 @@ def test_text_with_arrow_annotation_get_window_extent():
     # bounding box of annotation (text + arrow)
     bbox = ann.get_window_extent(renderer=renderer)
     # bounding box of arrow
-    arrow_bbox = ann.arrow.get_window_extent(renderer)
+    arrow_bbox = ann.arrow_patch.get_window_extent(renderer)
     # bounding box of annotation text
     ann_txt_bbox = Text.get_window_extent(ann)
 
-    # make sure annotation with in 50 px wider than
+    # make sure annotation width is 50 px wider than
     # just the text
     eq_(bbox.width, text_bbox.width + 50.0)
     # make sure the annotation text bounding box is same size

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -400,12 +400,14 @@ def test_text_with_arrow_annotation_get_window_extent():
 
 @cleanup
 def test_arrow_annotation_get_window_extent():
-    figure = Figure(dpi=100)
+    dpi = 100
+    dots_per_point = dpi / 72
+    figure = Figure(dpi=dpi)
     figure.set_figwidth(2.0)
     figure.set_figheight(2.0)
     renderer = RendererAgg(200, 200, 100)
 
-    # Text annotation with arrow
+    # Text annotation with arrow; arrow dimensions are in points
     annotation = Annotation(
         '', xy=(0.0, 50.0), xytext=(50.0, 50.0), xycoords='figure pixels',
         arrowprops={
@@ -417,9 +419,9 @@ def test_arrow_annotation_get_window_extent():
     points = bbox.get_points()
 
     eq_(bbox.width, 50.0)
-    assert_almost_equal(bbox.height, 10.0 / 0.72)
+    assert_almost_equal(bbox.height, 10.0 * dots_per_point)
     eq_(points[0, 0], 0.0)
-    eq_(points[0, 1], 50.0 - 5 / 0.72)
+    eq_(points[0, 1], 50.0 - 5 * dots_per_point)
 
 
 @cleanup

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -21,7 +21,7 @@ from matplotlib.artist import Artist
 from matplotlib.cbook import is_string_like, maxdict
 from matplotlib import docstring
 from matplotlib.font_manager import FontProperties
-from matplotlib.patches import YAArrow, FancyBboxPatch
+from matplotlib.patches import FancyBboxPatch
 from matplotlib.patches import FancyArrowPatch, Rectangle
 import matplotlib.transforms as mtransforms
 from matplotlib.transforms import Affine2D, Bbox, Transform
@@ -531,7 +531,7 @@ class Text(Artist):
             posx, posy = trans.transform_point((posx, posy))
 
             x_box, y_box, w_box, h_box = _get_textbox(self, renderer,
-                                                      with_descent=False)
+                                                      with_descent=True)
             self._bbox_patch.set_bounds(0., 0., w_box, h_box)
             theta = np.deg2rad(self.get_rotation())
             tr = mtransforms.Affine2D().rotate(theta)
@@ -548,7 +548,7 @@ class Text(Artist):
         """
 
         x_box, y_box, w_box, h_box = _get_textbox(self, renderer,
-                                                  with_descent=False)
+                                                  with_descent=True)
         self._bbox_patch.set_bounds(0., 0., w_box, h_box)
         theta = np.deg2rad(self.get_rotation())
         tr = mtransforms.Affine2D().rotate(theta)
@@ -557,7 +557,6 @@ class Text(Artist):
         fontsize_in_pixel = renderer.points_to_pixels(self.get_size())
         self._bbox_patch.set_mutation_scale(fontsize_in_pixel)
         self._bbox_patch.draw(renderer)
-
 
     def _update_clip_properties(self):
         clipprops = dict(clip_box=self.clipbox,
@@ -2114,7 +2113,6 @@ class Annotation(Text, _AnnotationBase):
         self.set_transform(self._get_xy_transform(
             renderer, self.xy, self.anncoords))
 
-
         ox0, oy0 = self._get_xy_display()
         ox1, oy1 = xy_pixel
 
@@ -2171,7 +2169,6 @@ class Annotation(Text, _AnnotationBase):
                 shrink_pts = shrink * r / renderer.points_to_pixels(1)
                 self.arrow_patch.shrinkA = shrink_pts
                 self.arrow_patch.shrinkB = shrink_pts
-
 
             # adjust the starting point of the arrow relative to
             # the textbox.
@@ -2242,7 +2239,6 @@ class Annotation(Text, _AnnotationBase):
         # Draw text, including FancyBboxPatch, after FancyArrowPatch.
         # Otherwise, a wedge arrowstyle can land partly on top of the Bbox.
         Text.draw(self, renderer)
-
 
     def get_window_extent(self, renderer=None):
         '''

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -549,7 +549,6 @@ class Text(Artist):
             fontsize_in_pixel = renderer.points_to_pixels(self.get_size())
             self._bbox_patch.set_mutation_scale(fontsize_in_pixel)
 
-
     def _draw_bbox(self, renderer, posx, posy):
 
         """ Update the location and the size of the bbox
@@ -2221,7 +2220,6 @@ class Annotation(Text, _AnnotationBase):
                     r.set_clip_on(False)
 
                     self.arrow_patch.set_patchA(r)
-
 
     @allow_rasterization
     def draw(self, renderer):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -93,8 +93,9 @@ docstring.interpd.update(Text="""
     animated                   [True | False]
     backgroundcolor            any matplotlib color
     bbox                       rectangle prop dict plus key 'pad' which is a
-                               pad in points; if a boxstyle is supplied, then
-                               pad is instead a fraction of the font size
+                               pad in points; if a boxstyle is supplied as
+                               a string, then pad is instead a fraction
+                               of the font size
     clip_box                   a matplotlib.transform.Bbox instance
     clip_on                    [True | False]
     color                      any matplotlib color
@@ -498,7 +499,9 @@ class Text(Artist):
             else:
                 if pad is None:
                     pad = 0.3
-            if "pad" not in boxstyle:
+
+            # boxstyle could be a callable or a string
+            if is_string_like(boxstyle) and "pad" not in boxstyle:
                 boxstyle += ",pad=%0.2f" % pad
 
             bbox_transmuter = props.pop("bbox_transmuter", None)


### PR DESCRIPTION
This fixes #4139, as an alternative to #4145, by eliminating the use of the bbox_artist debugging function.  With a second commit, it also fixes #4140.  