### PR TITLE
DOC: Update polar examples to use projection kwarg

### DIFF
--- a/examples/api/logo2.py
+++ b/examples/api/logo2.py
@@ -54,7 +54,7 @@ def add_matplotlib_text(ax):
 
 
 def add_polar_bar():
-    ax = fig.add_axes([0.025, 0.075, 0.2, 0.85], polar=True)
+    ax = fig.add_axes([0.025, 0.075, 0.2, 0.85], projection='polar')
 
     ax.axesPatch.set_alpha(axalpha)
     ax.set_axisbelow(True)

--- a/examples/pie_and_polar_charts/polar_bar_demo.py
+++ b/examples/pie_and_polar_charts/polar_bar_demo.py
@@ -10,7 +10,7 @@ theta = np.linspace(0.0, 2 * np.pi, N, endpoint=False)
 radii = 10 * np.random.rand(N)
 width = np.pi / 4 * np.random.rand(N)
 
-ax = plt.subplot(111, polar=True)
+ax = plt.subplot(111, projection='polar')
 bars = ax.bar(theta, radii, width=width, bottom=0.0)
 
 # Use custom colors and opacity

--- a/examples/pie_and_polar_charts/polar_scatter_demo.py
+++ b/examples/pie_and_polar_charts/polar_scatter_demo.py
@@ -14,7 +14,7 @@ theta = 2 * np.pi * np.random.rand(N)
 area = 200 * r**2 * np.random.rand(N)
 colors = theta
 
-ax = plt.subplot(111, polar=True)
+ax = plt.subplot(111, projection='polar')
 c = plt.scatter(theta, r, c=colors, s=area, cmap=plt.cm.hsv)
 c.set_alpha(0.75)
 

--- a/examples/pylab_examples/annotation_demo.py
+++ b/examples/pylab_examples/annotation_demo.py
@@ -94,7 +94,7 @@ if 1:
     # Text keyword args like horizontal and vertical alignment are
     # respected
     fig = plt.figure()
-    ax = fig.add_subplot(111, polar=True)
+    ax = fig.add_subplot(111, projection='polar')
     r = np.arange(0, 1, 0.001)
     theta = 2*2*np.pi*r
     line, = ax.plot(theta, r, color='#ee8d18', lw=3)

--- a/examples/pylab_examples/markevery_demo.py
+++ b/examples/pylab_examples/markevery_demo.py
@@ -90,7 +90,7 @@ axpolar = []
 for i, case in enumerate(cases):
     row = (i // cols)
     col = i % cols
-    axpolar.append(fig4.add_subplot(gs[row, col], polar=True))
+    axpolar.append(fig4.add_subplot(gs[row, col], projection='polar'))
     axpolar[-1].set_title('markevery=%s' % str(case))
     axpolar[-1].plot(theta, r, 'o', ls='-', ms=4, markevery=case)
 fig4.tight_layout()

--- a/examples/pylab_examples/polar_demo.py
+++ b/examples/pylab_examples/polar_demo.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 r = np.arange(0, 3.0, 0.01)
 theta = 2 * np.pi * r
 
-ax = plt.subplot(111, polar=True)
+ax = plt.subplot(111, projection='polar')
 ax.plot(theta, r, color='r', linewidth=3)
 ax.set_rmax(2.0)
 ax.grid(True)

--- a/examples/pylab_examples/polar_legend.py
+++ b/examples/pylab_examples/polar_legend.py
@@ -10,7 +10,7 @@ rc('ytick', labelsize=15)
 
 # force square figure and square axes looks better for polar, IMO
 fig = figure(figsize=(8, 8))
-ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], polar=True, axisbg='#d5de9c')
+ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection='polar', axisbg='#d5de9c')
 
 r = np.arange(0, 3.0, 0.01)
 theta = 2*np.pi*r

--- a/examples/pylab_examples/subplots_demo.py
+++ b/examples/pylab_examples/subplots_demo.py
@@ -66,6 +66,6 @@ plt.setp([a.get_xticklabels() for a in axarr[0, :]], visible=False)
 plt.setp([a.get_yticklabels() for a in axarr[:, 1]], visible=False)
 
 # Four polar axes
-plt.subplots(2, 2, subplot_kw=dict(polar=True))
+plt.subplots(2, 2, subplot_kw=dict(projection='polar'))
 
 plt.show()

--- a/examples/pylab_examples/transoffset.py
+++ b/examples/pylab_examples/transoffset.py
@@ -40,7 +40,7 @@ for x, y in zip(xs, ys):
 
 
 # offset_copy works for polar plots also.
-ax = plt.subplot(2, 1, 2, polar=True)
+ax = plt.subplot(2, 1, 2, projection='polar')
 
 trans_offset = mtrans.offset_copy(ax.transData, fig=fig, y=6, units='dots')
 


### PR DESCRIPTION
From the documentation of ``Figure.add_axes(self, *args, **kwargs)``
> kwargs are legal :class:`~matplotlib.axes.Axes` kwargs plus *projection* which sets the projection type of the axes.  (For backward compatibility, ``polar=True`` may also be provided, which is equivalent to ``projection='polar'``).

Looking back through the history, this "depreciation" (by documentation only, hence the inverted commas) occurred in 2007, see https://github.com/matplotlib/matplotlib/commit/633759b7f1e45c071eccfe708a2e9e489c77cfa1, so this PR seems well overdue.

Given its age I would give this a long time until we begin a formal deprecation, but a change in the docs makes for a good start.  Hopefully this can get backported in time to build the 1.5 docs?