### PR TITLE
Fix regression #5310. Allow assignment of list of numpy arrays to rcp…

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -79,7 +79,12 @@ def _listify_validator(scalar_validator, allow_stringlist=False):
                 else:
                     raise
         elif type(s) in (list, tuple):
-            return [scalar_validator(v) for v in s if v]
+            # The condition on this list comprehension will preserve the
+            # behavior of filtering out any empty strings (behavior was
+            # from the original validate_stringlist()), while allowing
+            # any non-string/text scalar values such as numbers and arrays.
+            return [scalar_validator(v) for v in s
+                    if not isinstance(v, six.string_types) or v]
         else:
             msg = "'s' must be of type [ string | list | tuple ]"
             raise ValueError(msg)

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -22,6 +22,7 @@ from itertools import chain
 import numpy as np
 from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_stringlist,
+                                validate_colorlist,
                                 validate_bool,
                                 validate_nseq_int,
                                 validate_nseq_float,
@@ -245,7 +246,9 @@ def test_Issue_1713():
 
 def _validation_test_helper(validator, arg, target):
     res = validator(arg)
-    if not isinstance(target, Cycler):
+    if isinstance(target, np.ndarray):
+        assert_true(np.all(res == target))
+    elif not isinstance(target, Cycler):
         assert_equal(res, target)
     else:
         # Cyclers can't simply be asserted equal. They don't implement __eq__
@@ -343,6 +346,17 @@ def test_validators():
                   (8, ValueError),
                   ('X', ValueError)),
         },
+        {'validator': validate_colorlist,
+         'success': (('r,g,b', ['r', 'g', 'b']),
+                     (['r', 'g', 'b'], ['r', 'g', 'b']),
+                     ('r, ,', ['r']),
+                     (['', 'g', 'blue'], ['g', 'blue']),
+                     ([np.array([1, 0, 0]), np.array([0, 1, 0])],
+                         np.array([[1, 0, 0], [0, 1, 0]])),
+                    ),
+         'fail': (('fish', ValueError),
+                 ),
+        }
     )
 
     for validator_dict in validation_tests:


### PR DESCRIPTION
…arams.

Had to have a bit of a kludge in the unit tests because you can't simply assert_equal() lists of numpy arrays any more, but it exercises that part correctly now.