### PR TITLE
capsize with default in matplotlibrc

### DIFF
--- a/doc/users/whats_new/rcparams.rst
+++ b/doc/users/whats_new/rcparams.rst
@@ -1,3 +1,8 @@
+Added ``errorbar.capsize`` key to rcParams
+``````````````````````````````````````````
+Controls the length of end caps on error bars. If set to zero, errorbars
+are turned off by default.
+
 Added ``xtick.minor.visible`` and ``ytick.minor.visible`` key to rcParams
 `````````````````````````````````````````````````````````````````````````
 Two new keys to control the minor ticks on x/y axis respectively, default set to ``False`` (no minor ticks on the axis).

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2596,7 +2596,7 @@ class Axes(_AxesBase):
         Call signature::
 
           errorbar(x, y, yerr=None, xerr=None,
-                   fmt='', ecolor=None, elinewidth=None, capsize=3,
+                   fmt='', ecolor=None, elinewidth=None, capsize=None,
                    barsabove=False, lolims=False, uplims=False,
                    xlolims=False, xuplims=False, errorevery=1,
                    capthick=None)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1862,7 +1862,8 @@ class Axes(_AxesBase):
 
         capsize : integer, optional
            determines the length in points of the error bar caps
-           default: 3
+           default: None, which will take the value from the
+           ``errorbar.capsize`` :data:`rcParam<matplotlib.rcParams>`.
 
         error_kw : dict, optional
             dictionary of kwargs to be passed to errorbar method. *ecolor* and
@@ -1928,7 +1929,7 @@ class Axes(_AxesBase):
         yerr = kwargs.pop('yerr', None)
         error_kw = kwargs.pop('error_kw', dict())
         ecolor = kwargs.pop('ecolor', None)
-        capsize = kwargs.pop('capsize', 3)
+        capsize = kwargs.pop('capsize', rcParams["errorbar.capsize"])
         error_kw.setdefault('ecolor', ecolor)
         error_kw.setdefault('capsize', capsize)
 
@@ -2189,8 +2190,10 @@ class Axes(_AxesBase):
         ecolor : scalar or array-like, optional, default: None
             specifies the color of errorbar(s)
 
-        capsize : integer, optional, default: 3
+        capsize : integer, optional
            determines the length in points of the error bar caps
+           default: None, which will take the value from the
+           ``errorbar.capsize`` :data:`rcParam<matplotlib.rcParams>`.
 
         error_kw :
             dictionary of kwargs to be passed to errorbar method. `ecolor` and
@@ -2583,7 +2586,7 @@ class Axes(_AxesBase):
 
     @docstring.dedent_interpd
     def errorbar(self, x, y, yerr=None, xerr=None,
-                 fmt='', ecolor=None, elinewidth=None, capsize=3,
+                 fmt='', ecolor=None, elinewidth=None, capsize=None,
                  barsabove=False, lolims=False, uplims=False,
                  xlolims=False, xuplims=False, errorevery=1, capthick=None,
                  **kwargs):
@@ -2630,7 +2633,8 @@ class Axes(_AxesBase):
             The linewidth of the errorbar lines. If *None*, use the linewidth.
 
           *capsize*: scalar
-            The length of the error bar caps in points
+            The length of the error bar caps in points; if *None*, it will
+            take the value from ``errorbar.capsize`` :data:`rcParam<matplotlib.rcParams>`.
 
           *capthick*: scalar
             An alias kwarg to *markeredgewidth* (a.k.a. - *mew*). This
@@ -2783,6 +2787,8 @@ class Axes(_AxesBase):
             return xs, ys
 
         plot_kw = {'label': '_nolegend_'}
+        if capsize is None:
+            capsize = rcParams["errorbar.capsize"]
         if capsize > 0:
             plot_kw['ms'] = 2. * capsize
         if capthick is not None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1860,7 +1860,7 @@ class Axes(_AxesBase):
             specifies the color of errorbar(s)
             default: None
 
-        capsize : integer, optional
+        capsize : scalar, optional
            determines the length in points of the error bar caps
            default: None, which will take the value from the
            ``errorbar.capsize`` :data:`rcParam<matplotlib.rcParams>`.
@@ -2190,7 +2190,7 @@ class Axes(_AxesBase):
         ecolor : scalar or array-like, optional, default: None
             specifies the color of errorbar(s)
 
-        capsize : integer, optional
+        capsize : scalar, optional
            determines the length in points of the error bar caps
            default: None, which will take the value from the
            ``errorbar.capsize`` :data:`rcParam<matplotlib.rcParams>`.
@@ -2634,7 +2634,8 @@ class Axes(_AxesBase):
 
           *capsize*: scalar
             The length of the error bar caps in points; if *None*, it will
-            take the value from ``errorbar.capsize`` :data:`rcParam<matplotlib.rcParams>`.
+            take the value from ``errorbar.capsize``
+            :data:`rcParam<matplotlib.rcParams>`.
 
           *capthick*: scalar
             An alias kwarg to *markeredgewidth* (a.k.a. - *mew*). This

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2751,7 +2751,7 @@ def csd(x, y, NFFT=None, Fs=None, Fc=None, detrend=None, window=None,
 # changes will be lost
 @_autogen_docstring(Axes.errorbar)
 def errorbar(x, y, yerr=None, xerr=None, fmt='', ecolor=None, elinewidth=None,
-             capsize=3, barsabove=False, lolims=False, uplims=False,
+             capsize=None, barsabove=False, lolims=False, uplims=False,
              xlolims=False, xuplims=False, errorevery=1, capthick=None,
              hold=None, **kwargs):
     ax = gca()

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -623,6 +623,9 @@ defaultParams = {
                                     validate_negative_linestyle_legacy],
     'contour.corner_mask':        [True, validate_corner_mask],
 
+    # errorbar props
+    'errorbar.capsize':      [3, validate_float],
+
     # axes props
     'axes.axisbelow':        [False, validate_bool],
     'axes.hold':             [True, validate_bool],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -363,6 +363,9 @@ backend      : %(backend)s
 #contour.negative_linestyle : dashed # dashed | solid
 #contour.corner_mask        : True   # True | False | legacy
 
+### ERRORBAR PLOTS
+#errorbar.capsize : 3             # length of end cap on error bars in pixels
+
 ### Agg rendering
 ### Warning: experimental, 2008/10/10
 #agg.path.chunksize : 0           # 0 to disable; values in the range


### PR DESCRIPTION
Some people prefer to not have ends caps on their error bars. This patch changes the default value of capsize in various function calls to "None". Inside the body of the function, "None" is then replaced by a default value taken from rcParams (the default value is still 3) under the key "errorbar.capsize". With this patch, end caps can be changed globally or turned off completely through a setting in matplotlibrc.