### PR TITLE
TST: bump python 3.5 version to rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,8 @@ matrix:
       env: TEST_ARGS=--pep8
     - python: 2.7
       env: BUILD_DOCS=true MOCK=mock
-    - python: "3.5.0b4"
+    - python: "3.5.0rc2"
       env: PRE=--pre
-  allow_failures:
-    - python : "3.5.0b4"
 
 before_install:
   - source tools/travis_tools.sh


### PR DESCRIPTION
 - bump 3.5 to rc2 (from b4)
 - make 3.5 a hard fail

I plan to self-merge this if it passes travis as it is only touching travis configuration.