### PR TITLE
Add Travis job with 3.6 nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
     - python: 2.7
       env: BUILD_DOCS=true MOCK=mock
     - python: "3.5.0rc4"
+      env: PRE=--pre
     - python: "nightly"
       env: PRE=--pre
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,10 @@ matrix:
     - python: 2.7
       env: BUILD_DOCS=true MOCK=mock
     - python: "3.5.0rc4"
+    - python: "nightly"
       env: PRE=--pre
+  allow_failures:
+    - python: "nightly"
 
 before_install:
   - source tools/travis_tools.sh

--- a/boilerplate.py
+++ b/boilerplate.py
@@ -214,8 +214,11 @@ def boilerplate_gen():
             has_data = 'data' in inspect.signature(base_func).parameters
             work_func = inspect.unwrap(base_func)
 
-            args, varargs, varkw, defaults = inspect.getargspec(work_func)
-
+            if six.PY2:
+                args, varargs, varkw, defaults = inspect.getargspec(work_func)
+            else:
+                (args, varargs, varkw, defaults, kwonlyargs, kwonlydefs,
+                    annotations) = inspect.getfullargspec(work_func)
             args.pop(0)  # remove 'self' argument
             if defaults is None:
                 defaults = ()

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1110,7 +1110,11 @@ class ArtistInspector(object):
             o = getattr(self.o, name)
             if not six.callable(o):
                 continue
-            if len(inspect.getargspec(o)[0]) < 2:
+            if six.PY2:
+                nargs = len(inspect.getargspec(o)[0])
+            else:
+                nargs = len(inspect.getfullargspec(o)[0])
+            if nargs < 2:
                 continue
             func = o
             if self.is_alias(func):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1781,7 +1781,11 @@ def _pprint_styles(_styles):
     _table = [["Class", "Name", "Attrs"]]
 
     for name, cls in sorted(_styles.items()):
-        args, varargs, varkw, defaults = inspect.getargspec(cls.__init__)
+        if six.PY2:
+            args, varargs, varkw, defaults = inspect.getargspec(cls.__init__)
+        else:
+            (args, varargs, varkw, defaults, kwonlyargs, kwonlydefs,
+                annotations) = inspect.getfullargspec(cls.__init__)
         if defaults:
             args = [(argname, argdefault)
                     for argname, argdefault in zip(args[1:], defaults)]


### PR DESCRIPTION
As suggested in #5009 

This job is allowed to fail and I expect it to fail due to the removal of the deprecated `inspect.getargspec`
I have also moved the --pre flag to this job from the 3.5rc2 one