### PR TITLE
[mpl_toolkits] Allow "figure" kwarg for host functions in parasite_axes

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -499,9 +499,8 @@ def host_axes(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_axes_class = host_axes_class_factory(axes_class)
-    if kwargs.get("figure") is not None:
-        fig = kwargs["figure"]
-    else:
+    fig = kwargs.get("figure", None)
+    if fig is None:
         fig = plt.gcf()
     ax = host_axes_class(fig, *args, **kwargs)
     fig.add_axes(ax)
@@ -524,9 +523,8 @@ def host_subplot(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_subplot_class = host_subplot_class_factory(axes_class)
-    if kwargs.get("figure") is not None:
-        fig = kwargs["figure"]
-    else:
+    fig = kwargs.get("figure", None)
+    if fig is None:
         fig = plt.gcf()
     ax = host_subplot_class(fig, *args, **kwargs)
     fig.add_subplot(ax)

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -487,7 +487,10 @@ def host_axes(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_axes_class = host_axes_class_factory(axes_class)
-    fig = plt.gcf()
+    if "figure" in kwargs:
+        fig = kwargs["figure"]
+    else:
+        fig = plt.gcf()
     ax = host_axes_class(fig, *args, **kwargs)
     fig.add_axes(ax)
     plt.draw_if_interactive()
@@ -497,7 +500,10 @@ def host_subplot(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_subplot_class = host_subplot_class_factory(axes_class)
-    fig = plt.gcf()
+    if "figure" in kwargs:
+        fig = kwargs["figure"]
+    else:
+        fig = plt.gcf()
     ax = host_subplot_class(fig, *args, **kwargs)
     fig.add_subplot(ax)
     plt.draw_if_interactive()

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -487,7 +487,7 @@ def host_axes(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_axes_class = host_axes_class_factory(axes_class)
-    if kwargs.get("figure") != None:
+    if kwargs.get("figure") is not None:
         fig = kwargs["figure"]
     else:
         fig = plt.gcf()
@@ -500,7 +500,7 @@ def host_subplot(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_subplot_class = host_subplot_class_factory(axes_class)
-    if kwargs.get("figure") != None:
+    if kwargs.get("figure") is not None:
         fig = kwargs["figure"]
     else:
         fig = plt.gcf()

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -487,7 +487,7 @@ def host_axes(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_axes_class = host_axes_class_factory(axes_class)
-    if "figure" in kwargs:
+    if kwargs.get("figure") != None:
         fig = kwargs["figure"]
     else:
         fig = plt.gcf()
@@ -500,7 +500,7 @@ def host_subplot(*args, **kwargs):
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_subplot_class = host_subplot_class_factory(axes_class)
-    if "figure" in kwargs:
+    if kwargs.get("figure") != None:
         fig = kwargs["figure"]
     else:
         fig = plt.gcf()

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -484,6 +484,18 @@ SubplotHost = subplot_class_factory(HostAxes)
 
 
 def host_axes(*args, **kwargs):
+    """
+    Create axes that can act as a hosts to parasitic axes.
+
+    Parameters
+    ----------
+    figure : `matplotlib.figure.Figure`
+        Figure to which the axes will be added. Defaults to the current figure
+        `pyplot.gcf()`.
+
+    *args, **kwargs :
+        Will be passed on to the underlying ``Axes`` object creation.
+    """
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_axes_class = host_axes_class_factory(axes_class)
@@ -497,6 +509,18 @@ def host_axes(*args, **kwargs):
     return ax
 
 def host_subplot(*args, **kwargs):
+    """
+    Create a subplot that can act as a host to parasitic axes.
+
+    Parameters
+    ----------
+    figure : `matplotlib.figure.Figure`
+        Figure to which the subplot will be added. Defaults to the current
+        figure `pyplot.gcf()`.
+
+    *args, **kwargs :
+        Will be passed on to the underlying ``Axes`` object creation.
+    """
     import matplotlib.pyplot as plt
     axes_class = kwargs.pop("axes_class", None)
     host_subplot_class = host_subplot_class_factory(axes_class)


### PR DESCRIPTION
Currently, ``host_axes`` and ``host_subplot`` of  ``mpl_toolkits.axes_grid1`` work on ``pyplot`` only. This patch allows a kwarg ``figure`` (defaulting to ``pyplot.gcf()``) to be passed so it becomes possible to use them on arbitrary figures as well.