### PR TITLE
Improve error message when freetype headers are not found using python3

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -428,7 +428,9 @@ class SetupPackage(object):
         `min_version` is the minimum version required.
 
         `version` will override the found version if this package
-        requires an alternate method for that.
+        requires an alternate method for that. Set version='unknown'
+        if the version is not known but you still want to disabled
+        pkg_config version check.
         """
         if version is None:
             version = pkg_config.get_version(package)
@@ -442,7 +444,7 @@ class SetupPackage(object):
             raise CheckFailed(
                 "Requires patches that have not been merged upstream.")
 
-        if min_version:
+        if min_version and version != 'unknown':
             if (not is_min_version(version, min_version)):
                 raise CheckFailed(
                     "Requires %s %s or later.  Found %s." %
@@ -895,12 +897,15 @@ class FreeType(SetupPackage):
         if version is None or 'No such file or directory\ngrep:' in version:
             version = self.version_from_header()
 
+        # pkg_config returns the libtool version rather than the
+        # freetype version so we need to explicitly pass the version
+        # to _check_for_pkg_config
         return self._check_for_pkg_config(
             'freetype2', 'ft2build.h',
             min_version='2.3', version=version)
 
     def version_from_header(self):
-        version = 'Failed to identify version.'
+        version = 'unknown'
         ext = self.get_extension()
         if ext is None:
             return version


### PR DESCRIPTION
Make it possible to disable the pgk-config version check even when a version is not known and use this with freetype.

This avoids trying to compare numbers to a string when the freetype version
cound not be found from headers or freetype-config. pgk-config is useless
for detecting the freetype version since it returns the libtool version and not the freetype version.

The result when freetype is not found is now (both python 2 and 3)
```
freetype: no  [The C/C++ header for freetype2 (ft2build.h)
                        could not be found.  You may need to install the
                        development package.]
```

There is still scope for some larger improvements in the setupext.py code but these are the minimum changes needed to fix the issue  reported at the mailing list here http://matplotlib.1069221.n5.nabble.com/matplotlib-devel-1-4-3-does-not-build-on-Ubuntu-14-with-python3-td45301.html

We might want to backport this to color_overhaul 