### PR TITLE
Implemented Issue #3225. Added a uniform_size parameter to legend.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1184,6 +1184,10 @@ class Figure(Artist):
           *title* : string
             the legend title
 
+          *uniform_size*: [ *None* | scalar ]
+            a uniform size of legend markers. If *None*, use original plot
+            settings
+
         Padding and spacing between various elements use following keywords
         parameters. The dimensions of these values are given as a fraction
         of the fontsize. Values from rcParams will be used if None.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -224,6 +224,7 @@ class Legend(Artist):
         title              the legend title
         bbox_to_anchor     the bbox that the legend will be anchored.
         bbox_transform     the transform for the bbox. transAxes if None.
+        uniform_size       the uniform size of legend marker
         ================   ====================================================
 
 
@@ -248,20 +249,8 @@ class Legend(Artist):
 
         if uniform_size is not None:
             uniform_handler_map = {
-                StemContainer: legend_handler.HandlerStem(),
-                ErrorbarContainer: legend_handler.HandlerErrorbar(),
-                Line2D: legend_handler.HandlerLine2D(),
-                Patch: legend_handler.HandlerPatch(),
-                LineCollection: legend_handler.HandlerLineCollection(),
-                RegularPolyCollection:
-                    legend_handler.HandlerRegularPolyCollection(),
-                CircleCollection: legend_handler.HandlerCircleCollection(),
-                BarContainer: legend_handler.HandlerPatch(
-                    update_func=legend_handler.update_from_first_child),
-                tuple: legend_handler.HandlerTuple(),
                 PathCollection:
                     legend_handler.HandlerPathCollection(sizes=[uniform_size]),
-                PolyCollection: legend_handler.HandlerPolyCollection()
                 }
             self.update_default_handler_map(uniform_handler_map)
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -253,12 +253,14 @@ class Legend(Artist):
                 Line2D: legend_handler.HandlerLine2D(),
                 Patch: legend_handler.HandlerPatch(),
                 LineCollection: legend_handler.HandlerLineCollection(),
-                RegularPolyCollection: legend_handler.HandlerRegularPolyCollection(),
+                RegularPolyCollection:
+                    legend_handler.HandlerRegularPolyCollection(),
                 CircleCollection: legend_handler.HandlerCircleCollection(),
                 BarContainer: legend_handler.HandlerPatch(
                     update_func=legend_handler.update_from_first_child),
                 tuple: legend_handler.HandlerTuple(),
-                PathCollection: legend_handler.HandlerPathCollection(sizes=[uniform_size]),
+                PathCollection:
+                    legend_handler.HandlerPathCollection(sizes=[uniform_size]),
                 PolyCollection: legend_handler.HandlerPolyCollection()
                 }
             self.update_default_handler_map(uniform_handler_map)
@@ -1011,3 +1013,4 @@ class Legend(Artist):
             self._draggable = None
 
         return self._draggable
+

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -185,6 +185,7 @@ class Legend(Artist):
                  bbox_transform=None,  # transform for the bbox
                  frameon=None,  # draw frame
                  handler_map=None,
+                 uniform_size=None,  # set legend points to be a uniform size
                  ):
         """
         - *parent*: the artist that contains the legend
@@ -244,6 +245,23 @@ class Legend(Artist):
         from matplotlib.figure import Figure
 
         Artist.__init__(self)
+
+        if uniform_size is not None:
+            uniform_handler_map = {
+                StemContainer: legend_handler.HandlerStem(),
+                ErrorbarContainer: legend_handler.HandlerErrorbar(),
+                Line2D: legend_handler.HandlerLine2D(),
+                Patch: legend_handler.HandlerPatch(),
+                LineCollection: legend_handler.HandlerLineCollection(),
+                RegularPolyCollection: legend_handler.HandlerRegularPolyCollection(),
+                CircleCollection: legend_handler.HandlerCircleCollection(),
+                BarContainer: legend_handler.HandlerPatch(
+                    update_func=legend_handler.update_from_first_child),
+                tuple: legend_handler.HandlerTuple(),
+                PathCollection: legend_handler.HandlerPathCollection(sizes=[uniform_size]),
+                PolyCollection: legend_handler.HandlerPolyCollection()
+                }
+            self.update_default_handler_map(uniform_handler_map)
 
         if prop is None:
             if fontsize is not None:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1013,4 +1013,3 @@ class Legend(Artist):
             self._draggable = None
 
         return self._draggable
-


### PR DESCRIPTION
fix for [3225](http://github.com/matplotlib/matplotlib/issues/3225)
An extra parameter uniform_size is added to legend so that user can specify a uniform_size for scatter plots.
e.g.
plt.legend(loc="lower left", markerscale=2., scatterpoints=1, fontsize=10,uniform_size=20)