### PR TITLE
figure option dialog does not properly handle units

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -63,6 +63,12 @@ def figure_edit(axes, parent=None):
                ('(Re-)Generate automatic legend', False),
                ]
 
+    # Save the unit data
+    xconverter = axes.xaxis.converter
+    yconverter = axes.yaxis.converter
+    xunits = axes.xaxis.get_units()
+    yunits = axes.yaxis.get_units()
+
     if has_curve:
         # Get / Curves
         linedict = {}
@@ -101,7 +107,7 @@ def figure_edit(axes, parent=None):
         has_curve = bool(curves)
 
     datalist = [(general, "Axes", "")]
-    if has_curve:
+    if has_curve and curves:
         datalist.append((curves, "Curves", ""))
 
     def apply_callback(data):
@@ -121,6 +127,14 @@ def figure_edit(axes, parent=None):
         axes.set_xlabel(xlabel)
         axes.set_ylim(ymin, ymax)
         axes.set_ylabel(ylabel)
+
+        # Restore the unit data
+        axes.xaxis.converter = xconverter
+        axes.yaxis.converter = yconverter
+        axes.xaxis.set_units( xunits )
+        axes.yaxis.set_units( yunits )
+        axes.xaxis._update_axisinfo()
+        axes.yaxis._update_axisinfo()
 
         if has_curve:
             # Set / Curves

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -131,8 +131,8 @@ def figure_edit(axes, parent=None):
         # Restore the unit data
         axes.xaxis.converter = xconverter
         axes.yaxis.converter = yconverter
-        axes.xaxis.set_units( xunits )
-        axes.yaxis.set_units( yunits )
+        axes.xaxis.set_units(xunits)
+        axes.yaxis.set_units(yunits)
         axes.xaxis._update_axisinfo()
         axes.yaxis._update_axisinfo()
 


### PR DESCRIPTION
The figure option dialog resets the axes and all unit information.  This saves the axes converter information so that it can be restored when the dialog values are applied to the figure.

This addresses an issue in #4897.
