### PR TITLE
Make examples that load npy files with datetime(objects) py3 compatible

### DIFF
--- a/doc/users/recipes.rst
+++ b/doc/users/recipes.rst
@@ -118,7 +118,15 @@ you will see that the x tick labels are all squashed together.
 
    import matplotlib.cbook as cbook
    datafile = cbook.get_sample_data('goog.npy')
-   r = np.load(datafile).view(np.recarray)
+   try:
+       # Python3 cannot load python2 .npy files with datetime(object) arrays
+       # unless the encoding is set to bytes. Hovever this option was
+       # not added until numpy 1.10 so this example will only work with
+       # python 2 or with numpy 1.10 and later.
+       r = np.load(datafile, encoding='bytes').view(np.recarray)
+   except TypeError:
+       # Old Numpy
+       r = np.load(datafile).view(np.recarray)
    plt.figure()
    plt.plot(r.date, r.close)
    plt.title('Default date handling can cause overlapping labels')
@@ -179,8 +187,14 @@ right.
 
    # load up some sample financial data
    datafile = cbook.get_sample_data('goog.npy')
-   r = np.load(datafile).view(np.recarray)
-
+   try:
+       # Python3 cannot load python2 .npy files with datetime(object) arrays
+       # unless the encoding is set to bytes. Hovever this option was
+       # not added until numpy 1.10 so this example will only work with
+       # python 2 or with numpy 1.10 and later.
+       r = np.load(datafile, encoding='bytes').view(np.recarray)
+   except TypeError:
+       r = np.load(datafile).view(np.recarray)
    # create two subplots with the shared x and y axes
    fig, (ax1, ax2) = plt.subplots(1,2, sharex=True, sharey=True)
 
@@ -363,4 +377,3 @@ argument takes a dictionary with keys that are Patch properties.
    # place a text box in upper left in axes coords
    ax.text(0.05, 0.95, textstr, transform=ax.transAxes, fontsize=14,
            verticalalignment='top', bbox=props)
-

--- a/examples/api/date_demo.py
+++ b/examples/api/date_demo.py
@@ -26,7 +26,14 @@ yearsFmt = mdates.DateFormatter('%Y')
 # The record array stores python datetime.date as an object array in
 # the date column
 datafile = cbook.get_sample_data('goog.npy')
-r = np.load(datafile).view(np.recarray)
+try:
+    # Python3 cannot load python2 .npy files with datetime(object) arrays
+    # unless the encoding is set to bytes. Hovever this option was
+    # not added until numpy 1.10 so this example will only work with
+    # python 2 or with numpy 1.10 and later.
+    r = np.load(datafile, encoding='bytes').view(np.recarray)
+except TypeError:
+    r = np.load(datafile).view(np.recarray)
 
 fig, ax = plt.subplots()
 ax.plot(r.date, r.adj_close)

--- a/examples/pylab_examples/centered_ticklabels.py
+++ b/examples/pylab_examples/centered_ticklabels.py
@@ -20,7 +20,14 @@ import matplotlib.pyplot as plt
 
 # load some financial data; apple's stock price
 fh = cbook.get_sample_data('aapl.npy.gz')
-r = np.load(fh)
+try:
+    # Python3 cannot load python2 .npy files with datetime(object) arrays
+    # unless the encoding is set to bytes. Hovever this option was
+    # not added until numpy 1.10 so this example will only work with
+    # python 2 or with numpy 1.10 and later.
+    r = np.load(fh, encoding='bytes')
+except TypeError:
+    r = np.load(fh)
 fh.close()
 r = r[-250:]  # get the last 250 days
 

--- a/examples/pylab_examples/scatter_demo2.py
+++ b/examples/pylab_examples/scatter_demo2.py
@@ -10,7 +10,14 @@ import matplotlib.cbook as cbook
 # The record array stores python datetime.date as an object array in
 # the date column
 datafile = cbook.get_sample_data('goog.npy')
-price_data = np.load(datafile).view(np.recarray)
+try:
+    # Python3 cannot load python2 .npy files with datetime(object) arrays
+    # unless the encoding is set to bytes. Hovever this option was
+    # not added until numpy 1.10 so this example will only work with
+    # python 2 or with numpy 1.10 and later
+    price_data = np.load(datafile, encoding='bytes').view(np.recarray)
+except TypeError:
+    price_data = np.load(datafile).view(np.recarray)
 price_data = price_data[-250:]  # get the most recent 250 trading days
 
 delta1 = np.diff(price_data.adj_close)/price_data.adj_close[:-1]


### PR DESCRIPTION
Requires np 1.10 to work under py3 because encoding wasn't added until 1.10 
