### PR TITLE
Remove mentions of SourceForge

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -66,12 +66,12 @@ you will also need to install compatible versions of
 `pyparsing <https://pypi.python.org/pypi/pyparsing/>`_, and
 `cycler <https://pypi.python.org/pypi/Cycler>`_
 in addition to
-`matplotlib <http://matplotlib.org/downloads.html>`_.
+`matplotlib <http://pypi.python.org/pypi/matplotlib/>`_.
 
 For Python 3.5 the `Visual C++ Redistributable for Visual Studio 2015
 <http://www.microsoft.com/en-us/download/details.aspx?id=48145>`_
 needs to be installed.
-In case Python 2.6 to 3.4 are not installed for all users (not the default), 
+In case Python 2.6 to 3.4 are not installed for all users (not the default),
 the Microsoft Visual C++ 2008 (
 `64 bit <http://www.microsoft.com/download/en/details.aspx?id=15336>`__
 or
@@ -109,19 +109,18 @@ standard Python shell or IPython. It is enabled as the default backend
 for the official binaries.  GTK3 is not supported on Windows.
 
 The Windows installers (:file:`*.exe`) and wheels (:file:`*.whl`) on
-the `download page <http://matplotlib.org/downloads.html>`_ do not
-contain test data or example code.
-If you want to try the many demos that come in the matplotlib source
-distribution, download the :file:`*.tar.gz` file and look in the
-:file:`examples` subdirectory.
+the `PyPI download page <http://pypi.python.org/pypi/matplotlib/>`_ do
+not contain test data or example code.  If you want to try the many
+demos that come in the matplotlib source distribution, download the
+:file:`*.tar.gz` file and look in the :file:`examples` subdirectory.
 To run the test suite, copy the :file:`lib\matplotlib\tests` and
-:file:`lib\mpl_toolkits\tests` directories from the source distribution to
-:file:`sys.prefix\Lib\site-packages\matplotlib` and
-:file:`sys.prefix\Lib\site-packages\mpl_toolkits` respectively, and install
-`nose <https://pypi.python.org/pypi/nose>`_,
-`mock <https://pypi.python.org/pypi/mock>`_,
-Pillow, MiKTeX, GhostScript, ffmpeg, avconv, mencoder, ImageMagick, and
-`Inkscape <http://inkscape.org/>`_.
+:file:`lib\mpl_toolkits\tests` directories from the source
+distribution to :file:`sys.prefix\Lib\site-packages\matplotlib` and
+:file:`sys.prefix\Lib\site-packages\mpl_toolkits` respectively, and
+install `nose <https://pypi.python.org/pypi/nose>`_, `mock
+<https://pypi.python.org/pypi/mock>`_, Pillow, MiKTeX, GhostScript,
+ffmpeg, avconv, mencoder, ImageMagick, and `Inkscape
+<http://inkscape.org/>`_.
 
 
 
@@ -133,10 +132,10 @@ Installing from source
 If you are interested in contributing to matplotlib development,
 running the latest source code, or just like to build everything
 yourself, it is not difficult to build matplotlib from source.  Grab
-the latest *tar.gz* release file from `the download page
-<http://matplotlib.org/downloads.html>`_, or if you want
-to develop matplotlib or just need the latest bugfixed version, grab
-the latest git version :ref:`install-from-git`.
+the latest *tar.gz* release file from `the PyPI files page
+<https://pypi.python.org/pypi/matplotlib/>`_, or if you want to
+develop matplotlib or just need the latest bugfixed version, grab the
+latest git version :ref:`install-from-git`.
 
 The standard environment variables `CC`, `CXX`, `PKG_CONFIG` are respected.
 This means you can set them if your toolchain is prefixed. This may be used for

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -178,12 +178,13 @@ axes and axis helpers in <a href="{{ pathto('mpl_toolkits/axes_grid/index') }}">
   <h1>Open source</h1>
 
 <p>
-Please consider <a href="http://numfocus.org/projects/">donating
-through Numfocus</a> to support matplotlib development or to
+Please
+consider <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=X9T4KLZT2794S">donating
+to the matplotlib project</a> through the Numfocus organization or to
 the <a href="http://numfocus.org/johnhunter/">John Hunter Memorial
 Fund</a>.
 </p>
-
+x
 <p>
 The matplotlib <a href="{{ pathto('users/license') }}">license</a> is based on the Python Software Foundation
 <a href="http://www.python.org/psf/license">(PSF)</a> license.

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -96,11 +96,11 @@ function getSnippet(id, url) {
   </table>
 </div>
 
-  <h1>Download</h1>
+  <h1>Installation</h1>
 
   Visit the
-  <a href="http://matplotlib.org/downloads.html">matplotlib downloads
-  page</a>.
+  <a href="http://matplotlib.org/users/installing.html">matplotlib
+  installation instructions.</a>.
 
   <h1>Documentation</h1>
 
@@ -131,8 +131,8 @@ Foundation Code of Conduct</a> in everything we do.</p>
 the <a href="{{ pathto('api/index') }}">api</a> docs,
 <a href="http://matplotlib.1069221.n5.nabble.com/matplotlib-users-f3.html">mailing
 list archives</a>, and join the matplotlib
-mailing lists <a href="https://mail.python.org/mailman/listinfo/matplotlib-users">Users</a>, 
-<a href="https://mail.python.org/mailman/listinfo/matplotlib-announce">Announce</a> and 
+mailing lists <a href="https://mail.python.org/mailman/listinfo/matplotlib-users">Users</a>,
+<a href="https://mail.python.org/mailman/listinfo/matplotlib-announce">Announce</a> and
 <a href="https://mail.python.org/mailman/listinfo/matplotlib-devel">Devel</a>.
 Check out the matplotlib questions
 on <a href="http://stackoverflow.com/questions/tagged/matplotlib">stackoverflow</a>.
@@ -178,8 +178,10 @@ axes and axis helpers in <a href="{{ pathto('mpl_toolkits/axes_grid/index') }}">
   <h1>Open source</h1>
 
 <p>
-Please consider <a href="http://sourceforge.net/project/project_donations.php?group_id=80706">donating</a>
-to support matplotlib development or to the <a href="http://numfocus.org/johnhunter/">John Hunter Memorial Fund</a>.
+Please consider <a href="http://numfocus.org/projects/">donating
+through Numfocus</a> to support matplotlib development or to
+the <a href="http://numfocus.org/johnhunter/">John Hunter Memorial
+Fund</a>.
 </p>
 
 <p>

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -90,84 +90,13 @@ Packaging
   :file:`release/win32` which you can use this to prepare the windows
   releases.
 
-Posting files
-=============
-
-Our current method is for the release manager to collect all of the
-binaries from the platform builders and post the files online on
-Sourceforge.  It is also possible that those building the binaries
-could upload to directly to Sourceforge.  We also post a source
-tarball to PyPI, since ``pip`` no longer trusts files downloaded from
-other sites.
-
-There are many ways to upload files to Sourceforge (`scp`, `rsync`,
-`sftp`, and a web interface) described in `Sourceforge Release File
-System documentation
-<https://sourceforge.net/apps/trac/sourceforge/wiki/Release%20files%20for%20download>`_.
-Below, we will use `sftp`.
-
-1. Create a directory containing all of the release files and `cd` to it.
-
-2. `sftp` to Sourceforge::
-
-     sftp USERNAME@frs.sourceforge.net:/home/frs/project/matplotlib/matplotlib
-
-3. Make a new directory for the release and move to it::
-
-     mkdir matplotlib-1.1.0rc1
-     cd matplotlib-1.1.0rc1
-
-4. Upload all of the files in the current directory on your local machine::
-
-     put *
-
-If this release is a final release, the default download for the
-matplotlib project should also be updated.  Login to Sourceforge and
-visit the `matplotlib files page
-<https://sourceforge.net/projects/matplotlib/files/matplotlib/>`_.
-Navigate to the tarball of the release you just updated, click on
-"Details" icon (it looks like a lower case ``i``), and make it the
-default download for all platforms.
-
-There is a list of direct links to downloads on matplotlib's main
-website.  This needs to be manually generated and updated every time
-new files are posted.
-
-1. Clone the matplotlib documentation repository and `cd` into it::
-
-     git clone git@github.com:matplotlib/matplotlib.github.com.git
-     cd matplotlib.github.com
-
-2. Update the list of downloads that you want to display by editing
-   the `downloads.txt` file.  Generally, this should contain the last two
-   final releases and any active release candidates.
-
-3. Update the downloads webpage by running the `update_downloads.py`
-   script.  This script requires `paramiko` (for `sftp` support) and
-   `jinja2` for templating.  Both of these dependencies can be
-   installed using pip::
-
-     pip install paramiko
-     pip install jinja2
-
-   Then update the download page::
-
-     ./update_downloads.py
-
-   You will be prompted for your Sourceforge username and password.
-
-4. Commit the changes and push them up to github::
-
-     git commit -m "Updating download list"
-     git push
 
 Update PyPI
 ===========
 
-Once the tarball has been posted on Sourceforge, you can register a
-link to the new release on PyPI.  This should only be done with final
-(non-release-candidate) releases, since doing so will hide any
-available stable releases.
+This step tells PyPI about the release and uploads a source
+tarball. This should only be done with final (non-release-candidate)
+releases, since doing so will hide any available stable releases.
 
 You may need to set up your `.pypirc` file as described in the
 `distutils register command documentation

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -597,7 +597,7 @@ in these environments.  Most importantly, you need to decide what
 kinds of images you want to generate (PNG, PDF, SVG) and configure the
 appropriate default backend.  For 99% of users, this will be the Agg
 backend, which uses the C++
-`antigrain <http://agg.sourceforge.net/antigrain.com/index.html>`_
+`antigrain <http://antigrain.com>`_
 rendering engine to make nice PNGs.  The Agg backend is also
 configured to recognize requests to generate other output formats
 (PDF, PS, EPS, SVG).  The easiest way to configure matplotlib to use

--- a/doc/faq/installing_faq.rst
+++ b/doc/faq/installing_faq.rst
@@ -390,8 +390,8 @@ Standalone binary installers for Windows
 
 If you have already installed Python and numpy, you can use one of the
 matplotlib binary installers for windows -- you can get these from the
-`download <http://matplotlib.org/downloads.html>`_ site.  Chose the files with
-an ``.exe`` extension that match your version of Python (e.g., ``py2.7`` if you
-installed Python 2.7).  If you haven't already installed Python, you can get
-the official version from the `Python web site
-<http://python.org/download/>`_.
+`the PyPI matplotlib page <http://pypi.python.org/pypi/matplotlib>`_
+site.  Choose the files with an ``.exe`` extension that match your
+version of Python (e.g., ``py2.7`` if you installed Python 2.7).  If
+you haven't already installed Python, you can get the official version
+from the `Python web site <http://python.org/download/>`_.

--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -70,7 +70,7 @@ directory by default::
 If you would like to use a different configuration directory, you can
 do so by specifying the location in your :envvar:`MPLCONFIGDIR`
 environment variable -- see
-:ref:`setting-linux-osx-environment-variables`.  Note that 
+:ref:`setting-linux-osx-environment-variables`.  Note that
 :envvar:`MPLCONFIGDIR` sets the location of both the configuration
 directory and the cache directory.
 
@@ -101,9 +101,8 @@ please provide the following information in your e-mail to the
         python -c `import matplotlib; print matplotlib.__version__`
 
   * where you obtained matplotlib (e.g., your Linux distribution's
-    packages or the matplotlib Sourceforge site, or
-    Anaconda_ or
-    `Enthought Canopy <https://www.enthought.com/products/canopy/>`_).
+    packages, github, PyPi, or Anaconda_ or `Enthought Canopy
+    <https://www.enthought.com/products/canopy/>`_).
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda/
 
@@ -168,9 +167,9 @@ simple test script in debug mode::
 
 and post :file:`build.out` and :file:`run.out` to the
 `matplotlib-devel
-<http://lists.sourceforge.net/mailman/listinfo/matplotlib-devel>`_
+<http://mail.python.org/mailman/listinfo/matplotlib-devel>`_
 mailing list (please do not post git problems to the `users list
-<http://lists.sourceforge.net/mailman/listinfo/matplotlib-users>`_).
+<https://mail.python.org/mailman/listinfo/matplotlib-users>`_).
 
 Of course, you will want to clearly describe your problem, what you
 are expecting and what you are getting, but often a clean build and

--- a/doc/faq/usage_faq.rst
+++ b/doc/faq/usage_faq.rst
@@ -437,7 +437,7 @@ macosx         Cocoa rendering in OSX windows
                is in non-interactive mode)
 ============   ================================================================
 
