### PR TITLE
Fix small option for docs build with sphinx 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       env: BUILD_DOCS=true
 
 install:
-  - pip install -q --use-mirrors nose python-dateutil $NUMPY pep8 pyparsing pillow sphinx==1.2.3
+  - pip install -q --use-mirrors nose python-dateutil $NUMPY pep8 pyparsing pillow sphinx!=1.3.0
   - sudo apt-get update && sudo apt-get -qq install inkscape libav-tools gdb mencoder
   # We use --no-install-recommends to avoid pulling in additional large latex docs that we don't need
 

--- a/doc/make.py
+++ b/doc/make.py
@@ -40,7 +40,7 @@ def html(buildername='html'):
     check_build()
     copy_if_out_of_date('../lib/matplotlib/mpl-data/matplotlibrc', '_static/matplotlibrc')
     if small_docs:
-        options = "-D plot_formats=\"[('png', 80)]\""
+        options = "-D plot_formats=png:80"
     else:
         options = ''
     if warnings_as_errors:

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -103,7 +103,9 @@ The plot directive has the following configuration options:
             [(suffix, dpi), suffix, ...]
 
         that determine the file format and the DPI. For entries whose
-        DPI was omitted, sensible defaults are chosen.
+        DPI was omitted, sensible defaults are chosen. When passing from
+        the command line through sphinx_build the list should be passed as
+        suffix:dpi,suffix:dpi, ....
 
     plot_html_show_formats
         Whether to show links to the files in HTML.
@@ -539,10 +541,17 @@ def render_figures(code, code_path, output_dir, output_base, context,
     formats = []
     plot_formats = config.plot_formats
     if isinstance(plot_formats, six.string_types):
-        plot_formats = eval(plot_formats)
+        # String Sphinx < 1.3, Split on , to mimic
+        # Sphinx 1.3 and later. Sphinx 1.3 always
+        # returns a list.
+        plot_formats = plot_formats.split(',')
     for fmt in plot_formats:
         if isinstance(fmt, six.string_types):
-            formats.append((fmt, default_dpi.get(fmt, 80)))
+            if ':' in fmt:
+                suffix,dpi = fmt.split(':')
+                formats.append((str(suffix), int(dpi)))
+            else:
+                formats.append((fmt, default_dpi.get(fmt, 80)))
         elif type(fmt) in (tuple, list) and len(fmt)==2:
             formats.append((str(fmt[0]), int(fmt[1])))
         else:


### PR DESCRIPTION
Sphinx 1.3 adds support for passing lists from the commandline.
This means that it splits on ',' which turns "[('png', 80)]"
into ["[('png'", "80)]"]. Fix this py passing the formats
on commandline as suffix0:dpi0,suffix1:dpi1...

Partial fix for #4215 