### PR TITLE
Fully save all GraphicsContext variables for MacOS backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -185,6 +185,17 @@ class GraphicsContextMac(_macosx.GraphicsContext, GraphicsContextBase):
     def __init__(self):
         GraphicsContextBase.__init__(self)
         _macosx.GraphicsContext.__init__(self)
+        self._savestack = []
+
+    def save(self):
+        savedvars = vars(self).copy()
+        savedvars.pop('_savestack', None)
+        self._savestack.append(savedvars)
+        _macosx.GraphicsContext.save(self)
+
+    def restore(self):
+        _macosx.GraphicsContext.restore(self)
+        vars(self).update(self._savestack.pop())
 
     def set_alpha(self, alpha):
         GraphicsContextBase.set_alpha(self, alpha)


### PR DESCRIPTION
Modifies the save/restore graphics context of the MacOS backend to fully save all GraphicsContext variables to a stack for the `GraphicsContextMac` class. Currently, the graphics context is saved to the stack in the underlying `_macosx.so` backend but the variables associated with the context from the `GraphicsContextBase` are not saved/restored so the corresponding `GraphicsContext` class is not in sync with the actual graphic context. This saves these variables to a stack so they are in sync. 

This fixes the issue seen in #4024 (PR #4201 must also be applied to fully fix #4024). Below is the example from issue #4024 before and after.

#### Before
![image](https://cloud.githubusercontent.com/assets/1505899/6544637/68087b5a-c50e-11e4-8959-fe2d7a158d67.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1505899/6544653/364cb382-c50f-11e4-8f48-8710c83e7d7c.png)
