### PR TITLE
[WIP] Proposed improvement in default log formatting

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -733,6 +733,8 @@ class LogFormatter(Formatter):
         return s
 
 
+SPECIAL_LOG = set((0, 0.1, 1, 10))
+
 class LogFormatterExponent(LogFormatter):
     """
     Format values for log axis; using ``exponent = log_base(value)``
@@ -776,11 +778,11 @@ class LogFormatterMathtext(LogFormatter):
         usetex = rcParams['text.usetex']
 
         # only label the decades
-        if x == 0:
+        if x in SPECIAL_LOG:
             if usetex:
-                return '$0$'
+                return '${0:g}$'.format(x)
             else:
-                return '$\mathdefault{0}$'
+                return '$\mathdefault{{{0:g}}}$'.format(x)
 
         fx = math.log(abs(x)) / math.log(b)
         is_decade = is_close_to_int(fx)


### PR DESCRIPTION
This is a proposed change in defaults for the upcoming 2.0 release, in response to @tacaswell's email on the matplotlib list (and this is by no means a finished PR).

When making log plots, having 10^0 and 10^1 instead of 1 and 10 looks unpolished and I often encounter users that comment (negatively) on it:

![logs_before](https://cloud.githubusercontent.com/assets/314716/8742090/1f9d3a16-2c94-11e5-9127-b3b6bd321bab.png)

I would like to propose that we fix this properly and make it so that the default log formatter uses 0.1, 1, and 10 in instead of 10^-1, 10^0, and 10^1. The current PR gives:

![logs](https://cloud.githubusercontent.com/assets/314716/8742099/47dc869e-2c94-11e5-99d8-981773823aa0.png)

The PR here is clearly not the final answer - at the moment you can see that the baseline for the labels is wrong on the x-axis for the 0.1, 1, and 10 values due to the lack of exponent. Presumably we could align the labels using the bottom of the labels instead of the top. Or we could an empty exponent. But for the y-axis, this looks a lot nicer. This would also need tests, etc.

Any thoughts about this?