### PR TITLE
Correct numpy doc format in cbook api docs

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2382,9 +2382,8 @@ def pts_to_prestep(x, *args):
         will be length ``2N + 1``
 
 
-    Example
-    -------
-
+    Examples
+    --------
     >> x_s, y1_s, y2_s = pts_to_prestep(x, y1, y2)
     """
     # do normalization
@@ -2423,9 +2422,8 @@ def pts_to_poststep(x, *args):
         will be length ``2N + 1``
 
 
-    Example
-    -------
-
+    Examples
+    --------
     >> x_s, y1_s, y2_s = pts_to_prestep(x, y1, y2)
     """
     # do normalization
@@ -2465,9 +2463,8 @@ def pts_to_midstep(x, *args):
         will be length ``2N + 1``
 
 
-    Example
-    -------
-
+    Examples
+    --------
     >> x_s, y1_s, y2_s = pts_to_prestep(x, y1, y2)
     """
     # do normalization


### PR DESCRIPTION
Example is not an allowed section header in numpydoc but Examples is. Even if we only have one example the section needs to be Examples. 

See how the example is missing from: http://matplotlib.org/devdocs/api/cbook_api.html#matplotlib.cbook.pts_to_midstep and friends. This PR fixes that. 

It's not caught by Travis because it is a numpydoc warning not a Sphinx warning so warnings as errors don't catch it. There was a warning in the docs build output which was how I found it. 