### PR TITLE
Fix msvc14 compile errors

### DIFF
--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -8,6 +8,7 @@
 
 #include <cmath>
 #include <vector>
+#include <algorithm>
 
 #include "agg_alpha_mask_u8.h"
 #include "agg_conv_curve.h"

--- a/src/_path.h
+++ b/src/_path.h
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <vector>
 #include <cmath>
+#include <algorithm>
 
 #include "agg_conv_contour.h"
 #include "agg_conv_curve.h"

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -3,6 +3,7 @@
 #define NO_IMPORT_ARRAY
 
 #include <string>
+#include <algorithm>
 
 #include "ft2font.h"
 #include "mplutils.h"


### PR DESCRIPTION
Fixes the following errors when compiling with Visual Studio 2015 for Python 3.5b4:
`error C2039: 'min': is not a member of 'std'`
`error C3861: 'max': identifier not found`