### PR TITLE
Removing intel preprocessors from qhull_a.h

### DIFF
--- a/extern/qhull/qhull_a.h
+++ b/extern/qhull/qhull_a.h
@@ -102,13 +102,8 @@
 #elif defined(__MWERKS__) && defined(__INTEL__)
 #   define QHULL_OS_WIN
 #endif
-#if defined(__INTEL_COMPILER) && !defined(QHULL_OS_WIN)
-template <typename T>
-inline void qhullUnused(T &x) { (void)x; }
-#  define QHULL_UNUSED(x) qhullUnused(x);
-#else
-#  define QHULL_UNUSED(x) (void)x;
-#endif
+
+#define QHULL_UNUSED(x) (void)x;
 
 /***** -libqhull.c prototypes (alphabetical after qhull) ********************/
 


### PR DESCRIPTION
I'm removing this section of code that caused builds with the Intel compiler to fail with the following error message:

```shell
icc -pthread -fno-strict-aliasing -O3 -fPIC -fp-model strict -fomit-frame-pointer -DNDEBUG -g -O3 -Wall -fPIC -DMPL_DEVNULL=/dev/null -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__qhull_ARRAY_API -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/usr/local/python2/2.7.8/x86_64/intel14/nonet/lib/python2.7/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iextern -I/usr/local/python2/2.7.8/x86_64/intel14/nonet/include/python2.7 -c src/qhull_wrap.c -o build/temp.linux-x86_64-2.7/src/qhull_wrap.o
In file included from src/qhull_wrap.c(10):
extern/qhull/qhull_a.h(106): warning #77: this declaration has no storage class or type specifier 
template <typename T> 
^

In file included from src/qhull_wrap.c(10):
extern/qhull/qhull_a.h(106): error: expected a ";"
template <typename T>
         ^

In file included from src/qhull_wrap.c(10):
extern/qhull/qhull_a.h(115): warning #12: parsing restarts here after previous syntax error
  void    qh_qhull(void);
                        ^

compilation aborted for src/qhull_wrap.c (code 2) 
error: command 'icc' failed with exit status 2
```

The issue is that Intel's C compiler (icc) cannot handle templates; however, forcing the use of Intel's C++ compiler (icpc) creates the opposite problem as it fails to interpret certain C syntax. See more details on the issue I opened here: https://github.com/matplotlib/matplotlib/issues/4518#issuecomment-111596313

Removal of this code block appears fairly innocuous however I'm not clear on the author's intent in including it. It may be that there are some unforeseen consequences. Incorporating these changes into my local build did not introduce any new unit test errors or failures.

QHULL_UNUSED gets called a few times (in extern/qhull/io.c) and it appears to be reading in a custom boolean type in both cases:

```shell
[frenchwr@vmps12 matplotlib]$ grep QHULL_UNUSED -r *
extern/qhull/io.c:  QHULL_UNUSED(unbounded);
extern/qhull/io.c:  QHULL_UNUSED(unbounded);
extern/qhull/qhull_a.h:  >--------------------------------</a><a name="QHULL_UNUSED">-</a>
extern/qhull/qhull_a.h:#define QHULL_UNUSED(x) (void)x;
```