### PR TITLE
stale artists do not handle being removed from axes properly

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -69,11 +69,13 @@ def allow_rasterization(draw):
 
 
 def _stale_figure_callback(self):
-    self.figure.stale = True
+    if self.figure:
+        self.figure.stale = True
 
 
 def _stale_axes_callback(self):
-    self.axes.stale = True
+    if self.axes:
+        self.axes.stale = True
 
 
 class Artist(object):


### PR DESCRIPTION
Artists do not properly guard against being removed from figures or Axes when tracking 'stale'. This will keep them from throwing an exception if they become stale after being removed from an Axes or Figure.

This addresses an issue in #4897.
