### PR TITLE
Use a specific version of Freetype for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dist
 .eggs
 # tox testing tool
 .tox
+setup.cfg
 
 # OS generated files #
 ######################

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ install:
     fi;
 
   # Use the special local version of freetype for testing
-  - echo '[test]\ntesting_freetype = True' > setup.cfg
+  - echo '[test]\nlocal_freetype = True' > setup.cfg
 
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ install:
     fi;
 
   # Use the special local version of freetype for testing
-  - echo '[test]\nlocal_freetype = True' > setup.cfg
+  - cp .travis/setup.cfg .
 
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
   # version since is it basically just a .ttf file
   # The current Travis Ubuntu image is to old to search .local/share/fonts so we store fonts in .fonts
 
-  # We install ipython to use the console highlighting. From IPython 3 this depends on jsonschema and misture.
+  # We install ipython to use the console highlighting. From IPython 3 this depends on jsonschema and mistune.
   # Neihter is installed as a dependency of IPython since they are not used by the IPython console.
   - |
     if [[ $BUILD_DOCS == true ]]; then
@@ -90,6 +90,10 @@ install:
       cp Felipa-Regular.ttf ~/.fonts
       fc-cache -f -v
     fi;
+
+  # Use the special local version of freetype for testing
+  - echo '[test]\ntesting_freetype = True' > setup.cfg
+
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,10 @@ install:
       cp tmp/usr/share/fonts/truetype/humor-sans/Humor-Sans.ttf ~/.fonts
       cp Felipa-Regular.ttf ~/.fonts
       fc-cache -f -v
+    else
+      # Use the special local version of freetype for testing
+      cp .travis/setup.cfg .
     fi;
-
-  # Use the special local version of freetype for testing
-  - cp .travis/setup.cfg .
 
   - python setup.py install
 

--- a/.travis/setup.cfg
+++ b/.travis/setup.cfg
@@ -1,0 +1,2 @@
+[test]
+local_freetype=True

--- a/INSTALL
+++ b/INSTALL
@@ -208,7 +208,7 @@ libpng 1.2 (or later)
 `pytz`
     Used to manipulate time-zone aware datetimes.
 
-:term:`freetype` 2.3 or later
+:term:`FreeType` 2.3 or later
     library for reading true type font files.
 
 ``cycler`` 0.9 or later

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -33,6 +33,22 @@ Optionally you can install:
 
   - `pep8 <http://pep8.readthedocs.org/en/latest>`_ to test coding standards
 
+Build matplotlib for image comparison tests
+-------------------------------------------
+
+matplotlib's test suite makes heavy use of image comparison tests,
+meaning the result of a plot is compared against a known good result.
+Unfortunately, different versions of freetype produce differently
+formed characters, causing these image comparisons to fail.  To make
+them reproducible, matplotlib can be built with a special local copy
+of freetype.  This is recommended for all matplotlib developers.
+
+Add the following content to a ``setup.cfg`` file at the root of the
+matplotlib source directory::
+
+  [test]
+  testing_freetype = True
+
 Running the tests
 -----------------
 
@@ -184,17 +200,6 @@ decorator:
    - `tol`: This is the image matching tolerance, the default `1e-3`.
      If some variation is expected in the image between runs, this
      value may be adjusted.
-
-Freetype version
-----------------
-
-Due to subtle differences in the font rendering under different
-version of freetype some care must be taken when generating the
-baseline images.  Currently (early 2015), almost all of the images
-were generated using ``freetype 2.5.3-21`` on Fedora 21 and only the
-fonts that ship with ``matplotlib`` (regenerated in PR #4031 / commit
-005cfde02751d274f2ab8016eddd61c3b3828446) and travis is using
-``freetype 2.4.8`` on ubuntu.
 
 Known failing tests
 -------------------

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -47,7 +47,7 @@ Add the following content to a ``setup.cfg`` file at the root of the
 matplotlib source directory::
 
   [test]
-  testing_freetype = True
+  local_freetype = True
 
 Running the tests
 -----------------

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -38,10 +38,10 @@ Build matplotlib for image comparison tests
 
 matplotlib's test suite makes heavy use of image comparison tests,
 meaning the result of a plot is compared against a known good result.
-Unfortunately, different versions of freetype produce differently
+Unfortunately, different versions of FreeType produce differently
 formed characters, causing these image comparisons to fail.  To make
 them reproducible, matplotlib can be built with a special local copy
