### PR TITLE
Agg restore_region is broken

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -357,7 +357,10 @@ class RendererAgg(RendererBase):
             else:
                 ox, oy = xy
 
-            self._renderer.restore_region(region, x1, y1, x2, y2, ox, oy)
+            # The incoming data is float, but the _renderer type-checking wants
+            # to see integers.
+            self._renderer.restore_region(region, int(x1), int(y1),
+                                          int(x2), int(y2), int(ox), int(oy))
 
         else:
             self._renderer.restore_region(region)


### PR DESCRIPTION
The original version used to have float parameters that would be converted to integers in the agg renderer C++ file.  The current version now performs some type-checking in the Python->C++ layer that will throw an exception tot he float values that are passed in.  This fix makes sure that we are indeed passing in integers to the C++ method.

This addresses an issue in #4897.
