### PR TITLE
ENH: add remove call back to axes

### DIFF
--- a/doc/users/whats_new/2015-07-23_axes_remove_method.rst
+++ b/doc/users/whats_new/2015-07-23_axes_remove_method.rst
@@ -1,0 +1,5 @@
+`ax.remove()` works as expected
+-------------------------------
+
+As with artists added to as `Axes`, `Axes` can be
+removed from their figure via ``ax.remove()``

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -908,6 +908,7 @@ class Figure(Artist):
 
         self._axstack.add(key, a)
         self.sca(a)
+        a._remove_method = lambda ax: self.delaxes(ax)
         self.stale = True
         return a
 
@@ -996,6 +997,7 @@ class Figure(Artist):
 
         self._axstack.add(key, a)
         self.sca(a)
+        a._remove_method = lambda ax: self.delaxes(ax)
         self.stale = True
         return a
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from matplotlib.externals import six
 from matplotlib.externals.six.moves import xrange
 
-from nose.tools import assert_equal, assert_true, assert_raises
+from nose.tools import assert_equal, assert_true
 from matplotlib.testing.decorators import image_comparison, cleanup
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
@@ -179,6 +179,16 @@ def test_set_fig_size():
     fig.set_size_inches((1, 3))
     assert_equal(fig.get_figwidth(), 1)
     assert_equal(fig.get_figheight(), 3)
+
+
+@cleanup
+def test_axes_remove():
+    fig, axes = plt.subplots(2, 2)
+    axes[-1, -1].remove()
+    for ax in axes.ravel()[:-1]:
+        assert ax in fig.axes
+    assert axes[-1, -1] not in fig.axes
+    assert_equal(len(fig.axes), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ax.remove() now works as expected

If this seems small enough I have no objection to it going into 1.5.