### PR TITLE
Write status message in single line in Qt toolbar.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -676,7 +676,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
     def set_message(self, s):
         self.message.emit(s)
         if self.coordinates:
-            self.locLabel.setText(s.replace(', ', '\n'))
+            self.locLabel.setText(s)
 
     def set_cursor(self, cursor):
         if DEBUG:


### PR DESCRIPTION
Currently, the status message is partially hidden when embedding a
Toolbar in a Qt4 app (see e.g. embedding_in_qt4_wtoolbar.py: activate
the pan tool and hover the mouse over the figure; the two lines of the
status messages don't fit in the toolbar).

The split-line message was introduced in 3c61684 to avoid automatic
horizontal expansion of the toolbar in presence of long messages (I
guess) but I cannot reproduce that issue right now.