### PR TITLE
Allow passing array-likes to pcolor{,mesh}.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4792,6 +4792,8 @@ class Axes(_AxesBase):
 
         if len(args) == 3:
             X, Y, C = args
+            X = np.asarray(X)
+            Y = np.asarray(Y)
             numRows, numCols = C.shape
         else:
             raise TypeError(

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -743,7 +743,7 @@ def test_pcolormesh_datetime_axis():
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
     base = datetime.datetime(2013, 1, 1)
     x = np.array([base + datetime.timedelta(days=d) for d in range(21)])
-    y = np.arange(21)
+    y = range(21)
     z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
     z = z1 * z2
     plt.subplot(221)
@@ -769,7 +769,7 @@ def test_pcolor_datetime_axis():
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
     base = datetime.datetime(2013, 1, 1)
     x = np.array([base + datetime.timedelta(days=d) for d in range(21)])
-    y = np.arange(21)
+    y = range(21)
     z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
     z = z1 * z2
     plt.subplot(221)


### PR DESCRIPTION
All's in the title.