### PR TITLE
FIX: add explict draw_if_interactive in figure()

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -531,6 +531,13 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
         _pylab_helpers.Gcf.set_active(figManager)
         figManager.canvas.figure.number = num
 
+        # make sure backends (inline) that we don't ship that expect this
+        # to be called in plotting commands to make the figure call show
+        # still work.  There is probably a better way to do this in the
+        # FigureManager base class.
+        if matplotlib.is_interactive():
+            draw_if_interactive()
+
         if _INSTALL_FIG_OBSERVER:
             figManager.canvas.figure.add_callback(_auto_draw_if_interactive)
 


### PR DESCRIPTION
With out this the IPython inline backend does not work without
calling `plt.show()` or `plt.draw_if_interactive()`.  Adding this line
back here is a quick hack to get things working again.  There is
probably a better solution in the figure manager base-class.

Closes #4774 

attn @michaelaye Can you confirm that this fixes it for you?