### PR TITLE
FIX: cast input to Rectangle to float

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -636,11 +636,11 @@ class Rectangle(Patch):
 
         Patch.__init__(self, **kwargs)
 
-        self._x = xy[0]
-        self._y = xy[1]
-        self._width = width
-        self._height = height
-        self._angle = angle
+        self._x = float(xy[0])
+        self._y = float(xy[1])
+        self._width = float(width)
+        self._height = float(height)
+        self._angle = float(angle)
         # Note: This cannot be calculated until this is added to an Axes
         self._rect_transform = transforms.IdentityTransform()
 


### PR DESCRIPTION
If user passes in uint, can get integer overflow (from trying
to negate it).  Cast all the input to Rectangle to float to be
safe.

Closes #4751