### PR TITLE
Fix for unpickling polar plot issue #4068

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -112,10 +112,6 @@ class PolarAffine(Affine2DBase):
         return self._mtx
     get_matrix.__doc__ = Affine2DBase.get_matrix.__doc__
 
-    def __getstate__(self):
-        return {}
-
-
 class InvertedPolarTransform(Transform):
     """
     The inverse of the polar transform, mapping Cartesian

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -112,6 +112,7 @@ class PolarAffine(Affine2DBase):
         return self._mtx
     get_matrix.__doc__ = Affine2DBase.get_matrix.__doc__
 
+
 class InvertedPolarTransform(Transform):
     """
     The inverse of the polar transform, mapping Cartesian

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -242,6 +242,16 @@ def test_grid():
     pickle.dump(ax, BytesIO())
 
 
+@cleanup
+def test_polar():
+    ax = plt.subplot(111, polar=True)
+    fig = plt.gcf()
+    result = BytesIO()
+    pf = pickle.dumps(fig)
+    pickle.loads(pf)
+    plt.draw()
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s'])

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -126,6 +126,7 @@ def test_simple():
     pickle.dump(fig, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
 
+@cleanup
 @image_comparison(baseline_images=['multi_pickle'],
                   extensions=['png'], remove_text=True)
 def test_complete():
@@ -194,6 +195,7 @@ def test_complete():
     assert_equal(fig.get_label(), 'Figure with a label?')
 
 
+@cleanup
 def test_no_pyplot():
     # tests pickle-ability of a figure not created with pyplot
     from matplotlib.backends.backend_pdf import FigureCanvasPdf as fc
@@ -206,12 +208,14 @@ def test_no_pyplot():
     pickle.dump(fig, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
 
+@cleanup
 def test_renderer():
     from matplotlib.backends.backend_agg import RendererAgg
     renderer = RendererAgg(10, 20, 30)
     pickle.dump(renderer, BytesIO())
 
 
+@cleanup
 def test_image():
     # Prior to v1.4.0 the Image would cache data which was not picklable
     # once it had been drawn.
@@ -224,6 +228,7 @@ def test_image():
     pickle.dump(fig, BytesIO())
 
 
+@cleanup
 def test_grid():
     from matplotlib.backends.backend_agg import new_figure_manager
     manager = new_figure_manager(1000)


### PR DESCRIPTION
This implements a fix for the bug documented in issue #4068 

`PolarAffine` of `lib/matplotlib/projections/polar.py` returned an empty state when being pickled because of an unimplemented `__getstate__` function. Removing this function resolved the reported exception and restored the expected behaviour. 