### PR TITLE
implemeted get_ticks_direction()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2015-10-21 Added get_ticks_direction()
+
 2015-02-27 Added the rcParam 'image.composite_image' to permit users 
 		   to decide whether they want the vector graphics backends to combine 
 		   all images within a set of axes into a single composite image.  

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1244,6 +1244,28 @@ class Axis(artist.Artist):
             return self.minor.locator()
         return self.major.locator()
 
+    def get_ticks_direction(self, minor=False):
+        """
+        Get the tick directions as a numpy array
+
+        Parameters
+        ----------
+        minor : boolean
+            True to return the minor tick directions,
+            False to return the major tick directions,
+            Default is False
+
+        Returns
+        -------
+        numpy array of tick directions
+        """
+        if minor:
+            return np.array(
+                [tick._tickdir for tick in self.get_minor_ticks()])
+        else:
+            return np.array(
+                [tick._tickdir for tick in self.get_major_ticks()])
+
     def _get_tick(self, major):
         'return the default tick instance'
         raise NotImplementedError('derived must override')


### PR DESCRIPTION
adresses #5277 .

example usage:

    >>>import numpy as np
    >>>import matplotlib.pyplot as plt

    >>>x = np.linspace(0, 2 * np.pi, 100)
    >>>y = 2 * np.sin(x)

    >>>fig, (ax0, ax1) = plt.subplots(nrows=2)

    >>>ax0.plot(x, y)
    [<matplotlib.lines.Line2D object at 0x7f4217d5bb00>]
    >>>ax0.set_title('normal spines')
    <matplotlib.text.Text object at 0x7f4217dee828>

    >>>ax1.plot(x, y)
    [<matplotlib.lines.Line2D object at 0x7f4217d5bd30>]
    >>>ax1.set_title('bottom-left spines')
    <matplotlib.text.Text object at 0x7f4217dab518>

    # Hide the right and top spines
    >>>ax1.spines['right'].set_visible(False)
    >>>ax1.spines['top'].set_visible(False)
    # Only show ticks on the left and bottom spines
    >>>ax1.yaxis.set_ticks_position('left')
    >>>ax1.xaxis.set_ticks_position('bottom')

    # Tweak spacing between subplots to prevent labels from overlapping
    >>>plt.subplots_adjust(hspace=0.5)

    >>>plt.show()
    >>>ax1.yaxis.get_ticks_direction(False)
    array(['in', 'in', 'in', 'in', 'in', 'in', 'in', 'in', 'in'], dtype='<U2')
    >>>ax1.xaxis.get_ticks_direction(False)
    array(['in', 'in', 'in', 'in', 'in', 'in', 'in', 'in'], dtype='<U2')
    >>>ax1.xaxis.get_ticks_direction(True)
    array([], dtype=float64)
    >>>ax1.tick_params(axis='y', direction='out')
    >>>ax1.yaxis.get_ticks_direction(False)
    array(['out', 'out', 'out', 'out', 'out', 'out', 'out', 'out', 'out'], dtype='<U3')

edit: python prompt in markdown gets mangled, fixed