### PR TITLE
FIX: argument order in RendereAgg.restore_region

### DIFF
--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -109,7 +109,7 @@ void RendererAgg::restore_region(BufferRegion &region)
 
 // Restore the part of the saved region with offsets
 void
-RendererAgg::restore_region(BufferRegion &region, int x, int y, int xx1, int yy1, int xx2, int yy2)
+RendererAgg::restore_region(BufferRegion &region, int xx1, int yy1, int xx2, int yy2, int x, int y )
 {
     if (region.get_data() == NULL) {
         throw "Cannot restore_region from NULL data";

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -215,7 +215,7 @@ class RendererAgg
 
     BufferRegion *copy_from_bbox(agg::rect_d in_rect);
     void restore_region(BufferRegion &reg);
-    void restore_region(BufferRegion &region, int x, int y, int xx1, int yy1, int xx2, int yy2);
+    void restore_region(BufferRegion &region, int xx1, int yy1, int xx2, int yy2, int x, int y);
 
     unsigned int width, height;
     double dpi;


### PR DESCRIPTION
In ba40160 Remove use of PyCXX in core C++ extensions the order
of the arguments into the `restore_region` that takes off sets
was swapped.  The order should be (x1, x2, y1, y2, offset_x, offset_y)
which was the order of `restore_region2` (a function removed as part
of the refactor in favor of simple dispatch in the wrapper code +
c++ function overloading) and the order of the arguments passed
out of the python layer, but at the c++ layer they were being mapped
to (offset_x, offset_y, x1, x2, y1, y2) which was causing a region
not of interest to be restored.

closes #4947