### PR TITLE
Fix `ValueError: invalid PNG header` on Windows

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1287,7 +1287,7 @@ def imread(fname, format=None):
         if cbook.is_string_like(fname):
             parsed = urlparse(fname)
             # If the string is a URL, assume png
-            if parsed.scheme != '':
+            if len(parsed.scheme) > 1:
                 ext = 'png'
             else:
                 basename, ext = os.path.splitext(fname)


### PR DESCRIPTION
On Windows the `urlparse(...).scheme != ''` test for URLs does not work.
For file names the drive letter is returned as scheme.

See also https://github.com/matplotlib/matplotlib/pull/5071.

This fixes one test failure on Windows:
```
======================================================================
ERROR: matplotlib.tests.test_image.test_imread_pil_uint16
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\matplotlib\testing\decorators.py", line 53, in failer
    result = f(*args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\tests\test_image.py", line 95, in test_imread_pil_uint16
    'baseline_images', 'test_image', 'uint16.tif'))
  File "X:\Python34\lib\site-packages\matplotlib\pyplot.py", line 2290, in imread
    return _imread(*args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\image.py", line 1324, in imread
    return handler(fd)
ValueError: invalid PNG header
```