### PR TITLE
Try expanding user for _open_file_or_url.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -974,7 +974,9 @@ def _open_file_or_url(fname):
         yield _url_lines(f)
         f.close()
     else:
-        with io.open(fname, encoding=locale.getdefaultlocale()[1]) as f:
+        fname = os.path.expanduser(fname)
+        encoding = locale.getdefaultlocale()[1]
+        with io.open(fname, encoding=encoding) as f:
             yield f
 
 


### PR DESCRIPTION
When opening a file, this attempts to expand the userpath if the initial open doesn't succeed.

This enables calls such as `plt.style.use('~/.config/matplotlib/matplotlibrc')`.