### PR TITLE
Avoid possible exception when toggling full-screen

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2479,7 +2479,8 @@ def key_press_handler(event, canvas, toolbar=None):
 
     # toggle fullscreen mode (default key 'f')
     if event.key in fullscreen_keys:
-        canvas.manager.full_screen_toggle()
+        if hasattr(canvas, 'manager'):
+            canvas.manager.full_screen_toggle()
 
     # quit the figure (defaut key 'ctrl+w')
     if event.key in quit_keys:

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2479,8 +2479,10 @@ def key_press_handler(event, canvas, toolbar=None):
 
     # toggle fullscreen mode (default key 'f')
     if event.key in fullscreen_keys:
-        if hasattr(canvas, 'manager'):
+        try:
             canvas.manager.full_screen_toggle()
+        except AttributeError:
+            pass
 
     # quit the figure (defaut key 'ctrl+w')
     if event.key in quit_keys:


### PR DESCRIPTION
In `examples/user_interfaces/embedding_in_tk.py`, a FigureCanvasTkAgg is embedded into a Tkinter window and the default mpl key bindings are implemented with matplotlib.backend_bases.key_press_handler. If the user attempts to toggle full-screen mode by pressing 'f', an AttributeError is raised because the FigureCanvasTkAgg has no 'manager' attribute. Indeed, since pyplot is not being used, no FigureManagerTkAgg object gets created. 

One fix is to check for the 'manager' attribute and do nothing if it doesn't exist. (This is what is done in FigureCanvasBase.get_window_title/set_window_title, for example.)

[Traceback](https://gist.github.com/jlutgen/d383ead64e773e89dc4a#file-gistfile1-txt)