### PR TITLE
Make sure pil files are closed correctly

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1259,8 +1259,10 @@ def imread(fname, format=None):
             from PIL import Image
         except ImportError:
             return None
-        image = Image.open(fname)
-        return pil_to_array(image)
+        with open(fname, 'rb') as f:
+            image = Image.open(f)
+            array = pil_to_array(image)
+        return array
 
     handlers = {'png': _png.read_png, }
     if format is None:


### PR DESCRIPTION
While fixing #4613  I noticed some warnings in the tests.

This silences some of them by making sure that the files are closed probably when reading files using PIL

It seems like PIL doesn't probably close the files so pass a open file to PIL instead using a context manager. 