-of freetype.  This is recommended for all matplotlib developers.
+of FreeType.  This is recommended for all matplotlib developers.
 
 Add the following content to a ``setup.cfg`` file at the root of the
 matplotlib source directory::

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -33,8 +33,8 @@ Optionally you can install:
 
   - `pep8 <http://pep8.readthedocs.org/en/latest>`_ to test coding standards
 
-Build matplotlib for image comparison tests
--------------------------------------------
+Building matplotlib for image comparison tests
+----------------------------------------------
 
 matplotlib's test suite makes heavy use of image comparison tests,
 meaning the result of a plot is compared against a known good result.

--- a/doc/glossary/index.rst
+++ b/doc/glossary/index.rst
@@ -22,8 +22,8 @@ Glossary
   EPS
       Encapsulated Postscript (`EPS <http://en.wikipedia.org/wiki/Encapsulated_PostScript>`_)
 
-  freetype
-      `freetype <http://www.freetype.org/>`_ is a font rasterization
+  FreeType
+      `FreeType <http://www.freetype.org/>`_ is a font rasterization
       library used by matplotlib which supports TrueType, Type 1, and
       OpenType fonts.
 

--- a/doc/users/screenshots.rst
+++ b/doc/users/screenshots.rst
@@ -252,7 +252,7 @@ Mathtext_examples
 
 Below is a sampling of the many TeX expressions now supported by matplotlib's
 internal mathtext engine.  The mathtext module provides TeX style mathematical
-expressions using `FreeTYpe <http://www.freetype.org/>`_
+expressions using `FreeType <http://www.freetype.org/>`_
 and the BaKoMa computer modern or `STIX <http://www.stixfonts.org>`_ fonts.
 See the :mod:`matplotlib.mathtext` module for additional details.
 

--- a/doc/users/screenshots.rst
+++ b/doc/users/screenshots.rst
@@ -252,7 +252,7 @@ Mathtext_examples
 
 Below is a sampling of the many TeX expressions now supported by matplotlib's
 internal mathtext engine.  The mathtext module provides TeX style mathematical
-expressions using `freetype2 <http://www.freetype.org/>`_
+expressions using `FreeTYpe <http://www.freetype.org/>`_
 and the BaKoMa computer modern or `STIX <http://www.stixfonts.org>`_ fonts.
 See the :mod:`matplotlib.mathtext` module for additional details.
 

--- a/doc/users/text_intro.rst
+++ b/doc/users/text_intro.rst
@@ -8,7 +8,7 @@ expressions, truetype support for raster and vector outputs, newline
 separated text with arbitrary rotations, and unicode support.  Because
 we embed the fonts directly in the output documents, e.g., for postscript
 or PDF, what you see on the screen is what you get in the hardcopy.
-`freetype2 <http://www.freetype.org/>`_ support
+`FreeType <http://www.freetype.org/>`_ support
 produces very nice, antialiased fonts, that look good even at small
 raster sizes.  matplotlib includes its own
 :mod:`matplotlib.font_manager`, thanks to Paul Barrett, which

