### PR TITLE
Fix for bug in set_cmap in NonUniformImage

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -847,7 +847,7 @@ class NonUniformImage(AxesImage):
     def set_norm(self, norm):
         if self._A is not None:
             raise RuntimeError('Cannot change colors after loading data')
-        super(NonUniformImage, self).set_norm(self, norm)
+        super(NonUniformImage, self).set_norm(norm)
 
     def set_cmap(self, cmap):
         if self._A is not None:

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -852,7 +852,7 @@ class NonUniformImage(AxesImage):
     def set_cmap(self, cmap):
         if self._A is not None:
             raise RuntimeError('Cannot change colors after loading data')
-        super(NonUniformImage, self).set_cmap(self, cmap)
+        super(NonUniformImage, self).set_cmap(cmap)
 
 
 class PcolorImage(martist.Artist, cm.ScalarMappable):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -441,10 +441,17 @@ def test_zoom_and_clip_upper_origin():
     ax.set_xlim(-0.5, 2.0)
 
 
+@cleanup
 def test_nonuniformimage_setcmap():
     ax = plt.gca()
     im = NonUniformImage(ax)
     im.set_cmap('Blues')
+
+@cleanup
+def test_nonuniformimage_setnorm():
+    ax = plt.gca()
+    im = NonUniformImage(ax)
+    im.set_norm(plt.Normalize())
 
 if __name__=='__main__':
     import nose

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -6,7 +6,7 @@ from matplotlib.externals import six
 import numpy as np
 
 from matplotlib.testing.decorators import image_comparison, knownfailureif, cleanup
-from matplotlib.image import BboxImage, imread
+from matplotlib.image import BboxImage, imread, NonUniformImage
 from matplotlib.transforms import Bbox
 from matplotlib import rcParams
 import matplotlib.pyplot as plt
@@ -440,6 +440,11 @@ def test_zoom_and_clip_upper_origin():
     ax.set_ylim(2.0, -0.5)
     ax.set_xlim(-0.5, 2.0)
 
+
+def test_nonuniformimage_setcmap():
+    ax = plt.gca()
+    im = NonUniformImage(ax)
+    im.set_cmap('Blues')
 
 if __name__=='__main__':
     import nose


### PR DESCRIPTION
I think this is a legitimate bug and attached fix.

Running the regression test without the fix produced the following error:

```python
Traceback (most recent call last):
  File "/opt/miniconda/envs/matplotlib-dev/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "test_image.py", line 447, in test_nonuniformimage_setcmap
    im.set_cmap('Blues')
  File "/home/stuart/GitHub/matplotlib/lib/matplotlib/image.py", line 855, in set_cmap
    super(NonUniformImage, self).set_cmap(self, cmap)
TypeError: set_cmap() takes exactly 2 arguments (3 given)
```