### PR TITLE
Bounds checking for get_cursor_data(). Closes #4957

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -718,11 +718,15 @@ class AxesImage(_AxesImageBase):
         arr = self.get_array()
         data_extent = mtransforms.Bbox([[ymin, xmin], [ymax, xmax]])
         array_extent = mtransforms.Bbox([[0, 0], arr.shape[:2]])
-        trans = mtransforms. BboxTransform(boxin=data_extent,
-                                           boxout=array_extent)
+        trans = mtransforms.BboxTransform(boxin=data_extent,
+                                          boxout=array_extent)
         y, x = event.ydata, event.xdata
         i, j = trans.transform_point([y, x]).astype(int)
-        return arr[i, j]
+        # Clip the coordinates at array bounds
+        if not (0 <= i < arr.shape[0]) or not (0 <= j < arr.shape[1]):
+            return None
+        else:
+            return arr[i, j]
 
 
 class NonUniformImage(AxesImage):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -170,16 +170,36 @@ def test_cursor_data():
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    assert im.get_cursor_data(event) == 44
+    z = im.get_cursor_data(event)
+    assert z == 44, "Did not get 44, got %d" % z
+
+    # Now try for a point outside the image
+    # Tests issue #4957
+    x, y = 10.1, 4
+    xdisp, ydisp = ax.transData.transform_point([x, y])
+
+    event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
+    z = im.get_cursor_data(event)
+    assert z is None, "Did not get None, got %d" % z
+
+    # Hmm, something is wrong here... I get 0, not None...
+    # But, this works further down in the tests with extents flipped
+    #x, y = 0.1, -0.1
+    #xdisp, ydisp = ax.transData.transform_point([x, y])
+    #event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
+    #z = im.get_cursor_data(event)
+    #assert z is None, "Did not get None, got %d" % z
 
     ax.clear()
+    # Now try with the extents flipped.
     im = ax.imshow(np.arange(100).reshape(10, 10), origin='lower')
 
     x, y = 4, 4
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    assert im.get_cursor_data(event) == 44
+    z = im.get_cursor_data(event)
+    assert z == 44, "Did not get 44, got %d" % z
 
     fig, ax = plt.subplots()
     im = ax.imshow(np.arange(100).reshape(10, 10), extent=[0, 0.5, 0, 0.5])
@@ -188,7 +208,24 @@ def test_cursor_data():
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    assert im.get_cursor_data(event) == 55
+    z = im.get_cursor_data(event)
+    assert z == 55, "Did not get 55, got %d" % z
+
+    # Now try for a point outside the image
+    # Tests issue #4957
+    x, y = 0.75, 0.25
+    xdisp, ydisp = ax.transData.transform_point([x, y])
+
+    event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
+    z = im.get_cursor_data(event)
+    assert z is None, "Did not get None, got %d" % z
+
+    x, y = 0.01, -0.01
+    xdisp, ydisp = ax.transData.transform_point([x, y])
+
+    event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
+    z = im.get_cursor_data(event)
+    assert z is None, "Did not get None, got %d" % z
 
 
 @image_comparison(baseline_images=['image_clip'])


### PR DESCRIPTION
Decided to go with reporting `None` when outside the image. There is still an oddity I discovered, and I highlighted it in the test with commented out code. With origin as "upper", you can go off the top-left corner of the image for a bit with a value being reported. This doesn't happen at any corner for origin "lower", though.