### PR TITLE
modifying sourceforge links

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -131,7 +131,9 @@ Foundation Code of Conduct</a> in everything we do.</p>
 the <a href="{{ pathto('api/index') }}">api</a> docs,
 <a href="http://matplotlib.1069221.n5.nabble.com/matplotlib-users-f3.html">mailing
 list archives</a>, and join the matplotlib
-mailing <a href="http://sourceforge.net/mail/?group_id=80706">lists</a>.
+mailing lists <a href="https://mail.python.org/mailman/listinfo/matplotlib-users">Users</a>, 
+<a href="https://mail.python.org/mailman/listinfo/matplotlib-announce">Announce</a> and 
+<a href="https://mail.python.org/mailman/listinfo/matplotlib-devel">Devel</a>.
 Check out the matplotlib questions
 on <a href="http://stackoverflow.com/questions/tagged/matplotlib">stackoverflow</a>.
 The <a href="{{ pathto('search') }}">search</a> tool searches all of

--- a/doc/devel/gitwash/this_project.inc
+++ b/doc/devel/gitwash/this_project.inc
@@ -2,4 +2,4 @@
 .. _matplotlib: http://matplotlib.org
 .. _`matplotlib github`: http://github.com/matplotlib/matplotlib
 
-.. _`matplotlib mailing list`: https://lists.sourceforge.net/lists/listinfo/matplotlib-devel
+.. _`matplotlib mailing list`: https://mail.python.org/mailman/listinfo/matplotlib-devel

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -503,7 +503,7 @@ Request a new feature
 
 Is there a feature you wish matplotlib had?  Then ask!  The best
 way to get started is to email the developer `mailing
-list <matplotlib-devel@lists.sourceforge.net>`_ for discussion.
+list <matplotlib-devel@python.org>`_ for discussion.
 This is an open source project developed primarily in the
 contributors free time, so there is no guarantee that your
 feature will be added.  The *best* way to get the feature
@@ -526,7 +526,7 @@ demonstrating what the bug is.  Including a clear, easy to test
 example makes it easy for the developers to evaluate the bug.  Expect
 that the bug reports will be a conversation.  If you do not want to
 register with github, please email bug reports to the `mailing list
-<matplotlib-devel@lists.sourceforge.net>`_.
+<matplotlib-devel@python.org>`_.
 
 
 The easiest way to submit patches to matplotlib is through pull

--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -92,7 +92,7 @@ There is a good chance your question has already been asked:
 If you are unable to find an answer to your question through search,
 please provide the following information in your e-mail to the
 `mailing list
-<http://lists.sourceforge.net/mailman/listinfo/matplotlib-users>`_:
+<https://mail.python.org/mailman/listinfo/matplotlib-users>`_:
 
   * your operating system; (Linux/UNIX users: post the output of ``uname -a``)
 

--- a/doc/glossary/index.rst
+++ b/doc/glossary/index.rst
@@ -84,7 +84,7 @@ Glossary
 
 
   pytz
-      `pytz <http://pytz.sourceforge.net/>`_ provides the Olson tz
+      `pytz <http://pythonhosted.org/pytz/>`_ provides the Olson tz
       database in Python. it allows accurate and cross platform
       timezone calculations and solves the issue of ambiguous times at
       the end of daylight savings

--- a/doc/users/screenshots.rst
+++ b/doc/users/screenshots.rst
@@ -252,7 +252,7 @@ Mathtext_examples
 
 Below is a sampling of the many TeX expressions now supported by matplotlib's
 internal mathtext engine.  The mathtext module provides TeX style mathematical
-expressions using `freetype2 <http://freetype.sourceforge.net/index2.html>`_
+expressions using `freetype2 <http://www.freetype.org/>`_
 and the BaKoMa computer modern or `STIX <http://www.stixfonts.org>`_ fonts.
 See the :mod:`matplotlib.mathtext` module for additional details.
 

--- a/doc/users/text_intro.rst
+++ b/doc/users/text_intro.rst
@@ -8,7 +8,7 @@ expressions, truetype support for raster and vector outputs, newline
 separated text with arbitrary rotations, and unicode support.  Because
 we embed the fonts directly in the output documents, e.g., for postscript
 or PDF, what you see on the screen is what you get in the hardcopy.
-`freetype2 <http://freetype.sourceforge.net/index2.html>`_ support
+`freetype2 <http://www.freetype.org/>`_ support
 produces very nice, antialiased fonts, that look good even at small
 raster sizes.  matplotlib includes its own
 :mod:`matplotlib.font_manager`, thanks to Paul Barrett, which

--- a/examples/event_handling/README.txt
+++ b/examples/event_handling/README.txt
@@ -9,10 +9,3 @@ events are aware of things like data coordinate space and whih axes
 the event occurs in so you don't have to mess with low level
 transformation details to go from canvas space to data space.  Object
 picking examples are also included.
-
-There is an event handling tutorial at
-http://matplotlib.sourceforge.net/pycon/event_handling_tut.pdf.  The
-ReST source for this document is included in the matplotlib source
-distribution.
-
-

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -37,7 +37,7 @@ parameter in your :file:`matplotlibrc` file.  If you leave out a
 assumed.  If you want to use a custom time zone, pass a
 :class:`pytz.timezone` instance with the tz keyword argument to
 :func:`num2date`, :func:`plot_date`, and any custom date tickers or
-locators you create.  See `pytz <http://pytz.sourceforge.net>`_ for
+locators you create.  See `pytz <http://pythonhosted.org/pytz/>`_ for
 information on :mod:`pytz` and timezone handling.
 
 The `dateutil module <http://labix.org/python-dateutil>`_ provides

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2005,7 +2005,7 @@ def colormaps():
       jet()
 
     The next set of palettes are from the `Yorick scientific visualisation
-    package <http://yorick.sourceforge.net/index.php>`_, an evolution of
+    package <http://dhmunro.github.io/yorick-doc/>`_, an evolution of
     the GIST package, both by David H. Munro:
 
       ============  =======================================================


### PR DESCRIPTION
With the change in mailinglists provider, there are a lot of **dead/dying** links

I did a search for `sourceforge` in the repo and tried to update as many links as I could.
There are some references to `natgrid`, `matplotlib.x.y.zip` and other downloads that I don't know how to handle