### PR TITLE
Fix FixedFormatter

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -287,10 +287,10 @@ class FixedFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         'Return the format for tick val *x* at position *pos*'
-        if pos is None or pos >= len(self.seq):
+        if x is None or x >= len(self.seq) or x < 0:
             return ''
         else:
-            return self.seq[pos]
+            return self.seq[int(np.round(x)]
 
     def get_offset(self):
         return self.offset_string


### PR DESCRIPTION
In investigating #4301, I discovered that when you set explicit tick labels, the value display in the toolbar doesn't work.  Strangely, it seems to have been this way at least since 1.1 (before that, I can't compile due to libpng API changes).

To reproduce:

```
import numpy as np
import seaborn as sns
import matplotlib.pyplot as plt

f, ax = plt.subplots(figsize=(9, 9))
plt.plot(np.arange(100))
plt.gca().set_xticklabels(['foo %s' % i for i in range(100)])
plt.show()
```

Looking at the FixedFormatter code, it seems that it's supposed to be keying the values from a kwarg `pos`, but I can't see anywhere in the code where `pos` is being passed...

Does this change make sense?  I think probably not, but it's broken as it stands in any event...

Cc: @efiring 
