### PR TITLE
API: remove agg path chunking logic

### DIFF
--- a/doc/api/api_changes/2015-05-24_remove_chunksize.rst
+++ b/doc/api/api_changes/2015-05-24_remove_chunksize.rst
@@ -1,0 +1,8 @@
+Remove chunk logic from backend_agg.draw_path and rcparams
+``````````````````````````````````````````````````````````
+
+Removes some old (~2008) experimental logic to chop up long paths in
+to shorter chunks before drawing.  This has largely been superseded by
+path simplification.
+
+This behavior has always been off by default.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -145,26 +145,7 @@ class RendererAgg(RendererBase):
         """
         Draw the path
         """
-        nmax = rcParams['agg.path.chunksize'] # here at least for testing
-        npts = path.vertices.shape[0]
-        if (nmax > 100 and npts > nmax and path.should_simplify and
-                rgbFace is None and gc.get_hatch() is None):
-            nch = np.ceil(npts/float(nmax))
-            chsize = int(np.ceil(npts/nch))
-            i0 = np.arange(0, npts, chsize)
-            i1 = np.zeros_like(i0)
-            i1[:-1] = i0[1:] - 1
-            i1[-1] = npts
-            for ii0, ii1 in zip(i0, i1):
-                v = path.vertices[ii0:ii1,:]
-                c = path.codes
-                if c is not None:
-                    c = c[ii0:ii1]
-                    c[0] = Path.MOVETO # move to end of last chunk
-                p = Path(v, c)
-                self._renderer.draw_path(gc, p, transform, rgbFace)
-        else:
-            self._renderer.draw_path(gc, path, transform, rgbFace)
+        self._renderer.draw_path(gc, path, transform, rgbFace)
 
     def draw_mathtext(self, gc, x, y, s, prop, angle):
         """

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -831,7 +831,6 @@ defaultParams = {
     'path.snap': [True, validate_bool],
     'path.sketch': [None, validate_sketch],
     'path.effects': [[], validate_any],
-    'agg.path.chunksize': [0, validate_int],       # 0 to disable chunking;
 
     # key-mappings (multi-character mappings should be a list/tuple)
     'keymap.fullscreen':   [('f', 'ctrl+f'), validate_stringlist],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -363,16 +363,6 @@ backend      : %(backend)s
 #contour.negative_linestyle : dashed # dashed | solid
 #contour.corner_mask        : True   # True | False | legacy
 
-### Agg rendering
-### Warning: experimental, 2008/10/10
-#agg.path.chunksize : 0           # 0 to disable; values in the range
-                                  # 10000 to 100000 can improve speed slightly
-                                  # and prevent an Agg rendering failure
-                                  # when plotting very large data sets,
-                                  # especially if they are very gappy.
-                                  # It may cause minor artifacts, though.
-                                  # A value of 20000 is probably a good
-                                  # starting point.
 ### SAVING FIGURES
 #path.simplify : True   # When True, simplify paths by removing "invisible"
                         # points to reduce file size and increase rendering


### PR DESCRIPTION
Removes experimental feature added in 2008 and never enabled by
default.

Closes #4404 

attn @efiring 
