### PR TITLE
Added code information to Poly3DCollection

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -888,6 +888,16 @@ class PolyCollection(_CollectionWithSizes):
 
     set_paths = set_verts
 
+    def set_verts_and_codes(self, verts, codes):
+        if (len(verts) != len(codes)):
+            raise ValueError("'codes' must be a 1D list or array "\
+                             "with the same length of 'verts' ")
+        self._paths = []
+        for xy, cds in zip(verts, codes):
+            if len(xy):
+                self._paths.append(mpath.Path(xy,cds))
+            else:
+                self._paths.append(mpath.Path(xy))
 
 class BrokenBarHCollection(PolyCollection):
     """


### PR DESCRIPTION
Fixes #4784 by adding path code information to the Poly3DCollection.
This adds two new methods, path_to_3d_segment_with_codes and
paths_to_3d_segments_with_codes which are meant to replace the
versions without "_with_codes".  A method was added to PolyCollection
to allow Poly3DCollection to set vertices with path codes.

This code was adapted from a PR by @ianthomas23.