### PR TITLE
Travis docs fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,9 @@ after_failure:
     cd $TRAVIS_BUILD_DIR/../tmp_test_dir
     tar cjf result_images.tar.bz2 result_images
     travis-artifacts upload --path result_images.tar.bz2
-    echo "The result images will only be uploaded if they are on the matplotlib/matplotlib repo - this is for security reasons to prevent arbitrary PRs echoing security details." else echo https://s3.amazonaws.com/matplotlib-test-results/artifacts/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/result_images.tar.bz2
+    echo https://s3.amazonaws.com/matplotlib-test-results/artifacts/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/result_images.tar.bz2
+  else
+    echo "The result images will only be uploaded if they are on the matplotlib/matplotlib repo - this is for security reasons to prevent arbitrary PRs echoing security details."
   fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ after_failure:
 
 after_success:
   |
-  if [[ $TRAVIS_PULL_REQUEST == false && $BUILD_DOCS == true && $TRAVIS_BRANCH == 'master' ]]; then
+  if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' && $BUILD_DOCS == true && $TRAVIS_BRANCH == 'master' ]]; then
     cd $TRAVIS_BUILD_DIR
     echo "Uploading documentation"
     openssl aes-256-cbc -K $encrypted_cc802e084cd0_key -iv $encrypted_cc802e084cd0_iv -in .travis/matplotlibDeployKey.enc -out .travis/matplotlibDeployKey -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,18 +49,20 @@ install:
   # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
   # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
   # version since is it basically just a .ttf file
+  # The current Travis Ubuntu image is to old to search .local/share/fonts so we store fonts in .fonts
 
   # We install ipython to use the console highlighting. From IPython 3 this depends on jsonschema and misture.
   # Neihter is installed as a dependency of IPython since they are not used by the IPython console.
   - |
     if [[ $BUILD_DOCS == true ]]; then
       pip install numpydoc linkchecker ipython jsonschema mistune
-      wget https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true
+      wget https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O Felipa-Regular.ttf
       wget http://mirrors.kernel.org/ubuntu/pool/universe/f/fonts-humor-sans/fonts-humor-sans_1.0-1_all.deb
       mkdir -p tmp
+      mkdir -p ~/.fonts
       dpkg -x fonts-humor-sans_1.0-1_all.deb tmp
-      cp tmp/usr/share/fonts/truetype/humor-sans/Humor-Sans.ttf ~/.local/share/fonts/
-      cp Felipa-Regular.ttf ~/.local/share/fonts/
+      cp tmp/usr/share/fonts/truetype/humor-sans/Humor-Sans.ttf ~/.fonts
+      cp Felipa-Regular.ttf ~/.fonts
       fc-cache -f -v
     fi;
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: BUILD_DOCS=true
 
 install:
-  - pip install -q --use-mirrors nose python-dateutil $NUMPY pep8 pyparsing pillow sphinx!=1.3.0
+  - pip install -q nose python-dateutil $NUMPY pep8 pyparsing pillow sphinx!=1.3.0
 
   # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
   # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
@@ -55,7 +55,8 @@ install:
   # Neihter is installed as a dependency of IPython since they are not used by the IPython console.
   - |
     if [[ $BUILD_DOCS == true ]]; then
-      pip install numpydoc linkchecker ipython jsonschema mistune
+      pip install numpydoc ipython jsonschema mistune
+      pip install -q linkchecker
       wget https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O Felipa-Regular.ttf
       wget http://mirrors.kernel.org/ubuntu/pool/universe/f/fonts-humor-sans/fonts-humor-sans_1.0-1_all.deb
       mkdir -p tmp


### PR DESCRIPTION
A few tweaks to Travis following the Container build merged in #4355 

* pip --use-mirrors is Deprecated and AFAIK not needed so remove.
* use pip -q on linkchecker which generates a lot of output (We can completely remove -q when travis upgrade to pip 6.1 which suppresses output.)
* Fix issue with copying font files. On this version of Ubuntu they need to go into ~/.fonts The file downloaded from github got a ?raw=true appended confusing the script. 
* Add TRAVIS_REPO_SLUG == 'matplotlib/matplotlib to docs upload to match other builds
* Reorder echo output when tests fails to be more logical. 