### PR TITLE
[MRG+1] The url of downloading historical prices of Yahoo Finance has changed

### DIFF
--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -339,7 +339,7 @@ def fetch_historical_yahoo(ticker, date1, date2, cachename=None,
         g = 'd'
 
     urlFmt = ('http://real-chart.finance.yahoo.com/table.csv?' +
-              's=%s&d=%d&e=%df=%d&g=%s&a=%d&b=%d&c=%d&ignore=.csv')
+              '&s=%s&d=%d&e=%d&f=%d&g=%s&a=%d&b=%d&c=%d&ignore=.csv')
 
     url = urlFmt % (ticker, d2[0], d2[1], d2[2], g, d1[0], d1[1], d1[2])
     # Cache the finance data if cachename is supplied, or there is a writable

--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -338,12 +338,10 @@ def fetch_historical_yahoo(ticker, date1, date2, cachename=None,
     else:
         g = 'd'
 
-    urlFmt = ('http://ichart.yahoo.com/table.csv?a=%d&b=%d&' +
-              'c=%d&d=%d&e=%d&f=%d&s=%s&y=0&g=%s&ignore=.csv')
+    urlFmt = ('http://real-chart.finance.yahoo.com/table.csv?' +
+              's=%s&d=%d&e=%df=%d&g=%s&a=%d&b=%d&c=%d&ignore=.csv')
 
-    url = urlFmt % (d1[0], d1[1], d1[2],
-                    d2[0], d2[1], d2[2], ticker, g)
-
+    url = urlFmt % (ticker, d2[0], d2[1], d2[2], g, d1[0], d1[1], d1[2])
     # Cache the finance data if cachename is supplied, or there is a writable
     # cache directory.
     if cachename is None and cachedir is not None:


### PR DESCRIPTION
It used to be the format like:
http://ichart.yahoo.com/table.csv?a=%d&b=%d&c=%d&d=%d&e=%d&f=%d&s=%s&y=0&g=%s&ignore=.csv
However, it seems to be changed to :
http://real-chart.finance.yahoo.com/table.csv?&s=%s&d=%d&e=%d&f=%d&g=%s&a=%d&b=%d&c=%d&ignore=.csv

It worked for me, and I wish you all giving some feedback to my first pull request!
Thanks
