### PR TITLE
AutoMinorLocator and and logarithmic axis

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1924,8 +1924,7 @@ class AutoLocator(MaxNLocator):
 class AutoMinorLocator(Locator):
     """
     Dynamically find minor tick positions based on the positions of
-    major ticks. Assumes the scale is linear and major ticks are
-    evenly spaced.
+    major ticks. The scale must be linear with major ticks evenly spaced.
     """
     def __init__(self, n=None):
         """
@@ -1939,6 +1938,10 @@ class AutoMinorLocator(Locator):
 
     def __call__(self):
         'Return the locations of the ticks'
+        if self.axis.get_scale() != 'linear':
+            warnings.warn('AutoMinorLocator only works with linear scale')
+            return []
+
         majorlocs = self.axis.get_majorticklocs()
         try:
             majorstep = majorlocs[1] - majorlocs[0]

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1938,8 +1938,9 @@ class AutoMinorLocator(Locator):
 
     def __call__(self):
         'Return the locations of the ticks'
-        if self.axis.get_scale() != 'linear':
-            warnings.warn('AutoMinorLocator only works with linear scale')
+        if self.axis.get_scale() == 'log':
+            warnings.warn('AutoMinorLocator does not work with logarithmic '
+                          'scale')
             return []
 
         majorlocs = self.axis.get_majorticklocs()


### PR DESCRIPTION
Adds logic to check the scale when generating the ticks for `AutoMinorLocator` rather than just assuming it is linear scale. Outputs a warning if scale is not linear with no minor ticks.