### PR TITLE
Deprecate color keyword argument in scatter

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3672,6 +3672,11 @@ class Axes(_AxesBase):
         # since it isn't, I am giving it low priority.
         co = kwargs.pop('color', None)
         if co is not None:
+            msg = (
+                "The 'color' keyword argument to scatter is deprecated, "
+                "please use 'c' instead."
+            )
+            warnings.warn(msg, mplDeprecation, stacklevel=1)
             if edgecolors is None:
                 edgecolors = co
             if facecolors is None:


### PR DESCRIPTION
There is a comment in `Axes.scatter` stating "'color' should be deprecated in scatter, or clearly defined; since it isn't, I am giving it low priority.". It is neither defined in the documentation nor deprecated, so this adds a deprecated warning to be more explicit about it.