### PR TITLE
Enh scale collections with size

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -82,8 +82,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
     _transOffset = transforms.IdentityTransform()
     _transforms = []
 
-
-
     def __init__(self,
                  edgecolors=None,
                  facecolors=None,
@@ -285,11 +283,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
         edgecolors = self.get_edgecolor()
         do_single_path_optimization = False
         if (len(paths) == 1 and len(trans) <= 1 and
-            len(facecolors) == 1 and len(edgecolors) == 1 and
-            len(self._linewidths) == 1 and
-            self._linestyles == [(None, None)] and
-            len(self._antialiaseds) == 1 and len(self._urls) == 1 and
-            self.get_hatch() is None):
+                len(facecolors) == 1 and len(edgecolors) == 1 and
+                len(self._linewidths) == 1 and
+                self._linestyles == [(None, None)] and
+                len(self._antialiaseds) == 1 and len(self._urls) == 1 and
+                self.get_hatch() is None):
             if len(trans):
                 combined_transform = (transforms.Affine2D(trans[0]) +
                                       transform)
@@ -298,7 +296,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             extents = paths[0].get_extents(combined_transform)
             width, height = renderer.get_canvas_width_height()
             if (extents.width < width and
-                extents.height < height):
+                    extents.height < height):
                 do_single_path_optimization = True
 
         if do_single_path_optimization:


### PR DESCRIPTION
This was prompted by http://stackoverflow.com/questions/32444037/how-can-i-create-many-thousands-of-circles#32446502

I suspect that this is not the right way to achieve this (as it is mostly broken under log transform and the notion of 'area' under blended transform is confused)

but, with this patch 

``` python
import matplotlib.pyplot as plt
import matplotlib.collections as mc
import numpy as np

ax = plt.gca()
cc = mc.CircleCollection(sizes=.001 * np.pi*np.random.rand(10000)**2,
                         offsets=np.random.rand(10000, 2),
                         transOffset=ax.transData,
                         facecolors='rgb')
cc.set_size_transform(ax.transData)
ax.add_collection(cc)


ax.set_aspect('equal')
```

Does the 'right thing' and renders relatively snappily (0.1-0.2 s).
