### PR TITLE
backends: declare public API

### DIFF
--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -10,8 +10,7 @@ import warnings
 # ipython relies on interactive_bk being defined here
 from matplotlib.rcsetup import interactive_bk
 
-__all__ = ['backend','show','draw_if_interactive',
-           'new_figure_manager', 'backend_version']
+__all__ = list(map(str, ['backend', 'pylab_setup']))
 
 backend = matplotlib.get_backend() # validates, to match all_backends
 

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -48,6 +48,9 @@ try:
 except ImportError:
     _has_pil = False
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager',
+                         'RendererAgg', 'FigureCanvasAgg', 'FigureCanvas']))
+
 backend_version = 'v2.2'
 
 def get_hinting_flag():

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -58,6 +58,10 @@ from matplotlib.path         import Path
 from matplotlib.transforms   import Bbox, Affine2D
 from matplotlib.font_manager import ttfFontProperty
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager',
+                         'RendererCairo', 'FigureCanvasCairo',
+                         'FigureCanvas']))
+
 _debug = False
 #_debug = True
 

--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -32,6 +32,9 @@ from matplotlib.mathtext import MathTextParser
 from matplotlib.transforms import Affine2D
 from matplotlib.backends._backend_gdk import pixbuf_get_pixels_array
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager',
+                         'RendererGDK', 'FigureCanvasGDK']))
+
 backend_version = "%d.%d.%d" % gtk.pygtk_version
 _debug = False
 

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -45,6 +45,10 @@ from matplotlib import cbook
 from matplotlib import verbose
 from matplotlib import rcParams
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'show',
+                         'draw_if_interactive', 'FigureCanvasGTK',
+                         'FigureManagerGTK', 'FigureCanvas']))
+
 backend_version = "%d.%d.%d" % gtk.pygtk_version
 
 _debug = False

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -45,6 +45,10 @@ from matplotlib import cbook
 from matplotlib import verbose
 from matplotlib import rcParams
 
+__all__ = list(map(str, ['backend_version', 'show', 'draw_if_interactive',
+                         'FigureCanvasGTK3', 'FigureManagerGTK3',
+                         'FigureCanvas']))
+
 backend_version = "%s.%s.%s" % (Gtk.get_major_version(), Gtk.get_micro_version(), Gtk.get_minor_version())
 
 _debug = False

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -18,6 +18,8 @@ if six.PY3 and not HAS_CAIRO_CFFI:
         "The Gtk3Agg backend is known to not work on Python 3.x with pycairo. "
         "Try installing cairocffi.")
 
+__all__ = list(map(str, ['new_figure_manager', 'show', 'FigureCanvasGTK3Agg',
+                         'FigureManagerGTK3Agg', 'FigureCanvas']))
 
 class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
                           backend_agg.FigureCanvasAgg):

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -8,6 +8,10 @@ from . import backend_cairo
 from .backend_cairo import cairo, HAS_CAIRO_CFFI
 from matplotlib.figure import Figure
 
+__all__ = list(map(str, ['new_figure_manager', 'show', 'RendererGTK3Cairo',
+                         'FigureCanvasGTK3Cairo', 'FigureManagerGTK3Cairo',
+                         'FigureCanvas']))
+
 class RendererGTK3Cairo(backend_cairo.RendererCairo):
     def set_context(self, ctx):
         if HAS_CAIRO_CFFI:

--- a/lib/matplotlib/backends/backend_gtkagg.py
+++ b/lib/matplotlib/backends/backend_gtkagg.py
@@ -17,6 +17,9 @@ from matplotlib.backends.backend_gtk import gtk, FigureManagerGTK, FigureCanvasG
      NavigationToolbar2GTK
 from matplotlib.backends._gtkagg import agg_to_gtk_drawable
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'show',
+                         'draw_if_interactive', 'FigureCanvasGTKAgg',
+                         'FigureManagerGTKAgg', 'FigureCanvas']))
 
 DEBUG = False
 

