### PR TITLE
Fix compression of grayscale rasterized images when using (e)ps distilled with xpdf.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1598,6 +1598,7 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
     else: paper_option = "-sPAPERSIZE=%s" % ptype
 
     command = 'ps2pdf -dAutoFilterColorImages=false \
+-dAutoFilterGrayImages=false -sGrayImageFilter=FlateEncode \
 -sColorImageFilter=FlateEncode %s "%s" "%s" > "%s"'% \
 (paper_option, tmpfile, pdffile, outfile)
     if sys.platform == 'win32': command = command.replace('=', '#')


### PR DESCRIPTION
When exporting figures containing rasterized grayscale images to eps, the resulting files show strange compression artifacts when distillation with xpdf is used. In particular, the above problem occurs whenever imshow is used in conjunction with grayscale colormaps. The change below makes matplotlib use the same compression and filter settings for both rasterized grayscale images and color images when using (e)ps distilled with xpdf. See issue description at matplotlib/matplotlib#4207.