### PR TITLE
Returning the Poly3DCollection when calling bar3d

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2427,6 +2427,8 @@ class Axes3D(Axes):
         self.add_collection(col)
 
         self.auto_scale_xyz((minx, maxx), (miny, maxy), (minz, maxz), had_data)
+        
+        return col
 
     def set_title(self, label, fontdict=None, loc='center', **kwargs):
         ret = Axes.set_title(self, label, fontdict=fontdict, loc=loc, **kwargs)


### PR DESCRIPTION
bar3d does not return the Poly3DCollection which is annoying if one wishes to update the bar plot;

Without the modification, I feel I have to do :
ax.bar3d( ...)
col = ax.collections[-1]
And then for animating :

While(True):
   col.remove()
   ax.bar3d(...)
   col = ax.collections[-1]

with the modification, I can merge the ax.bar3d(..); col = .. ;   as  col = ax.bar3d(...)