### PR TITLE
decode the execution path string based file system encoding

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -668,7 +668,7 @@ def _get_data_path():
                                'directory')
         return path
     
-    _file=_decode_filesystem_path(__file__)
+    _file = _decode_filesystem_path(__file__)
     path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path
@@ -676,7 +676,7 @@ def _get_data_path():
     # setuptools' namespace_packages may highjack this init file
     # so need to try something known to be in matplotlib, not basemap
     import matplotlib.afm
-    _file=_decode_filesystem_path(matplotlib.afm.__file__)
+    _file = _decode_filesystem_path(matplotlib.afm.__file__)
     path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -652,11 +652,13 @@ def _get_cachedir():
 
 get_cachedir = verbose.wrap('CACHEDIR=%s', _get_cachedir, always=False)
 
+
 def _decode_filesystem_path(path):
     if isinstance(path, bytes):
         return path.decode(sys.getfilesystemencoding())
     else:
         return path
+
 
 def _get_data_path():
     'get the path to matplotlib data'
@@ -667,7 +669,7 @@ def _get_data_path():
             raise RuntimeError('Path in environment MATPLOTLIBDATA not a '
                                'directory')
         return path
-    
+
     _file = _decode_filesystem_path(__file__)
     path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -652,6 +652,11 @@ def _get_cachedir():
 
 get_cachedir = verbose.wrap('CACHEDIR=%s', _get_cachedir, always=False)
 
+def _decode_filesystem_path(path):
+    if isinstance(path, bytes):
+        return path.decode(sys.getfilesystemencoding())
+    else:
+        return path
 
 def _get_data_path():
     'get the path to matplotlib data'
@@ -662,11 +667,8 @@ def _get_data_path():
             raise RuntimeError('Path in environment MATPLOTLIBDATA not a '
                                'directory')
         return path
-
-    if hasattr(__file__, 'decode'):
-        _file = __file__.decode(sys.getfilesystemencoding())
-    else:
-        _file = __file__
+    
+    _file=_decode_filesystem_path(__file__)
     path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path
@@ -674,21 +676,14 @@ def _get_data_path():
     # setuptools' namespace_packages may highjack this init file
     # so need to try something known to be in matplotlib, not basemap
     import matplotlib.afm
-    if hasattr(matplotlib.afm.__file__, 'decode'):
-        _file = matplotlib.afm.__file__.decode(sys.getfilesystemencoding())
-    else:
-        _file = matplotlib.afm.__file__
+    _file=_decode_filesystem_path(matplotlib.afm.__file__)
     path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path
 
     # py2exe zips pure python, so still need special check
     if getattr(sys, 'frozen', None):
-        if hasattr(sys.executable, 'decode'):
-            _file = sys.executable.decode(sys.getfilesystemencoding())
-        else:
-            _file = sys.executable
-        exe_path = os.path.dirname(_file)
+        exe_path = os.path.dirname(_decode_filesystem_path(sys.executable))
         path = os.path.join(exe_path, 'mpl-data')
         if os.path.isdir(path):
             return path

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -664,9 +664,9 @@ def _get_data_path():
         return path
 
     if hasattr(__file__, 'decode'):
-        _file=__file__.decode(sys.getfilesystemencoding())
+        _file = __file__.decode(sys.getfilesystemencoding())
     else:
-        _file=__file__
+        _file = __file__
     path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path
@@ -675,9 +675,9 @@ def _get_data_path():
     # so need to try something known to be in matplotlib, not basemap
     import matplotlib.afm
     if hasattr(matplotlib.afm.__file__, 'decode'):
-        _file=matplotlib.afm.__file__.decode(sys.getfilesystemencoding())
+        _file = matplotlib.afm.__file__.decode(sys.getfilesystemencoding())
     else:
-        _file=matplotlib.afm.__file__
+        _file = matplotlib.afm.__file__
     path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path
@@ -685,9 +685,9 @@ def _get_data_path():
     # py2exe zips pure python, so still need special check
     if getattr(sys, 'frozen', None):
         if hasattr(sys.executable, 'decode'):
-            _file=sys.executable.decode(sys.getfilesystemencoding())
+            _file = sys.executable.decode(sys.getfilesystemencoding())
         else:
-            _file=sys.executable
+            _file = sys.executable
         exe_path = os.path.dirname(_file)
         path = os.path.join(exe_path, 'mpl-data')
         if os.path.isdir(path):

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -663,20 +663,32 @@ def _get_data_path():
                                'directory')
         return path
 
-    path = os.sep.join([os.path.dirname(__file__.decode(sys.getfilesystemencoding())), 'mpl-data'])
+    if hasattr(__file__, 'decode'):
+        _file=__file__.decode(sys.getfilesystemencoding())
+    else:
+        _file=__file__
+    path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path
 
     # setuptools' namespace_packages may highjack this init file
     # so need to try something known to be in matplotlib, not basemap
     import matplotlib.afm
-    path = os.sep.join([os.path.dirname(matplotlib.afm.__file__.decode(sys.getfilesystemencoding())), 'mpl-data'])
+    if hasattr(matplotlib.afm.__file__, 'decode'):
+        _file=matplotlib.afm.__file__.decode(sys.getfilesystemencoding())
+    else:
+        _file=matplotlib.afm.__file__
+    path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
     if os.path.isdir(path):
         return path
 
     # py2exe zips pure python, so still need special check
     if getattr(sys, 'frozen', None):
-        exe_path = os.path.dirname(sys.executable.decode(sys.getfilesystemencoding()))
+        if hasattr(sys.executable, 'decode'):
+            _file=sys.executable.decode(sys.getfilesystemencoding())
+        else:
+            _file=sys.executable
+        exe_path = os.path.dirname(_file)
         path = os.path.join(exe_path, 'mpl-data')
         if os.path.isdir(path):
             return path

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -663,20 +663,20 @@ def _get_data_path():
                                'directory')
         return path
 
-    path = os.sep.join([os.path.dirname(__file__), 'mpl-data'])
+    path = os.sep.join([os.path.dirname(__file__.decode(sys.getfilesystemencoding())), 'mpl-data'])
     if os.path.isdir(path):
         return path
 
     # setuptools' namespace_packages may highjack this init file
     # so need to try something known to be in matplotlib, not basemap
     import matplotlib.afm
-    path = os.sep.join([os.path.dirname(matplotlib.afm.__file__), 'mpl-data'])
+    path = os.sep.join([os.path.dirname(matplotlib.afm.__file__.decode(sys.getfilesystemencoding())), 'mpl-data'])
     if os.path.isdir(path):
         return path
 
     # py2exe zips pure python, so still need special check
     if getattr(sys, 'frozen', None):
-        exe_path = os.path.dirname(sys.executable)
+        exe_path = os.path.dirname(sys.executable.decode(sys.getfilesystemencoding()))
         path = os.path.join(exe_path, 'mpl-data')
         if os.path.isdir(path):
             return path


### PR DESCRIPTION
When my py file importing matplotlib run in a folder where the path contains gbk encoding character, matplotlib will raise a unicode decode error.The changes in line 666/673/679 will fix the problem.