### PR TITLE
added axes inversion to cla()

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -959,6 +959,7 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
+            self.viewLim.intervalx = (0, 1)
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -982,6 +983,7 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
+            self.viewLim.intervaly = (0, 1)
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):
@@ -1071,6 +1073,7 @@ class _AxesBase(martist.Artist):
         if self._sharey:
             self.yaxis.set_visible(yaxis_visible)
             self.patch.set_visible(patch_visible)
+
         self.stale = True
 
     def clear(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -959,7 +959,10 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
-            self.set_xlim(0, 1)
+            try:
+                self.set_xlim(0, 1)
+            except TypeError:
+                pass
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -983,7 +986,10 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
-            self.set_ylim(0, 1)
+            try:
+                self.set_ylim(0, 1)
+            except TypeError:
+                pass
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -959,7 +959,8 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
-            self.viewLim.intervalx = (0, 1)
+            #self.viewLim.intervalx = (0, 1)
+            self.set_xlim(0,1)
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -983,7 +984,8 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
-            self.viewLim.intervaly = (0, 1)
+            #self.viewLim.intervaly = (0, 1)
+            self.set_ylim(0,1)
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -959,8 +959,7 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
-            #self.viewLim.intervalx = (0, 1)
-            self.set_xlim(0,1)
+            self.set_xlim(0, 1)
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -984,8 +983,7 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
-            #self.viewLim.intervaly = (0, 1)
-            self.set_ylim(0,1)
+            self.set_ylim(0, 1)
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -21,13 +21,13 @@ from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 import matplotlib.markers as mmarkers
 from numpy.testing import assert_array_equal
-import warnings
 from matplotlib.cbook import IgnoredKeywordWarning
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have
 #       different baseline images to prevent race conditions when nose runs
 #       the tests with multiple threads.
+
 
 @image_comparison(baseline_images=['formatter_ticker_001',
                                    'formatter_ticker_002',
@@ -135,24 +135,25 @@ def test_twinx_cla():
     assert_true(ax.patch.get_visible())
     assert_true(ax.yaxis.get_visible())
 
+
 @cleanup
 def test_inverted_cla():
-    # Github PR #5450. Setting autoscale should reset 
+    # Github PR #5450. Setting autoscale should reset
     # axes to be non-inverted.
     # plotting an image, then 1d graph, axis is now down
-    fig = plt.figure(0);
+    fig = plt.figure(0)
     ax = fig.gca()
     # test that a new axis is not inverted per default
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
-    img = np.random.random((100,100))
+    img = np.random.random((100, 100))
     ax.imshow(img)
     # test that a image axis is inverted
     assert not(ax.xaxis_inverted())
     assert ax.yaxis_inverted()
     ax.cla()
-    x = np.linspace(0,2*np.pi,100);
-    ax.plot(x,np.cos(x))
+    x = np.linspace(0, 2*np.pi, 100)
+    ax.plot(x, np.cos(x))
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
 
@@ -168,15 +169,16 @@ def test_inverted_cla():
     ax0 = plt.subplot(211)
     ax1 = plt.subplot(212, sharey=ax0)
     ax0.imshow(img)
-    ax1.plot(x,np.cos(x))
+    ax1.plot(x, np.cos(x))
     ax0.cla()
     assert not(ax1.yaxis_inverted())
     ax1.cla()
     # clearing the nonmaster should not touch limits
     ax0.imshow(img)
-    ax1.plot(x,np.cos(x))
+    ax1.plot(x, np.cos(x))
     ax1.cla()
     assert ax.yaxis_inverted()
+
 
 @image_comparison(baseline_images=["minorticks_on_rcParams_both"], extensions=['png'])
 def test_minorticks_on_rcParams_both():
@@ -343,7 +345,7 @@ def test_single_point():
     plt.plot('a', 'a', 'o', data=data)
 
     plt.subplot(212)
-    plt.plot('b','b', 'o', data=data)
+    plt.plot('b', 'b', 'o', data=data)
 
 
 @image_comparison(baseline_images=['single_date'])
@@ -562,11 +564,12 @@ def test_hexbin_extent():
 
 
 @image_comparison(baseline_images=['hexbin_empty'], remove_text=True,
-	extensions=['png'])
+                  extensions=['png'])
 def test_hexbin_empty():
     # From #3886: creating hexbin from empty dataset raises ValueError
     ax = plt.gca()
     ax.hexbin([], [])
+
 
 @cleanup
 def test_hexbin_pickable():
@@ -658,7 +661,7 @@ def test_imshow():
     ax.imshow(r)
 
     # Reuse testcase from above for a labeled data test
-    data={"r": r}
+    data = {"r": r}
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.imshow("r", data=data)
@@ -1149,18 +1152,20 @@ def test_hist_log():
 
 
 @image_comparison(baseline_images=['hist_bar_empty'], remove_text=True,
-	extensions=['png'])
+                  extensions=['png'])
 def test_hist_bar_empty():
     # From #3886: creating hist from empty dataset raises ValueError
     ax = plt.gca()
     ax.hist([], histtype='bar')
 
+
 @image_comparison(baseline_images=['hist_step_empty'], remove_text=True,
-	extensions=['png'])
+                  extensions=['png'])
 def test_hist_step_empty():
     # From #3886: creating hist from empty dataset raises ValueError
     ax = plt.gca()
     ax.hist([], histtype='step')
