### PR TITLE
BUG: when autoscaling, handle tiny but non-zero values; closes #4318

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -552,6 +552,15 @@ def test_transform_angles():
     assert_raises(ValueError, t.transform_angles, angles, points[0:2, :])
 
 
+def test_nonsingular():
+    # test for zero-expansion type cases; other cases may be added later
+    zero_expansion = np.array([-0.001, 0.001])
+    cases = [(0, np.nan), (0, 0), (0, 7.9e-317)]
+    for args in cases:
+        out = np.array(mtrans.nonsingular(*args))
+        assert_array_equal(out, zero_expansion)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'],  exit=False)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2726,16 +2726,23 @@ def nonsingular(vmin, vmax, expander=0.001, tiny=1e-15, increasing=True):
 
     Returns *vmin*, *vmax*, expanded and/or swapped if necessary.
 
-    If either input is inf or NaN, or if both inputs are 0,
-    returns -*expander*, *expander*.
+    If either input is inf or NaN, or if both inputs are 0 or very
+    close to zero, it returns -*expander*, *expander*.
     '''
     if (not np.isfinite(vmin)) or (not np.isfinite(vmax)):
         return -expander, expander
+
     swapped = False
     if vmax < vmin:
         vmin, vmax = vmax, vmin
         swapped = True
-    if vmax - vmin <= max(abs(vmin), abs(vmax)) * tiny:
+
+    maxabsvalue = max(abs(vmin), abs(vmax))
+    if maxabsvalue < (1e6 / tiny) * np.MachAr(float).xmin:
+        vmin = -expander
+        vmax = expander
+
+    elif vmax - vmin <= maxabsvalue * tiny:
         if vmax == 0 and vmin == 0:
             vmin = -expander
             vmax = expander


### PR DESCRIPTION
This is a fairly minimal ad hoc change to nonsingular, which is in the spirit of that function.