### PR TITLE
FIX: Make array_view.size return 0 for empty arrays

### DIFF
--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -481,7 +481,17 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
 
     size_t size() const
     {
-        return (size_t)dim(0);
+        bool empty = (ND == 0);
+        for (size_t i = 0; i < ND; i++) {
+            if (m_shape[i] == 0) {
+                empty = true;
+            }
+        }
+        if (empty) {
+            return 0;
+        } else {
+            return (size_t)dim(0);
+        }
     }
 
     bool empty() const


### PR DESCRIPTION
This is an API change that seems somewhat illogical to me, but it probably avoids errors like #5185 without fixes like #5241, which seems more puzzling to me. What I mean by illogical is that a sequence with a nonzero number of zero-sized elements is presented as having length 0. But making it consistent in that corner case is probably more puzzling to code using `array_view` than returning the actual number of empty elements.