### PR TITLE
Lock mock down to a version that we know works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ matrix:
     - python: 2.6
       env: NUMPY=numpy==1.6 MOCK=mock==1.0.1
     - python: 2.7
-      env: MOCK=mock
+      env: MOCK=mock==1.0.1
     - python: 3.3
     - python: 3.4
     - python: 2.7
-      env: TEST_ARGS=--pep8
+      env: TEST_ARGS=--pep8 MOCK=mock==1.0.1
     - python: 2.7
-      env: BUILD_DOCS=true MOCK=mock
+      env: BUILD_DOCS=true MOCK=mock==1.0.1
     - python: "nightly"
       env: PRE=--pre
   allow_failures:


### PR DESCRIPTION
This is a simpler alternative to #4687 to get master back to passing. Installing new versions of mock as happens on python 2.7 and the pep8 tests don't work well with the current version of setuptools on Travis. This gets around it by explicitly installing the old mock version in all python 2 envs.

I would appreciate if someone could merge either this #4687 asap to get the master branch back to parsing. 