--- a/lib/matplotlib/backends/backend_gtkcairo.py
+++ b/lib/matplotlib/backends/backend_gtkcairo.py
@@ -14,6 +14,10 @@ if gtk.pygtk_version < (2,7,0):
 from matplotlib.backends import backend_cairo
 from matplotlib.backends.backend_gtk import *
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager',
+                         'FigureCanvasGTKCairo', 'FigureManagerGTKCairo',
+                         'FigureCanvas']))
+
 backend_version = 'PyGTK(%d.%d.%d) ' % gtk.pygtk_version + \
                   'Pycairo(%s)' % backend_cairo.backend_version
 

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -7,6 +7,7 @@ from matplotlib._image import frombuffer
 from matplotlib.backends.backend_agg import RendererAgg
 from matplotlib.tight_bbox import process_figure_for_rasterizing
 
+__all__ = [str('MixedModeRenderer')]
 
 class MixedModeRenderer(object):
     """

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -25,6 +25,8 @@ from matplotlib.backends.backend_webagg_core import (FigureManagerWebAgg,
 from matplotlib.backend_bases import (ShowBase, NavigationToolbar2,
                                       TimerBase, FigureCanvasBase)
 
+__all__ = list(map(str, ['new_figure_manager', 'show', 'draw_if_interactive',
+                         'FigureManagerNbAgg', 'FigureCanvasNbAgg']))
 
 class Show(ShowBase):
     def __call__(self, block=None):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -50,6 +50,10 @@ from matplotlib.path import Path
 from matplotlib import _path
 from matplotlib import ttconv
 
+__all__ = list(map(str, ['new_figure_manager', 'RendererPdf',
+                         'FigureCanvasPdf', 'FigureManagerPdf',
+                         'FigureCanvas']))
+
 # Overview
 #
 # The low-level knowledge about pdf syntax lies mainly in the pdfRepr

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -29,6 +29,8 @@ from matplotlib.cbook import is_string_like, is_writable_file_like
 from matplotlib.compat import subprocess
 from matplotlib.compat.subprocess import check_output
 
+__all__ = list(map(str, ['new_figure_manager', 'FigureCanvasPgf',
+                         'FigureManagerPgf', 'FigureCanvas']))
 
 ###############################################################################
 
@@ -720,10 +722,6 @@ class GraphicsContextPgf(GraphicsContextBase):
     pass
 
 ########################################################################
-
-
-def draw_if_interactive():
-    pass
 
 
 def new_figure_manager(num, *args, **kwargs):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -53,6 +53,9 @@ backend_version = 'Level II'
 
 debugPS = 0
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'RendererPS',
+                         'FigureCanvasPS', 'FigureManagerPS', 'FigureCanvas']))
+
 
 class PsBackendHelper(object):
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -49,9 +49,6 @@ try:
 except NameError:
     from sets import Set as set
 
-if sys.platform.startswith('win'): cmd_split = '&'
-else: cmd_split = ';'
-
 backend_version = 'Level II'
 
 debugPS = 0

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -40,6 +40,10 @@ from .backend_qt5 import (backend_version, SPECIAL_KEYS, SUPER, ALT, CTRL,
 
 from .backend_qt5 import FigureCanvasQT as FigureCanvasQT5
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'show',
+                         'draw_if_interactive', 'FigureCanvasQT',
+                         'FigureManagerQT', 'FigureCanvas']))
+
 DEBUG = False
 
 

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -28,6 +28,10 @@ from .backend_qt4 import draw_if_interactive
 from .backend_qt4 import backend_version
 ######
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'show',
+                         'draw_if_interactive', 'FigureCanvasQTAgg',
+                         'FigureManagerQT', 'FigureCanvas']))
+
 DEBUG = False
 
 _decref = ctypes.pythonapi.Py_DecRef

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -31,6 +31,10 @@ except ImportError:
 from .qt_compat import QtCore, QtGui, QtWidgets, _getSaveFileName, __version__
 from matplotlib.backends.qt_editor.formsubplottool import UiSubplotTool
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'show',
+                         'draw_if_interactive', 'FigureManagerQT',
+                         'FigureCanvasQT', 'FigureCanvas']))
+
 backend_version = __version__
 
 # SPECIAL_KEYS are keys that do *not* return their unicode name

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -24,6 +24,9 @@ from .backend_qt5 import draw_if_interactive
 from .backend_qt5 import backend_version
 ######
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'show',
+                         'draw_if_interactive', 'FigureCanvasQTAgg',
+                         'FigureManagerQT', 'FigureCanvas']))
 
 DEBUG = False
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -31,6 +31,10 @@ from xml.sax.saxutils import escape as escape_xml_text
 
 backend_version = __version__
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager',
+                         'FigureCanvasSVG', 'FigureManagerSVG',
+                         'FigureCanvas']))
+
 # ----------------------------------------------------------------------
 # SimpleXMLWriter class
 #

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -74,6 +74,10 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase,\
 from matplotlib.figure import Figure
 from matplotlib.transforms import Bbox
 
+__all__ = list(map(str, ['new_figure_manager', 'show', 'draw_if_interactive',
+                         'FigureCanvasTemplate', 'FigureManagerTemplate',
+                         'FigureCanvas']))
+
 
 class RendererTemplate(RendererBase):
     """

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -32,6 +32,10 @@ from matplotlib.widgets import SubplotTool
 
 import matplotlib.cbook as cbook
 
