### PR TITLE
multiple canvas support for Windows

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -246,14 +246,14 @@ class FigureCanvasTkAgg(FigureCanvasAgg):
         # event to the window containing the canvas instead.
         # See http://wiki.tcl.tk/3893 (mousewheel) for details
         root = self._tkcanvas.winfo_toplevel()
-        root.bind("<MouseWheel>", self.scroll_event_windows)
+        root.bind("<MouseWheel>", self.scroll_event_windows, "+")
 
         # Can't get destroy events by binding to _tkcanvas. Therefore, bind
         # to the window and filter.
         def filter_destroy(evt):
             if evt.widget is self._tkcanvas:
                 self.close_event()
-        root.bind("<Destroy>", filter_destroy)
+        root.bind("<Destroy>", filter_destroy, "+")
 
         self._master = master
         self._tkcanvas.focus_set()


### PR DESCRIPTION
On Windows platform the bind of the mousewheel event is made on the main application window rather than the canvas. As a side effect, if you have multiple canvas in the same application, only the last one created answers to mousewheeel events.

This patch makes the bindings chain rather than replacing each other. In the callbacks (scroll_event_windows, filter_destroy), event filtering is done to check if the canvas should answer.