### PR TITLE
Bugfix for issue #750 (gridlines for 3d axes cover a plotted surface …

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1072,6 +1072,7 @@ class Axes3D(Axes):
         self._zmargin = 0
 
         Axes.cla(self)
+        Axes.set_axis_off(self)
 
         self.grid(rcParams['axes3d.grid'])
 


### PR DESCRIPTION
…after ax.cla() is called)