### PR TITLE
DOC: "Customizing matplotlib" should mention style sheets

### DIFF
--- a/doc/users/customizing.rst
+++ b/doc/users/customizing.rst
@@ -4,6 +4,33 @@
 Customizing matplotlib
 **********************
 
+.. _customizing-with-dynamic-rc-settings:
+
+Dynamic rc settings
+===================
+
+You can also dynamically change the default rc settings in a python script or
+interactively from the python shell. All of the rc settings are stored in a
+dictionary-like variable called :data:`matplotlib.rcParams`, which is global to
+the matplotlib package. rcParams can be modified directly, for example::
+
+    import matplotlib as mpl
+    mpl.rcParams['lines.linewidth'] = 2
+    mpl.rcParams['lines.color'] = 'r'
+
+Matplotlib also provides a couple of convenience functions for modifying rc
+settings. The :func:`matplotlib.rc` command can be used to modify multiple
+settings in a single group at once, using keyword arguments::
+
+    import matplotlib as mpl
+    mpl.rc('lines', linewidth=2, color='r')
+
+The :func:`matplotlib.rcdefaults` command will restore the standard matplotlib
+default settings.
+
+There is some degree of validation when setting the values of rcParams, see
+:mod:`matplotlib.rcsetup` for details.
+
 .. _customizing-with-matplotlibrc-files:
 
 The :file:`matplotlibrc` file
@@ -45,34 +72,6 @@ loaded from, one can do the following::
   '/home/foo/.config/matplotlib/matplotlibrc'
 
 See below for a sample :ref:`matplotlibrc file<matplotlibrc-sample>`.
-
-.. _customizing-with-dynamic-rc-settings:
-
-Dynamic rc settings
-===================
-
-You can also dynamically change the default rc settings in a python script or
-interactively from the python shell. All of the rc settings are stored in a
-dictionary-like variable called :data:`matplotlib.rcParams`, which is global to
-the matplotlib package. rcParams can be modified directly, for example::
-
-    import matplotlib as mpl
-    mpl.rcParams['lines.linewidth'] = 2
-    mpl.rcParams['lines.color'] = 'r'
-
-Matplotlib also provides a couple of convenience functions for modifying rc
-settings. The :func:`matplotlib.rc` command can be used to modify multiple
-settings in a single group at once, using keyword arguments::
-
-    import matplotlib as mpl
-    mpl.rc('lines', linewidth=2, color='r')
-
-The :func:`matplotlib.rcdefaults` command will restore the standard matplotlib
-default settings.
-
-There is some degree of validation when setting the values of rcParams, see
-:mod:`matplotlib.rcsetup` for details.
-
 
 .. _matplotlibrc-sample:
 

--- a/doc/users/customizing.rst
+++ b/doc/users/customizing.rst
@@ -4,6 +4,16 @@
 Customizing matplotlib
 **********************
 
+Using style sheets
+==================
+
+Style sheets provide a means for more specific and/or temporary configuration
+modifications, but in a  repeatable and well-ordered manner. A style sheet is a
+file with the same syntax as the :file:`matplotlibrc` file, and when applied, it
+will override the :file:`matplotlibrc`.
+
+For more information and examples, see :ref:`style-sheets`.
+
 .. _customizing-with-dynamic-rc-settings:
 
 Dynamic rc settings

--- a/doc/users/style_sheets.rst
+++ b/doc/users/style_sheets.rst
@@ -26,7 +26,7 @@ Defining your own style
 
 You can create custom styles and use them by calling ``style.use`` with the
 path or URL to the style sheet. Alternatively, if you add your ``<style-name>.mplstyle`` 
-file to ``mpl_configdir/stylelib`, you can reuse your custom style sheet with a call to 
+file to ``mpl_configdir/stylelib``, you can reuse your custom style sheet with a call to 
 ``style.use(<style-name>)``. By default ``mpl_configdir`` should be ``~/.config/matplotlib``, 
 but you can check where yours is with ``matplotlib.get_configdir()``, you may need to 
 create this directory. Note that a custom style sheet in ``mpl_configdir/stylelib`` 


### PR DESCRIPTION
Fixes #4507.

Also note that there was a missing ` character, causing some of the regular text to [appear monospace](http://matplotlib.org/users/style_sheets.html#defining-your-own-style).