### PR TITLE
FIX : fix mis-matched new/delete in CXX

### DIFF
--- a/extern/CXX/Python2/ExtensionType.hxx
+++ b/extern/CXX/Python2/ExtensionType.hxx
@@ -125,7 +125,7 @@ namespace Py
 
         ~ExtensionClassMethodsTable()
         {
-            delete m_methods_table;
+            delete[] m_methods_table;
         }
 
         // check that all methods added are unique


### PR DESCRIPTION
The problem here is that the constructor for
ExtensionClassMethodsTable() is allocating an array of m_methods_table,
so it should be deallocated with delete[].