### PR TITLE
MNT: Mailmap fixes and simplification

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -20,7 +20,7 @@ Jake Vanderplas <jakevdp@gmail.com>
 Jake Vanderplas <jakevdp@gmail.com> <jakevdp@yahoo.com>
 Jake Vanderplas <jakevdp@gmail.com> <vanderplas@astro.washington.edu>
 James R. Evans <jrevans1@earthlink.net>
-Jeff Lutgen <jlutgen@users.noreply.github.com>
+Jeff Lutgen <jlutgen@gmail.com> <jlutgen@users.noreply.github.com>
 Jeffrey Bingham <bingjeff@gmail.com>
 Jens Hedegaard Nielsen <jenshnielsen@gmail.com>
 Jens Hedegaard Nielsen <jenshnielsen@gmail.com> <jens.nielsen@ucl.ac.uk>

--- a/.mailmap
+++ b/.mailmap
@@ -1,74 +1,66 @@
-Andrew Dawson <ajdawson@acm.org> Andrew Dawson <dawson@atm.ox.ac.uk>
-anykraus <kraus@mpip-mainz.mpg.de> anykraus <anykraus@users.noreply.github.com>
+Andrew Dawson <ajdawson@acm.org> <dawson@atm.ox.ac.uk>
+anykraus <kraus@mpip-mainz.mpg.de> <anykraus@users.noreply.github.com>
 Ariel Hernán Curiale <curiale@gmail.com>
-Ben Cohen <bj.cohen19@gmail.com> Ben Cohen <ben@cohen-family.org>
-Ben Root <ben.v.root@gmail.com> Benjamin Root <ben.v.root@gmail.com>
+Ben Cohen <bj.cohen19@gmail.com> <ben@cohen-family.org>
+Ben Root <ben.v.root@gmail.com>
 Casper van der Wel <caspervdw@gmail.com>
-Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
-Christoph Gohlke <cgohlke@uci.edu> C. Gohlke <cgohlke@uci.edu>
-Cimarron Mittelsteadt <cimarronm@gmail.com> Cimarron <cimarronm@gmail.com>
+Christoph Gohlke <cgohlke@uci.edu> <cgohlke@uci.edu>
+Cimarron Mittelsteadt <cimarronm@gmail.com>
+Daniel Hyams <dhyams@gmail.com>
 Daniel Hyams <dhyams@gmail.com> Daniel Hyams <dhyams@gitdev.(none)>
-Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>
 David Kua <david@kua.io> <david.kua@mail.utoronto.ca>
 endolith <endolith@gmail.com>
-Eric Dill <thedizzle@gmail.com> Eric Dill <edill@bnl.gov>
-Erik Bray <erik.m.bray@gmail.com> Erik M. Bray <embray@stsci.edu>
+Eric Dill <thedizzle@gmail.com> <edill@bnl.gov>
+Erik Bray <erik.m.bray@gmail.com> <embray@stsci.edu>
 Eric Ma <ericmajinglong@gmail.com> <ericmjl@Erics-MacBook-Pro.local>
 Eric Ma <ericmajinglong@gmail.com> <ericmjl@users.noreply.github.com>
 Francesco Montesano <franz.bergesund@gmail.com> montefra <franz.bergesund@gmail.com>
 Jaime Fernandez <jaime.frio@gmail.com>
 Jake Vanderplas <jakevdp@gmail.com>
-Jake Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@yahoo.com>
-Jake Vanderplas <jakevdp@gmail.com> Jake Vanderplas <vanderplas@astro.washington.edu>
-James R. Evans <jrevans1@earthlink.net> James Evans <jrevans1@earthlink.net>
+Jake Vanderplas <jakevdp@gmail.com> <jakevdp@yahoo.com>
+Jake Vanderplas <jakevdp@gmail.com> <vanderplas@astro.washington.edu>
+James R. Evans <jrevans1@earthlink.net>
 Jeff Lutgen <jlutgen@users.noreply.github.com>
-Jeffrey Bingham <bingjeff@gmail.com> Jeff Bingham <bingjeff@gmail.com>
-Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens Hedegaard Nielsen <jens.nielsen@ucl.ac.uk>
-Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H Nielsen <jenshnielsen@gmail.com>
-Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H. Nielsen <jenshnielsen@gmail.com>
-Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H. Nielsen <jens.nielsen@ucl.ac.uk>
-John Hunter <jdh2358@gmail.com> jdh2358 <jdh2358@gmail.com>
+Jeffrey Bingham <bingjeff@gmail.com>
+Jens Hedegaard Nielsen <jenshnielsen@gmail.com>
+Jens Hedegaard Nielsen <jenshnielsen@gmail.com> <jens.nielsen@ucl.ac.uk>
+John Hunter <jdh2358@gmail.com>
 Jorrit Wronski <jowr@mek.dtu.dk>
 Jouni K. Seppänen <jks@iki.fi>
