### PR TITLE
ENH: property if DrawingArea clips children

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -598,6 +598,10 @@ class DrawingArea(OffsetBox):
 
     @property
     def clip_children(self):
+        """
+        If the children of this DrawingArea should be clipped
+        by DrawingArea bounding box.
+        """
         return self._clip_children
 
     @clip_children.setter

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -570,7 +570,7 @@ class DrawingArea(OffsetBox):
     """
     The DrawingArea can contain any Artist as a child. The DrawingArea
     has a fixed width and height. The position of children relative to
-    the parent is fixed. The children can be  clipped at the
+    the parent is fixed. The children can be clipped at the
     boundaries of the parent.
     """
 
@@ -595,6 +595,15 @@ class DrawingArea(OffsetBox):
         self.offset_transform.translate(0, 0)
 
         self.dpi_transform = mtransforms.Affine2D()
+
+    @property
+    def clip_children(self):
+        return self._clip_children
+
+    @clip_children.setter
+    def clip_children(self, val):
+        self._clip_children = bool(val)
+        self.stale = True
 
     def get_transform(self):
         """

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -2,8 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import nose
-
-from matplotlib.testing.decorators import image_comparison
+from nose.tools import assert_true, assert_false
+from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.lines as mlines
@@ -44,6 +44,43 @@ def test_offsetbox_clipping():
     ax.set_xlim((0, 1))
     ax.set_ylim((0, 1))
 
+
+@cleanup
+def test_offsetbox_clip_children():
+    # - create a plot
+    # - put an AnchoredOffsetbox with a child DrawingArea
+    #   at the center of the axes
+    # - give the DrawingArea a gray background
+    # - put a black line across the bounds of the DrawingArea
+    # - see that the black line is clipped to the edges of
+    #   the DrawingArea.
+    fig, ax = plt.subplots()
+    size = 100
+    da = DrawingArea(size, size, clip=True)
+    bg = mpatches.Rectangle((0, 0), size, size,
+                            facecolor='#CCCCCC',
+                            edgecolor='None',
+                            linewidth=0)
+    line = mlines.Line2D([-size*.5, size*1.5], [size/2, size/2],
+                         color='black',
+                         linewidth=10)
+    anchored_box = AnchoredOffsetbox(
+        loc=10,
+        child=da,
+        pad=0.,
+        frameon=False,
+        bbox_to_anchor=(.5, .5),
+        bbox_transform=ax.transAxes,
+        borderpad=0.)
+
+    da.add_artist(bg)
+    da.add_artist(line)
+    ax.add_artist(anchored_box)
+
+    fig.canvas.draw()
+    assert_false(fig.stale)
+    da.clip_children = True
+    assert_true(fig.stale)
 
 if __name__ == '__main__':
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
Add proprety `clip_children` to provide user interface if DrawingArea tries to clip it's children.

Did not include get/set methods and used property instead.  I hope going forward we will drop the `set/get_*` methods in favor of some sort of descriptor based solution. 

`getp`/`setp` should probably be updated to look for properties first and then for getter/setter methods.  That can be added to this PR or can be put off until after we sort out if we are going to use traitlets.

Builds on work of @has2k1