### PR TITLE
Backport DOC: Fix description of draw_markers in api_changes.rst

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -1545,7 +1545,7 @@ New methods:
 
   * :meth:`draw_markers(self, gc, marker_path, marker_trans, path,
     trans, rgbFace)
-    <matplotlib.backend_bases.RendererBase.draw_markers`
+    <matplotlib.backend_bases.RendererBase.draw_markers>`
 
   * :meth:`draw_path_collection(self, master_transform, cliprect,
     clippath, clippath_trans, paths, all_transforms, offsets,


### PR DESCRIPTION
Patch from
https://sources.debian.net/src/matplotlib/1.4.2-3.1/debian/patches/40_bts608939_draw_markers_description.patch/