### PR TITLE
Do not run Windows' file system convert tool

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -262,6 +262,10 @@ class MovieWriter(object):
         Check to see if a MovieWriter subclass is actually available by
         running the commandline tool.
         '''
+        if platform.system() == 'Windows' and cls.bin_path() == 'convert':
+            # On Windows, the full path to convert must be specified in
+            # matplotlibrc since convert is also the name of a system tool.
+            return False
         try:
             p = subprocess.Popen(cls.bin_path(),
                              shell=False,


### PR DESCRIPTION
See also #5446.
This should fix two test errors on Windows when ImageMagick is not set up correctly:
```
======================================================================
ERROR: matplotlib.tests.test_animation.test_save_animation_smoketest('imagemagick', 'gif')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\aroot\stage\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "C:\aroot\stage\lib\site-packages\matplotlib\testing\decorators.py", line 118, in wrapped_function
    func(*args, **kwargs)
  File "C:\aroot\stage\lib\site-packages\matplotlib\tests\test_animation.py", line 57, in check_save_animation
    anim.save(F.name, fps=30, writer=writer, bitrate=500)
  File "C:\aroot\stage\lib\site-packages\matplotlib\animation.py", line 780, in save
    writer.grab_frame(**savefig_kwargs)
  File "C:\aroot\stage\lib\site-packages\matplotlib\animation.py", line 225, in grab_frame
    dpi=self.dpi, **savefig_kwargs)
  File "C:\aroot\stage\lib\site-packages\matplotlib\figure.py", line 1539, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "C:\aroot\stage\lib\site-packages\matplotlib\backend_bases.py", line 2230, in print_figure
    **kwargs)
  File "C:\aroot\stage\lib\site-packages\matplotlib\backends\backend_agg.py", line 519, in print_raw
    fileobj.write(renderer._renderer.buffer_rgba())
OSError: [Errno 22] Invalid argument

======================================================================
ERROR: matplotlib.tests.test_animation.test_save_animation_smoketest('imagemagick_file', 'gif')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\aroot\stage\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "C:\aroot\stage\lib\site-packages\matplotlib\testing\decorators.py", line 118, in wrapped_function
    func(*args, **kwargs)
  File "C:\aroot\stage\lib\site-packages\matplotlib\tests\test_animation.py", line 57, in check_save_animation
    anim.save(F.name, fps=30, writer=writer, bitrate=500)
  File "C:\aroot\stage\lib\site-packages\matplotlib\animation.py", line 780, in save
    writer.grab_frame(**savefig_kwargs)
  File "C:\aroot\stage\lib\contextlib.py", line 66, in __exit__
    next(self.gen)
  File "C:\aroot\stage\lib\site-packages\matplotlib\animation.py", line 191, in saving
    self.finish()
  File "C:\aroot\stage\lib\site-packages\matplotlib\animation.py", line 382, in finish
    + ' Try running with --verbose-debug')
RuntimeError: Error creating movie, return code: 4 Try running with --verbose-debug
```