### PR TITLE
TST: fix `AttributeError: 'module' object has no attribute 'nl_langinfo'` on Windows

### DIFF
--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -199,7 +199,7 @@ def test_date_formatter_strftime():
             expanded_formatter = mdates.DateFormatter(locale_d_fmt)
             assert_equal(locale_formatter.strftime(dt),
                          expanded_formatter.strftime(dt))
-        except ImportError:
+        except (ImportError, AttributeError):
             pass
 
     for year in range(1, 3000, 71):


### PR DESCRIPTION
Fixes one test error:
```
======================================================================
ERROR: Tests that DateFormatter matches datetime.strftime,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\matplotlib\tests\test_dates.py", line 207, in test_date_formatter_strftime
    test_strftime_fields(datetime.datetime(year, 1, 1))
  File "X:\Python34\lib\site-packages\matplotlib\tests\test_dates.py", line 198, in test_strftime_fields
    locale_d_fmt = locale.nl_langinfo(locale.D_FMT)
AttributeError: 'module' object has no attribute 'nl_langinfo'
```