### PR TITLE
ENH: plotting methods can unpack labeled data

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1551,20 +1551,20 @@ def unpack_labeled_data(wl_args=None, wl_kwargs=None, label_pos=None):
             data = kwargs.pop('data', None)
             if data is not None:
                 if wl_args is None:
-                    args = tuple(_replacer(data, a) for a in args)
+                    new_args = tuple(_replacer(data, a) for a in args)
                 else:
-                    args = tuple(_replacer(data, a) if j in wl_args else a
-                                 for j, a in enumerate(args))
+                    new_args = tuple(_replacer(data, a) if j in wl_args else a
+                                     for j, a in enumerate(args))
 
                 if wl_kwargs is None:
-                    kwargs = dict((k, _replacer(data, v))
-                                  for k, v in six.iteritems(kwargs))
+                    new_kwargs = dict((k, _replacer(data, v))
+                                      for k, v in six.iteritems(kwargs))
                 else:
-                    kwargs = dict(
+                    new_kwargs = dict(
                         (k, _replacer(data, v) if k in wl_kwargs else v)
                         for k, v in six.iteritems(kwargs))
             if (label_pos is not None and ('label' not in kwargs or
-                    kwargs['label'] is None)):
+                                           kwargs['label'] is None)):
                 if len(args) > label_arg:
                     try:
                         kwargs['label'] = args[label_arg].name
@@ -1572,11 +1572,11 @@ def unpack_labeled_data(wl_args=None, wl_kwargs=None, label_pos=None):
                         pass
                 elif label_kwarg in kwargs:
                     try:
-                        kwargs['label'] = args[label_kwarg].name
+                        kwargs['label'] = kwargs[label_kwarg].name
                     except AttributeError:
                         pass
 
-            return func(ax, *args, **kwargs)
+            return func(ax, *new_args, **new_kwargs)
         return inner
     return param
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1528,7 +1528,7 @@ def _replacer(data, key):
         return key
 
 
-def unpack_labeled_data(wl_args=None, wl_kwargs=None):
+def unpack_labeled_data(wl_args=None, wl_kwargs=None, label_pos=None):
     """
     A decorator to add a 'data' kwarg to any a function.  The signature
     of the input function must be ::
@@ -1537,6 +1537,9 @@ def unpack_labeled_data(wl_args=None, wl_kwargs=None):
 
     so this is suitable for use with Axes methods.
     """
+    if label_pos is not None:
+        label_arg, label_kwarg = label_pos
+
     if wl_kwargs is not None:
         wl_kwargs = set(wl_kwargs)
     if wl_args is not None:
@@ -1560,6 +1563,18 @@ def unpack_labeled_data(wl_args=None, wl_kwargs=None):
                     kwargs = dict(
                         (k, _replacer(data, v) if k in wl_kwargs else v)
                         for k, v in six.iteritems(kwargs))
+            if (label_pos is not None and ('label' not in kwargs or
+                    kwargs['label'] is None)):
+                if len(args) > label_arg:
+                    try:
+                        kwargs['label'] = args[label_arg].name
+                    except AttributeError:
+                        pass
+                elif label_kwarg in kwargs:
+                    try:
+                        kwargs['label'] = args[label_kwarg].name
+                    except AttributeError:
+                        pass
 
             return func(ax, *args, **kwargs)
         return inner

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1563,6 +1563,9 @@ def unpack_labeled_data(wl_args=None, wl_kwargs=None, label_pos=None):
                     new_kwargs = dict(
                         (k, _replacer(data, v) if k in wl_kwargs else v)
                         for k, v in six.iteritems(kwargs))
+            else:
+                new_args, new_kwargs = args, kwargs
+
             if (label_pos is not None and ('label' not in kwargs or
                                            kwargs['label'] is None)):
                 if len(args) > label_arg:
@@ -1572,7 +1575,7 @@ def unpack_labeled_data(wl_args=None, wl_kwargs=None, label_pos=None):
                         pass
                 elif label_kwarg in kwargs:
                     try:
