### PR TITLE
BUG/API : fix color validation

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -345,6 +345,16 @@ class Legend(Artist):
         # We use FancyBboxPatch to draw a legend frame. The location
         # and size of the box will be updated during the drawing time.
 
+        if rcParams["legend.facecolor"] == 'inherit':
+            facecolor = rcParams["axes.facecolor"]
+        else:
+            facecolor = rcParams["legend.facecolor"]
+
+        if rcParams["legend.edgecolor"] == 'inherit':
+            edgecolor = rcParams["axes.edgecolor"]
+        else:
+            edgecolor = rcParams["legend.edgecolor"]
+
         self.legendPatch = FancyBboxPatch(
             xy=(0.0, 0.0), width=1., height=1.,
             facecolor=rcParams["axes.facecolor"],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -235,6 +235,12 @@ class validate_nseq_int(object):
             raise ValueError('Could not convert all entries to ints')
 
 
+def validate_color_or_None(s):
+    if s is None:
+        return None
+    return validate_color(s)
+
+
 def validate_color(s):
     'return a valid color arg'
     try:
@@ -245,6 +251,7 @@ def validate_color(s):
     if is_color_like(s):
         return s
     stmp = '#' + s
+
     if is_color_like(stmp):
         return stmp
     # If it is still valid, it must be a tuple.
@@ -595,7 +602,7 @@ defaultParams = {
     'image.lut':           [256, validate_int],  # lookup table
     'image.origin':        ['upper', six.text_type],  # lookup table
     'image.resample':      [False, validate_bool],
-    # Specify whether vector graphics backends will combine all images on a 
+    # Specify whether vector graphics backends will combine all images on a
     # set of axes into a single composite image
     'image.composite_image': [True, validate_bool],
 
@@ -685,6 +692,8 @@ defaultParams = {
     # the relative size of legend markers vs. original
     'legend.markerscale': [1.0, validate_float],
     'legend.shadow': [False, validate_bool],
+    'legend.facecolor': [None, validate_color_or_None],
+    'legend.edgecolor': [None, validate_color_or_None],
 
     ## tick properties
     'xtick.major.size':  [4, validate_float],    # major xtick size in points

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -235,9 +235,10 @@ class validate_nseq_int(object):
             raise ValueError('Could not convert all entries to ints')
 
 
-def validate_color_or_None(s):
-    if s is None:
-        return None
+def validate_color_or_inherit(s):
+    'return a valid color arg'
+    if s == 'inherit':
+        return s
     return validate_color(s)
 
 
@@ -692,8 +693,8 @@ defaultParams = {
     # the relative size of legend markers vs. original
     'legend.markerscale': [1.0, validate_float],
     'legend.shadow': [False, validate_bool],
-    'legend.facecolor': [None, validate_color_or_None],
-    'legend.edgecolor': [None, validate_color_or_None],
+    'legend.facecolor': ['inherit', validate_color_or_inherit],
+    'legend.edgecolor': ['inherit', validate_color_or_inherit],
 
     ## tick properties
     'xtick.major.size':  [4, validate_float],    # major xtick size in points


### PR DESCRIPTION
Possible fix for #4192.

This adds a new validation (validate_color_or_None) method for color
which allows None and restores `validate_color` to fail on None.

This will allow selected color rcparams to be `None` (not `'None'`)
which the library should interpret as "don't use this rcparam".

Not 100% that this fixes all of the problems.