### PR TITLE
correct rst syntax for code blocks

### DIFF
--- a/doc/devel/color_changes.rst
+++ b/doc/devel/color_changes.rst
@@ -74,6 +74,7 @@ above, only with a more limited luminence variation.
 Example script
 ++++++++++++++
 ::
+
    import numpy as np
    import matplotlib.pyplot as plt
 
@@ -112,6 +113,7 @@ ordering.
 Example script
 ++++++++++++++
 ::
+
    import numpy as np
    import matplotlib.pyplot as plt
 


### PR DESCRIPTION
Following the merge of The Color overhaul branch the docs build fail since code block must be surrounded by blank lines. This is both a failure due to warnings as errors on the docs build branch and causes the code blocks to be rendered incorrectly. See http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#literal-blocks