### PR TITLE
Add option to package DLL files

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -83,3 +83,9 @@
 #
 #backend = Agg
 #
+
+[package_data]
+# Package additional files found in the lib/matplotlib directories.
+#
+# On Windows, package DLL files.
+#dlls = True

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ mpl_packages = [
     setupext.DviPng(),
     setupext.Ghostscript(),
     setupext.LaTeX(),
-    setupext.PdfToPs()
+    setupext.PdfToPs(),
     'Optional package data',
     setupext.Dlls(),
     ]

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,8 @@ mpl_packages = [
     setupext.Ghostscript(),
     setupext.LaTeX(),
     setupext.PdfToPs()
+    'Optional package data',
+    setupext.Dlls(),
     ]
 
 

--- a/setupext.py
+++ b/setupext.py
@@ -2165,3 +2165,22 @@ class PdfToPs(SetupPackage):
             pass
 
         raise CheckFailed()
+
+
+class OptionalPackageData(OptionalPackage):
+    config_category = "package_data"
+
+
+class Dlls(OptionalPackageData):
+    """
+    On Windows, this packages any DLL files that can be found in the 
+    lib/matplotlib/* directories.
+    """
+    name = "dlls"
+
+    def check_requirements(self):
+        if sys.platform != 'win32':
+            raise CheckFailed("Microsoft Windows only")
+
+    def get_package_data(self):
+        return {'': ['*.dll']}


### PR DESCRIPTION
This would allow to package the msvcp140.dll file required by C++ extensions built with Visual Studio 2015. See https://github.com/matplotlib/matplotlib/pull/5100.