### PR TITLE
Travis: Upgrade pip and setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,11 @@ before_install:
   - source venv/bin/activate
 
 install:
+  # Upgrade pip and setuptools. Mock has issues with the default version of
+  # setuptools
+  - |
+    pip install --upgrade pip
+    pip install --upgrade setuptools
   # Install only from travis wheelhouse
   - if [ -z "$PRE" ]; then
         wheelhouse_pip_install python-dateutil $NUMPY pyparsing pillow sphinx!=1.3.0;

--- a/tools/travis_tools.sh
+++ b/tools/travis_tools.sh
@@ -1,5 +1,6 @@
 # Tools for working with travis-ci
-export WHEELHOUSE="http://travis-wheels.scikit-image.org/"
+export WHEELHOST="travis-wheels.scikit-image.org"
+export WHEELHOUSE="http://${WHEELHOST}/"
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804
@@ -21,5 +22,5 @@ retry () {
 
 wheelhouse_pip_install() {
     # Install pip requirements via travis wheelhouse
-    retry pip install --timeout=60 --no-index --find-links $WHEELHOUSE $@
+    retry pip install --timeout=60 --no-index --trusted-host $WHEELHOST --find-links $WHEELHOUSE $@
 }


### PR DESCRIPTION
The installed version has issues with mock. i.e https://travis-ci.org/matplotlib/matplotlib/jobs/70838060
This upgrades pip and setuptools before installing anything else. The other alternative is to limit mock to an older version. 