### PR TITLE
Revert "made idle_event() in backend_bases.py return True"

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1980,7 +1980,6 @@ class FigureCanvasBase(object):
         s = 'idle_event'
         event = IdleEvent(s, self, guiEvent=guiEvent)
         self.callbacks.process(s, event)
-        return True
 
     def grab_mouse(self, ax):
         """


### PR DESCRIPTION
Reverts matplotlib/matplotlib#3769

This commit caused #4092  which is far worse than what this was fixing.

Closes #4092 