### PR TITLE
Calculate text size and descent correctly

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -172,7 +172,7 @@ class RendererMac(RendererBase):
         size = self.points_to_pixels(points)
         width, height, descent = self.gc.get_text_width_height_descent(
             six.text_type(s), family, size, weight, style)
-        return  width, height, 0.0*descent
+        return  width, height, descent
 
     def flipy(self):
         return False


### PR DESCRIPTION
The calculation of text sizes and descent were always a bit off in the MacOSX backend. For example,
```python
>>> plot([0,2],[1,1],'k--')
>>> text(0,1,'xxx',fontsize=50,verticalalignment='center')
```
will draw the xxx below the dashed line, instead of centered on it. It's hardly noticeable for common text sizes, but still it should be fixed.
This pull request fixes the text size & descent calculation, and makes sure that text appears in the correct location. 