+
 
 @image_comparison(baseline_images=['hist_steplog'], remove_text=True, tol=0.05)
 def test_hist_steplog():
@@ -1391,7 +1396,7 @@ def test_stackplot():
     ax.set_ylim((0, 70))
 
     # Reuse testcase from above for a labeled data test
-    data={"x": x, "y1": y1, "y2": y2, "y3": y3}
+    data = {"x": x, "y1": y1, "y2": y2, "y3": y3}
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
     ax.stackplot("x", "y1", "y2", "y3", data=data)
@@ -1790,7 +1795,7 @@ def test_boxplot():
     ax.set_ylim((-30, 30))
 
     # Reuse testcase from above for a labeled data test
-    data={"x": [x, x]}
+    data = {"x": [x, x]}
     fig, ax = plt.subplots()
     ax.boxplot("x", bootstrap=10000, notch=1, data=data)
     ax.set_ylim((-30, 30))
@@ -1831,6 +1836,7 @@ def test_boxplot_autorange_whiskers():
     ax.boxplot([x, x], bootstrap=10000, notch=1)
     ax.set_ylim((-5, 5))
 
+
 def _rc_test_bxp_helper(ax, rc_dict):
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
@@ -1838,13 +1844,14 @@ def _rc_test_bxp_helper(ax, rc_dict):
         ax.boxplot([x, x])
     return ax
 
+
 @image_comparison(baseline_images=['boxplot_rc_parameters'],
                   savefig_kwarg={'dpi': 100}, remove_text=True, tol=1)
 def test_boxplot_rc_parameters():
     fig, ax = plt.subplots(3)
 
     rc_axis0 = {
-        'boxplot.notch':True,
+        'boxplot.notch': True,
         'boxplot.whiskers': [5, 95],
         'boxplot.bootstrap': 10000,
 
@@ -2214,7 +2221,6 @@ def test_errorbar():
 
     fig.suptitle('Variable errorbars')
 
-
     # Reuse te first testcase from above for a labeled data test
     data = {"x": x, "y": y}
     fig = plt.figure()
@@ -2461,10 +2467,11 @@ def test_rgba_markers():
         for j, rcolor in enumerate(rcolors):
             for k, bcolor in enumerate(bcolors):
                 axs[i].plot(j+1, k+1, 'o', mfc=bcolor, mec=rcolor,
-                           alpha=alpha, **kw)
+                            alpha=alpha, **kw)
                 axs[i].plot(j+1, k+3, 'x', mec=rcolor, alpha=alpha, **kw)
     for ax in axs:
         ax.axis([-1, 4, 0, 5])
+
 
 @image_comparison(baseline_images=['mollweide_grid'], remove_text=True)
 def test_mollweide_grid():
@@ -3824,8 +3831,8 @@ def test_pie_linewidth_0():
     fig = plt.figure()
     ax = fig.gca()
     ax.pie("s", explode="ex", labels="l", colors="c",
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0}, data=data)
+           autopct='%1.1f%%', shadow=True, startangle=90,
+           wedgeprops={'linewidth': 0}, data=data)
     ax.axis('equal')
 
     # And again to test the pyplot functions which should also be able to be
@@ -3843,13 +3850,13 @@ def test_pie_center_radius():
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
     sizes = [15, 30, 45, 10]
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0) # only "explode" the 2nd slice (i.e. 'Hogs')
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
 
     plt.pie(sizes, explode=explode, labels=labels, colors=colors,
             autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0}, center=(1,2), radius=1.5)
+            wedgeprops={'linewidth': 0}, center=(1, 2), radius=1.5)
 
-    plt.annotate("Center point", xy=(1,2), xytext=(1,1.5),
+    plt.annotate("Center point", xy=(1, 2), xytext=(1, 1.5),
                  arrowprops=dict(arrowstyle="->",
                                  connectionstyle="arc3"))
     # Set aspect ratio to be equal so that pie is drawn as a circle.
@@ -3931,8 +3938,8 @@ def test_set_get_ticklabels():
 
     # set ticklabel to the other plot, expect the 2 plots have same label setting
     # pass get_ticklabels return value as ticklabels argument
-    ax[1].set_xticklabels(ax[0].get_xticklabels() )
-    ax[1].set_yticklabels(ax[0].get_yticklabels() )
+    ax[1].set_xticklabels(ax[0].get_xticklabels())
+    ax[1].set_yticklabels(ax[0].get_yticklabels())
 
 
 @image_comparison(baseline_images=['o_marker_path_snap'], extensions=['png'],
@@ -3992,7 +3999,7 @@ def test_pathological_hexbin():
 def test_color_None():
     # issue 3855
     fig, ax = plt.subplots()
-    ax.plot([1,2], [1,2], color=None)
+    ax.plot([1, 2], [1, 2], color=None)
 
 
 @cleanup
@@ -4035,13 +4042,13 @@ def test_move_offsetlabel():
 
 
 @image_comparison(baseline_images=['rc_spines'], extensions=['png'],
-                  savefig_kwarg={'dpi':40})
+                  savefig_kwarg={'dpi': 40})
 def test_rc_spines():
     rc_dict = {
-        'axes.spines.left':False,
-        'axes.spines.right':False,
-        'axes.spines.top':False,
-        'axes.spines.bottom':False}
+        'axes.spines.left': False,
+        'axes.spines.right': False,
+        'axes.spines.top': False,
+        'axes.spines.bottom': False}
     with matplotlib.rc_context(rc_dict):
         fig, ax = plt.subplots()
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -143,28 +143,30 @@ def test_inverted_cla():
     # plotting an image, then 1d graph, axis is now down
     fig = plt.figure(0)
     ax = fig.gca()
