### PR TITLE
API/FIX : don't accept None for x or y in plot

### DIFF
--- a/doc/api/api_changes/2015-04-08_plot_noNone.rst
+++ b/doc/api/api_changes/2015-04-08_plot_noNone.rst
@@ -1,0 +1,15 @@
+Disallow ``None`` as x or y value in ax.plot
+````````````````````````````````````````````
+
+Do not allow ``None`` as a valid input for the ``x`` or ``y`` args in
+`ax.plot`.  This may break some user code, but this was never officially
+supported (ex documented) and allowing ``None`` objects through can lead
+to confusing exceptions downstream.
+
+To create an empty line use ::
+
+  ln1, = ax.plot([], [], ...)
+  ln2, = ax.plot([], ...)
+
+In either case to update the data in the `Line2D` object you must update
+both the ``x`` and ``y`` data.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -263,6 +263,13 @@ class _process_plot_var_args(object):
             raise ValueError('third arg must be a format string')
         else:
             linestyle, marker, color = None, None, None
+
+        # Don't allow any None value; These will be up-converted
+        # to one element array of None which causes problems
+        # downstream.
+        if any(v is None for v in tup):
+            raise ValueError("x and y must not be None")
+
         kw = {}
         for k, v in zip(('linestyle', 'marker', 'color'),
                         (linestyle, marker, color)):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3668,6 +3668,13 @@ def test_bar_negative_width():
         assert_equal(b._height, indx + 1)
 
 
+@cleanup
+def test_no_None():
+    fig, ax = plt.subplots()
+    assert_raises(ValueError, plt.plot, None)
+    assert_raises(ValueError, plt.plot, None, None)
+
+
 if __name__ == '__main__':
     import nose
     import sys


### PR DESCRIPTION
This addresses #4339 by preventing it.

Other option are to convert`None` -> `np.nan`.