### PR TITLE
PRF: only check some artists on mousemove

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -147,6 +147,23 @@ class Artist(object):
         # callback has one parameter, which is the child to be removed.
         if self._remove_method is not None:
             self._remove_method(self)
+            # clear stale callback
+            self.stale_callback = None
+            _ax_flag = False
+            if hasattr(self, 'axes') and self.axes:
+                # remove from the mouse hit list
+                self.axes.mouseover_set.discard(self)
+                # mark the axes as stale
+                self.axes.stale = True
+                # decouple the artist from the axes
+                self.axes = None
+                _ax_flag = True
+
+            if self.figure:
+                self.figure = None
+                if not _ax_flag:
+                    self.figure = True
+
         else:
             raise NotImplementedError('cannot remove artist')
         # TODO: the fix for the collections relim problem is to move the

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -214,7 +214,9 @@ class Artist(object):
 
     @axes.setter
     def axes(self, new_axes):
-        if self._axes is not None and new_axes != self._axes:
+
+        if (new_axes is not None and
+                (self._axes is not None and new_axes != self._axes)):
             raise ValueError("Can not reset the axes.  You are "
                              "probably trying to re-use an artist "
                              "in more than one Axes which is not "

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -103,7 +103,7 @@ class Artist(object):
         self._contains = None
         self._rasterized = None
         self._agg_filter = None
-
+        self._mouseover = False
         self.eventson = False  # fire events only if eventson
         self._oid = 0  # an observer id
         self._propobservers = {}  # a dict from oids to funcs
@@ -960,6 +960,21 @@ class Artist(object):
         except (TypeError, IndexError):
             data = [data]
         return ', '.join('{:0.3g}'.format(item) for item in data)
+
+    @property
+    def mouseover(self):
+        return self._mouseover
+
+    @mouseover.setter
+    def mouseover(self, val):
+        val = bool(val)
+        self._mouseover = val
+        ax = self.axes
+        if ax:
+            if val:
+                ax.mouseover_set.add(self)
+            else:
+                ax.mouseover_set.discard(self)
 
 
 class ArtistInspector(object):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -786,6 +786,8 @@ class _AxesBase(martist.Artist):
             a.set_transform(self.transData)
 
         a.axes = self
+        if a.mouseover:
+            self.mouseover_set.add(a)
 
     def _gen_axes_patch(self):
         """
@@ -916,6 +918,7 @@ class _AxesBase(martist.Artist):
         self.tables = []
         self.artists = []
         self.images = []
+        self.mouseover_set = set()
         self._current_image = None  # strictly for pyplot via _sci, _gci
         self.legend_ = None
         self.collections = []  # collection.Collection instances

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2815,9 +2815,11 @@ class NavigationToolbar2(object):
             except (ValueError, OverflowError):
                 pass
             else:
-                artists = event.inaxes.hitlist(event)
+                artists = [a for a in event.inaxes.mouseover_set
+                           if a.contains(event)]
 
                 if artists:
+
                     a = max(enumerate(artists), key=lambda x: x[1].zorder)[1]
                     if a is not event.inaxes.patch:
                         data = a.get_cursor_data(event)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -99,7 +99,7 @@ class _AxesImageBase(martist.Artist, cm.ScalarMappable):
         """
         martist.Artist.__init__(self)
         cm.ScalarMappable.__init__(self, norm, cmap)
-
+        self._mouseover = True
         if origin is None:
             origin = rcParams['image.origin']
         self.origin = origin

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -14,6 +14,9 @@ import matplotlib.transforms as mtrans
 import matplotlib.collections as mcollections
 from matplotlib.testing.decorators import image_comparison, cleanup
 
+from nose.tools import (assert_true, assert_false, assert_is, assert_in,
+                        assert_not_in)
+
 
 @cleanup
 def test_patch_transform_of_none():
@@ -142,6 +145,30 @@ def test_cull_markers():
     svg = io.BytesIO()
     fig.savefig(svg, format="svg")
     assert len(svg.getvalue()) < 20000
+
+
+@cleanup
+def test_remove():
+    fig, ax = plt.subplots()
+    im = ax.imshow(np.arange(36).reshape(6, 6))
+
+    assert_true(fig.stale)
+    assert_true(ax.stale)
+
+    fig.canvas.draw()
+    assert_false(fig.stale)
+    assert_false(ax.stale)
+
+    assert_in(im, ax.mouseover_set)
+    assert_is(im.axes, ax)
+
+    im.remove()
+
+    assert_is(im.axes, None)
+    assert_is(im.figure, None)
+    assert_not_in(im, ax.mouseover_set)
+    assert_true(fig.stale)
+    assert_true(ax.stale)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -14,8 +14,7 @@ import matplotlib.transforms as mtrans
 import matplotlib.collections as mcollections
 from matplotlib.testing.decorators import image_comparison, cleanup
 
-from nose.tools import (assert_true, assert_false, assert_is, assert_in,
-                        assert_not_in)
+from nose.tools import (assert_true, assert_false)
 
 
 @cleanup
@@ -159,14 +158,14 @@ def test_remove():
     assert_false(fig.stale)
     assert_false(ax.stale)
 
-    assert_in(im, ax.mouseover_set)
-    assert_is(im.axes, ax)
+    assert_true(im in ax.mouseover_set)
+    assert_true(im.axes is ax)
 
     im.remove()
 
-    assert_is(im.axes, None)
-    assert_is(im.figure, None)
-    assert_not_in(im, ax.mouseover_set)
+    assert_true(im.axes is None)
+    assert_true(im.figure is None)
+    assert_true(im not in ax.mouseover_set)
     assert_true(fig.stale)
     assert_true(ax.stale)
 


### PR DESCRIPTION
Instead of walking the full hitlist of the Axes, only check artists
that ask to be part of the mouseover events.

This is still missing logic to remove the artist from the mouseover_set
when removing the artist from the Axes.

This is an alternative to  #4847

attn @blink1073 