### PR TITLE
MAINT: use travis wheel repository for 3.5 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ matrix:
     - python: 3.3
     - python: 3.4
     - python: 3.5
-      env: PRE=--pre
     - python: 2.7
       env: TEST_ARGS=--pep8
     - python: 2.7


### PR DESCRIPTION
Python 3.5 wheels now built and up on travis-wheels container.