### PR TITLE
MNT: changed close button color and text

### DIFF
--- a/lib/matplotlib/backends/web_backend/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/nbagg_mpl.js
@@ -118,7 +118,7 @@ mpl.figure.prototype._init_toolbar = function() {
 
     // Add the close button to the window.
     var buttongrp = $('<div class="btn-group inline pull-right"></div>');
-    var button = $('<button class="btn btn-mini btn-primary" href="#" title="Stop Interaction"><i class="fa fa-stop icon-remove icon-large"></i></button>');
+    var button = $('<button class="btn btn-mini btn-primary" href="#" title="Stop Interaction"><i class="fa fa-power-off icon-remove icon-large"></i></button>');
     button.click(function (evt) { fig.handle_close(fig, {}); } );
     button.mouseover('Stop Interaction', toolbar_mouse_event);
     buttongrp.append(button);

--- a/lib/matplotlib/backends/web_backend/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/nbagg_mpl.js
@@ -118,9 +118,9 @@ mpl.figure.prototype._init_toolbar = function() {
 
     // Add the close button to the window.
     var buttongrp = $('<div class="btn-group inline pull-right"></div>');
-    var button = $('<button class="btn btn-mini btn-danger" href="#" title="Close figure"><i class="fa fa-times icon-remove icon-large"></i></button>');
+    var button = $('<button class="btn btn-mini btn-primary" href="#" title="Stop Interaction"><i class="fa fa-stop icon-remove icon-large"></i></button>');
     button.click(function (evt) { fig.handle_close(fig, {}); } );
-    button.mouseover('Close figure', toolbar_mouse_event);
+    button.mouseover('Stop Interaction', toolbar_mouse_event);
     buttongrp.append(button);
     var titlebar = this.root.find($('.ui-dialog-titlebar'));
     titlebar.prepend(buttongrp);


### PR DESCRIPTION
 - Changed color from red (btn-danger) to blue (btn-primary)
 - Changed mouse-over text from 'Close Figure' -> 'Stop Interaction'
 - Changed icon from times -> stop

![so](https://cloud.githubusercontent.com/assets/199813/9287449/0fb3227c-42e3-11e5-982a-214593a7c51a.png)

Thoughts?

attn @pelson @doraf 