### PR TITLE
Fixed issue with `rasterized` not working for errorbar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2821,7 +2821,7 @@ class Axes(_AxesBase):
             for key in ('linewidth', 'lw'):
                 if key in kwargs:
                     lines_kw[key] = kwargs[key]
-        for key in ('transform', 'alpha', 'zorder'):
+        for key in ('transform', 'alpha', 'zorder', 'rasterized'):
             if key in kwargs:
                 lines_kw[key] = kwargs[key]
 
@@ -2873,7 +2873,7 @@ class Axes(_AxesBase):
             plot_kw['markeredgewidth'] = capthick
         # For backwards-compat, allow explicit setting of
         # 'mew' or 'markeredgewidth' to over-ride capthick.
-        for key in ('markeredgewidth', 'mew', 'transform', 'alpha', 'zorder'):
+        for key in ('markeredgewidth', 'mew', 'transform', 'alpha', 'zorder', 'rasterized'):
             if key in kwargs:
                 plot_kw[key] = kwargs[key]
 


### PR DESCRIPTION
This pull request fixes the `rasterized` argument not being passed to the lines of the errorbar