### PR TITLE
add missing tornado import

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -22,6 +22,7 @@ import time
 import warnings
 
 import numpy as np
+import tornado
 
 from matplotlib.backends import backend_agg
 from matplotlib.figure import Figure


### PR DESCRIPTION
#5384 Moved code around but forgot to add a Tornado import to webagg_core which now uses it. This should be fine since the web_agg backend depends on tornado anyway 