### PR TITLE
Added feature for specifying uniform handle sizes for scatter plost.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -506,7 +506,19 @@ class Axes(_AxesBase):
         else:
             raise TypeError('Invalid arguments to legend.')
 
-        self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
+        # If uniform_size is specified, verify that there's no conflicting
+        # parameters.
+        if 'uniform_size' in kwargs:
+            if 'markerscale' in kwargs or 'handler_map' in kwargs:
+                raise TypeError("Cannot specify 'markerscale' or " +
+                                "'handler_map' to legend when " +
+                                "'uniform_size' is specified.")
+            uniform_size = kwargs.pop('uniform_size')
+            self.legend_ = mlegend.UniformLegend(self, handles, labels,
+                                                 uniform_size, **kwargs)
+        else:
+            self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
+
         self.legend_._remove_method = lambda h: setattr(self, 'legend_', None)
         return self.legend_
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -40,6 +40,7 @@ import matplotlib.colorbar as cbar
 from matplotlib.axes import Axes, SubplotBase, subplot_class_factory
 from matplotlib.blocking_input import BlockingMouseInput, BlockingKeyMouseInput
 from matplotlib.legend import Legend
+from matplotlib.legend import UniformLegend
 from matplotlib.patches import Rectangle
 from matplotlib.projections import (get_projection_names,
                                     process_projection_requirements)
