### PR TITLE
Travis switch from nightly to 3.5 beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ matrix:
       env: TEST_ARGS=--pep8
     - python: 2.7
       env: BUILD_DOCS=true MOCK=mock
-    - python: "nightly"
+    - python: "3.5.0b3"
       env: PRE=--pre
   allow_failures:
-    - python : "nightly"
+    - python : "3.5.0b3"
 
 before_install:
   - source tools/travis_tools.sh


### PR DESCRIPTION
Travis now has a 3.5 beta and nightly will point to 3.6 branch that will likely be unstable so switch to the 3.5 beta branch which is more interesting. There is also a 3.5 nightly that we could consider. 

At some point we probably want to make this a real test job and not allow failure.