### PR TITLE
BUG: Quiver must copy U, V, C args so they can't change before draw()

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -529,11 +529,13 @@ class Quiver(mcollections.PolyCollection):
         mcollections.PolyCollection.draw(self, renderer)
 
     def set_UVC(self, U, V, C=None):
-        U = ma.masked_invalid(U, copy=False).ravel()
-        V = ma.masked_invalid(V, copy=False).ravel()
+        # We need to ensure we have a copy, not a reference
+        # to an array that might change before draw().
+        U = ma.masked_invalid(U, copy=True).ravel()
+        V = ma.masked_invalid(V, copy=True).ravel()
         mask = ma.mask_or(U.mask, V.mask, copy=False, shrink=True)
         if C is not None:
-            C = ma.masked_invalid(C, copy=False).ravel()
+            C = ma.masked_invalid(C, copy=True).ravel()
             mask = ma.mask_or(mask, C.mask, copy=False, shrink=True)
             if mask is ma.nomask:
                 C = C.filled()

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -83,6 +83,15 @@ def test_quiver_single():
     ax.quiver([1], [1], [2], [2])
 
 
+@cleanup
+def test_quiver_copy():
+    fig, ax = plt.subplots()
+    uv = dict(u=np.array([1.1]), v=np.array([2.0]))
+    q0 = ax.quiver([1], [1], uv['u'], uv['v'])
+    uv['v'][0] = 0
+    assert q0.V[0] == 2.0
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
The bug was revealed when a user was plotting to successive subplots inside a loop iterating through a numerical integration.  U and V were references to objects that were updated inside the loop, but the figure was not drawn until the end.  Therefore all panels showed the quiver of the last iteration.