### PR TITLE
Fix segfault in ft2font

### DIFF
--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -10,7 +10,11 @@
 static PyObject *convert_xys_to_array(std::vector<double> &xys)
 {
     npy_intp dims[] = {(npy_intp)xys.size() / 2, 2 };
-    return PyArray_SimpleNewFromData(2, dims, NPY_DOUBLE, &xys[0]);
+    if (dims[0] > 0) {
+        return PyArray_SimpleNewFromData(2, dims, NPY_DOUBLE, &xys[0]);
+    } else {
+        return PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+    }
 }
 
 /**********************************************************************
@@ -664,7 +668,9 @@ static PyObject *PyFT2Font_set_text(PyFT2Font *self, PyObject *args, PyObject *k
         return NULL;
     }
 
-    CALL_CPP("set_text", self->x->set_text(size, &codepoints[0], angle, flags, xys));
+    if (size > 0) {
+        CALL_CPP("set_text", self->x->set_text(size, &codepoints[0], angle, flags, xys));
+    }
 
     return convert_xys_to_array(xys);
 }

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -668,9 +668,11 @@ static PyObject *PyFT2Font_set_text(PyFT2Font *self, PyObject *args, PyObject *k
         return NULL;
     }
 
+    uint32_t* codepoints_array = NULL;
     if (size > 0) {
-        CALL_CPP("set_text", self->x->set_text(size, &codepoints[0], angle, flags, xys));
+        codepoints_array = &codepoints[0];
     }
+    CALL_CPP("set_text", self->x->set_text(size, codepoints_array, angle, flags, xys));
 
     return convert_xys_to_array(xys);
 }


### PR DESCRIPTION
On Windows, Python 2.7, 32 and 64 bit, the `sankey_demo_rankine.py` example segfaults in the `ft2font.pyd` extension at <https://github.com/matplotlib/matplotlib/blob/master/src/ft2font_wrapper.cpp#L667>. Apparently on that platform `std::vector` of size 0 doesn't like to be indexed.
Please review: I did not check if not calling `CALL_CPP("set_text", self->x->set_text(size, &codepoints[0], angle, flags, xys))` for size 0 has any side effects.