### PR TITLE
Remove various Python 2.6 related workarounds

### DIFF
--- a/examples/misc/multiprocess.py
+++ b/examples/misc/multiprocess.py
@@ -1,15 +1,10 @@
 # Demo of using multiprocessing for generating data in one process and plotting
 # in another.
 # Written by Robert Cimrman
-# Requires >= Python 2.6 for the multiprocessing module or having the
-# standalone processing module installed
 
 from __future__ import print_function
 import time
-try:
-    from multiprocessing import Process, Pipe
-except ImportError:
-    from processing import Process, Pipe
+from multiprocessing import Process, Pipe
 import numpy as np
 
 import matplotlib

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -197,10 +197,11 @@ if not hasattr(sys, 'argv'):  # for modpython
 
 
 major, minor1, minor2, s, tmp = sys.version_info
-_python26 = (major == 2 and minor1 >= 6) or major >= 3
+_python27 = (major == 2 and minor1 >= 7)
+_python34 = (major == 3 and minor1 >= 4)
 
-if not _python26:
-    raise ImportError('matplotlib requires Python 2.6 or later')
+if not (_python27 or _python34):
+    raise ImportError('matplotlib requires Python 2.7 or 3.4 or later')
 
 
 if not compare_versions(numpy.__version__, __version__numpy__):

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -235,23 +235,6 @@ class LatexManagerFactory(object):
             LatexManagerFactory.previous_instance = new_inst
             return new_inst
 
-class WeakSet(object):
-    # TODO: Poor man's weakref.WeakSet.
-    #       Remove this once python 2.6 support is dropped from matplotlib.
-
-    def __init__(self):
-        self.weak_key_dict = weakref.WeakKeyDictionary()
-
-    def add(self, item):
-        self.weak_key_dict[item] = None
-
-    def discard(self, item):
-        if item in self.weak_key_dict:
-            del self.weak_key_dict[item]
-
-    def __iter__(self):
-        return six.iterkeys(self.weak_key_dict)
-
 
 class LatexManager(object):
     """
@@ -259,7 +242,7 @@ class LatexManager(object):
     determining the metrics of text elements. The LaTeX environment can be
     modified by setting fonts and/or a custem preamble in the rc parameters.
     """
-    _unclean_instances = WeakSet()
+    _unclean_instances = weakref.WeakSet()
 
     @staticmethod
     def _build_latex_header():

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -191,20 +191,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         import textwrap
 
         if isinstance(func, classmethod):
-            try:
-                func = func.__func__
-            except AttributeError:
-                # classmethods in Python2.6 and below lack the __func__
-                # attribute so we need to hack around to get it
-                method = func.__get__(None, object)
-                if hasattr(method, '__func__'):
-                    func = method.__func__
-                elif hasattr(method, 'im_func'):
-                    func = method.im_func
-                else:
-                    # Nothing we can do really...  just return the original
-                    # classmethod
-                    return func
+            func = func.__func__
             is_classmethod = True
         else:
             is_classmethod = False

--- a/lib/matplotlib/tests/test_labeled_data_unpacking.py
+++ b/lib/matplotlib/tests/test_labeled_data_unpacking.py
@@ -7,17 +7,10 @@ try:
     # 3.2+ versions
     from nose.tools import assert_regex, assert_not_regex
 except ImportError:
-    try:
-        # 2.7 versions
-        from nose.tools import assert_regexp_matches, assert_not_regexp_matches
-        assert_regex = assert_regexp_matches
-        assert_not_regex = assert_not_regexp_matches
-    except ImportError:
-        # 2.6 versions
-        def noop(txt, regex):
-            raise SkipTest("No assert for regex matching in py2.6")
-        assert_regex = noop
-        assert_not_regex = noop
+    # 2.7 versions
+    from nose.tools import assert_regexp_matches, assert_not_regexp_matches
+    assert_regex = assert_regexp_matches
+    assert_not_regex = assert_not_regexp_matches
 
 from ..testing import assert_produces_warning
 

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_less
 from matplotlib.externals import six
 
 import matplotlib
@@ -71,13 +71,11 @@ def test_label_without_ticks():
     spine = ax.spines['left']
     spinebbox = spine.get_transform().transform_path(
         spine.get_path()).get_extents()
-    # replace with assert_less if >python2.6
-    assert_true(ax.yaxis.label.get_position()[0] < spinebbox.xmin,
+    assert_less(ax.yaxis.label.get_position()[0], spinebbox.xmin,
                 "Y-Axis label not left of the spine")
 
     spine = ax.spines['bottom']
     spinebbox = spine.get_transform().transform_path(
         spine.get_path()).get_extents()
-    # replace with assert_less if >python2.6
-    assert_true(ax.xaxis.label.get_position()[1] < spinebbox.ymin,
+    assert_less(ax.xaxis.label.get_position()[1], spinebbox.ymin,
                 "X-Axis label not below the spine")

--- a/setupext.py
+++ b/setupext.py
@@ -9,6 +9,7 @@ import multiprocessing
 import os
 import re
 import subprocess
+from subprocess import check_output
 import sys
 import warnings
 from textwrap import fill
@@ -17,32 +18,6 @@ import versioneer
 
 
 PY3 = (sys.version_info[0] >= 3)
-
-
-try:
-    from subprocess import check_output
-except ImportError:
-    # check_output is not available in Python 2.6
-    def check_output(*popenargs, **kwargs):
-        """
-        Run command with arguments and return its output as a byte
-        string.
-
-        Backported from Python 2.7 as it's implemented as pure python
-        on stdlib.
-        """
-        process = subprocess.Popen(
-            stdout=subprocess.PIPE, *popenargs, **kwargs)
-        output, unused_err = process.communicate()
-        retcode = process.poll()
-        if retcode:
-            cmd = kwargs.get("args")
-            if cmd is None:
-                cmd = popenargs[0]
-            error = subprocess.CalledProcessError(retcode, cmd)
-            error.output = output
-            raise error
-        return output
 
 
 if sys.platform != 'win32':

--- a/setupext.py
+++ b/setupext.py
@@ -529,13 +529,13 @@ class Python(SetupPackage):
 
         if major < 2:
             raise CheckFailed(
-                "Requires Python 2.6 or later")
-        elif major == 2 and minor1 < 6:
+                "Requires Python 2.7 or later")
+        elif major == 2 and minor1 < 7:
             raise CheckFailed(
-                "Requires Python 2.6 or later (in the 2.x series)")
-        elif major == 3 and minor1 < 1:
+                "Requires Python 2.7 or later (in the 2.x series)")
+        elif major == 3 and minor1 < 4:
             raise CheckFailed(
-                "Requires Python 3.1 or later (in the 3.x series)")
+                "Requires Python 3.4 or later (in the 3.x series)")
 
         return sys.version
 


### PR DESCRIPTION
Now that we don't support 2.6 any more we might as well get rid of this. This is what I found from grepping the code so there might as well be more that we can delete. 

I also fixed the version check in `__init__` we might want to backport that to 2.0.x