### PR TITLE
Use lock directory to prevent race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,6 @@ script:
   # Travis VM to run out of memory (since so many copies of inkscape and
   # ghostscript are running at the same time).
   - echo Testing using $NPROC processes
-  # Generate the font caches in a single process before starting the
-  # multiple processes
-  - python -c "from matplotlib import font_manager"
   - |
     if [[ $BUILD_DOCS == false ]]; then
       export MPL_REPO_DIR=$PWD  # needed for pep8-conformance test of the examples

--- a/LICENSE/LICENSE_CONDA
+++ b/LICENSE/LICENSE_CONDA
@@ -1,0 +1,51 @@
+Except where noted below, conda is released under the following terms:
+
+(c) 2012 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Exceptions
+==========
+
+versioneer.py is Public Domain
+
+The ProgressBar package is released under the following terms:
+
+# progressbar  - Text progress bar library for Python.
+# Copyright (c) 2005 Nilton Volpato
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1405,10 +1405,9 @@ if USE_FONTCONFIG and sys.platform != 'win32':
 else:
     _fmcache = None
 
-    if not 'TRAVIS' in os.environ:
-        cachedir = get_cachedir()
-        if cachedir is not None:
-            _fmcache = os.path.join(cachedir, 'fontList.json')
+    cachedir = get_cachedir()
+    if cachedir is not None:
+        _fmcache = os.path.join(cachedir, 'fontList.json')
 
     fontManager = None
 
@@ -1419,9 +1418,13 @@ else:
 
     def _rebuild():
         global fontManager
+
         fontManager = FontManager()
+
         if _fmcache:
-            json_dump(fontManager, _fmcache)
+            with cbook.Locked(cachedir):
+                json_dump(fontManager, _fmcache)
+
         verbose.report("generated new fontManager")
 
     if _fmcache:

--- a/tests.py
+++ b/tests.py
@@ -21,13 +21,6 @@ from nose.plugins import attrib
 from matplotlib.testing.noseclasses import KnownFailure
 from matplotlib import default_test_modules
 
-from matplotlib import font_manager
-# Make sure the font caches are created before starting any possibly
-# parallel tests
-if font_manager._fmcache is not None:
-    while not os.path.exists(font_manager._fmcache):
-        time.sleep(0.5)
-
 plugins = [KnownFailure, attrib.Plugin]
 
 # Nose doesn't automatically instantiate all of the plugins in the


### PR DESCRIPTION
Creation of the font cache has race conditions.

~~Adds a dependency on lockfile.  We could vendor it if we want to, but the last thing I want to do is maintain cross-platform lockfile code...~~

Fix #5226.