### PR TITLE
BUG: Dot should not be spaced when used as a decimal separator

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -2504,17 +2504,22 @@ class Parser(object):
                     break
             # Binary operators at start of string should not be spaced
             if (c in self._binary_operators and
-                    (len(s[:loc].split()) == 0 or prev_char == '{')):
+                    (len(s[:loc].split()) == 0 or prev_char == '{' or
+                        prev_char in self._left_delim)):
                 return [char]
             else:
-                return [Hlist( [self._make_space(0.2),
-                                char,
-                                self._make_space(0.2)] ,
+                return [Hlist([self._make_space(0.2),
+                               char,
+                               self._make_space(0.2)] ,
                                do_kern = True)]
         elif c in self._punctuation_symbols:
-            return [Hlist( [char,
-                            self._make_space(0.2)] ,
-                           do_kern = True)]
+            # Do not space dots as decimal separators
+            if (c == '.' and s[loc - 1].isdigit() and s[loc + 1].isdigit()):
+                return [char]
+            else:
+                return [Hlist([char,
+                               self._make_space(0.2)],
+                               do_kern = True)]
         return [char]
 
     snowflake = symbol


### PR DESCRIPTION
I removed the spacing after the dot when the previous and next characters are digits, i.e., when it is being used as a decimal separator. 

I also sneaked in a change a few lines above so that binary operators will not be spaced after a parens (so that `$(-2)$` is not spaced as if it was an operation), see #5020.

I added a test for this dot spacing issue, but given the high threshold for these tests I am not sure whether it would fail even if the spacing is as before this PR. At least it runs through the new code.

attn @mdboom 