### PR TITLE
Fix csv2rec for passing in both names and comments.

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2877,9 +2877,9 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
                 continue
             if i == 0:
                 converters = [mybool]*len(row)
-            i += 1
             if checkrows and i > checkrows:
                 break
+            i += 1
             for j, (name, item) in enumerate(zip(names, row)):
                 func = converterd.get(j)
                 if func is None:

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2867,12 +2867,17 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
         'print':  'print_',
         }
 
-    def get_converters(reader):
+    def get_converters(reader, comments):
 
         converters = None
-        for i, row in enumerate(reader):
+        i = 0
+        for row in reader:
+            if (len(row) and comments is not None and
+                    row[0].startswith(comments)):
+                continue
             if i == 0:
                 converters = [mybool]*len(row)
+            i += 1
             if checkrows and i > checkrows:
                 break
             for j, (name, item) in enumerate(zip(names, row)):
@@ -2925,7 +2930,7 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
             names = [n.strip() for n in names.split(',')]
 
     # get the converter functions by inspecting checkrows
-    converters = get_converters(reader)
+    converters = get_converters(reader, comments)
     if converters is None:
         raise ValueError('Could not find any valid data in CSV file')
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2880,6 +2880,7 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
             if checkrows and i > checkrows:
                 break
             i += 1
+
             for j, (name, item) in enumerate(zip(names, row)):
                 func = converterd.get(j)
                 if func is None:

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -340,7 +340,6 @@ class csv_testcase(CleanupTestCase):
         assert_raises(ValueError, mlab.rec2csv, bad, self.fd)
 
     def test_csv2rec_names_with_comments(self):
-        self.fd.seek(0)
         self.fd.write('# comment\n1,2,3\n4,5,6\n')
         self.fd.seek(0)
         array = mlab.csv2rec(self.fd, names='a,b,c')

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -339,6 +339,14 @@ class csv_testcase(CleanupTestCase):
         # the bad recarray should trigger a ValueError for having ndim > 1.
         assert_raises(ValueError, mlab.rec2csv, bad, self.fd)
 
+    def test_csv2rec_names_with_comments(self):
+        self.fd.seek(0)
+        self.fd.write('# comment\n1,2,3\n4,5,6\n')
+        self.fd.seek(0)
+        array = mlab.csv2rec(self.fd, names='a,b,c')
+        assert len(array) == 2
+        assert len(array.dtype) == 3
+
 
 class window_testcase(CleanupTestCase):
     def setUp(self):


### PR DESCRIPTION
Currently `csv2rec` fails when parsing a CSV file with a comment if one provides the column names.

For example with a file test.txt containing:

    # comment
    1,2,3
    4,5,6

Calling `csv2rec('test.txt', names=['a', 'b', 'c'])` raises an `IndexError`.

This PR patches it by honoring the `comments` argument passed to `csv2rec`.