### PR TITLE
Fix triangulation test for numpy1.6

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -968,7 +968,7 @@ def test_trirefiner_fortran_contiguous_triangles():
     triangles1 = np.array([[2, 0, 3], [2, 1, 0]])
     assert_false(np.isfortran(triangles1))
 
-    triangles2 = np.copy(triangles1, order='F')
+    triangles2 = np.array(triangles1, copy=True, order='F')
     assert_true(np.isfortran(triangles2))
 
     x = np.array([0.39, 0.59, 0.43, 0.32])


### PR DESCRIPTION
This should get backported to ``master``, and https://github.com/matplotlib/matplotlib/commit/0c074fcf333fa51d5eaeff216e4bc9a3ab32a254 should get backported to ``color_overhaul``.