### PR TITLE
Rasterize colorbar when it has many colors; closes #4480

### DIFF
--- a/doc/users/whats_new/rasterized_colorbar.rst
+++ b/doc/users/whats_new/rasterized_colorbar.rst
@@ -1,0 +1,10 @@
+Dense colorbars are rasterized
+``````````````````````````````
+Vector file formats (pdf, ps, svg) are efficient for
+many types of plot element, but for some they can yield
+excessive file size and even rendering artifacts, depending
+on the renderer used for screen display.  This is a problem
+for colorbars that show a large number of shades, as is
+most commonly the case.  Now, if a colorbar is showing
+50 or more colors, it will be rasterized in vector
+backends.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -256,6 +256,8 @@ class ColorbarBase(cm.ScalarMappable):
                    'min': slice(1, None),
                    'max': slice(0, -1)}
 
+    n_rasterize = 50  # rasterize solids if number of colors >= n_rasterize
+
     def __init__(self, ax, cmap=None,
                  norm=None,
                  alpha=None,
@@ -517,6 +519,8 @@ class ColorbarBase(cm.ScalarMappable):
                                     colors=(mpl.rcParams['axes.edgecolor'],),
                                     linewidths=linewidths)
             self.ax.add_collection(self.dividers)
+        elif len(self._y) >= self.n_rasterize:
+            self.solids.set_rasterized(True)
 
     def add_lines(self, levels, colors, linewidths, erase=True):
         '''


### PR DESCRIPTION
I think this is the simplest possible way to reduce the number of complaints about the appearance of the colorbar as rendered from vector files.  It could be made more complicated by using an rcParam for the threshold, and/or by adding a kwarg, but I'm not convinced that either of these would be worthwhile.