--- a/examples/pylab_examples/font_table_ttf.py
+++ b/examples/pylab_examples/font_table_ttf.py
@@ -1,6 +1,6 @@
 # -*- noplot -*-
 """
-matplotlib has support for freetype fonts.  Here's a little example
+matplotlib has support for FreeType fonts.  Here's a little example
 using the 'table' command to build a font table that shows the glyphs
 by character code.
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1501,7 +1501,7 @@ def _init_tests():
 
     # The version of FreeType to install locally for running the
     # tests.  This must match the value in `setupext.py`
-    LOCAL_FREETYPE_VERSION = '2.5.2'
+    LOCAL_FREETYPE_VERSION = '2.6.1'
 
     from matplotlib import ft2font
     if (ft2font.__freetype_version__ != LOCAL_FREETYPE_VERSION or

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1506,9 +1506,10 @@ def _init_tests():
     from matplotlib import ft2font
     if (ft2font.__freetype_version__ != LOCAL_FREETYPE_VERSION or
         ft2font.__freetype_build_type__ != 'local'):
-        raise ImportError(
+        warnings.warn(
             "matplotlib is not built with the correct freetype version to run "
-            "tests.  Set local_freetype=True in setup.cfg and rebuild.")
+            "tests.  Set local_freetype=True in setup.cfg and rebuild.  Expect "
+            "many image comparison failures below.")
 
     try:
         import nose

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1499,7 +1499,7 @@ def _init_tests():
     if not os.path.isdir(os.path.join(os.path.dirname(__file__), 'tests')):
         raise ImportError("matplotlib test data is not installed")
 
-    # The version of freetype to install locally for running the
+    # The version of FreeType to install locally for running the
     # tests.  This must match the value in `setupext.py`
     LOCAL_FREETYPE_VERSION = '2.5.2'
 
@@ -1507,9 +1507,9 @@ def _init_tests():
     if (ft2font.__freetype_version__ != LOCAL_FREETYPE_VERSION or
         ft2font.__freetype_build_type__ != 'local'):
         warnings.warn(
-            "matplotlib is not built with the correct freetype version to run "
-            "tests.  Set local_freetype=True in setup.cfg and rebuild.  Expect "
-            "many image comparison failures below.")
+            "matplotlib is not built with the correct FreeType version to run "
+            "tests.  Set local_freetype=True in setup.cfg and rebuild. "
+            "Expect many image comparison failures below.")
 
     try:
         import nose

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1499,6 +1499,17 @@ def _init_tests():
     if not os.path.isdir(os.path.join(os.path.dirname(__file__), 'tests')):
         raise ImportError("matplotlib test data is not installed")
 
+    # The version of freetype to install locally for running the
+    # tests.  This must match the value in `setupext.py`
+    LOCAL_FREETYPE_VERSION = '2.5.2'
+
+    from matplotlib import ft2font
+    if (ft2font.__freetype_version__ != LOCAL_FREETYPE_VERSION or
+        ft2font.__freetype_build_type__ != 'local'):
+        raise ImportError(
+            "matplotlib is not built with the correct freetype version to run "
+            "tests.  Set local_freetype=True in setup.cfg and rebuild.")
+
     try:
         import nose
         try:

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -113,7 +113,7 @@ class MathtextBackend(object):
       - :meth:`render_rect_filled`
       - :meth:`get_results`
 
-    And optionally, if you need to use a Freetype hinting style:
+    And optionally, if you need to use a FreeType hinting style:
 
       - :meth:`get_hinting_type`
     """
@@ -150,7 +150,7 @@ class MathtextBackend(object):
 
     def get_hinting_type(self):
         """
-        Get the Freetype hinting type to use with this particular
+        Get the FreeType hinting type to use with this particular
         backend.
         """
         return LOAD_NO_HINTING

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -195,10 +195,10 @@ backend      : %(backend)s
 
 #text.hinting : auto   # May be one of the following:
                        #   'none': Perform no hinting
-                       #   'auto': Use freetype's autohinter
+                       #   'auto': Use FreeType's autohinter
                        #   'native': Use the hinting information in the
                        #             font file, if available, and if your
-                       #             freetype library supports it
+                       #             FreeType library supports it
                        #   'either': Use the native hinting information,
                        #             or the autohinter if none is available.
                        # For backward compatibility, this value may also be
@@ -357,9 +357,9 @@ backend      : %(backend)s
 #image.lut    : 256               # the size of the colormap lookup table
 #image.origin : upper             # lower | upper
 #image.resample  : False
-#image.composite_image : True     # When True, all the images on a set of axes are 
-                                  # combined into a single composite image before 
-                                  # saving a figure as a vector graphics file, 
+#image.composite_image : True     # When True, all the images on a set of axes are
+                                  # combined into a single composite image before
+                                  # saving a figure as a vector graphics file,
                                   # such as a PDF.
 
 ### CONTOUR PLOTS

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -8,6 +8,13 @@
 # This can be a single directory or a comma-delimited list of directories.
 #basedirlist = /usr
 
+[test]
+# If you plan to develop matplotlib and run or add to the test suite,
+# set this to True.  It will download and build a specific version of
+# freetype, and then use that to build the ft2font extension.  This
+# ensures that test images are exactly reproducible.
+#local_freetype = False
+
 [status]
 # To suppress display of the dependencies and their versions
 # at the top of the build log, uncomment the following line:

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -11,7 +11,7 @@
 [test]
 # If you plan to develop matplotlib and run or add to the test suite,
 # set this to True.  It will download and build a specific version of
-# freetype, and then use that to build the ft2font extension.  This
+# FreeType, and then use that to build the ft2font extension.  This
 # ensures that test images are exactly reproducible.
 #local_freetype = False
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from __future__ import print_function, absolute_import
 from distribute_setup import use_setuptools
 use_setuptools()
 from setuptools.command.test import test as TestCommand
+from setuptools.command.build_ext import build_ext as BuildExtCommand
 
 import sys
 
@@ -239,8 +240,19 @@ class NoseTestCommand(TestCommand):
                   argv=['nosetests'] + self.test_args,
                   exit=True)
 
