### PR TITLE
Update to score_family in font_manager.py

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1118,7 +1118,7 @@ class FontManager(object):
                 options = [x.lower() for x in options]
                 if family2 in options:
                     idx = options.index(family2)
-                    return (i + idx / len(options)) * step
+                    return (i + (idx / len(options))) * step
             elif family1 == family2:
                 # The score should be weighted by where in the
                 # list the font was found.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1099,15 +1099,16 @@ class FontManager(object):
         Returns a match score between the list of font families in
         *families* and the font family name *family2*.
 
-        An exact match anywhere in the list returns 0.0.
+        An exact match at the head of the list returns 0.0.
 
-        A match by generic font name will return 0.1.
+        A match further down the list will return between 0 and 1.
 
         No match will return 1.0.
         """
         if not isinstance(families, (list, tuple)):
             families = [families]
         family2 = family2.lower()
+        step = 1 / len(families)
         for i, family1 in enumerate(families):
             family1 = family1.lower()
             if family1 in font_family_aliases:
@@ -1117,12 +1118,11 @@ class FontManager(object):
                 options = [x.lower() for x in options]
                 if family2 in options:
                     idx = options.index(family2)
-                    return ((0.1 * (idx / len(options))) *
-                            ((i + 1) / len(families)))
+                    return (i + idx / len(options)) * step
             elif family1 == family2:
                 # The score should be weighted by where in the
                 # list the font was found.
-                return i / len(families)
+                return i * step
         return 1.0
 
     def score_style(self, style1, style2):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1107,6 +1107,8 @@ class FontManager(object):
         """
         if not isinstance(families, (list, tuple)):
             families = [families]
+        elif len(families) == 0:
+            return 1.0
         family2 = family2.lower()
         step = 1 / len(families)
         for i, family1 in enumerate(families):


### PR DESCRIPTION
This PR fixes the score calculation for the case of matching a generic font name given in the `families` list.

The returned score is now constrained by the position `i` of the match in the list. If the font being scored (`family2`) is the first choice for that generic name in rcParams, it will receive the same score as if it were an exact match for that position in the `families` list, namely `i / len(families)`. If the font being scored is in the alias list but not the first choice, the returned score will be greater than `i / len(families)` but less than `(i + 1) / len(families)`, ensuring that the preferred order of fonts listed in both `families` and rcParams font alias list are respected.