### PR TITLE
Fix PathEffect rendering on some backends

### DIFF
--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -98,6 +98,9 @@ class PathEffectRenderer(RendererBase):
         self._path_effects = path_effects
         self._renderer = renderer
 
+    def new_gc(self):
+        return self._renderer.new_gc()
+
     def copy_with_path_effect(self, path_effects):
         return self.__class__(path_effects, self._renderer)
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -124,7 +124,8 @@ def test_composite_image():
 @cleanup
 def test_patheffects():
     with matplotlib.rc_context():
-        matplotlib.rcParams['path.effects'] = [patheffects.withStroke(linewidth=4, foreground='w')]
+        matplotlib.rcParams['path.effects'] = [
+            patheffects.withStroke(linewidth=4, foreground='w')]
         fig, ax = plt.subplots()
         ax.plot([1, 2, 3])
         with io.BytesIO() as ps:

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -10,6 +10,7 @@ from matplotlib.externals import six
 
 import matplotlib
 import matplotlib.pyplot as plt
+from matplotlib import patheffects
 from matplotlib.testing.decorators import cleanup, knownfailureif
 
 
@@ -118,6 +119,16 @@ def test_composite_image():
         ps.seek(0)
         buff = ps.read()
         assert buff.count(six.b(' colorimage')) == 2
+
+
+@cleanup
+def test_patheffects():
+    with matplotlib.rc_context():
+        matplotlib.rcParams['path.effects'] = [patheffects.withStroke(linewidth=4, foreground='w')]
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3])
+        with io.BytesIO() as ps:
+            fig.savefig(ps, format='ps')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The special sub-GC that is created by the PathEffectRenderer was of
GraphicsContextBase, rather than the backend-specific GC.

Fix #5049, Fix #4024 

Note that while this fixes the crashes in #5049, it does not mean that the sketch effect behind xkcd actually works in all backends -- that's more of a feature enhancement than a bugfix, because it never worked on all backends.