### PR TITLE
make sure an autoreleasepool is in place

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -6264,8 +6264,10 @@ static PyTypeObject TimerType = {
 static bool verify_framework(void)
 {
 #ifdef COMPILING_FOR_10_6
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
     NSRunningApplication* app = [NSRunningApplication currentApplication];
     NSApplicationActivationPolicy activationPolicy = [app activationPolicy];
+    [pool release];
     switch (activationPolicy) {
         case NSApplicationActivationPolicyRegular:
         case NSApplicationActivationPolicyAccessory:
@@ -6380,6 +6382,7 @@ void init_macosx(void)
 
     PyOS_InputHook = wait_for_stdin;
 
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
     WindowServerConnectionManager* connectionManager = [WindowServerConnectionManager sharedManager];
     NSWorkspace* workspace = [NSWorkspace sharedWorkspace];
     NSNotificationCenter* notificationCenter = [workspace notificationCenter];
@@ -6387,6 +6390,7 @@ void init_macosx(void)
                            selector: @selector(launch:)
                                name: NSWorkspaceDidLaunchApplicationNotification
                              object: nil];
+    [pool release];
 #if PY3K
     return module;
 #endif


### PR DESCRIPTION
Fix for issue #5473 . Whether or not a designated autoreleasepool needs to be in place apparently depends on the Mac OS X version and compiler used.