### PR TITLE
Remove or update my old e-mail in places

### DIFF
--- a/lib/matplotlib/fontconfig_pattern.py
+++ b/lib/matplotlib/fontconfig_pattern.py
@@ -6,9 +6,6 @@ See the `fontconfig pattern specification
 information.
 """
 
-# Author : Michael Droettboom <mdroe@stsci.edu>
-# License : matplotlib license (PSF compatible)
-
 # This class is defined here because it must be available in:
 #   - The old-style config framework (:file:`rcsetup.py`)
 #   - The traits-based config framework (:file:`mpltraits.py`)

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -13,9 +13,6 @@ The Bakoma distribution of the TeX Computer Modern fonts, and STIX
 fonts are supported.  There is experimental support for using
 arbitrary fonts, but results may vary without proper tweaking and
 metrics for those fonts.
-
-If you find TeX expressions that don't parse or render properly,
-please email mdroe@stsci.edu, but please check KNOWN ISSUES below first.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/setup.py
+++ b/setup.py
@@ -348,7 +348,7 @@ if __name__ == '__main__':
         version=__version__,
         description="Python plotting package",
         author="John D. Hunter, Michael Droettboom",
-        author_email="mdroe@stsci.edu",
+        author_email="matplotlib-users@python.org",
         url="http://matplotlib.org",
         long_description="""
         matplotlib strives to produce publication quality 2D graphics


### PR DESCRIPTION
Thanks, @WeatherGod, for noticing this

Notably, I'm changing the main contact email to `matplotlib-users@python.org`, our main user mailing address.  Yes, users will need to subscribe to post to that, but they'll get a helpful message to that effect when they try it.  I think using a central e-mail like this rather than an individual is preferable.