@@ -1222,7 +1223,21 @@ class Figure(Artist):
 
         .. plot:: mpl_examples/pylab_examples/figlegend_demo.py
         """
-        l = Legend(self, handles, labels, *args, **kwargs)
+
+        # If uniform_size is specified, verify that there's no conflicting
+        # parameters.
+        l = None
+        if 'uniform_size' in kwargs:
+            if 'markerscale' in kwargs or 'handler_map' in kwargs:
+                raise TypeError("Cannot specify 'markerscale' or " +
+                                "'handler_map' to legend when " +
+                                "'uniform_size' is specified.")
+            uniform_size = kwargs.pop('uniform_size')
+            l = UniformLegend(self, handles, labels, uniform_size, *args,
+                              **kwargs)
+        else:
+            l = Legend(self, handles, labels, *args, **kwargs)
+
         self.legends.append(l)
         l._remove_method = lambda h: self.legends.remove(h)
         return l

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -803,7 +803,7 @@ class Legend(Artist):
         return self._legend_title_box._text
 
     def get_window_extent(self, *args, **kwargs):
-        'return a extent of the legend'
+        'return a extent of the the legend'
         return self.legendPatch.get_window_extent(*args, **kwargs)
 
     def get_frame_on(self):
@@ -993,3 +993,100 @@ class Legend(Artist):
             self._draggable = None
 
         return self._draggable
+
+
+class UniformLegend(Legend):
+    def __str__(self):
+        return "uniformLegend"
+
+    def __init__(self, parent, handles, labels,uniform_size,
+                 loc=None,
+                 numpoints=None,    # the number of points in the legend line
+                 markerfirst=True,  # controls ordering (left-to-right) of
+                                    # legend marker and label
+                 scatterpoints=None,    # number of scatter points
+                 scatteryoffsets=None,
+                 prop=None,          # properties for the legend texts
+                 fontsize=None,        # keyword to set font size directly
+
+                 # spacing & pad defined as a fraction of the font-size
+                 borderpad=None,      # the whitespace inside the legend border
+                 labelspacing=None,   # the vertical space between the legend
+                                      # entries
+                 handlelength=None,   # the length of the legend handles
+                 handleheight=None,   # the height of the legend handles
+                 handletextpad=None,  # the pad between the legend handle
+                                      # and text
+                 borderaxespad=None,  # the pad between the axes and legend
+                                      # border
+                 columnspacing=None,  # spacing between columns
+
+                 ncol=1,     # number of columns
+                 mode=None,  # mode for horizontal distribution of columns.
+                             # None, "expand"
+
+                 fancybox=None,  # True use a fancy box, false use a rounded
+                                 # box, none use rc
+                 shadow=None,
+                 title=None,  # set a title for the legend
+
+                 framealpha=None,  # set frame alpha
+
+                 bbox_to_anchor=None,  # bbox that the legend will be anchored.
+                 bbox_transform=None,  # transform for the bbox
+                 frameon=None
+                 ):
+        uniformHandlerMap = {
+        StemContainer:
+            legend_handler.HandlerUniformStem(uniform_size=uniform_size),
+        ErrorbarContainer:
+            legend_handler.HandlerUniformErrorBar(uniform_size=uniform_size),
+        Line2D: legend_handler.HandlerUniformLine2D(uniform_size=uniform_size),
+        PathCollection:
+            legend_handler.HandlerPathCollection(sizes=[uniform_size]*3),
+        RegularPolyCollection:
+            legend_handler.HandlerRegularPolyCollection(sizes=[uniform_size]*3),
+        CircleCollection: 
+            legend_handler.HandlerCircleCollection(sizes=[uniform_size]*3),
+        }
+
+        Legend.__init__(self,parent,handles,labels,
+                 loc=loc,
+                 numpoints=numpoints,    # the number of points in the legend line
+                 markerscale=None,  # the relative size of legend markers
+                                    # vs. original
+                 markerfirst=markerfirst,  # controls ordering (left-to-right) of
+                                    # legend marker and label
+                 scatterpoints=scatterpoints,    # number of scatter points
+                 scatteryoffsets=scatteryoffsets,
+                 prop=prop,          # properties for the legend texts
+                 fontsize=fontsize,        # keyword to set font size directly
+
+                 # spacing & pad defined as a fraction of the font-size
+                 borderpad=borderpad,      # the whitespace inside the legend border
+                 labelspacing=labelspacing,   # the vertical space between the legend
+                                      # entries
+                 handlelength=handlelength,   # the length of the legend handles
+                 handleheight=handleheight,   # the height of the legend handles
+                 handletextpad=handletextpad,  # the pad between the legend handle
+                                      # and text
+                 borderaxespad=borderaxespad,  # the pad between the axes and legend
+                                      # border
+                 columnspacing=columnspacing,  # spacing between columns
+
+                 ncol=1,     # number of columns
+                 mode=mode,  # mode for horizontal distribution of columns.
+                             # None, "expand"
+
+                 fancybox=fancybox,  # True use a fancy box, false use a rounded
+                                 # box, none use rc
+                 shadow=shadow,
+                 title=title,  # set a title for the legend
+
+                 framealpha=framealpha,  # set frame alpha
+
+                 bbox_to_anchor=bbox_to_anchor,  # bbox that the legend will be anchored.
+                 bbox_transform=bbox_transform,  # transform for the bbox
+                 frameon=frameon,  # draw frame
+                 handler_map=uniformHandlerMap,
+               )

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1056,6 +1056,7 @@ class UniformLegend(Legend):
         Legend.__init__(self, parent, handles, labels,
                         loc=loc,
                         numpoints=numpoints,
+                        # markerscale does nothing when using uniform sizing.
                         markerscale=None,
                         markerfirst=markerfirst,
                         scatterpoints=scatterpoints,
@@ -1078,5 +1079,7 @@ class UniformLegend(Legend):
                         bbox_to_anchor=bbox_to_anchor,
                         bbox_transform=bbox_transform,
                         frameon=frameon,
+                        # Override with custom handler map that forces uniform
+                        # sizing.
                         handler_map=uniformHandlerMap,
                         )

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -803,7 +803,7 @@ class Legend(Artist):
         return self._legend_title_box._text
 
     def get_window_extent(self, *args, **kwargs):
-        'return a extent of the the legend'
+        'return a extent of the legend'
         return self.legendPatch.get_window_extent(*args, **kwargs)
 
     def get_frame_on(self):
@@ -999,7 +999,7 @@ class UniformLegend(Legend):
     def __str__(self):
         return "uniformLegend"
 
-    def __init__(self, parent, handles, labels,uniform_size,
+    def __init__(self, parent, handles, labels, uniform_size,
                  loc=None,
                  numpoints=None,    # the number of points in the legend line
                  markerfirst=True,  # controls ordering (left-to-right) of
@@ -1037,56 +1037,46 @@ class UniformLegend(Legend):
                  frameon=None
                  ):
         uniformHandlerMap = {
-        StemContainer:
+            StemContainer:
             legend_handler.HandlerUniformStem(uniform_size=uniform_size),
-        ErrorbarContainer:
+            ErrorbarContainer:
             legend_handler.HandlerUniformErrorBar(uniform_size=uniform_size),
-        Line2D: legend_handler.HandlerUniformLine2D(uniform_size=uniform_size),
-        PathCollection:
+            Line2D:
+            legend_handler.HandlerUniformLine2D(uniform_size=uniform_size),
+            PathCollection:
             legend_handler.HandlerPathCollection(sizes=[uniform_size]*3),
-        RegularPolyCollection:
-            legend_handler.HandlerRegularPolyCollection(sizes=[uniform_size]*3),
-        CircleCollection: 
+            RegularPolyCollection:
+            legend_handler.HandlerRegularPolyCollection(
+                sizes=[uniform_size]*3),
+            CircleCollection:
             legend_handler.HandlerCircleCollection(sizes=[uniform_size]*3),
         }
 
-        Legend.__init__(self,parent,handles,labels,
-                 loc=loc,
-                 numpoints=numpoints,    # the number of points in the legend line
-                 markerscale=None,  # the relative size of legend markers
-                                    # vs. original
-                 markerfirst=markerfirst,  # controls ordering (left-to-right) of
-                                    # legend marker and label
-                 scatterpoints=scatterpoints,    # number of scatter points
-                 scatteryoffsets=scatteryoffsets,
-                 prop=prop,          # properties for the legend texts
-                 fontsize=fontsize,        # keyword to set font size directly
-
-                 # spacing & pad defined as a fraction of the font-size
-                 borderpad=borderpad,      # the whitespace inside the legend border
-                 labelspacing=labelspacing,   # the vertical space between the legend
-                                      # entries
-                 handlelength=handlelength,   # the length of the legend handles
-                 handleheight=handleheight,   # the height of the legend handles
-                 handletextpad=handletextpad,  # the pad between the legend handle
-                                      # and text
-                 borderaxespad=borderaxespad,  # the pad between the axes and legend
-                                      # border
-                 columnspacing=columnspacing,  # spacing between columns
-
-                 ncol=1,     # number of columns
-                 mode=mode,  # mode for horizontal distribution of columns.
-                             # None, "expand"
-
-                 fancybox=fancybox,  # True use a fancy box, false use a rounded
-                                 # box, none use rc
-                 shadow=shadow,
-                 title=title,  # set a title for the legend
-
-                 framealpha=framealpha,  # set frame alpha
-
-                 bbox_to_anchor=bbox_to_anchor,  # bbox that the legend will be anchored.
-                 bbox_transform=bbox_transform,  # transform for the bbox
-                 frameon=frameon,  # draw frame
-                 handler_map=uniformHandlerMap,
-               )
+        # Consult Legend.__init__ for purpose of each parameter.
+        Legend.__init__(self, parent, handles, labels,
+                        loc=loc,
+                        numpoints=numpoints,
+                        markerscale=None,
+                        markerfirst=markerfirst,
+                        scatterpoints=scatterpoints,
+                        scatteryoffsets=scatteryoffsets,
+                        prop=prop,
+                        fontsize=fontsize,
+                        borderpad=borderpad,
+                        labelspacing=labelspacing,
+                        handlelength=handlelength,
+                        handleheight=handleheight,
+                        handletextpad=handletextpad,
+                        borderaxespad=borderaxespad,
+                        columnspacing=columnspacing,
+                        ncol=1,
+                        mode=mode,
+                        fancybox=fancybox,
+                        shadow=shadow,
+                        title=title,
+                        framealpha=framealpha,
+                        bbox_to_anchor=bbox_to_anchor,
+                        bbox_transform=bbox_transform,
+                        frameon=frameon,
+                        handler_map=uniformHandlerMap,
+                        )

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -617,3 +617,52 @@ class HandlerPolyCollection(HandlerBase):
         self.update_prop(p, orig_handle, legend)
         p.set_transform(trans)
         return [p]
+class HandlerUniformLine2D(HandlerLine2D):
+    """
+    Handler for Uniform sized Line2D instances
+    """
+
+    def __init__(self, uniform_size, **kw):
+        self._uniform_size = uniform_size
+        HandlerLine2D.__init__(self, **kw)
+
+    def create_artists(self, legend, orig_handle,
+                       xdescent, ydescent, width, height, fontsize,
+                       trans):
+        artists = HandlerLine2D.create_artists(self, legend, orig_handle,
+                                               xdescent, ydescent, width, height, fontsize,
+                                               trans)
+        artists[-1].set_markersize(self._uniform_size)
+        return artists
+class HandlerUniformErrorBar(HandlerErrorbar):
+    """
+    Handler for Uniform sized Error instances
+    """
+
+    def __init__(self, uniform_size, **kw):
+        self._uniform_size = uniform_size
+        HandlerErrorbar.__init__(self, **kw)
+
+    def create_artists(self, legend, orig_handle,
+                       xdescent, ydescent, width, height, fontsize,
+                       trans):
+        artists = HandlerErrorbar.create_artists(self, legend, orig_handle,
+                                                 xdescent, ydescent, width, height, fontsize,
+                                                 trans)
+        artists[-1].set_markersize(self._uniform_size)
+        return artists
+class HandlerUniformStem(HandlerStem):
+    def __init__(self, uniform_size, **kw):
+
+        HandlerStem.__init__(self, **kw)
+        self._uniform_size = uniform_size
+
+    def create_artists(self, legend, orig_handle,
+                       xdescent, ydescent, width, height, fontsize,
+                       trans):
+        artists = HandlerStem.create_artists(self, legend, orig_handle,
+                                             xdescent, ydescent,
+                                             width, height, fontsize,
+                                             trans)
+        artists[0].set_markersize(self._uniform_size)
+        return artists

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -617,6 +617,8 @@ class HandlerPolyCollection(HandlerBase):
         self.update_prop(p, orig_handle, legend)
         p.set_transform(trans)
         return [p]
+
+
 class HandlerUniformLine2D(HandlerLine2D):
     """
     Handler for Uniform sized Line2D instances
