### PR TITLE
Added native dpi option for print_figure

### DIFF
--- a/doc/users/whats_new/updated_figure.rst
+++ b/doc/users/whats_new/updated_figure.rst
@@ -1,0 +1,9 @@
+Updated Figure.savefig()
+------------------------
+
+Added support to save the figure with the same dpi as the figure on the screen using dpi='figure'
+
+Example:
+	f = plt.figure(dpi=25)				# dpi set to 25
+	S = plt.scatter([1,2,3],[4,5,6])
+	f.savefig('output.png', dpi='figure')	# output savefig dpi set to 25 (same as figure)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2084,7 +2084,6 @@ class FigureCanvasBase(object):
 
         *dpi*
             the dots per inch to save the figure in; if None, use savefig.dpi
-            if 'native' use dpi from figure
 
         *facecolor*
             the facecolor of the figure
@@ -2128,8 +2127,6 @@ class FigureCanvasBase(object):
 
         if dpi is None:
             dpi = rcParams['savefig.dpi']
-        elif dpi == 'native':
-            dpi = self.figure.dpi
 
         origDPI = self.figure.dpi
         origfacecolor = self.figure.get_facecolor()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2084,6 +2084,7 @@ class FigureCanvasBase(object):
 
         *dpi*
             the dots per inch to save the figure in; if None, use savefig.dpi
+            if 'native' use dpi from figure
 
         *facecolor*
             the facecolor of the figure
@@ -2127,6 +2128,8 @@ class FigureCanvasBase(object):
 
         if dpi is None:
             dpi = rcParams['savefig.dpi']
+        elif dpi == 'native':
+            dpi = self.figure.dpi
 
         origDPI = self.figure.dpi
         origfacecolor = self.figure.get_facecolor()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1424,9 +1424,10 @@ class Figure(Artist):
 
         Keyword arguments:
 
-          *dpi*: [ *None* | ``scalar > 0`` ]
+          *dpi*: [ *None* | ``scalar > 0`` | 'figure']
             The resolution in dots per inch.  If *None* it will default to
-            the value ``savefig.dpi`` in the matplotlibrc file.
+            the value ``savefig.dpi`` in the matplotlibrc file. If 'figure'
+            it will set the dpi to be the value of the figure.
 
           *facecolor*, *edgecolor*:
             the colors of the figure rectangle
@@ -1473,6 +1474,8 @@ class Figure(Artist):
         """
 
         kwargs.setdefault('dpi', rcParams['savefig.dpi'])
+        if kwargs['dpi'] == 'figure':
+            kwargs['dpi'] = self.get_dpi()
         frameon = kwargs.pop('frameon', rcParams['savefig.frameon'])
         transparent = kwargs.pop('transparent',
                                  rcParams['savefig.transparent'])

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -117,6 +117,15 @@ def validate_float_or_None(s):
     except ValueError:
         raise ValueError('Could not convert "%s" to float' % s)
 
+def validate_dpi(s):
+    """confirm s is string 'figure' or convert s to float or raise"""
+    if s == 'figure':
+        return s
+    try:
+        return float(s)
+    except ValueError:
+        raise ValueError('"%s" is not string "figure" or'
+            ' could not convert "%s" to float' % (s, s))
 
 def validate_int(s):
     """convert s to int or raise"""
@@ -749,7 +758,7 @@ defaultParams = {
                                                      closedmax=False)],
 
     ## Saving figure's properties
-    'savefig.dpi':         [100, validate_float],   # DPI
+    'savefig.dpi':         [100, validate_dpi],   # DPI
     'savefig.facecolor':   ['w', validate_color],  # facecolor; white
     'savefig.edgecolor':   ['w', validate_color],  # edgecolor; white
     'savefig.frameon':     [True, validate_bool],


### PR DESCRIPTION
As per #305, Added the option to set dpi='native' in canvas.print_figure(). Doing so will set the "canvas print_figure" dpi equal to the figure dpi.