### PR TITLE
FIX : hide ref counting violence unless needed

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -23,7 +23,7 @@ from .backend_qt5 import show
 from .backend_qt5 import draw_if_interactive
 from .backend_qt5 import backend_version
 ######
-
+from .qt_compat import QT_API
 
 DEBUG = False
 
@@ -127,7 +127,8 @@ class FigureCanvasQTAggBase(object):
                                   QtGui.QImage.Format_ARGB32)
             # Adjust the stringBuffer reference count to work around a memory
             # leak bug in QImage() under PySide on Python 3.x
-            ctypes.c_long.from_address(id(stringBuffer)).value = 1
+            if QT_API == 'PySide' and six.PY3:
+                ctypes.c_long.from_address(id(stringBuffer)).value = 1
 
             pixmap = QtGui.QPixmap.fromImage(qImage)
             p = QtGui.QPainter(self)


### PR DESCRIPTION
Hide the violence added in 078ddc179ca1656b6dc023604d26b0dc076f49d2 to
ref counting on temporary QImage objects which prevents a memory leak
under PySide and py3k.

This seems to break blitting under PyQt4 and python3 resulting in
a

  *** Error in `python': corrupted double-linked list:
      0x00000000024a9940 ***

error which kills the gui.

This needs testing on more platforms (only have done pyqt4 + py3k as of now)

attn @mfitzp