### PR TITLE
added None option to _get_view, also fixed a typo

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3300,7 +3300,7 @@ class _AxesBase(martist.Artist):
         self.set_xlim((xmin, xmax))
         self.set_ylim((ymin, ymax))
 
-    def _set_view_from_bbox(self, bbox, original_view, direction='in',
+    def _set_view_from_bbox(self, bbox, original_view=None, direction='in',
                             mode=None, twinx=False, twiny=False):
         """
         Update view from a selection bbox.
@@ -3318,7 +3318,8 @@ class _AxesBase(martist.Artist):
 
         original_view : any
             A view saved from before initiating the selection, the result of
-            calling :meth:`_get_view`.
+            calling :meth:`_get_view`. If set to none, _get_view will be called
+            to obtain current view state.
 
         direction : str
             The direction to apply the bounding box.
@@ -3340,7 +3341,10 @@ class _AxesBase(martist.Artist):
 
         lastx, lasty, x, y = bbox
 
-        x0, y0, x1, y1 = original_view
+        if(original_view is None):
+            original_view = self._getview()
+        else:
+            x0, x1, y0, y1 = original_view
 
         # zoom to rect
         inverse = self.transData.inverted()

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3300,7 +3300,7 @@ class _AxesBase(martist.Artist):
         self.set_xlim((xmin, xmax))
         self.set_ylim((ymin, ymax))
 
-    def _set_view_from_bbox(self, bbox, original_view=None, direction='in',
+    def _set_view_from_bbox(self, bbox, direction='in',
                             mode=None, twinx=False, twiny=False):
         """
         Update view from a selection bbox.
@@ -3315,11 +3315,6 @@ class _AxesBase(martist.Artist):
 
         bbox : tuple
             The selected bounding box limits, in *display* coordinates.
-
-        original_view : any
-            A view saved from before initiating the selection, the result of
-            calling :meth:`_get_view`. If set to None, _get_view will be called
-            to obtain current view state.
 
         direction : str
             The direction to apply the bounding box.
@@ -3347,11 +3342,6 @@ class _AxesBase(martist.Artist):
         x, y = inverse.transform_point((x, y))
         Xmin, Xmax = self.get_xlim()
         Ymin, Ymax = self.get_ylim()
-
-        if original_view is not None:
-            x0, x1, y0, y1 = original_view
-        else:
-            x0, x1, y0, y1 = Xmin, Xmax, Ymin, Ymax
 
         if twinx:
             x0, x1 = Xmin, Xmax

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3318,7 +3318,7 @@ class _AxesBase(martist.Artist):
 
         original_view : any
             A view saved from before initiating the selection, the result of
-            calling :meth:`_get_view`. If set to none, _get_view will be called
+            calling :meth:`_get_view`. If set to None, _get_view will be called
             to obtain current view state.
 
         direction : str
@@ -3341,17 +3341,17 @@ class _AxesBase(martist.Artist):
 
         lastx, lasty, x, y = bbox
 
-        if original_view is None:
-            original_view = self._get_view()
-        else:
-            x0, x1, y0, y1 = original_view
-
         # zoom to rect
         inverse = self.transData.inverted()
         lastx, lasty = inverse.transform_point((lastx, lasty))
         x, y = inverse.transform_point((x, y))
         Xmin, Xmax = self.get_xlim()
         Ymin, Ymax = self.get_ylim()
+
+        if original_view is not None:
+            x0, x1, y0, y1 = original_view
+        else:
+            x0, x1, y0, y1 = Xmin, Xmax, Ymin, Ymax
 
         if twinx:
             x0, x1 = Xmin, Xmax

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3341,8 +3341,8 @@ class _AxesBase(martist.Artist):
 
         lastx, lasty, x, y = bbox
 
-        if(original_view is None):
-            original_view = self._getview()
+        if original_view is None:
+            original_view = self._get_view()
         else:
             x0, x1, y0, y1 = original_view
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3074,7 +3074,7 @@ class NavigationToolbar2(object):
             else:
                 continue
 
-            a._set_view_from_bbox((lastx, lasty, x, y), view, direction,
+            a._set_view_from_bbox((lastx, lasty, x, y), direction,
                                   self._zoom_mode, twinx, twiny)
 
         self.draw()

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -777,7 +777,7 @@ class ToolZoom(ZoomPanBase):
             else:
                 continue
 
-            a._set_view_from_bbox((lastx, lasty, x, y), view, direction,
+            a._set_view_from_bbox((lastx, lasty, x, y), direction,
                                   self._zoom_mode, twinx, twiny)
 
         self._zoom_mode = None


### PR DESCRIPTION
This pull request contains two modifications:
  1. Fixed a typo
    x0,y0 should be x0,x1
  2. Added a None option to original_view. If No original_view supplied, the function _set_view_from_bbox grabs the current view and uses this as its original_view reference.