### PR TITLE
cbook.is_sequence_of_strings knows string objects

### DIFF
--- a/doc/users/whats_new/cbook.rst
+++ b/doc/users/whats_new/cbook.rst
@@ -1,0 +1,18 @@
+cbook.is_sequence_of_strings recognizes string objects
+``````````````````````````````````````````````````````
+
+This is primarily how pandas stores a sequence of strings.
+
+    import pandas as pd
+    import matplotlib.cbook as cbook
+
+    a = np.array(['a', 'b', 'c'])
+    print(cbook.is_sequence_of_strings(a))  # True
+
+    a = np.array(['a', 'b', 'c'], dtype=object)
+    print(cbook.is_sequence_of_strings(a))  # True
+
+    s = pd.Series(['a', 'b', 'c'])
+    print(cbook.is_sequence_of_strings(s))  # True
+
+Previously, the last two prints returned false.

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -783,8 +783,12 @@ def is_sequence_of_strings(obj):
     """
     if not iterable(obj):
         return False
-    if is_string_like(obj):
-        return False
+    if is_string_like(obj) and not isinstance(obj, np.ndarray):
+        try:
+            obj = obj.values
+        except AttributeError:
+            # not pandas
+            return False
     for o in obj:
         if not is_string_like(o):
             return False

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -26,6 +26,23 @@ def test_is_string_like():
     assert cbook.is_string_like("hello world")
     assert_equal(cbook.is_string_like(10), False)
 
+    y = ['a', 'b', 'c']
+    assert_equal(cbook.is_string_like(y), False)
+
+    y = np.array(y)
+    assert_equal(cbook.is_string_like(y), False)
+
+    y = np.array(y, dtype=object)
+    assert cbook.is_string_like(y)
+
+
+def test_is_sequence_of_strings():
+    y = ['a', 'b', 'c']
+    assert cbook.is_sequence_of_strings(y)
+
+    y = np.array(y, dtype=object)
+    assert cbook.is_sequence_of_strings(y)
+
 
 def test_restrict_dict():
     d = {'foo': 'bar', 1: 2}


### PR DESCRIPTION
**Issue**
`cbook.is_sequence_of_strings` cannot tell of a pandas series is contains strings. Pandas series are numpy arrays of type `object`.

**Problem**
`cbook.is_sequence_of_strings` uses `cbook.is_string_like` to dismiss strings as not sequences of strings. However, numpy string arrays of `dtype=object` are string-like since they support string concatenation.

**Solution**
Do not dismiss an `ndarray` if it appears string-like, go ahead and peak inside.

**For reviewer**
- https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/cbook.py#L763-L791
- Another alternative would be to have numpy string arrays of `dtype=object` to be *not* string-like but this is probably more destructive as `is_string_like` appears over 100 times in the code base, vs `is_sequence_of_strings` which is used only [two](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/blocking_input.py#L43) [times](https://github.com/matplotlib/matplotlib/blob/master/lib/mpl_toolkits/mplot3d/axes3d.py#L2231).