### PR TITLE
ENH: first draft of ensure_ax decorator

### DIFF
--- a/doc/users/whats_new/2015-07-30_ensure_ax.rst
+++ b/doc/users/whats_new/2015-07-30_ensure_ax.rst
@@ -1,5 +1,5 @@
-Decorators to ensure an Axes exists & ``plt.quick_axes``
---------------------------------------------------------
+Decorators to ensure an Axes exists & ``plt.gna``
+-------------------------------------------------
 
 Added a top-level function to `pyplot` to create a single axes
 figure and return the `Axes` object.
@@ -15,4 +15,4 @@ positional argument and returns a function which allows the axes to be
 passed either as the first positional argument or as a kwarg.  If the
 `Axes` is not provided either gets the current axes (via `plt.gca()`)
 for `ensure_ax` and `ensure_ax_meth` or creating a new single-axes figure
-(via `plt.quick_axes`) for `ensure_new_ax`
+(via `plt.gna`) for `ensure_new_ax`

--- a/doc/users/whats_new/2015-07-30_ensure_ax.rst
+++ b/doc/users/whats_new/2015-07-30_ensure_ax.rst
@@ -1,0 +1,18 @@
+Decorators to ensure an Axes exists & ``plt.quick_axes``
+--------------------------------------------------------
+
+Added a top-level function to `pyplot` to create a single axes
+figure and return the `Axes` object.
+
+Added decorators ::
+
+  ensure_ax
+  ensure_ax_meth
+  ensure_new_ax
+
+which take a function or method that expects an `Axes` as the first
+positional argument and returns a function which allows the axes to be
+passed either as the first positional argument or as a kwarg.  If the
+`Axes` is not provided either gets the current axes (via `plt.gca()`)
+for `ensure_ax` and `ensure_ax_meth` or creating a new single-axes figure
+(via `plt.quick_axes`) for `ensure_new_ax`

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -287,33 +287,6 @@ def ensure_ax_meth(func):
     return inner
 
 
-def register_func(func):
-    """
-    Registers a function to be wrapped and made available in the
-    pyplot namespace for convenient interactive command line use.
-
-    Parameters
-    ----------
-    func : callable
-
-        First parameter of function must be an `Axes` object.  Will
-        be wrapped by `ensure_ax`
-
-    Returns
-    -------
-    callable
-
-        The wrapped function.
-    """
-    mod = sys.modules[__name__]
-    f_name = func.__name__
-    if hasattr(mod, f_name):
-        raise RuntimeError("Function already exists with that name")
-    setattr(mod, f_name, ensure_ax(func))
-
-    return getattr(mod, f_name)
-
-
 @docstring.copy_dedent(Artist.findobj)
 def findobj(o=None, match=None, include_self=True):
     if o is None:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -287,7 +287,7 @@ def ensure_new_ax(func):
             ax = args[0]
             args = args[1:]
         else:
-            ax = quick_axes()
+            ax = gna()
         return func(ax, *args, **kwargs)
     pre_doc = inner.__doc__
     if pre_doc is None:
@@ -1385,7 +1385,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
     return ret
 
 
-def quick_axes(figsize=None, tight_layout=False):
+def gna(figsize=None, tight_layout=False):
     """
     Create a single new axes in a new figure.
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1339,6 +1339,30 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
     return ret
 
 
+def quick_axes(figsize=None, tight_layout=False):
+    """
+    Create a single new axes in a new figure.
+
+    This is a convenience function for working interactively
+    and should not be used in scripts.
+
+    Parameters
+    ----------
+    figsize : tuple, optional
+        Figure size in inches (w, h)
+
+    tight_layout : bool, optional
+        If tight layout shoudl be used.
+
+    Returns
+    -------
+    ax : Axes
+       New axes
+    """
+    _, ax = subplots(figsize=figsize, tight_layout=tight_layout)
+    return ax
+
+
 def subplot2grid(shape, loc, rowspan=1, colspan=1, **kwargs):
     """
     Create a subplot in a grid.  The grid is specified by *shape*, at

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -193,6 +193,7 @@ def uninstall_repl_displayhook():
 draw_all = _pylab_helpers.Gcf.draw_all
 
 _ENSURE_AX_DOC = """
+
 This function has been decorated by pyplot to have
 an implicit reference to the `plt.gca()` passed as the first argument.
 
@@ -206,6 +207,7 @@ The wrapped function can be called as any of ::
 
 
 _ENSURE_AX_NEW_DOC = """
