### PR TITLE
TST : Test with numpy 1.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ env:
     - secure: E7OCdqhZ+PlwJcn+Hd6ns9TDJgEUXiUNEI0wu7xjxB2vBRRIKtZMbuaZjd+iKDqCKuVOJKu0ClBUYxmgmpLicTwi34CfTUYt6D4uhrU+8hBBOn1iiK51cl/aBvlUUrqaRLVhukNEBGZcyqAjXSA/Qsnp2iELEmAfOUa92ZYo1sk=
     - BUILD_DOCS=false
     - TEST_ARGS=--no-pep8
+    - NUMPY=numpy
 
 language: python
 
 matrix:
   include:
     - python: 2.6
+      env: NUMPY=numpy==1.6
     - python: 2.7
     - python: 3.3
     - python: 3.4
@@ -21,7 +23,7 @@ matrix:
       env: BUILD_DOCS=true
 
 install:
-  - pip install -q --use-mirrors nose python-dateutil numpy pep8==1.5.7 pyparsing pillow
+  - pip install -q --use-mirrors nose python-dateutil $NUMPY pep8==1.5.7 pyparsing pillow
   - sudo apt-get update && sudo apt-get -qq install inkscape libav-tools mencoder
   # We use --no-install-recommends to avoid pulling in additional large latex docs that we don't need
   - if [[ $BUILD_DOCS == true ]]; then sudo apt-get install -qq --no-install-recommends dvipng texlive-latex-base texlive-latex-extra texlive-fonts-recommended graphviz; fi


### PR DESCRIPTION
Couple it with Python 2.6, since those are older versions of
the dependencies.

Back-port of 0c074fcf333fa51d5eaeff216e4bc9a3ab32a254 to color-overhaul
branch.