+
+class BuildExtraLibraries(BuildExtCommand):
+    def run(self):
+        for package in good_packages:
+            package.do_custom_build()
+
+        return super(BuildExtraLibraries, self).run()
+
+
 cmdclass = versioneer.get_cmdclass()
 cmdclass['test'] = NoseTestCommand
+cmdclass['build_ext'] = BuildExtraLibraries
+
 
 # One doesn't normally see `if __name__ == '__main__'` blocks in a setup.py,
 # however, this is needed on Windows to avoid creating infinite subprocesses
@@ -303,8 +315,6 @@ if __name__ == '__main__':
     # Now collect all of the information we need to build all of the
     # packages.
     for package in good_packages:
-        if isinstance(package, str):
-            continue
         packages.extend(package.get_packages())
         namespace_packages.extend(package.get_namespace_packages())
         py_modules.extend(package.get_py_modules())

--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ class BuildExtraLibraries(BuildExtCommand):
         for package in good_packages:
             package.do_custom_build()
 
-        return super(BuildExtraLibraries, self).run()
+        return BuildExtCommand.run(self)
 
 
 cmdclass = versioneer.get_cmdclass()

--- a/setupext.py
+++ b/setupext.py
@@ -1001,7 +1001,7 @@ class FreeType(SetupPackage):
         cflags = 'CFLAGS="{0} -fPIC" '.format(os.environ.get('CFLAGS', ''))
 
         subprocess.check_call(
-            ['tar zxf {0}'.format(tarball)], shell=True, cwd='build')
+            ['tar', 'zxf', tarball], cwd='build')
         subprocess.check_call(
             [cflags +
              './configure --without-zlib --without-bzip2 --without-png'],

--- a/setupext.py
+++ b/setupext.py
@@ -996,13 +996,16 @@ class FreeType(SetupPackage):
                 raise IOError("{0} does not match expected hash.".format(tarball))
 
         print("Building {0}".format(tarball))
+        cflags = 'CFLAGS="{0} -fPIC" '.format(os.environ.get('CFLAGS', ''))
+
         subprocess.check_call(
             ['tar zxf {0}'.format(tarball)], shell=True, cwd='build')
         subprocess.check_call(
-            ['CFLAGS=-fPIC ./configure --without-zlib --without-bzip2 --without-png'],
+            [cflags +
+             './configure --without-zlib --without-bzip2 --without-png'],
             shell=True, cwd=src_path)
         subprocess.check_call(
-            ['CFLAGS=-fPIC make'], shell=True, cwd=src_path)
+            [cflags + 'make'], shell=True, cwd=src_path)
 
 
 class FT2Font(SetupPackage):

--- a/setupext.py
+++ b/setupext.py
@@ -990,6 +990,8 @@ class FreeType(SetupPackage):
             else:
                 from urllib.request import urlretrieve
 
+            if not os.path.exists('build'):
+                os.makedirs('build')
             urlretrieve(tarball_url, tarball_path)
 
             if get_file_hash(tarball_path) != LOCAL_FREETYPE_HASH:

--- a/setupext.py
+++ b/setupext.py
@@ -980,10 +980,10 @@ class FreeType(SetupPackage):
         subprocess.check_call(
             ['tar zxf {0}'.format(tarball)], shell=True, cwd='build')
         subprocess.check_call(
-            ['./configure --without-zlib --without-bzip2 --without-png'],
+            ['CFLAGS=-fPIC ./configure --without-zlib --without-bzip2 --without-png'],
             shell=True, cwd=src_path)
         subprocess.check_call(
-            ['make'], shell=True, cwd=src_path)
+            ['CFLAGS=-fPIC make'], shell=True, cwd=src_path)
 
 
 class FT2Font(SetupPackage):

--- a/setupext.py
+++ b/setupext.py
@@ -20,9 +20,9 @@ import versioneer
 PY3 = (sys.version_info[0] >= 3)
 
 
-# This is the version of freetype to use when building a local version
-# of freetype.  It must match the value in
-# lib/matplotlib.__init__.py:validate_test_dependencies
+# This is the version of FreeType to use when building a local
+# version.  It must match the value in
+# lib/matplotlib.__init__.py
 LOCAL_FREETYPE_VERSION = '2.5.2'
 # md5 hash of the freetype tarball
 LOCAL_FREETYPE_HASH = '004320381043d275c4e28bbacf05a1b7'

--- a/setupext.py
+++ b/setupext.py
@@ -23,9 +23,9 @@ PY3 = (sys.version_info[0] >= 3)
 # This is the version of FreeType to use when building a local
 # version.  It must match the value in
 # lib/matplotlib.__init__.py
