### PR TITLE
Bug in text draw method when path_effects are set

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -639,16 +639,18 @@ class Text(Artist):
 
             if self.get_path_effects():
                 from matplotlib.patheffects import PathEffectRenderer
-                renderer = PathEffectRenderer(self.get_path_effects(),
-                                              renderer)
+                textrenderer = PathEffectRenderer(self.get_path_effects(),
+                                                  renderer)
+            else:
+                textrenderer = renderer
 
             if self.get_usetex():
-                renderer.draw_tex(gc, x, y, clean_line,
-                                  self._fontproperties, angle, mtext=mtext)
+                textrenderer.draw_tex(gc, x, y, clean_line,
+                                      self._fontproperties, angle, mtext=mtext)
             else:
-                renderer.draw_text(gc, x, y, clean_line,
-                                   self._fontproperties, angle,
-                                   ismath=ismath, mtext=mtext)
+                textrenderer.draw_text(gc, x, y, clean_line,
+                                       self._fontproperties, angle,
+                                       ismath=ismath, mtext=mtext)
 
         gc.restore()
         renderer.close_group('text')


### PR DESCRIPTION
Fixes a bug in the text draw method where the input `renderer` was being overwritten in the inner loop when path_effects are set.