### PR TITLE
Fix URLError: <urlopen error unknown url type: c> on Windows

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1316,7 +1316,7 @@ def imread(fname, format=None):
     if cbook.is_string_like(fname):
         parsed = urlparse(fname)
         # If fname is a URL, download the data
-        if parsed.scheme != '':
+        if len(parsed.scheme) > 1:
             fd = BytesIO(urlopen(fname).read())
             return handler(fd)
         else:


### PR DESCRIPTION
On Windows the `urlparse(...).scheme != ''` test for URLs does not work. For file names the drive letter is returned as `scheme`:
```
>>> from matplotlib.externals.six.moves.urllib.parse import urlparse
>>> urlparse(r'C:\Windows\notepad.exe').scheme
'c'
```

Due to this issue `watermark_image.py` fails:
```
loading X:\Python35\lib\site-packages\matplotlib\mpl-data\sample_data\logo2.png
Traceback (most recent call last):
  File "watermark_image.py", line 12, in <module>
    im = image.imread(datafile)
  File "X:\Python35\lib\site-packages\matplotlib\image.py", line 1320, in imread
    fd = BytesIO(urlopen(fname).read())
  File "X:\Python35\lib\urllib\request.py", line 162, in urlopen
    return opener.open(url, data, timeout)
  File "X:\Python35\lib\urllib\request.py", line 465, in open
    response = self._open(req, data)
  File "X:\Python35\lib\urllib\request.py", line 488, in _open
    'unknown_open', req)
  File "X:\Python35\lib\urllib\request.py", line 443, in _call_chain
    result = func(*args)
  File "X:\Python35\lib\urllib\request.py", line 1310, in unknown_open
    raise URLError('unknown url type: %s' % type)
urllib.error.URLError: <urlopen error unknown url type: x>
```