-                        kwargs['label'] = kwargs[label_kwarg].name
+                        new_kwargs['label'] = kwargs[label_kwarg].name
                     except AttributeError:
                         pass
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -902,7 +902,7 @@ class Axes(_AxesBase):
         self.autoscale_view(scaley=False)
         return p
 
-    @unpack_labeled_data
+    @unpack_labeled_data(wl_args={1, 2, 3}, wl_kwargs={'y', 'xmin', 'xmax'})
     @docstring.dedent
     def hlines(self, y, xmin, xmax, colors='k', linestyles='solid',
                label='', **kwargs):
@@ -981,7 +981,7 @@ class Axes(_AxesBase):
 
         return coll
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def vlines(self, x, ymin, ymax, colors='k', linestyles='solid',
                label='', **kwargs):
@@ -1062,7 +1062,7 @@ class Axes(_AxesBase):
 
         return coll
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def eventplot(self, positions, orientation='horizontal', lineoffsets=1,
                   linelengths=1, linewidths=None, colors=None,
@@ -1245,7 +1245,7 @@ class Axes(_AxesBase):
         return colls
 
     #### Basic plotting
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def plot(self, *args, **kwargs):
         """
@@ -1390,7 +1390,7 @@ class Axes(_AxesBase):
         self.autoscale_view(scalex=scalex, scaley=scaley)
         return lines
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def plot_date(self, x, y, fmt='o', tz=None, xdate=True, ydate=False,
                   **kwargs):
@@ -1464,7 +1464,7 @@ class Axes(_AxesBase):
 
         return ret
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def loglog(self, *args, **kwargs):
         """
@@ -1526,7 +1526,7 @@ class Axes(_AxesBase):
 
         return l
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def semilogx(self, *args, **kwargs):
         """
@@ -1579,7 +1579,7 @@ class Axes(_AxesBase):
         self._hold = b  # restore the hold
         return l
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def semilogy(self, *args, **kwargs):
         """
@@ -1632,7 +1632,7 @@ class Axes(_AxesBase):
 
         return l
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def acorr(self, x, **kwargs):
         """
@@ -1694,7 +1694,7 @@ class Axes(_AxesBase):
         """
         return self.xcorr(x, x, **kwargs)
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def xcorr(self, x, y, normed=True, detrend=mlab.detrend_none,
               usevlines=True, maxlags=10, **kwargs):
@@ -1784,7 +1784,7 @@ class Axes(_AxesBase):
 
     #### Specialized plotting
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def step(self, x, y, *args, **kwargs):
         """
         Make a step plot.
@@ -1822,7 +1822,7 @@ class Axes(_AxesBase):
 
         return self.plot(x, y, *args, **kwargs)
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def bar(self, left, height, width=0.8, bottom=None, **kwargs):
         """
@@ -2249,7 +2249,7 @@ class Axes(_AxesBase):
                            bottom=bottom, orientation='horizontal', **kwargs)
         return patches
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def broken_barh(self, xranges, yrange, **kwargs):
         """
@@ -2295,7 +2295,7 @@ class Axes(_AxesBase):
 
         return col
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def stem(self, *args, **kwargs):
         """
         Create a stem plot.
@@ -2383,7 +2383,8 @@ class Axes(_AxesBase):
 
         return stem_container
 
