### PR TITLE
use numpy.finfo instead of numpy.MachAr for speedup

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2738,7 +2738,7 @@ def nonsingular(vmin, vmax, expander=0.001, tiny=1e-15, increasing=True):
         swapped = True
 
     maxabsvalue = max(abs(vmin), abs(vmax))
-    if maxabsvalue < (1e6 / tiny) * np.MachAr(float).xmin:
+    if maxabsvalue < (1e6 / tiny) * np.finfo(float).min: 
         vmin = -expander
         vmax = expander
 


### PR DESCRIPTION
numpy.MachAr() is expensive to use just to determine
min/max float value; use numpy.finfo() instead since
it caches this information.   This results in
significant performance gains when updating axes limits
frequently.