### PR TITLE
BUG: Make webagg work without IPython installed

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -26,9 +26,10 @@ from matplotlib.figure import Figure
 from matplotlib import is_interactive
 from matplotlib.backends.backend_webagg_core import (FigureManagerWebAgg,
                                                      FigureCanvasWebAggCore,
-                                                     NavigationToolbar2WebAgg)
+                                                     NavigationToolbar2WebAgg,
+                                                     TimerTornado)
 from matplotlib.backend_bases import (ShowBase, NavigationToolbar2,
-                                      TimerBase, FigureCanvasBase)
+                                      FigureCanvasBase)
 
 
 class Show(ShowBase):
@@ -183,38 +184,6 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
     def remove_comm(self, comm_id):
         self.web_sockets = set([socket for socket in self.web_sockets
                                 if not socket.comm.comm_id == comm_id])
-
-
-class TimerTornado(TimerBase):
-    def _timer_start(self):
-        self._timer_stop()
-        if self._single:
-            ioloop = tornado.ioloop.IOLoop.instance()
-            self._timer = ioloop.add_timeout(
-                datetime.timedelta(milliseconds=self.interval),
-                self._on_timer)
-        else:
-            self._timer = tornado.ioloop.PeriodicCallback(
-                self._on_timer,
-                self.interval)
-            self._timer.start()
-
-    def _timer_stop(self):
-        if self._timer is None:
-            return
-        elif self._single:
-            ioloop = tornado.ioloop.IOLoop.instance()
-            ioloop.remove_timeout(self._timer)
-        else:
-            self._timer.stop()
-
-        self._timer = None
-
-    def _timer_set_interval(self):
-        # Only stop and restart it if the timer has already been started
-        if self._timer is not None:
-            self._timer_stop()
-            self._timer_start()
 
 
 class FigureCanvasNbAgg(FigureCanvasWebAggCore):

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -39,7 +39,7 @@ from matplotlib import backend_bases
 from matplotlib.figure import Figure
 from matplotlib._pylab_helpers import Gcf
 from . import backend_webagg_core as core
-from .backend_nbagg import TimerTornado
+from .backend_webagg_core import TimerTornado
 
 
 def new_figure_manager(num, *args, **kwargs):

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -519,3 +519,35 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
         payload.update(kwargs)
         for s in self.web_sockets:
             s.send_json(payload)
+
+
+class TimerTornado(backend_bases.TimerBase):
+    def _timer_start(self):
+        self._timer_stop()
+        if self._single:
+            ioloop = tornado.ioloop.IOLoop.instance()
+            self._timer = ioloop.add_timeout(
+                datetime.timedelta(milliseconds=self.interval),
+                self._on_timer)
+        else:
+            self._timer = tornado.ioloop.PeriodicCallback(
+                self._on_timer,
+                self.interval)
+            self._timer.start()
+
+    def _timer_stop(self):
+        if self._timer is None:
+            return
+        elif self._single:
+            ioloop = tornado.ioloop.IOLoop.instance()
+            ioloop.remove_timeout(self._timer)
+        else:
+            self._timer.stop()
+
+        self._timer = None
+
+    def _timer_set_interval(self):
+        # Only stop and restart it if the timer has already been started
+        if self._timer is not None:
+            self._timer_stop()
+            self._timer_start()


### PR DESCRIPTION
webagg is supposed to be completely independent of IPython, and work with only tornado installed.

At some point or other, this was broken by putting a common piece of functionality, `TornadoTimer` in `nbagg` instead of `webagg_core`.  This just reorganizes things so `webagg` can be used with `IPython` installed again.