### PR TITLE
[Bug] masking of NaN Z values in pcolormesh

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4983,6 +4983,7 @@ class Axes(_AxesBase):
             else:
                 X, Y = np.meshgrid(np.arange(numCols + 1),
                                    np.arange(numRows + 1))
+            C = cbook.safe_masked_invalid(C)
             return X, Y, C
 
         if len(args) == 3:
@@ -5015,6 +5016,7 @@ class Axes(_AxesBase):
                                 ' X (%d) and/or Y (%d); see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))
             C = C[:Ny - 1, :Nx - 1]
+        C = cbook.safe_masked_invalid(C)
         return X, Y, C
 
     @unpack_labeled_data(label_namer=None)


### PR DESCRIPTION
In `pcolormesh` non-finite values (e.g. NaNs) are not currently masked. The function allows the input of masked arrays, so there is an easy workaround of masking the array before passing it in (see http://stackoverflow.com/questions/7778343/pcolormesh-with-missing-values). It would make more sense IMHO, though, to mask the array internally as is done in `imshow`. This would fix what I believe is a bug, namely that the autoscaling of the Z axis does not work if the array contains NaNs.