### PR TITLE
Fixed reference issue in LatexManager

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -222,19 +222,19 @@ class LatexManagerFactory(object):
     def get_latex_manager():
         texcommand = get_texcommand()
         latex_header = LatexManager._build_latex_header()
-        prev = LatexManagerFactory.previous_instance
+        if LatexManagerFactory.previous_instance:
+            prev = LatexManagerFactory.previous_instance()
 
-        # check if the previous instance of LatexManager can be reused
-        if prev and prev.latex_header == latex_header and prev.texcommand == texcommand:
-            if rcParams.get("pgf.debug", False):
-                print("reusing LatexManager")
-            return prev
-        else:
-            if rcParams.get("pgf.debug", False):
-                print("creating LatexManager")
-            new_inst = LatexManager()
-            LatexManagerFactory.previous_instance = new_inst
-            return new_inst
+            # check if the previous instance of LatexManager can be reused
+            if prev and prev.latex_header == latex_header and prev.texcommand == texcommand:
+                if rcParams.get("pgf.debug", False):
+                    print("reusing LatexManager")
+                return prev
+        if rcParams.get("pgf.debug", False):
+            print("creating LatexManager")
+        new_inst = LatexManager()
+        LatexManagerFactory.previous_instance = weakref.ref(new_inst)
+        return new_inst
 
 class WeakSet(object):
     # TODO: Poor man's weakref.WeakSet.


### PR DESCRIPTION
This fixes a potential bug in the pgf backend. The issue is that the class LatexManagerFactory keeps a strong reference to a LatexManager object while the class LatexManager has `__del__` method to clean up its  objects. While the python interpreter shuts down, the LatexManager destructor (`__del__`) will run because of the presence of the strong reference, but this potentially can lead to an exception (but ignored) since it relies on, for instance, `os.path` module, which possibly can be in the state of destruction.

Actually this causes an issue in matplotlib embedded in Sage. Look http://trac.sagemath.org/ticket/14798

The fix is to use weak referencing.  