### PR TITLE
Fix #347: Faster text rendering in Agg

### DIFF
--- a/doc/users/whats_new/faster-text-rendering.rst
+++ b/doc/users/whats_new/faster-text-rendering.rst
@@ -1,0 +1,5 @@
+Faster text rendering
+---------------------
+
+Rendering text in the Agg backend is now less fuzzy and about 20%
+faster to draw.

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -789,11 +789,8 @@ inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, in
         }
 
         for (int yi = text.y1; yi < text.y2; ++yi) {
-            for (int xi = text.x1; xi < text.x2; ++xi) {
-                typename ImageArray::value_type pixel = image(
-                        yi - (y - image.dim(0)), xi - x);
-                pixFmt.blend_pixel(xi, yi, gc.color, pixel);
-            }
+            pixFmt.blend_solid_hspan(text.x1, yi, (text.x2 - text.x1), gc.color,
+                                     &image(yi - (y - image.dim(0)), text.x1 - x));
         }
     }
 }


### PR DESCRIPTION
When the text isn't rotated, we can skip a lot of machinery by just doing a direct blending of text pixels onto the output buffer.

With the `simple_plot_fps` demo, I get about 6fps after, 5fps before this change.

Cc: @Tillsten: would you be willing to kick the tires on this one?