### PR TITLE
Correctly calculate margins on log scales

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3774,7 +3774,11 @@ class Axes(_AxesBase):
             self.set_ymargin(0.05)
 
         self.add_collection(collection)
-        self.autoscale_view()
+        try:
+            self.autoscale_view()
+        except NotImplementedError:
+            # This happens if the axes are not separable.
+            pass
 
         return collection
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2062,8 +2062,14 @@ class _AxesBase(martist.Artist):
             if scaley:
                 self.set_ybound(y0, y1)
             # Handling the x and y transformations at the same time allows us
-            # to save a couple calls to invTransLimits.transform().
-            invTrans = (self.transScale + self.transLimits).inverted()
+            # to save a couple calls to invTrans.transform().
+            try:
+                transLimits = self.transLimits
+            except AttributeError as e:
+                raise NotImplementedError(
+                    'margins are not implemented for non-separable axes')
+            else:
+                invTrans = (self.transScale + transLimits).inverted()
             assert(x0 < x1 and y0 < y1)
             p0 = invTrans.transform((-self._xmargin, -self._ymargin))
             p1 = invTrans.transform((1 + self._xmargin, 1 + self._ymargin))

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2057,18 +2057,22 @@ class _AxesBase(martist.Artist):
 
         # Step 2
         if self._xmargin > 0 or self._ymargin > 0:
-            if scalex:
-                self.set_xbound(x0, x1)
-            if scaley:
-                self.set_ybound(y0, y1)
             # Handling the x and y transformations at the same time allows us
             # to save a couple calls to invTrans.transform().
             try:
                 transLimits = self.transLimits
-            except AttributeError as e:
+            except AttributeError:
                 raise NotImplementedError(
                     'margins are not implemented for non-separable axes')
             else:
+                # Update bounds after checking for transLimits because if the
+                # axes are not separable, we should allow the caller to catch
+                # the NotImplementedError without there being any lasting
+                # changes to the view.
+                if scalex:
+                    self.set_xbound(x0, x1)
+                if scaley:
+                    self.set_ybound(y0, y1)
                 invTrans = (self.transScale + transLimits).inverted()
             assert(x0 < x1 and y0 < y1)
             p0 = invTrans.transform((-self._xmargin, -self._ymargin))

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2013,9 +2013,15 @@ class _AxesBase(martist.Artist):
                 x0, x1 = mtransforms.nonsingular(x0, x1, increasing=False,
                                                  expander=0.05)
             if self._xmargin > 0:
-                delta = (x1 - x0) * self._xmargin
-                x0 -= delta
-                x1 += delta
+                if self.get_xscale() == 'linear':
+                    delta = (x1 - x0) * self._xmargin
+                    x0 -= delta
+                    x1 += delta
+                else: # log scale
+                    assert(0 < x0 < x1)
+                    factor = pow(x1 / x0, self._xmargin)
+                    x1 *= factor
+                    x0 /= factor
             if not _tight:
                 x0, x1 = xlocator.view_limits(x0, x1)
             self.set_xbound(x0, x1)
@@ -2037,9 +2043,15 @@ class _AxesBase(martist.Artist):
                 y0, y1 = mtransforms.nonsingular(y0, y1, increasing=False,
                                                  expander=0.05)
             if self._ymargin > 0:
-                delta = (y1 - y0) * self._ymargin
-                y0 -= delta
-                y1 += delta
+                if self.get_yscale() == 'linear':
+                    delta = (y1 - y0) * self._ymargin
+                    y0 -= delta
+                    y1 += delta
+                else: # log scale
+                    assert(0 < y0 < y1)
+                    factor = pow(y1 / y0, self._ymargin)
+                    y1 *= factor
+                    y0 /= factor
             if not _tight:
                 y0, y1 = ylocator.view_limits(y0, y1)
             self.set_ybound(y0, y1)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2017,7 +2017,7 @@ class _AxesBase(martist.Artist):
                     delta = (x1 - x0) * self._xmargin
                     x0 -= delta
                     x1 += delta
-                else: # log scale
+                else:     # log scale
                     assert(0 < x0 < x1)
                     factor = pow(x1 / x0, self._xmargin)
                     x1 *= factor
@@ -2047,7 +2047,7 @@ class _AxesBase(martist.Artist):
                     delta = (y1 - y0) * self._ymargin
                     y0 -= delta
                     y1 += delta
