### PR TITLE
Throw errors when indexing into empty array_view objects

### DIFF
--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -539,7 +539,17 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
 
     size_t size() const
     {
-        return (size_t)dim(0);
+        bool empty = (ND == 0);
+        for (size_t i = 0; i < ND; i++) {
+            if (m_shape[i] == 0) {
+                empty = true;
+            }
+        }
+        if (empty) {
+            return 0;
+        } else {
+            return (size_t)dim(0);
+        }
     }
 
     bool empty() const

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -539,13 +539,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
 
     size_t size() const
     {
-        bool empty = (ND == 0);
-        for (size_t i = 0; i < ND; i++) {
-            if (m_shape[i] == 0) {
-                empty = true;
-            }
-        }
-        if (empty) {
+        if (m_data == NULL) {
             return 0;
         } else {
             return (size_t)dim(0);

--- a/src/py_exceptions.h
+++ b/src/py_exceptions.h
@@ -32,7 +32,7 @@ class exception : public std::exception
     }                                                                                              \
     catch (const std::bad_alloc)                                                                   \
     {                                                                                              \
-        PyErr_Format(PyExc_MemoryError, "In %s: Out of memory", (name));                         \
+        PyErr_Format(PyExc_MemoryError, "In %s: Out of memory", (name));                           \
         {                                                                                          \
             cleanup;                                                                               \
         }                                                                                          \
@@ -40,7 +40,15 @@ class exception : public std::exception
     }                                                                                              \
     catch (const std::overflow_error &e)                                                           \
     {                                                                                              \
-        PyErr_Format(PyExc_OverflowError, "In %s: %s", (name), e.what());                        \
+        PyErr_Format(PyExc_OverflowError, "In %s: %s", (name), e.what());                          \
+        {                                                                                          \
+            cleanup;                                                                               \
+        }                                                                                          \
+        return (errorcode);                                                                        \
+    }                                                                                              \
+    catch (const std::out_of_range &e)                                                             \
+    {                                                                                              \
+        PyErr_Format(PyExc_IndexError, "In %s: %s", (name), e.what());                             \
         {                                                                                          \
             cleanup;                                                                               \
         }                                                                                          \
@@ -48,7 +56,7 @@ class exception : public std::exception
     }                                                                                              \
     catch (char const *e)                                                                          \
     {                                                                                              \
-        PyErr_Format(PyExc_RuntimeError, "In %s: %s", (name), e);                                \
+        PyErr_Format(PyExc_RuntimeError, "In %s: %s", (name), e);                                  \
         {                                                                                          \
             cleanup;                                                                               \
         }                                                                                          \


### PR DESCRIPTION
A lower-level complement to #5246, raises an exception when indexing into an `array_view` that includes no data. Should catch issues like #5185 while not adding a big performance penalty in the normal case of nonempty arrays, but of course doesn't catch out-of-bounds errors in that case. I didn't measure the performance impact, but running the tests felt subjectively as fast as usual.