### PR TITLE
Try to make backend_gdk compatible with numpy 1.6

### DIFF
--- a/src/_backend_gdk.c
+++ b/src/_backend_gdk.c
@@ -52,7 +52,15 @@ static PyObject *pixbuf_get_pixels_array(PyObject *self, PyObject *args)
 
     /* the array holds a ref to the pixbuf pixels through this wrapper*/
     Py_INCREF(py_pixbuf);
-    PyArray_SetBaseObject(array, (PyObject *)py_pixbuf);
+#if NPY_API_VERSION >= 0x00000007
+    if (PyArray_SetBaseObject(array, (PyObject *)py_pixbuf) == -1) {
+        Py_DECREF(py_pixbuf);
+        Py_DECREF(array);
+        return NULL;
+    }
+#else
+    PyArray_BASE(array) = py_pixbuf;
+#endif
     return PyArray_Return(array);
 }
 

--- a/src/_backend_gdk.c
+++ b/src/_backend_gdk.c
@@ -59,7 +59,7 @@ static PyObject *pixbuf_get_pixels_array(PyObject *self, PyObject *args)
         return NULL;
     }
 #else
-    PyArray_BASE(array) = py_pixbuf;
+    PyArray_BASE(array) = (PyObject *) py_pixbuf;
 #endif
     return PyArray_Return(array);
 }


### PR DESCRIPTION
Fixes #5078, at least according to a quick test with `import matplotlib.backends.backend_gdk`