### PR TITLE
Properly handle transparency for animations

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -222,7 +222,7 @@ class MovieWriter(object):
             # Tell the figure to save its data to the sink, using the
             # frame format and dpi.
             self.fig.savefig(self._frame_sink(), format=self.frame_format,
-                             dpi=self.dpi, **savefig_kwargs)
+                             dpi=self.dpi, flatten=True, **savefig_kwargs)
         except RuntimeError:
             out, err = self._proc.communicate()
             verbose.report('MovieWriter -- Error '
@@ -358,7 +358,7 @@ class FileMovieWriter(MovieWriter):
             # frame format and dpi.
             myframesink = self._frame_sink()
             self.fig.savefig(myframesink, format=self.frame_format,
-                             dpi=self.dpi, **savefig_kwargs)
+                             dpi=self.dpi, flatten=True, **savefig_kwargs)
             myframesink.close()
 
         except RuntimeError:

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -514,7 +514,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         # Flatten RGBA if used with fileformat that doesn't handle trnasparency
         if kwargs.get('flatten', False):
             w, h = int(renderer.width), int(renderer.height)
-            img = np.array(memoryview(img)).reshape((w, h, 4))
+            img = np.array(memoryview(img)).reshape((h, w, 4))
             img = mimage.flatten_rgba(img)
 
         try:
@@ -581,7 +581,7 @@ class FigureCanvasAgg(FigureCanvasBase):
                 should be stored as a progressive JPEG file.
             """
             buf, (w, h) = self.print_to_buffer()
-            buf = np.array(memoryview(buf)).reshape((w, h, 4))
+            buf = np.array(memoryview(buf)).reshape((h, w, 4))
 
             if kwargs.pop("dryrun", False):
                 return

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -542,7 +542,6 @@ class FigureCanvasAgg(FigureCanvasBase):
         if kwargs.get('flatten', False):
             img = img.buffer_rgba()
             w, h = int(renderer.width), int(renderer.height)
-            img = renderer._renderer.buffer_rgba()
             img = np.array(memoryview(img)).reshape((h, w, 4))
             img = mimage.flatten_rgba(img)
         try:

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -542,13 +542,14 @@ class FigureCanvasAgg(FigureCanvasBase):
 
         alpha = src[:,:,3]
         src_rgb = src[:,:,:3]
-        h, w, _ = src.shape
+        w, h, _ = src.shape
 
-        result = np.empty((h,w,4))
+        result = np.empty((w, h, 4))
         result[:,:,0] = (255 - alpha)*bg[0] + alpha*src_rgb[:,:,0]
         result[:,:,1] = (255 - alpha)*bg[1] + alpha*src_rgb[:,:,1]
         result[:,:,2] = (255 - alpha)*bg[2] + alpha*src_rgb[:,:,2]
         result = (result/255).astype(np.uint8)
+        result[:,:,3] = 255
         return result
         
     def print_png(self, filename_or_obj, *args, **kwargs):
@@ -566,8 +567,8 @@ class FigureCanvasAgg(FigureCanvasBase):
             if kwargs.get('flatten', False):
                 w, h = int(renderer.width), int(renderer.height)
                 img = renderer._renderer.buffer_rgba()
-                img = np.array(memoryview(img))
-                img = self.flatten_rgba(img).reshape((h, w, 4))
+                img = np.array(memoryview(img)).reshape((h,w,4))
+                img = self.flatten_rgba(img)
                 _png.write_png(img, filename_or_obj, self.figure.dpi)
             else:
                 _png.write_png(renderer._renderer, filename_or_obj, self.figure.dpi)

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -585,8 +585,8 @@ class FigureCanvasAgg(FigureCanvasBase):
 
             if kwargs.pop("dryrun", False):
                 return
-            # The image is "pasted" onto a white background image to safely
-            # handle any transparency
+
+            # Flatten RGBA image to safely handle transparent regions
             buf = mimage.flatten_rgba(buf)
             img = Image.frombuffer('RGBA', (w, h), buf, 'raw', 'RGBA', 0, 1)
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1502,3 +1502,45 @@ def thumbnail(infile, thumbfile, scale=0.1, interpolation='bilinear',
     ax.imshow(im, aspect='auto', resample=True, interpolation=interpolation)
     fig.savefig(thumbfile, dpi=dpi)
     return fig
+
+def flatten_rgba(src, bg=None):
+    """
+    Flatten an RGBA image *src* with a background color *bg*.
+    The resulting image will have an alpha channel, but no transparency.
+    This can be useful when interfacing with file formats that don't support
+    transparency or only support boolean transparency.
+
+    Parameters
+    ----------
+    src : MxNx4 Numpy array, dtype=uint8
+        Image source in RGBA to be flattened.
+
+    bg  : Tuple(int,int,int), optional
+        Background color to merge *src* with.  If no bg color is provided
+        the color from the rcParam 'savefig.facecolor' will be use.
+
+    Returns
+    -------
+    dest : MxNx4 Numpy array, dtype=uint8
+    """
+
+    if bg is None:
+        bg = mcolors.colorConverter.to_rgb(
+                 rcParams.get('savefig.facecolor', 'white'))
+        bg = tuple([int(x * 255.0) for x in bg])
+
+    # Numpy images have dtype=uint8 which will overflow
+    src = src.astype(np.uint16)
+
+    alpha = src[:,:,3]
+    src_rgb = src[:,:,:3]
+    w, h, _ = src.shape
+
+    dest = np.empty((w, h, 4))
+    dest[:,:,0] = (255 - alpha)*bg[0] + alpha*src_rgb[:,:,0]
+    dest[:,:,1] = (255 - alpha)*bg[1] + alpha*src_rgb[:,:,1]
+    dest[:,:,2] = (255 - alpha)*bg[2] + alpha*src_rgb[:,:,2]
+    dest = (dest/255).astype(np.uint8)
+    dest[:,:,3] = 255
+
+    return dest

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1503,6 +1503,7 @@ def thumbnail(infile, thumbfile, scale=0.1, interpolation='bilinear',
     fig.savefig(thumbfile, dpi=dpi)
     return fig
 
+
 def flatten_rgba(src, bg=None):
     """
     Flatten an RGBA image *src* with a background color *bg*.
