### PR TITLE
Fix Line2D function set_markersize so it doesn't fail if given a string ...

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1036,7 +1036,7 @@ class Line2D(Artist):
 
         ACCEPTS: float
         """
-        self._markersize = sz
+        self._markersize = float(sz)
 
     def set_xdata(self, x):
         """


### PR DESCRIPTION
...instead of a float.

I ran into an issue in my wxPython GUI where plotting fails because set_markersize is passed a string instead of a float.  I wasn't able to figure out where the string argument was coming from, but this simple fix gets rid of the problem.  

Here is the end of the error traceback I was getting:

  File "/Users/xxxx/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib/lines.py", line 752, in draw
    snap = renderer.points_to_pixels(self._markersize) >= snap
  File "/Users/xxxx/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/matplotlib/backends/backend_agg.py", line 299, in points_to_pixels
    return points*self.dpi/72.0
TypeError: can't multiply sequence by non-int of type 'float'