### PR TITLE
Fix Agg clipping

### DIFF
--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -479,7 +479,7 @@ RendererAgg::draw_path(GCAgg &gc, PathIterator &path, agg::trans_affine &trans, 
 
     trans *= agg::trans_affine_scaling(1.0, -1.0);
     trans *= agg::trans_affine_translation(0.0, (double)height);
-    bool clip = !face.first && gc.has_hatchpath() && !path.has_curves();
+    bool clip = !face.first && !gc.has_hatchpath() && !path.has_curves();
     bool simplify = path.should_simplify() && clip;
     double snapping_linewidth = points_to_pixels(gc.linewidth);
     if (gc.color.a == 0.0) {


### PR DESCRIPTION
Addresses the slowness mentioned in #5016.

In the epic C++ refactor in ba4016014cb4fb4927e36ce8ea429fed47dcb787, the line that determines whether to perform clipping of paths to the figure size in the Agg backend changed from:

```
    bool clip = !face.first && gc.hatchpath.isNone() && !path.has_curves();
```

to 

```
    bool clip = !face.first && gc.has_hatchpath() && !path.has_curves();
```

Spot the problem?  It means we were only clipping when there *was* a hatch, rather than when there *wasn't* a hatch -- effectively disabling it for most things.

This should have a major impact on panning and zooming performance of large time series.

I'm not exactly sure how to write a test for this -- the result, by its nature, isn't visible, and this is pretty deep into the C++ code to make a "unit test" out of it.  I'll think on that some more, but in the meantime I thought it better to just address this very serious regression.