### PR TITLE
Fix test  docs build on Travis with Sphinx 1.3.0 Edit (Lock travis on 1.2.3 for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       env: BUILD_DOCS=true
 
 install:
-  - pip install -q --use-mirrors nose python-dateutil $NUMPY pep8 pyparsing pillow sphinx
+  - pip install -q --use-mirrors nose python-dateutil $NUMPY pep8 pyparsing pillow sphinx==1.2.3
   - sudo apt-get update && sudo apt-get -qq install inkscape libav-tools gdb mencoder
   # We use --no-install-recommends to avoid pulling in additional large latex docs that we don't need
 

--- a/lib/matplotlib/sphinxext/tests/tinypages/conf.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/conf.py
@@ -14,6 +14,8 @@
 
 import sys
 from os.path import join as pjoin, abspath
+import sphinx
+from distutils.version import LooseVersion
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -99,7 +101,10 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+if LooseVersion(sphinx.__version__) >= LooseVersion('1.3'):
+    html_theme = 'classic'
+else:
+    html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Sphinx 1.3 was just released. This introduced a number of new warnings which caused a test failure and our docs to stop building since we treat warnings as errors.  

The test failed due to a renamed theme. So I have changed the config to set the theme name depending on the Sphinx version. (This might need a backport to the color overhaul branch)

The docs fail with:

```
WARNING: the config value 'html_domain_indices' has type `list', defaults to `bool.'
```

Which is treated as an error. This looks like a bug in Sphinx it self since according to http://sphinx-doc.org/config.html?highlight=html_domain_indices#confval-html_domain_indices a list should be fully legal

In the interest of having a functional Sphinx build I have disabled the warnings as errors until we can get to the bottom of this. 
