### PR TITLE
Fix syntax error

### DIFF
--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -14,7 +14,7 @@ def test_fontconfig_preamble():
     tm1 = TexManager()
     font_config1 = tm1.get_font_config()
 
-    plt.rcParams['text.latex.preamble'] = [r'\usepackage{txfonts}']
+    plt.rcParams['text.latex.preamble'] = ['\\usepackage{txfonts}']
     tm2 = TexManager()
     font_config2 = tm2.get_font_config()
 


### PR DESCRIPTION
Using `\u`, even in a raw string, is a syntax error when `unicode_literals` is on.