### PR TITLE
Explicitly install Mock at version 1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,15 @@ language: python
 matrix:
   include:
     - python: 2.6
-      env: NUMPY=numpy==1.6
+      env: NUMPY=numpy==1.6 MOCK=true
     - python: 2.7
+      env: MOCK=true
     - python: 3.3
     - python: 3.4
     - python: 2.7
       env: TEST_ARGS=--pep8
     - python: 2.7
-      env: BUILD_DOCS=true
+      env: BUILD_DOCS=true MOCK=true
     - python: "nightly"
       env: PRE=--pre
   allow_failures:
@@ -63,6 +64,12 @@ install:
   # Always install from pypi
   - pip install $PRE nose pep8
 
+  # Install mock on python 2. We limit to 1.0.1 at the moment
+  # https://github.com/matplotlib/matplotlib/issues/4613
+  - |
+    if [[ $MOCK == true ]]; then
+      pip install mock==1.0.1
+    fi;
   # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
   # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
   # version since is it basically just a .ttf file


### PR DESCRIPTION
There are bugs with version 1.1.1 at the moment. See https://github.com/matplotlib/matplotlib/issues/4613