-    @unpack_labeled_data
+    @unpack_labeled_data(wl_args={1, 3, 4},
+                         wl_kwargs={'x', 'labels', 'colors'})
     def pie(self, x, explode=None, labels=None, colors=None,
             autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
             startangle=None, radius=None, counterclock=True,
@@ -2603,7 +2604,7 @@ class Axes(_AxesBase):
         else:
             return slices, texts, autotexts
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def errorbar(self, x, y, yerr=None, xerr=None,
                  fmt='', ecolor=None, elinewidth=None, capsize=None,
@@ -2967,7 +2968,7 @@ class Axes(_AxesBase):
 
         return errorbar_container  # (l0, caplines, barcols)
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def boxplot(self, x, notch=None, sym=None, vert=None, whis=None,
                 positions=None, widths=None, patch_artist=None,
                 bootstrap=None, usermedians=None, conf_intervals=None,
@@ -3253,7 +3254,7 @@ class Axes(_AxesBase):
                            manage_xticks=manage_xticks)
         return artists
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def bxp(self, bxpstats, positions=None, widths=None, vert=True,
             patch_artist=False, shownotches=False, showmeans=False,
             showcaps=True, showbox=True, showfliers=True,
@@ -3638,7 +3639,7 @@ class Axes(_AxesBase):
         return dict(whiskers=whiskers, caps=caps, boxes=boxes,
                     medians=medians, fliers=fliers, means=means)
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def scatter(self, x, y, s=20, c=None, marker='o', cmap=None, norm=None,
                 vmin=None, vmax=None, alpha=None, linewidths=None,
@@ -3846,7 +3847,7 @@ class Axes(_AxesBase):
 
         return collection
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def hexbin(self, x, y, C=None, gridsize=100, bins=None,
                xscale='linear', yscale='linear', extent=None,
@@ -4347,7 +4348,7 @@ class Axes(_AxesBase):
         return qk
     quiverkey.__doc__ = mquiver.QuiverKey.quiverkey_doc
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def quiver(self, *args, **kw):
         if not self._hold:
             self.cla()
@@ -4358,12 +4359,12 @@ class Axes(_AxesBase):
         return q
     quiver.__doc__ = mquiver.Quiver.quiver_doc
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def stackplot(self, x, *args, **kwargs):
         return mstack.stackplot(self, x, *args, **kwargs)
     stackplot.__doc__ = mstack.stackplot.__doc__
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def streamplot(self, x, y, u, v, density=1, linewidth=None, color=None,
                    cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
                    minlength=0.1, transform=None, zorder=1, start_points=None):
@@ -4384,7 +4385,7 @@ class Axes(_AxesBase):
         return stream_container
     streamplot.__doc__ = mstream.streamplot.__doc__
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def barbs(self, *args, **kw):
         """
@@ -4401,7 +4402,7 @@ class Axes(_AxesBase):
         self.autoscale_view()
         return b
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def fill(self, *args, **kwargs):
         """
@@ -4453,7 +4454,7 @@ class Axes(_AxesBase):
         self.autoscale_view()
         return patches
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def fill_between(self, x, y1, y2=0, where=None, interpolate=False,
                      step=None,
@@ -4607,7 +4608,7 @@ class Axes(_AxesBase):
         self.autoscale_view()
         return collection
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def fill_betweenx(self, y, x1, x2=0, where=None,
                       step=None, **kwargs):
@@ -4732,7 +4733,7 @@ class Axes(_AxesBase):
         return collection
 
     #### plotting z(x,y): imshow, pcolor and relatives, contour
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def imshow(self, X, cmap=None, norm=None, aspect=None,
                interpolation=None, alpha=None, vmin=None, vmax=None,
@@ -4937,7 +4938,7 @@ class Axes(_AxesBase):
             C = C[:Ny - 1, :Nx - 1]
         return X, Y, C
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def pcolor(self, *args, **kwargs):
         """
@@ -5214,7 +5215,7 @@ class Axes(_AxesBase):
         self.add_collection(collection, autolim=False)
         return collection
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def pcolormesh(self, *args, **kwargs):
         """
@@ -5363,7 +5364,7 @@ class Axes(_AxesBase):
         self.add_collection(collection, autolim=False)
         return collection
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def pcolorfast(self, *args, **kwargs):
         """
@@ -5551,7 +5552,7 @@ class Axes(_AxesBase):
         self.autoscale_view(tight=True)
         return ret
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def contour(self, *args, **kwargs):
         if not self._hold:
             self.cla()
@@ -5559,7 +5560,7 @@ class Axes(_AxesBase):
         return mcontour.QuadContourSet(self, *args, **kwargs)
     contour.__doc__ = mcontour.QuadContourSet.contour_doc
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def contourf(self, *args, **kwargs):
         if not self._hold:
             self.cla()
@@ -5600,7 +5601,7 @@ class Axes(_AxesBase):
 
     #### Data analysis
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def hist(self, x, bins=10, range=None, normed=False, weights=None,
              cumulative=False, bottom=None, histtype='bar', align='mid',
@@ -6141,7 +6142,7 @@ class Axes(_AxesBase):
         else:
             return n, bins, cbook.silent_list('Lists of Patches', patches)
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def hist2d(self, x, y, bins=10, range=None, normed=False, weights=None,
                cmin=None, cmax=None, **kwargs):
@@ -6235,7 +6236,7 @@ class Axes(_AxesBase):
 
         return h, xedges, yedges, pc
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def psd(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
@@ -6360,7 +6361,7 @@ class Axes(_AxesBase):
         else:
             return pxx, freqs, line
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def csd(self, x, y, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
@@ -6472,7 +6473,7 @@ class Axes(_AxesBase):
         else:
             return pxy, freqs, line
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def magnitude_spectrum(self, x, Fs=None, Fc=None, window=None,
                            pad_to=None, sides=None, scale=None,
@@ -6572,7 +6573,7 @@ class Axes(_AxesBase):
 
         return spec, freqs, lines[0]
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def angle_spectrum(self, x, Fs=None, Fc=None, window=None,
                        pad_to=None, sides=None, **kwargs):
@@ -6650,7 +6651,7 @@ class Axes(_AxesBase):
 
         return spec, freqs, lines[0]
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def phase_spectrum(self, x, Fs=None, Fc=None, window=None,
                        pad_to=None, sides=None, **kwargs):
@@ -6728,7 +6729,7 @@ class Axes(_AxesBase):
 
         return spec, freqs, lines[0]
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def cohere(self, x, y, NFFT=256, Fs=2, Fc=0, detrend=mlab.detrend_none,
                window=mlab.window_hanning, noverlap=0, pad_to=None,
@@ -6796,7 +6797,7 @@ class Axes(_AxesBase):
 
         return cxy, freqs
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     @docstring.dedent_interpd
     def specgram(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
                  window=None, noverlap=None,
@@ -7114,7 +7115,7 @@ class Axes(_AxesBase):
                                                  integer=True))
         return im
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def violinplot(self, dataset, positions=None, vert=True, widths=0.5,
                    showmeans=False, showextrema=True, showmedians=False,
                    points=100, bw_method=None):
@@ -7216,7 +7217,7 @@ class Axes(_AxesBase):
                            widths=widths, showmeans=showmeans,
                            showextrema=showextrema, showmedians=showmedians)
 
-    @unpack_labeled_data
+    @unpack_labeled_data()
     def violin(self, vpstats, positions=None, vert=True, widths=0.5,
                showmeans=False, showextrema=True, showmedians=False):
         """Drawing function for violin plots.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -11,6 +11,7 @@ import numpy as np
 from numpy import ma
 
 import matplotlib
+from matplotlib import unpack_labeled_data
 
 import matplotlib.cbook as cbook
 from matplotlib.cbook import mplDeprecation, STEP_LOOKUP_MAP
@@ -901,6 +902,7 @@ class Axes(_AxesBase):
         self.autoscale_view(scaley=False)
         return p
 
+    @unpack_labeled_data
     @docstring.dedent
     def hlines(self, y, xmin, xmax, colors='k', linestyles='solid',
                label='', **kwargs):
@@ -979,6 +981,7 @@ class Axes(_AxesBase):
 
         return coll
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def vlines(self, x, ymin, ymax, colors='k', linestyles='solid',
                label='', **kwargs):
@@ -1059,6 +1062,7 @@ class Axes(_AxesBase):
 
         return coll
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def eventplot(self, positions, orientation='horizontal', lineoffsets=1,
                   linelengths=1, linewidths=None, colors=None,
@@ -1241,6 +1245,7 @@ class Axes(_AxesBase):
         return colls
 
     #### Basic plotting
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def plot(self, *args, **kwargs):
         """
@@ -1385,6 +1390,7 @@ class Axes(_AxesBase):
         self.autoscale_view(scalex=scalex, scaley=scaley)
         return lines
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def plot_date(self, x, y, fmt='o', tz=None, xdate=True, ydate=False,
                   **kwargs):
@@ -1458,6 +1464,7 @@ class Axes(_AxesBase):
 
         return ret
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def loglog(self, *args, **kwargs):
         """
@@ -1519,6 +1526,7 @@ class Axes(_AxesBase):
 
         return l
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def semilogx(self, *args, **kwargs):
         """
@@ -1571,6 +1579,7 @@ class Axes(_AxesBase):
         self._hold = b  # restore the hold
         return l
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def semilogy(self, *args, **kwargs):
         """
@@ -1623,6 +1632,7 @@ class Axes(_AxesBase):
 
         return l
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def acorr(self, x, **kwargs):
         """
@@ -1684,6 +1694,7 @@ class Axes(_AxesBase):
         """
         return self.xcorr(x, x, **kwargs)
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def xcorr(self, x, y, normed=True, detrend=mlab.detrend_none,
               usevlines=True, maxlags=10, **kwargs):
@@ -1773,6 +1784,7 @@ class Axes(_AxesBase):
 
     #### Specialized plotting
 
+    @unpack_labeled_data
     def step(self, x, y, *args, **kwargs):
         """
         Make a step plot.
@@ -1810,6 +1822,7 @@ class Axes(_AxesBase):
 
         return self.plot(x, y, *args, **kwargs)
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def bar(self, left, height, width=0.8, bottom=None, **kwargs):
         """
@@ -2236,6 +2249,7 @@ class Axes(_AxesBase):
                            bottom=bottom, orientation='horizontal', **kwargs)
         return patches
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def broken_barh(self, xranges, yrange, **kwargs):
         """
@@ -2281,6 +2295,7 @@ class Axes(_AxesBase):
 
         return col
 
+    @unpack_labeled_data
     def stem(self, *args, **kwargs):
         """
         Create a stem plot.
@@ -2368,6 +2383,7 @@ class Axes(_AxesBase):
 
         return stem_container
 
+    @unpack_labeled_data
     def pie(self, x, explode=None, labels=None, colors=None,
             autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
             startangle=None, radius=None, counterclock=True,
@@ -2587,6 +2603,7 @@ class Axes(_AxesBase):
         else:
             return slices, texts, autotexts
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def errorbar(self, x, y, yerr=None, xerr=None,
                  fmt='', ecolor=None, elinewidth=None, capsize=None,
@@ -2950,6 +2967,7 @@ class Axes(_AxesBase):
 
         return errorbar_container  # (l0, caplines, barcols)
 
+    @unpack_labeled_data
     def boxplot(self, x, notch=None, sym=None, vert=None, whis=None,
                 positions=None, widths=None, patch_artist=None,
                 bootstrap=None, usermedians=None, conf_intervals=None,
@@ -3235,6 +3253,7 @@ class Axes(_AxesBase):
                            manage_xticks=manage_xticks)
         return artists
 
+    @unpack_labeled_data
     def bxp(self, bxpstats, positions=None, widths=None, vert=True,
             patch_artist=False, shownotches=False, showmeans=False,
             showcaps=True, showbox=True, showfliers=True,
@@ -3619,6 +3638,7 @@ class Axes(_AxesBase):
         return dict(whiskers=whiskers, caps=caps, boxes=boxes,
                     medians=medians, fliers=fliers, means=means)
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def scatter(self, x, y, s=20, c=None, marker='o', cmap=None, norm=None,
                 vmin=None, vmax=None, alpha=None, linewidths=None,
@@ -3826,6 +3846,7 @@ class Axes(_AxesBase):
 
         return collection
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def hexbin(self, x, y, C=None, gridsize=100, bins=None,
                xscale='linear', yscale='linear', extent=None,
@@ -4326,6 +4347,7 @@ class Axes(_AxesBase):
         return qk
     quiverkey.__doc__ = mquiver.QuiverKey.quiverkey_doc
 
+    @unpack_labeled_data
     def quiver(self, *args, **kw):
         if not self._hold:
             self.cla()
@@ -4336,10 +4358,12 @@ class Axes(_AxesBase):
         return q
     quiver.__doc__ = mquiver.Quiver.quiver_doc
 
+    @unpack_labeled_data
     def stackplot(self, x, *args, **kwargs):
         return mstack.stackplot(self, x, *args, **kwargs)
     stackplot.__doc__ = mstack.stackplot.__doc__
 
+    @unpack_labeled_data
     def streamplot(self, x, y, u, v, density=1, linewidth=None, color=None,
                    cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
                    minlength=0.1, transform=None, zorder=1, start_points=None):
@@ -4360,6 +4384,7 @@ class Axes(_AxesBase):
         return stream_container
     streamplot.__doc__ = mstream.streamplot.__doc__
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def barbs(self, *args, **kw):
         """
@@ -4376,6 +4401,7 @@ class Axes(_AxesBase):
         self.autoscale_view()
         return b
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def fill(self, *args, **kwargs):
         """
@@ -4427,6 +4453,7 @@ class Axes(_AxesBase):
         self.autoscale_view()
         return patches
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def fill_between(self, x, y1, y2=0, where=None, interpolate=False,
                      step=None,
@@ -4580,6 +4607,7 @@ class Axes(_AxesBase):
         self.autoscale_view()
         return collection
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def fill_betweenx(self, y, x1, x2=0, where=None,
                       step=None, **kwargs):
@@ -4704,7 +4732,7 @@ class Axes(_AxesBase):
         return collection
 
     #### plotting z(x,y): imshow, pcolor and relatives, contour
-
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def imshow(self, X, cmap=None, norm=None, aspect=None,
                interpolation=None, alpha=None, vmin=None, vmax=None,
@@ -4909,6 +4937,7 @@ class Axes(_AxesBase):
             C = C[:Ny - 1, :Nx - 1]
         return X, Y, C
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def pcolor(self, *args, **kwargs):
         """
@@ -5185,6 +5214,7 @@ class Axes(_AxesBase):
         self.add_collection(collection, autolim=False)
         return collection
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def pcolormesh(self, *args, **kwargs):
         """
@@ -5333,6 +5363,7 @@ class Axes(_AxesBase):
         self.add_collection(collection, autolim=False)
         return collection
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def pcolorfast(self, *args, **kwargs):
         """
@@ -5520,6 +5551,7 @@ class Axes(_AxesBase):
         self.autoscale_view(tight=True)
         return ret
 
+    @unpack_labeled_data
     def contour(self, *args, **kwargs):
         if not self._hold:
             self.cla()
@@ -5527,6 +5559,7 @@ class Axes(_AxesBase):
         return mcontour.QuadContourSet(self, *args, **kwargs)
     contour.__doc__ = mcontour.QuadContourSet.contour_doc
 
+    @unpack_labeled_data
     def contourf(self, *args, **kwargs):
         if not self._hold:
             self.cla()
@@ -5567,6 +5600,7 @@ class Axes(_AxesBase):
 
     #### Data analysis
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def hist(self, x, bins=10, range=None, normed=False, weights=None,
              cumulative=False, bottom=None, histtype='bar', align='mid',
@@ -6107,6 +6141,7 @@ class Axes(_AxesBase):
         else:
             return n, bins, cbook.silent_list('Lists of Patches', patches)
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def hist2d(self, x, y, bins=10, range=None, normed=False, weights=None,
                cmin=None, cmax=None, **kwargs):
@@ -6200,6 +6235,7 @@ class Axes(_AxesBase):
 
         return h, xedges, yedges, pc
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def psd(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
@@ -6324,6 +6360,7 @@ class Axes(_AxesBase):
         else:
             return pxx, freqs, line
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def csd(self, x, y, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
@@ -6435,6 +6472,7 @@ class Axes(_AxesBase):
         else:
             return pxy, freqs, line
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def magnitude_spectrum(self, x, Fs=None, Fc=None, window=None,
                            pad_to=None, sides=None, scale=None,
@@ -6534,6 +6572,7 @@ class Axes(_AxesBase):
 
         return spec, freqs, lines[0]
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def angle_spectrum(self, x, Fs=None, Fc=None, window=None,
                        pad_to=None, sides=None, **kwargs):
@@ -6611,6 +6650,7 @@ class Axes(_AxesBase):
 
         return spec, freqs, lines[0]
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def phase_spectrum(self, x, Fs=None, Fc=None, window=None,
                        pad_to=None, sides=None, **kwargs):
@@ -6688,6 +6728,7 @@ class Axes(_AxesBase):
 
         return spec, freqs, lines[0]
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def cohere(self, x, y, NFFT=256, Fs=2, Fc=0, detrend=mlab.detrend_none,
                window=mlab.window_hanning, noverlap=0, pad_to=None,
@@ -6755,6 +6796,7 @@ class Axes(_AxesBase):
 
         return cxy, freqs
 
+    @unpack_labeled_data
     @docstring.dedent_interpd
     def specgram(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
                  window=None, noverlap=None,
@@ -7072,6 +7114,7 @@ class Axes(_AxesBase):
                                                  integer=True))
         return im
 
+    @unpack_labeled_data
     def violinplot(self, dataset, positions=None, vert=True, widths=0.5,
                    showmeans=False, showextrema=True, showmedians=False,
                    points=100, bw_method=None):
@@ -7173,6 +7216,7 @@ class Axes(_AxesBase):
                            widths=widths, showmeans=showmeans,
                            showextrema=showextrema, showmedians=showmedians)
 
+    @unpack_labeled_data
     def violin(self, vpstats, positions=None, vert=True, widths=0.5,
                showmeans=False, showextrema=True, showmedians=False):
         """Drawing function for violin plots.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -902,7 +902,7 @@ class Axes(_AxesBase):
         self.autoscale_view(scaley=False)
         return p
 
-    @unpack_labeled_data(wl_args={1, 2, 3}, wl_kwargs={'y', 'xmin', 'xmax'})
+    @unpack_labeled_data(wl_args=[1, 2, 3], wl_kwargs=['y', 'xmin', 'xmax'])
     @docstring.dedent
     def hlines(self, y, xmin, xmax, colors='k', linestyles='solid',
                label='', **kwargs):
@@ -2383,8 +2383,8 @@ class Axes(_AxesBase):
 
         return stem_container
 
-    @unpack_labeled_data(wl_args={1, 3, 4},
-                         wl_kwargs={'x', 'labels', 'colors'})
+    @unpack_labeled_data(wl_args=[1, 3, 4],
+                         wl_kwargs=['x', 'labels', 'colors'])
     def pie(self, x, explode=None, labels=None, colors=None,
             autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
             startangle=None, radius=None, counterclock=True,

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -31,7 +31,7 @@ import matplotlib.text as mtext
 import matplotlib.image as mimage
 from matplotlib.offsetbox import OffsetBox
 from matplotlib.artist import allow_rasterization
-from matplotlib.cbook import iterable
+from matplotlib.cbook import iterable, get_index_y
 
 rcParams = matplotlib.rcParams
 
@@ -277,12 +277,11 @@ class _process_plot_var_args(object):
             if v is not None:
                 kw[k] = v
 
-        y = np.atleast_1d(tup[-1])
-
         if len(tup) == 2:
             x = np.atleast_1d(tup[0])
+            y = np.atleast_1d(tup[-1])
         else:
-            x = np.arange(y.shape[0], dtype=float)
+            x, y = get_index_y(tup[-1])
 
         x, y = self._xy_from_xy(x, y)
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2490,6 +2490,34 @@ STEP_LOOKUP_MAP = {'pre': pts_to_prestep,
                    'step-post': pts_to_poststep,
                    'step-mid': pts_to_midstep}
 
+
+def get_index_y(y):
+    """
+    A helper function to get the index of an input to plot
+    against if x values are not explicitly given.
+
+    Tries to get `y.index` (works if this is a pd.Series), if that
+    fails, return np.arange(y.shape[0]).
+
+    This will be extended in the future to deal with more types of
+    labeled data.
+
+    Parameters
+    ----------
+    y : scalar or array-like
+        The proposed y-value
+
+    Returns
+    -------
+    x, y : ndarray
+       The x and y values to plot.
+    """
+    try:
+        return y.index.values, y.values
+    except AttributeError:
+        y = np.atleast_1d(y)
+        return np.arange(y.shape[0], dtype=float), y
+
 # Numpy > 1.6.x deprecates putmask in favor of the new copyto.
 # So long as we support versions 1.6.x and less, we need the
 # following local version of putmask.  We choose to make a

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -809,7 +809,7 @@ defaultParams = {
     'xtick.minor.pad':   [4, validate_float],    # distance to label in points
     'xtick.color':       ['k', validate_color],  # color of the xtick labels
     'xtick.minor.visible':   [False, validate_bool],    # visiablility of the x axis minor ticks
-    
+
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
     'xtick.direction':   ['in', six.text_type],            # direction of xticks
@@ -966,7 +966,8 @@ defaultParams = {
     'animation.convert_path':  ['convert', six.text_type],
      # Additional arguments for mencoder movie writer (using pipes)
 
-    'animation.convert_args':  [[], validate_stringlist]}
+    'animation.convert_args':  [[], validate_stringlist],
+    'unpack_labeled': [True, validate_bool], }
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -966,8 +966,7 @@ defaultParams = {
     'animation.convert_path':  ['convert', six.text_type],
      # Additional arguments for mencoder movie writer (using pipes)
 
-    'animation.convert_args':  [[], validate_stringlist],
-    'unpack_labeled': [True, validate_bool], }
+    'animation.convert_args':  [[], validate_stringlist]}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After discussions with Brian Granger, Fernando Perez Peter Wang, Matthew
Rocklin and Jake VanderPlas this is a proposal for how to deal with
labeled data in matplotlib.

The approach taken is that if the optional kwarg 'data' is passed in any
other string args/kwargs to the function are replaced be the result
`data[k]` if the key exists in `data`, else leave the value as-is.

Fernando made a compelling case that this needs to go in ASAP. 

This still needs docs + tests + a bit more thought on how to deal with functions where we do some internal broadcasting (mostly `plot`).  Maybe pass in names as a coma separated list?  I would prefer to, long term, simplify the low-level plot and have either the users do the looping or provide higher-level plotting functions which do the looping.

There is the possibility that some of the string args/kwargs we already take may conflict with names in the labeled data (ex `ha='center'` would not work with a data structure where `'center' in data`).

@pzwang expressed concern that we may be painting ourselves into a corner with this API as it is mostly just the difference between

```python
ax.plot('a', 'b', data=LD)
```
vs
```python
ax.plot(LD['a'], LD['b']) 
```

The unpacking attempts can be disabled via a rcparam.  That could also be implemented as an import time rcparam which disables the decorator all together.

This should work with any `data` object that supports getitem and returns something that `np.asarray` works on.

attn @matplotlib/developers @jakevdp @fperez @mrocklin @ellisonbg @pzwang @mwaskom @jreback @andrewcollette 