### PR TITLE
FIX: gracefully deal with empty size lists

### DIFF
--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -306,7 +306,7 @@ class HandlerRegularPolyCollection(HandlerNpointsYoffsets):
                  xdescent, ydescent, width, height, fontsize):
         if self._sizes is None:
             handle_sizes = orig_handle.get_sizes()
-            if not handle_sizes:
+            if not len(handle_sizes):
                 handle_sizes = [1]
             size_max = max(handle_sizes) * legend.markerscale ** 2
             size_min = min(handle_sizes) * legend.markerscale ** 2

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -305,8 +305,11 @@ class HandlerRegularPolyCollection(HandlerNpointsYoffsets):
     def get_sizes(self, legend, orig_handle,
                  xdescent, ydescent, width, height, fontsize):
         if self._sizes is None:
-            size_max = max(orig_handle.get_sizes()) * legend.markerscale ** 2
-            size_min = min(orig_handle.get_sizes()) * legend.markerscale ** 2
+            handle_sizes = orig_handle.get_sizes()
+            if not handle_sizes:
+                handle_sizes = [1]
+            size_max = max(handle_sizes) * legend.markerscale ** 2
+            size_min = min(handle_sizes) * legend.markerscale ** 2
 
             numpoints = self.get_numpoints(legend)
             if numpoints < 4:

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -249,6 +249,17 @@ def test_nanscatter():
 
     ax.legend([h], ["scatter"])
 
+    fig, ax = plt.subplots()
+    for color in ['red', 'green', 'blue']:
+        n = 750
+        x, y = np.random.rand(2, n)
+        scale = 200.0 * np.random.rand(n)
+        ax.scatter(x, y, c=color, s=scale, label=color,
+                   alpha=0.3, edgecolors='none')
+
+    ax.legend()
+    ax.grid(True)
+
 
 if __name__ == '__main__':
     import nose

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -240,6 +240,16 @@ def test_legend_stackplot():
     ax.legend(loc=0)
 
 
+@cleanup
+def test_nanscatter():
+    fig, ax = plt.subplots()
+
+    h = ax.scatter([np.nan], [np.nan], marker="o",
+                   facecolor="r", edgecolor="r", s=3)
+
+    ax.legend([h], ["scatter"])
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
In HandlerRegularPolyCollection gracefully deal with empty
size lists.

Fixes #4365