### PR TITLE
Two bugs in colors.BoundaryNorm

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1270,22 +1270,22 @@ class BoundaryNorm(Normalize):
     def __call__(self, x, clip=None):
         if clip is None:
             clip = self.clip
-        x = ma.asarray(x)
-        mask = ma.getmaskarray(x)
-        xx = x.filled(self.vmax + 1)
+        _x = ma.asarray(x)
+        mask = ma.getmaskarray(_x)
+        xx = np.atleast_1d(_x.filled(self.vmax + 1))
         if clip:
-            np.clip(xx, self.vmin, self.vmax)
-        iret = np.zeros(x.shape, dtype=np.int16)
+            np.clip(xx, self.vmin, self.vmax, out=xx)
+        iret = np.atleast_1d(np.zeros(_x.shape, dtype=np.int16))
         for i, b in enumerate(self.boundaries):
             iret[xx >= b] = i
         if self._interp:
             scalefac = float(self.Ncmap - 1) / (self.N - 2)
             iret = (iret * scalefac).astype(np.int16)
         iret[xx < self.vmin] = -1
-        iret[xx >= self.vmax] = self.Ncmap
+        iret[xx >= self.vmax] = self.Ncmap  # ISSUE here: clip is ignored
         ret = ma.array(iret, mask=mask)
-        if ret.shape == () and not mask:
-            ret = int(ret)  # assume python scalar
+        if _x.shape == () and not mask:
+            ret = int(ret[0])  # assume python scalar
         return ret
 
     def inverse(self, value):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -84,15 +84,37 @@ def test_BoundaryNorm():
         assert_array_equal(bn([v]), ex)
 
     # Clipping
-    # For the "3" I do not know: isn't clipping also supposed to clip the max?
     bn = mcolors.BoundaryNorm(boundaries, 3, clip=True)
-    expected = [0, 0, 2, 3]
+    expected = [0, 0, 2, 2]
     for v, ex in zip(vals, expected):
         ret = bn(v)
         assert_true(isinstance(ret, six.integer_types))
         assert_array_equal(ret, ex)
         assert_array_equal(bn([v]), ex)
 
+    # Masked arrays
+    boundaries = [0, 1.1, 2.2]
+    vals = [-1., np.NaN, 0, 1.4, 9]
+
+    # Without interpolation
+    ncolors = len(boundaries) - 1
+    bn = mcolors.BoundaryNorm(boundaries, ncolors)
+    expected = np.ma.masked_array([-1, -99, 0, 1, 2], mask=[0, 1, 0, 0, 0])
+    assert_array_equal(bn(vals), expected)
+
+    # With interpolation
+    bn = mcolors.BoundaryNorm(boundaries, len(boundaries))
+    expected = np.ma.masked_array([-1, -99, 0, 2, 3], mask=[0, 1, 0, 0, 0])
+    assert_array_equal(bn(vals), expected)
+
+    # Non-trivial masked arrays
+    vals = [np.Inf, np.NaN]
+    assert_true(np.all(bn(vals).mask))
+    vals = [np.Inf]
+    assert_true(np.all(bn(vals).mask))
+
+    # Invalid scalar raises an exception
+    assert_raises(Exception, bn, np.NaN)
 
 def test_LogNorm():
     """

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -94,7 +94,7 @@ def test_BoundaryNorm():
 
     # Masked arrays
     boundaries = [0, 1.1, 2.2]
-    vals = [-1., np.NaN, 0, 1.4, 9]
+    vals = np.ma.masked_invalid([-1., np.NaN, 0, 1.4, 9])
 
     # Without interpolation
     ncolors = len(boundaries) - 1
@@ -108,13 +108,11 @@ def test_BoundaryNorm():
     assert_array_equal(bn(vals), expected)
 
     # Non-trivial masked arrays
-    vals = [np.Inf, np.NaN]
+    vals = np.ma.masked_invalid([np.Inf, np.NaN])
     assert_true(np.all(bn(vals).mask))
-    vals = [np.Inf]
+    vals = np.ma.masked_invalid([np.Inf])
     assert_true(np.all(bn(vals).mask))
 
-    # Invalid scalar raises an exception
-    assert_raises(Exception, bn, np.NaN)
 
 def test_LogNorm():
     """


### PR DESCRIPTION
**Bug 1: calling BoundaryNorm with a scalar**

Short discussion on the ML: http://matplotlib.1069221.n5.nabble.com/Misleading-BoundaryNorm-error-td45970.html
I added some extra tests to the previous test-suite which was quite short.

**Bug 2: clipping was ignored**

The previous call to np.clip was silently useless (not in place). I don't think that clipping makes much sense in the case of BoundaryNorm but still.
Before merging, I'd like to discuss the point I mention in the code comments: what about clipping the max values? Currently this is inconsistent and I'd like to change it, but I'd like to have your opinion on it. 

*disclaimer: this is my first PR, I hope to have done everything right. I did not see the "maintenance" branch so I branched from master. I think there are a couple of thing we can do better with these normalizing tools but I need more time to think about it...*