### PR TITLE
fixes #2885, #3935, #3693, for hatched fill

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -490,7 +490,7 @@ class RendererPgf(RendererBase):
 
             # combine clip and path for clipping
             self._print_pgf_clip(gc)
-            self._print_pgf_path(gc, path, transform)
+            self._print_pgf_path(gc, path, transform, rgbFace)
             writeln(self.fh, r"\pgfusepath{clip}")
 
             # build pattern definition


### PR DESCRIPTION
The last patch only removed clipping for the colour fill, hatches in fill_between were still clipped. Passing through rgbFace fixes this.