### PR TITLE
DOC/TST : document and test negative width to bar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1855,6 +1855,8 @@ class Axes(_AxesBase):
             If `edge`, aligns bars by their left edges (for vertical bars) and
             by their bottom edges (for horizontal bars). If `center`, interpret
             the `left` argument as the coordinates of the centers of the bars.
+            To align on the align bars on the right edge pass a negative
+            `width`.
 
         orientation : 'vertical' | 'horizontal', optional, default: 'vertical'
             The orientation of the bars.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1819,11 +1819,13 @@ class Axes(_AxesBase):
         height : sequence of scalars
             the heights of the bars
 
-        width : scalar or array-like, optional, default: 0.8
+        width : scalar or array-like, optional
             the width(s) of the bars
+            default: 0.8
 
-        bottom : scalar or array-like, optional, default: None
+        bottom : scalar or array-like, optional
             the y coordinate(s) of the bars
+            default: None
 
         color : scalar or array-like, optional
             the colors of the bar faces
@@ -1831,42 +1833,49 @@ class Axes(_AxesBase):
         edgecolor : scalar or array-like, optional
             the colors of the bar edges
 
-        linewidth : scalar or array-like, optional, default: None
+        linewidth : scalar or array-like, optional
             width of bar edge(s). If None, use default
             linewidth; If 0, don't draw edges.
+            default: None
 
-        xerr : scalar or array-like, optional, default: None
+        xerr : scalar or array-like, optional
             if not None, will be used to generate errorbar(s) on the bar chart
+            default: None
 
-        yerr : scalar or array-like, optional, default: None
+        yerr : scalar or array-like, optional
             if not None, will be used to generate errorbar(s) on the bar chart
+            default: None
 
-        ecolor : scalar or array-like, optional, default: None
+        ecolor : scalar or array-like, optional
             specifies the color of errorbar(s)
+            default: None
 
-        capsize : integer, optional, default: 3
+        capsize : integer, optional
            determines the length in points of the error bar caps
+           default: 3
 
-        error_kw :
+        error_kw : dict, optional
             dictionary of kwargs to be passed to errorbar method. *ecolor* and
             *capsize* may be specified here rather than as independent kwargs.
 
-        align : ['edge' | 'center'], optional, default: 'edge'
-            If `edge`, aligns bars by their left edges (for vertical bars) and
-            by their bottom edges (for horizontal bars). If `center`, interpret
+        align : {'edge',  'center'}, optional
+            If 'edge', aligns bars by their left edges (for vertical bars) and
+            by their bottom edges (for horizontal bars). If 'center', interpret
             the `left` argument as the coordinates of the centers of the bars.
             To align on the align bars on the right edge pass a negative
             `width`.
 
-        orientation : 'vertical' | 'horizontal', optional, default: 'vertical'
+        orientation : {'vertical',  'horizontal'}, optional
             The orientation of the bars.
 
-        log : boolean, optional, default: False
-            If true, sets the axis to be log scale
+        log : boolean, optional
+            If true, sets the axis to be log scale.
+            default: False
 
         Returns
         -------
-        `matplotlib.patches.Rectangle` instances.
+        bars : matplotlib.container.BarContainer
+            Container with all of the bars + errorbars
 
         Notes
         -----

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -131,7 +131,7 @@ def test_twinx_cla():
 
 @image_comparison(baseline_images=["minorticks_on_rcParams_both"], extensions=['png'])
 def test_minorticks_on_rcParams_both():
-    
+
     fig = plt.figure()
     matplotlib.rcParams['xtick.minor.visible'] = True
     matplotlib.rcParams['ytick.minor.visible'] = True
@@ -3569,11 +3569,13 @@ def test_pathological_hexbin():
         fig.savefig(out)
         assert_equal(len(w), 0)
 
+
 @cleanup
 def test_color_None():
     # issue 3855
     fig, ax = plt.subplots()
     ax.plot([1,2], [1,2], color=None)
+
 
 @cleanup
 def test_color_alias():
@@ -3582,10 +3584,12 @@ def test_color_alias():
     line = ax.plot([0, 1], c='lime')[0]
     assert_equal('lime', line.get_color())
 
+
 @cleanup
 def test_numerical_hist_label():
     fig, ax = plt.subplots()
     ax.hist([range(15)] * 5, label=range(5))
+
 
 @cleanup
 def test_move_offsetlabel():
@@ -3594,6 +3598,18 @@ def test_move_offsetlabel():
     ax.plot(data)
     ax.yaxis.tick_right()
     assert_equal((1, 0.5), ax.yaxis.offsetText.get_position())
+
+
+@cleanup
+def test_bar_negative_width():
+    fig, ax = plt.subplots()
+    res = ax.bar(range(1, 5), range(1, 5), width=-1)
+    assert_equal(len(res), 4)
+    for indx, b in enumerate(res):
+        assert_equal(b._x, indx)
+        assert_equal(b._width, 1)
+        assert_equal(b._height, indx + 1)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
`ax.bar` allows you to specify the left edge of the bars.  The
'align' keyword allows the user to tell mpl to interpret the left
edges as the centers.  To use the left edges as the right edges the
user can simply pass a negative width.

 - Added note to the 'align' entry in the docstring
 - Added test to make sure this does not get 'fixed' with validation on
   width in bar