### PR TITLE
FIX: set internal flags first in FigureCanvasBase

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2123,6 +2123,8 @@ class FigureCanvasBase(object):
             tight bbox is calculated.
 
         """
+        self._is_saving = True
+
         if format is None:
             # get format from filename, or from backend's default filetype
             if cbook.is_string_like(filename):
@@ -2216,7 +2218,6 @@ class FigureCanvasBase(object):
         else:
             _bbox_inches_restore = None
 
-        self._is_saving = True
         try:
             #result = getattr(self, method_name)(
             result = print_method(

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1678,12 +1678,6 @@ class FigureCanvasBase(object):
                          'Tagged Image File Format')
 
     def __init__(self, figure):
-        # put this first to make sure that we prevent any attempts to
-        # re-draw while we are constructing the canvas.
-        # See issue #5094, this only trigged on saving a png when:
-        #  - using a non-agg backend
-        #  - in interactive mode
-        #  - not bunching `draw_idle` calls (ex not in IPython)
         self._is_idle_drawing = True
         self._is_saving = False
         figure.set_canvas(self)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1685,7 +1685,7 @@ class FigureCanvasBase(object):
         #  - in interactive mode
         #  - not bunching `draw_idle` calls (ex not in IPython)
         self._is_idle_drawing = True
-
+        self._is_saving = False
         figure.set_canvas(self)
         self.figure = figure
         # a dictionary from event name to a dictionary that maps cid->func
@@ -1698,7 +1698,6 @@ class FigureCanvasBase(object):
         self.scroll_pick_id = self.mpl_connect('scroll_event', self.pick)
         self.mouse_grabber = None  # the axes currently grabbing mouse
         self.toolbar = None  # NavigationToolbar2 will set me
-        self._is_saving = False
         self._is_idle_drawing = False
 
     @contextmanager

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1678,6 +1678,14 @@ class FigureCanvasBase(object):
                          'Tagged Image File Format')
 
     def __init__(self, figure):
+        # put this first to make sure that we prevent any attempts to
+        # re-draw while we are constructing the canvas.
+        # See issue #5094, this only trigged on saving a png when:
+        #  - using a non-agg backend
+        #  - in interactive mode
+        #  - not bunching `draw_idle` calls (ex not in IPython)
+        self._is_idle_drawing = True
+
         figure.set_canvas(self)
         self.figure = figure
         # a dictionary from event name to a dictionary that maps cid->func

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -560,7 +560,6 @@ class Figure(Artist):
         ACCEPTS: a FigureCanvas instance
         """
         self.canvas = canvas
-        self.stale = True
 
     def hold(self, b=None):
         """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -681,11 +681,11 @@ def draw():
     :class:`~matplotlib.figure.Figure` instance, :attr:`fig`, that
     was created using a :mod:`~matplotlib.pyplot` function, is::
 
-        fig.canvas.draw()
+        fig.canvas.draw_idle()
 
 
     """
-    get_current_fig_manager().canvas.draw()
+    get_current_fig_manager().canvas.draw_idle()
 
 
 @docstring.copy_dedent(Figure.savefig)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -666,24 +666,18 @@ def clf():
 
 
 def draw():
-    """
-    Redraw the current figure.
+    """Redraw the current figure.
 
-    This is used in interactive mode to update a figure that
-    has been altered using one or more plot object method calls;
-    it is not needed if figure modification is done entirely
-    with pyplot functions, if a sequence of modifications ends
-    with a pyplot function, or if matplotlib is in non-interactive
-    mode and the sequence of modifications ends with :func:`show` or
-    :func:`savefig`.
+    This is used in interactive mode to update a figure that has been
+    altered, but not automatically re-drawn.  This should be only rarely
+    needed, but there may be ways to modify the state of a figure with
+    out marking it as `stale`.  Please report these cases as bugs.
 
     A more object-oriented alternative, given any
     :class:`~matplotlib.figure.Figure` instance, :attr:`fig`, that
     was created using a :mod:`~matplotlib.pyplot` function, is::
 
         fig.canvas.draw_idle()
-
-
     """
     get_current_fig_manager().canvas.draw_idle()
 
@@ -692,7 +686,7 @@ def draw():
 def savefig(*args, **kwargs):
     fig = gcf()
     res = fig.savefig(*args, **kwargs)
-    draw()   # need this if 'transparent=True' to reset colors
+    fig.canvas.draw_idle()   # need this if 'transparent=True' to reset colors
     return res
 
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -564,7 +564,7 @@ def _auto_draw_if_interactive(fig, val):
     fig : Figure
         A figure object which is assumed to be associated with a canvas
     """
-    if val and matplotlib.is_interactive():
+    if val and matplotlib.is_interactive() and not fig.canvas.is_saving():
         fig.canvas.draw_idle()
 
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -24,20 +24,19 @@ needs_tex = knownfailureif(
 
 
 def _test_savefig_to_stringio(format='ps', use_log=False):
+    fig, ax = plt.subplots()
     buffers = [
         six.moves.StringIO(),
         io.StringIO(),
         io.BytesIO()]
 
-    plt.figure()
-
     if use_log:
-        plt.yscale('log')
+        ax.set_yscale('log')
 
-    plt.plot([1, 2], [1, 2])
-    plt.title("Déjà vu")
+    ax.plot([1, 2], [1, 2])
+    ax.set_title("Déjà vu")
     for buffer in buffers:
-        plt.savefig(buffer, format=format)
+        fig.savefig(buffer, format=format)
 
     values = [x.getvalue() for x in buffers]
 


### PR DESCRIPTION
If interactive mode is on using the model where every time any artist is
invalidated/marked as stale a `draw_idle` is triggered and the user is
using a non-Agg based backend, saving a png will result in a draw_idle
call triggered from inside the __init__ method of `FigureCanvasBase`
which then fails because the full object has not been set up (this is
not a problem using the IPython hooks because the stale state is only
checked once when all user code has completed executing).

closes #5094 

attn @mdehoon 