### PR TITLE
Improve compatibility for h264 ffmpeg-encoded videos. (Backport #5340)

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -405,6 +405,12 @@ class FFMpegBase(object):
         # The %dk adds 'k' as a suffix so that ffmpeg treats our bitrate as in
         # kbps
         args = ['-vcodec', self.codec]
+        # For h264, the default format is yuv444p, which is not compatible
+        # with quicktime (and others). Specifying yuv420p fixes playback on
+        # iOS,as well as HTML5 video in firefox and safari (on both Win and
+        # OSX). Also fixes internet explorer. This is as of 2015/10/29.
+        if self.codec == 'h264' and '-pix_fmt' not in self.extra_args:
+            args.extend(['-pix_fmt', 'yuv420p'])
         if self.bitrate > 0:
             args.extend(['-b', '%dk' % self.bitrate])
         if self.extra_args:


### PR DESCRIPTION
Default pixel format of yuv444p is, apparently, not widely supported.
Changing to yuv420p fixes playback with Quicktime, on iOS, and with a
wide array of browsers (for HTML5 video).

Backports #5340.