### PR TITLE
bug: Figure.savefig(fname="...") not working

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1536,6 +1536,8 @@ class Figure(Artist):
             original_frameon = self.get_frameon()
             self.set_frameon(frameon)
 
+        if "fname" in kwargs:
+            kwargs["filename"] = kwargs.pop("fname")
         self.canvas.print_figure(*args, **kwargs)
 
         if frameon:


### PR DESCRIPTION
Due to a mismatch in `kwarg` names `Figure.savefig(fname="...")` is raising an exception (i.e. specifying output filename as `kwarg` as opposed to first (and only) `arg`. I think this bug was introduced with 8cdc0da6d1847b028801f1b9bac58d15f5d4ef06.

Code to reproduce:

``` python
import matplotlib.pyplot as plt

plt.switch_backend("AGG")

fig = plt.figure()
plt.plot(range(5))
fig.savefig("/tmp/savefig1.png")  # works
fig.savefig(fname="/tmp/savefig2.png")  # does not work, raises
```

```
Traceback (most recent call last):
  File "/tmp/savefig_bug.py", line 8, in <module>
    fig.savefig(fname="/tmp/savefig2.png")
  File "/home/megies/git/matplotlib/lib/matplotlib/figure.py", line 1539, in savefig
    self.canvas.print_figure(*args, **kwargs)
TypeError: print_figure() takes at least 2 arguments (4 given)
```

The attached commit fixes the problem.
