### PR TITLE
Replace use of str() with six.text_type() for Py2&3 compatibility [backport to color_overhaul]

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -137,7 +137,7 @@ def _create_qApp():
                 if display is None or not re.search(':\d', display):
                     raise RuntimeError('Invalid DISPLAY variable')
 
-            qApp = QtWidgets.QApplication([str(" ")])
+            qApp = QtWidgets.QApplication([six.text_type(" ")])
             qApp.lastWindowClosed.connect(qApp.quit)
         else:
             qApp = app
@@ -560,7 +560,7 @@ class FigureManagerQT(FigureManagerBase):
         self.window.close()
 
     def get_window_title(self):
-        return str(self.window.windowTitle())
+        return six.text_type(self.window.windowTitle())
 
     def set_window_title(self, title):
         self.window.setWindowTitle(title)
@@ -733,7 +733,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                 self.canvas.print_figure(six.text_type(fname))
             except Exception as e:
                 QtWidgets.QMessageBox.critical(
-                    self, "Error saving file", str(e),
+                    self, "Error saving file", six.text_type(e),
                     QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.NoButton)
 
 
@@ -849,7 +849,7 @@ def exception_handler(type, value, tb):
     if hasattr(value, 'strerror') and value.strerror is not None:
         msg += value.strerror
     else:
-        msg += str(value)
+        msg += six.text_type(value)
 
     if len(msg):
         error_msg_qt(msg)


### PR DESCRIPTION
Version 1 of the PyQt APIs return QVariant types that must be
cast to Python strings before use. To catch this `get_window_title()`
in `backend_qt5.py` wrapped the call to `self.window.windowTitle()`
with `str()`. This fails on Python 2 if the window title contains
unicode characters.

This is replaced with `six.text_type` for Py2&3 compatibility with
unicode types.

A number of other locations in the same file were also using `str()`
for potentially unicode data. These are also fixed in this commit.

Fixes #4275.