### PR TITLE
TST : suppress  all of the success messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
       export MPL_REPO_DIR=$PWD  # needed for pep8-conformance test of the examples
       mkdir ../tmp_test_dir
       cd ../tmp_test_dir
-      gdb -return-child-result -batch -ex r -ex bt --args python ../matplotlib/tests.py -sv --processes=$NPROC --process-timeout=300 $TEST_ARGS
+      gdb -return-child-result -batch -ex r -ex bt --args python ../matplotlib/tests.py -sv --processes=$NPROC --process-timeout=300 $TEST_ARGS -q
     else
       cd doc
       python make.py html --small --warningsaserrors


### PR DESCRIPTION
We don't need to see all of the test ok lines (which make the output too long to fit in the main travis ui).