### PR TITLE
DOC: Fix encoding for LaTeX

### DIFF
--- a/doc/style_changes.rst
+++ b/doc/style_changes.rst
@@ -10,7 +10,7 @@ upcoming 2.0 release!
 The new default color map will be 'viridis' (aka `option
 D <http://bids.github.io/colormap/>`_).  For an introduction to color
 theory and how 'viridis' was generated watch Nathaniel Smith and
-Stéfan van der Walt's talk from SciPy2015
+Stéfan van der Walt's talk from SciPy2015
 
 .. raw:: html
 


### PR DESCRIPTION
Instead of a combining acute accent, use a single-codepoint encoding

Backported from master