### PR TITLE
showpage at the end of .eps files

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1732,6 +1732,7 @@ def pstoeps(tmpfile, bbox=None, rotated=False):
                     write(b'countdictstack\n')
                     write(b'exch sub { end } repeat\n')
                     write(b'restore\n')
+                    write(b'showpage\n')
                     write(b'%%EOF\n')
                 elif line.startswith(b'%%PageBoundingBox'):
                     pass


### PR DESCRIPTION
There can be problems with viewing of *.eps files using evince or okular. See, for example, this thread:
https://bugs.launchpad.net/ubuntu/+source/evince/+bug/1348384
There are the same problems in the last releases of Fedora. Note that the same *.eps files which can not be viewed with evince/okular can be opened and viewed with inkscape, ghostscript etc.
These commits allow to avoid such problems. I understand that *.eps files without showpage at the end are valid. But the presence of showpage is allowed and should not lead to some problems.