### PR TITLE
Document get_cachedir() in troubleshooting

### DIFF
--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -44,7 +44,7 @@ locate your :file:`.matplotlib/` directory, use
 
     >>> import matplotlib as mpl
     >>> mpl.get_configdir()
-    '/home/darren/.matplotlib'
+    '/home/darren/.config/matplotlib'
 
 On unix-like systems, this directory is generally located in your
 :envvar:`HOME` directory. 

--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -34,8 +34,8 @@ and printing the ``__file__`` attribute::
 
 .. _locating-matplotlib-config-dir:
 
-:file:`.matplotlib` directory location
-======================================
+:file:`.matplotlib` and `.cache` directory location
+===================================================
 
 Each user has a matplotlib configuration directory which may contain a
 :ref:`matplotlibrc <customizing-with-matplotlibrc-files>` file. To
@@ -47,18 +47,31 @@ locate your :file:`.matplotlib/` directory, use
     '/home/darren/.matplotlib'
 
 On unix-like systems, this directory is generally located in your
-:envvar:`HOME` directory.  On windows, it is in your documents and
-settings directory by default::
+:envvar:`HOME` directory. 
+
+In addition, users have a cache directory. On unix-like systems, this is 
+separate to the configuration directory by default. To locate your 
+:file:`.cache/` directory, use :func:`matplotlib.get_cachedir`::
+
+    >>> import matplotlib as mpl
+    >>> mpl.get_cachedir()
+    '/home/darren/.cache/matplotlib'
+    
+On windows, both the config directory and the cache directory are 
+the same and are in your documents and settings directory by default::
 
     >>> import matplotlib
     >>> mpl.get_configdir()
+    'C:\\Documents and Settings\\jdhunter\\.matplotlib'
+    >>> mpl.get_cachedir()
     'C:\\Documents and Settings\\jdhunter\\.matplotlib'
 
 If you would like to use a different configuration directory, you can
 do so by specifying the location in your :envvar:`MPLCONFIGDIR`
 environment variable -- see
-:ref:`setting-linux-osx-environment-variables`.
-
+:ref:`setting-linux-osx-environment-variables`.  Note that 
+:envvar:`MPLCONFIGDIR` sets the location of both the configuration
+directory and the cache directory.
 
 .. _reporting-problems:
 

--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -34,8 +34,8 @@ and printing the ``__file__`` attribute::
 
 .. _locating-matplotlib-config-dir:
 
-:file:`.matplotlib` and `.cache` directory location
-===================================================
+:file:`matplotlib` configuration and cache directory locations
+==============================================================
 
 Each user has a matplotlib configuration directory which may contain a
 :ref:`matplotlibrc <customizing-with-matplotlibrc-files>` file. To
@@ -50,7 +50,7 @@ On unix-like systems, this directory is generally located in your
 :envvar:`HOME` directory under the :file:`.config/` directory. 
 
 In addition, users have a cache directory. On unix-like systems, this is 
-separate to the configuration directory by default. To locate your 
+separate from the configuration directory by default. To locate your 
 :file:`.cache/` directory, use :func:`matplotlib.get_cachedir`::
 
     >>> import matplotlib as mpl
@@ -58,7 +58,8 @@ separate to the configuration directory by default. To locate your
     '/home/darren/.cache/matplotlib'
     
 On windows, both the config directory and the cache directory are 
-the same and are in your documents and settings directory by default::
+the same and are in your :file:`Documents and Settings` or :file:`Users` 
+directory by default::
 
     >>> import matplotlib
     >>> mpl.get_configdir()

--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -39,7 +39,7 @@ and printing the ``__file__`` attribute::
 
 Each user has a matplotlib configuration directory which may contain a
 :ref:`matplotlibrc <customizing-with-matplotlibrc-files>` file. To
-locate your :file:`.matplotlib/` directory, use
+locate your :file:`matplotlib/` configuration directory, use
 :func:`matplotlib.get_configdir`::
 
     >>> import matplotlib as mpl
@@ -47,7 +47,7 @@ locate your :file:`.matplotlib/` directory, use
     '/home/darren/.config/matplotlib'
 
 On unix-like systems, this directory is generally located in your
-:envvar:`HOME` directory. 
+:envvar:`HOME` directory under the :file:`.config/` directory. 
 
 In addition, users have a cache directory. On unix-like systems, this is 
 separate to the configuration directory by default. To locate your 


### PR DESCRIPTION
On unix-like systems, configuration directory and cache directory are normally different. Document how to locate cache dir in troubleshooting FAQ