### PR TITLE
Fix lw float cast

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1041,7 +1041,7 @@ class GraphicsContextBase(object):
         """
         Set the linewidth in points
         """
-        self._linewidth = w
+        self._linewidth = float(w)
 
     def set_linestyle(self, style):
         """

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -407,7 +407,7 @@ class GraphicsContextCairo(GraphicsContextBase):
 
 
     def set_linewidth(self, w):
-        self._linewidth = w
+        self._linewidth = float(w)
         self.ctx.set_line_width (self.renderer.points_to_pixels(w))
 
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -259,6 +259,7 @@ class RendererPS(RendererBase):
             if store: self.color = (r,g,b)
 
     def set_linewidth(self, linewidth, store=1):
+        linewidth = float(linewidth)
         if linewidth != self.linewidth:
             self._pswriter.write("%1.3f setlinewidth\n"%linewidth)
             if store: self.linewidth = linewidth
@@ -451,10 +452,10 @@ class RendererPS(RendererBase):
         ps backend support arbitrary scaling of image.
         """
         return True
-        
+
     def option_image_nocomposite(self):
         """
-        return whether to generate a composite image from multiple images on 
+        return whether to generate a composite image from multiple images on
         a set of axes
         """
         return not rcParams['image.composite_image']

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -560,10 +560,12 @@ class GraphicsContextWx(GraphicsContextBase):
         """
         DEBUG_MSG("set_linewidth()", 1, self)
         self.select()
-        if w>0 and w<1: w = 1
+        if w > 0 and w < 1:
+            w = 1
         GraphicsContextBase.set_linewidth(self, w)
         lw = int(self.renderer.points_to_pixels(self._linewidth))
-        if lw==0: lw = 1
+        if lw == 0:
+            lw = 1
         self._pen.SetWidth(lw)
         self.gfx_ctx.SetPen(self._pen)
         self.unselect()
@@ -789,12 +791,12 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         """
         DEBUG_MSG("draw_idle()", 1, self)
         self._isDrawn = False  # Force redraw
-        
+
         # Triggering a paint event is all that is needed to defer drawing
         # until later. The platform will send the event when it thinks it is
         # a good time (usually as soon as there are no other events pending).
         self.Refresh(eraseBackground=False)
-        
+
     def draw(self, drawDC=None):
         """
         Render the figure using RendererWx instance renderer, or using a
@@ -1739,7 +1741,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         color.Set(r,g,b, 0x60)
         dc.SetBrush(wx.Brush(color))
         dc.DrawRectangleRect(rect)
-        
+
 
     def set_status_bar(self, statbar):
         self.statbar = statbar

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -558,6 +558,7 @@ class GraphicsContextWx(GraphicsContextBase):
         """
         Set the line width.
         """
+        w = float(w)
         DEBUG_MSG("set_linewidth()", 1, self)
         self.select()
         if w > 0 and w < 1:

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -919,7 +919,7 @@ class Line2D(Artist):
 
         ACCEPTS: float value in points
         """
-        self._linewidth = w
+        self._linewidth = float(w)
 
     def set_linestyle(self, linestyle):
         """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -334,7 +334,7 @@ class Patch(artist.Artist):
         """
         if w is None:
             w = mpl.rcParams['patch.linewidth']
-        self._linewidth = w
+        self._linewidth = float(w)
 
     def set_lw(self, lw):
         """alias for set_linewidth"""


### PR DESCRIPTION
there is a `set_linewidth` in `backend_gdk.py`, but it calls the parent class `set_linewdith` which already has the needed cast.