### PR TITLE
STY: update example with preferred plt.subplots

### DIFF
--- a/examples/animation/bayes_update.py
+++ b/examples/animation/bayes_update.py
@@ -40,8 +40,7 @@ class UpdateDist(object):
         self.line.set_data(self.x, y)
         return self.line,
 
-fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1)
+fig, ax = plt.subplots()
 ud = UpdateDist(ax, prob=0.7)
 anim = FuncAnimation(fig, ud, frames=np.arange(100), init_func=ud.init,
                      interval=100, blit=True)


### PR DESCRIPTION
Tweaked bayes_update.py to conform with preference for ``fig, ax = plt.subplots()``