### PR TITLE
TransformWrapper pickling fixes

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1533,6 +1533,10 @@ class TransformWrapper(Transform):
             msg = ("'child' must be an instance of"
                    " 'matplotlib.transform.Transform'")
             raise ValueError(msg)
+        self._init(child)
+        self.set_children(child)
+
+    def _init(self, child):
         Transform.__init__(self)
         self.input_dims = child.input_dims
         self.output_dims = child.output_dims
@@ -1553,7 +1557,7 @@ class TransformWrapper(Transform):
 
     def __setstate__(self, state):
         # re-initialise the TransformWrapper with the state's child
-        self.__init__(state['child'])
+        self._init(state['child'])
 
     def __repr__(self):
         return "TransformWrapper(%r)" % self._child
@@ -1564,7 +1568,6 @@ class TransformWrapper(Transform):
 
     def _set(self, child):
         self._child = child
-        self.set_children(child)
 
         self.transform = child.transform
         self.transform_affine = child.transform_affine
@@ -1593,6 +1596,7 @@ class TransformWrapper(Transform):
                    " output dimensions as the current child.")
             raise ValueError(msg)
 
+        self.set_children(child)
         self._set(child)
 
         self._invalid = 0

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1552,12 +1552,18 @@ class TransformWrapper(Transform):
             return str(self._child)
 
     def __getstate__(self):
-        # only store the child
-        return {'child': self._child}
+        # only store the child and parents
+        return {
+            'child': self._child,
+            # turn the weakkey dictionary into a normal dictionary
+            'parents': dict(six.iteritems(self._parents))
+        }
 
     def __setstate__(self, state):
         # re-initialise the TransformWrapper with the state's child
         self._init(state['child'])
+        # turn the normal dictionary back into a WeakValueDictionary
+        self._parents = WeakValueDictionary(state['parents'])
 
     def __repr__(self):
         return "TransformWrapper(%r)" % self._child


### PR DESCRIPTION
Calling set_children may or may not work if the child has been unpickled yet, and it actually causes duplicate parents to be set in the times when it does appear to work.

Using the example from #4908 with some additional prints:
```python
import pickle
import matplotlib.transforms as mtransforms

class TestTransform(object):
    def __init__(self):
        self.identity = mtransforms.IdentityTransform()
        self.identity2 = mtransforms.IdentityTransform()
        self.composite = self.identity + self.identity2
        self.wrapper = mtransforms.TransformWrapper(self.composite)
        #self.wrapper = mtransforms.TransformWrapper(self.identity)

c = TestTransform()
print(c.wrapper._child, list(c.wrapper._child._parents.items()))
pkl = pickle.dumps(c)
ret = pickle.loads(pkl)
print(ret.wrapper._child, list(ret.wrapper._child._parents.items()))
```
If it succeeds, the result is:
```
$ python3 test_pickle.py 
IdentityTransform() [(139932718695928, TransformWrapper(IdentityTransform()))]
IdentityTransform() [(139932718695928, TransformWrapper(IdentityTransform())), (139932718696656, TransformWrapper(IdentityTransform()))]
```
You can see that the unpickled child transform has a second fictitious parent.

So the simple fix appears to be to avoid calling `set_children`...

Fixes #4908.