### PR TITLE
mep12 on pythonic_matplotlib.py

### DIFF
--- a/examples/pylab_examples/pythonic_matplotlib.py
+++ b/examples/pylab_examples/pythonic_matplotlib.py
@@ -1,5 +1,5 @@
 """
-Some people prefer to write more pythonic, object oriented, code
+Some people prefer to write more pythonic, object-oriented code
 rather than use the pyplot interface to matplotlib.  This example shows
 you how.
 

--- a/examples/pylab_examples/pythonic_matplotlib.py
+++ b/examples/pylab_examples/pythonic_matplotlib.py
@@ -36,7 +36,7 @@ The syntax of set is
 
 if called with an object, set calls
 
-  plt.object.set_somestring(attribute)
+  object.set_somestring(attribute)
 
 if called with a sequence, set does
 

--- a/examples/pylab_examples/pythonic_matplotlib.py
+++ b/examples/pylab_examples/pythonic_matplotlib.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
 """
 Some people prefer to write more pythonic, object oriented, code
-rather than use the pylab interface to matplotlib.  This example shows
+rather than use the pyplot interface to matplotlib.  This example shows
 you how.
 
 Unless you are an application developer, I recommend using part of the
-pylab interface, particularly the figure, close, subplot, axes, and
+pyplot interface, particularly the figure, close, subplot, axes, and
 show commands.  These hide a lot of complexity from you that you don't
 need to see in normal figure creation, like instantiating DPI
 instances, managing the bounding boxes of the figure elements,
@@ -21,11 +20,11 @@ embedding them in application windows, etc.
 If you are a web application developer, you may want to use the
 example in webapp_demo.py, which shows how to use the backend agg
 figure canvase directly, with none of the globals (current figure,
-current axes) that are present in the pylab interface.  Note that
-there is no reason why the pylab interface won't work for web
+current axes) that are present in the pyplot interface.  Note that
+there is no reason why the pyplot interface won't work for web
 application developers, however.
 
-If you see an example in the examples dir written in pylab interface,
+If you see an example in the examples dir written in pyplot interface,
 and you want to emulate that using the true python method calls, there
 is an easy mapping.  Many of those examples use 'set' to control
 figure properties.  Here's how to map those commands onto instance
@@ -33,11 +32,11 @@ methods
 
 The syntax of set is
 
-  setp(object or sequence, somestring, attribute)
+  plt.setp(object or sequence, somestring, attribute)
 
 if called with an object, set calls
 
-  object.set_somestring(attribute)
+  plt.object.set_somestring(attribute)
 
 if called with a sequence, set does
 
@@ -53,7 +52,7 @@ So for your example, if a is your axes object, you can do
 """
 
 
-from pylab import figure, show
+from matplotlib.pyplot import figure, show
 from numpy import arange, sin, pi
 
 t = arange(0.0, 1.0, 0.01)


### PR DESCRIPTION
I have intentionally left out changing all the function names from `function_name` to `plt.function_name()` or `np.function_name()`, as I think it's mostly the advanced user that will prefer to look at this example, and would know to trace the function names back to the correct import.