### PR TITLE
Fix mathtext_wx example not redrawing plots

### DIFF
--- a/examples/user_interfaces/mathtext_wx.py
+++ b/examples/user_interfaces/mathtext_wx.py
@@ -43,10 +43,11 @@ class CanvasFrame(wx.Frame):
 
         self.figure = Figure()
         self.axes = self.figure.add_subplot(111)
-        self.change_plot(0)
 
         self.canvas = FigureCanvas(self, -1, self.figure)
 
+        self.change_plot(0)        
+        
         self.sizer = wx.BoxSizer(wx.VERTICAL)
         self.add_buttonbar()
         self.sizer.Add(self.canvas, 1, wx.LEFT | wx.TOP | wx.GROW)
@@ -106,7 +107,7 @@ class CanvasFrame(wx.Frame):
         s = functions[plot_number][1](t)
         self.axes.clear()
         self.axes.plot(t, s)
-        self.Refresh()
+        self.canvas.draw()
 
 
 class MyApp(wx.App):

--- a/examples/user_interfaces/mathtext_wx.py
+++ b/examples/user_interfaces/mathtext_wx.py
@@ -46,8 +46,8 @@ class CanvasFrame(wx.Frame):
 
         self.canvas = FigureCanvas(self, -1, self.figure)
 
-        self.change_plot(0)        
-        
+        self.change_plot(0)
+
         self.sizer = wx.BoxSizer(wx.VERTICAL)
         self.add_buttonbar()
         self.sizer.Add(self.canvas, 1, wx.LEFT | wx.TOP | wx.GROW)


### PR DESCRIPTION
Running the [mathtext_wx example](https://github.com/matplotlib/matplotlib/blob/master/examples/user_interfaces/mathtext_wx.py) on Windows 7 or 10 with matplotlib 1.4.3 or 1.5.0rc2 and wxPython 3.0.2, the plot is not updated when pressing buttons or selecting menu items.
This PR fixes the example but might not be the correct fix.