### PR TITLE
Generate reversed ListedColormaps

### DIFF
--- a/lib/matplotlib/_cm_listed.py
+++ b/lib/matplotlib/_cm_listed.py
@@ -1038,5 +1038,4 @@ for (name, data) in (('magma', _magma_data),
     cmaps[name] = ListedColormap(data, name=name)
     # generate reversed colormap
     name = name + '_r'
-    data = [rgb for rgb in reversed(data)]
-    cmaps[name] = ListedColormap(data, name=name)
+    cmaps[name] = ListedColormap(list(reversed(data)), name=name)

--- a/lib/matplotlib/_cm_listed.py
+++ b/lib/matplotlib/_cm_listed.py
@@ -1036,3 +1036,7 @@ for (name, data) in (('magma', _magma_data),
                      ('viridis', _viridis_data)):
 
     cmaps[name] = ListedColormap(data, name=name)
+    # generate reversed colormap
+    name = name + '_r'
+    data = [rgb for rgb in reversed(data)]
+    cmaps[name] = ListedColormap(data, name=name)


### PR DESCRIPTION
This example currently fails with 1.5.0rc1:
```python
>>> import numpy as np
>>> import matplotlib.pyplot as plt
>>> plt.imshow(np.random.rand(64, 64), cmap='viridis_r')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "X:\Python27\lib\site-packages\matplotlib\pyplot.py", line 3024, in imshow
    **kwargs)
  File "X:\Python27\lib\site-packages\matplotlib\__init__.py", line 1806, in inner
    return func(ax, *args, **kwargs)
  File "X:\Python27\lib\site-packages\matplotlib\axes\_axes.py", line 4940, in imshow
    resample=resample, **kwargs)
  File "X:\Python27\lib\site-packages\matplotlib\image.py", line 597, in __init__
    **kwargs
  File "X:\Python27\lib\site-packages\matplotlib\image.py", line 109, in __init__
    cm.ScalarMappable.__init__(self, norm, cmap)
  File "X:\Python27\lib\site-packages\matplotlib\cm.py", line 202, in __init__
    self.cmap = get_cmap(cmap)
  File "X:\Python27\lib\site-packages\matplotlib\cm.py", line 167, in get_cmap
    % (name, ', '.join(cmap_d.keys())))
ValueError: Colormap viridis_r is not recognized. Possible values are: Spectral, <snip>
```
This PR generates the 'viridis_r', 'plasma_r', 'inferno_r', and 'magma_r' colormaps.