### PR TITLE
Implement draw_idle

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -309,6 +309,9 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasBase):
         self.renderer = RendererMac(figure.dpi, width, height)
         _macosx.FigureCanvas.__init__(self, width, height)
 
+    def draw_idle(self, *args, **kwargs):
+        self.invalidate()
+
     def resize(self, width, height):
         self.renderer.set_width_height(width, height)
         dpi = self.figure.dpi


### PR DESCRIPTION
Implements draw_idle for the MacOSX backend. This function simply calls canvas.invalidate, which is implemented in the Objective-C extension module.