### PR TITLE
Add rc parameters for tight_layout parameters

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1728,6 +1728,13 @@ class Figure(Artist):
                                          rect=rect)
 
         self.subplots_adjust(**kwargs)
+        self._tight_parameters.update(
+                (k, v) for k, v in (
+                        ('pad', pad),
+                        ('h_pad', h_pad),
+                        ('w_pad', w_pad),
+                        ('rect', rect),
+                ) if v is not None)
 
 
 def figaspect(arg):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1691,7 +1691,7 @@ class Figure(Artist):
 
         return bbox_inches
 
-    def tight_layout(self, renderer=None, pad=1.08, h_pad=None,
+    def tight_layout(self, renderer=None, pad=None, h_pad=None,
                      w_pad=None, rect=None):
         """
         Adjust subplot parameters to give specified padding.
@@ -1701,9 +1701,11 @@ class Figure(Artist):
           *pad* : float
             padding between the figure edge and the edges of subplots,
             as a fraction of the font-size.
+            Defaults to rc ``figure.autolayout.pad``.
           *h_pad*, *w_pad* : float
             padding (height/width) between edges of adjacent subplots.
-            Defaults to `pad_inches`.
+            Defaults to `pad` if given or rc ``figure.autolayout.hpad``,
+            ``figure.autolayout.wpad``.
           *rect* : if rect is given, it is interpreted as a rectangle
             (left, bottom, right, top) in the normalized figure
             coordinate that the whole subplots area (including

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -276,7 +276,7 @@ class GridSpec(GridSpecBase):
         return [k for k in self._AllowedKeys if getattr(self, k)]
 
 
-    def tight_layout(self, fig, renderer=None, pad=1.08, h_pad=None, w_pad=None, rect=None):
+    def tight_layout(self, fig, renderer=None, pad=None, h_pad=None, w_pad=None, rect=None):
         """
         Adjust subplot parameters to give specified padding.
 
@@ -284,9 +284,11 @@ class GridSpec(GridSpecBase):
 
         pad : float
             padding between the figure edge and the edges of subplots, as a fraction of the font-size.
+            Defaults to rc ``figure.autolayout.pad``.
         h_pad, w_pad : float
             padding (height/width) between edges of adjacent subplots.
-            Defaults to `pad_inches`.
+            Defaults to `pad` if given or rc ``figure.autolayout.hpad``,
+            ``figure.autolayout.wpad``.
         rect : if rect is given, it is interpreted as a rectangle
             (left, bottom, right, top) in the normalized figure
             coordinate that the whole subplots area (including

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1358,7 +1358,7 @@ def subplot_tool(targetfig=None):
     return ret
 
 
-def tight_layout(pad=1.08, h_pad=None, w_pad=None, rect=None):
+def tight_layout(pad=None, h_pad=None, w_pad=None, rect=None):
     """
     Automatically adjust subplot parameters to give specified padding.
 
@@ -1366,9 +1366,10 @@ def tight_layout(pad=1.08, h_pad=None, w_pad=None, rect=None):
 
     pad : float
         padding between the figure edge and the edges of subplots, as a fraction of the font-size.
+        Defaults to rc ``figure.autolayout.pad``.
     h_pad, w_pad : float
         padding (height/width) between edges of adjacent subplots.
-        Defaults to `pad_inches`.
+        Defaults to `pad` if given or rc ``figure.autolayout.hpad``, ``figure.autolayout.wpad``.
     rect : if rect is given, it is interpreted as a rectangle
         (left, bottom, right, top) in the normalized figure
         coordinate that the whole subplots area (including

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1047,8 +1047,12 @@ defaultParams = {
     'figure.facecolor':  ['0.75', validate_color],  # facecolor; scalar gray
     'figure.edgecolor':  ['w', validate_color],  # edgecolor; white
     'figure.frameon':    [True, validate_bool],
-    'figure.autolayout': [False, validate_bool],
     'figure.max_open_warning': [20, validate_int],
+
+    'figure.autolayout': [False, validate_bool],
+    'figure.autolayout.pad': [1.08, validate_float],
+    'figure.autolayout.hpad': [1.08, validate_float],
+    'figure.autolayout.wpad': [1.08, validate_float],
 
     'figure.subplot.left': [0.125, ValidateInterval(0, 1, closedmin=True,
                                                        closedmax=True)],

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -39,7 +39,7 @@ def auto_adjust_subplotpars(fig, renderer,
                             num1num2_list,
                             subplot_list,
                             ax_bbox_list=None,
-                            pad=1.08, h_pad=None, w_pad=None,
+                            pad=None, h_pad=None, w_pad=None,
                             rect=None):
     """
     Return a dictionary of subplot parameters so that spacing between
@@ -62,29 +62,38 @@ def auto_adjust_subplotpars(fig, renderer,
     pad : float
       padding between the figure edge and the edges of subplots, as a fraction
       of the font-size.
+      Defaults to rc ``figure.autolayout.pad``.
+
     h_pad, w_pad : float
       padding (height/width) between edges of adjacent subplots.
-        Defaults to `pad_inches`.
+      Defaults to `pad` if given or rc ``figure.autolayout.hpad``,
+      ``figure.autolayout.wpad``.
 
     rect
       [left, bottom, right, top] in normalized (0, 1) figure coordinates.
     """
     rows, cols = nrows_ncols
 
-    pad_inches = pad * FontProperties(
+    if h_pad is None:
+        if pad is not None:
+            h_pad = pad
+        else:
+            h_pad = rcParams["figure.autolayout.hpad"]
+    vpad_inches = h_pad * FontProperties(
                     size=rcParams["font.size"]).get_size_in_points() / 72.
 
-    if h_pad is not None:
-        vpad_inches = h_pad * FontProperties(
-                        size=rcParams["font.size"]).get_size_in_points() / 72.
-    else:
-        vpad_inches = pad_inches
+    if w_pad is None:
+        if pad is not None:
+            w_pad = pad
+        else:
+            w_pad = rcParams["figure.autolayout.wpad"]
+    hpad_inches = w_pad * FontProperties(
+                    size=rcParams["font.size"]).get_size_in_points() / 72.
 
-    if w_pad is not None:
-        hpad_inches = w_pad * FontProperties(
-                        size=rcParams["font.size"]).get_size_in_points() / 72.
-    else:
-        hpad_inches = pad_inches
+    if pad is None:
+        pad = rcParams["figure.autolayout.pad"]
+    pad_inches = pad * FontProperties(
+                    size=rcParams["font.size"]).get_size_in_points() / 72.
 
     if len(subplot_list) == 0:
         raise RuntimeError("")
@@ -261,7 +270,7 @@ def get_subplotspec_list(axes_list, grid_spec=None):
 
 
 def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
-                            pad=1.08, h_pad=None, w_pad=None, rect=None):
+                            pad=None, h_pad=None, w_pad=None, rect=None):
     """
     Return subplot parameters for tight-layouted-figure with specified
     padding.
@@ -280,10 +289,12 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
       *pad* : float
         padding between the figure edge and the edges of subplots,
         as a fraction of the font-size.
+        Defaults to rc ``figure.autolayout.pad``.
 
       *h_pad*, *w_pad* : float
         padding (height/width) between edges of adjacent subplots.
-        Defaults to `pad_inches`.
+        Defaults to `pad` if given or rc ``figure.autolayout.hpad``,
+        ``figure.autolayout.wpad``.
 
       *rect* : if rect is given, it is interpreted as a rectangle
         (left, bottom, right, top) in the normalized figure
@@ -366,9 +377,6 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
             right -= (1 - kwargs["right"])
         if top is not None:
             top -= (1 - kwargs["top"])
-
-        #if h_pad is None: h_pad = pad
-        #if w_pad is None: w_pad = pad
 
         kwargs = auto_adjust_subplotpars(fig, renderer,
                                          nrows_ncols=(max_nrows, max_ncols),

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -357,9 +357,9 @@ backend      : %(backend)s
 #image.lut    : 256               # the size of the colormap lookup table
 #image.origin : upper             # lower | upper
 #image.resample  : False
-#image.composite_image : True     # When True, all the images on a set of axes are 
-                                  # combined into a single composite image before 
-                                  # saving a figure as a vector graphics file, 
+#image.composite_image : True     # When True, all the images on a set of axes are
+                                  # combined into a single composite image before
+                                  # saving a figure as a vector graphics file,
                                   # such as a PDF.
 
 ### CONTOUR PLOTS

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -335,11 +335,16 @@ backend      : %(backend)s
 #figure.dpi       : 80      # figure dots per inch
 #figure.facecolor : 0.75    # figure facecolor; 0.75 is scalar gray
 #figure.edgecolor : white   # figure edgecolor
-#figure.autolayout : False  # When True, automatically adjust subplot
-                            # parameters to make the plot fit the figure
 #figure.max_open_warning : 20  # The maximum number of figures to open through
                                # the pyplot interface before emitting a warning.
                                # If less than one this feature is disabled.
+
+# Figure tight_layout parameters. All dimensions are in units of the font size.
+#figure.autolayout : False      # When True, automatically adjust subplot
+                                # parameters to make the plot fit the figure
+#figure.autolayout.pad  : 1.08  # padding between the figure edge and the edges of subplots
+#figure.autolayout.hpad : 1.08  # vertical padding between edges of adjacent subplots
+#figure.autolayout.wpad : 1.08  # horizontal padding between edges of adjacent subplots
 
 # The figure subplot parameters.  All dimensions are a fraction of the
 # figure width or height


### PR DESCRIPTION
The second commit fixes what I think is a bug. Setting the parameters using `fig.tight_layout(…)` would not save them. Not sure about backward compatibility here.

To preserve backward compatibility, calling `fig.tight_layout(pad=pad)` will set `h_pad = w_pad = pad`. All three paddings default to `1.08` (in units of `font.size`).

This probably needs tests and a what's new entry, but I thought I would propose it first.

Fixes #5266.
