### PR TITLE
Fixes to funcanimation

### DIFF
--- a/examples/animation/animate_decay.py
+++ b/examples/animation/animate_decay.py
@@ -10,10 +10,16 @@ def data_gen(t=0):
         t += 0.1
         yield t, np.sin(2*np.pi*t) * np.exp(-t/10.)
 
+def init():
+    ax.set_ylim(-1.1, 1.1)
+    ax.set_xlim(0, 10)
+    del xdata[:]
+    del ydata[:]
+    line.set_data(xdata,ydata)
+    return line,
+
 fig, ax = plt.subplots()
 line, = ax.plot([], [], lw=2)
-ax.set_ylim(-1.1, 1.1)
-ax.set_xlim(0, 5)
 ax.grid()
 xdata, ydata = [], []
 
@@ -33,5 +39,5 @@ def run(data):
     return line,
 
 ani = animation.FuncAnimation(fig, run, data_gen, blit=False, interval=10,
-                              repeat=False)
+                              repeat=False, init_func=init)
 plt.show()

--- a/examples/animation/animate_decay.py
+++ b/examples/animation/animate_decay.py
@@ -10,12 +10,13 @@ def data_gen(t=0):
         t += 0.1
         yield t, np.sin(2*np.pi*t) * np.exp(-t/10.)
 
+
 def init():
     ax.set_ylim(-1.1, 1.1)
     ax.set_xlim(0, 10)
     del xdata[:]
     del ydata[:]
-    line.set_data(xdata,ydata)
+    line.set_data(xdata, ydata)
     return line,
 
 fig, ax = plt.subplots()

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -611,6 +611,7 @@ class Animation(object):
         # actually start the event_source. We also disconnect _start
         # from the draw_events
         self.event_source.add_callback(self._step)
+        self._init_draw()
         self.event_source.start()
         self._fig.canvas.mpl_disconnect(self._first_draw_id)
         self._first_draw_id = None  # So we can check on save
@@ -760,6 +761,9 @@ class Animation(object):
         # since GUI widgets are gone. Either need to remove extra code to
         # allow for this non-existant use case or find a way to make it work.
         with writer.saving(self._fig, filename, dpi):
+            for anim in all_anim:
+                # Clear the initial frame
+                anim._init_draw()
             for data in zip(*[a.new_saved_frame_seq()
                               for a in all_anim]):
                 for anim, d in zip(all_anim, data):

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1084,7 +1084,10 @@ class FuncAnimation(TimedAnimation):
         # no saved frames, generate a new frame sequence and take the first
         # save_count entries in it.
         if self._save_seq:
-            return iter(self._save_seq)
+            # While iterating we are going to update _save_seq
+            # so make a copy to safely iterate over
+            self._old_saved_seq = self._save_seq.copy()
+            return iter(self._old_saved_seq)
         else:
             return itertools.islice(self.new_frame_seq(), self.save_count)
 


### PR DESCRIPTION
While reviewing #4785 I discovered a few issues with the decay animation example:

1. The example does not reset the plotted data when the animation is rerun/resaved after having been running/saved once. To solve this I added an init function to resets the animation. 

1. The init function is only called at construction time and not when restarting the animation so the above doesn't work. I adapted the code to make sure that init is called at both the beginning of a save sequence and when showing the animation. 

1. When saving the figure more than once or showing and saving the animation the second version of the animation contains wrong frames (the first frame at the end or missing frames in the beginning an so on) This is caused by the animation iterating over `_save_seq` and updating `_save_seq` while iterating. I have fixed this by copying `_save_seq` before iterating.  

@dopplershift does this make sense or do you see a better way of fixing these issues?