### PR TITLE
sphinxext pot_directive: more robust backend switching

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -139,6 +139,7 @@ from matplotlib.externals.six.moves import xrange
 import sys, os, shutil, io, re, textwrap
 from os.path import relpath
 import traceback
+import warnings
 
 if not six.PY3:
     import cStringIO
@@ -166,8 +167,15 @@ except ImportError:
 
 import matplotlib
 import matplotlib.cbook as cbook
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
+try:
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("error", UserWarning)
+        matplotlib.use('Agg')
+except UserWarning:
+    import matplotlib.pyplot as plt
+    plt.switch_backend("Agg")
+else:
+    import matplotlib.pyplot as plt
 from matplotlib import _pylab_helpers
 
 __version__ = 2


### PR DESCRIPTION
I've run into a problem with sphinxext plot_directive during a sphinx build, namely that `matplotlib.use("Agg")` was showing that warning and not being able to switch the backend. I didn't succeed in debugging where matplotlib was imported before it in the stack (it used to work for our documentation beforehand with the same build routine), but the proposed dynamic fallback to `plt.switch_backend()` worked like a charm for me.