### PR TITLE
setupext.py: let the user set a different pkg-config

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -135,6 +135,14 @@ the latest *tar.gz* release file from `the download page
 to develop matplotlib or just need the latest bugfixed version, grab
 the latest git version :ref:`install-from-git`.
 
+The standard environment variables `CC`, `CXX`, `PKG_CONFIG` are respected.
+This means you can set them if your toolchain is prefixed. This may be used for
+cross compiling.
+
+  export CC=x86_64-pc-linux-gnu-gcc
+  export CXX=x86_64-pc-linux-gnu-g++
+  export PKG_CONFIG=x86_64-pc-linux-gnu-pkg-config
+
 Once you have satisfied the requirements detailed below (mainly
 python, numpy, libpng and freetype), you can build matplotlib::
 

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -98,6 +98,16 @@ IPython's ``HTML`` display class::
     from IPython.display import HTML
     HTML(anim.to_html5_video())
 
+Prefixed pkg-config for building
+--------------------------------
+
+Handling of `pkg-config` has been fixed in so far as it is now possible to set
+it using the environment variable `PKG_CONFIG`. This is important if your
+toolchain is prefixed. This is done in a simpilar way as setting `CC` or `CXX`
+before building. An example follows.
+
+    export PKG_CONFIG=x86_64-pc-linux-gnu-pkg-config
+
 
 .. _whats-new-1-4:
 

--- a/setupext.py
+++ b/setupext.py
@@ -252,8 +252,13 @@ class PkgConfig(object):
         if sys.platform == 'win32':
             self.has_pkgconfig = False
         else:
+            try:
+                self.pkg_config = os.environ['PKG_CONFIG']
+            except KeyError:
+                self.pkg_config = 'pkg-config'
+
             self.set_pkgconfig_path()
-            status, output = getstatusoutput("pkg-config --help")
+            status, output = getstatusoutput(self.pkg_config + " --help")
             self.has_pkgconfig = (status == 0)
             if not self.has_pkgconfig:
                 print("IMPORTANT WARNING:")
@@ -286,7 +291,7 @@ class PkgConfig(object):
 
         executable = alt_exec
         if self.has_pkgconfig:
-            executable = 'pkg-config {0}'.format(package)
+            executable = (self.pkg_config + ' {0}').format(package)
 
         use_defaults = True
 
@@ -330,7 +335,7 @@ class PkgConfig(object):
             return None
 
         status, output = getstatusoutput(
-            "pkg-config %s --modversion" % (package))
+            self.pkg_config + " %s --modversion" % (package))
         if status == 0:
             return output
         return None


### PR DESCRIPTION
Use the environment variable PKG_CONFIG to determine the correct
pkg-config executable. Default to 'pkg-config' if the variable is not
set.

This allows the user to cross compile. E.g., PKG_CONFIG can be set to
'x86_64-pc-linux-gnu-pkg-config'.

I did not touch any windows specific functions, which still call
'pkg-config' directly.