### PR TITLE
Fix single-shot timers in nbagg backend

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -3,6 +3,7 @@
 # lib/matplotlib/backends/web_backend/nbagg_uat.ipynb to help verify
 # that changes made maintain expected behaviour.
 
+import datetime
 from base64 import b64encode
 import json
 import io
@@ -171,7 +172,6 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
 
 class TimerTornado(TimerBase):
     def _timer_start(self):
-        import datetime
         self._timer_stop()
         if self._single:
             ioloop = tornado.ioloop.IOLoop.instance()
@@ -182,10 +182,15 @@ class TimerTornado(TimerBase):
             self._timer = tornado.ioloop.PeriodicCallback(
                 self._on_timer,
                 self.interval)
-        self._timer.start()
+            self._timer.start()
 
     def _timer_stop(self):
-        if self._timer is not None:
+        if self._timer is None:
+            return
+        elif self._single:
+            ioloop = tornado.ioloop.IOLoop.instance()
+            ioloop.remove_timeout(self._timer)
+        else:
             self._timer.stop()
             self._timer = None
 

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -192,7 +192,8 @@ class TimerTornado(TimerBase):
             ioloop.remove_timeout(self._timer)
         else:
             self._timer.stop()
-            self._timer = None
+
+        self._timer = None
 
     def _timer_set_interval(self):
         # Only stop and restart it if the timer has already been started

--- a/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
+++ b/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
@@ -522,7 +522,7 @@
       "text = ax.text(0.5, 0.5, '', ha='center') \n",
       "timer = fig.canvas.new_timer(500, [(update, [text], {})])\n",
       "\n",
-      "time.single_shot = True\n",
+      "timer.single_shot = True\n",
       "timer.start()\n",
       "\n",
       "plt.show()"

--- a/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
+++ b/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
@@ -1,7 +1,23 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:a1ac68aba163c75eab3d1fc91aa4d9a8ca66b09159619563827a19967d96814b"
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  },
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -17,7 +33,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -42,7 +59,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -70,7 +88,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -90,7 +109,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -109,7 +129,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -128,7 +149,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -148,7 +170,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -167,7 +190,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -189,7 +213,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -210,7 +235,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -227,7 +253,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -244,7 +271,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -263,7 +291,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -298,7 +327,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -323,7 +353,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -361,7 +392,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -394,7 +426,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -438,7 +471,110 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### UAT 17 - Timers\n",
+      "\n",
+      "Single-shot timers follow a completely different code path in the nbagg backend than regular timers (such as those used in the animation example above.)  The next set of tests ensures that both \"regular\" and \"single-shot\" timers work properly.\n",
+      "\n",
+      "The following should show a simple clock that updates twice a second:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      "import time\n",
+      "\n",
+      "fig, ax = plt.subplots()\n",
+      "text = ax.text(0.5, 0.5, '', ha='center')\n",
+      "\n",
+      "def update(text):\n",
+      "    text.set(text=time.ctime())\n",
+      "    text.axes.figure.canvas.draw()\n",
+      "    \n",
+      "timer = fig.canvas.new_timer(500, [(update, [text], {})])\n",
+      "timer.start()\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "However, the following should only update once and then stop:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      "fig, ax = plt.subplots()\n",
+      "text = ax.text(0.5, 0.5, '', ha='center') \n",
+      "timer = fig.canvas.new_timer(500, [(update, [text], {})])\n",
+      "\n",
+      "time.single_shot = True\n",
+      "timer.start()\n",
+      "\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "And the next two examples should never show any visible text at all:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      "fig, ax = plt.subplots()\n",
+      "text = ax.text(0.5, 0.5, '', ha='center')\n",
+      "timer = fig.canvas.new_timer(500, [(update, [text], {})])\n",
+      "\n",
+      "timer.start()\n",
+      "timer.stop()\n",
+      "\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      "fig, ax = plt.subplots()\n",
+      "text = ax.text(0.5, 0.5, '', ha='center')\n",
+      "timer = fig.canvas.new_timer(500, [(update, [text], {})])\n",
+      "\n",
+      "timer.single_shot = True\n",
+      "timer.start()\n",
+      "timer.stop()\n",
+      "\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
     }
    ],
    "metadata": {}


### PR DESCRIPTION
Single-shot timers are currently non-functional (raise an error) when using the `nbagg` backed.

To reproduce the issue, try running the following _in an ipython notebook_ (I can't seem to find a way to set up a fully independent `nbagg` figure without manually starting a "full" notebook):

```
import numpy as np
import matplotlib
matplotlib.use('nbAgg')
import matplotlib.pyplot as plt

fig, ax = plt.subplots()

def callback(ax):
    ax.plot(np.random.random((10, 10)))
    ax.figure.canvas.draw()

timer = fig.canvas.new_timer(1000, [(callback, [ax], {})])
timer.single_shot = True
timer.start()

plt.show()
```

Ideally, you'd get a figure that would update with a plot 1 second after being displayed.  Instead, you'll get an `AttributeError`:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-346b07a4494a> in <module>()
     13 timer = fig.canvas.new_timer(500, [(callback, [ax], {})])
     14 timer.single_shot = True
---> 15 timer.start()
     16 #timer.stop()
     17 

/home/jofer/anaconda/lib/python2.7/site-packages/matplotlib/backend_bases.pyc in start(self, interval)
   1218         if interval is not None:
   1219             self._set_interval(interval)
-> 1220         self._timer_start()
   1221 
   1222     def stop(self):

/home/jofer/anaconda/lib/python2.7/site-packages/matplotlib/backends/backend_nbagg.pyc in _timer_start(self)
    186                 self._on_timer,
    187                 self.interval)
--> 188         self._timer.start()
    189 
    190     def _timer_stop(self):

AttributeError: '_Timeout' object has no attribute 'start'
```

Fully fixing this issue is slightly more complex than it seems at first glance.  Basically, single-shot timers need to follow a completely different code path than regular timers when using Tornado.

I've added some additional user acceptance tests to `/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb` and can vouch that the current changes don't break any of the manual user acceptance tests in the notebook.