### PR TITLE
Use BytesIO from io.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -17,10 +17,11 @@ import sys
 import time
 import warnings
 import zlib
+from io import BytesIO
 
 import numpy as np
 from matplotlib.externals.six import unichr
-from matplotlib.externals.six import BytesIO
+
 
 from datetime import datetime
 from math import ceil, cos, floor, pi, sin


### PR DESCRIPTION
Fix bad merge from 8fe495a705153bdb7a224f58c02d54272c321094

As noted by @WeatherGod in #4605 master is failing. 

```
That is because the merge of the six branch (#4501) changed it from

from io import BytesIO 
to

from matplotlib.externals.six import BytesIO
six.BytesIO is stringIO.stringIO in python 2

while #4603 changed it to use BytesIO all over.

I.e I think the merge in 8fe495a is wrong
```