### PR TITLE
Change documentation of legend to reflect default upper-right

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -288,7 +288,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        loc : int or string or pair of floats, default: 0
+        loc : int or string or pair of floats, default: 'upper right'
             The location of the legend. Possible codes are:
 
                 ===============   =============


### PR DESCRIPTION
The documentation states that the default legend position is 0, which would position it at the "best" place. I've actually believed this and assumed that legend positioning was broken before (if the default is "best", then why bother setting it manually?), but after digging found that this is not the case.

The actual default is controlled at 
https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/legend.py#L315
which takes the `None` default and pulls the `rcParam["legend.loc"]` which defaults to "upper right". The defaults code actually mentions at
https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/rcsetup.py#L663
that it should be changed at some point, but I don't know the reasoning for that so the documentation fix seemed the easiest way.

This literally just changes the docstring to match the current behavior; an alternate patch would be to actually change the default to reflect the documentation.