### PR TITLE
Provide message if test data is not installed

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1484,6 +1484,9 @@ default_test_modules = [
 
 
 def verify_test_dependencies():
+    if not os.path.isdir(os.path.join(os.path.dirname(__file__), 'tests')):
+        raise ImportError("matplotlib test data is not installed")
+
     try:
         import nose
         try:

--- a/tests.py
+++ b/tests.py
@@ -45,6 +45,10 @@ def run(extra_args):
     else:
         faulthandler.enable()
 
+    if not os.path.isdir(
+            os.path.join(os.path.dirname(matplotlib.__file__), 'tests')):
+        raise ImportError("matplotlib test data is not installed")
+
     nose.main(addplugins=[x() for x in plugins],
               defaultTest=default_test_modules,
               argv=sys.argv + extra_args)


### PR DESCRIPTION
I'd like to squeak this one in 1.5.  One of the things I'd like to do for the conda package for 1.5 is to not include the test data (brings the package size down to 6MB from 46MB).  This will provide a nice error message if the test data is not included.