### PR TITLE
Faster image generation in WebAgg/NbAgg backends

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -143,11 +143,6 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
     def __init__(self, *args, **kwargs):
         backend_agg.FigureCanvasAgg.__init__(self, *args, **kwargs)
 
-        # A buffer to hold the PNG data for the last frame.  This is
-        # retained so it can be resent to each client without
-        # regenerating it.
-        self._png_buffer = io.BytesIO()
-
         # Set to True when the renderer contains data that is newer
         # than the PNG buffer.
         self._png_is_old = True
@@ -225,24 +220,19 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 diff = buff != last_buffer
                 output = np.where(diff, buff, 0)
 
-            # Clear out the PNG data buffer rather than recreating it
-            # each time.  This reduces the number of memory
-            # (de)allocations.
-            self._png_buffer.truncate()
-            self._png_buffer.seek(0)
-
             # TODO: We should write a new version of write_png that
             # handles the differencing inline
-            _png.write_png(
+            buff = _png.write_png(
                 output.view(dtype=np.uint8).reshape(output.shape + (4,)),
-                self._png_buffer)
+                None, compression=6, filter=_png.PNG_FILTER_NONE)
 
             # Swap the renderer frames
             self._renderer, self._last_renderer = (
                 self._last_renderer, renderer)
             self._force_full = False
             self._png_is_old = False
-        return self._png_buffer.getvalue()
+
+        return buff
 
     def get_renderer(self, cleared=None):
         # Mirrors super.get_renderer, but caches the old one

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -83,7 +83,42 @@ static void flush_png_data(png_structp png_ptr)
     Py_XDECREF(result);
 }
 
-const char *Py_write_png__doc__ = "write_png(buffer, file, dpi=0)";
+const char *Py_write_png__doc__ =
+    "write_png(buffer, file, dpi=0, compression=6, filter=auto)\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "buffer : numpy array of image data\n"
+    "    Must be an MxNxD array of dtype uint8.\n"
+    "    - if D is 1, the image is greyscale\n"
+    "    - if D is 3, the image is RGB\n"
+    "    - if D is 4, the image is RGBA\n"
+    "\n"
+    "file : str path, file-like object or None\n"
+    "    - If a str, must be a file path\n"
+    "    - If a file-like object, must write bytes\n"
+    "    - If None, a byte string containing the PNG data will be returned\n"
+    "\n"
+    "dpi : float\n"
+    "    The dpi to store in the file metadata.\n"
+    "\n"
+    "compression : int\n"
+    "    The level of lossless zlib compression to apply.  0 indicates no\n"
+    "    compression.  Values 1-9 indicate low/fast through high/slow\n"
+    "    compression.  Default is 6.\n"
+    "\n"
+    "filter : int\n"
+    "    Filter to apply.  Must be one of the constants: PNG_FILTER_NONE,\n"
+    "    PNG_FILTER_SUB, PNG_FILTER_UP, PNG_FILTER_AVG, PNG_FILTER_PAETH.\n"
+    "    See the PNG standard for more information.\n"
+    "    If not provided, libpng will try to automatically determine the\n"
+    "    best filter on a line-by-line basis.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "buffer : bytes or None\n"
+    "    Byte string containing the PNG content if None was passed in for\n"
+    "    file, otherwise None is returned.\n";
 
 static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
 {
@@ -546,21 +581,46 @@ exit:
     }
 }
 
-const char *Py_read_png_float__doc__ = "read_png_float(file)";
+const char *Py_read_png_float__doc__ =
+    "read_png_float(file)\n"
+    "\n"
+    "Read in a PNG file, converting values to floating-point doubles\n"
+    "in the range (0, 1)\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "file : str path or file-like object\n";
 
 static PyObject *Py_read_png_float(PyObject *self, PyObject *args, PyObject *kwds)
 {
     return _read_png(args, true);
 }
 
-const char *Py_read_png_int__doc__ = "read_png_int(file)";
+const char *Py_read_png_int__doc__ =
+    "read_png_int(file)\n"
+    "\n"
+    "Read in a PNG file with original integer values.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "file : str path or file-like object\n";
 
 static PyObject *Py_read_png_int(PyObject *self, PyObject *args, PyObject *kwds)
 {
     return _read_png(args, false);
 }
 
-const char *Py_read_png__doc__ = "read_png(file)";
+const char *Py_read_png__doc__ =
+    "read_png(file)\n"
+    "\n"
+    "Read in a PNG file, converting values to floating-point doubles\n"
+    "in the range (0, 1)\n"
+    "\n"
+    "Alias for read_png_float()\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "file : str path or file-like object\n";
 
 static PyMethodDef module_methods[] = {
     {"write_png", (PyCFunction)Py_write_png, METH_VARARGS|METH_KEYWORDS, Py_write_png__doc__},


### PR DESCRIPTION
- Write the PNG data to string buffer, rather than an io.BytesIO
  to eliminate the cost of memory reallocation

- Add compression and filter arguments to `_png.write_png`

- Use compression=3 and filter=NONE, which seems to be a sweet spot
  for processing time vs. file size

Most of the speed increase comes from this last point.  There are two knobs that libpng provides: compression level, which is just the zlib lossless compression level 0-9, and filter, which is described here: http://www.w3.org/TR/PNG-Filters.html

While the PNG standard says that the filter is to prepare the image for optimum compression, for typical plotting images which have lots of solid colors, it actually appears to make compression worse. (I suspect the filtering helps mainly on photographic images).  Worse yet, the algorithm that automatically determines which filtering algorithm will be optimal takes a significant amount of runtime overhead.  By selecting an algorithm explicitly, we can eliminate that overhead entirely.

To benchmark, I used a series of 16 difference images collected directly from a WebAgg session.  I then ran these images through different combinations of compression and filter and compared the runtime and resulting file sizes.  These benchmark images are available at mdboom/webagg-speed.

The results are below:

![figure_1](https://cloud.githubusercontent.com/assets/38294/10911726/23c78c7e-8214-11e5-8c4b-86452e266cec.png)

The behavior prior to this PR was compression of 6, filter of "auto", which corresponds to the "X" at time ~2.2s in the plot.  After this PR, I've changed it to compression of 6, filter of "NONE", which seems like a good low risk choice.  It is not significantly worse in terms of data size, and more than 4x better in runtime.  One could be more aggressive on runtime by decreasing compression to 1 or 2 at the expense of a little file size, but that could be detrimental over a low bandwidth connection.