### PR TITLE
MNT: more minor tweaks to qt_compat.py

### DIFF
--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -109,9 +109,18 @@ if _sip_imported:
         except:
             res = 'QVariant API v2 specification failed. Defaulting to v1.'
             verbose.report(cond + res, 'helpful')
+    if QT_API == QT_API_PYQT5:
+        try:
+            from PyQt5 import QtCore, QtGui, QtWidgets
+            _getSaveFileName = QtWidgets.QFileDialog.getSaveFileName
+        except ImportError:
+            # fell through, tried PyQt5, failed fall back to PyQt4
+            QT_API = rcParams['backend.qt4']
+            QT_RC_MAJOR_VERSION = 4
 
+    # needs to be if so we can re-test the value of QT_API which may
+    # have been changed in the above if block
     if QT_API in [QT_API_PYQT, QT_API_PYQTv2]:  # PyQt4 API
-
         from PyQt4 import QtCore, QtGui
 
         try:
@@ -131,9 +140,8 @@ if _sip_imported:
             def _getSaveFileName(*args, **kwargs):
                 return QtGui.QFileDialog.getSaveFileName(*args, **kwargs), None
 
-    else:  # PyQt5 API
-        from PyQt5 import QtCore, QtGui, QtWidgets
-        _getSaveFileName = QtWidgets.QFileDialog.getSaveFileName
+    else:
+        raise RuntimeError("No PyQt bindings found despite sip importing")
 
     # Alias PyQt-specific functions for PySide compatibility.
     QtCore.Signal = QtCore.pyqtSignal

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -141,7 +141,9 @@ if _sip_imported:
                 return QtGui.QFileDialog.getSaveFileName(*args, **kwargs), None
 
     else:
-        raise RuntimeError("No PyQt bindings found despite sip importing")
+        raise RuntimeError("PyQt{4,5} bindings found despite sip importing\n"
+                           "Please install PyQt4 or PyQt5, uninstall sip or "
+                           "explicitly set the pyside backend.")
 
     # Alias PyQt-specific functions for PySide compatibility.
     QtCore.Signal = QtCore.pyqtSignal


### PR DESCRIPTION
If we the backend is not a Qt* backend, a version of pyqt has not been
imported and PyQt5 is not installed qt_compat would raise as
ImportError.  Now it will gracefully fall back to PyQt4.

attn @jrevans @mfitzp 