-Julien Schueller <julien.schueller@gmail.com> jschueller <schueller@porsche-l64.phimeca.lan>
-Julien Schueller <julien.schueller@gmail.com> Julien Schueller <schueller@bx-l64.phimeca.lan>
-Julien Schueller <julien.schueller@gmail.com> Julien Schueller <schueller@porsche-l64.phimeca.lan>
-Kevin Davies <kdavies4@gmail.com> Kevin Davies <daviesk24@yahoo.com>
-kikocorreoso <kikocorreoso@gmail.com> kikocorreoso <kikocorreoso@users.noreply.github.com>
+Julien Schueller <julien.schueller@gmail.com> <schueller@porsche-l64.phimeca.lan>
+Julien Schueller <julien.schueller@gmail.com> <schueller@bx-l64.phimeca.lan>
+Kevin Davies <kdavies4@gmail.com> <daviesk24@yahoo.com>
+kikocorreoso <kikocorreoso@gmail.com> <kikocorreoso@users.noreply.github.com>
 Leeonadoh <leo.sunpeng.li@gmail.com>
-Lennart Fricke <lennart@die-frickes.eu> Lennart Fricke <lennart.fricke@kabelmail.de>
-Levi Kilcher <levi.kilcher@nrel.gov> Levi Kilcher <Levi.Kilcher@nrel.gov>
-Martin Fitzpatrick <martin.fitzpatrick@gmail.com> Martin Fitzpatrick <mfitzp@abl.es>
+Lennart Fricke <lennart@die-frickes.eu> <lennart.fricke@kabelmail.de>
+Levi Kilcher <levi.kilcher@nrel.gov>
+Martin Fitzpatrick <martin.fitzpatrick@gmail.com> <mfitzp@abl.es>
 Matthew Emmett <memmett@gmail.com>
 Matthew Emmett <memmett@gmail.com> <memmett@unc.edu>
-Matthias Bussonnier <bussonniermatthias@gmail.com> Bussonnier Matthias <bussonniermatthias@gmail.com>
-Matthias Bussonnier <bussonniermatthias@gmail.com> Matthias BUSSONNIER <bussonniermatthias@gmail.com>
-Michael Droettboom <mdboom@gmail.com> Michael Droettboom <mdroe@stsci.edu>
+Matthias Bussonnier <bussonniermatthias@gmail.com>
+Michael Droettboom <mdboom@gmail.com> <mdroe@stsci.edu>
 Michael Droettboom <mdboom@gmail.com> Michael Droettboom <mdboom@debian-vm>
 Michiel de Hoon <mjldehoon@yahoo.com>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@mad002s-MacBook-Air.local>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@michiel-de-hoons-computer.local>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@Michiels-MacBook-Pro.local>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@tkx294.genome.gsc.riken.jp>
-MinRK <benjaminrk@gmail.com> Min RK <minrk@kerbin.local>
 MinRK <benjaminrk@gmail.com>
-Nelle Varoquaux <nelle.varoquaux@gmail.com> Varoquaux <nelle.varoquaux@gmail.com>
+MinRK <benjaminrk@gmail.com> Min RK <minrk@kerbin.local>
+Nelle Varoquaux <nelle.varoquaux@gmail.com>
 Nic Eggert <nic.eggert@gmail.com> Nic Eggert <nic@eggert.pw>
 Nic Eggert <nic.eggert@gmail.com> Nic Eggert <nse23@cornell.edu>
-Nicolas P. Rougier <Nicolas.Rougier@inria.fr> Nicolas Rougier <Nicolas.Rougier@inria.fr>
+Nicolas P. Rougier <Nicolas.Rougier@inria.fr>
 OceanWolf <juichenieder-tigger@yahoo.co.uk>
 Patrick Chen <pat.chen@mail.utoronto.ca>
