### PR TITLE
FIX: make sure nans are dealt with in path

### DIFF
--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -225,6 +225,7 @@ class PathNanRemover : protected EmbeddedQueue<4>
                     code = m_source->vertex(x, y);
                     // This de-reference makes sure this loop is not
                     // optimized out of existence
+		    // This is working around an apparent bug in gcc 5.1
                     _x = *x;
                     _y = *y;
 

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -218,15 +218,21 @@ class PathNanRemover : protected EmbeddedQueue<4>
                 code == (agg::path_cmd_end_poly | agg::path_flags_close)) {
                 return code;
             }
+	    double _x, _y;
 
             if (MPL_notisfinite64(*x) || MPL_notisfinite64(*y)) {
                 do {
                     code = m_source->vertex(x, y);
+                    // This de-reference makes sure this loop is not
+                    // optimized out of existence
+                    _x = *x;
+                    _y = *y;
+
                     if (code == agg::path_cmd_stop ||
                         code == (agg::path_cmd_end_poly | agg::path_flags_close)) {
                         return code;
                     }
-                } while (MPL_notisfinite64(*x) || MPL_notisfinite64(*y));
+                } while (MPL_notisfinite64(_x) || MPL_notisfinite64(_y));
                 return agg::path_cmd_move_to;
             }
 


### PR DESCRIPTION
With gcc 5.1.0 it seems that the inner loop of the fast-path in
PathNanRemover gets optimized out of existence and the first non-finite
entry in the path prevents any further drawing.

This PR (rather hackishly) adds explicit de-references to x and y
to the loop to make sure the compiler does not decide it is unneeded.

Closes #4525

attn @efiring @mdboom @ianthomas23 I am in a bit over my head here (not that that has ever stopped me before).