### PR TITLE
Qt5: Add flag that informs paintEvent if the agg buffer needs to updated, fix rubberband

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2763,6 +2763,10 @@ class NavigationToolbar2(object):
         """Draw a rectangle rubberband to indicate zoom limits"""
         pass
 
+    def remove_rubberband(self):
+        """Remove the rubberband"""
+        pass
+
     def forward(self, *args):
         """Move forward in the view lim stack"""
         self._views.forward()
@@ -3035,6 +3039,8 @@ class NavigationToolbar2(object):
         for zoom_id in self._ids_zoom:
             self.canvas.mpl_disconnect(zoom_id)
         self._ids_zoom = []
+
+        self.remove_rubberband()
 
         if not self._xypress:
             return

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -54,8 +54,8 @@ def new_figure_manager_given_figure(num, figure):
     return FigureManagerQT(canvas, num)
 
 
-class FigureCanvasQTAgg(FigureCanvasQTAggBase,
-                        FigureCanvasQT, FigureCanvasAgg):
+class FigureCanvasQTAgg(FigureCanvasQT, FigureCanvasQTAggBase,
+                        FigureCanvasAgg):
     """
     The canvas the figure renders into.  Calls the draw and print fig
     methods, creates the renderers, etc...
@@ -69,6 +69,7 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         if DEBUG:
             print('FigureCanvasQtAgg: ', figure)
         FigureCanvasQT.__init__(self, figure)
+        FigureCanvasQTAggBase.__init__(self, figure)
         FigureCanvasAgg.__init__(self, figure)
         self._drawRect = None
         self.blitbox = None

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -682,6 +682,9 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         rect = [int(val)for val in (min(x0, x1), min(y0, y1), w, h)]
         self.canvas.drawRectangle(rect)
 
+    def remove_rubberband(self):
+        self.canvas.drawRectangle(None)
+
     def configure_subplots(self):
         image = os.path.join(matplotlib.rcParams['datapath'],
                              'images', 'matplotlib.png')

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -415,9 +415,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
     stop_event_loop.__doc__ = FigureCanvasBase.stop_event_loop_default.__doc__
 
-    def draw_idle(self):
-        self.update()
-
 
 class MainWindow(QtWidgets.QMainWindow):
     closing = QtCore.Signal()

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -67,7 +67,7 @@ class FigureCanvasQTAggBase(object):
 
     def drawRectangle(self, rect):
         self._drawRect = rect
-        self.draw_idle()
+        self.update()
 
     def paintEvent(self, e):
         """
@@ -140,9 +140,14 @@ class FigureCanvasQTAggBase(object):
             pixmap = QtGui.QPixmap.fromImage(qImage)
             p = QtGui.QPainter(self)
             p.drawPixmap(QtCore.QPoint(l, self.renderer.height-t), pixmap)
+
+            # draw the zoom rectangle to the QPainter
+            if self._drawRect is not None:
+                p.setPen(QtGui.QPen(QtCore.Qt.black, 1, QtCore.Qt.DotLine))
+                x, y, w, h = self._drawRect
+                p.drawRect(x, y, w, h)
             p.end()
             self.blitbox = None
-        self._drawRect = None
 
     def draw(self):
         """


### PR DESCRIPTION
Added a flag for determining if paintEvent needs to update the agg buffer or not. The buffer is updated when draw_idle triggers the paintEvent and the buffer is considered valid after using draw and when using blit.

Discussion in #4943, Speed up Example in #4947

