### PR TITLE
Set figure width and height with set_size_inches

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -766,23 +766,21 @@ class Figure(Artist):
         self.dpi = val
         self.stale = True
 
-    def set_figwidth(self, val):
+    def set_figwidth(self, val, **kwargs):
         """
         Set the width of the figure in inches
 
         ACCEPTS: float
         """
-        self.bbox_inches.x1 = val
-        self.stale = True
+        self.set_size_inches(val, self.get_figheight(), **kwargs)
 
-    def set_figheight(self, val):
+    def set_figheight(self, val, **kwargs):
         """
         Set the height of the figure in inches
 
         ACCEPTS: float
         """
-        self.bbox_inches.y1 = val
-        self.stale = True
+        self.set_size_inches(self.get_figwidth(), val, **kwargs)
 
     def set_frameon(self, b):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -659,7 +659,7 @@ class Figure(Artist):
         self.stale = True
         return im
 
-    def set_size_inches(self, *args, **kwargs):
+    def set_size_inches(self, w, h=None, forward=False):
         """
         set_size_inches(w,h, forward=False)
 
@@ -682,11 +682,10 @@ class Figure(Artist):
         matplotlib.Figure.get_size_inches
         """
 
-        forward = kwargs.get('forward', False)
-        if len(args) == 1:
-            w, h = args[0]
-        else:
-            w, h = args
+        # the width and height have been passed in as a tuple to the first
+        # argument, so unpack them
+        if h is None:
+            w, h = w
 
         dpival = self.dpi
         self.bbox_inches.p1 = w, h
@@ -766,21 +765,21 @@ class Figure(Artist):
         self.dpi = val
         self.stale = True
 
-    def set_figwidth(self, val, **kwargs):
+    def set_figwidth(self, val, forward=False):
         """
         Set the width of the figure in inches
 
         ACCEPTS: float
         """
-        self.set_size_inches(val, self.get_figheight(), **kwargs)
+        self.set_size_inches(val, self.get_figheight(), forward=forward)
 
-    def set_figheight(self, val, **kwargs):
+    def set_figheight(self, val, forward=False):
         """
         Set the height of the figure in inches
 
         ACCEPTS: float
         """
-        self.set_size_inches(self.get_figwidth(), val, **kwargs)
+        self.set_size_inches(self.get_figwidth(), val, forward=forward)
 
     def set_frameon(self, b):
         """

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -158,6 +158,24 @@ def test_iterability_axes_argument():
     plt.close(fig)
 
 
+@cleanup
+def test_set_fig_size():
+    fig = plt.figure()
+
+    # check figwidth
+    fig.set_figwidth(5)
+    assert_equal(fig.get_figwidth(), 5)
+
+    # check figheight
+    fig.set_figheight(1)
+    assert_equal(fig.get_figheight(), 1)
+
+    # check using set_size_inches
+    fig.set_size_inches(2, 4)
+    assert_equal(fig.get_figwidth(), 2)
+    assert_equal(fig.get_figheight(), 4)
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -175,6 +175,11 @@ def test_set_fig_size():
     assert_equal(fig.get_figwidth(), 2)
     assert_equal(fig.get_figheight(), 4)
 
+    # check using tuple to first argument
+    fig.set_size_inches((1, 3))
+    assert_equal(fig.get_figwidth(), 1)
+    assert_equal(fig.get_figheight(), 3)
+
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
Fixes #4673

This modifies `set_figwidth` and `set_figheight` so that they call `set_size_inches` and pass along any additional kwargs (such as `forward`). It also adds some very basic tests for calling all three methods.