### PR TITLE
Keep alpha on marker edges.  Fixes #4580

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -928,7 +928,7 @@ class GraphicsContextBase(object):
         """
         return self._snap
 
-    def set_alpha(self, alpha):
+    def set_alpha(self, alpha, update_foreground=True):
         """
         Set the alpha value used for blending - not supported on all backends.
         If ``alpha=None`` (the default), the alpha components of the
@@ -942,7 +942,9 @@ class GraphicsContextBase(object):
         else:
             self._alpha = 1.0
             self._forced_alpha = False
-        self.set_foreground(self._rgb, isRGBA=True)
+
+        if update_foreground:
+            self.set_foreground(self._rgb, isRGBA=True)
 
     def set_antialiased(self, b):
         """

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -780,7 +780,7 @@ class Line2D(Artist):
                 else:
                     gc.set_linewidth(0)
                 if rgbaFace is not None:
-                    gc.set_alpha(rgbaFace[3])
+                    gc.set_alpha(rgbaFace[3], False)
 
                 renderer.draw_markers(gc, marker_path, marker_trans,
                                       subsampled, affine.frozen(),


### PR DESCRIPTION
This fixes #4580.
``GraphicsContextBase`` allows for the foreground color (i.e. the marker line color) to get set independntly from the alpha of the fill colour, but calling ``set_alpha`` overrides the already set colour with alpha.

Here we add a keyword to decide whether we should set_alpha should do this or not.

Note, this behaviour may need tweaking to check if the "foreground color" has had an explicit alpha set or not.  Or perhaps we go for a different behaviour altogether.  Whatever we decide it shouldn't take too much tweaking to implement.