### PR TITLE
Fix for issue #4180 trirefiner not dealing with fortran contiguous triangles

### DIFF
--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -57,7 +57,7 @@ class Triangulation(object):
         else:
             # Triangulation specified. Copy, since we may correct triangle
             # orientation.
-            self.triangles = np.array(triangles, dtype=np.int32)
+            self.triangles = np.array(triangles, dtype=np.int32, order='C')
             if self.triangles.ndim != 2 or self.triangles.shape[1] != 3:
                 raise ValueError('triangles must be a (?,3) array')
             if self.triangles.max() >= len(self.x):


### PR DESCRIPTION
One-line fix for issue #4180, plus new test based on OP's report.

Should also be ported to master branch as although master doesn't suffer from the bug, we may as well include the test to ensure it isn't accidentally added in the future.