### PR TITLE
OffsetImage: use dpi_cor in get_extent

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1339,7 +1339,7 @@ class OffsetImage(OffsetBox):
         else:
             dpi_cor = 1.
 
-        zoom = self.get_zoom() 
+        zoom = self.get_zoom()
         data = self.get_data()
         ny, nx = data.shape[:2]
         w, h = dpi_cor * nx * zoom, dpi_cor * ny * zoom

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1342,7 +1342,7 @@ class OffsetImage(OffsetBox):
         zoom = self.get_zoom() 
         data = self.get_data()
         ny, nx = data.shape[:2]
-        w, h = dpi_cor nx * zoom, dpi_cor * ny * zoom
+        w, h = dpi_cor * nx * zoom, dpi_cor * ny * zoom
 
         return w, h, 0, 0
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1334,17 +1334,15 @@ class OffsetImage(OffsetBox):
         return mtransforms.Bbox.from_bounds(ox - xd, oy - yd, w, h)
 
     def get_extent(self, renderer):
-
-        # FIXME dpi_cor is never used
         if self._dpi_cor:  # True, do correction
             dpi_cor = renderer.points_to_pixels(1.)
         else:
             dpi_cor = 1.
 
-        zoom = self.get_zoom()
+        zoom = self.get_zoom() 
         data = self.get_data()
         ny, nx = data.shape[:2]
-        w, h = nx * zoom, ny * zoom
+        w, h = dpi_cor nx * zoom, dpi_cor * ny * zoom
 
         return w, h, 0, 0
 


### PR DESCRIPTION
Before the image was always drawn with 72 dpi in the pdf backend, indepent of the dpi setting..