### PR TITLE
move NavigationToolbar2 canvas assignment to __new__

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2720,9 +2720,13 @@ class NavigationToolbar2(object):
         ('Save', 'Save the figure', 'filesave', 'save_figure'),
       )
 
+    def __new__(cls, canvas):
+        instance = super(NavigationToolbar2, cls).__new__(cls, canvas)
+        instance.canvas = canvas
+        canvas.toolbar = instance
+        return instance
+
     def __init__(self, canvas):
-        self.canvas = canvas
-        canvas.toolbar = self
         # a dict from axes index to a list of view limits
         self._views = cbook.Stack()
         self._positions = cbook.Stack()  # stack of subplot positions


### PR DESCRIPTION
Should prevent copy-paste of assignment of `canvas` and `canvas.toolbar` from `__init__` when sublcassing `NavigationToolbar2`.