### PR TITLE
BUG : fix non-uniform grids in pcolorfast

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -853,8 +853,9 @@ class PcolorImage(martist.Artist, cm.ScalarMappable):
         l, b, r, t = self.axes.bbox.extents
         width = (round(r) + 0.5) - (round(l) - 0.5)
         height = (round(t) + 0.5) - (round(b) - 0.5)
-        width = width * magnification
-        height = height * magnification
+        # The extra cast-to-int is only needed for python2
+        width = int(round(width * magnification))
+        height = int(round(height * magnification))
         if self._rgbacache is None:
             A = self.to_rgba(self._A, bytes=True)
             self._rgbacache = A

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3675,6 +3675,17 @@ def test_no_None():
     assert_raises(ValueError, plt.plot, None, None)
 
 
+@cleanup
+def test_pcolor_fast_non_uniform():
+    Z = np.arange(6).reshape((3, 2))
+    X = np.array([0, 1, 2, 10])
+    Y = np.array([0, 1, 2])
+
+    plt.figure()
+    ax = plt.subplot(111)
+    ax.pcolorfast(X, Y, Z.T)
+
+
 if __name__ == '__main__':
     import nose
     import sys


### PR DESCRIPTION
Closes #4227 

attn @mdboom @efiring  This fixes the problem, but I have no idea why (I just looked at the c++ header, it wanted ints so I made sure it get ints).