### PR TITLE
fix rcParams legend.facecolor and edgecolor never being used

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -357,8 +357,8 @@ class Legend(Artist):
 
         self.legendPatch = FancyBboxPatch(
             xy=(0.0, 0.0), width=1., height=1.,
-            facecolor=rcParams["axes.facecolor"],
-            edgecolor=rcParams["axes.edgecolor"],
+            facecolor=facecolor,
+            edgecolor=edgecolor,
             mutation_scale=self._fontsize,
             snap=True
             )


### PR DESCRIPTION
They were correctly read from rcParams, but ignored after that. See the old code : 

<pre>
if rcParams["legend.facecolor"] == 'inherit':
    facecolor = rcParams["axes.facecolor"]
else:
    facecolor = rcParams["legend.facecolor"]

if rcParams["legend.edgecolor"] == 'inherit':
    edgecolor = rcParams["axes.edgecolor"]
else:
    edgecolor = rcParams["legend.edgecolor"]

self.legendPatch = FancyBboxPatch(
    xy=(0.0, 0.0), width=1., height=1.,
<b>    facecolor=rcParams["axes.facecolor"],
    edgecolor=rcParams["axes.edgecolor"],</b>
    mutation_scale=self._fontsize,
    snap=True
    )
</pre>