-LOCAL_FREETYPE_VERSION = '2.5.2'
+LOCAL_FREETYPE_VERSION = '2.6.1'
 # md5 hash of the freetype tarball
-LOCAL_FREETYPE_HASH = '004320381043d275c4e28bbacf05a1b7'
+LOCAL_FREETYPE_HASH = '348e667d728c597360e4a87c16556597'
 
 if sys.platform != 'win32':
     if sys.version_info[0] < 3:
@@ -1003,9 +1003,8 @@ class FreeType(SetupPackage):
         subprocess.check_call(
             ['tar', 'zxf', tarball], cwd='build')
         subprocess.check_call(
-            [cflags +
-             './configure --without-zlib --without-bzip2 --without-png'],
-            shell=True, cwd=src_path)
+            [cflags + './configure --with-zlib=no --with-bzip2=no '
+             '--with-png=no --with-harfbuzz=no'], shell=True, cwd=src_path)
         subprocess.check_call(
             [cflags + 'make'], shell=True, cwd=src_path)
 

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -25,8 +25,8 @@
  transform is placed on the font to shrink it back to the desired
  size.  While it is a bit surprising that the dpi setting affects
  hinting, whereas the global transform does not, this is documented
- behavior of freetype, and therefore hopefully unlikely to change.
- The freetype 2 tutorial says:
+ behavior of FreeType, and therefore hopefully unlikely to change.
+ The FreeType 2 tutorial says:
 
       NOTE: The transformation is applied to every glyph that is
       loaded through FT_Load_Glyph and is completely independent of

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -511,6 +511,10 @@ FT2Font::FT2Font(FT_Open_Args &open_args, long hinting_factor_) : image(), face(
         throw "Could not set the fontsize";
     }
 
+    if (open_args.stream != NULL) {
+        face->face_flags |= FT_FACE_FLAG_EXTERNAL_STREAM;
+    }
+
     static FT_Matrix transform = { 65536 / hinting_factor, 0, 0, 65536 };
     FT_Set_Transform(face, &transform, 0);
 }

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-/* A python interface to freetype2 */
+/* A python interface to FreeType */
 #ifndef _FT2FONT_H
 #define _FT2FONT_H
 #include <vector>
@@ -21,7 +21,7 @@ extern "C" {
 #define FIXED_MAJOR(val) (long)((val & 0xffff000) >> 16)
 #define FIXED_MINOR(val) (long)(val & 0xffff)
 
-// the freetype string rendered into a width, height buffer
+// the FreeType string rendered into a width, height buffer
 class FT2Image
 {
   public:

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -7,6 +7,9 @@
 // From Python
 #include <structmember.h>
 
+#define STRINGIFY(s) XSTRINGIFY(s)
+#define XSTRINGIFY(s) #s
+
 static PyObject *convert_xys_to_array(std::vector<double> &xys)
 {
     npy_intp dims[] = {(npy_intp)xys.size() / 2, 2 };
@@ -1759,7 +1762,7 @@ PyMODINIT_FUNC initft2font(void)
     int error = FT_Init_FreeType(&_ft2Library);
 
     if (error) {
-        PyErr_SetString(PyExc_RuntimeError, "Could not find initialize the freetype2 library");
+        PyErr_SetString(PyExc_RuntimeError, "Could not initialize the freetype2 library");
         INITERROR;
     }
 
@@ -1772,6 +1775,10 @@ PyMODINIT_FUNC initft2font(void)
         if (PyModule_AddStringConstant(m, "__freetype_version__", version_string)) {
             INITERROR;
         }
+    }
+
+    if (PyModule_AddStringConstant(m, "__freetype_build_type__", STRINGIFY(FREETYPE_BUILD_TYPE))) {
+        INITERROR;
     }
 
     import_array();

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -463,11 +463,14 @@ static PyObject *PyFT2Font_new(PyTypeObject *type, PyObject *args, PyObject *kwd
     PyFT2Font *self;
     self = (PyFT2Font *)type->tp_alloc(type, 0);
     self->x = NULL;
+    self->fname = NULL;
     self->py_file = NULL;
     self->fp = NULL;
     self->close_file = 0;
     self->offset = 0;
     memset(&self->stream, 0, sizeof(FT_StreamRec));
+    self->mem = 0;
+    self->mem_size = 0;
     return (PyObject *)self;
 }
 


### PR DESCRIPTION
This should theoretically allow us to turn down the tolerance on image comparison tests.

If all is going well, this should pass Travis-CI, which is now using a locally-built freetype.