### PR TITLE
MNT: Add space to pylab examples with figsize and/or tight_layout

### DIFF
--- a/examples/pylab_examples/axis_equal_demo.py
+++ b/examples/pylab_examples/axis_equal_demo.py
@@ -29,4 +29,5 @@ plt.axis([-3, 3, -3, 3])
 plt.plot([0, 4], [0, 4])
 plt.title('still equal after adding line', fontsize=10)
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/contour_image.py
+++ b/examples/pylab_examples/contour_image.py
@@ -30,7 +30,7 @@ levels = np.arange(-2.0, 1.601, 0.4)  # Boost the upper limit to avoid truncatio
 norm = cm.colors.Normalize(vmax=abs(Z).max(), vmin=-abs(Z).max())
 cmap = cm.PRGn
 
-plt.figure()
+plt.figure(figsize=(10,12))
 
 
 plt.subplot(2, 2, 1)
@@ -65,7 +65,6 @@ cset3 = plt.contour(X, Y, Z, (0,),
                 hold='on')
 plt.title('Filled contours')
 plt.colorbar(cset1)
-#hot()
 
 
 plt.subplot(2, 2, 2)
@@ -104,4 +103,5 @@ plt.setp(plt.gca(), ylim=ylim[::-1])
 plt.title("Image, origin from rc, reversed y-axis")
 plt.colorbar(im)
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/fancybox_demo.py
+++ b/examples/pylab_examples/fancybox_demo.py
@@ -127,7 +127,7 @@ def test4(ax):
 
 
 def test_all():
-    plt.clf()
+    plt.figure(figsize=(10, 10))
 
     ax = plt.subplot(2, 2, 1)
     test1(ax)
@@ -157,7 +157,7 @@ def test_all():
     ax.set_ylim(0., 1.)
     ax.set_aspect(2.)
 
-    plt.draw()
+    plt.tight_layout()
     plt.show()
 
 test_all()

--- a/examples/pylab_examples/log_demo.py
+++ b/examples/pylab_examples/log_demo.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -34,5 +33,5 @@ plt.errorbar(x, y, xerr=0.1*x, yerr=5.0 + 0.75*y)
 ax.set_ylim(ymin=0.1)
 ax.set_title('Errorbars go negative')
 
-
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/markevery_demo.py
+++ b/examples/pylab_examples/markevery_demo.py
@@ -49,7 +49,7 @@ for i, case in enumerate(cases):
     ax.append(fig1.add_subplot(gs[row, col]))
     ax[-1].set_title('markevery=%s' % str(case))
     ax[-1].plot(x, y, 'o', ls='-', ms=4, markevery=case)
-#fig1.tight_layout()
+fig1.tight_layout()
 
 # plot each markevery case for log x and y scales
 fig2 = plt.figure(num=2, figsize=figsize)

--- a/examples/pylab_examples/nan_test.py
+++ b/examples/pylab_examples/nan_test.py
@@ -26,4 +26,5 @@ plt.xlabel('time (s)')
 plt.ylabel('more nans')
 plt.grid(True)
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/pcolor_demo.py
+++ b/examples/pylab_examples/pcolor_demo.py
@@ -49,4 +49,5 @@ plt.title('pcolorfast')
 plt.colorbar()
 
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/psd_demo.py
+++ b/examples/pylab_examples/psd_demo.py
@@ -15,6 +15,7 @@ plt.plot(t, s)
 plt.subplot(212)
 plt.psd(s, 512, 1/dt)
 
+plt.tight_layout()
 plt.show()
 
 """

--- a/examples/pylab_examples/psd_demo2.py
+++ b/examples/pylab_examples/psd_demo2.py
@@ -39,4 +39,5 @@ ax4.psd(y, NFFT=len(t)//2, pad_to=len(t), noverlap=int(0.2*len(t)/2.), Fs=fs)
 ax4.set_ylabel('')
 plt.title('overlap')
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/psd_demo_complex.py
+++ b/examples/pylab_examples/psd_demo_complex.py
@@ -14,6 +14,7 @@ xn = (A * np.exp(2j * np.pi * f * t)).sum(axis=0) + 5 * np.random.randn(*t.shape
 
 yticks = np.arange(-50, 30, 10)
 xticks = np.arange(-500, 550, 100)
+plt.figure(figsize=(10, 4))
 plt.subplots_adjust(hspace=0.45, wspace=0.3)
 ax = plt.subplot(1, 2, 1)
 
@@ -21,7 +22,7 @@ plt.psd(xn, NFFT=301, Fs=fs, window=mlab.window_none, pad_to=1024,
         scale_by_freq=True)
 plt.title('Periodogram')
 plt.yticks(yticks)
-plt.xticks(xticks)
+plt.xticks(xticks, rotation=-45)
 plt.grid(True)
 plt.xlim(-500, 500)
 
@@ -29,10 +30,11 @@ plt.subplot(1, 2, 2, sharex=ax, sharey=ax)
 plt.psd(xn, NFFT=150, Fs=fs, window=mlab.window_none, noverlap=75, pad_to=512,
         scale_by_freq=True)
 plt.title('Welch')
-plt.xticks(xticks)
+plt.xticks(xticks, rotation=-45)
 plt.yticks(yticks)
 plt.ylabel('')
 plt.grid(True)
 plt.xlim(-500, 500)
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/scatter_star_poly.py
+++ b/examples/pylab_examples/scatter_star_poly.py
@@ -27,4 +27,5 @@ plt.scatter(x, y, s=80, c=z, marker='+')
 plt.subplot(326)
 plt.scatter(x, y, s=80, c=z, marker=(5, 2))
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/spectrum_demo.py
+++ b/examples/pylab_examples/spectrum_demo.py
@@ -26,4 +26,5 @@ plt.angle_spectrum(s, Fs=Fs)
 plt.subplot(3, 2, 6)
 plt.phase_spectrum(s, Fs=Fs)
 
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
As nice as http://matplotlib.org/examples/pylab_examples/contour_image.html makes matplotlib look, I added tight_layout to a handful (and other minor adjustments) to them less crowded (particularly the tick layouts)
