### PR TITLE
A few WX phoenix related changes

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1713,7 +1713,10 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         rubberBandColor = '#C0C0FF'  # or load from config?
 
         # Set a pen for the border
-        color = wx.NamedColour(rubberBandColor)
+        if wxc.is_phoenix:
+            color = wx.Colour(rubberBandColor)
+        else:
+            color = wx.NamedColour(rubberBandColor)
         dc.SetPen(wx.Pen(color, 1))
 
         # use the same color, plus alpha for the brush

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1720,7 +1720,10 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         r, g, b, a = color.Get(True)
         color.Set(r, g, b, 0x60)
         dc.SetBrush(wx.Brush(color))
-        dc.DrawRectangleRect(rect)
+        if wxc.is_phoenix:
+            dc.DrawRectangle(rect)
+        else:
+            dc.DrawRectangleRect(rect)
 
     def set_status_bar(self, statbar):
         self.statbar = statbar

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -832,7 +832,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         if self.IsShownOnScreen():
             if not drawDC:
                 # not called from OnPaint use a ClientDC
-                drawDC = wx.ClientDC(self)
+                drawDC = wxc.ClientDC(self)
 
             # ensure that canvas has no 'left' over stuff when resizing frame
             drawDC.Clear()
@@ -1687,7 +1687,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def draw_rubberband(self, event, x0, y0, x1, y1):
         # Use an Overlay to draw a rubberband-like bounding box.
 
-        dc = wx.ClientDC(self.canvas)
+        dc = wxc.ClientDC(self.canvas)
         odc = wx.DCOverlay(self.wxoverlay, dc)
         odc.Clear()
 
@@ -1720,10 +1720,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         r, g, b, a = color.Get(True)
         color.Set(r, g, b, 0x60)
         dc.SetBrush(wx.Brush(color))
-        if wxc.is_phoenix:
-            dc.DrawRectangle(rect)
-        else:
-            dc.DrawRectangleRect(rect)
+        dc.DrawRectangleRect(rect)
 
     def set_status_bar(self, statbar):
         self.statbar = statbar

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1713,10 +1713,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         rubberBandColor = '#C0C0FF'  # or load from config?
 
         # Set a pen for the border
-        if wxc.is_phoenix:
-            color = wx.Colour(rubberBandColor)
-        else:
-            color = wx.NamedColour(rubberBandColor)
+        color = wxc.NamedColour(rubberBandColor)
         dc.SetPen(wx.Pen(color, 1))
 
         # use the same color, plus alpha for the brush

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -28,6 +28,9 @@ if LooseVersion(wx.VERSION_STRING) < LooseVersion("2.8.12"):
     print(" wxPython version %s was imported." % backend_version)
     raise ImportError(missingwx)
 
+# Import ClientCD so we can Monkey patch it.
+ClientDC = wx.ClientDC
+
 if is_phoenix:
     # define all the wxPython phoenix stuff
 
@@ -83,6 +86,8 @@ if is_phoenix:
     NamedColour = wx.Colour
     StockCursor = wx.Cursor
 
+    # Moneypatch ClientDC to for rename of DrawRectangleRect to DrawRectangle
+    ClientDC.DrawRectangleRect = ClientDC.DrawRectangle
 else:
     # define all the wxPython classic stuff
 

--- a/setupext.py
+++ b/setupext.py
@@ -1849,20 +1849,22 @@ class BackendWxAgg(OptionalBackendPackage):
     name = "wxagg"
 
     def check_requirements(self):
+        wxversioninstalled = True
         try:
             import wxversion
         except ImportError:
-            raise CheckFailed("requires wxPython")
+            wxversioninstalled = False
 
-        try:
-            _wx_ensure_failed = wxversion.AlreadyImportedError
-        except AttributeError:
-            _wx_ensure_failed = wxversion.VersionError
+        if wxversioninstalled:
+            try:
+                _wx_ensure_failed = wxversion.AlreadyImportedError
+            except AttributeError:
+                _wx_ensure_failed = wxversion.VersionError
 
-        try:
-            wxversion.ensureMinimal('2.8')
-        except _wx_ensure_failed:
-            pass
+            try:
+                wxversion.ensureMinimal('2.8')
+            except _wx_ensure_failed:
+                pass
 
         try:
             import wx


### PR DESCRIPTION
* Two additional methods have changed name in WX Phoenix. We should probably do consider doing this in a more elegant way but for now these are the minimal changes to make zoom work probably.

* Don't depend on wxversion in setupext. It's no longer a dependency of the wx backend so neither should it be here.
