### PR TITLE
Bugfix for TriAnalyzer mismatched indexes

### DIFF
--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -48,7 +48,8 @@ class TriAnalyzer(object):
 
         """
         compressed_triangles = self._triangulation.get_masked_triangles()
-        node_used = (np.bincount(np.ravel(compressed_triangles)) != 0)
+        node_used = (np.bincount(np.ravel(compressed_triangles),
+                                 minlength=self._triangulation.x.size) != 0)
         x = self._triangulation.x[node_used]
         y = self._triangulation.y[node_used]
         ux = np.max(x)-np.min(x)


### PR DESCRIPTION
This is a bugfix for issue #4999.

It follows a tightening up in numpy 1.10 when indexing one array with a second boolean array which is smaller, such as

    x = np.asarray([1.0, 2.0, 3.0, 4.0])
    index_array = np.asarray([False, True])
    y = x[index_array]

Here `index_array` is shorter than `x`.  Prior to numpy 1.10 this was acceptable, with `index_array` padded out with `False` values.  In numpy 1.10 it issues a `VisibleDeprecationWarning`.

The problem occurs in `TriAnalyzer` for a `Triangulation` that contains points that are not referenced by any triangles, which can occur if triangles are masked out.  The solution is to make sure the boolean array is of the correct size, which is easily accomplished in this case using the `minlength` kwarg which was added to `numpy.bincount` in version 1.6.

I have not added an explicit test as the existing `test_triangulation.test_tritools` already finds the bug.

Thanks to @WeatherGod for reporting the problem.