### PR TITLE
Add note about nbagg middle click button

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -15,7 +15,7 @@ graphics contexts must implement to serve as a matplotlib backend
 
 :class:`Event`
     The base class for all of the matplotlib event
-    handling.  Derived classes suh as :class:`KeyEvent` and
+    handling.  Derived classes such as :class:`KeyEvent` and
     :class:`MouseEvent` store the meta data like keys and buttons
     pressed, x and y locations in pixel and
     :class:`~matplotlib.axes.Axes` coordinates.
@@ -1499,7 +1499,9 @@ class MouseEvent(LocationEvent):
 
     *button*
         button pressed None, 1, 2, 3, 'up', 'down' (up and down are used
-        for scroll events)
+        for scroll events).  Note that in the nbagg backend, both the
+        middle and right clicks return 3 since right clicking will bring
+        up the context menu in some browsers.
 
     *key*
         the key depressed when the mouse event triggered (see

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -296,7 +296,8 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             # The right mouse button pops up a context menu, which
             # doesn't work very well, so use the middle mouse button
             # instead.  It doesn't seem that it's possible to disable
-            # the context menu in recent versions of Chrome.
+            # the context menu in recent versions of Chrome.  If this
+            # is resolved, please also adjust the docstring in MouseEvent.
             if button == 2:
                 button = 3
 


### PR DESCRIPTION
In nbagg backend right now, MouseEvent.button maps to 3 for both
middle clicks and right clicks. Added a note about this in
MouseEvent docstring.

Closes #4289 for now.

Change-Id: I1a191382191087ebb9072626c9f4dfb59c519d89