-Paul Ivanov <pivanov314@gmail.com> Paul Ivanov <pi@berkeley.edu>
-Per Parker <wisalam@live.com> Per <wisalam@live.com>
-Per Parker <wisalam@live.com> solvents <wisalam@live.com>
-Peter Würtz <pwuertz@gmail.com> Peter Würtz <pwuertz@googlemail.com>
-Peter Würtz <pwuertz@gmail.com> pwuertz <pwuertz@gmail.com>
-Peter Würtz <pwuertz@gmail.com> pwuertz <pwuertz@googlemail.com>
-Phil Elson <pelson.pub@gmail.com> pelson <pelson.pub@gmail.com>
-Phil Elson <pelson.pub@gmail.com> pelson <philipelson@hotmail.com>
-Phil Elson <pelson.pub@gmail.com> Phil Elson <philipelson@gmail.com>
-Phil Elson <pelson.pub@gmail.com> Phil Elson <philipelson@hotmail.com>
-Scott Lasley <selasley@me.com> selasley <selasley@me.com>
+Paul Ivanov <pivanov314@gmail.com> <pi@berkeley.edu>
+Per Parker <wisalam@live.com>
+Peter Würtz <pwuertz@gmail.com>
+Peter Würtz <pwuertz@gmail.com> <pwuertz@googlemail.com>
+Phil Elson <pelson.pub@gmail.com>
+Phil Elson <pelson.pub@gmail.com> <philipelson@hotmail.com>
+Phil Elson <pelson.pub@gmail.com> <philipelson@gmail.com>
+Scott Lasley <selasley@me.com>
 Simon Cross <hodgestar+github@gmail.com> <hodgestar@gmail.com>
 sohero <herosgq@gmail.com> sohero <ivip@tom.com>
 Stefan van der Walt <stefanv@berkeley.edu> <stefan@sun.ac.za>

--- a/.mailmap
+++ b/.mailmap
@@ -1,46 +1,63 @@
 Andrew Dawson <ajdawson@acm.org> Andrew Dawson <dawson@atm.ox.ac.uk>
 anykraus <kraus@mpip-mainz.mpg.de> anykraus <anykraus@users.noreply.github.com>
+Ariel Hernán Curiale <curiale@gmail.com>
 Ben Cohen <bj.cohen19@gmail.com> Ben Cohen <ben@cohen-family.org>
 Ben Root <ben.v.root@gmail.com> Benjamin Root <ben.v.root@gmail.com>
+Casper van der Wel <caspervdw@gmail.com>
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
 Christoph Gohlke <cgohlke@uci.edu> C. Gohlke <cgohlke@uci.edu>
 Cimarron Mittelsteadt <cimarronm@gmail.com> Cimarron <cimarronm@gmail.com>
 Daniel Hyams <dhyams@gmail.com> Daniel Hyams <dhyams@gitdev.(none)>
 Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>
+David Kua <david@kua.io> <david.kua@mail.utoronto.ca>
+endolith <endolith@gmail.com>
 Eric Dill <thedizzle@gmail.com> Eric Dill <edill@bnl.gov>
 Erik Bray <erik.m.bray@gmail.com> Erik M. Bray <embray@stsci.edu>
+Eric Ma <ericmajinglong@gmail.com> <ericmjl@Erics-MacBook-Pro.local>
+Eric Ma <ericmajinglong@gmail.com> <ericmjl@users.noreply.github.com>
 Francesco Montesano <franz.bergesund@gmail.com> montefra <franz.bergesund@gmail.com>
+Jaime Fernandez <jaime.frio@gmail.com>
+Jake Vanderplas <jakevdp@gmail.com>
 Jake Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@yahoo.com>
 Jake Vanderplas <jakevdp@gmail.com> Jake Vanderplas <vanderplas@astro.washington.edu>
 James R. Evans <jrevans1@earthlink.net> James Evans <jrevans1@earthlink.net>
+Jeff Lutgen <jlutgen@users.noreply.github.com>
 Jeffrey Bingham <bingjeff@gmail.com> Jeff Bingham <bingjeff@gmail.com>
 Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens Hedegaard Nielsen <jens.nielsen@ucl.ac.uk>
 Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H Nielsen <jenshnielsen@gmail.com>
 Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H. Nielsen <jenshnielsen@gmail.com>
 Jens Hedegaard Nielsen <jenshnielsen@gmail.com> Jens H. Nielsen <jens.nielsen@ucl.ac.uk>
 John Hunter <jdh2358@gmail.com> jdh2358 <jdh2358@gmail.com>
-Jouni K. Seppänen <jks@iki.fi> Jouni K. Seppänen <jks@iki.fi>
+Jorrit Wronski <jowr@mek.dtu.dk>
+Jouni K. Seppänen <jks@iki.fi>
 Julien Schueller <julien.schueller@gmail.com> jschueller <schueller@porsche-l64.phimeca.lan>
 Julien Schueller <julien.schueller@gmail.com> Julien Schueller <schueller@bx-l64.phimeca.lan>
 Julien Schueller <julien.schueller@gmail.com> Julien Schueller <schueller@porsche-l64.phimeca.lan>
 Kevin Davies <kdavies4@gmail.com> Kevin Davies <daviesk24@yahoo.com>
 kikocorreoso <kikocorreoso@gmail.com> kikocorreoso <kikocorreoso@users.noreply.github.com>
