### PR TITLE
Travis: Set exit to true in nose.main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,7 @@ class NoseTestCommand(TestCommand):
         nose.main(addplugins=[x() for x in plugins],
                   defaultTest=testmodules,
                   argv=['nosetests'] + self.test_args,
-                  exit=False)
+                  exit=True)
 
 
 # One doesn't normally see `if __name__ == '__main__'` blocks in a setup.py,


### PR DESCRIPTION
Following the merge of #4668 tests do not fail correctly on Travis. This sets exit to True in nose.main. Otherwise the exit status is not set correctly and Travis does not fail on failure.

Compare https://travis-ci.org/matplotlib/matplotlib/jobs/71108096 which should have failed but does not to the result of the python 3.5 job on this branch 