### PR TITLE
Text box widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
+
 2015-11-16 Levels passed to contour(f) and tricontour(f) must be in increasing
            order.
+
+2015-10-21 Added TextBox widget
+
 
 2015-10-21 Added get_ticks_direction()
 

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -245,8 +245,8 @@ Widgets
 -------
 
 Added TextBox Widget
-
 ````````````````````
+
 Added a widget that allows text entry by reading key events when it is active. 
 Text caret in text box is visible when it is active, can be moved using arrow keys but not mouse
 

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -1,4 +1,4 @@
-.. _whats-new:
+w.. _whats-new:
 
 ************************
 What's new in matplotlib
@@ -243,6 +243,13 @@ Some parameters have been added, others have been improved.
 
 Widgets
 -------
+
+Added TextBox Widget
+
+````````````````````
+Added a widget that allows text entry by reading key events when it is active. 
+Text caret in text box is visible when it is active, can be moved using arrow keys but not mouse
+
 
 Active state of Selectors
 `````````````````````````

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -1,4 +1,4 @@
-w.. _whats-new:
+.. _whats-new:
 
 ************************
 What's new in matplotlib

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -248,7 +248,7 @@ Added TextBox Widget
 ````````````````````
 
 Added a widget that allows text entry by reading key events when it is active. 
-Text caret in text box is visible when it is active, can be moved using arrow keys but not mouse
+Text caret in text box is visible when it is active, can be moved using arrow keys and mouse
 
 
 Active state of Selectors

--- a/examples/widgets/textbox.py
+++ b/examples/widgets/textbox.py
@@ -9,6 +9,7 @@ s = t ** 2
 initial_text = "t ** 2"
 l, = plt.plot(t, s, lw=2)
 
+
 def submit(text):
     ydata = eval(text)
     l.set_ydata(ydata)
@@ -16,7 +17,7 @@ def submit(text):
     plt.draw()
 
 axbox = plt.axes([0.1, 0.05, 0.8, 0.075])
-text_box = TextBox(axbox, 'Evaluate', initial = initial_text)
+text_box = TextBox(axbox, 'Evaluate', initial=initial_text)
 text_box.on_submit(submit)
 
 plt.show()

--- a/examples/widgets/textbox.py
+++ b/examples/widgets/textbox.py
@@ -1,0 +1,22 @@
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.widgets import TextBox
+fig, ax = plt.subplots()
+plt.subplots_adjust(bottom=0.2)
+t = np.arange(-2.0, 2.0, 0.001)
+s = t ** 2
+initial_text = "t ** 2"
+l, = plt.plot(t, s, lw=2)
+
+def submit(text):
+    ydata = eval(text)
+    l.set_ydata(ydata)
+    ax.set_ylim(np.min(ydata), np.max(ydata))
+    plt.draw()
+
+axbox = plt.axes([0.1, 0.05, 0.8, 0.075])
+text_box = TextBox(axbox, 'Evaluate', initial = initial_text)
+text_box.on_submit(submit)
+
+plt.show()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -706,6 +706,7 @@ class TextBox(AxesWidget):
         self.connect_event('button_release_event', self._release)
         self.connect_event('motion_notify_event', self._motion)
         self.connect_event('key_press_event', self._keypress)
+        self.connect_event('resize_event', self._resize)
         ax.set_navigate(False)
         ax.set_axis_bgcolor(color)
         ax.set_xticks([])
@@ -843,7 +844,10 @@ class TextBox(AxesWidget):
             event.canvas.grab_mouse(self.ax)
         if not(self.capturekeystrokes):
             self.begin_typing(event.x)
-
+    
+    def _resize(self, event):
+        self.stop_typing()
+    
     def _motion(self, event):
         if self.ignore(event):
             return

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -17,6 +17,7 @@ from matplotlib.externals import six
 from matplotlib.externals.six.moves import zip
 
 import numpy as np
+from matplotlib import rcParams
 
 from .mlab import dist
 from .patches import Circle, Rectangle, Ellipse
@@ -621,6 +622,256 @@ class CheckButtons(AxesWidget):
         except KeyError:
             pass
 
+class TextBox(AxesWidget):
+    """
+    A GUI neutral text input box.
+
+    For the text box to remain responsive
+    you must keep a reference to it.
+
+    The following attributes are accessible
+
+      *ax*
+        The :class:`matplotlib.axes.Axes` the button renders into.
+
+      *label*
+        A :class:`matplotlib.text.Text` instance.
+
+      *color*
+        The color of the text box when not hovering.
+
+      *hovercolor*
+        The color of the text box when hovering.
+
+    Call :meth:`on_text_change` to be updated whenever the text changes
+    Call :meth:`on_submit` to be updated whenever the user hits enter or leaves the text entry field
+    """
+
+    def __init__(self, ax, label, initial = '', 
+                 color='.95', hovercolor='1'):
+        """
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            The :class:`matplotlib.axes.Axes` instance the button
+            will be placed into.
+
+        label : str
+            Label for this text box. Accepts string.
+        
+        initial : str
+            Initial value in the text box
+            
+        color : color
+            The color of the box
+
+        hovercolor : color
+            The color of the box when the mouse is over it
+        """
+        AxesWidget.__init__(self, ax)
+        
+        self.DIST_FROM_LEFT = .05        
+        
+        self.params_to_disable = []
+        for key in rcParams.keys():                   
+            if u'keymap' in key:
+               self.params_to_disable += [key]
+        
+        self.text = initial
+        
+        
+        
+        
+        self.label = ax.text(0.0,0.5, label,
+                             verticalalignment='center',
+                             horizontalalignment='right',
+                             transform=ax.transAxes)
+        self.text_disp = self._make_text_disp(self.text)
+        
+        self.cnt = 0
+        self.change_observers = {}
+        self.submit_observers = {}
+        
+        self.ax.set_xlim(0, 1)      #If these lines are removed, the cursor won't appear 
+        self.ax.set_ylim(0, 1)      #the first time the box is clicked
+        
+        self.cursor_index = 0;
+        self.cursor = self.ax.vlines(0, 0, 0)    #because this is initialized, _render_cursor 
+        self.cursor.set_visible(False)           #can assume that cursor exists
+        
+        
+        self.connect_event('button_press_event', self._click)
+        self.connect_event('button_release_event', self._release)
+        self.connect_event('motion_notify_event', self._motion)
+        self.connect_event('key_press_event', self._keypress)
+        ax.set_navigate(False)
+        ax.set_axis_bgcolor(color)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        self.color = color
+        self.hovercolor = hovercolor
+
+        self._lastcolor = color
+        
+        self.capturekeystrokes = False        
+    
+    
+
+                
+    def _make_text_disp(self, string):
+        return self.ax.text(self.DIST_FROM_LEFT, 0.5, string,
+                             verticalalignment='center',
+                             horizontalalignment='left',
+                             transform=self.ax.transAxes)
+    def _rendercursor(self):
+        #this is a hack to figure out where the cursor should go.
+        #we draw the text up to where the cursor should go, measure 
+        #save its dimensions, draw the real text, then put the cursor
+        #at the saved dimensions
+        
+        widthtext = self.text[:self.cursor_index]
+        no_text = False
+        if(widthtext == "" or widthtext == " " or widthtext == "  "):
+            no_text = widthtext == ""
+            widthtext = ","
+        
+        
+        wt_disp = self._make_text_disp(widthtext)
+        
+        self.ax.figure.canvas.draw()
+        bb = wt_disp.get_window_extent()
+        inv = self.ax.transData.inverted()
+        bb = inv.transform(bb)
+        wt_disp.set_visible(False)
+        if no_text:
+            bb[1, 0] = bb[0, 0]        
+        #hack done
+        self.cursor.set_visible(False)
+        
+        
+        self.cursor = self.ax.vlines(bb[1, 0], bb[0, 1], bb[1, 1])
+        self.ax.figure.canvas.draw()
+
+    def _notify_submit_observers(self):
+        for cid, func in six.iteritems(self.submit_observers):
+                func(self.text)
+                
+    def _release(self, event):
+        if self.ignore(event):
+            return
+        if event.canvas.mouse_grabber != self.ax:
+            return
+        event.canvas.release_mouse(self.ax)
+        
+    def _keypress(self, event):
+        if self.ignore(event):
+            return
+        if self.capturekeystrokes:
+            key = event.key
+            
+            if(len(key) == 1):
+               self.text = (self.text[:self.cursor_index] + key + 
+                            self.text[self.cursor_index:])
+               self.cursor_index += 1
+            elif key == "right":
+               if self.cursor_index != len(self.text):
+                   self.cursor_index += 1
+            elif key == "left":
+               if self.cursor_index != 0:
+                   self.cursor_index -= 1
+            elif key == "home":
+               self.cursor_index = 0
+            elif key == "end":
+               self.cursor_index = len(self.text)
+            elif(key == "backspace"):
+                if self.cursor_index != 0:
+                    self.text = (self.text[:self.cursor_index - 1] + 
+                        self.text[self.cursor_index:])
+                    self.cursor_index -= 1
+            elif(key == "delete"):
+                if self.cursor_index != len(self.text):
+                    self.text = (self.text[:self.cursor_index] + 
+                        self.text[self.cursor_index + 1:])
+            self.text_disp.remove()
+            self.text_disp = self._make_text_disp(self.text)
+            self._rendercursor()
+            for cid, func in six.iteritems(self.change_observers):
+                func(self.text)
+            if key == "enter":
+                self._notify_submit_observers()       
+        
+    def _click(self, event):
+        if self.ignore(event):
+            return
+        if event.inaxes != self.ax:
+            notifysubmit = False    
+            #because _notify_submit_users might throw an error in the 
+            #user's code, we only want to call it once we've already done
+            #our cleanup.
+            if self.capturekeystrokes:
+               for key in self.params_to_disable:
+                    rcParams[key] = self.reset_params[key]
+               notifysubmit = True
+            self.capturekeystrokes = False
+            self.cursor.set_visible(False)
+            self.ax.figure.canvas.draw()
+            
+            if notifysubmit:
+                self._notify_submit_observers()
+            return
+        if not self.eventson:
+            return
+        if event.canvas.mouse_grabber != self.ax:
+            event.canvas.grab_mouse(self.ax)
+        if not(self.capturekeystrokes):
+            self.capturekeystrokes = True
+            self.reset_params = {}
+            for key in self.params_to_disable:
+                self.reset_params[key] = rcParams[key]
+                rcParams[key] = []
+            self.cursor_index = len(self.text)
+            self._rendercursor()
+
+
+    def _motion(self, event):
+        if self.ignore(event):
+            return
+        if event.inaxes == self.ax:
+            c = self.hovercolor
+        else:
+            c = self.color
+        if c != self._lastcolor:
+            self.ax.set_axis_bgcolor(c)
+            self._lastcolor = c
+            if self.drawon:
+                self.ax.figure.canvas.draw()
+
+    def on_text_change(self, func):
+        """
+        When the text changes, call this *func* with event
+
+        A connection id is returned which can be used to disconnect
+        """
+        cid = self.cnt
+        self.change_observers[cid] = func
+        self.cnt += 1
+        return cid
+    def on_submit(self, func):
+        """
+        When the user hits enter or leaves the submision box, call this *func* with event
+
+        A connection id is returned which can be used to disconnect
+        """
+        cid = self.cnt
+        self.submit_observers[cid] = func
+        self.cnt += 1
+        return cid
+    def disconnect(self, cid):
+        """remove the observer with connection id *cid*"""
+        try:
+            del self.observers[cid]
+        except KeyError:
+            pass
 
 class RadioButtons(AxesWidget):
     """
@@ -917,6 +1168,7 @@ class SubplotTool(Widget):
         self.targetfig.subplots_adjust(hspace=val)
         if self.drawon:
             self.targetfig.canvas.draw()
+
 
 
 class Cursor(AxesWidget):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -622,14 +622,14 @@ class CheckButtons(AxesWidget):
         except KeyError:
             pass
 
+
 class TextBox(AxesWidget):
     """
     A GUI neutral text input box.
 
-    For the text box to remain responsive
-    you must keep a reference to it.
+    For the text box to remain responsive you must keep a reference to it.
 
-    The following attributes are accessible
+    The following attributes are accessible:
 
       *ax*
         The :class:`matplotlib.axes.Axes` the button renders into.
@@ -643,11 +643,13 @@ class TextBox(AxesWidget):
       *hovercolor*
         The color of the text box when hovering.
 
-    Call :meth:`on_text_change` to be updated whenever the text changes
-    Call :meth:`on_submit` to be updated whenever the user hits enter or leaves the text entry field
+    Call :meth:`on_text_change` to be updated whenever the text changes.
+
+    Call :meth:`on_submit` to be updated whenever the user hits enter or
+    leaves the text entry field.
     """
 
-    def __init__(self, ax, label, initial = '', 
+    def __init__(self, ax, label, initial='',
                  color='.95', hovercolor='1'):
         """
         Parameters
@@ -658,10 +660,10 @@ class TextBox(AxesWidget):
 
         label : str
             Label for this text box. Accepts string.
-        
+
         initial : str
             Initial value in the text box
-            
+
         color : color
             The color of the box
 
@@ -669,32 +671,37 @@ class TextBox(AxesWidget):
             The color of the box when the mouse is over it
         """
         AxesWidget.__init__(self, ax)
-        
-        self.DIST_FROM_LEFT = .05        
-        
+
+        self.DIST_FROM_LEFT = .05
+
         self.params_to_disable = []
-        for key in rcParams.keys():                   
+        for key in rcParams.keys():
             if u'keymap' in key:
-               self.params_to_disable += [key]
-        
+                self.params_to_disable += [key]
+
         self.text = initial
-        self.label = ax.text(0.0,0.5, label,
+        self.label = ax.text(0.0, 0.5, label,
                              verticalalignment='center',
                              horizontalalignment='right',
                              transform=ax.transAxes)
         self.text_disp = self._make_text_disp(self.text)
-        
+
         self.cnt = 0
         self.change_observers = {}
         self.submit_observers = {}
-        
-        self.ax.set_xlim(0, 1)      #If these lines are removed, the cursor won't appear 
-        self.ax.set_ylim(0, 1)      #the first time the box is clicked
-        
-        self.cursor_index = 0;
-        self.cursor = self.ax.vlines(0, 0, 0)    #because this is initialized, _render_cursor 
-        self.cursor.set_visible(False)           #can assume that cursor exists
-        
+
+        # If these lines are removed, the cursor won't appear the first
+        # time the box is clicked:
+        self.ax.set_xlim(0, 1)
+        self.ax.set_ylim(0, 1)
+
+        self.cursor_index = 0
+
+        # Because this is initialized, _render_cursor
+        # can assume that cursor exists.
+        self.cursor = self.ax.vlines(0, 0, 0)
+        self.cursor.set_visible(False)
+
         self.connect_event('button_press_event', self._click)
         self.connect_event('button_release_event', self._release)
         self.connect_event('motion_notify_event', self._motion)
@@ -707,105 +714,107 @@ class TextBox(AxesWidget):
         self.hovercolor = hovercolor
 
         self._lastcolor = color
-        
-        self.capturekeystrokes = False        
-           
+
+        self.capturekeystrokes = False
+
     def _make_text_disp(self, string):
         return self.ax.text(self.DIST_FROM_LEFT, 0.5, string,
-                             verticalalignment='center',
-                             horizontalalignment='left',
-                             transform=self.ax.transAxes)
+                            verticalalignment='center',
+                            horizontalalignment='left',
+                            transform=self.ax.transAxes)
+
     def _rendercursor(self):
-        #this is a hack to figure out where the cursor should go.
-        #we draw the text up to where the cursor should go, measure 
-        #save its dimensions, draw the real text, then put the cursor
-        #at the saved dimensions
-        
+        # this is a hack to figure out where the cursor should go.
+        # we draw the text up to where the cursor should go, measure
+        # save its dimensions, draw the real text, then put the cursor
+        # at the saved dimensions
+
         widthtext = self.text[:self.cursor_index]
         no_text = False
         if(widthtext == "" or widthtext == " " or widthtext == "  "):
             no_text = widthtext == ""
-            widthtext = ","   
-        
+            widthtext = ","
+
         wt_disp = self._make_text_disp(widthtext)
-        
+
         self.ax.figure.canvas.draw()
         bb = wt_disp.get_window_extent()
         inv = self.ax.transData.inverted()
         bb = inv.transform(bb)
         wt_disp.set_visible(False)
         if no_text:
-            bb[1, 0] = bb[0, 0]        
-        #hack done
-        self.cursor.set_visible(False)   
-        
+            bb[1, 0] = bb[0, 0]
+        # hack done
+        self.cursor.set_visible(False)
+
         self.cursor = self.ax.vlines(bb[1, 0], bb[0, 1], bb[1, 1])
         self.ax.figure.canvas.draw()
 
     def _notify_submit_observers(self):
         for cid, func in six.iteritems(self.submit_observers):
                 func(self.text)
-                
+
     def _release(self, event):
         if self.ignore(event):
             return
         if event.canvas.mouse_grabber != self.ax:
             return
         event.canvas.release_mouse(self.ax)
-        
+
     def _keypress(self, event):
         if self.ignore(event):
             return
         if self.capturekeystrokes:
             key = event.key
-            
+
             if(len(key) == 1):
-               self.text = (self.text[:self.cursor_index] + key + 
-                            self.text[self.cursor_index:])
-               self.cursor_index += 1
+                self.text = (self.text[:self.cursor_index] + key +
+                             self.text[self.cursor_index:])
+                self.cursor_index += 1
             elif key == "right":
-               if self.cursor_index != len(self.text):
-                   self.cursor_index += 1
+                if self.cursor_index != len(self.text):
+                    self.cursor_index += 1
             elif key == "left":
-               if self.cursor_index != 0:
-                   self.cursor_index -= 1
+                if self.cursor_index != 0:
+                    self.cursor_index -= 1
             elif key == "home":
-               self.cursor_index = 0
+                self.cursor_index = 0
             elif key == "end":
-               self.cursor_index = len(self.text)
+                self.cursor_index = len(self.text)
             elif(key == "backspace"):
                 if self.cursor_index != 0:
-                    self.text = (self.text[:self.cursor_index - 1] + 
-                        self.text[self.cursor_index:])
+                    self.text = (self.text[:self.cursor_index - 1] +
+                                 self.text[self.cursor_index:])
                     self.cursor_index -= 1
             elif(key == "delete"):
                 if self.cursor_index != len(self.text):
-                    self.text = (self.text[:self.cursor_index] + 
-                        self.text[self.cursor_index + 1:])
+                    self.text = (self.text[:self.cursor_index] +
+                                 self.text[self.cursor_index + 1:])
+
             self.text_disp.remove()
             self.text_disp = self._make_text_disp(self.text)
             self._rendercursor()
             for cid, func in six.iteritems(self.change_observers):
                 func(self.text)
             if key == "enter":
-                self._notify_submit_observers()       
-        
+                self._notify_submit_observers()
+
     def _click(self, event):
         if self.ignore(event):
             return
         if event.inaxes != self.ax:
-            notifysubmit = False    
-            #because _notify_submit_users might throw an error in the 
-            #user's code, we only want to call it once we've already done
-            #our cleanup.
+            notifysubmit = False
+            # because _notify_submit_users might throw an error in the
+            # user's code, we only want to call it once we've already done
+            # our cleanup.
             if self.capturekeystrokes:
-               for key in self.params_to_disable:
+                for key in self.params_to_disable:
                     rcParams[key] = self.reset_params[key]
-               notifysubmit = True
+                notifysubmit = True
             self.capturekeystrokes = False
             self.cursor.set_visible(False)
             self.ax.figure.canvas.draw()
-            
+
             if notifysubmit:
                 self._notify_submit_observers()
             return
@@ -837,32 +846,34 @@ class TextBox(AxesWidget):
 
     def on_text_change(self, func):
         """
-        When the text changes, call this *func* with event
+        When the text changes, call this *func* with event.
 
-        A connection id is returned which can be used to disconnect
+        A connection id is returned which can be used to disconnect.
         """
         cid = self.cnt
         self.change_observers[cid] = func
         self.cnt += 1
         return cid
-        
+
     def on_submit(self, func):
         """
-        When the user hits enter or leaves the submision box, call this *func* with event
+        When the user hits enter or leaves the submision box, call this
+        *func* with event.
 
-        A connection id is returned which can be used to disconnect
+        A connection id is returned which can be used to disconnect.
         """
         cid = self.cnt
         self.submit_observers[cid] = func
         self.cnt += 1
         return cid
-        
+
     def disconnect(self, cid):
         """remove the observer with connection id *cid*"""
         try:
             del self.observers[cid]
         except KeyError:
             pass
+
 
 class RadioButtons(AxesWidget):
     """
@@ -2512,4 +2523,4 @@ class Lasso(AxesWidget):
             self.ax.draw_artist(self.line)
             self.canvas.blit(self.ax.bbox)
         else:
-            self.canvas.draw_idle()
+            self.canvas.draw_idle()time the 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -680,7 +680,7 @@ class TextBox(AxesWidget):
                 self.params_to_disable += [key]
 
         self.text = initial
-        self.label = ax.text(0.0, 0.5, label,
+        self.label = ax.text(-0.01, 0.5, label,
                              verticalalignment='center',
                              horizontalalignment='right',
                              transform=ax.transAxes)
@@ -726,7 +726,7 @@ class TextBox(AxesWidget):
     def _rendercursor(self):
         # this is a hack to figure out where the cursor should go.
         # we draw the text up to where the cursor should go, measure
-        # save its dimensions, draw the real text, then put the cursor
+        # and save its dimensions, draw the real text, then put the cursor
         # at the saved dimensions
 
         widthtext = self.text[:self.cursor_index]
@@ -798,38 +798,51 @@ class TextBox(AxesWidget):
                 func(self.text)
             if key == "enter":
                 self._notify_submit_observers()
+                
+    def begin_typing(x):
+        self.capturekeystrokes = True
+        #disable command keys so that the user can type without
+        #command keys causing figure to be saved, etc
+        self.reset_params = {}
+        for key in self.params_to_disable:
+            self.reset_params[key] = rcParams[key]
+            rcParams[key] = []
+        #now, we have to figure out where the cursor goes.
+        #approximate it based on assuming all characters the same length
+        print(x)
+        self.cursor_index = len(self.text)
+        self._rendercursor()
+    
+    def stop_typing():
+        notifysubmit = False
+        # because _notify_submit_users might throw an error in the
+        # user's code, we only want to call it once we've already done
+        # our cleanup.
+        if self.capturekeystrokes:
+            #since the user is no longer typing, 
+            #reactivate the standard command keys
+            for key in self.params_to_disable:
+                rcParams[key] = self.reset_params[key]
+            notifysubmit = True
+        self.capturekeystrokes = False
+        self.cursor.set_visible(False)
+        self.ax.figure.canvas.draw()
+        if notifysubmit:
+            self._notify_submit_observers()
 
+    
     def _click(self, event):
         if self.ignore(event):
             return
         if event.inaxes != self.ax:
-            notifysubmit = False
-            # because _notify_submit_users might throw an error in the
-            # user's code, we only want to call it once we've already done
-            # our cleanup.
-            if self.capturekeystrokes:
-                for key in self.params_to_disable:
-                    rcParams[key] = self.reset_params[key]
-                notifysubmit = True
-            self.capturekeystrokes = False
-            self.cursor.set_visible(False)
-            self.ax.figure.canvas.draw()
-
-            if notifysubmit:
-                self._notify_submit_observers()
+            self.stop_typing()
             return
         if not self.eventson:
             return
         if event.canvas.mouse_grabber != self.ax:
             event.canvas.grab_mouse(self.ax)
         if not(self.capturekeystrokes):
-            self.capturekeystrokes = True
-            self.reset_params = {}
-            for key in self.params_to_disable:
-                self.reset_params[key] = rcParams[key]
-                rcParams[key] = []
-            self.cursor_index = len(self.text)
-            self._rendercursor()
+            self.begin_typing(exent.x)
 
     def _motion(self, event):
         if self.ignore(event):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1161,7 +1161,6 @@ class SubplotTool(Widget):
             self.targetfig.canvas.draw()
 
 
-
 class Cursor(AxesWidget):
     """
     A horizontal and vertical line that spans the axes and moves with

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -799,7 +799,7 @@ class TextBox(AxesWidget):
             if key == "enter":
                 self._notify_submit_observers()
                 
-    def begin_typing(x):
+    def begin_typing(self, x):
         self.capturekeystrokes = True
         #disable command keys so that the user can type without
         #command keys causing figure to be saved, etc
@@ -813,7 +813,7 @@ class TextBox(AxesWidget):
         self.cursor_index = len(self.text)
         self._rendercursor()
     
-    def stop_typing():
+    def stop_typing(self):
         notifysubmit = False
         # because _notify_submit_users might throw an error in the
         # user's code, we only want to call it once we've already done
@@ -842,7 +842,7 @@ class TextBox(AxesWidget):
         if event.canvas.mouse_grabber != self.ax:
             event.canvas.grab_mouse(self.ax)
         if not(self.capturekeystrokes):
-            self.begin_typing(exent.x)
+            self.begin_typing(event.x)
 
     def _motion(self, event):
         if self.ignore(event):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -802,7 +802,7 @@ class TextBox(AxesWidget):
                 func(self.text)
             if key == "enter":
                 self._notify_submit_observers()
-                
+
     def begin_typing(self, x):
         self.capturekeystrokes = True
         #disable command keys so that the user can type without
@@ -815,7 +815,7 @@ class TextBox(AxesWidget):
         #approximate it based on assuming all characters the same length
         self.cursor_index = len(self.text)
         self._rendercursor()
-    
+
     def stop_typing(self):
         notifysubmit = False
         # because _notify_submit_users might throw an error in the
@@ -833,7 +833,7 @@ class TextBox(AxesWidget):
         if notifysubmit:
             self._notify_submit_observers()
 
-    
+
     def _click(self, event):
         if self.ignore(event):
             return
@@ -846,10 +846,10 @@ class TextBox(AxesWidget):
             event.canvas.grab_mouse(self.ax)
         if not(self.capturekeystrokes):
             self.begin_typing(event.x)
-    
+
     def _resize(self, event):
         self.stop_typing()
-    
+
     def _motion(self, event):
         if self.ignore(event):
             return

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -711,7 +711,7 @@ class TextBox(AxesWidget):
         self.connect_event('key_press_event', self._keypress)
         self.connect_event('resize_event', self._resize)
         ax.set_navigate(False)
-        ax.set_axis_bgcolor(color)
+        ax.set_facecolor(color)
         ax.set_xticks([])
         ax.set_yticks([])
         self.color = color
@@ -811,10 +811,6 @@ class TextBox(AxesWidget):
         for key in self.params_to_disable:
             self.reset_params[key] = rcParams[key]
             rcParams[key] = []
-        #now, we have to figure out where the cursor goes.
-        #approximate it based on assuming all characters the same length
-        self.cursor_index = len(self.text)
-        self._rendercursor()
 
     def stop_typing(self):
         notifysubmit = False
@@ -822,7 +818,7 @@ class TextBox(AxesWidget):
         # user's code, we only want to call it once we've already done
         # our cleanup.
         if self.capturekeystrokes:
-            #since the user is no longer typing, 
+            #since the user is no longer typing,
             #reactivate the standard command keys
             for key in self.params_to_disable:
                 rcParams[key] = self.reset_params[key]
@@ -833,6 +829,31 @@ class TextBox(AxesWidget):
         if notifysubmit:
             self._notify_submit_observers()
 
+    def position_cursor(self, x):
+        #now, we have to figure out where the cursor goes.
+        #approximate it based on assuming all characters the same length
+        if len(self.text) == 0:
+            self.cursor_index = 0
+        else:
+            bb = self.text_disp.get_window_extent()
+
+            trans = self.ax.transData
+            inv = self.ax.transData.inverted()
+            bb = trans.transform(inv.transform(bb))
+
+            text_start = bb[0, 0]
+            text_end = bb[1, 0]
+
+            ratio = (x - text_start) / (text_end - text_start)
+
+            if ratio < 0:
+                ratio = 0
+            if ratio > 1:
+                ratio = 1
+
+            self.cursor_index = int(len(self.text) * ratio)
+
+        self._rendercursor()
 
     def _click(self, event):
         if self.ignore(event):
@@ -846,6 +867,7 @@ class TextBox(AxesWidget):
             event.canvas.grab_mouse(self.ax)
         if not(self.capturekeystrokes):
             self.begin_typing(event.x)
+        self.position_cursor(event.x)
 
     def _resize(self, event):
         self.stop_typing()
@@ -858,7 +880,7 @@ class TextBox(AxesWidget):
         else:
             c = self.color
         if c != self._lastcolor:
-            self.ax.set_axis_bgcolor(c)
+            self.ax.set_facecolor(c)
             self._lastcolor = c
             if self.drawon:
                 self.ax.figure.canvas.draw()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -678,10 +678,6 @@ class TextBox(AxesWidget):
                self.params_to_disable += [key]
         
         self.text = initial
-        
-        
-        
-        
         self.label = ax.text(0.0,0.5, label,
                              verticalalignment='center',
                              horizontalalignment='right',
@@ -699,7 +695,6 @@ class TextBox(AxesWidget):
         self.cursor = self.ax.vlines(0, 0, 0)    #because this is initialized, _render_cursor 
         self.cursor.set_visible(False)           #can assume that cursor exists
         
-        
         self.connect_event('button_press_event', self._click)
         self.connect_event('button_release_event', self._release)
         self.connect_event('motion_notify_event', self._motion)
@@ -714,10 +709,7 @@ class TextBox(AxesWidget):
         self._lastcolor = color
         
         self.capturekeystrokes = False        
-    
-    
-
-                
+           
     def _make_text_disp(self, string):
         return self.ax.text(self.DIST_FROM_LEFT, 0.5, string,
                              verticalalignment='center',
@@ -733,8 +725,7 @@ class TextBox(AxesWidget):
         no_text = False
         if(widthtext == "" or widthtext == " " or widthtext == "  "):
             no_text = widthtext == ""
-            widthtext = ","
-        
+            widthtext = ","   
         
         wt_disp = self._make_text_disp(widthtext)
         
@@ -746,8 +737,7 @@ class TextBox(AxesWidget):
         if no_text:
             bb[1, 0] = bb[0, 0]        
         #hack done
-        self.cursor.set_visible(False)
-        
+        self.cursor.set_visible(False)   
         
         self.cursor = self.ax.vlines(bb[1, 0], bb[0, 1], bb[1, 1])
         self.ax.figure.canvas.draw()
@@ -832,7 +822,6 @@ class TextBox(AxesWidget):
             self.cursor_index = len(self.text)
             self._rendercursor()
 
-
     def _motion(self, event):
         if self.ignore(event):
             return
@@ -856,6 +845,7 @@ class TextBox(AxesWidget):
         self.change_observers[cid] = func
         self.cnt += 1
         return cid
+        
     def on_submit(self, func):
         """
         When the user hits enter or leaves the submision box, call this *func* with event
@@ -866,6 +856,7 @@ class TextBox(AxesWidget):
         self.submit_observers[cid] = func
         self.cnt += 1
         return cid
+        
     def disconnect(self, cid):
         """remove the observer with connection id *cid*"""
         try:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2523,4 +2523,4 @@ class Lasso(AxesWidget):
             self.ax.draw_artist(self.line)
             self.canvas.blit(self.ax.bbox)
         else:
-            self.canvas.draw_idle()time the 
+            self.canvas.draw_idle()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -650,7 +650,7 @@ class TextBox(AxesWidget):
     """
 
     def __init__(self, ax, label, initial='',
-                 color='.95', hovercolor='1'):
+                 color='.95', hovercolor='1', label_pad=.01):
         """
         Parameters
         ----------
@@ -669,6 +669,9 @@ class TextBox(AxesWidget):
 
         hovercolor : color
             The color of the box when the mouse is over it
+            
+        label_pad : float
+            the distance between the label and the right side of the textbox
         """
         AxesWidget.__init__(self, ax)
 
@@ -680,7 +683,7 @@ class TextBox(AxesWidget):
                 self.params_to_disable += [key]
 
         self.text = initial
-        self.label = ax.text(-0.01, 0.5, label,
+        self.label = ax.text(-label_pad, 0.5, label,
                              verticalalignment='center',
                              horizontalalignment='right',
                              transform=ax.transAxes)
@@ -810,7 +813,6 @@ class TextBox(AxesWidget):
             rcParams[key] = []
         #now, we have to figure out where the cursor goes.
         #approximate it based on assuming all characters the same length
-        print(x)
         self.cursor_index = len(self.text)
         self._rendercursor()
     


### PR DESCRIPTION
Several users (myself included) have wanted the ability to do text input as a widget. This text box widget is implemented by capturing keystrokes and adding them to a string, with special cases for keys like "enter", "left", "right" etc. 

http://stackoverflow.com/questions/25231449/do-text-number-input-fields-exist-in-matplotlib
http://stackoverflow.com/questions/25449398/matplotlib-user-enters-numeric-input-through-figure