### PR TITLE
Avoid making nose a dependency for matplotlib.testing.compare

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import matplotlib
 from matplotlib.compat import subprocess
-from matplotlib.testing.noseclasses import ImageComparisonFailure
+from matplotlib.testing.exceptions import ImageComparisonFailure
 from matplotlib import _png
 from matplotlib import _get_cachedir
 from matplotlib import cbook

--- a/lib/matplotlib/testing/exceptions.py
+++ b/lib/matplotlib/testing/exceptions.py
@@ -1,0 +1,10 @@
+class KnownFailureTest(Exception):
+    '''Raise this exception to mark a test as a known failing test.'''
+    pass
+
+class KnownFailureDidNotFailTest(Exception):
+    '''Raise this exception to mark a test should have failed but did not.'''
+    pass
+
+class ImageComparisonFailure(AssertionError):
+    '''Raise this exception to mark a test as a comparison between two images.'''

--- a/lib/matplotlib/testing/exceptions.py
+++ b/lib/matplotlib/testing/exceptions.py
@@ -1,10 +1,16 @@
 class KnownFailureTest(Exception):
-    '''Raise this exception to mark a test as a known failing test.'''
-    pass
+    """
+    Raise this exception to mark a test as a known failing test.
+    """
+
 
 class KnownFailureDidNotFailTest(Exception):
-    '''Raise this exception to mark a test should have failed but did not.'''
-    pass
+    """
+    Raise this exception to mark a test should have failed but did not.
+    """
+
 
 class ImageComparisonFailure(AssertionError):
-    '''Raise this exception to mark a test as a comparison between two images.'''
+    """
+    Raise this exception to mark a test as a comparison between two images.
+    """

--- a/lib/matplotlib/testing/noseclasses.py
+++ b/lib/matplotlib/testing/noseclasses.py
@@ -5,17 +5,9 @@ import six
 
 import os
 from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
-
-class KnownFailureTest(Exception):
-    '''Raise this exception to mark a test as a known failing test.'''
-    pass
-
-class KnownFailureDidNotFailTest(Exception):
-    '''Raise this exception to mark a test should have failed but did not.'''
-    pass
-
-class ImageComparisonFailure(AssertionError):
-    '''Raise this exception to mark a test as a comparison between two images.'''
+from matplotlib.testing.exceptions import (KnownFailureTest,
+                                           KnownFailureDidNotFailTest,
+                                           ImageComparisonFailure)
 
 class KnownFailure(ErrorClassPlugin):
     '''Plugin that installs a KNOWNFAIL error class for the

--- a/lib/matplotlib/testing/noseclasses.py
+++ b/lib/matplotlib/testing/noseclasses.py
@@ -9,6 +9,7 @@ from matplotlib.testing.exceptions import (KnownFailureTest,
                                            KnownFailureDidNotFailTest,
                                            ImageComparisonFailure)
 
+
 class KnownFailure(ErrorClassPlugin):
     '''Plugin that installs a KNOWNFAIL error class for the
     KnownFailureClass exception.  When KnownFailureTest is raised,
@@ -38,7 +39,7 @@ class KnownFailure(ErrorClassPlugin):
         if disable:
             self.enabled = False
 
-    def addError( self, test, err, *zero_nine_capt_args ):
+    def addError(self, test, err, *zero_nine_capt_args):
         # Fixme (Really weird): if I don't leave empty method here,
         # nose gets confused and KnownFails become testing errors when
         # using the MplNosePlugin and MplTestCase.

--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -194,7 +194,6 @@ def test_pep8_conformance_installed_files():
                           'type1font.py',
                           'widgets.py',
                           'testing/decorators.py',
-                          'testing/noseclasses.py',
                           'testing/jpl_units/Duration.py',
                           'testing/jpl_units/Epoch.py',
                           'testing/jpl_units/EpochConverter.py',


### PR DESCRIPTION
This is done by moving the exceptions that are testing framework-independent into matplotlib.testing.exceptions. I want to use functions from ``matplotlib.testing.compare`` for pytest and it seems unecesary to have nose as a dependency too for those functions since they are more generic.

(have rebased and currently pushing to fork is taking a long time due to large repo size!)