-    # test that a new axis is not inverted per default
+    # 1. test that a new axis is not inverted per default
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
     img = np.random.random((100, 100))
     ax.imshow(img)
-    # test that a image axis is inverted
+    # 2. test that a image axis is inverted
     assert not(ax.xaxis_inverted())
     assert ax.yaxis_inverted()
+    # 3. test that clearing and plotting a line, axes are
+    # not inverted
     ax.cla()
     x = np.linspace(0, 2*np.pi, 100)
     ax.plot(x, np.cos(x))
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
 
-    # autoscaling should not bring back axes to normal
+    # 4. autoscaling should not bring back axes to normal
     ax.cla()
     ax.imshow(img)
     plt.autoscale()
     assert not(ax.xaxis_inverted())
     assert ax.yaxis_inverted()
 
-    # two shared axes. Clearing the master axis should bring axes in shared
+    # 5. two shared axes. Clearing the master axis should bring axes in shared
     # axies back to normal
     ax0 = plt.subplot(211)
     ax1 = plt.subplot(212, sharey=ax0)
@@ -173,7 +175,7 @@ def test_inverted_cla():
     ax0.cla()
     assert not(ax1.yaxis_inverted())
     ax1.cla()
-    # clearing the nonmaster should not touch limits
+    # 6. clearing the nonmaster should not touch limits
     ax0.imshow(img)
     ax1.plot(x, np.cos(x))
     ax1.cla()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -135,6 +135,48 @@ def test_twinx_cla():
     assert_true(ax.patch.get_visible())
     assert_true(ax.yaxis.get_visible())
 
+@cleanup
+def test_inverted_cla():
+    # Github PR #5450. Setting autoscale should reset 
+    # axes to be non-inverted.
+    # plotting an image, then 1d graph, axis is now down
+    fig = plt.figure(0);
+    ax = fig.gca()
+    # test that a new axis is not inverted per default
+    assert not(ax.xaxis_inverted())
+    assert not(ax.yaxis_inverted())
+    img = np.random.random((100,100))
+    ax.imshow(img)
+    # test that a image axis is inverted
+    assert not(ax.xaxis_inverted())
+    assert ax.yaxis_inverted()
+    ax.cla()
+    x = np.linspace(0,2*np.pi,100);
+    ax.plot(x,np.cos(x))
+    assert not(ax.xaxis_inverted())
+    assert not(ax.yaxis_inverted())
+
+    # autoscaling should not bring back axes to normal
+    ax.cla()
+    ax.imshow(img)
+    plt.autoscale()
+    assert not(ax.xaxis_inverted())
+    assert ax.yaxis_inverted()
+
+    # two shared axes. Clearing the master axis should bring axes in shared
+    # axies back to normal
+    ax0 = plt.subplot(211)
+    ax1 = plt.subplot(212, sharey=ax0)
+    ax0.imshow(img)
+    ax1.plot(x,np.cos(x))
+    ax0.cla()
+    assert not(ax1.yaxis_inverted())
+    ax1.cla()
+    # clearing the nonmaster should not touch limits
+    ax0.imshow(img)
+    ax1.plot(x,np.cos(x))
+    ax1.cla()
+    assert ax.yaxis_inverted()
 
 @image_comparison(baseline_images=["minorticks_on_rcParams_both"], extensions=['png'])
 def test_minorticks_on_rcParams_both():


### PR DESCRIPTION
This has been bothering me a little. When axes are cleared, the x/y-axis should have the positive direction consistently point the same way.

Here is sample code:

``` python
import numpy as np
import matplotlib.pyplot as plt
img = np.random.random((100,100))
plt.imshow(img)
plt.cla()
x = np.linspace(0,2*np.pi,100)
plt.plot(x,np.cos(x))
```

Upon clearing, the yaxis is inverted. This is because plotting the image inverts the y axis since the origin is located in the upper left hand corner. If not image was previously plotted to the figure, the y axis would not have been inverted. I have tested it and it works nicely.

What do you think? Is this worth adding? As a user, I can definitely say this is a feature that would greatly simplify my life.

I'm pinging @fariza and @OceanWolf since they reviewed a pull request touching similar functions. (@Oceanwolf, still have not done the div by zero checking but will later)

thanks for reading!
