### PR TITLE
ENH: add modified CMRmap colormap with improved linearity

### DIFF
--- a/lib/matplotlib/_cm.py
+++ b/lib/matplotlib/_cm.py
@@ -1889,6 +1889,18 @@ _CMRmap_data = {'red':     ((0.000, 0.00, 0.00),
                            (0.875, 0.50, 0.50),
                            (1.000, 1.00, 1.00))}
 
+# Modification of CMRmap to improve linearity of luminance
+# by Christopher Hummersone, BSD Licensed
+# http://www.mathworks.com/matlabcentral/fileexchange/39552-modified-cmrmap
+_CMRmap2_data = ((0.0, 0.0,  0.0),
+                 (0.1, 0.1,  0.35),
+                 (0.3, 0.15, 0.65),
+                 (0.6, 0.2,  0.50),
+                 (1.0, 0.25, 0.15),
+                 (0.9, 0.55, 0.0),
+                 (0.9, 0.75, 0.1),
+                 (0.9, 0.9,  0.5),
+                 (1.0, 1.0,  1.0))
 
 # An MIT licensed, colorblind-friendly heatmap from Wistia:
 #   https://github.com/wistia/heatmap-palette
@@ -1927,6 +1939,7 @@ datad = {
     'bwr':    _bwr_data,
     'brg':    _brg_data,
     'CMRmap': _CMRmap_data,
+    'CMRmap2': _CMRmap2_data,
     'cool':   _cool_data,
     'copper': _copper_data,
     'cubehelix': _cubehelix_data,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2106,6 +2106,8 @@ def colormaps():
                     maintains an aesthetically pleasing color image that
                     automatically reproduces to a monotonic grayscale with
                     discrete, quantifiable saturation levels." [#]_
+      CMRmap2       Modified version of CMRmap that improves its luminosity
+                    linearity for low values. [#]_
       cubehelix     Unlike most other color schemes cubehelix was designed
                     by D.A. Green to be monotonically increasing in terms
                     of perceived brightness. Also, when printed on a black
@@ -2160,6 +2162,10 @@ def colormaps():
       Color-Scale Images
       <http://www.mathworks.com/matlabcentral/fileexchange/2662-cmrmap-m>`_
       by Carey Rappaport
+
+    .. [#] See `Modified CMRmap
+      <http://www.mathworks.com/matlabcentral/fileexchange/39552-modified-cmrmap>`_
+      by Christopher Hummersone
 
     .. [#] Changed to distinguish from ColorBrewer's *Spectral* map.
       :func:`spectral` still works, but


### PR DESCRIPTION
The CMRmap colormap has some linearity problems as seen in the [Choosing Colormaps](http://matplotlib.org/users/colormaps.html) page. In 2012, Christopher Hummerstone uploaded to the mathworks file exchange [a tweaked version of CMRmap with improved linearity](http://www.mathworks.com/matlabcentral/fileexchange/39552-modified-cmrmap). It is by no means perfect (there is still a kink in the red-orange transition), but better than the original. I think it's worth being in matplotlib because: a) there are no sequential colormaps from black to white and several different colors in between (blue-red-orange), b) it holds well under colorblindness tests. I have added it here with name `CMRmap2`.

Luminosity profile of this version with the code used in the [Choosing Colormaps](http://matplotlib.org/users/colormaps.html) page:
![miscellaneous](https://cloud.githubusercontent.com/assets/576258/10262815/e1f47e58-69cf-11e5-80df-0f81aa44debc.png)


In my opinion, this version could outright replace CMRmap (maybe having the original CMRmap as `CMRmap_legacy`, as discussed in #4681 for the perceptually correct blues), but this would slightly change existing code output.