### PR TITLE
Fix TransformWrapper pickles (take 2)

### DIFF
--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -279,6 +279,9 @@ def test_transform():
     assert_equal(obj.wrapper._child, obj.composite)
     # Check child -> parent links of TransformWrapper.
     assert_equal(list(obj.wrapper._parents.values()), [obj.composite2])
+    # Check input and output dimensions are set as expected.
+    assert_equal(obj.wrapper.input_dims, obj.composite.input_dims)
+    assert_equal(obj.wrapper.output_dims, obj.composite.output_dims)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1552,10 +1552,14 @@ class TransformWrapper(Transform):
         def __str__(self):
             return str(self._child)
 
+    # NOTE: Transform.__[gs]etstate__ should be sufficient when using only
+    # Python 3.4+.
     def __getstate__(self):
-        # only store the child and parents
+        # only store the child information and parents
         return {
             'child': self._child,
+            'input_dims': self.input_dims,
+            'output_dims': self.output_dims,
             # turn the weakkey dictionary into a normal dictionary
             'parents': dict(six.iteritems(self._parents))
         }
@@ -1563,6 +1567,9 @@ class TransformWrapper(Transform):
     def __setstate__(self, state):
         # re-initialise the TransformWrapper with the state's child
         self._init(state['child'])
+        # The child may not be unpickled yet, so restore its information.
+        self.input_dims = state['input_dims']
+        self.output_dims = state['output_dims']
         # turn the normal dictionary back into a WeakValueDictionary
         self._parents = WeakValueDictionary(state['parents'])
 


### PR DESCRIPTION
As it turns out, the fix from #4915 was incomplete. Unpickling seems to ensure that the child _object_ exists, but not that its _state_ has been restored. This can be seen in the enhanced test where `child.input_dims` is not yet unpickled when the `TransformWrapper` is unpickled. So copying `input_dims` from the child results in garbage in the wrapper _some_ of the time.

~~I was stuck in following the original method of saving the child that I didn't realize there's a simpler solution: just don't override `__[gs]etstate__` in `TransformWrapper`. The parent class `TransformNode` provides `__[gs]etstate__` that saves the whole `self.__dict__` which will save/restore everything.~~ Unfortunately, that fix only works on Python 3.4+.

~~This PR is a little bit bigger than that because I reverted #4915 since the extra methods are no longer necessary.~~