### PR TITLE
Bug in ParseTuple for PyQuadContourGenerator_init

### DIFF
--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -29,7 +29,7 @@ static int PyQuadContourGenerator_init(PyQuadContourGenerator* self, PyObject* a
 {
     QuadContourGenerator::CoordinateArray x, y, z;
     QuadContourGenerator::MaskArray mask;
-    bool corner_mask;
+    int corner_mask;
     long chunk_size;
 
     if (!PyArg_ParseTuple(args, "O&O&O&O&il",


### PR DESCRIPTION
This is a fix for issue #4222. On compilers where `bool` is not the same size as `int`, there is a stack overrun of the variadic function `PyArg_ParseTuple` in `PyQuadContourGenerator_init`. 