### PR TITLE
Add latex preamble to texmanager _fontconfig

### DIFF
--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -2,8 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import matplotlib.pyplot as plt
-
 from matplotlib.texmanager import TexManager
+
 
 def test_fontconfig_preamble():
     """

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -1,0 +1,21 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import matplotlib.pyplot as plt
+
+from matplotlib.texmanager import TexManager
+
+def test_fontconfig_preamble():
+    """
+    Test that the preamble is included in _fontconfig
+    """
+    plt.rcParams['text.usetex'] = True
+
+    tm1 = TexManager()
+    font_config1 = tm1.get_font_config()
+
+    plt.rcParams['text.latex.preamble'] = [r'\usepackage{txfonts}']
+    tm2 = TexManager()
+    font_config2 = tm2.get_font_config()
+
+    assert font_config1 != font_config2

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -203,6 +203,9 @@ Could not rename old TeX cache dir "%s": a suitable configuration
                                    'default.' % ff, 'helpful')
                 setattr(self, font_family_attr, self.font_info[font_family])
             fontconfig.append(getattr(self, font_family_attr)[0])
+        # Add a hash of the latex preamble to fontconfig
+        preamble_bytes = six.text_type(self.get_custom_preamble()).encode('utf-8')
+        fontconfig.append(md5(preamble_bytes).hexdigest())
         self._fontconfig = ''.join(fontconfig)
 
         # The following packages and commands need to be included in the latex

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -203,7 +203,9 @@ Could not rename old TeX cache dir "%s": a suitable configuration
                                    'default.' % ff, 'helpful')
                 setattr(self, font_family_attr, self.font_info[font_family])
             fontconfig.append(getattr(self, font_family_attr)[0])
-        # Add a hash of the latex preamble to fontconfig
+        # Add a hash of the latex preamble to self._fontconfig so that the
+        # correct png is selected for strings rendered with same font and dpi
+        # even if the latex preamble changes within the session
         preamble_bytes = six.text_type(self.get_custom_preamble()).encode('utf-8')
         fontconfig.append(md5(preamble_bytes).hexdigest())
         self._fontconfig = ''.join(fontconfig)


### PR DESCRIPTION
The contents of ``TexManager._fontconfig`` determines whether the png for a given string/dpi/font combination is rendered from TeX or reused from the cache. Right now, there is no information of the custom latex preamble in ``_fontconfig``, so a second string with a different latex preamble will reuse the png from the first call. Note that the tex and dvi files are generated as generating this depends on the ``_rc_cache`` which includes the latex preamble, so the expensive call to TeX is made but then the png is not used. This PR adds a hash of the latex preamble to ``TexManager._fontconfig`` so that a new png is read if preamble changes.

A minimal example which should produce two different images:
```python
import matplotlib.pyplot as plt
plt.rcParams['text.usetex'] = True
plt.rcParams['font.family'] = 'serif'
for font,preamble in zip(['cm','times'], [' ',r'\usepackage{txfonts}']):
    plt.rcParams['text.latex.preamble'] = preamble
    f = plt.figure(figsize=(3,1))
    f.text(0.5,0.5,'This is some test text $e^{-i\pi}=-1$', ha='center',va='center')
    f.savefig('texmanager_test_{0}.png'.format(font))
```