### PR TITLE
Fix Cairo memleak

### DIFF
--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -177,8 +177,8 @@ static PyObject *PyImage_color_conv(PyImage *self, PyObject *args, PyObject *kwd
                      free(buff));
 
     PyObject *result = PyByteArray_FromStringAndSize((const char *)buff, size);
+    free(buff);
     if (result == NULL) {
-        free(buff);
         return NULL;
     }
 


### PR DESCRIPTION
Thanks to #5360, you can see a small memleak with the Cairo backend, apparently only 26.4889 bytes/loop. After fixing the leak, it's -0.7111 bytes/loop (aka 0).