### PR TITLE
Fixed ZoomPanBase to work with log plots

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3322,7 +3322,7 @@ class _AxesBase(martist.Artist):
         Parameters
         ----------
 
-        bbox : 4-tuple or 2 tuple
+        bbox : 4-tuple or 3 tuple
             * If result is a 4 tuple, it is the selected bounding box limits,
                 in *display* coordinates.
             * If result is a 3 tuple, it is an (xp, yp, scl) triple, where
@@ -3352,7 +3352,6 @@ class _AxesBase(martist.Artist):
         if(len(bbox) == 3):
             # Zooming code
             xp, yp, scl = bbox
-            print("in set view, for zooming with scale {}".format(scl))
 
             # Should not happen
             if(scl == 0):
@@ -3380,6 +3379,11 @@ class _AxesBase(martist.Artist):
 
             bbox = [xzc - xwidth/2./scl, yzc - ywidth/2./scl, xzc +
                     xwidth/2./scl, yzc + ywidth/2./scl]
+        elif(len(bbox) != 4):
+            # should be len 3 or 4 but nothing else
+            print("Warning in _set_view_from_bbox: bounding box is not a
+                  tuple of length 3 or\ 4. Ignoring the view change...\n");
+            return
 
         # Just grab bounding box
         lastx, lasty, x, y = bbox

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -487,14 +487,14 @@ class _AxesBase(martist.Artist):
             self._shared_x_axes.join(self, sharex)
             if sharex._adjustable == 'box':
                 sharex._adjustable = 'datalim'
-                #warnings.warn(
+                # warnings.warn(
                 #    'shared axes: "adjustable" is being changed to "datalim"')
             self._adjustable = 'datalim'
         if sharey is not None:
             self._shared_y_axes.join(self, sharey)
             if sharey._adjustable == 'box':
                 sharey._adjustable = 'datalim'
-                #warnings.warn(
+                # warnings.warn(
                 #    'shared axes: "adjustable" is being changed to "datalim"')
             self._adjustable = 'datalim'
         self.set_label(label)
@@ -1003,11 +1003,11 @@ class _AxesBase(martist.Artist):
 
         self.grid(False)  # Disable grid on init to use rcParameter
         self.grid(self._gridOn, which=rcParams['axes.grid.which'],
-                    axis=rcParams['axes.grid.axis'])
+                  axis=rcParams['axes.grid.axis'])
         props = font_manager.FontProperties(
-                    size=rcParams['axes.titlesize'],
-                    weight=rcParams['axes.titleweight']
-                )
+            size=rcParams['axes.titlesize'],
+            weight=rcParams['axes.titleweight']
+            )
 
         self.titleOffsetTrans = mtransforms.ScaledTranslation(
             0.0, 5.0 / 72.0, self.figure.dpi_scale_trans)
