### PR TITLE
MNT: make extra_args in MovieWriter more forgiving

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -108,8 +108,11 @@ class MovieWriter(object):
         The format used in writing frame data, defaults to 'rgba'
 
     args_key : str
-        Key used to look up default `extra_args` in rcParams.  Subclasses
-        should over-ride this value
+        Key used to look up default `extra_args` in rcParams.  If not `None`
+        the value of this attribute must be in `rcParams`
+
+        Subclasses should over-ride this value and update `rcsetup.py`
+        accordingly.
 
     exec_key : str
         Key to look up path to binary in rcParams.  Subclasses should either
@@ -136,8 +139,11 @@ class MovieWriter(object):
             automatically by the underlying utility.
         extra_args: list of strings or None
             A list of extra string arguments to be passed to the underlying
-            movie utiltiy. The default is None, which passes the additional
-            argurments in the `self.args_key` rcParam.
+            movie utiltiy.
+
+            If `None` then the default `extra_args` list is retrieved from
+            `rcParams` using the key specified by `cls.args_key`.  If
+            `cls.args_key` is also `None` an empty list is used.
         metadata: dict of string:string or None
             A dictionary of keys and values for metadata to include in the
             output file. Some keys that may be of use include:

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -104,6 +104,8 @@ class MovieWriter(object):
     frame_format: string
         The format used in writing frame data, defaults to 'rgba'
     '''
+    args_key = None
+
     def __init__(self, fps=5, codec=None, bitrate=None, extra_args=None,
                  metadata=None):
         '''
@@ -142,10 +144,12 @@ class MovieWriter(object):
         else:
             self.bitrate = bitrate
 
-        if extra_args is None:
+        if extra_args is None and self.args_key is not None:
             self.extra_args = list(rcParams[self.args_key])
-        else:
+        elif extra_args:
             self.extra_args = extra_args
+        else:
+            self.extra_args = []
 
         if metadata is None:
             self.metadata = dict()

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -101,8 +101,20 @@ class MovieWriter(object):
     The use of the context manager ensures that setup and cleanup are
     performed as necessary.
 
-    frame_format: string
+    Attributes
+    ----------
+
+    frame_format : string
         The format used in writing frame data, defaults to 'rgba'
+
+    args_key : str
+        Key used to look up default `extra_args` in rcParams.  Subclasses
+        should over-ride this value
+
+    exec_key : str
+        Key to look up path to binary in rcParams.  Subclasses should either
+        override this attribute at the class level or override the classmethod
+        ``bin_path``.
     '''
     args_key = None
 
@@ -125,7 +137,7 @@ class MovieWriter(object):
         extra_args: list of strings or None
             A list of extra string arguments to be passed to the underlying
             movie utiltiy. The default is None, which passes the additional
-            argurments in the 'animation.extra_args' rcParam.
+            argurments in the `self.args_key` rcParam.
         metadata: dict of string:string or None
             A dictionary of keys and values for metadata to include in the
             output file. Some keys that may be of use include:


### PR DESCRIPTION
As currently set up it assumes that there in as rcParams entry
to extract the default extra arguments, this makes that optional to
ease writing non-core MovieWriter sub-classes.

addresses part of #5403 

attn @WarrenWeckesser @dopplershift @WeatherGod 
