### PR TITLE
text update properties does not handle bbox properly

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -240,7 +240,8 @@ class Text(Artist):
         """
         bbox = kwargs.pop('bbox', None)
         super(Text, self).update(kwargs)
-        self.set_bbox(bbox)  # depends on font properties
+        if bbox:
+            self.set_bbox(bbox)  # depends on font properties
 
     def __getstate__(self):
         d = super(Text, self).__getstate__()


### PR DESCRIPTION
Added a check to make sure any existing bbox is not overridden.

The previous behavior would overwrite the bbox property to None even if it was not specified.  This now keeps the bbox property as it was unless bbox is specified as a parameter to 'update'.

This addresses an issue in #4897.