@@ -1122,7 +1122,7 @@ class _AxesBase(martist.Artist):
         .. deprecated:: 1.5
         """
         cbook.warn_deprecated(
-                '1.5', name='set_color_cycle', alternative='set_prop_cycle')
+            '1.5', name='set_color_cycle', alternative='set_prop_cycle')
         self.set_prop_cycle('color', clist)
 
     def ishold(self):
@@ -3381,8 +3381,8 @@ class _AxesBase(martist.Artist):
                     xwidth/2./scl, yzc + ywidth/2./scl]
         elif(len(bbox) != 4):
             # should be len 3 or 4 but nothing else
-            print("Warning in _set_view_from_bbox: bounding box is not a
-                  tuple of length 3 or\ 4. Ignoring the view change...\n");
+            print("Warning in _set_view_from_bbox: bounding box is not a\
+                  tuple of length 3 or\ 4. Ignoring the view change...\n")
             return
 
         # Just grab bounding box

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3377,12 +3377,12 @@ class _AxesBase(martist.Artist):
             xzc = (xp*(scl - 1) + xcen)/scl
             yzc = (yp*(scl - 1) + ycen)/scl
 
-            bbox = [xzc - xwidth/2./scl, yzc - ywidth/2./scl, 
+            bbox = [xzc - xwidth/2./scl, yzc - ywidth/2./scl,
                     xzc + xwidth/2./scl, yzc + ywidth/2./scl]
         elif len(bbox) != 4:
             # should be len 3 or 4 but nothing else
             warnings.warn('Warning in _set_view_from_bbox: bounding box is not a\
-                  tuple of length 3 or\ 4. Ignoring the view change...')
+                  tuple of length 3 or 4. Ignoring the view change...')
             return
 
         # Just grab bounding box

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3326,8 +3326,8 @@ class _AxesBase(martist.Artist):
             * If bbox is a 4 tuple, it is the selected bounding box limits,
                 in *display* coordinates.
             * If bbox is a 3 tuple, it is an (xp, yp, scl) triple, where
-                (xp,yp) are the center of zoom and scl the scale factor to zoom
-                by
+                (xp,yp) is the center of zooming and scl the scale factor to
+                zoom by.
 
         direction : str
             The direction to apply the bounding box.
@@ -3349,16 +3349,16 @@ class _AxesBase(martist.Artist):
         Xmin, Xmax = self.get_xlim()
         Ymin, Ymax = self.get_ylim()
 
-        if(len(bbox) == 3):
+        if len(bbox) == 3:
             # Zooming code
             xp, yp, scl = bbox
 
             # Should not happen
-            if(scl == 0):
+            if scl == 0:
                 scl = 1.
 
             # direction = 'in'
-            if(scl > 1):
+            if scl > 1:
                 direction = 'in'
             else:
                 direction = 'out'
@@ -3377,12 +3377,12 @@ class _AxesBase(martist.Artist):
             xzc = (xp*(scl - 1) + xcen)/scl
             yzc = (yp*(scl - 1) + ycen)/scl
 
-            bbox = [xzc - xwidth/2./scl, yzc - ywidth/2./scl, xzc +
-                    xwidth/2./scl, yzc + ywidth/2./scl]
-        elif(len(bbox) != 4):
+            bbox = [xzc - xwidth/2./scl, yzc - ywidth/2./scl, 
+                    xzc + xwidth/2./scl, yzc + ywidth/2./scl]
+        elif len(bbox) != 4:
             # should be len 3 or 4 but nothing else
-            print("Warning in _set_view_from_bbox: bounding box is not a\
-                  tuple of length 3 or\ 4. Ignoring the view change...\n")
+            warnings.warn('Warning in _set_view_from_bbox: bounding box is not a\
+                  tuple of length 3 or\ 4. Ignoring the view change...')
             return
 
         # Just grab bounding box

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3323,9 +3323,9 @@ class _AxesBase(martist.Artist):
         ----------
 
         bbox : 4-tuple or 3 tuple
-            * If result is a 4 tuple, it is the selected bounding box limits,
+            * If bbox is a 4 tuple, it is the selected bounding box limits,
                 in *display* coordinates.
-            * If result is a 3 tuple, it is an (xp, yp, scl) triple, where
+            * If bbox is a 3 tuple, it is an (xp, yp, scl) triple, where
                 (xp,yp) are the center of zoom and scl the scale factor to zoom
                 by
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -642,10 +642,9 @@ class ZoomPanBase(ToolToggleBase):
         ax = event.inaxes
         ax._set_view_from_bbox([event.x, event.y, scl])
 
-        # first check if last scroll was done within
-        # the timing threshold. If yes, delete previous view
-        if(time.time()-self.lastscroll < self.scrollthresh):
-            # remove the last view and push the current
+        # If last scroll was done within the timing threshold, delete the
+        # previous view
+        if (time.time()-self.lastscroll) < self.scrollthresh:
             self.toolmanager.get_tool(_views_positions).back()
 
         self.figure.canvas.draw_idle()  # force re-draw


### PR DESCRIPTION
Tested this code in a matplotlib 1.4.3 environment and current branch. Fixed ZoomPanBase to work in non-linear plots by changing the scale in the axes coordinates and using the respective tranformation functions: transScale and transLimits transforms. 

See tutorial on axes transformations for more details:
http://matplotlib.org/users/transforms_tutorial.html

Note: It did not work in my version 1.4.2. The issue is traceable to the TransScale.transform.inverted() routine expecting a 2 dimensional array rather than 1d array. If applying this to this older version this should be investigated/tested.

Testing code used (use mouse scroll wheel afterwards):
```python
import matplotlib.pyplot as plt
import matplotlib.backend_tools as bt
import numpy as np

fig1 = plt.figure(0)
zm = bt.ZoomPanBase(fig1,"foo")


img = np.random.random((100,100))
ax = fig1.add_subplot(111)

x = np.linspace(10,1000,1000)
y = 1/x**4

#uncomment the one you want to test, and comment the other
#ax.imshow(img)
ax.loglog(x,y)

def foofunc():
    pass

zm._press = foofunc
zm._release = foofunc

zm.enable("foo")
```