### PR TITLE
Fix #5302: Proper alpha-blending for jpeg

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -38,6 +38,7 @@ from matplotlib.ft2font import FT2Font, LOAD_FORCE_AUTOHINT, LOAD_NO_HINTING, \
 from matplotlib.mathtext import MathTextParser
 from matplotlib.path import Path
 from matplotlib.transforms import Bbox, BboxBase
+from matplotlib import colors as mcolors
 
 from matplotlib.backends._backend_agg import RendererAgg as _RendererAgg
 from matplotlib import _png
@@ -575,7 +576,10 @@ class FigureCanvasAgg(FigureCanvasBase):
             # The image is "pasted" onto a white background image to safely
             # handle any transparency
             image = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
-            background = Image.new('RGB', size, (255, 255, 255))
+            color = mcolors.colorConverter.to_rgb(
+                rcParams.get('savefig.facecolor', 'white'))
+            color = tuple([int(x * 255.0) for x in color])
+            background = Image.new('RGB', size, color)
             background.paste(image, image)
             options = restrict_dict(kwargs, ['quality', 'optimize',
                                              'progressive'])

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -551,7 +551,6 @@ class FigureCanvasAgg(FigureCanvasBase):
         return result
 
     if _has_pil:
-
         # add JPEG support
         def print_jpg(self, filename_or_obj, *args, **kwargs):
             """
@@ -573,14 +572,18 @@ class FigureCanvasAgg(FigureCanvasBase):
             buf, size = self.print_to_buffer()
             if kwargs.pop("dryrun", False):
                 return
+            # The image is "pasted" onto a white background image to safely
+            # handle any transparency
             image = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
+            background = Image.new('RGB', size, (255, 255, 255))
+            background.paste(image, image)
             options = restrict_dict(kwargs, ['quality', 'optimize',
                                              'progressive'])
 
             if 'quality' not in options:
                 options['quality'] = rcParams['savefig.jpeg_quality']
 
-            return image.save(filename_or_obj, format='jpeg', **options)
+            return background.save(filename_or_obj, format='jpeg', **options)
         print_jpeg = print_jpg
 
         # add TIFF support

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -453,6 +453,28 @@ def test_nonuniformimage_setnorm():
     im = NonUniformImage(ax)
     im.set_norm(plt.Normalize())
 
+@knownfailureif(not HAS_PIL)
+@cleanup
+def test_jpeg_alpha():
+    plt.figure(figsize=(1, 1), dpi=300)
+    # Create an image that is all black, with a gradient from 0-1 in
+    # the alpha channel from left to right.
+    im = np.zeros((300, 300, 4), dtype=np.float)
+    im[..., 3] = np.linspace(0.0, 1.0, 300)
+
+    plt.figimage(im)
+
+    buff = io.BytesIO()
+    plt.savefig(buff, transparent=True, format='jpg', dpi=300)
+
+    buff.seek(0)
+    image = Image.open(buff)
+
+    # If this fails, there will be only one color (all black). If this
+    # is working, we should have all 256 shades of grey represented.
+    assert len(image.getcolors(256)) == 256
+
+
 if __name__=='__main__':
     import nose
     nose.runmodule(argv=['-s','--with-doctest'], exit=False)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -473,9 +473,11 @@ def test_jpeg_alpha():
 
     # If this fails, there will be only one color (all black). If this
     # is working, we should have all 256 shades of grey represented.
+    print("num colors: ", len(image.getcolors(256)))
     assert len(image.getcolors(256)) >= 170 and len(image.getcolors(256)) <= 180
     # The fully transparent part should be red, not white or black
     # or anything else
+    print("corner pixel: ", image.getpixel((0, 0)))
     assert image.getpixel((0, 0)) == (254, 0, 0)
 
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -474,7 +474,7 @@ def test_jpeg_alpha():
     # If this fails, there will be only one color (all black). If this
     # is working, we should have all 256 shades of grey represented.
     print("num colors: ", len(image.getcolors(256)))
-    assert len(image.getcolors(256)) >= 170 and len(image.getcolors(256)) <= 180
+    assert len(image.getcolors(256)) >= 175 and len(image.getcolors(256)) <= 185
     # The fully transparent part should be red, not white or black
     # or anything else
     print("corner pixel: ", image.getpixel((0, 0)))

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -8,7 +8,7 @@ import numpy as np
 from matplotlib.testing.decorators import image_comparison, knownfailureif, cleanup
 from matplotlib.image import BboxImage, imread, NonUniformImage
 from matplotlib.transforms import Bbox
-from matplotlib import rcParams
+from matplotlib import rcParams, rc_context
 import matplotlib.pyplot as plt
 from nose.tools import assert_raises
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -465,14 +465,18 @@ def test_jpeg_alpha():
     plt.figimage(im)
 
     buff = io.BytesIO()
-    plt.savefig(buff, transparent=True, format='jpg', dpi=300)
+    with rc_context({'savefig.facecolor': 'red'}):
+        plt.savefig(buff, transparent=True, format='jpg', dpi=300)
 
     buff.seek(0)
     image = Image.open(buff)
 
     # If this fails, there will be only one color (all black). If this
     # is working, we should have all 256 shades of grey represented.
-    assert len(image.getcolors(256)) == 256
+    assert len(image.getcolors(256)) == 179
+    # The fully transparent part should be red, not white or black
+    # or anything else
+    assert image.getpixel(0, 0) == (0, 0, 255)
 
 
 if __name__=='__main__':

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -473,10 +473,10 @@ def test_jpeg_alpha():
 
     # If this fails, there will be only one color (all black). If this
     # is working, we should have all 256 shades of grey represented.
-    assert len(image.getcolors(256)) == 179
+    assert len(image.getcolors(256)) >= 170 and len(image.getcolors(256)) <= 180
     # The fully transparent part should be red, not white or black
     # or anything else
-    assert image.getpixel(0, 0) == (0, 0, 255)
+    assert image.getpixel((0, 0)) == (254, 0, 0)
 
 
 if __name__=='__main__':


### PR DESCRIPTION
Saving a JPEG with an alpha channel doesn't look right -- I think pillow just removes the alpha channel altogether and uses the rest of the RGB values as-is.

This blends RGBA images onto a white background before saving.

This is JPEG-specific since it's our only raster output file format that doesn't support alpha blending.  If we ever grow another (unlikely) this will need to be duplicated there.