### PR TITLE
FIX: fix second error line drawing codepath

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3008,7 +3008,7 @@ class Axes(_AxesBase):
                     caplines.extend(self.plot(xup, yup, 'k_', **plot_kw))
 
         if not barsabove and plot_line:
-            l0, = self.plot(x, y, fmt, **kwargs)
+            l0, = self.plot(x, y, fmt, label='_nolegend_', **kwargs)
 
         if ecolor is None:
             if l0 is None and 'color' in self._get_lines._prop_keys:


### PR DESCRIPTION
Now that `plot` knows how to dig into pandas Series to extract
a label, make sure all internal calls to `plot` in `errorbar` pass
`label='_nolegend_'`.

Closes #5393 

This is a minimal fix without tests, errorbar needs some more general attention.