### PR TITLE
TST: properly fence-post qt{4,5} backend tests

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1429,6 +1429,7 @@ default_test_modules = [
     'matplotlib.tests.test_backend_pgf',
     'matplotlib.tests.test_backend_ps',
     'matplotlib.tests.test_backend_qt4',
+    'matplotlib.tests.test_backend_qt5',
     'matplotlib.tests.test_backend_svg',
     'matplotlib.tests.test_basic',
     'matplotlib.tests.test_bbox_tight',

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -15,7 +15,7 @@ import matplotlib
 from matplotlib.figure import Figure
 
 
-from .backend_qt5agg import FigureCanvasQTAggBase
+from .backend_qt5agg import FigureCanvasQTAggBase as _FigureCanvasQTAggBase
 
 from .backend_agg import FigureCanvasAgg
 from .backend_qt4 import QtCore
@@ -52,6 +52,11 @@ def new_figure_manager_given_figure(num, figure):
     """
     canvas = FigureCanvasQTAgg(figure)
     return FigureManagerQT(canvas, num)
+
+
+class FigureCanvasQTAggBase(_FigureCanvasQTAggBase):
+    def __init__(self, figure):
+        self._agg_draw_pending = False
 
 
 class FigureCanvasQTAgg(FigureCanvasQTAggBase,

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -139,19 +139,22 @@ if _sip_imported:
             # call to getapi() can fail in older versions of sip
             def _getSaveFileName(*args, **kwargs):
                 return QtGui.QFileDialog.getSaveFileName(*args, **kwargs), None
-
-    # Alias PyQt-specific functions for PySide compatibility.
-    QtCore.Signal = QtCore.pyqtSignal
     try:
-        QtCore.Slot = QtCore.pyqtSlot
-    except AttributeError:
-        # Not a perfect match but works in simple cases
-        QtCore.Slot = QtCore.pyqtSignature
+        # Alias PyQt-specific functions for PySide compatibility.
+        QtCore.Signal = QtCore.pyqtSignal
+        try:
+            QtCore.Slot = QtCore.pyqtSlot
+        except AttributeError:
+            # Not a perfect match but works in simple cases
+            QtCore.Slot = QtCore.pyqtSignature
 
-    QtCore.Property = QtCore.pyqtProperty
-    __version__ = QtCore.PYQT_VERSION_STR
+        QtCore.Property = QtCore.pyqtProperty
+        __version__ = QtCore.PYQT_VERSION_STR
+    except NameError:
+        # QtCore did not get imported, fall back to pyside
+        QT_API = QT_API_PYSIDE
 
-else:  # try importing pyside
+if QT_API == QT_API_PYSIDE:  # try importing pyside
     try:
         from PySide import QtCore, QtGui, __version__, __version_info__
     except ImportError:

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -17,6 +17,7 @@ except ImportError:
 
 try:
     from matplotlib.backends.qt_compat import QtCore
+
     from matplotlib.backends.backend_qt4 import (MODIFIER_KEYS,
                                                  SUPER, ALT, CTRL, SHIFT)
 
@@ -24,7 +25,11 @@ try:
     _, AltModifier, AltKey = MODIFIER_KEYS[ALT]
     _, SuperModifier, SuperKey = MODIFIER_KEYS[SUPER]
     _, ShiftModifier, ShiftKey = MODIFIER_KEYS[SHIFT]
-    HAS_QT = True
+    py_qt_ver = int(QtCore.PYQT_VERSION_STR.split('.')[0])
+    if py_qt_ver != 4:
+        HAS_QT = False
+    else:
+        HAS_QT = True
 except ImportError:
     HAS_QT = False
 
@@ -33,7 +38,7 @@ except ImportError:
 @knownfailureif(not HAS_QT)
 @switch_backend('Qt4Agg')
 def test_fig_close():
-    #save the state of Gcf.figs
+    # save the state of Gcf.figs
     init_figs = copy.copy(Gcf.figs)
 
     # make a figure using pyplot interface

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -7,6 +7,7 @@ from matplotlib import pyplot as plt
 from matplotlib.testing.decorators import cleanup, switch_backend
 from matplotlib.testing.decorators import knownfailureif
 from matplotlib._pylab_helpers import Gcf
+import matplotlib.style as mstyle
 import copy
 
 try:
@@ -16,7 +17,8 @@ except ImportError:
     import mock
 
 try:
-    from matplotlib.backends.qt_compat import QtCore
+    with mstyle.context({'backend': 'Qt4Agg'}):
+        from matplotlib.backends.qt_compat import QtCore
 
     from matplotlib.backends.backend_qt4 import (MODIFIER_KEYS,
                                                  SUPER, ALT, CTRL, SHIFT)
@@ -25,11 +27,14 @@ try:
     _, AltModifier, AltKey = MODIFIER_KEYS[ALT]
     _, SuperModifier, SuperKey = MODIFIER_KEYS[SUPER]
     _, ShiftModifier, ShiftKey = MODIFIER_KEYS[SHIFT]
-    py_qt_ver = int(QtCore.PYQT_VERSION_STR.split('.')[0])
-    if py_qt_ver != 4:
-        HAS_QT = False
-    else:
-        HAS_QT = True
+
+    try:
+        py_qt_ver = int(QtCore.PYQT_VERSION_STR.split('.')[0])
+    except AttributeError:
+        py_qt_ver = QtCore.__version_info__[0]
+    print(py_qt_ver)
+    HAS_QT = py_qt_ver == 4
+
 except ImportError:
     HAS_QT = False
 

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -103,7 +103,7 @@ def test_control():
 def test_unicode_upper():
     assert_correct_key(QtCore.Qt.Key_Aacute,
                        ShiftModifier,
-                       chr(193))
+                       six.unichr(193))
 
 
 @cleanup
@@ -111,7 +111,7 @@ def test_unicode_upper():
 def test_unicode_lower():
     assert_correct_key(QtCore.Qt.Key_Aacute,
                        QtCore.Qt.NoModifier,
-                       chr(225))
+                       six.unichr(225))
 
 
 @cleanup
@@ -135,7 +135,7 @@ def test_control_alt():
 def test_modifier_order():
     assert_correct_key(QtCore.Qt.Key_Aacute,
                        (ControlModifier | AltModifier | SuperModifier),
-                       'ctrl+alt+super+' + chr(225))
+                       'ctrl+alt+super+' + six.unichr(225))
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -1,12 +1,12 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
 from matplotlib.externals import six
 
 from matplotlib import pyplot as plt
 from matplotlib.testing.decorators import cleanup, switch_backend
 from matplotlib.testing.decorators import knownfailureif
 from matplotlib._pylab_helpers import Gcf
+import matplotlib.style as mstyle
 import copy
 
 try:
@@ -16,7 +16,8 @@ except ImportError:
     import mock
 
 try:
-    from matplotlib.backends.qt_compat import QtCore
+    with mstyle.context({'backend': 'Qt5Agg'}):
+        from matplotlib.backends.qt_compat import QtCore, __version__
     from matplotlib.backends.backend_qt5 import (MODIFIER_KEYS,
                                                  SUPER, ALT, CTRL, SHIFT)
 
@@ -24,11 +25,10 @@ try:
     _, AltModifier, AltKey = MODIFIER_KEYS[ALT]
     _, SuperModifier, SuperKey = MODIFIER_KEYS[SUPER]
     _, ShiftModifier, ShiftKey = MODIFIER_KEYS[SHIFT]
-    py_qt_ver = int(QtCore.PYQT_VERSION_STR.split('.')[0])
-    if py_qt_ver != 5:
-        HAS_QT = False
-    else:
-        HAS_QT = True
+
+    py_qt_ver = int(__version__.split('.')[0])
+    HAS_QT = py_qt_ver == 5
+
 except ImportError:
     HAS_QT = False
 

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from matplotlib.externals import six
 
 from matplotlib import pyplot as plt
-from matplotlib.testing.decorators import cleanup
+from matplotlib.testing.decorators import cleanup, switch_backend
 from matplotlib.testing.decorators import knownfailureif
 from matplotlib._pylab_helpers import Gcf
 import copy
@@ -24,17 +24,19 @@ try:
     _, AltModifier, AltKey = MODIFIER_KEYS[ALT]
     _, SuperModifier, SuperKey = MODIFIER_KEYS[SUPER]
     _, ShiftModifier, ShiftKey = MODIFIER_KEYS[SHIFT]
-    HAS_QT = True
+    py_qt_ver = int(QtCore.PYQT_VERSION_STR.split('.')[0])
+    if py_qt_ver != 5:
+        HAS_QT = False
+    else:
+        HAS_QT = True
 except ImportError:
     HAS_QT = False
 
 
 @cleanup
 @knownfailureif(not HAS_QT)
+@switch_backend('Qt5Agg')
 def test_fig_close():
-    # force switch to the Qt5 backend
-    plt.switch_backend('Qt5Agg')
-
     # save the state of Gcf.figs
     init_figs = copy.copy(Gcf.figs)
 
@@ -50,6 +52,7 @@ def test_fig_close():
     assert(init_figs == Gcf.figs)
 
 
+@switch_backend('Qt5Agg')
 def assert_correct_key(qt_key, qt_mods, answer):
     """
     Make a figure
@@ -57,7 +60,6 @@ def assert_correct_key(qt_key, qt_mods, answer):
     Catch the event
     Assert sent and caught keys are the same
     """
-    plt.switch_backend('Qt5Agg')
     qt_canvas = plt.figure().canvas
 
     event = mock.Mock()
@@ -101,7 +103,7 @@ def test_control():
 def test_unicode_upper():
     assert_correct_key(QtCore.Qt.Key_Aacute,
                        ShiftModifier,
-                       unichr(193))
+                       chr(193))
 
 
 @cleanup
@@ -109,7 +111,7 @@ def test_unicode_upper():
 def test_unicode_lower():
     assert_correct_key(QtCore.Qt.Key_Aacute,
                        QtCore.Qt.NoModifier,
-                       unichr(225))
+                       chr(225))
 
 
 @cleanup
@@ -133,7 +135,7 @@ def test_control_alt():
 def test_modifier_order():
     assert_correct_key(QtCore.Qt.Key_Aacute,
                        (ControlModifier | AltModifier | SuperModifier),
-                       'ctrl+alt+super+' + unichr(225))
+                       'ctrl+alt+super+' + chr(225))
 
 
 @cleanup


### PR DESCRIPTION
This issue is that the new 'default' qt version is 5 if it is
available.  In the tests the backend is Agg so we are hitting the
fall through behavior.  If both pyqt4 and pyqt5 are installed, then
`QtCore` will be from PyQt5, but the backend_qt4Agg code assumes that it
is seeing the PyQt4 version of the classes.  This results in error on
`__init__` due to the change between PyQt4 and PyQt5.

Added test_backend_qt5.py to white listed tests.

closes #5194