### PR TITLE
Directly link matplotlib.org and not sourceforge.net

### DIFF
--- a/doc/users/style_sheets.rst
+++ b/doc/users/style_sheets.rst
@@ -84,6 +84,6 @@ changes, you can write something like the following::
    >>> plt.show()
 
 
-.. _matplotlibrc: http://matplotlib.sourceforge.net/users/customizing.html
+.. _matplotlibrc: http://matplotlib.org/users/customizing.html
 .. _ggplot: http://had.co.nz/ggplot/
 .. _R: http://www.r-project.org/


### PR DESCRIPTION
Due to sourceforge's recent practice of adding AdWare to some downloads, it gets blocked if you use the ublock browser extension. Since the linked sourceforge page redirects to matplotlib.org anyway, it doesn't seem to make sense to not directly link to matplotlib.org.