### PR TITLE
API/CLN: remove threading classes from cbook

### DIFF
--- a/doc/api/api_changes/2015-07-16_remove_threading.rst
+++ b/doc/api/api_changes/2015-07-16_remove_threading.rst
@@ -1,0 +1,5 @@
+Removed threading related classes from cbook
+````````````````````````````````````````````
+The classes ``Scheduler``, ``Timeout``, and ``Idle`` were in cbook, but
+are not used internally.  They appear to be a prototype for the idle event
+system which was not working and has recently been pulled out.


### PR DESCRIPTION
These are not used anywhere internally and no one should
be using these externally.