### PR TITLE
MNT: Deprecate idle_event and remove it from all but wx backends

### DIFF
--- a/doc/api/api_changes/2015-06-21_idle_event.rst
+++ b/doc/api/api_changes/2015-06-21_idle_event.rst
@@ -1,0 +1,9 @@
+deprecated idle_event
+`````````````````````
+
+The `idle_event` was broken or missing in most backends and causes spurious
+warnings in some cases, and its use in creating animations is now obsolete due
+to the animations module. Therefore code involving it has been removed from all
+but the wx backend (where it partially works), and its use is deprecated.  The
+animations module may be used instead to create animations.
+

--- a/examples/event_handling/idle_and_timeout.py
+++ b/examples/event_handling/idle_and_timeout.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 """
 Demonstrate/test the idle and timeout API
 
+WARNING: idle_event is deprecated. Use the animations module instead.
+
 This is only tested on gtk so far and is a prototype implementation
 """
 import numpy as np

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2331,6 +2331,10 @@ class FigureCanvasBase(object):
             cid = canvas.mpl_connect('button_press_event', on_press)
 
         """
+        if s == 'idle_event':
+            warnings.warn("idle_event is only implemented for the wx backend, "
+                          "and will be removed in matplotlib 2.1. Use the "
+                          "animations module instead.", mplDeprecation)
 
         return self.callbacks.connect(s, func)
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -60,7 +60,7 @@ from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
 import matplotlib.tight_bbox as tight_bbox
 import matplotlib.textpath as textpath
 from matplotlib.path import Path
-from matplotlib.cbook import mplDeprecation
+from matplotlib.cbook import mplDeprecation, warn_deprecated
 import matplotlib.backend_tools as tools
 
 try:
@@ -2332,9 +2332,10 @@ class FigureCanvasBase(object):
 
         """
         if s == 'idle_event':
-            warnings.warn("idle_event is only implemented for the wx backend, "
-                          "and will be removed in matplotlib 2.1. Use the "
-                          "animations module instead.", mplDeprecation)
+            warn_deprecated(1.5,
+                "idle_event is only implemented for the wx backend, and will "
+                "be removed in matplotlib 2.1. Use the animations module "
+                "instead.")
 
         return self.callbacks.connect(s, func)
 

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -243,14 +243,11 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         self.set_flags(gtk.CAN_FOCUS)
         self._renderer_init()
 
-        self._idle_event_id = gobject.idle_add(self.idle_event)
-
         self.last_downclick = {}
 
     def destroy(self):
         #gtk.DrawingArea.destroy(self)
         self.close_event()
-        gobject.source_remove(self._idle_event_id)
         if self._idle_draw_id != 0:
             gobject.source_remove(self._idle_draw_id)
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -210,15 +210,11 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         self.set_double_buffered(True)
         self.set_can_focus(True)
         self._renderer_init()
-        self._idle_event_id = GLib.idle_add(self.idle_event)
         default_context = GLib.main_context_get_thread_default() or GLib.main_context_default()
-        self._idle_event_source = default_context.find_source_by_id(self._idle_event_id)
 
     def destroy(self):
         #Gtk.DrawingArea.destroy(self)
         self.close_event()
-        if not self._idle_event_source.is_destroyed():
-            GLib.source_remove(self._idle_event_id)
         if self._idle_draw_id != 0:
             GLib.source_remove(self._idle_draw_id)
 

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -73,8 +73,6 @@ class FigureCanvasQT(FigureCanvasQT5):
         self.figure = figure
         self.setMouseTracking(True)
         self._idle = True
-        # hide until we can test and fix
-        # self.startTimer(backend_IdleEvent.milliseconds)
         w, h = self.get_width_height()
         self.resize(w, h)
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -240,14 +240,8 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         self.figure = figure
         self.setMouseTracking(True)
         self._idle = True
-        # hide until we can test and fix
-        # self.startTimer(backend_IdleEvent.milliseconds)
         w, h = self.get_width_height()
         self.resize(w, h)
-
-    def __timerEvent(self, event):
-        # hide until we can test and fix
-        self.mpl_idle_event(event)
 
     def enterEvent(self, event):
         FigureCanvasBase.enter_notify_event(self, guiEvent=event)


### PR DESCRIPTION
This PR deprecates `idle_event` and removes code related to it from the gtk backend.

The reasoning for this is discussed in #4534, but briefly, idle_event functionality is broken or missing in all but the wx backends (and doesn't work very well there either) and code related to it causes spurious warning in the gtk backend (see #3769).

The animations module should be used instead of idle_event for animations.

Please let me know if there is anything else to add.