-.. _`Anti-Grain Geometry`: http://agg.sourceforge.net/antigrain.com/index.html
+.. _`Anti-Grain Geometry`: http://antigrain.com/
 .. _Postscript: http://en.wikipedia.org/wiki/PostScript
 .. _`Portable Document Format`: http://en.wikipedia.org/wiki/Portable_Document_Format
 .. _`Scalable Vector Graphics`: http://en.wikipedia.org/wiki/Scalable_Vector_Graphics

--- a/doc/glossary/index.rst
+++ b/doc/glossary/index.rst
@@ -8,7 +8,7 @@ Glossary
 .. glossary::
 
   AGG
-      The Anti-Grain Geometry (`Agg <http://agg.sourceforge.net/antigrain.com/index.html>`_) rendering engine, capable of rendering
+      The Anti-Grain Geometry (`Agg <http://antigrain.com/>`_) rendering engine, capable of rendering
       high-quality images
 
   Cairo

--- a/doc/mpl_toolkits/index.rst
+++ b/doc/mpl_toolkits/index.rst
@@ -135,9 +135,7 @@ Natgrid
 
 mpl_toolkits.natgrid is an interface to natgrid C library for gridding
 irregularly spaced data.  This requires a separate installation of the
-natgrid toolkit from the sourceforge `download
-<http://sourceforge.net/project/showfiles.php?group_id=80706&package_id=142792>`_
-page.
+`natgrid toolkit <http://github.com/matplotlib/natgrid>`__.
 
 
 .. _toolkit_matplotlibvenn:

