### PR TITLE
qt backend default bbox not set when blitting

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -153,6 +153,11 @@ class FigureCanvasQTAggBase(object):
         """
         Blit the region in bbox
         """
+        # If bbox is None, blit the entire canvas. Otherwise
+        # blit only the area defined by the bbox.
+        if bbox is None and self.figure:
+            bbox = self.figure.bbox
+
         self.blitbox = bbox
         l, b, w, h = bbox.bounds
         t = b + h


### PR DESCRIPTION
Changed the 'blit' method to blit the entire figure if no bbox is specified.

This addresses an issue in #4897.