### PR TITLE
Fix IndexError in cursor_demo.py.

### DIFF
--- a/examples/pylab_examples/cursor_demo.py
+++ b/examples/pylab_examples/cursor_demo.py
@@ -60,7 +60,7 @@ class SnaptoCursor(object):
 
         x, y = event.xdata, event.ydata
 
-        indx = np.searchsorted(self.x, [x])[0]
+        indx = min(np.searchsorted(self.x, [x])[0], len(self.x) - 1)
         x = self.x[indx]
         y = self.y[indx]
         # update the line positions


### PR DESCRIPTION
An out-of-bounds error could be triggered before by bringing the mouse all
the way to the right of the graph, making `searchsorted` return `len(self.x)`
instead of `len(self.x) - 1`.