### PR TITLE
FIX: violinplot crashed if input variance was zero

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7165,6 +7165,9 @@ class Axes(_AxesBase):
         """
 
         def _kde_method(X, coords):
+            # fallback gracefully if the vector contains only one value
+            if np.all(X[0] == X):
+                return (X[0] == coords).astype(float)
             kde = mlab.GaussianKDE(X, bw_method)
             return kde.evaluate(coords)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3895,6 +3895,11 @@ def test_shared_scale():
         assert_equal(ax.get_yscale(), 'linear')
         assert_equal(ax.get_xscale(), 'linear')
 
+@cleanup
+def test_violin_point_mass():
+    """Violin plot should handle point mass pdf gracefully."""
+    plt.violinplot(np.array([0, 0]))
+
 if __name__ == '__main__':
     import nose
     import sys


### PR DESCRIPTION
plt.violinplot would always throw an error if any of the data columns were composed of a single repeated element. 

This bug is described in detail in the stackexchage post: 
http://stats.stackexchange.com/questions/89754/statsmodels-error-in-kde-on-a-list-of-repeated-values

Although the answer there claims that this is *not* a bug, I disagree. A point mass is a perfectly reasonable and common data point to have, and should not require the user to workaround it themselves.

The current default method of getting "coords" [min(X):max(X):100], ensures that the point mass will be correctly displayed by default. 

The simple test added to tests/test_axes.py can be used to reproduce the behavior.