### PR TITLE
Dont call plt.ion in system monitor example

### DIFF
--- a/examples/pylab_examples/system_monitor.py
+++ b/examples/pylab_examples/system_monitor.py
@@ -24,7 +24,7 @@ def get_stats():
 
 # turn interactive mode on for dynamic updates.  If you aren't in
 # interactive mode, you'll need to use a GUI event handler/timer.
-plt.ion()
+# plt.ion()
 
 fig, ax = plt.subplots()
 ind = np.arange(1, 4)


### PR DESCRIPTION
This breaks the docs build following the merge of #4506 

This is likely just a temporary fix to get the docs building inspired by what was done in #4506