### PR TITLE
hist2d() is now using pcolormesh instead of pcolorfast

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6087,7 +6087,7 @@ class Axes(_AxesBase):
 
         Other parameters
         -----------------
-        kwargs : :meth:`pcolorfast` properties.
+        kwargs : :meth:`pcolormesh` properties.
 
         See also
         --------
@@ -6117,7 +6117,7 @@ class Axes(_AxesBase):
         if cmax is not None:
             h[h > cmax] = None
 
-        pc = self.pcolorfast(xedges, yedges, h.T, **kwargs)
+        pc = self.pcolormesh(xedges, yedges, h.T, **kwargs)
         self.set_xlim(xedges[0], xedges[-1])
         self.set_ylim(yedges[0], yedges[-1])
 


### PR DESCRIPTION
Pull request in response to issue #4615  
