### PR TITLE
Only call init function at the begining of a save when user supplied

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -771,7 +771,8 @@ class Animation(object):
         with writer.saving(self._fig, filename, dpi):
             for anim in all_anim:
                 # Clear the initial frame
-                anim._init_draw()
+                if anim._init_func:
+                    anim._init_draw()
             for data in zip(*[a.new_saved_frame_seq()
                               for a in all_anim]):
                 for anim, d in zip(all_anim, data):


### PR DESCRIPTION
If a user supplied function is given it is probably needed to restart the animation. The default just inserts the first frame and restarts the animation which is not useful. Fixes #5399