### PR TITLE
Force frame rate of FFMpegFileWriter input

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -446,7 +446,8 @@ class FFMpegFileWriter(FileMovieWriter, FFMpegBase):
     def _args(self):
         # Returns the command line parameters for subprocess to use
         # ffmpeg to create a movie using a collection of temp images
-        return [self.bin_path(), '-r', str(self.fps), '-i', self._base_temp_name(),
+        return [self.bin_path(), '-r', str(self.fps),
+                '-i', self._base_temp_name(),
                 '-vframes', str(self._frame_counter),
                 '-r', str(self.fps)] + self.output_args
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -446,7 +446,7 @@ class FFMpegFileWriter(FileMovieWriter, FFMpegBase):
     def _args(self):
         # Returns the command line parameters for subprocess to use
         # ffmpeg to create a movie using a collection of temp images
-        return [self.bin_path(), '-i', self._base_temp_name(),
+        return [self.bin_path(), '-r', str(self.fps), '-i', self._base_temp_name(),
                 '-vframes', str(self._frame_counter),
                 '-r', str(self.fps)] + self.output_args
 


### PR DESCRIPTION
The output video file was observed to skip frames, when input frame rate does not match output (e.g., when fps=1, or interval=1000).

See https://www.ffmpeg.org/ffmpeg.html#Description for a description of the solution.