### PR TITLE
Hopefully fix bus_error/seg_fault in contour code

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1442,9 +1442,9 @@ class QuadContourSet(ContourSet):
         else:
             x, y, z = self._contour_args(args, kwargs)
 
-            _mask = ma.getmask(z)
-            if _mask is ma.nomask or not _mask.any():
-                _mask = None
+            self._mask = ma.getmask(z)
+            if self._mask is ma.nomask or not self._mask.any():
+                self._mask = None
 
             self._corner_mask = kwargs.get('corner_mask', None)
             if self._corner_mask is None:
@@ -1454,10 +1454,11 @@ class QuadContourSet(ContourSet):
                 cbook.warn_deprecated('1.5',
                                       name="corner_mask='legacy'",
                                       alternative='corner_mask=False or True')
-                contour_generator = _cntr.Cntr(x, y, z.filled(), _mask)
+                contour_generator = _cntr.Cntr(x, y, z.filled(), self._mask)
             else:
                 contour_generator = _contour.QuadContourGenerator(
-                    x, y, z.filled(), _mask, self._corner_mask, self.nchunk)
+                    x, y, z.filled(), self._mask, self._corner_mask,
+                    self.nchunk)
 
             t = self.get_transform()
 


### PR DESCRIPTION
The mask is created as a temporary array in the python ```__init__``` function by copying the mask from the numpy masked array into _mask. However, _mask may be gced when __init__ has run and the destructor of the array_view of _mask in the cpp code decreases the refcount. Fix this by making _mask a part of the python class. An attempt to fix #4222 