### PR TITLE
TST: fix PermissionError on Windows

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from nose.tools import assert_equal
 from matplotlib.externals import six
 
+import sys
 import os
 import tempfile
 import warnings
@@ -24,9 +25,14 @@ def test_font_priority():
 
 def test_json_serialization():
     with tempfile.NamedTemporaryFile() as temp:
-        temp.close()
+        if sys.platform == 'win32':
+            # on Windows, an open NamedTemporaryFile can not be used
+            # to open the file a second time
+            temp.close()
         json_dump(fontManager, temp.name)
         copy = json_load(temp.name)
+        if sys.platform == 'win32':
+            os.remove(temp.name)
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', 'findfont: Font family.*not found')
         for prop in ({'family': 'STIXGeneral'},

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -24,6 +24,7 @@ def test_font_priority():
 
 def test_json_serialization():
     with tempfile.NamedTemporaryFile() as temp:
+        temp.close()
         json_dump(fontManager, temp.name)
         copy = json_load(temp.name)
     with warnings.catch_warnings():


### PR DESCRIPTION
On Windows, a open [NamedTemporaryFile](https://docs.python.org/2/library/tempfile.html#tempfile.NamedTemporaryFile) can not be used to open the file a second time.

Fixes one test error:
```
======================================================================
ERROR: matplotlib.tests.test_font_manager.test_json_serialization
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python35\lib\site-packages\matplotlib\tests\test_font_manager.py", line 27, in test_json_serialization
    json_dump(fontManager, temp.name)
  File "X:\Python35\lib\site-packages\matplotlib\font_manager.py", line 978, in json_dump
    with open(filename, 'w') as fh:
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\gohlke\\AppData\\Local\\Temp\\tmpc1j8d7dc'
```