### PR TITLE
locale.getdefaultlocale() fails on OS X

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -992,6 +992,8 @@ def _open_file_or_url(fname):
     else:
         fname = os.path.expanduser(fname)
         encoding = locale.getdefaultlocale()[1]
+        if encoding == None:
+            encoding = "utf-8"
         with io.open(fname, encoding=encoding) as f:
             yield f
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -992,7 +992,7 @@ def _open_file_or_url(fname):
     else:
         fname = os.path.expanduser(fname)
         encoding = locale.getdefaultlocale()[1]
-        if encoding == None:
+        if encoding is None:
             encoding = "utf-8"
         with io.open(fname, encoding=encoding) as f:
             yield f


### PR DESCRIPTION
For any reason ``locale.getdefaultlocale()`` fails on OS X (returns None), which subsequently produces errors and makes the ``matplotlib`` module unusable. Checking for a ``None`` result and then setting the default encoding to ``"utf-8"`` seems to help.