--- a/doc/pyplots/tex_demo.py
+++ b/doc/pyplots/tex_demo.py
@@ -4,7 +4,7 @@ Demo of TeX rendering.
 You can use TeX to render all of your matplotlib text if the rc
 parameter text.usetex is set.  This works currently on the agg and ps
 backends, and requires that you have tex and the other dependencies
-described at http://matplotlib.sf.net/matplotlib.texmanager.html
+described at http://matplotlib.org/users/usetex.html
 properly installed on your system.  The first time you run a script
 you will see a lot of output from tex and associated tools.  The next
 time, the run may be silent, as a lot of the information is cached in

--- a/doc/users/intro.rst
+++ b/doc/users/intro.rst
@@ -73,7 +73,7 @@ backends: PS creates `PostScript®
 <http://www.adobe.com/products/postscript/>`_ hardcopy, SVG
 creates `Scalable Vector Graphics <http://www.w3.org/Graphics/SVG/>`_
 hardcopy, Agg creates PNG output using the high quality `Anti-Grain
-Geometry <http://agg.sourceforge.net/antigrain.com/index.html>`_
+Geometry <http://antigrain.com/>`_
 library that ships with matplotlib, GTK embeds matplotlib in a
 `Gtk+ <http://www.gtk.org/>`_
 application, GTKAgg uses the Anti-Grain renderer to create a figure
