### PR TITLE
Py26 format

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -161,20 +161,21 @@ for link, target in required_symlinks:
         with open(link, 'r') as content:
             delete = target == content.read()
         if delete:
-            symlink_warnings.append('deleted:  doc/{}'.format(link))
+            symlink_warnings.append('deleted:  doc/{0}'.format(link))
             os.unlink(link)
         else:
-            raise RuntimeError("doc/{} should be a directory or symlink -- it isn't")
+            raise RuntimeError("doc/{0} should be a directory or symlink -- it"
+                               " isn't")
     if not os.path.exists(link):
         if hasattr(os, 'symlink'):
             os.symlink(target, link)
         else:
-            symlink_warnings.append('files copied to {}'.format(link))
+            symlink_warnings.append('files copied to {0}'.format(link))
             shutil.copytree(os.path.join(link, '..', target), link)
 
 if sys.platform == 'win32' and len(symlink_warnings) > 0:
-    print('The following items related to symlinks will show up '+ 
-            'as spurious changes in your \'git status\':\n\t{}' 
+    print('The following items related to symlinks will show up '
+          'as spurious changes in your \'git status\':\n\t{0}'
                     .format('\n\t'.join(symlink_warnings)))
 
 parser = argparse.ArgumentParser(description='Build matplotlib docs')

--- a/examples/pylab_examples/contour_corner_mask.py
+++ b/examples/pylab_examples/contour_corner_mask.py
@@ -24,7 +24,7 @@ for i, corner_mask in enumerate(corner_masks):
     plt.subplot(1, 2, i+1)
     cs = plt.contourf(x, y, z, corner_mask=corner_mask)
     plt.contour(cs, colors='k')
-    plt.title('corner_mask = {}'.format(corner_mask))
+    plt.title('corner_mask = {0}'.format(corner_mask))
 
     # Plot grid.
     plt.grid(c='k', ls='-', alpha=0.3)

--- a/examples/pylab_examples/legend_demo3.py
+++ b/examples/pylab_examples/legend_demo3.py
@@ -6,7 +6,7 @@ x = np.linspace(0, 1)
 # Plot the lines y=x**n for n=1..4.
 ax = plt.subplot(2, 1, 1)
 for n in range(1, 5):
-    plt.plot(x, x**n, label="n={}".format(n))
+    plt.plot(x, x**n, label="n={0}".format(n))
 plt.legend(loc="upper left", bbox_to_anchor=[0, 1],
            ncol=2, shadow=True, title="Legend", fancybox=True)
 ax.get_legend().get_title().set_color("red")

--- a/examples/specialty_plots/topographic_hillshading.py
+++ b/examples/specialty_plots/topographic_hillshading.py
@@ -54,7 +54,7 @@ for col, ve in zip(axes.T, [0.1, 1, 10]):
 
 # Label rows and columns
 for ax, ve in zip(axes[0], [0.1, 1, 10]):
-    ax.set_title('{}'.format(ve), size=18)
+    ax.set_title('{0}'.format(ve), size=18)
 for ax, mode in zip(axes[:, 0], ['Hillshade', 'hsv', 'overlay', 'soft']):
     ax.set_ylabel(mode, size=18)
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -281,7 +281,7 @@ class Verbose(object):
             try:
                 fileo = open(fname, 'w')
             except IOError:
-                raise ValueError('Verbose object could not open log file "{}"'
+                raise ValueError('Verbose object could not open log file "{0}"'
                                  ' for writing.\nCheck your matplotlibrc '
                                  'verbose.fileo setting'.format(fname))
             else:

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -693,7 +693,7 @@ class Animation(object):
                       "'savefig_kwargs' as it is only currently supported "
                       "with the writers 'ffmpeg_file' and 'mencoder_file' "
                       "(writer used: "
-                      "'{}').".format(
+                      "'{0}').".format(
                           writer if isinstance(writer, six.string_types)
                           else writer.__class__.__name__))
                 savefig_kwargs.pop('bbox_inches')

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -74,10 +74,10 @@ def connection_info():
     result = []
     for manager in Gcf.get_all_fig_managers():
         fig = manager.canvas.figure
-        result.append('{} - {}'.format((fig.get_label() or
+        result.append('{0} - {0}'.format((fig.get_label() or
                                         "Figure {0}".format(manager.num)),
                                        manager.web_sockets))
-    result.append('Figures pending show: {}'.format(len(Gcf._activeQue)))
+    result.append('Figures pending show: {0}'.format(len(Gcf._activeQue)))
     return '\n'.join(result)
 
 

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -329,10 +329,10 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             self._force_full = True
             self.draw_idle()
         else:
-            handler = getattr(self, 'handle_{}'.format(e_type), None)
+            handler = getattr(self, 'handle_{0}'.format(e_type), None)
             if handler is None:
                 import warnings
-                warnings.warn('Unhandled message type {}. {}'.format(
+                warnings.warn('Unhandled message type {0}. {1}'.format(
                                                         e_type, event))
             else:
                 return handler(event)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1709,7 +1709,7 @@ class LightSource(object):
             try:
                 blend = blend_mode(rgb, intensity, **kwargs)
             except TypeError:
-                msg = '"blend_mode" must be callable or one of {}'
+                msg = '"blend_mode" must be callable or one of {0}'
                 raise ValueError(msg.format(lookup.keys))
 
         # Only apply result where hillshade intensity isn't masked

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -244,7 +244,8 @@ class MarkerStyle(object):
                 Path(marker)
                 self._marker_function = self._set_vertices
             except ValueError:
-                raise ValueError('Unrecognized marker style {}'.format(marker))
+                raise ValueError('Unrecognized marker style'
+                                 ' {0}'.format(marker))
 
         self._marker = marker
         self._recache()

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2553,7 +2553,7 @@ def rec_join(key, r1, r2, jointype='inner', defaults=None, r1postfix='1',
 
         dt2 = r2.dtype[name]
         if dt1 != dt2:
-            msg = "The '{}' fields in arrays 'r1' and 'r2' must have the same"
+            msg = "The '{0}' fields in arrays 'r1' and 'r2' must have the same"
             msg += " dtype."
             raise ValueError(msg.format(name))
         if dt1.num > dt2.num:

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -56,7 +56,7 @@ class AbstractPathEffect(object):
         for k, v in six.iteritems(new_gc_dict):
             set_method = getattr(gc, 'set_' + k, None)
             if set_method is None or not six.callable(set_method):
-                raise AttributeError('Unknown property {}'.format(k))
+                raise AttributeError('Unknown property {0}'.format(k))
             set_method(v)
         return gc
 

--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -152,7 +152,7 @@ def assert_pep8_conformance(module=matplotlib, exclude_files=None,
             raise ValueError('Some exclude patterns were unnecessary as the '
                              'files they pointed to either passed the PEP8 '
                              'tests or do not point to a file:\n  '
-                             '{}'.format('\n  '.join(unexpectedly_good)))
+                             '{0}'.format('\n  '.join(unexpectedly_good)))
 
 
 def test_pep8_conformance_installed_files():

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -97,7 +97,7 @@ def test_PathEffect_points_to_pixels():
 
     assert isinstance(pe_renderer, path_effects.PathEffectRenderer), (
                 'Expected a PathEffectRendere instance, got '
-                'a {} instance.'.format(type(pe_renderer)))
+                'a {0} instance.'.format(type(pe_renderer)))
 
     # Confirm that using a path effects renderer maintains point sizes
     # appropriately. Otherwise rendered font would be the wrong size.

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -66,7 +66,7 @@ def tripcolor(ax, *args, **kwargs):
 
     if shading not in ['flat', 'gouraud']:
         raise ValueError("shading must be one of ['flat', 'gouraud'] "
-                         "not {}".format(shading))
+                         "not {0}".format(shading))
 
     tri, args, kwargs = Triangulation.get_from_args_and_kwargs(*args, **kwargs)
 


### PR DESCRIPTION
fix few string formatting to avoid bugs with python 2.6. I hope that I got everything since grep [1] does not show me any match

[1] ``grep -r --include=*.py --exclude=.eggs/* -B 10 "\.format(" | grep {}``