### PR TITLE
Allow URL strings to be passed to imread

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -75,6 +75,13 @@ directive - ``close-figs`` - that closes any previous figure windows before
 creating the plots.  This can help avoid some surprising duplicates of plots
 when using ``plot_directive``.
 
+Support for URL string arguments to ``imread``
+----------------------------------------------
+
+The ``imread`` function now accepts URL strings that point to remote PNG
+files. This circumvents the generation of a HTTPResponse object directly.
+
+
 .. _whats-new-1-4:
 
 new in matplotlib-1.4

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1227,21 +1227,8 @@ def imread(fname, format=None):
             from PIL import Image
         except ImportError:
             return None
-        if cbook.is_string_like(fname):
-            parsed = urlparse(fname)
-            # If the string is a URL, then download the data
-            if parsed.scheme is not '':
-                fh = BytesIO(urlopen(fname).read())
-                image = Image.open(fh)
-                return pil_to_array(image)
-            else:
-                # force close the file after reading the image
-                with open(fname, "rb") as fh:
-                    image = Image.open(fh)
-                    return pil_to_array(image)
-        else:
-            image = Image.open(fname)
-            return pil_to_array(image)
+        image = Image.open(fname)
+        return pil_to_array(image)
 
     handlers = {'png': _png.read_png, }
     if format is None:

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1235,7 +1235,7 @@ def imread(fname, format=None):
         if cbook.is_string_like(fname):
             parsed = urlparse(fname)
             # If the string is a URL, assume png
-            if parsed.scheme is not '':
+            if parsed.scheme != '':
                 ext = 'png'
             else:
                 basename, ext = os.path.splitext(fname)
@@ -1264,7 +1264,8 @@ def imread(fname, format=None):
     if cbook.is_string_like(fname):
         parsed = urlparse(fname)
         # If fname is a URL, download the data
-        if parsed.scheme is not '':
+        if parsed.scheme != '':
+            print('Scheme: %s' % parsed.scheme)
             fd = BytesIO(urlopen(fname).read())
             return handler(fd)
         else:

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1219,7 +1219,7 @@ def imread(fname, format=None):
     matplotlib can only read PNGs natively, but if `PIL
     <http://www.pythonware.com/products/pil/>`_ is installed, it will
     use it to load the image and return an array (if possible) which
-    can be used with :func:`~matplotlib.pyplot.imshow`. Note, URL strings 
+    can be used with :func:`~matplotlib.pyplot.imshow`. Note, URL strings
     may not be compatible with PIL. Check the PIL documentation for more
     information.
     """

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1204,8 +1204,9 @@ def imread(fname, format=None):
     """
     Read an image from a file into an array.
 
-    *fname* may be a string path or a Python file-like object.  If
-    using a file object, it must be opened in binary mode.
+    *fname* may be a string path, a valid URL, or a Python
+    file-like object.  If using a file object, it must be opened in binary
+    mode.
 
     If *format* is provided, will try to read file of that type,
     otherwise the format is deduced from the filename.  If nothing can
@@ -1218,7 +1219,9 @@ def imread(fname, format=None):
     matplotlib can only read PNGs natively, but if `PIL
     <http://www.pythonware.com/products/pil/>`_ is installed, it will
     use it to load the image and return an array (if possible) which
-    can be used with :func:`~matplotlib.pyplot.imshow`.
+    can be used with :func:`~matplotlib.pyplot.imshow`. Note, URL strings 
+    may not be compatible with PIL. Check the PIL documentation for more
+    information.
     """
 
     def pilread(fname):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1265,7 +1265,6 @@ def imread(fname, format=None):
         parsed = urlparse(fname)
         # If fname is a URL, download the data
         if parsed.scheme != '':
-            print('Scheme: %s' % parsed.scheme)
             fd = BytesIO(urlopen(fname).read())
             return handler(fd)
         else:


### PR DESCRIPTION
These modifications allow valid URL strings to be passed directly into imread. URL recognition is done using the standard library function urlparse. If the string contains a valid url scheme, it will be used to download and process the data using a combination of urlopen and BytesIO (StringIO in python 2). (I followed methodology in the `pandas.read_*` functions, which also allow valid URL strings.)

Things that I haven't done: 
* No tests
* Update documentation
I'll do these things if this code addition seems acceptable. 

One other thing that I've noticed, the `matplotlib.pyplot.imread` function signature does not match the `matplotlib.image.imread` signature. It seems like the doc string would be a little easier to follow if the function signatures matched. Maybe that is not something to address in this PR.

