### PR TITLE
FIX: remove unicode in wx_compat

### DIFF
--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -28,7 +28,7 @@ if LooseVersion(wx.VERSION_STRING) < LooseVersion("2.8.12"):
     print(" wxPython version %s was imported." % backend_version)
     raise ImportError(missingwx)
 
-# Import ClientCD so we can Monkey patch it.
+# Import ClientCD so we can Monkey patch it.
 ClientDC = wx.ClientDC
 
 if is_phoenix:


### PR DESCRIPTION
This looks like it is a non-break space (or so emacs claims)

             position: 340 of 472 (72%), column: 2
            character:   (displayed as  ) (codepoint 160, #o240, #xa0)
    preferred charset: unicode (Unicode (ISO10646))
code point in charset: 0xA0
               script: latin
               syntax: . 	which means: punctuation
             category: .:Base, b:Arabic, j:Japanese, l:Latin
             to input: type "C-x 8 RET HEX-CODEPOINT" or "C-x 8 RET NAME"
          buffer code: #xC2 #xA0
            file code: #xC2 #xA0 (encoded by coding system utf-8-unix)
              display: by this font (glyph code)
    xft:-unknown-Liberation Mono-normal-normal-normal-*-13-*-*-*-m-0-iso10646-1 (#x62)
       hardcoded face: nobreak-space

Character code properties: customize what to show
  name: NO-BREAK SPACE
  old-name: NON-BREAKING SPACE
  general-category: Zs (Separator, Space)
  decomposition: (noBreak 32) (noBreak ' ')