### PR TITLE
Add Seaborn style sheets; addresses #4566

### DIFF
--- a/lib/matplotlib/mpl-data/stylelib/seaborn-darkgrid.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-darkgrid.mplstyle
@@ -1,26 +1,4 @@
-# Seaborn base context
-figure.figsize: 8.0, 5.5
-axes.labelsize: 11
-axes.titlesize: 12
-xtick.labelsize: 10
-ytick.labelsize: 10
-legend.fontsize: 10
-
-grid.linewidth: 1
-lines.linewidth: 1.75
-patch.linewidth: .3
-lines.markersize: 7
-lines.markeredgewidth: 0
-
-xtick.major.width: 1
-ytick.major.width: 1
-xtick.minor.width: .5
-ytick.minor.width: .5
-
-xtick.major.pad: 7
-ytick.major.pad: 7
-
-# Common parameters
+# Seaborn common parameters
 # .15 = dark_gray
 # .8 = light_gray
 figure.facecolor: white
@@ -40,7 +18,7 @@ font.sans-serif: Arial, Liberation Sans, Bitstream Vera Sans, sans-serif
 grid.linestyle: -
 lines.solid_capstyle: round
 
-# darkgrid parameters
+# Seaborn darkgrid parameters
 axes.grid: True
 axes.facecolor: EAEAF2
 axes.edgecolor: white
@@ -50,6 +28,3 @@ xtick.major.size: 0
 ytick.major.size: 0
 xtick.minor.size: 0
 ytick.minor.size: 0
-
-# deep palette
-axes.color_cycle: 4C72B0, 55A868, C44E52, 8172B2, CCB974, 64B5CD

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-deep.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-deep.mplstyle
@@ -1,0 +1,2 @@
+# Seaborn deep palette
+axes.color_cycle: 4C72B0, 55A868, C44E52, 8172B2, CCB974, 64B5CD

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-notebook.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-notebook.mplstyle
@@ -1,0 +1,21 @@
+# Seaborn notebook context
+figure.figsize: 8.0, 5.5
+axes.labelsize: 11
+axes.titlesize: 12
+xtick.labelsize: 10
+ytick.labelsize: 10
+legend.fontsize: 10
+
+grid.linewidth: 1
+lines.linewidth: 1.75
+patch.linewidth: .3
+lines.markersize: 7
+lines.markeredgewidth: 0
+
+xtick.major.width: 1
+ytick.major.width: 1
+xtick.minor.width: .5
+ytick.minor.width: .5
+
+xtick.major.pad: 7
+ytick.major.pad: 7

--- a/lib/matplotlib/mpl-data/stylelib/seaborn.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn.mplstyle
@@ -1,0 +1,55 @@
+# Seaborn base context
+figure.figsize: 8.0, 5.5
+axes.labelsize: 11
+axes.titlesize: 12
+xtick.labelsize: 10
+ytick.labelsize: 10
+legend.fontsize: 10
+
+grid.linewidth: 1
+lines.linewidth: 1.75
+patch.linewidth: .3
+lines.markersize: 7
+lines.markeredgewidth: 0
+
+xtick.major.width: 1
+ytick.major.width: 1
+xtick.minor.width: .5
+ytick.minor.width: .5
+
+xtick.major.pad: 7
+ytick.major.pad: 7
+
+# Common parameters
+# .15 = dark_gray
+# .8 = light_gray
+figure.facecolor: white
+text.color: .15
+axes.labelcolor: .15
+legend.frameon: False
+legend.numpoints: 1
+legend.scatterpoints: 1
+xtick.direction: out
+ytick.direction: out
+xtick.color: .15
+ytick.color: .15
+axes.axisbelow: True
+image.cmap: Greys
+font.family: sans-serif
+font.sans-serif: Arial, Liberation Sans, Bitstream Vera Sans, sans-serif
+grid.linestyle: -
+lines.solid_capstyle: round
+
+# darkgrid parameters
+axes.grid: True
+axes.facecolor: EAEAF2
+axes.edgecolor: white
+axes.linewidth: 0
+grid.color: white
+xtick.major.size: 0
+ytick.major.size: 0
+xtick.minor.size: 0
+ytick.minor.size: 0
+
+# deep palette
+axes.color_cycle: 4C72B0, 55A868, C44E52, 8172B2, CCB974, 64B5CD


### PR DESCRIPTION
This commit adds the default Seaborn "darkgrid" style to the style library.