### PR TITLE
Memory leak for Cursor useblit=True on PySide/Python3

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -125,6 +125,10 @@ class FigureCanvasQTAggBase(object):
             stringBuffer = reg.to_string_argb()
             qImage = QtGui.QImage(stringBuffer, w, h,
                                   QtGui.QImage.Format_ARGB32)
+            # Adjust the stringBuffer reference count to work around a memory leak bug
+            # in QImage() under PySide on Python 3.x
+            ctypes.c_long.from_address(id(stringBuffer)).value=1
+            
             pixmap = QtGui.QPixmap.fromImage(qImage)
             p = QtGui.QPainter(self)
             p.drawPixmap(QtCore.QPoint(l, self.renderer.height-t), pixmap)


### PR DESCRIPTION
There is a memory leak in PySide under Python3. When creating
QImage objects from a data buffer the reference to the buffer
is not released. This leads to a memory leak when moving the
cursor around the window, and eventually a crash.

A workaround is to manually set the reference counter to the
correct value `1` after creating the QImage object. This is
a temporary local variable, and no side effects are expected.

This is a fix for bug #4283 