### PR TITLE
fix for issue #5201, empty extension triangle for vmin < 1.0

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -679,7 +679,6 @@ class ColorbarBase(cm.ScalarMappable):
                 b[-1] = 1.1 * b[-1]     
         self._process_values(b)
 
-
     def _find_range(self):
         '''
         Set :attr:`vmin` and :attr:`vmax` attributes to the first and
@@ -820,7 +819,6 @@ class ColorbarBase(cm.ScalarMappable):
         if self._extend_upper() and not self.extendrect:
             X[-1, :] = 0.5
         return X, Y
-
 
     def _locate(self, x):
         '''

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -674,10 +674,11 @@ class ColorbarBase(cm.ScalarMappable):
 
             b = self.norm.inverse(self._uniform_y(self.cmap.N + 1))
             if self._extend_lower():
-                b[0] = b[0] - 1
+                b[0] = 0.9 * b[0]
             if self._extend_upper():
-                b[-1] = b[-1] + 1
+                b[-1] = 1.1 * b[-1]     
         self._process_values(b)
+
 
     def _find_range(self):
         '''
@@ -819,6 +820,7 @@ class ColorbarBase(cm.ScalarMappable):
         if self._extend_upper() and not self.extendrect:
             X[-1, :] = 0.5
         return X, Y
+
 
     def _locate(self, x):
         '''

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -11,9 +11,11 @@ from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 from matplotlib import rcParams
 from matplotlib.colors import BoundaryNorm
+from matplotlib.colors import LogNorm
 from matplotlib.cm import get_cmap
 from matplotlib import cm
 from matplotlib.colorbar import ColorbarBase
+from nose.tools import assert_greater_equal
 
 
 def _get_cmap_norms():
@@ -254,7 +256,16 @@ def test_colorbarbase():
     ax = plt.gca()
     ColorbarBase(ax, plt.cm.bone)
 
-
+@cleanup
+def test_colorbar_lognorm_extension():
+    # Issue #5201: empty triangle plotted
+    # for logarithmic colorbar with vmin < 1.0
+    ax = plt.gca()
+    
+    cb = ColorbarBase(ax, norm=LogNorm(vmin=1, vmax=1000.0), orientation='vertical', extend='both')
+    
+    assert_greater_equal(cb._values[0], 0.0)
+    
 @image_comparison(
     baseline_images=['colorbar_closed_patch'],
     remove_text=True)


### PR DESCRIPTION
This should fix the empty triangle problem for cases where vmin < 1.0.

Instead of subtracting 1, decrease the value by 10% (same for max value), this way the values cannot become negative (and the color NaN / white)