+
 This function has been decorated by pyplot to create a new
 axes if one is not explicitly passed.
 
@@ -265,7 +267,7 @@ def ensure_ax(func):
         pre_doc = ''
     else:
         pre_doc = dedent(pre_doc)
-    inner.__doc__ = _ENSURE_AX_DOC.format(func=func.__name__, obj='') + pre_doc
+    inner.__doc__ = pre_doc + _ENSURE_AX_DOC.format(func=func.__name__, obj='')
 
     return inner
 
@@ -292,8 +294,8 @@ def ensure_new_ax(func):
         pre_doc = ''
     else:
         pre_doc = dedent(pre_doc)
-    inner.__doc__ = (_ENSURE_AX_NEW_DOC.format(func=func.__name__, obj='') +
-                     pre_doc)
+    inner.__doc__ = (pre_doc +
+                     _ENSURE_AX_NEW_DOC.format(func=func.__name__, obj=''))
 
     return inner
 
@@ -326,8 +328,8 @@ def ensure_ax_meth(func):
         pre_doc = ''
     else:
         pre_doc = dedent(pre_doc)
-    inner.__doc__ = _ENSURE_AX_DOC.format(func=func.__name__,
-                                          obj='obj.') + pre_doc
+    inner.__doc__ = pre_doc + _ENSURE_AX_DOC.format(func=func.__name__,
+                                                    obj='obj.')
     return inner
 
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -205,6 +205,22 @@ The wrapped function can be called as any of ::
 """
 
 
+_ENSURE_AX_NEW_DOC = """
+This function has been decorated by pyplot to create a new
+axes if one is not explicitly passed.
+
+The wrapped function can be called as any of ::
+
+   {obj}{func}(*args, **kwargs)
+   {obj}{func}(ax, *args, **kwargs)
+   {obj}{func}(.., ax=ax)
+
+The first will make a new figure and axes, the other two
+will add to the axes passed in.
+
+"""
+
+
 def ensure_ax(func):
     """Decorator to ensure that the function gets an `Axes` object.
 
@@ -250,6 +266,34 @@ def ensure_ax(func):
     else:
         pre_doc = dedent(pre_doc)
     inner.__doc__ = _ENSURE_AX_DOC.format(func=func.__name__, obj='') + pre_doc
+
+    return inner
+
+
+def ensure_new_ax(func):
+    """Decorator to ensure that the function gets a new `Axes` object.
+
+    Same as ensure_ax expect that a new figure and axes are created
+    if an Axes is not explicitly passed.
+
+    """
+    @wraps(func)
+    def inner(*args, **kwargs):
+        if 'ax' in kwargs:
+            ax = kwargs.pop('ax')
+        elif len(args) > 0 and isinstance(args[0], Axes):
+            ax = args[0]
+            args = args[1:]
+        else:
+            ax = quick_axes()
+        return func(ax, *args, **kwargs)
+    pre_doc = inner.__doc__
+    if pre_doc is None:
+        pre_doc = ''
+    else:
+        pre_doc = dedent(pre_doc)
+    inner.__doc__ = (_ENSURE_AX_NEW_DOC.format(func=func.__name__, obj='') +
+                     pre_doc)
 
     return inner
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -237,7 +237,7 @@ def ensure_ax(func):
     @wraps(func)
     def inner(*args, **kwargs):
         if 'ax' in kwargs:
-            ax = kwargs.pop('ax', None)
+            ax = kwargs.pop('ax')
         elif len(args) > 0 and isinstance(args[0], Axes):
             ax = args[0]
             args = args[1:]
@@ -270,7 +270,7 @@ def ensure_ax_meth(func):
         s = args[0]
         args = args[1:]
         if 'ax' in kwargs:
