### PR TITLE
The Visual C++ Redistributable for Visual Studio 2015 is required for Python 3.5

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -68,8 +68,11 @@ you will also need to install compatible versions of
 in addition to
 `matplotlib <http://matplotlib.org/downloads.html>`_.
 
-In case Python is not installed for all users (not the default), the
-Microsoft Visual C++ 2008 (
+For Python 3.5 the `Visual C++ Redistributable for Visual Studio 2015
+<http://www.microsoft.com/en-us/download/details.aspx?id=48145>`_
+needs to be installed.
+In case Python 2.6 to 3.4 are not installed for all users (not the default), 
+the Microsoft Visual C++ 2008 (
 `64 bit <http://www.microsoft.com/download/en/details.aspx?id=15336>`__
 or
 `32 bit <http://www.microsoft.com/download/en/details.aspx?id=29>`__


### PR DESCRIPTION
I raised the issue on matplotlib-devel on 9/15/2015:

> A related issue: The matplotlib extensions for Python 3.5 depend on the
> Visual Studio 2015 C/C++ runtime DLLs, specifically vcruntime140.dll and
> msvcp140.dll. Vcruntime140.dll is installed with Python 3.5.0 final,
> however not copied to virtual environments. Msvcp140.dll is not
> distributed with Python 3.5.
>
> Possible solutions:
>
> 1) ship msvcp140.dll in the matplotlib package directory. Python and
> other packages might still fail to load, but that's not matplotlib's
> problem. This is the preferred way to ship dependencies according to
> Microsoft. I personally dislike shipping system DLLs next to extensions.
> See also <http://stevedower.id.au/blog/building-for-python-3-5-part-two/>
>
> 2) require users to install the "Visual C++ Redistributable for Visual
> Studio 2015"
> <http://www.microsoft.com/en-us/download/details.aspx?id=48145>. This
> requires administrator privileges. In the long run this will be much
> less trouble for users.
