### PR TITLE
support vertical quiverkey

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -243,7 +243,7 @@ class QuiverKey(martist.Artist):
         self.color = kw.pop('color', None)
         self.label = label
         self._labelsep_inches = kw.pop('labelsep', 0.1)
-        self._vswap = kw.pop('vswap',False)
+        self._vswap = kw.pop('vswap', False)
         vswap = {True: 'vertical', False: 0}
         self.labelsep = (self._labelsep_inches * Q.ax.figure.dpi)
 
@@ -303,7 +303,7 @@ class QuiverKey(martist.Artist):
             self.Q.Umask = ma.nomask
             if self._vswap:
                 self.verts = self.Q._make_verts(np.zeros((1,)),
-                                                array([self.U]))
+                                                np.array([self.U]))
             else:
                 self.verts = self.Q._make_verts(np.array([self.U]),
                                                 np.zeros((1,)))


### PR DESCRIPTION
add support to a vertical aligned (y wise) quiverkey.

The label for N and S are still over the arrow, but for label=W (my case) this snippet works.

Useful for a x-z plane quiver plot when the quiver arrows components have different units and user need to provide information about this in the plot. The currently default behaviour is to only plot a horizontal (x) quiverkey, while the vertical is assumed to be the same.

This also support the user to select if he wants to make a key that is horizontal or vertical aligned. Say that the flow is along y and the quiverkey is horizontal, the reader always need to rotate in his mind the vector to have a grasp about the magnitude.
