### PR TITLE
Only use asynchronous redraw methods when handling GUI events in Qt5Agg (fix #4604)

### DIFF
--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -73,22 +73,6 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         self._drawRect = None
         self.blitbox = None
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
-        # it has been reported that Qt is semi-broken in a windows
-        # environment.  If `self.draw()` uses `update` to trigger a
-        # system-level window repaint (as is explicitly advised in the
-        # Qt documentation) the figure responds very slowly to mouse
-        # input.  The work around is to directly use `repaint`
-        # (against the advice of the Qt documentation).  The
-        # difference between `update` and repaint is that `update`
-        # schedules a `repaint` for the next time the system is idle,
-        # where as `repaint` repaints the window immediately.  The
-        # risk is if `self.draw` gets called with in another `repaint`
-        # method there will be an infinite recursion.  Thus, we only
-        # expose windows users to this risk.
-        if sys.platform.startswith('win'):
-            self._priv_update = self.repaint
-        else:
-            self._priv_update = self.update
 
 
 FigureCanvas = FigureCanvasQTAgg

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -334,8 +334,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         hinch = h / dpival
         self.figure.set_size_inches(winch, hinch)
         FigureCanvasBase.resize_event(self)
-        self.draw()
-        self.update()
+        self.draw_idle()
         QtWidgets.QWidget.resizeEvent(self, event)
 
     def sizeHint(self):
@@ -417,17 +416,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     stop_event_loop.__doc__ = FigureCanvasBase.stop_event_loop_default.__doc__
 
     def draw_idle(self):
-        'update drawing area only if idle'
-        d = self._idle
-        self._idle = False
-
-        def idle_draw(*args):
-            try:
-                self.draw()
-            finally:
-                self._idle = True
-        if d:
-            QtCore.QTimer.singleShot(0, idle_draw)
+        self._priv_update()
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -666,7 +655,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         self._update_buttons_checked()
 
     def dynamic_update(self):
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def set_message(self, s):
         self.message.emit(s)

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -416,7 +416,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     stop_event_loop.__doc__ = FigureCanvasBase.stop_event_loop_default.__doc__
 
     def draw_idle(self):
-        self._priv_update()
+        self.update()
 
 
 class MainWindow(QtWidgets.QMainWindow):

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -63,7 +63,7 @@ class FigureCanvasQTAggBase(object):
 
     def drawRectangle(self, rect):
         self._drawRect = rect
-        self.repaint()
+        self.draw_idle()
 
     def paintEvent(self, e):
         """
@@ -71,6 +71,7 @@ class FigureCanvasQTAggBase(object):
         In Qt, all drawing should be done inside of here when a widget is
         shown onscreen.
         """
+        FigureCanvasAgg.draw(self)
 
         # FigureCanvasQT.paintEvent(self, e)
         if DEBUG:

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -147,7 +147,7 @@ class FigureCanvasQTAggBase(object):
         # causes problems with code that uses the result of the
         # draw() to update plot elements.
         FigureCanvasAgg.draw(self)
-        self._priv_update()
+        self.update()
 
     def blit(self, bbox=None):
         """
@@ -184,22 +184,6 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         self._drawRect = None
         self.blitbox = None
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
-        # it has been reported that Qt is semi-broken in a windows
-        # environment.  If `self.draw()` uses `update` to trigger a
-        # system-level window repaint (as is explicitly advised in the
-        # Qt documentation) the figure responds very slowly to mouse
-        # input.  The work around is to directly use `repaint`
-        # (against the advice of the Qt documentation).  The
-        # difference between `update` and repaint is that `update`
-        # schedules a `repaint` for the next time the system is idle,
-        # where as `repaint` repaints the window immediately.  The
-        # risk is if `self.draw` gets called with in another `repaint`
-        # method there will be an infinite recursion.  Thus, we only
-        # expose windows users to this risk.
-        if sys.platform.startswith('win'):
-            self._priv_update = self.repaint
-        else:
-            self._priv_update = self.update
 
 
 FigureCanvas = FigureCanvasQTAgg


### PR DESCRIPTION
When handling events like mouse movements during zoom/pan, the Qt5 backend forced a redraw of the Agg canvas for every event. Redraw operations should be done only when the GUI is ready to display another frame, else the rendering performance is going to be crushed on systems where Qt emits events more frequently.