@@ -630,10 +632,13 @@ class HandlerUniformLine2D(HandlerLine2D):
                        xdescent, ydescent, width, height, fontsize,
                        trans):
         artists = HandlerLine2D.create_artists(self, legend, orig_handle,
-                                               xdescent, ydescent, width, height, fontsize,
-                                               trans)
+                                               xdescent, ydescent,
+                                               width, height,
+                                               fontsize, trans)
         artists[-1].set_markersize(self._uniform_size)
         return artists
+
+
 class HandlerUniformErrorBar(HandlerErrorbar):
     """
     Handler for Uniform sized Error instances
@@ -647,10 +652,13 @@ class HandlerUniformErrorBar(HandlerErrorbar):
                        xdescent, ydescent, width, height, fontsize,
                        trans):
         artists = HandlerErrorbar.create_artists(self, legend, orig_handle,
-                                                 xdescent, ydescent, width, height, fontsize,
-                                                 trans)
+                                                 xdescent, ydescent,
+                                                 width, height,
+                                                 fontsize, trans)
         artists[-1].set_markersize(self._uniform_size)
         return artists
+
+
 class HandlerUniformStem(HandlerStem):
     def __init__(self, uniform_size, **kw):
 
@@ -662,7 +670,7 @@ class HandlerUniformStem(HandlerStem):
                        trans):
         artists = HandlerStem.create_artists(self, legend, orig_handle,
                                              xdescent, ydescent,
-                                             width, height, fontsize,
-                                             trans)
+                                             width, height,
+                                             fontsize, trans)
         artists[0].set_markersize(self._uniform_size)
         return artists


### PR DESCRIPTION
Fix for issue #3225
The user can choose to provide the `scatter_uni_size` keyword within the call to pyplot.legend, which will set the legend handles to be of the specified size:

``` python
x1, y1 = [1, 1]
x2, y2 = [1, 2]
plt.figure()
plt.scatter(x1, y1, marker='o', label='first', s=20, c='b')
plt.scatter(x2, y2, marker='o', label='second', s=50, c='r')
plt.legend(scatter_uni_size=30)
# plt.legend(handler_map={PathCollection: lh.HandlerPathCollection()}, scatter_uni_size=30)
plt.show()
```

Switching `plt.legend(scatter_uni_size=30)` with the commented line, we see that a warning is thrown if the user provides their own custom handler, while specifying `scatter_uni_size`. In this case, `scatter_uni_size` is ignored.

In contrast with #4247, this fix works by defining a custom handler for `PathCollection` that sets the size to the one given. This fix does not modify the default mappings, as it can modify more than just the intended subplot, demonstrated by the following:

``` python
x1, y1 = [1, 1]
x2, y2 = [1, 2]
x3, y3 = [1, 1]
x4, y4 = [1, 2]

plt.figure(1)
plt.subplot(211)
plt.scatter(x1, y1, marker='o', label='first', s=20, c='b')
plt.scatter(x2, y2, marker='o', label='second', s=50., c='r')
legend.Legend.update_default_handler_map({
    PathCollection: lh.HandlerPathCollection(sizes=[30])})
plt.legend()

# Modifying the default handler mapping propagates the changes to the below as well.
plt.subplot(212)
plt.scatter(x3, y3, marker='o', label='third', s=20, c='b')
plt.scatter(x4, y4, marker='o', label='fourth', s=50, c='r')
plt.legend()
plt.show()
```

The 2nd subplot will also recieve the changes done to the default mapping. However, by replacing

``` python
legend.Legend.update_default_handler_map({
    PathCollection: lh.HandlerPathCollection(sizes=[30])})
plt.legend()
```

with

``` python
plt.legend(scatter_uni_size=30)
```

the 2nd subplot will remain unaffected. 

Tests will be implemented soon.
