### PR TITLE
DFLT: change formats for AutoDateFormatter

### DIFF
--- a/doc/users/whats_new/rcparams.rst
+++ b/doc/users/whats_new/rcparams.rst
@@ -1,0 +1,19 @@
+Configuration (rcParams)
+------------------------
+
+
++----------------------------+--------------------------------------------------+
+| Parameter                  | Description                                      |
++============================+==================================================+
+|`date.autoformatter.year`   | foramt string for 'year' scale dates             |
++----------------------------+--------------------------------------------------+
+|`date.autoformatter.month`  | format string for 'month' scale dates            |
++----------------------------+--------------------------------------------------+
+|`date.autoformatter.day`    | format string for 'day' scale dates              |
++----------------------------+--------------------------------------------------+
+|`date.autoformatter.hour`   | format string for 'hour' scale times             |
++----------------------------+--------------------------------------------------+
+|`date.autoformatter.minute` | format string for 'minute' scale times           |
++----------------------------+--------------------------------------------------+
+|`date.autoformatter.second` | format string for 'second' scale times           |
++----------------------------+--------------------------------------------------+

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -114,7 +114,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from matplotlib.externals import six
 from matplotlib.externals.six.moves import xrange, zip
-
+from matplotlib import rcParams
 import re
 import time
 import math
@@ -629,12 +629,12 @@ class AutoDateFormatter(ticker.Formatter):
     format string.  The default looks like this::
 
         self.scaled = {
-           365.0  : '%Y',
-           30.    : '%b %Y',
-           1.0    : '%b %d %Y',
-           1./24. : '%H:%M:%S',
-           1. / (24. * 60.): '%H:%M:%S.%f',
-           }
+            DAYS_PER_YEAR: rcParams['date.autoformat.year'],
+            DAYS_PER_MONTH: rcParams['date.autoformat.month'],
+            1.0: rcParams['date.autoformat.day'],
+            1. / HOURS_PER_DAY: rcParams['date.autoformat.hour'],
+            1. / (MINUTES_PER_DAY): rcParams['date.autoformat.minute'],
+            1. / (SEC_PER_DAY): rcParams['date.autoformat.second']}
 
 
     The algorithm picks the key in the dictionary that is >= the
@@ -685,11 +685,12 @@ class AutoDateFormatter(ticker.Formatter):
         self._tz = tz
         self.defaultfmt = defaultfmt
         self._formatter = DateFormatter(self.defaultfmt, tz)
-        self.scaled = {DAYS_PER_YEAR: '%Y',
-                       DAYS_PER_MONTH: '%b %Y',
-                       1.0: '%b %d %Y',
-                       1. / HOURS_PER_DAY: '%H:%M:%S',
-                       1. / (MINUTES_PER_DAY): '%H:%M:%S.%f'}
+        self.scaled = {DAYS_PER_YEAR: rcParams['date.autoformatter.year'],
+                       DAYS_PER_MONTH: rcParams['date.autoformatter.month'],
+                       1.0: rcParams['date.autoformatter.day'],
+                       1. / HOURS_PER_DAY: rcParams['date.autoformatter.hour'],
+                       1. / (MINUTES_PER_DAY): rcParams['date.autoformatter.minute'],
+                       1. / (SEC_PER_DAY): rcParams['date.autoformatter.second'],}
 
     def __call__(self, x, pos=None):
         locator_unit_scale = float(self._locator._get_unit())

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -212,6 +212,13 @@ axes.spines.top     : True
 polaraxes.grid      : True    # display grid on polar axes
 axes3d.grid         : True    # display grid on 3d axes
 
+date.autoformatter.year   :'%Y'
+date.autoformatter.month  :'%b %Y'
+date.autoformatter.day    :'%b %d %Y'
+date.autoformatter.hour   :'%H:%M:%S'
+date.autoformatter.minute :'%H:%M:%S.%f'
+date.autoformatter.second :'%H:%M:%S.%f'
+
 ### TICKS
 # see http://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
 xtick.major.size     : 4      # major tick size in points
@@ -418,7 +425,7 @@ pdf.use14corefonts : False
 pgf.debug           : False
 pgf.texsystem       : xelatex
 pgf.rcfonts         : True
-pgf.preamble        : 
+pgf.preamble        :
 
 # svg backend params
 svg.image_inline : True       # write raster image data directly into the svg file

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -965,6 +965,13 @@ defaultParams = {
     'polaraxes.grid': [True, validate_bool],  # display polar grid or
                                                      # not
     'axes3d.grid': [True, validate_bool],  # display 3d grid
+    # TODO validate that these are valid datetime format strings
+    'date.autoformatter.year': ['%Y', six.text_type],
+    'date.autoformatter.month': ['%Y-%m', six.text_type],
+    'date.autoformatter.day': ['%Y-%m-%d', six.text_type],
+    'date.autoformatter.hour': ['%H:%M', six.text_type],
+    'date.autoformatter.minute': ['%H:%M:%S', six.text_type],
+    'date.autoformatter.second': ['%H:%M:%S.%f', six.text_type],
 
     #legend properties
     'legend.fancybox': [False, validate_bool],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -265,6 +265,7 @@ backend      : %(backend)s
                                          # small compared to the minimum absolute
                                          # value of the data.
 
+
 #axes.unicode_minus  : True    # use unicode for the minus symbol
                                # rather than hyphen.  See
                                # http://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
@@ -278,6 +279,22 @@ backend      : %(backend)s
 
 #polaraxes.grid      : True    # display grid on polar axes
 #axes3d.grid         : True    # display grid on 3d axes
+
+### DATES
+# These control the default format strings used in AutoDateFormatter.
+# Any valid format datetime format string can be used (see the python
+# `datetime` for details).  For example using '%%x' will use the locale date representation
+# '%%X' will use the locale time representation and '%%c' will use the full locale datetime
+# representation.
+# These values map to the scales:
+#    {'year': 365, 'month': 30, 'day': 1, 'hour': 1/24, 'minute': 1 / (24 * 60)}
+
+# date.autoformatter.year     : '%%Y'
+# date.autoformatter.month    : '%%Y-%%m'
+# date.autoformatter.day      : '%%Y-%%m-%%d'
+# date.autoformatter.hour     : '%%H:%%M'
+# date.autoformatter.minute   : '%%H:%%M:%%S'
+# date.autoformatter.second   : '%%H:%%M:%%S.%%f'
 
 ### TICKS
 # see http://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick


### PR DESCRIPTION
 - Use ISO complient formats by default
 - aded extra level of scale (seconds)
 - add rcparams for all of these strings

closes #4808 closes #4809 closes #5086