@@ -1517,7 +1518,7 @@ def flatten_rgba(src, bg=None):
 
     bg  : Tuple(int,int,int), optional
         Background color to merge *src* with.  If no bg color is provided
-        the color from the rcParam 'savefig.facecolor' will be use.
+        the color from the rcParam 'savefig.facecolor' will be used.
 
     Returns
     -------
@@ -1529,18 +1530,18 @@ def flatten_rgba(src, bg=None):
                  rcParams.get('savefig.facecolor', 'white'))
         bg = tuple([int(x * 255.0) for x in bg])
 
-    # Numpy images have dtype=uint8 which will overflow
+    # Numpy images have dtype=uint8 which will overflow for these calculations
     src = src.astype(np.uint16)
 
-    alpha = src[:,:,3]
-    src_rgb = src[:,:,:3]
+    alpha = src[:, :, 3]
+    src_rgb = src[:, :, :3]
     w, h, _ = src.shape
 
     dest = np.empty((w, h, 4))
-    dest[:,:,0] = (255 - alpha)*bg[0] + alpha*src_rgb[:,:,0]
-    dest[:,:,1] = (255 - alpha)*bg[1] + alpha*src_rgb[:,:,1]
-    dest[:,:,2] = (255 - alpha)*bg[2] + alpha*src_rgb[:,:,2]
+    dest[:, :, 0] = (255 - alpha)*bg[0] + alpha*src_rgb[:, :, 0]
+    dest[:, :, 1] = (255 - alpha)*bg[1] + alpha*src_rgb[:, :, 1]
+    dest[:, :, 2] = (255 - alpha)*bg[2] + alpha*src_rgb[:, :, 2]
     dest = (dest/255).astype(np.uint8)
