### PR TITLE
Refactoring: fewer variables, slightly faster code

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -461,8 +461,7 @@ def gcf():
         return figure()
 
 def fignum_exists(num):
-    allLabels = get_figlabels()
-    return _pylab_helpers.Gcf.has_fignum(num) or num in allLabels 
+    return _pylab_helpers.Gcf.has_fignum(num) or num in get_figlabels()
 
 
 def get_fignums():


### PR DESCRIPTION
The previous code made me wonder why we had to use a variable that was used only once: I was wondering whether `get_figlabels()` had any side effect. Not only is the fact that this is not the case now explicit, but the code does not do any unnecessary call to `get_figlabels()` anymore.

See the discussion at https://github.com/matplotlib/matplotlib/commit/0346946e4eeebe72448a666598496cb031eb094f#commitcomment-10206373.