### PR TITLE
TST: fix test_mlab.test_griddata_nn failures on Windows

### DIFF
--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -2768,7 +2768,7 @@ def test_griddata_nn():
                   [-0.1000099, 0.4999943, 1.0999964, 1.6999979],
                   [-0.3000128, 0.2999894, 0.8999913, 1.4999933]]
     zi = mlab.griddata(x, y, z, xi, yi, interp='nn')
-    np.testing.assert_array_almost_equal(zi, correct_zi)
+    np.testing.assert_array_almost_equal(zi, correct_zi, 5)
 
     # Decreasing xi or yi should raise ValueError.
     assert_raises(ValueError, mlab.griddata, x, y, z, xi[::-1], yi,
@@ -2779,7 +2779,7 @@ def test_griddata_nn():
     # Passing 2D xi and yi arrays to griddata.
     xi, yi = np.meshgrid(xi, yi)
     zi = mlab.griddata(x, y, z, xi, yi, interp='nn')
-    np.testing.assert_array_almost_equal(zi, correct_zi)
+    np.testing.assert_array_almost_equal(zi, correct_zi, 5)
 
     # Masking z array.
     z_masked = np.ma.array(z, mask=[False, False, False, True, False])


### PR DESCRIPTION
Fixes `matplotlib.tests.test_mlab.test_griddata_nn` failure by reducing decimal precision by 1.
```
======================================================================
FAIL: matplotlib.tests.test_mlab.test_griddata_nn
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\matplotlib\testing\decorators.py", line 53, in failer
    result = f(*args, **kwargs)
  File "X:\Python34\lib\site-packages\matplotlib\tests\test_mlab.py", line 2771, in test_griddata_nn
    np.testing.assert_array_almost_equal(zi, correct_zi)
  File "X:\Python34\lib\site-packages\numpy\testing\utils.py", line 842, in assert_array_almost_equal
    precision=decimal)
  File "X:\Python34\lib\site-packages\numpy\testing\utils.py", line 665, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Arrays are not almost equal to 6 decimals

(mismatch 81.25%)
 x: array([[ 0.500004,  1.100003,  1.700001,  2.299999],
       [ 0.300001,  0.899998,  1.499996,  2.099996],
       [-0.100005,  0.499993,  1.099992,  1.699992],
       [-0.300006,  0.299993,  0.899992,  1.499991]])
 y: array([[ 0.499993,  1.099998,  1.700003,  2.300008],
       [ 0.299992,  0.899998,  1.500003,  2.100006],
       [-0.10001 ,  0.499994,  1.099996,  1.699998],
       [-0.300013,  0.299989,  0.899991,  1.499993]])

```