### PR TITLE
Qt5: Eliminate slow path when showing messages

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -471,6 +471,10 @@ class FigureManagerQT(FigureManagerBase):
         else:
             tbs_height = 0
 
+        # add text label to status bar
+        self.statusbar_label = QtWidgets.QLabel()
+        self.window.statusBar().addWidget(self.statusbar_label)
+
         # resize the main window so it will display the canvas with the
         # requested size:
         cs = canvas.sizeHint()
@@ -493,8 +497,7 @@ class FigureManagerQT(FigureManagerBase):
 
     @QtCore.Slot()
     def _show_message(self, s):
-        # Fixes a PySide segfault.
-        self.window.statusBar().showMessage(s)
+        self.statusbar_label.setText(s)
 
     def full_screen_toggle(self):
         if self.window.isFullScreen():


### PR DESCRIPTION
For every single mouse-move event the Qt5 backend displays a message (x, y coordinates) via `QStatusBar.showMessage()`. This function forces an immediate update of the GUI and causes the application to lag behind mouse movements in case the update process cannot keep up with the event-rate.
As an alternative approach I added a QLabel to the QStatusBar and changed its text property for displaying messages. The redraws for message updates are now handled asynchronously and thus result in much better GUI performance, at least on the systems I tested.