### PR TITLE
Merge pull request #5410 from mdboom/get-charmap-removal

### DIFF
--- a/examples/misc/ftface_props.py
+++ b/examples/misc/ftface_props.py
@@ -63,5 +63,4 @@ for style in ('Italic',
 
 print(dir(font))
 
-cmap = font.get_charmap()
 print(font.get_kerning)

--- a/lib/matplotlib/_mathtext_data.py
+++ b/lib/matplotlib/_mathtext_data.py
@@ -1,8 +1,6 @@
 """
 font data tables for truetype and afm computer modern fonts
 """
-# this dict maps symbol names to fontnames, glyphindex.  To get the
-# glyph index from the character code, you have to use get_charmap
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -883,13 +883,12 @@ end"""
             # Make the "Differences" array, sort the ccodes < 255 from
             # the multi-byte ccodes, and build the whole set of glyph ids
             # that we need from this font.
-            cmap = font.get_charmap()
             glyph_ids = []
             differences = []
             multi_byte_chars = set()
             for c in characters:
                 ccode = c
-                gind = cmap.get(ccode) or 0
+                gind = font.get_char_index(ccode)
                 glyph_ids.append(gind)
                 glyph_name = font.get_glyph_name(gind)
                 if ccode <= 255:
@@ -999,12 +998,11 @@ end"""
             # Make the 'W' (Widths) array, CidToGidMap and ToUnicode CMap
             # at the same time
             cid_to_gid_map = ['\u0000'] * 65536
-            cmap = font.get_charmap()
             widths = []
             max_ccode = 0
             for c in characters:
                 ccode = c
-                gind = cmap.get(ccode) or 0
+                gind = font.get_char_index(ccode)
                 glyph = font.load_char(ccode, flags=LOAD_NO_HINTING)
                 widths.append((ccode, glyph.horiAdvance / 6))
                 if ccode < 65536:
@@ -2011,7 +2009,6 @@ class RendererPdf(RendererBase):
             between chunks of 1-byte characters and 2-byte characters.
             Only used for Type 3 fonts."""
             chunks = [(a, ''.join(b)) for a, b in chunks]
-            cmap = font.get_charmap()
 
             # Do the rotation and global translation as a single matrix
             # concatenation up front
@@ -2041,7 +2038,7 @@ class RendererPdf(RendererBase):
                     lastgind = None
                     for c in chunk:
                         ccode = ord(c)
-                        gind = cmap.get(ccode)
+                        gind = font.get_char_index(ccode)
                         if gind is not None:
                             if mode == 2 and chunk_type == 2:
                                 glyph_name = font.get_glyph_name(gind)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -762,7 +762,6 @@ grestore
             ps_name = ps_name.encode('ascii', 'replace').decode('ascii')
             self.set_font(ps_name, prop.get_size_in_points())
 
-            cmap = font.get_charmap()
             lastgind = None
             #print 'text', s
             lines = []
@@ -770,7 +769,7 @@ grestore
             thisy = 0
             for c in s:
                 ccode = ord(c)
-                gind = cmap.get(ccode)
+                gind = font.get_char_index(ccode)
                 if gind is None:
                     ccode = ord('?')
                     name = '.notdef'
@@ -1138,10 +1137,9 @@ class FigureCanvasPS(FigureCanvasBase):
                 for font_filename, chars in six.itervalues(ps_renderer.used_characters):
                     if len(chars):
                         font = get_font(font_filename)
-                        cmap = font.get_charmap()
                         glyph_ids = []
                         for c in chars:
-                            gind = cmap.get(c) or 0
+                            gind = font.get_char_index(c)
                             glyph_ids.append(gind)
 
                         fonttype = rcParams['ps.fonttype']

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -6,7 +6,7 @@ from matplotlib.externals import six
 
 import os
 
-from matplotlib.font_manager import findfont, FontProperties
+from matplotlib.font_manager import (findfont, FontProperties, get_font)
 from matplotlib import rc_context
 
 
@@ -17,3 +17,9 @@ def test_font_priority():
         font = findfont(
             FontProperties(family=["sans-serif"]))
     assert_equal(os.path.basename(font), 'cmmi10.ttf')
+
+    # Smoketest get_charmap, which isn't used internally anymore
+    font = get_font(font)
+    cmap = font.get_charmap()
+    assert len(cmap) == 131
+    assert cmap[8729] == 30

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -173,7 +173,6 @@ class TextToPath(object):
 
         # Mostly copied from backend_svg.py.
 
-        cmap = font.get_charmap()
         lastgind = None
 
         currx = 0
@@ -192,7 +191,7 @@ class TextToPath(object):
 
         for c in s:
             ccode = ord(c)
-            gind = cmap.get(ccode)
+            gind = font.get_char_index(ccode)
             if gind is None:
                 ccode = ord('?')
                 gind = 0


### PR DESCRIPTION
MNT: Remove uses of font.get_charmap

Conflicts:
    lib/matplotlib/tests/test_font_manager.py

Conflicts with merging the tests, resloved to add only relavent code.


attn @mdboom 