### PR TITLE
Prf mouse move hitlist

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2813,15 +2813,14 @@ class NavigationToolbar2(object):
                 pass
             else:
                 artists = event.inaxes.hitlist(event)
-                if event.inaxes.patch in artists:
-                    artists.remove(event.inaxes.patch)
 
                 if artists:
-                    artists.sort(key=lambda x: x.zorder)
-                    a = artists[-1]
-                    data = a.get_cursor_data(event)
-                    if data is not None:
-                        s += ' [%s]' % a.format_cursor_data(data)
+                    a = max(enumerate(artists), key=lambda x: x[1].zorder)[1]
+                    if a is not event.inaxes.patch:
+                        data = a.get_cursor_data(event)
+                        if data is not None:
+                            s += ' [%s]' % a.format_cursor_data(data)
+
                 if len(self.mode):
                     self.set_message('%s, %s' % (self.mode, s))
                 else:

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -50,7 +50,8 @@ except NameError:
 from .path import Path
 
 DEBUG = False
-
+# we need this later, but this is very expensive to set up
+MINFLOAT = np.MachAr(float).xmin
 MaskedArray = ma.MaskedArray
 
 
@@ -2738,7 +2739,7 @@ def nonsingular(vmin, vmax, expander=0.001, tiny=1e-15, increasing=True):
         swapped = True
 
     maxabsvalue = max(abs(vmin), abs(vmax))
-    if maxabsvalue < (1e6 / tiny) * np.MachAr(float).xmin:
+    if maxabsvalue < (1e6 / tiny) * MINFLOAT:
         vmin = -expander
         vmax = expander
 


### PR DESCRIPTION
This address some of #4767.

The issue in https://github.com/matplotlib/matplotlib/commit/604299f5b893339c588725888977081f1a9f2279 is that ` np.MachAr(float).xmin` takes ~8-10 ms and gets 2x in the `hitlist` code path.  Moving this to a constant at the top is a major speed up and for a blank figure gets the hitlist run time down to 5-6ms from a bit over 20ms (on the computer I was testing on).

There is still an issue that sorting out if the cursor hits a `Line2D` artist takes at least 1ms so if you have 300 lines, it takes a third of a second for the callback to run.

Long term, we should look into making this code faster by making contains run faster (a lot of time is spent in https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/lines.py#L36), by finding a way to cache this in a smart way but in the short term I think we need to add a per-axes way of turning this off and probably default to off.

attn @blink1073 @mdboom @pwuertz 