### PR TITLE
resize_event not working with MacOSX backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -323,6 +323,7 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasBase):
         width /= dpi
         height /= dpi
         self.figure.set_size_inches(width, height)
+        FigureCanvasBase.resize_event(self)
 
     def _print_bitmap(self, filename, *args, **kwargs):
         # In backend_bases.py, print_figure changes the dpi of the figure.


### PR DESCRIPTION
Currently ``resize_event`` does not work with the MacOS X backend. The following example illustrates the issue:

```python
import matplotlib 
matplotlib.use('MacOSX')
import matplotlib.pyplot as plt 

def on_resize(event): 
    print("resizing")

fig = plt.figure() 
ax = fig.add_subplot(1,1,1)
ax.plot([1,2,3])
fig.canvas.mpl_connect('resize_event', on_resize) 
plt.show() 
```

when resizing the figure, nothing is printed. If the backend is changed to ``Qt4Agg``, the message is printed as expected. This indicates a backend-specific issue.

cc @mdehoon 