### PR TITLE
MNT: more control of colorbar with CountourSet

### DIFF
--- a/doc/api/api_changes/2016-01-03_colorbar.rst
+++ b/doc/api/api_changes/2016-01-03_colorbar.rst
@@ -1,0 +1,12 @@
+`ColorBar` raises TypeError rather than ignore user input
+`````````````````````````````````````````````````````````
+
+In ``__init__`` `ColorBar` ignores user supplied ``cmap`` and ``norm``
+keyword arguments in favor of retrieving those values from the
+``mappable`` passed in.  If those keywords are supplied, `ColorBar`
+will now raise a `TypeError` rather than silently dropping user supplied
+input.
+
+If ``mappable`` is a `contour.ContourSet` then a `TypeError` will be raised
+if the user provides any of
+``('alpha', 'boundaries', 'values', 'extend', 'filled')``

--- a/examples/pylab_examples/contour_demo.py
+++ b/examples/pylab_examples/contour_demo.py
@@ -80,7 +80,7 @@ levels = np.arange(-1.2, 1.6, 0.2)
 CS = plt.contour(Z, levels,
                  origin='lower',
                  linewidths=2,
-                 extent=(-3, 3, -2, 2))
+                 extent=(-3, 3, -2, 2), extend='both')
 
 # Thicken the zero contour.
 zc = CS.collections[6]
@@ -92,7 +92,7 @@ plt.clabel(CS, levels[1::2],  # label every second level
            fontsize=14)
 
 # make a colorbar for the contour lines
-CB = plt.colorbar(CS, shrink=0.8, extend='both')
+CB = plt.colorbar(CS, shrink=0.8)
 
 plt.title('Lines with colorbar')
 #plt.hot()  # Now change the colormap for the contour lines and colorbar

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -889,18 +889,21 @@ class Colorbar(ColorbarBase):
         mappable.autoscale_None()
 
         self.mappable = mappable
+        kw = cbook.normalize_kwargs(kw, forbidden=('cmap', 'norm'))
         kw['cmap'] = cmap = mappable.cmap
-        kw['norm'] = norm = mappable.norm
+        kw['norm'] = mappable.norm
 
         if isinstance(mappable, contour.ContourSet):
             CS = mappable
+            override_list = ('alpha', 'boundaries', 'values', 'extend',
+                             'filled')
+            kw = cbook.normalize_kwargs(kw, forbidden=override_list)
             kw['alpha'] = mappable.get_alpha()
             kw['boundaries'] = CS._levels
             kw['values'] = CS.cvalues
             kw['extend'] = CS.extend
-            #kw['ticks'] = CS._levels
-            kw.setdefault('ticks', ticker.FixedLocator(CS.levels, nbins=10))
             kw['filled'] = CS.filled
+            kw.setdefault('ticks', ticker.FixedLocator(CS.levels, nbins=10))
             ColorbarBase.__init__(self, ax, **kw)
             if not CS.filled:
                 self.add_lines(CS)
@@ -909,7 +912,7 @@ class Colorbar(ColorbarBase):
                 kw.setdefault('extend', cmap.colorbar_extend)
 
             if isinstance(mappable, martist.Artist):
-                kw['alpha'] = mappable.get_alpha()
+                kw.setdefault('alpha', mappable.get_alpha())
 
             ColorbarBase.__init__(self, ax, **kw)
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -272,13 +272,13 @@ def test_colorbar_closed_patch():
     values = np.linspace(0, 10, 5)
 
     with rc_context({'axes.linewidth': 16}):
-        plt.colorbar(im, cax=ax2, cmap=cmap, orientation='horizontal',
+        plt.colorbar(im, cax=ax2, orientation='horizontal',
                      extend='both', extendfrac=0.5, values=values)
-        plt.colorbar(im, cax=ax3, cmap=cmap, orientation='horizontal',
+        plt.colorbar(im, cax=ax3,  orientation='horizontal',
                      extend='both', values=values)
-        plt.colorbar(im, cax=ax4, cmap=cmap, orientation='horizontal',
+        plt.colorbar(im, cax=ax4, orientation='horizontal',
                      extend='both', extendrect=True, values=values)
-        plt.colorbar(im, cax=ax5, cmap=cmap, orientation='horizontal',
+        plt.colorbar(im, cax=ax5, orientation='horizontal',
                      extend='neither', values=values)
 
 
@@ -292,9 +292,8 @@ def test_colorbar_ticks():
     Z = X * Y
     clevs = np.array([-12, -5, 0, 5, 12], dtype=float)
     colors = ['r', 'g', 'b', 'c']
-    cs = ax.contourf(X, Y, Z, clevs, colors=colors)
-    cbar = fig.colorbar(cs, ax=ax, extend='neither',
-                        orientation='horizontal', ticks=clevs)
+    cs = ax.contourf(X, Y, Z, clevs, colors=colors, extend='neither')
+    cbar = fig.colorbar(cs, ax=ax, orientation='horizontal')
     assert len(cbar.ax.xaxis.get_ticklocs()) == len(clevs)
 
 


### PR DESCRIPTION
In the `ColorBar` constructor values are extracted from the mappable if
it is a ContourSet.  Instead of always overwriting user-input only,
respect user input if given.

This came up while looking into  #5055 

``` python
import matplotlib.pyplot as plt
import numpy as np
import matplotlib.colors as mplc

x, y = np.mgrid[0:1:0.01, 0:1:0.01]
r = np.sqrt(x ** 2 + y ** 2)
z = np.sin(6 * np.pi * r)

norm = mplc.Normalize(0, 0.5)
fig0, ax0 = plt.subplots(1, 1, )
cf0 = ax0.contourf(x, y, z, np.arange(0, .5, .01), norm=norm,
                   extend='both', cmap='viridis')
cbar0 = plt.colorbar(cf0, extend='neither')
```

now results in 

![so](https://cloud.githubusercontent.com/assets/199813/9838626/211101ce-5a30-11e5-96b5-344c2084a123.png)

Currently on master the `extend` kwarg to `colorbar` was silently ignored.

Possibly related to #5034 / #4850 

attn @efiring @fmaussion @lkilcher
