### PR TITLE
On Windows, use absolute paths to figures in Sphinx documents if necessary

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -748,7 +748,12 @@ def run(arguments, content, options, state_machine, state, lineno):
     # how to link to files from the RST file
     dest_dir_link = os.path.join(relpath(setup.confdir, rst_dir),
                                  source_rel_dir).replace(os.path.sep, '/')
-    build_dir_link = relpath(build_dir, rst_dir).replace(os.path.sep, '/')
+    try:
+        build_dir_link = relpath(build_dir, rst_dir).replace(os.path.sep, '/')
+    except ValueError:
+        # on Windows, relpath raises ValueError when path and start are on
+        # different mounts/drives
+        build_dir_link = build_dir
     source_link = dest_dir_link + '/' + output_base + source_ext
 
     # make figures


### PR DESCRIPTION
Fixes one test error:
```
======================================================================
ERROR: test suite for <class 'matplotlib.sphinxext.tests.test_tinypages.TestTinyPages'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\nose\suite.py", line 210, in run
    self.setUp()
  File "X:\Python35\lib\site-packages\nose\suite.py", line 293, in setUp
    self.setupContext(ancestor)
  File "X:\Python35\lib\site-packages\nose\suite.py", line 316, in setupContext
    try_run(context, names)
  File "X:\Python35\lib\site-packages\nose\util.py", line 471, in try_run
    return func()
  File "X:\Python35\lib\site-packages\matplotlib\sphinxext\tests\test_tinypages.py", line 58, in setup_class
    out, err))
RuntimeError: sphinx-build failed with stdout:
b'Running Sphinx v1.3.1\r\nmaking output directory...\r\nloading pickled environment... not yet created\r\nbuilding [mo]: targets for 0 po files that are out of date\r\nbuilding [html]: targets for 2 source files that are out of date\r\nupdating environment: 2 added, 0 changed, 0 removed\r\nreading sources... [ 50%] index                                                \rreading sources... [100%] some_plots                                           \r'
stderr:
b'\r\nException occurred:\r\n  File "x:\\python35\\lib\\ntpath.py", line 574, in relpath\r\n    path_drive, start_drive))\r\nValueError: path is on mount \'C:\', start on mount \'X:\'\r\nThe full traceback has been saved in C:\\Users\\gohlke\\AppData\\Local\\Temp\\sphinx-err-mcdwp97s.log, if you want to report the issue to the developers.\r\nPlease also report this if it was a user error, so that a better error message can be provided next time.\r\nA bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!\r\n'
```

```
# Sphinx version: 1.3.1
# Python version: 3.5.0 (CPython)
# Docutils version: 0.12 release
# Jinja2 version: 2.8
# Last messages:
#   Running Sphinx v1.3.1
#   making output directory...
#   loading pickled environment...
#   not yet created
#   building [mo]: targets for 0 po files that are out of date
#   building [html]: targets for 2 source files that are out of date
#   updating environment:
#   2 added, 0 changed, 0 removed
#   reading sources... [ 50%] index
#   reading sources... [100%] some_plots
# Loaded extensions:
#   matplotlib.sphinxext.plot_directive (unknown version) from x:\python35\lib\site-packages\matplotlib\sphinxext\plot_directive.py
#   alabaster (0.7.6) from x:\python35\lib\site-packages\alabaster\__init__.py
Traceback (most recent call last):
  File "x:\python35\lib\site-packages\sphinx\cmdline.py", line 245, in main
    app.build(opts.force_all, filenames)
  File "x:\python35\lib\site-packages\sphinx\application.py", line 264, in build
    self.builder.build_update()
  File "x:\python35\lib\site-packages\sphinx\builders\__init__.py", line 245, in build_update
    'out of date' % len(to_build))
  File "x:\python35\lib\site-packages\sphinx\builders\__init__.py", line 259, in build
    self.doctreedir, self.app))
  File "x:\python35\lib\site-packages\sphinx\environment.py", line 618, in update
    self._read_serial(docnames, app)
  File "x:\python35\lib\site-packages\sphinx\environment.py", line 638, in _read_serial
    self.read_doc(docname, app)
  File "x:\python35\lib\site-packages\sphinx\environment.py", line 791, in read_doc
    pub.publish()
  File "x:\python35\lib\site-packages\docutils\core.py", line 217, in publish
    self.settings)
  File "x:\python35\lib\site-packages\sphinx\environment.py", line 126, in read
    self.parse()
  File "x:\python35\lib\site-packages\docutils\readers\__init__.py", line 78, in parse
    self.parser.parse(self.input, document)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\__init__.py", line 172, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 170, in run
    input_source=document['source'])
  File "x:\python35\lib\site-packages\docutils\statemachine.py", line 239, in run
    context, state, transitions)
  File "x:\python35\lib\site-packages\docutils\statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2961, in text
    self.section(title.lstrip(), source, style, lineno + 1, messages)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 395, in new_subsection
    node=section_node, match_titles=True)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 282, in nested_parse
    node=node, match_titles=match_titles)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "x:\python35\lib\site-packages\docutils\statemachine.py", line 239, in run
    context, state, transitions)
  File "x:\python35\lib\site-packages\docutils\statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2299, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2311, in explicit_construct
    return method(self, expmatch)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2054, in directive
    directive_class, match, type_name, option_presets)
  File "x:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2103, in run_directive
    result = directive_instance.run()
  File "x:\python35\lib\site-packages\docutils\parsers\rst\__init__.py", line 397, in run
    self.state, self.state_machine)
  File "x:\python35\lib\site-packages\matplotlib\sphinxext\plot_directive.py", line 189, in plot_directive
    return run(arguments, content, options, state_machine, state, lineno)
  File "x:\python35\lib\site-packages\matplotlib\sphinxext\plot_directive.py", line 751, in run
    build_dir_link = relpath(build_dir, rst_dir).replace(os.path.sep, '/')
  File "x:\python35\lib\ntpath.py", line 574, in relpath
    path_drive, start_drive))
ValueError: path is on mount 'C:', start on mount 'X:'
```