### PR TITLE
STY: update example with preferred plt.subplots()

### DIFF
--- a/examples/images_contours_and_fields/streamplot_demo_features.py
+++ b/examples/images_contours_and_fields/streamplot_demo_features.py
@@ -16,13 +16,14 @@ U = -1 - X**2 + Y
 V = 1 + X - Y**2
 speed = np.sqrt(U*U + V*V)
 
-plt.streamplot(X, Y, U, V, color=U, linewidth=2, cmap=plt.cm.autumn)
-plt.colorbar()
+fig0, ax0 = plt.subplots()
+strm = ax0.streamplot(X, Y, U, V, color=U, linewidth=2, cmap=plt.cm.autumn)
+fig0.colorbar(strm.lines)
 
-f, (ax1, ax2) = plt.subplots(ncols=2)
+fig1, (ax1, ax2) = plt.subplots(ncols=2)
 ax1.streamplot(X, Y, U, V, density=[0.5, 1])
 
-lw = 5*speed/speed.max()
+lw = 5*speed / speed.max()
 ax2.streamplot(X, Y, U, V, density=0.6, color='k', linewidth=lw)
 
 plt.show()


### PR DESCRIPTION
* Edit first example in streamplot_demo_features.py to conform with preference for `fig, ax = plt.subplots()`, tweaking style of second example for consistency.

* Add whitespace around `/` operator for readability (can revert this if preferred).