### PR TITLE
Revert "WX Monkey patch ClientDC for name changes"

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -832,7 +832,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         if self.IsShownOnScreen():
             if not drawDC:
                 # not called from OnPaint use a ClientDC
-                drawDC = wxc.ClientDC(self)
+                drawDC = wx.ClientDC(self)
 
             # ensure that canvas has no 'left' over stuff when resizing frame
             drawDC.Clear()
@@ -1688,7 +1688,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def draw_rubberband(self, event, x0, y0, x1, y1):
         # Use an Overlay to draw a rubberband-like bounding box.
 
-        dc = wxc.ClientDC(self.canvas)
+        dc = wx.ClientDC(self.canvas)
         odc = wx.DCOverlay(self.wxoverlay, dc)
         odc.Clear()
 
@@ -1721,7 +1721,10 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         r, g, b, a = color.Get(True)
         color.Set(r, g, b, 0x60)
         dc.SetBrush(wx.Brush(color))
-        dc.DrawRectangleRect(rect)
+        if wxc.is_phoenix:
+            dc.DrawRectangle(rect)
+        else:
+            dc.DrawRectangleRect(rect)
 
     def set_status_bar(self, statbar):
         self.statbar = statbar

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -28,9 +28,6 @@ if LooseVersion(wx.VERSION_STRING) < LooseVersion("2.8.12"):
     print(" wxPython version %s was imported." % backend_version)
     raise ImportError(missingwx)
 
-# Import ClientCD so we can Monkey patch it.
-ClientDC = wx.ClientDC
-
 if is_phoenix:
     # define all the wxPython phoenix stuff
 
@@ -86,8 +83,6 @@ if is_phoenix:
     NamedColour = wx.Colour
     StockCursor = wx.Cursor
 
-    # Moneypatch ClientDC to for rename of DrawRectangleRect to DrawRectangle
-    ClientDC.DrawRectangleRect = ClientDC.DrawRectangle
 else:
     # define all the wxPython classic stuff
 


### PR DESCRIPTION
This doesn't actually work correctly I could probably fix the actual monkey patching but we should 
also patch GCDC in addition to DC which I missed the first time round. Overall the simple solution seems better. 

This reverts commit 752d738cfbd1ce12322d5e19453a9c8b66721db1.