### PR TITLE
Fix #4332.  Fix flicker in wx* backends

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -834,9 +834,6 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
                 # not called from OnPaint use a ClientDC
                 drawDC = wx.ClientDC(self)
 
-            # ensure that canvas has no 'left' over stuff when resizing frame
-            drawDC.Clear()
-
             # following is for 'WX' backend on Windows
             # the bitmap can not be in use by another DC,
             # see GraphicsContextWx._cache


### PR DESCRIPTION
This seems to have been introduced in 758f82690a8760f0feb49f71a3070b89da4ee158.  I tried resizing the window in all kinds of horrific ways, but couldn't see the issue described in the comment.

Tested with wxPython 3.0.0 on Python 2.7 on Linux and Mac.  (I haven't managed to get wxPhoenix compiled yet...)

Cc: @wernerfb