### PR TITLE
stale artists do not handle being removed from axes properly

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -69,11 +69,13 @@ def allow_rasterization(draw):
 
 
 def _stale_figure_callback(self):
-    self.figure.stale = True
+    if self.figure:
+        self.figure.stale = True
 
 
 def _stale_axes_callback(self):
-    self.axes.stale = True
+    if self.axes:
+        self.axes.stale = True
 
 
 class Artist(object):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -280,7 +280,7 @@ class Text(Artist):
 
     def _get_xy_display(self):
         'get the (possibly unit converted) transformed x, y in display coords'
-        x, y = self.get_position()
+        x, y = self._get_unitless_position()
         return self.get_transform().transform_point((x, y))
 
     def _get_multialignment(self):
@@ -536,8 +536,8 @@ class Text(Artist):
 
             trans = self.get_transform()
 
-            # don't use self.get_position here, which refers to text position
-            # in Text, and dash position in TextWithDash:
+            # don't use self._get_unitless position here, which refers to text
+            # position in Text, and dash position in TextWithDash:
             posx = float(self.convert_xunits(self._x))
             posy = float(self.convert_yunits(self._y))
 
@@ -877,11 +877,19 @@ class Text(Artist):
         """
         return self._horizontalalignment
 
-    def get_position(self):
-        "Return the position of the text as a tuple (*x*, *y*)"
+    def _get_unitless_position(self):
+        "Return the unitless position of the text as a tuple (*x*, *y*)"
+        # This will get the position with all unit information stripped away.
+        # This is here for convienience since it is done in several locations.
         x = float(self.convert_xunits(self._x))
         y = float(self.convert_yunits(self._y))
         return x, y
+
+    def get_position(self):
+        "Return the position of the text as a tuple (*x*, *y*)"
+        # This should return the same data (possible unitized) as was
+        # specified with 'set_x' and 'set_y'.
+        return self._x, self._y
 
     def get_prop_tup(self):
         """
@@ -891,7 +899,7 @@ class Text(Artist):
         want to cache derived information about text (e.g., layouts) and
         need to know if the text has changed.
         """
-        x, y = self.get_position()
+        x, y = self._get_unitless_position()
         return (x, y, self.get_text(), self._color,
                 self._verticalalignment, self._horizontalalignment,
                 hash(self._fontproperties),
@@ -1365,11 +1373,19 @@ class TextWithDash(Text):
 
         #self.set_bbox(dict(pad=0))
 
-    def get_position(self):
-        "Return the position of the text as a tuple (*x*, *y*)"
+    def _get_unitless_position(self):
+        "Return the unitless position of the text as a tuple (*x*, *y*)"
+        # This will get the position with all unit information stripped away.
+        # This is here for convienience since it is done in several locations.
         x = float(self.convert_xunits(self._dashx))
         y = float(self.convert_yunits(self._dashy))
         return x, y
+
+    def get_position(self):
+        "Return the position of the text as a tuple (*x*, *y*)"
+        # This should return the same data (possibly unitized) as was
+        # specified with set_x and set_y
+        return self._dashx, self._dashy
 
     def get_prop_tup(self):
         """
@@ -1402,7 +1418,7 @@ class TextWithDash(Text):
         with respect to the actual canvas's coordinates we need to map
         back and forth.
         """
-        dashx, dashy = self.get_position()
+        dashx, dashy = self._get_unitless_position()
         dashlength = self.get_dashlength()
         # Shortcircuit this process if we don't have a dash
         if dashlength == 0.0:


### PR DESCRIPTION
Artists do not properly guard against being removed from figures or Axes when tracking 'stale'.  This will keep them from throwing an exception if they become stale after being removed from an Axes or Figure.

This addresses an issue in #4897.
