### PR TITLE
BUG: allow facecolors to be overridden in LineCollection

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1109,6 +1109,8 @@ class LineCollection(Collection):
 
         *facecolors*
            The facecolors of the LineCollection. Default is 'none'
+           Setting to a value other than 'none' will lead to a filled
+           polygon being drawn between points on each line.
 
         The use of :class:`~matplotlib.cm.ScalarMappable` is optional.
         If the :class:`~matplotlib.cm.ScalarMappable` array

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1053,6 +1053,7 @@ class LineCollection(Collection):
                  cmap=None,
                  pickradius=5,
                  zorder=2,
+                 facecolors='none',
                  **kwargs
                  ):
         """
@@ -1106,6 +1107,9 @@ class LineCollection(Collection):
         *zorder*
            The zorder of the LineCollection.  Default is 2
 
+        *facecolors*
+           The facecolors of the LineCollection. Default is 'none'
+
         The use of :class:`~matplotlib.cm.ScalarMappable` is optional.
         If the :class:`~matplotlib.cm.ScalarMappable` array
         :attr:`~matplotlib.cm.ScalarMappable._A` is not None (i.e., a call to
@@ -1124,7 +1128,7 @@ class LineCollection(Collection):
         Collection.__init__(
             self,
             edgecolors=colors,
-            facecolors='none',
+            facecolors=facecolors,
             linewidths=linewidths,
             linestyles=linestyles,
             antialiaseds=antialiaseds,


### PR DESCRIPTION
Very small change, fully backward compatible.

Current behavior is this:

```python
import matplotlib.pyplot as plt
from matplotlib.collections import LineCollection
import numpy as np

points = np.random.rand(5, 3, 2)
colors = plt.cm.jet(np.linspace(0, 1, 5))
coll = LineCollection(points, facecolors=colors)
```
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-66-7da275dddf5c> in <module>()
      5 points = np.random.rand(5, 3, 2)
      6 colors = plt.cm.jet(np.linspace(0, 1, 5))
----> 7 coll = LineCollection(points, facecolors=colors)

/Users/jakevdp/anaconda/envs/py3k/lib/python3.3/site-packages/matplotlib/collections.py in __init__(self, segments, linewidths, colors, antialiaseds, linestyles, offsets, transOffset, norm, cmap, pickradius, zorder, **kwargs)
   1081             pickradius=pickradius,
   1082             zorder=zorder,
-> 1083             **kwargs)
   1084 
   1085         self.set_segments(segments)

TypeError: __init__() got multiple values for keyword argument 'facecolors'
```