### PR TITLE
include links to the mailing list in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,3 +29,13 @@ Or from the python interpreter::
 
 Consider reading http://matplotlib.org/devel/coding_guide.html#testing for
 more information.
+
+Contact
+=======
+matplotlib's communication channels include active mailing lists:
+
+* Matplotlib-announce (https://mail.python.org/mailman/listinfo/matplotlib-announce),
+* Matplotlib-devel (https://mail.python.org/mailman/listinfo/matplotlib-devel),
+* Matplotlib-users (https://mail.python.org/mailman/listinfo/matplotlib-users).
+
+The latter is probably a good starting point for general questions and discussions.


### PR DESCRIPTION
This should hopefully help the actual mailing lists gain some Google traction. (As opposed to the old sourceforge ones which still come out on top when googling.)