@@ -92,5 +92,3 @@ embed matplotlib in a Gtk+ EEG application that runs on Windows, Linux
 and Macintosh OS X.
 
 .. [*] MATLAB is a registered trademark of The MathWorks, Inc.
-
-

--- a/doc/users/screenshots.rst
+++ b/doc/users/screenshots.rst
@@ -279,10 +279,9 @@ rendering of strings with the *usetex* option.
 EEG demo
 =========
 
-You can embed matplotlib into pygtk, wx, Tk, FLTK, or Qt
-applications.  Here is a screenshot of an EEG viewer called pbrain,
-which is part of the NeuroImaging in Python suite
-`NIPY <http://nipy.sourceforge.net/nipy/stable/index.html>`_.
+You can embed matplotlib into pygtk, wx, Tk, FLTK, or Qt applications.
+Here is a screenshot of an EEG viewer called `pbrain
+<http://github.com/nipy/pbrain>`__.
 
 .. image:: ../_static/eeg_small.png
 

--- a/doc/users/usetex.rst
+++ b/doc/users/usetex.rst
@@ -151,7 +151,7 @@ Troubleshooting
 * If you still need help, please see :ref:`reporting-problems`
 
 .. _LaTeX: http://www.tug.org
-.. _dvipng: http://sourceforge.net/projects/dvipng
+.. _dvipng: http://www.nongnu.org/dvipng/
 .. _Ghostscript: http://www.cs.wisc.edu/~ghost/
 .. _PSNFSS: http://www.ctan.org/tex-archive/macros/latex/required/psnfss/psnfss2e.pdf
 .. _Poppler: http://poppler.freedesktop.org/

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -2000,9 +2000,9 @@ figures since the last call.  Eric has done a lot of testing on the
 user interface toolkits and versions and platforms he has access to,
 but it is not possible to test them all, so please report problems to
 the `mailing list
-<http://sourceforge.net/mailarchive/forum.php?forum_name=matplotlib-users>`_
+<http://mail.python.org/mailman/listinfo/matplotlib-users`_
 and `bug tracker
-<http://sourceforge.net/tracker/?group_id=80706&atid=560720>`_.
+<http://github.com/matplotlib/matplotlib/issues>`_.
 
 
 mplot3d graphs can be embedded in arbitrary axes

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -17,16 +17,12 @@ directories found here:
   * animation - dynamic plots, see the tutorial at
     http://www.scipy.org/Cookbook/Matplotlib/Animations
 
