### PR TITLE
BUG: recent numpy fails on non-int shape

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -207,7 +207,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             # pixels can be compared in one numpy call, rather than
             # needing to compare each plane separately.
             buff = np.frombuffer(renderer.buffer_rgba(), dtype=np.uint32)
-            buff.shape = (renderer.height, renderer.width)
+            buff.shape = (int(renderer.height), int(renderer.width))
 
             # If any pixels have transparency, we need to force a full
             # draw as we cannot overlay new on top of old.
@@ -220,7 +220,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 self.set_image_mode('diff')
                 last_buffer = np.frombuffer(self._last_renderer.buffer_rgba(),
                                             dtype=np.uint32)
-                last_buffer.shape = (renderer.height, renderer.width)
+                last_buffer.shape = (int(renderer.height), int(renderer.width))
 
                 diff = buff != last_buffer
                 output = np.where(diff, buff, 0)

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -207,7 +207,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             # pixels can be compared in one numpy call, rather than
             # needing to compare each plane separately.
             buff = np.frombuffer(renderer.buffer_rgba(), dtype=np.uint32)
-            buff.shape = (int(renderer.height), int(renderer.width))
+            buff.shape = (renderer.height, renderer.width)
 
             # If any pixels have transparency, we need to force a full
             # draw as we cannot overlay new on top of old.
@@ -220,7 +220,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 self.set_image_mode('diff')
                 last_buffer = np.frombuffer(self._last_renderer.buffer_rgba(),
                                             dtype=np.uint32)
-                last_buffer.shape = (int(renderer.height), int(renderer.width))
+                last_buffer.shape = (renderer.height, renderer.width)
 
                 diff = buff != last_buffer
                 output = np.where(diff, buff, 0)
@@ -249,6 +249,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         # so that we can do things such as produce a diff image
         # in get_diff_image
         _, _, w, h = self.figure.bbox.bounds
+        w, h = int(w), int(h)
         key = w, h, self.figure.dpi
         try:
             self._lastKey, self._renderer


### PR DESCRIPTION
With the current numpy master branch, the WebAgg backend fails during the `draw()` method

```
 File "/usr/local/lib/python2.7/dist-packages/matplotlib-1.5.0rc2+149.g50f373f-py2.7-linux-x86_64.egg/matplotlib/backends/backend_webagg_core.py", line 287, in handle_event
    self.draw()
  File "/usr/local/lib/python2.7/dist-packages/matplotlib-1.5.0rc2+149.g50f373f-py2.7-linux-x86_64.egg/matplotlib/backends/backend_webagg_core.py", line 181, in draw
    self.manager.refresh_all()
  File "/usr/local/lib/python2.7/dist-packages/matplotlib-1.5.0rc2+149.g50f373f-py2.7-linux-x86_64.egg/matplotlib/backends/backend_webagg_core.py", line 473, in refresh_all
    diff = self.canvas.get_diff_image()
  File "/usr/local/lib/python2.7/dist-packages/matplotlib-1.5.0rc2+149.g50f373f-py2.7-linux-x86_64.egg/matplotlib/backends/backend_webagg_core.py", line 211, in get_diff_image
    buff.shape = (renderer.height, renderer.width)
TypeError: 'numpy.float64' object cannot be interpreted as an index
```

This patch remedies the problem, though not at its source. It might be useful to track down what causes the width and height to be float64 in the first place.