-                else: # log scale
+                else:     # log scale
                     assert(0 < y0 < y1)
                     factor = pow(y1 / y0, self._ymargin)
                     y1 *= factor

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3648,23 +3648,39 @@ def test_margins():
 @cleanup
 def test_view_limits_with_margins():
     '''Tests that autoscale_view correctly calculates the new view limits
-    with a nonzero margin, for both linear and logarithmic axis scales.'''
-    MARGIN = 0.5
-    LIN_BOUNDS = (-0.35, 1.45)
-    LOG_BOUNDS = (0.1 / np.sqrt(10), np.sqrt(10))
-    data = [0.1, 1]
+    with a nonzero margin, for various kinds of plots.
+
+    The test uses a linear plot, a logarithmic plot, a symlog plot,
+    and a polar plot as an example of a nonlinear coordinate transformation.'''
 
     fig1, ax1 = plt.subplots(1, 1)
+    data = [0.1, 1]
     ax1.plot(data, data)
-    ax1.margins(MARGIN)
-    assert_equal(ax1.get_xbound(), LIN_BOUNDS)
-    assert_equal(ax1.get_ybound(), LIN_BOUNDS)
+    ax1.margins(0.5)
+    np.testing.assert_array_almost_equal(ax1.get_xbound(), (-0.35, 1.45))
+    np.testing.assert_array_almost_equal(ax1.get_ybound(), (-0.35, 1.45))
 
     fig2, ax2 = plt.subplots(1, 1)
+    data = [0.1, 1]
     ax2.loglog(data, data)
-    ax2.margins(MARGIN)
-    assert_equal(ax2.get_xbound(), LOG_BOUNDS)
-    assert_equal(ax2.get_ybound(), LOG_BOUNDS)
+    ax2.margins(0.5)
+    np.testing.assert_array_almost_equal(ax2.get_xbound(), (0.1 / np.sqrt(10), np.sqrt(10)))
+    np.testing.assert_array_almost_equal(ax2.get_ybound(), (0.1 / np.sqrt(10), np.sqrt(10)))
+
+    fig3, ax3 = plt.subplots(1, 1)
+    DATAMAX = 10
+    data = np.linspace(-DATAMAX, DATAMAX, 101)
+    ax3.plot(data, data)
+    BASE = 10
+    ax3.set_xscale('symlog', linthreshx=1, linscalex=1, basex=BASE)
+    ax3.set_yscale('symlog', linthreshy=1, linscaley=1, basey=BASE)
+    MARGIN = 0.5
+    ax3.margins(MARGIN)
+    # To understand the following line, see the implementation of
+    # matplotlib.scale.SymmetricalLogTransform.transform_non_affine()
+    BOUND = DATAMAX * BASE ** (2 * (1 + BASE / (BASE - 1)) * MARGIN)
+    np.testing.assert_array_almost_equal(ax3.get_xbound(), (-BOUND, BOUND))
+    np.testing.assert_array_almost_equal(ax3.get_ybound(), (-BOUND, BOUND))
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3682,6 +3682,10 @@ def test_view_limits_with_margins():
     np.testing.assert_array_almost_equal(ax3.get_xbound(), (-BOUND, BOUND))
     np.testing.assert_array_almost_equal(ax3.get_ybound(), (-BOUND, BOUND))
 
+    ax4 = plt.subplot(111, polar=True)
+    data = np.linspace(0, 2*np.pi, 51)
+    ax4.plot(data, data)
+    assert_raises(NotImplementedError, ax4.margins, 0.5)
 
 @cleanup
 def test_length_one_hist():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3646,6 +3646,28 @@ def test_margins():
 
 
 @cleanup
+def test_view_limits_with_margins():
+    '''Tests that autoscale_view correctly calculates the new view limits
+    with a nonzero margin, for both linear and logarithmic axis scales.'''
+    MARGIN = 0.5
+    LIN_BOUNDS = (-0.35, 1.45)
+    LOG_BOUNDS = (0.1 / np.sqrt(10), np.sqrt(10))
+    data = [0.1, 1]
+
+    fig1, ax1 = plt.subplots(1, 1)
+    ax1.plot(data, data)
+    ax1.margins(MARGIN)
+    assert_equal(ax1.get_xbound(), LIN_BOUNDS)
+    assert_equal(ax1.get_ybound(), LIN_BOUNDS)
+
+    fig2, ax2 = plt.subplots(1, 1)
+    ax2.loglog(data, data)
+    ax2.margins(MARGIN)
+    assert_equal(ax2.get_xbound(), LOG_BOUNDS)
+    assert_equal(ax2.get_ybound(), LOG_BOUNDS)
+
+
+@cleanup
 def test_length_one_hist():
     fig, ax = plt.subplots()
     ax.hist(1)


### PR DESCRIPTION
This (very small) change calculates the view limits when a log axis is given a nonzero margin, in a way that gives the same visual effect as for a linear axis.
