### PR TITLE
FIX: add check if the renderer exists

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -75,7 +75,11 @@ class FigureCanvasQTAggBase(object):
         In Qt, all drawing should be done inside of here when a widget is
         shown onscreen.
         """
-        # FigureCanvasQT.paintEvent(self, e)
+        # if the canvas does not have a renderer, then give up and wait for
+        # FigureCanvasAgg.draw(self) to be called
+        if not hasattr(self, 'renderer'):
+            return
+
         if DEBUG:
             print('FigureCanvasQtAgg.paintEvent: ', self,
                   self.get_width_height())


### PR DESCRIPTION
There exists a path where paintEvent can be called before the first time
that `draw` has been called.  This results in an exception because the
call to `FigureCanvasAgg.draw(self)` is what create the renderer
attribute on the canvas.

Closes #5058

@astrofrog @efiring @pwuertz 