### PR TITLE
Fix the fontdict parameter in set_xticklabels/set_yticklabels

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2883,7 +2883,9 @@ class _AxesBase(martist.Artist):
 
         ACCEPTS: sequence of strings
         """
-        ret = self.xaxis.set_ticklabels(labels, fontdict,
+        if fontdict is not None:
+            kwargs.update(fontdict)
+        ret = self.xaxis.set_ticklabels(labels,
                                         minor=minor, **kwargs)
         self.stale = True
         return ret
@@ -3143,7 +3145,9 @@ class _AxesBase(martist.Artist):
 
         ACCEPTS: sequence of strings
         """
-        return self.yaxis.set_ticklabels(labels, fontdict,
+        if fontdict is not None:
+            kwargs.update(fontdict)
+        return self.yaxis.set_ticklabels(labels,
                                          minor=minor, **kwargs)
 
     def xaxis_date(self, tz=None):


### PR DESCRIPTION
The fontdict parameter is not properly used in set_xticklabels/set_yticklabes. The following code works with this patch now.
```python
import matplotlib.pyplot as plt
import matplotlib.font_manager as fm

prop = fm.FontProperties(fname='/path/to/fonts.ttf')
plt.plot([1,2,3], [1,2,3])
plt.gca().set_xticklabels([u'一', u'二', u'三', u'四', u'五'], fontdict={'fontproperties': prop})
```