-  * api - working with the matplotlib API directory.  See the
-    doc/artist_api_tut.txt in the matplotlib src directory ((PDF at
-    http://matplotlib.sf.net/pycon)
+  * api - working with the matplotlib API directory.
 
   * axes_grid - Examples related to the AxesGrid toolkit
 
   * event_handling - how to interact with your figure, mouse presses,
-    key presses, object picking, etc.  See the event handling tutorial
-    in the "doc" directory of the source distribution (PDF at
-    http://matplotlib.sf.net/pycon)
+    key presses, object picking, etc.
 
   * misc - some miscellaneous examples.  some demos for loading and
     working with record arrays

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1076,8 +1076,9 @@ def _rc_params_in_file(fname, fail_on_error=False):
 Bad key "%s" on line %d in
 %s.
 You probably need to get an updated matplotlibrc file from
-http://matplotlib.sf.net/_static/matplotlibrc or from the matplotlib source
-distribution""" % (key, cnt, fname), file=sys.stderr)
+http://github.com/matplotlib/matplotlib/blob/master/matplotlibrc.template
+or from the matplotlib source distribution""" % (key, cnt, fname),
+                  file=sys.stderr)
 
     return config
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3417,12 +3417,11 @@ def griddata(x, y, z, xi, yi, interp='nn'):
         try:
             from mpl_toolkits.natgrid import _natgrid
         except ImportError:
-            raise RuntimeError("To use interp='nn' (Natural Neighbor "
-                               "interpolation) in griddata, natgrid must be "
-                               "installed. Either install it from http://"
-                               "sourceforge.net/projects/matplotlib/files/"
-                               "matplotlib-toolkits, or use interp='linear' "
-                               "instead.")
+            raise RuntimeError(
+                "To use interp='nn' (Natural Neighbor interpolation) in "
+                "griddata, natgrid must be installed. Either install it "
+                "from http://github.com/matplotlib/natgrid or use "
+                "interp='linear' instead.")
 
         if xi.ndim == 2:
             # natgrid expects 1D xi and yi arrays.

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -26,8 +26,8 @@ as follows::
   Z = self.texmanager.get_rgba(s, size=12, dpi=80, rgb=(1,0,0))
 
 To enable tex rendering of all text in your matplotlib figure, set
-text.usetex in your matplotlibrc file (http://matplotlib.sf.net/matplotlibrc)
-or include these two lines in your script::
+text.usetex in your matplotlibrc file or include these two lines in
+your script::
 
   from matplotlib import rc
   rc('text', usetex=True)

--- a/setup.py
+++ b/setup.py
@@ -366,7 +366,7 @@ if __name__ == '__main__':
         package_dir=package_dir,
         package_data=package_data,
         classifiers=classifiers,
-        download_url="https://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-{0}/matplotlib-{0}.tar.gz".format(__version__),
+        download_url="http://matplotlib.org/users/installing.html",
 
         # List third-party Python packages that we require
         install_requires=install_requires,


### PR DESCRIPTION
As discussed, for a number of reasons, we feel we should move away from
SourceForge.

Fix #5227

Related to https://github.com/matplotlib/matplotlib.github.com/pull/12