### PR TITLE
position of text annotations looses unit information

### DIFF
--- a/doc/api/api_changes/2015-08-17-JRE.rst
+++ b/doc/api/api_changes/2015-08-17-JRE.rst
@@ -1,0 +1,11 @@
+ Preserve units with Text position
+ `````````````````````````````````
+
+Previously the 'get_position' method on Text would strip away unit information
+even though the units were still present.  There was no inherent need to do
+this, so it has been changed so that unit data (if present) will be preserved.
+Essentially a call to 'get_position' will return the exact value from a call to
+'set_position'.
+
+If you wish to get the old behaviour, then you can use the new method called
+'get_unitless_position'.

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -280,7 +280,7 @@ class Text(Artist):
 
     def _get_xy_display(self):
         'get the (possibly unit converted) transformed x, y in display coords'
-        x, y = self.get_position()
+        x, y = self._get_unitless_position()
         return self.get_transform().transform_point((x, y))
 
     def _get_multialignment(self):
@@ -536,8 +536,8 @@ class Text(Artist):
 
             trans = self.get_transform()
 
-            # don't use self.get_position here, which refers to text position
-            # in Text, and dash position in TextWithDash:
+            # don't use self._get_unitless_position here, which refers to text
+            # position in Text, and dash position in TextWithDash:
             posx = float(self.convert_xunits(self._x))
             posy = float(self.convert_yunits(self._y))
 
@@ -877,11 +877,19 @@ class Text(Artist):
         """
         return self._horizontalalignment
 
-    def get_position(self):
-        "Return the position of the text as a tuple (*x*, *y*)"
+    def _get_unitless_position(self):
+        "Return the unitless position of the text as a tuple (*x*, *y*)"
+        # This will get the position with all unit information stripped away.
+        # This is here for convienience since it is done in several locations.
         x = float(self.convert_xunits(self._x))
         y = float(self.convert_yunits(self._y))
         return x, y
+
+    def get_position(self):
+        "Return the position of the text as a tuple (*x*, *y*)"
+        # This should return the same data (possible unitized) as was
+        # specified with 'set_x' and 'set_y'.
+        return self._x, self._y
 
     def get_prop_tup(self):
         """
@@ -891,7 +899,7 @@ class Text(Artist):
         want to cache derived information about text (e.g., layouts) and
         need to know if the text has changed.
         """
-        x, y = self.get_position()
+        x, y = self._get_unitless_position()
         return (x, y, self.get_text(), self._color,
                 self._verticalalignment, self._horizontalalignment,
                 hash(self._fontproperties),
@@ -950,7 +958,7 @@ class Text(Artist):
             raise RuntimeError('Cannot get window extent w/o renderer')
 
         bbox, info, descent = self._get_layout(self._renderer)
-        x, y = self.get_position()
+        x, y = self._get_unitless_position()
         x, y = self.get_transform().transform_point((x, y))
         bbox = bbox.translated(x, y)
         if dpi is not None:
@@ -1365,11 +1373,19 @@ class TextWithDash(Text):
 
         #self.set_bbox(dict(pad=0))
 
-    def get_position(self):
-        "Return the position of the text as a tuple (*x*, *y*)"
+    def _get_unitless_position(self):
+        "Return the unitless position of the text as a tuple (*x*, *y*)"
+        # This will get the position with all unit information stripped away.
+        # This is here for convienience since it is done in several locations.
         x = float(self.convert_xunits(self._dashx))
         y = float(self.convert_yunits(self._dashy))
         return x, y
+
+    def get_position(self):
+        "Return the position of the text as a tuple (*x*, *y*)"
+        # This should return the same data (possibly unitized) as was
+        # specified with set_x and set_y
+        return self._dashx, self._dashy
 
     def get_prop_tup(self):
         """
@@ -1402,7 +1418,7 @@ class TextWithDash(Text):
         with respect to the actual canvas's coordinates we need to map
         back and forth.
         """
-        dashx, dashy = self.get_position()
+        dashx, dashy = self._get_unitless_position()
         dashlength = self.get_dashlength()
         # Shortcircuit this process if we don't have a dash
         if dashlength == 0.0:

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -280,7 +280,7 @@ class Text(Artist):
 
     def _get_xy_display(self):
         'get the (possibly unit converted) transformed x, y in display coords'
-        x, y = self._get_unitless_position()
+        x, y = self.get_unitless_position()
         return self.get_transform().transform_point((x, y))
 
     def _get_multialignment(self):
@@ -536,7 +536,7 @@ class Text(Artist):
 
             trans = self.get_transform()
 
-            # don't use self._get_unitless_position here, which refers to text
+            # don't use self.get_unitless_position here, which refers to text
             # position in Text, and dash position in TextWithDash:
             posx = float(self.convert_xunits(self._x))
             posy = float(self.convert_yunits(self._y))
@@ -877,7 +877,7 @@ class Text(Artist):
         """
         return self._horizontalalignment
 
-    def _get_unitless_position(self):
+    def get_unitless_position(self):
         "Return the unitless position of the text as a tuple (*x*, *y*)"
         # This will get the position with all unit information stripped away.
         # This is here for convienience since it is done in several locations.
@@ -899,7 +899,7 @@ class Text(Artist):
         want to cache derived information about text (e.g., layouts) and
         need to know if the text has changed.
         """
-        x, y = self._get_unitless_position()
+        x, y = self.get_unitless_position()
         return (x, y, self.get_text(), self._color,
                 self._verticalalignment, self._horizontalalignment,
                 hash(self._fontproperties),
@@ -958,7 +958,7 @@ class Text(Artist):
             raise RuntimeError('Cannot get window extent w/o renderer')
 
         bbox, info, descent = self._get_layout(self._renderer)
-        x, y = self._get_unitless_position()
+        x, y = self.get_unitless_position()
         x, y = self.get_transform().transform_point((x, y))
         bbox = bbox.translated(x, y)
         if dpi is not None:
@@ -1373,7 +1373,7 @@ class TextWithDash(Text):
 
         #self.set_bbox(dict(pad=0))
 
-    def _get_unitless_position(self):
+    def get_unitless_position(self):
         "Return the unitless position of the text as a tuple (*x*, *y*)"
         # This will get the position with all unit information stripped away.
         # This is here for convienience since it is done in several locations.
@@ -1418,7 +1418,7 @@ class TextWithDash(Text):
         with respect to the actual canvas's coordinates we need to map
         back and forth.
         """
-        dashx, dashy = self._get_unitless_position()
+        dashx, dashy = self.get_unitless_position()
         dashlength = self.get_dashlength()
         # Shortcircuit this process if we don't have a dash
         if dashlength == 0.0:


### PR DESCRIPTION
A person could set the position using units, but when getting them back, the units would be stripped away.  This made no sense since the unitized data was still present and the units were only being stripped away for use in internal methods.  This fixes the behavior so the user will get back exactly what they set and the internal routines will still get the unitless data as needed.

This addresses an issue in #4897.