### PR TITLE
DOC: cp missing `manage_xticks` from `bxp` to `boxplot` docstring [backport]

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3077,6 +3077,9 @@ class Axes(_AxesBase):
             *meanprops*. Not recommended if *shownotches* is also True.
             Otherwise, means will be shown as points.
 
+          manage_xticks : bool, default = True
+            If the function should adjust the xlim and xtick locations.
+
         Returns
         -------
 


### PR DESCRIPTION
An entry for `manage_xticks` appears to not have been added in bdda1d505d58694145cd2c794a16f5579e64dea5 that created this argument. Not sure if this was intentional, but from the duplication of information in the docstrings of `pyplot.bxp` and `pyplot.boxplot`, likely not. Relevant discussion in #2922.