-    dest[:,:,3] = 255
+    dest[:, :, 3] = 255
 
     return dest

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -455,7 +455,7 @@ def test_nonuniformimage_setnorm():
 
 @knownfailureif(not HAS_PIL)
 @cleanup
-def test_jpeg_alpha():
+def test_flatten():
     plt.figure(figsize=(1, 1), dpi=300)
     # Create an image that is all black, with a gradient from 0-1 in
     # the alpha channel from left to right.
@@ -464,21 +464,43 @@ def test_jpeg_alpha():
 
     plt.figimage(im)
 
-    buff = io.BytesIO()
-    with rc_context({'savefig.facecolor': 'red'}):
-        plt.savefig(buff, transparent=True, format='jpg', dpi=300)
+    jpg_buf = io.BytesIO()
+    pngF_buf = io.BytesIO()
+    png_buf = io.BytesIO()
 
-    buff.seek(0)
-    image = Image.open(buff)
+    with rc_context({'savefig.facecolor': 'red'}):
+        plt.savefig(jpg_buf, transparent=True, format='jpg', dpi=300)
+        plt.savefig(pngF_buf, transparent=True, format='png',
+                    flatten=True, dpi=300)
+        plt.savefig(png_buf, transparent=True, format='png', dpi=300)
+
+    jpg_buf.seek(0)
+    pngF_buf.seek(0)
+    png_buf.seek(0)
+
+    jpg_im = Image.open(jpg_buf)
+    pngF_im = Image.open(pngF_buf)
+    png_im = Image.open(png_buf)
 
     # If this fails, there will be only one color (all black). If this
     # is working, we should have all 256 shades of grey represented.
-    print("num colors: ", len(image.getcolors(256)))
-    assert len(image.getcolors(256)) >= 175 and len(image.getcolors(256)) <= 185
+    print("num colors [jpg]: ", len(jpg_im.getcolors(256)))
+    print("num colors [png, flattened]: ", len(pngF_im.getcolors(256)))
+    print("num colors [png, not flattened]: ", len(png_im.getcolors(256)))
+
+    assert len(jpg_im.getcolors(256)) >= 175 and len(jpg_im.getcolors(256)) <= 185
+    assert len(pngF_im.getcolor(256)) == 256
+    assert len(png_im.getcolor(256)) == 256
+
     # The fully transparent part should be red, not white or black
-    # or anything else
-    print("corner pixel: ", image.getpixel((0, 0)))
-    assert image.getpixel((0, 0)) == (254, 0, 0)
+    # or anything else when flattened.
+    print("corner pixel [jpg]: ", jpg_im.getpixel((0, 0)))
+    print("corner pixel [png, flattened]: ", pngF_im.getpixel((0,0)))
+    print("corner pixel [png, not flattened]: ", png_im.getpixel((0,0)))
+
+    assert jpg_im.getpixel((0, 0)) == (254, 0, 0)
+    assert pngF_im.getpixel((0,0)) == (255, 0, 0, 255)
+    assert png_im.getpixel((0,0)) == (255, 255, 255, 0)
 
 
 if __name__=='__main__':

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -489,8 +489,8 @@ def test_flatten():
     print("num colors [png, not flattened]: ", len(png_im.getcolors(256)))
 
     assert len(jpg_im.getcolors(256)) >= 175 and len(jpg_im.getcolors(256)) <= 185
-    assert len(pngF_im.getcolor(256)) == 256
-    assert len(png_im.getcolor(256)) == 256
+    assert len(pngF_im.getcolors(256)) == 256
+    assert len(png_im.getcolors(256)) == 256
 
     # The fully transparent part should be red, not white or black
     # or anything else when flattened.


### PR DESCRIPTION
This PR is a first attempt at fixing #5335.  I have added a `flatten` kwarg for `savefig` in the agg backend that will allow animation.py remove all transparency before sending it to its respective animator.  I don't think it would be a good idea to merge this just yet, but was looking for feedback before proceeding.

I guess I would still need to write a test.  I'm not sure I handled the dimensions correctly for `_write_png`, animations look correct from `write='imagemagick_file` but that's definitely worth double checking.