-            ax = kwargs.pop('ax', None)
+            ax = kwargs.pop('ax')
         elif len(args) > 1 and isinstance(args[0], Axes):
             ax = args[0]
             args = args[1:]

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -198,9 +198,9 @@ an implicit reference to the `plt.gca()` passed as the first argument.
 
 The wrapped function can be called as any of ::
 
-   func(*args, **kwargs)
-   func(ax, *args, **kwargs)
-   func(.., ax=ax)
+   {obj}{func}(*args, **kwargs)
+   {obj}{func}(ax, *args, **kwargs)
+   {obj}{func}(.., ax=ax)
 
 """
 
@@ -249,7 +249,7 @@ def ensure_ax(func):
         pre_doc = ''
     else:
         pre_doc = dedent(pre_doc)
-    inner.__doc__ = _ENSURE_AX_DOC + pre_doc
+    inner.__doc__ = _ENSURE_AX_DOC.format(func=func.__name__, obj='') + pre_doc
 
     return inner
 
@@ -282,7 +282,8 @@ def ensure_ax_meth(func):
         pre_doc = ''
     else:
         pre_doc = dedent(pre_doc)
-    inner.__doc__ = _ENSURE_AX_DOC + pre_doc
+    inner.__doc__ = _ENSURE_AX_DOC.format(func=func.__name__,
+                                          obj='obj.') + pre_doc
     return inner
 
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -261,6 +261,33 @@ def ensure_ax_meth(func):
     return inner
 
 
+def register_func(func):
+    """
+    Registers a function to be wrapped and made available in the
+    pyplot namespace for convenient interactive command line use.
+
+    Parameters
+    ----------
+    func : callable
+
+        First parameter of function must be an `Axes` object.  Will
+        be wrapped by `ensure_ax`
+
+    Returns
+    -------
+    callable
+
+        The wrapped function.
+    """
+    mod = sys.modules[__name__]
+    f_name = func.__name__
+    if hasattr(mod, f_name):
+        raise RuntimeError("Function already exists with that name")
+    setattr(mod, f_name, ensure_ax(func))
+
+    return getattr(mod, f_name)
+
+
 @docstring.copy_dedent(Artist.findobj)
 def findobj(o=None, match=None, include_self=True):
     if o is None:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -192,6 +192,18 @@ def uninstall_repl_displayhook():
 
 draw_all = _pylab_helpers.Gcf.draw_all
 
+_ENSURE_AX_DOC = """
+This function has been decorated by pyplot to have
+an implicit reference to the `plt.gca()` passed as the first argument.
+
+The wrapped function can be called as any of ::
+
+   func(*args, **kwargs)
+   func(ax, *args, **kwargs)
+   func(.., ax=ax)
+
+"""
+
 
 def ensure_ax(func):
     """Decorator to ensure that the function gets an `Axes` object.
@@ -232,6 +244,13 @@ def ensure_ax(func):
         else:
             ax = gca()
         return func(ax, *args, **kwargs)
+    pre_doc = inner.__doc__
+    if pre_doc is None:
+        pre_doc = ''
+    else:
+        pre_doc = dedent(pre_doc)
+    inner.__doc__ = _ENSURE_AX_DOC + pre_doc
+
     return inner
 
 
@@ -258,6 +277,12 @@ def ensure_ax_meth(func):
         else:
             ax = gca()
         return func(s, ax, *args, **kwargs)
+    pre_doc = inner.__doc__
+    if pre_doc is None:
+        pre_doc = ''
+    else:
+        pre_doc = dedent(pre_doc)
+    inner.__doc__ = _ENSURE_AX_DOC + pre_doc
     return inner
 
 


### PR DESCRIPTION
Decorator for making user functions using the suggested signature
work with the state machine to plot the the implicit currently active
Axes.

This started from a discussion at https://github.com/lmfit/lmfit-py/pull/146#issuecomment-61304420 and was mostly implemented by @danielballan at https://github.com/Nikea/xray-vision/blob/master/xray_vision/utils/mpl_helpers.py (which is for my day-job at BNL).

This is roughly related to my on-going attempts to simplify `pyplot` (see #3587,  #2736 and #4091)

This need a lot more documentation before they are merged, throwing this up to get feed back.