### PR TITLE
BUG: Fix alternate toolbar import on Python 3.

### DIFF
--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -304,7 +304,7 @@ class ToolManager(object):
             else:
                 mod = 'backend_tools'
                 current_module = __import__(mod,
-                                            globals(), locals(), [mod], -1)
+                                            globals(), locals(), [mod], 1)
 
                 callback_class = getattr(current_module, callback_class, False)
         if callable(callback_class):


### PR DESCRIPTION
In #4699, @OceanWolf recommended enabling an alternate toolbar for some zoom testing, but it fails on Python 3 due to some import changes.