### PR TITLE
Add tick_values method to the date Locators

### DIFF
--- a/doc/api/api_changes/2015-04-12_microsecondlocator.rst
+++ b/doc/api/api_changes/2015-04-12_microsecondlocator.rst
@@ -1,0 +1,17 @@
+Removed `args` and `kwargs` from `MicrosecondLocator.__call__`
+``````````````````````````````````````````````````````````````
+
+The call signature of :meth:`~matplotlib.dates.MicrosecondLocator.__call__`
+has changed from `__call__(self, *args, **kwargs)` to `__call__(self)`.
+This is consistent with the super class :class:`~matplotlib.ticker.Locator`
+and also all the other Locators derived from this super class.
+
+
+No `ValueError` for the MicrosecondLocator and YearLocator
+``````````````````````````````````````````````````````````
+
+The :class:`~matplotlib.dates.MicrosecondLocator` and
+:class:`~matplotlib.dates.YearLocator` objects when called will return
+an empty list if the axes have no data or the view has no interval.
+Previously, they raised a `ValueError`. This is consistent with all
+the Date Locators.

--- a/doc/users/whats_new/datelocators.rst
+++ b/doc/users/whats_new/datelocators.rst
@@ -1,0 +1,15 @@
+Date Locators
+-------------
+
+Date Locators (derived from :class:`~matplotlib.dates.DateLocator`) now
+implement the :meth:`~matplotlib.tickers.Locator.tick_values` method.
+This is expected of all Locators derived from :class:`~matplotlib.tickers.Locator`.
+
+The Date Locators can now be used easily without creating axes
+
+    from datetime import datetime
+    from matplotlib.dates import YearLocator
+    t0 = datetime(2002, 10, 9, 12, 10)
+    tf = datetime(2005, 10, 9, 12, 15)
+    loc = YearLocator()
+    values = loc.tick_values(t0, tf)


### PR DESCRIPTION
*Issue*
Date Locators are a subclass of `matplotlib.ticker.Locator` and they should override the `tick_values` method. This method allows Locators to be queried for tick locations using two limits. Without `tick_values` this only axes with data on them can get tick locations by calling on the `Locator`
object. Or the user has to go through the hussle of creating dummy axes, add data to them, then use `Locator`.

*Problem*
The date Locators have implemented the tick generation logic in the `__call__` method. This is in contrast with the `Locators` implemented in `matplotlib.ticker` for which the `__call__` method gets the limits from the axes and then lets `tick_values` to do the the rest.

*Solution*
- Have the `__call__` method of the date Locators get the limits and let `tick_values` do the calculations.
- Make `MicrosecondLocator.__call__` access the axes using the same helper method that the other date Locators use.
- For the tests, `matplotlib.tests.test_dates:test_auto_date_locator` is still appropriate. All the Locators are tested in there.