### PR TITLE
DOC: Fix typo, broken link in references

### DIFF
--- a/doc/users/colormaps.rst
+++ b/doc/users/colormaps.rst
@@ -192,7 +192,7 @@ References
 ==========
 
 .. [Ware] http://ccom.unh.edu/sites/default/files/publications/Ware_1988_CGA_Color_sequences_univariate_maps.pdf
-.. [Moreland] http://www.sandia.gov/~kmorel/documents/ColorMaps/ColorMapsExpanded.pdf
+.. [Moreland] http://www.kennethmoreland.com/color-maps/ColorMapsExpanded.pdf
 .. [list-colormaps] https://gist.github.com/endolith/2719900#id7
 .. [mycarta-banding] http://mycarta.wordpress.com/2012/10/14/the-rainbow-is-deadlong-live-the-rainbow-part-4-cie-lab-heated-body/
 .. [mycarta-jet] http://mycarta.wordpress.com/2012/10/06/the-rainbow-is-deadlong-live-the-rainbow-part-3/


### PR DESCRIPTION
The `Moreland` reference linked to an academic personal site that no longer resolves. The fixed link points to the [paper](http://www.kennethmoreland.com/color-maps/ColorMapsExpanded.pdf) now hosted on Kenneth Moreland's personal site.