### PR TITLE
TST: drop py2.6 & py3.3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,11 @@ language: python
 
 matrix:
   include:
-    - python: 2.6
-      env: NUMPY=numpy==1.6 MOCK=mock
     - python: 2.7
-      env: MOCK=mock PANDAS=pandas
-    - python: 3.3
+      env: MOCK=mock NUMPY=numpy==1.6
     - python: 3.4
     - python: 3.5
+      env: PANDAS=pandas
     - python: 2.7
       env: TEST_ARGS=--pep8
     - python: 2.7

--- a/setup.py
+++ b/setup.py
@@ -119,8 +119,11 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: Python Software Foundation License',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Topic :: Scientific/Engineering :: Visualization',
     ]
 


### PR DESCRIPTION
As discussed on the mailing list, going forward we will be dropping
support for python 2.6 and python 3.3.

This allows mpl to use ordered dicts and is required for in-progress
traitlet/serialization work.

 - moved minimum support numpy test to 2.7
 - moved pandas optional test dep to 3.5

http://matplotlib.1069221.n5.nabble.com/Matplotlib-devel-supported-python-versions-tt46154.html