### PR TITLE
PY2K : in python2 lists don't have copy method

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1142,7 +1142,7 @@ class FuncAnimation(TimedAnimation):
         if self._save_seq:
             # While iterating we are going to update _save_seq
             # so make a copy to safely iterate over
-            self._old_saved_seq = self._save_seq.copy()
+            self._old_saved_seq = list(self._save_seq)
             return iter(self._old_saved_seq)
         else:
             return itertools.islice(self.new_frame_seq(), self.save_count)


### PR DESCRIPTION
Addresses one issue brought up by @WeatherGod in #4967