+__all__ = list(map(str, ['backend_version', 'new_figure_manager', 'show',
+                         'draw_if_interactive', 'FigureCanvasTkAgg',
+                         'FigureManagerTkAgg', 'FigureCanvas']))
+
 rcParams = matplotlib.rcParams
 verbose = matplotlib.verbose
 

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -41,6 +41,9 @@ from matplotlib._pylab_helpers import Gcf
 from . import backend_webagg_core as core
 from .backend_nbagg import TimerTornado
 
+__all__ = list(map(str, ['new_figure_manager', 'show', 'draw_if_interactive',
+                         'FigureCanvasWebAgg', 'FigureCanvas']))
+
 
 def new_figure_manager(num, *args, **kwargs):
     """

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -28,6 +28,9 @@ from matplotlib.figure import Figure
 from matplotlib import backend_bases
 from matplotlib import _png
 
+__all__ = list(map(str, ['new_figure_manager', 'FigureCanvasWebAggCore',
+                         'FigureManagerWebAgg']))
+
 
 def new_figure_manager(num, *args, **kwargs):
     """

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -89,6 +89,9 @@ class fake_stderr(object):
     #WxLogger =wx.LogStderr()
     #sys.stderr = fake_stderr
 
+__all__ = list(map(str, ['new_figure_manager', 'show', 'draw_if_interactive',
+                         'FigureCanvasWx', 'FigureManagerWx', 'FigureCanvas']))
+
 # the True dots per inch on the screen; should be display dependent
 # see
 # http://groups.google.com/groups?q=screen+dpi+x11&hl=en&lr=&ie=UTF-8&oe=UTF-8&safe=off&selm=7077.26e81ad5%40swift.cs.tcd.ie&rnum=5

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -15,6 +15,9 @@ from .backend_wx import (FigureManagerWx, FigureCanvasWx,
 
 import wx
 
+__all__ = list(map(str, ['new_figure_manager', 'show', 'FigureCanvasWxAgg',
+                         'FigureCanvas']))
+
 
 show = backend_wx.Show()
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -60,12 +60,6 @@ import re
 
 DEBUG = False
 
-if sys.platform.startswith('win'):
-    cmd_split = '&'
-else:
-    cmd_split = ';'
-
-
 def dvipng_hack_alpha():
     try:
         p = Popen(['dvipng', '-version'], stdin=PIPE, stdout=PIPE,


### PR DESCRIPTION
This is a successor request to #4363. It was decided that removing unused imports from the backends was bad for backwards compatibility. This time, we simply declare the public API via the `__all__` module constant.
