### PR TITLE
guard all CaptureMouse() with try/except

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1041,7 +1041,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        try:
+            self.CaptureMouse()
+        except wx._core.PyAssertionError:
+            pass
         FigureCanvasBase.button_press_event(self, x, y, 3, guiEvent=evt)
 
     def _onRightButtonDClick(self, evt):
@@ -1049,7 +1052,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        try:
+            self.CaptureMouse()
+        except wx._core.PyAssertionError:
+            pass
         FigureCanvasBase.button_press_event(self, x, y, 3,
                                             dblclick=True, guiEvent=evt)
 
@@ -1067,7 +1073,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        try:
+            self.CaptureMouse()
+        except wx._core.PyAssertionError:
+            pass
         FigureCanvasBase.button_press_event(self, x, y, 1, guiEvent=evt)
 
     def _onLeftButtonDClick(self, evt):
@@ -1075,7 +1084,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        try:
+            self.CaptureMouse()
+        except wx._core.PyAssertionError:
+            pass
         FigureCanvasBase.button_press_event(self, x, y, 1,
                                             dblclick=True, guiEvent=evt)
 
@@ -1095,7 +1107,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        try:
+            self.CaptureMouse()
+        except wx._core.PyAssertionError:
+            pass
         FigureCanvasBase.button_press_event(self, x, y, 2, guiEvent=evt)
 
     def _onMiddleButtonDClick(self, evt):
@@ -1103,7 +1118,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        try:
+            self.CaptureMouse()
+        except wx._core.PyAssertionError:
+            pass
         FigureCanvasBase.button_press_event(self, x, y, 2,
                                             dblclick=True, guiEvent=evt)
 


### PR DESCRIPTION
This addresses #5101, and replaces all `self.CaptureMouse()` calls in backend_wx.py with

```python
try:
    self.CaptureMouse()
except wx._core.PyAssertionError:
    pass
```

so as to avoid exceptions, especially on Linux, that prevent complete wx interaction.   I have not yet tested this on OS X or Windows.
