### PR TITLE
TST: skip test if cannot see the internet

### DIFF
--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from matplotlib.externals import six
-
+from six.moves.urllib.error import URLError
 """
 Core functions and attributes for the matplotlib style library:
 
@@ -83,6 +83,8 @@ def use(style):
             try:
                 rc = rc_params_from_file(style, use_default_template=False)
                 mpl.rcParams.update(rc)
+            except URLError:
+                raise
             except IOError:
                 msg = ("'%s' not found in the style library and input is "
                        "not a valid URL or path. See `style.available` for "

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -15,6 +15,7 @@ from matplotlib import style
 from matplotlib.style.core import USER_LIBRARY_PATHS, STYLE_EXTENSION
 
 from matplotlib.externals import six
+from six.moves.urllib.error import URLError
 
 PARAM = 'image.cmap'
 VALUE = 'pink'
@@ -57,9 +58,12 @@ def test_use():
 
 
 def test_use_url():
-    with temp_style('test', DUMMY_SETTINGS):
-        with style.context('https://gist.github.com/adrn/6590261/raw'):
-            assert mpl.rcParams['axes.facecolor'] == "#adeade"
+    try:
+        with temp_style('test', DUMMY_SETTINGS):
+            with style.context('https://gist.github.com/adrn/6590261/raw'):
+                assert mpl.rcParams['axes.facecolor'] == "#adeade"
+    except URLError:
+        raise SkipTest("Probably on a system that does not allow internet")
 
 
 def test_context():


### PR DESCRIPTION
`style.use` can now raise a URLError instead of an IOError if the the
url is inaccessable.  This is backwards-compatible as URLError is a
sub-class of IOError (which has been merged into OSError is 3.3+).