### PR TITLE
sphinxext/plot_directive does not accept a caption

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -651,10 +651,6 @@ def render_figures(code, code_path, output_dir, output_base, context,
 
 
 def run(arguments, content, options, state_machine, state, lineno):
-    # The user may provide a filename *or* Python code content, but not both
-    if arguments and content:
-        raise RuntimeError("plot:: directive can't have both args and content")
-
     document = state_machine.document
     config = document.settings.env.config
     nofigs = 'nofigs' in options

--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -84,8 +84,7 @@ class TestTinyPages(object):
             html_contents = fobj.read()
         assert_true('# Only a comment' in html_contents)
         # check plot defined in external file.
-        assert_true(file_same(range_4, plot_file(15)))
-        assert_true(file_same(range_6, plot_file(16)))
-        assert_true(file_same(range_4, plot_file(17)))
+        assert_true(file_same(range_4, pjoin(self.html_dir, 'range4.png'))
+        assert_true(file_same(range_6, pjoin(self.html_dir, 'range6.png'))
         # check if figure caption made it into html file
-        assert_true('This is the caption for plot 17.')
+        assert_true('This is the caption for plot 15.')

--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -87,4 +87,4 @@ class TestTinyPages(object):
         assert_true(file_same(range_4, pjoin(self.html_dir, 'range4.png')))
         assert_true(file_same(range_6, pjoin(self.html_dir, 'range6.png')))
         # check if figure caption made it into html file
-        assert_true('This is the caption for plot 15.')
+        assert_true('This is the caption for plot 15.' in html_contents)

--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -83,3 +83,9 @@ class TestTinyPages(object):
         with open(pjoin(self.html_dir, 'some_plots.html'), 'rt') as fobj:
             html_contents = fobj.read()
         assert_true('# Only a comment' in html_contents)
+        # check plot defined in external file.
+        assert_true(file_same(range_4, plot_file(15)))
+        assert_true(file_same(range_6, plot_file(16)))
+        assert_true(file_same(range_4, plot_file(17)))
+        # check if figure caption made it into html file
+        assert_true('This is the caption for plot 17.')

--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -84,7 +84,7 @@ class TestTinyPages(object):
             html_contents = fobj.read()
         assert_true('# Only a comment' in html_contents)
         # check plot defined in external file.
-        assert_true(file_same(range_4, pjoin(self.html_dir, 'range4.png'))
-        assert_true(file_same(range_6, pjoin(self.html_dir, 'range6.png'))
+        assert_true(file_same(range_4, pjoin(self.html_dir, 'range4.png')))
+        assert_true(file_same(range_6, pjoin(self.html_dir, 'range6.png')))
         # check if figure caption made it into html file
         assert_true('This is the caption for plot 15.')

--- a/lib/matplotlib/sphinxext/tests/tinypages/range4.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/range4.py
@@ -2,7 +2,9 @@ from matplotlib import pyplot as plt
 
 plt.figure()
 plt.plot(range(4))
+plt.show()
 
 def range6():
     plt.figure()
     plt.plot(range(6))
+    plt.show()

--- a/lib/matplotlib/sphinxext/tests/tinypages/range4.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/range4.py
@@ -1,0 +1,8 @@
+from matplotlib import pyplot as plt
+
+plt.figure()
+plt.plot(range(4))
+
+def range6():
+    plt.figure()
+    plt.plot(range(6))

--- a/lib/matplotlib/sphinxext/tests/tinypages/range4.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/range4.py
@@ -3,8 +3,3 @@ from matplotlib import pyplot as plt
 plt.figure()
 plt.plot(range(4))
 plt.show()
-
-def range6():
-    plt.figure()
-    plt.plot(range(6))
-    plt.show()

--- a/lib/matplotlib/sphinxext/tests/tinypages/range6.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/range6.py
@@ -1,0 +1,10 @@
+from matplotlib import pyplot as plt
+
+def range4():
+    '''This function should never be called if the plot_diective works as expected.'''
+    raise NotImplementedError
+
+def range6():
+    plt.figure()
+    plt.plot(range(6))
+    plt.show()

--- a/lib/matplotlib/sphinxext/tests/tinypages/range6.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/range6.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot as plt
 
 def range4():
-    '''This function should never be called if the plot_diective works as expected.'''
+    '''This function should never be called if the plot_directive works as expected.'''
     raise NotImplementedError
 
 def range6():

--- a/lib/matplotlib/sphinxext/tests/tinypages/range6.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/range6.py
@@ -7,6 +7,7 @@ def range4():
 
 
 def range6():
+    '''This is the function that should be executed.'''
     plt.figure()
     plt.plot(range(6))
     plt.show()

--- a/lib/matplotlib/sphinxext/tests/tinypages/range6.py
+++ b/lib/matplotlib/sphinxext/tests/tinypages/range6.py
@@ -1,8 +1,10 @@
 from matplotlib import pyplot as plt
 
+
 def range4():
-    '''This function should never be called if the plot_directive works as expected.'''
+    '''This is never be called if plot_directive works as expected.'''
     raise NotImplementedError
+
 
 def range6():
     plt.figure()

--- a/lib/matplotlib/sphinxext/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/sphinxext/tests/tinypages/some_plots.rst
@@ -115,16 +115,15 @@ Plot 14 uses ``include-source``:
 
     # Only a comment
 
-Plot 15 uses an external file with the plot commands:
+Plot 15 uses an external file with the plot commands and a caption:
 
 .. plot:: range4.py
+
+   This is the caption for plot 15.
+
 
 Plot 16 uses a specific function in a file with plot commands:
 
-.. plot:: range4.py range6
-	  
-Plot 17 uses an external file and a caption:
+.. plot:: range6.py range6
 
-.. plot:: range4.py
 
-   This is the caption for plot 17.

--- a/lib/matplotlib/sphinxext/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/sphinxext/tests/tinypages/some_plots.rst
@@ -114,3 +114,17 @@ Plot 14 uses ``include-source``:
     :include-source:
 
     # Only a comment
+
+Plot 15 uses an external file with the plot commands:
+
+.. plot:: range4.py
+
+Plot 16 uses a specific function in a file with plot commands:
+
+.. plot:: range4.py range6
+	  
+Plot 17 uses an external file and a caption:
+
+.. plot:: range4.py
+
+   This is the caption for plot 17.


### PR DESCRIPTION
According to the docstring I should be able to do
```
     When a path to a source file is given, the content of the
     directive may optionally contain a caption for the plot::

       .. plot:: path/to/plot.py

          This is the caption for the plot

```

However, when I try this I get:
```
Exception occurred:
  File "/Users/hamogu/anaconda/lib/python2.7/site-packages/matplotlib/sphinxext/plot_directive.py", line 640, in run
    raise RuntimeError("plot:: directive can't have both args and content")
RuntimeError: plot:: directive can't have both args and content
```
The code to generate the caption is there, but because of this line
https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/sphinxext/plot_directive.py#L655
it is impossible to get there.

@mdboom: I'm sure you had a good reason to put this check there when you wrote it, thus I'll leave this as an issue and don't just submit a PR to remove this check.
(Also, I don't know much about how matplotlib runs tests and the code in the doc string should probably be turned into a doctest...)