### PR TITLE
Removed BOM from Unicode text

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -163,14 +163,14 @@ def pdfRepr(obj):
     elif isinstance(obj, (six.integer_types, np.integer)):
         return ("%d" % obj).encode('ascii')
 
-    # Unicode strings are encoded in UTF-16BE with byte-order mark.
+    # Unicode strings are encoded in UTF-16BE.
     elif isinstance(obj, six.text_type):
         try:
             # But maybe it's really ASCII?
             s = obj.encode('ASCII')
             return pdfRepr(s)
         except UnicodeEncodeError:
-            s = codecs.BOM_UTF16_BE + obj.encode('UTF-16BE')
+            s = obj.encode('UTF-16BE')
             return pdfRepr(s)
 
     # Strings are written in parentheses, with backslashes and parens


### PR DESCRIPTION
This is a fix for bug #4199.  When running on Python 3, the BOM gets rendered as visible text characters.  I freely admit that this patch might be a bad way to fix the issue I observed, and might introduce other bugs.  But I know it fixed it in my use case.  Please see bug #4199 for MWE and thoughts.