+Leeonadoh <leo.sunpeng.li@gmail.com>
 Lennart Fricke <lennart@die-frickes.eu> Lennart Fricke <lennart.fricke@kabelmail.de>
 Levi Kilcher <levi.kilcher@nrel.gov> Levi Kilcher <Levi.Kilcher@nrel.gov>
 Martin Fitzpatrick <martin.fitzpatrick@gmail.com> Martin Fitzpatrick <mfitzp@abl.es>
+Matthew Emmett <memmett@gmail.com>
+Matthew Emmett <memmett@gmail.com> <memmett@unc.edu>
 Matthias Bussonnier <bussonniermatthias@gmail.com> Bussonnier Matthias <bussonniermatthias@gmail.com>
 Matthias Bussonnier <bussonniermatthias@gmail.com> Matthias BUSSONNIER <bussonniermatthias@gmail.com>
 Michael Droettboom <mdboom@gmail.com> Michael Droettboom <mdroe@stsci.edu>
 Michael Droettboom <mdboom@gmail.com> Michael Droettboom <mdboom@debian-vm>
+Michiel de Hoon <mjldehoon@yahoo.com>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@mad002s-MacBook-Air.local>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@michiel-de-hoons-computer.local>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@Michiels-MacBook-Pro.local>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@tkx294.genome.gsc.riken.jp>
 MinRK <benjaminrk@gmail.com> Min RK <minrk@kerbin.local>
+MinRK <benjaminrk@gmail.com>
 Nelle Varoquaux <nelle.varoquaux@gmail.com> Varoquaux <nelle.varoquaux@gmail.com>
 Nic Eggert <nic.eggert@gmail.com> Nic Eggert <nic@eggert.pw>
 Nic Eggert <nic.eggert@gmail.com> Nic Eggert <nse23@cornell.edu>
 Nicolas P. Rougier <Nicolas.Rougier@inria.fr> Nicolas Rougier <Nicolas.Rougier@inria.fr>
+OceanWolf <juichenieder-tigger@yahoo.co.uk>
+Patrick Chen <pat.chen@mail.utoronto.ca>
 Paul Ivanov <pivanov314@gmail.com> Paul Ivanov <pi@berkeley.edu>
 Per Parker <wisalam@live.com> Per <wisalam@live.com>
 Per Parker <wisalam@live.com> solvents <wisalam@live.com>
@@ -52,10 +69,13 @@ Phil Elson <pelson.pub@gmail.com> pelson <philipelson@hotmail.com>
 Phil Elson <pelson.pub@gmail.com> Phil Elson <philipelson@gmail.com>
 Phil Elson <pelson.pub@gmail.com> Phil Elson <philipelson@hotmail.com>
 Scott Lasley <selasley@me.com> selasley <selasley@me.com>
+Simon Cross <hodgestar+github@gmail.com> <hodgestar@gmail.com>
 sohero <herosgq@gmail.com> sohero <ivip@tom.com>
+Stefan van der Walt <stefanv@berkeley.edu> <stefan@sun.ac.za>
 switham <github@mac-guyver.com> switham <switham_github@mac-guyver.com>
 Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <tcaswell@bnl.gov>
 Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <tcaswell@uchicago.edu>
 Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <“tcaswell@gmail.com”>
+Werner F Bruhin <wernerfbd@gmx.ch>
 Yunfei Yang <yangyunf@iits-b473-20053.(none)> Yunfei Yang <yangyunf@iits-b473-20057.(none)>
 Yunfei Yang <yangyunf@iits-b473-20053.(none)> Yunfei Yang <yangyunf@iits-b473-20061.(none)>


### PR DESCRIPTION
Remove some duplication from `git shortlog` by adding new mappings and altering some mappings (the first commit), and simplify the `.mailmap` file by matching on email address in most cases, which allows removing some redundant mappings (the second commit; this should have no effect on the shortlog output).

I have tried to guess the preferred spelling and email address for the contributors affected by the first commit, but could have gotten it wrong. Here is a list of those contributors:

- [x] @curiale
- [x] @caspervdw
- [x] @dkua 
- [x] @endolith 
- [x] @ericmjl 
- [x] @jaimefrio 
- [x] @jakevdp 
- [x] @jlutgen 
- [x] @jowr
- [x] @leeonadoh 
- [ ] @memmett
- [x] @mdehoon 
- [x] @minrk 
- [ ] @OceanWolf 
- [ ] @patchen 
- [x] @hodgestar
- [x] @stefanv 
- [ ] @wernerfb 