### PR TITLE
Fixed compiler warnings in _macosx.m

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1770,8 +1770,8 @@ static PyObject*
 GraphicsContext_draw_quad_mesh (GraphicsContext* self, PyObject* args)
 {
     CGAffineTransform master;
-    int meshWidth;
-    int meshHeight;
+    size_t meshWidth;
+    size_t meshHeight;
     PyObject* coordinates;
     PyArrayObject* coordinates_arr = 0;
     PyObject* offsets;
@@ -1793,7 +1793,7 @@ GraphicsContext_draw_quad_mesh (GraphicsContext* self, PyObject* args)
         return NULL;
     }
 
-    if(!PyArg_ParseTuple(args, "O&iiOOO&OiO",
+    if(!PyArg_ParseTuple(args, "O&IIOOO&OiO",
                                _transformation_converter, &master,
                                &meshWidth,
                                &meshHeight,
@@ -3740,7 +3740,7 @@ FigureCanvas_write_bitmap(FigureCanvas* self, PyObject* args)
         return NULL;
     }
 
-    data = [rep representationUsingType:filetype properties:nil];
+    data = [rep representationUsingType:filetype properties:[NSDictionary dictionary]];
 
     [data writeToFile: filename atomically: YES];
     [pool release];
@@ -4575,7 +4575,7 @@ NavigationToolbar_get_active (NavigationToolbar* self)
     }
     NSMenu* menu = [button menu];
     NSArray* items = [menu itemArray];
-    unsigned int n = [items count];
+    size_t n = [items count];
     int* states = calloc(n, sizeof(int));
     if (!states)
     {
@@ -4597,14 +4597,13 @@ NavigationToolbar_get_active (NavigationToolbar* self)
             m++;
         }
     }
-    int j = 0;
+    Py_ssize_t list_index = 0;
     PyObject* list = PyList_New(m);
-    for (i = 0; i < n; i++)
+    for (size_t state_index = 0; state_index < n; state_index++)
     {
-        if(states[i]==1)
+        if(states[state_index]==1)
         {
-            PyList_SET_ITEM(list, j, PyLong_FromLong(i));
-            j++;
+            PyList_SET_ITEM(list, list_index++, PyLong_FromSize_t(state_index));
         }
     }
     free(states);

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1770,8 +1770,8 @@ static PyObject*
 GraphicsContext_draw_quad_mesh (GraphicsContext* self, PyObject* args)
 {
     CGAffineTransform master;
-    size_t meshWidth;
-    size_t meshHeight;
+    int meshWidth;
+    int meshHeight;
     PyObject* coordinates;
     PyArrayObject* coordinates_arr = 0;
     PyObject* offsets;
@@ -1793,7 +1793,7 @@ GraphicsContext_draw_quad_mesh (GraphicsContext* self, PyObject* args)
         return NULL;
     }
 
-    if(!PyArg_ParseTuple(args, "O&IIOOO&OiO",
+    if(!PyArg_ParseTuple(args, "O&iiOOO&OiO",
                                _transformation_converter, &master,
                                &meshWidth,
                                &meshHeight,
@@ -1887,8 +1887,8 @@ GraphicsContext_draw_quad_mesh (GraphicsContext* self, PyObject* args)
     }
 
     size_t i = 0;
-    size_t iw = 0;
-    size_t ih = 0;
+    int iw = 0;
+    int ih = 0;
 
     /* Preset graphics context properties if possible */
     CGContextSetShouldAntialias(cr, antialiased);


### PR DESCRIPTION
Fixes warnings
```
src/_macosx.m:1919:21: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
    for (ih = 0; ih < meshHeight; ih++)
                 ~~ ^ ~~~~~~~~~~
src/_macosx.m:1921:25: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
        for (iw = 0; iw < meshWidth; iw++, i++)
                     ~~ ^ ~~~~~~~~~
src/_macosx.m:3743:17: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
    data = [rep representationUsingType:filetype properties:nil];
                ^                                           ~~~
src/_macosx.m:4602:19: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
    for (i = 0; i < n; i++)
                ~ ^ ~
```