### PR TITLE
Update dateutil URL.

### DIFF
--- a/doc/glossary/index.rst
+++ b/doc/glossary/index.rst
@@ -16,7 +16,7 @@ Glossary
 
 
   dateutil
-      The `dateutil <http://labix.org/python-dateutil>`_ library
+      The `dateutil <https://dateutil.readthedocs.org>`_ library
       provides extensions to the standard datetime module
 
   EPS

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -40,7 +40,7 @@ assumed.  If you want to use a custom time zone, pass a
 locators you create.  See `pytz <http://pythonhosted.org/pytz/>`_ for
 information on :mod:`pytz` and timezone handling.
 
-The `dateutil module <http://labix.org/python-dateutil>`_ provides
+The `dateutil module <https://dateutil.readthedocs.org>`_ provides
 additional code to handle date ticking, making it easy to place ticks
 on any kinds of dates.  See examples below.
 
@@ -88,7 +88,7 @@ Here are all the date tickers:
       :class:`matplotlib.dates.rrulewrapper`.  The
       :class:`rrulewrapper` is a simple wrapper around a
       :class:`dateutil.rrule` (`dateutil
-      <http://labix.org/python-dateutil>`_) which allow almost
+      <https://dateutil.readthedocs.org>`_) which allow almost
       arbitrary date tick specifications.  See `rrule example
       <../examples/pylab_examples/date_demo_rrule.html>`_.
 


### PR DESCRIPTION
The current dateutil documentation is at [Read the Docs](https://dateutil.readthedocs.org). The old labix.org documentation is no longer updated and is increasingly out of date with the current library.

I have not updated [this reference](https://github.com/matplotlib/matplotlib/blob/cefab28635aa5e5f79ab3a8d22f5b8894a2609f1/lib/matplotlib/mlab.py#L2744) because that section is not currently included in the ReadTheDocs documentation (I'll remedy that in the next release). I also did not update [this reference](https://github.com/matplotlib/matplotlib/blob/9079a37e8503cd0d570a1509f67c67a729b39911/doc/users/whats_new.rst#L1705) because it seems historical anyway, but I could if that's preferred.