### PR TITLE
qt backend has more draws than necessary

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -72,7 +72,7 @@ class FigureCanvasQTAggBase(object):
         shown onscreen.
         """
         # If we have not rendered the Agg backend yet, do so now.
-        if not hasattr( self, 'renderer' ):
+        if not hasattr(self, 'renderer'):
             FigureCanvasAgg.draw(self)
 
         # FigureCanvasQT.paintEvent(self, e)

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -71,7 +71,9 @@ class FigureCanvasQTAggBase(object):
         In Qt, all drawing should be done inside of here when a widget is
         shown onscreen.
         """
-        FigureCanvasAgg.draw(self)
+        # If we have not rendered the Agg backend yet, do so now.
+        if not hasattr( self, 'renderer' ):
+            FigureCanvasAgg.draw(self)
 
         # FigureCanvasQT.paintEvent(self, e)
         if DEBUG:


### PR DESCRIPTION
Sometimes (such as at widget creation), Qt tries to paint itself before matplotlib has called 'draw'.  It seems like someone the Agg draw here to solve this problem.  We cannot and should not call this every time Qt wants to paint itself.  That costs a huge hit in performance because then matplotlib would be refreshing the Agg backend twice for every call to 'draw'.  This fixes it so that if Qt tries to paint itself before the Agg buffers have been updated, then it will cause Agg to update itself first.

This addresses an issue in #4897.

