### PR TITLE
fix bug

### DIFF
--- a/examples/pylab_examples/table_demo.py
+++ b/examples/pylab_examples/table_demo.py
@@ -18,7 +18,7 @@ values = np.arange(0, 2500, 500)
 value_increment = 1000
 
 # Get some pastel shades for the colors
-colors = plt.cm.BuPu(np.linspace(0, 0.5, len(columns)))
+colors = plt.cm.BuPu(np.linspace(0, 0.5, len(rows)))
 n_rows = len(data)
 
 index = np.arange(len(columns)) + 0.3


### PR DESCRIPTION
well, the columns here should be rows, as we want to give different colors by row index.
there is no problem in this example, because the matrix here is 5*5.
But if the length of rows is bigger than that of columns, it will raise Exception, such as
plt.bar(index, data[row], bar_width, bottom=y_offset, color=colors[row])
IndexError: index 2 is out of bounds for axis 0 with size 2