### PR TITLE
DOC: Note about pixel placement in imshow

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4682,6 +4682,12 @@ class Axes(_AxesBase):
         See also
         --------
         matshow : Plot a matrix or an array as an image.
+        
+        Notes
+        -----
+        Unless *extent* is used, pixel centers will be located at integer
+        coordinates. In other words: the origin will coincide with the center
+        of pixel (0, 0).
 
         Examples
         --------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4682,7 +4682,7 @@ class Axes(_AxesBase):
         See also
         --------
         matshow : Plot a matrix or an array as an image.
-        
+
         Notes
         -----
         Unless *extent* is used, pixel centers will be located at integer


### PR DESCRIPTION
For my work on feature finding in trackpy, I was confused about how `imshow` places pixels on the plot. There does appear to be a comment about that in the `extent` parameter docstring, but I think it deserves extra attention in a note. @tacaswell asked me for this PR to make this clearer.