### PR TITLE
Always remake the subsliced line.  Fix #5270

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -717,10 +717,8 @@ class Line2D(Artist):
             i0, = self._x_filled.searchsorted([x0], 'left')
             i1, = self._x_filled.searchsorted([x1], 'right')
             subslice = slice(max(i0 - 1, 0), i1 + 1)
-            # Don't remake the Path unless it will be sufficiently smaller.
-            if subslice.start > 100 or len(self._x) - subslice.stop > 100:
-                self.ind_offset = subslice.start
-                self._transform_path(subslice)
+            self.ind_offset = subslice.start
+            self._transform_path(subslice)
 
         transf_path = self._get_transformed_path()
 


### PR DESCRIPTION
Before, the subsliced line will only be made if it's sufficiently
smaller than before.  However, when zooming out after zooming in,
it may actually be *larger* than before.  Rather than tracking which is
occurring, it's best to just always remake -- it doesn't seem to be an
important optimization anyway.