### PR TITLE
Contour levels must be increasing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2015-11-16 Levels passed to contour(f) and tricontour(f) must be in increasing
+           order.
+
 2015-10-21 Added get_ticks_direction()
 
 2015-02-27 Added the rcParam 'image.composite_image' to permit users 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1191,6 +1191,8 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             self.levels = lev
         if self.filled and len(self.levels) < 2:
             raise ValueError("Filled contours require at least 2 levels.")
+        if len(self.levels) > 1 and np.amin(np.diff(self.levels)) <= 0.0:
+            raise ValueError("Contour levels must be increasing")
 
     def _process_levels(self):
         """
@@ -1674,13 +1676,15 @@ class QuadContourSet(ContourSet):
           contour(Z,V)
           contour(X,Y,Z,V)
 
-        draw contour lines at the values specified in sequence *V*
+        draw contour lines at the values specified in sequence *V*,
+        which must be in increasing order.
 
         ::
 
           contourf(..., V)
 
-        fill the ``len(V)-1`` regions between the values in *V*
+        fill the ``len(V)-1`` regions between the values in *V*,
+        which must be in increasing order.
 
         ::
 
@@ -1743,8 +1747,8 @@ class QuadContourSet(ContourSet):
 
           *levels*: [level0, level1, ..., leveln]
             A list of floating point numbers indicating the level
-            curves to draw; e.g., to draw just the zero contour pass
-            ``levels=[0]``
+            curves to draw, in increasing order; e.g., to draw just
+            the zero contour pass ``levels=[0]``
 
           *origin*: [ *None* | 'upper' | 'lower' | 'image' ]
             If *None*, the first value of *Z* will correspond to the

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -9,7 +9,8 @@ import numpy as np
 from matplotlib import mlab
 from matplotlib.testing.decorators import cleanup, image_comparison
 from matplotlib import pyplot as plt
-from nose.tools import assert_raises
+from nose.tools import assert_equal, assert_raises
+import warnings
 
 import re
 
@@ -271,6 +272,11 @@ def test_contourf_decreasing_levels():
     z = [[0.1, 0.3], [0.5, 0.7]]
     plt.figure()
     assert_raises(ValueError, plt.contourf, z, [1.0, 0.0])
+    # Legacy contouring algorithm gives a warning rather than raising an error,
+    # plus a DeprecationWarning.
+    with warnings.catch_warnings(record=True) as w:
+        plt.contourf(z, [1.0, 0.0], corner_mask='legacy')
+    assert_equal(len(w), 2)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -9,6 +9,7 @@ import numpy as np
 from matplotlib import mlab
 from matplotlib.testing.decorators import cleanup, image_comparison
 from matplotlib import pyplot as plt
+from nose.tools import assert_raises
 
 import re
 
@@ -262,6 +263,14 @@ def test_corner_mask():
     for corner_mask in [False, True]:
         fig = plt.figure()
         plt.contourf(z, corner_mask=corner_mask)
+
+
+@cleanup
+def test_contourf_decreasing_levels():
+    # github issue 5477.
+    z = [[0.1, 0.3], [0.5, 0.7]]
+    plt.figure()
+    assert_raises(ValueError, plt.contourf, z, [1.0, 0.0])
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -10,7 +10,7 @@ from nose.tools import assert_equal, assert_raises, assert_true, assert_false
 from numpy.testing import assert_array_equal, assert_array_almost_equal,\
     assert_array_less
 import numpy.ma.testutils as matest
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import cleanup, image_comparison
 import matplotlib.cm as cm
 from matplotlib.path import Path
 
@@ -1019,6 +1019,16 @@ def test_trianalyzer_mismatched_indices():
     # numpy >= 1.10 raises a VisibleDeprecationWarning in the following line
     # prior to the fix.
     triang2 = analyser._get_compressed_triangulation()
+
+
+@cleanup
+def test_tricontourf_decreasing_levels():
+    # github issue 5477.
+    x = [0.0, 1.0, 1.0]
+    y = [0.0, 0.0, 1.0]
+    z = [0.2, 0.4, 0.6]
+    plt.figure()
+    assert_raises(ValueError, plt.tricontourf, x, y, z, [1.0, 0.0])
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tri/_tri_wrapper.cpp
+++ b/lib/matplotlib/tri/_tri_wrapper.cpp
@@ -295,6 +295,12 @@ static PyObject* PyTriContourGenerator_create_filled_contour(PyTriContourGenerat
         return NULL;
     }
 
+    if (lower_level >= upper_level)
+    {
+        PyErr_SetString(PyExc_ValueError,
+            "filled contour levels must be increasing");
+    }
+
     PyObject* result;
     CALL_CPP("create_filled_contour",
              (result = self->ptr->create_filled_contour(lower_level,

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -141,13 +141,15 @@ class TriContourSet(ContourSet):
 
           tricontour(..., Z, V)
 
-        draw contour lines at the values specified in sequence *V*
+        draw contour lines at the values specified in sequence *V*,
+        which must be in increasing order.
 
         ::
 
           tricontourf(..., Z, V)
 
-        fill the (len(*V*)-1) regions between the values in *V*
+        fill the (len(*V*)-1) regions between the values in *V*,
+        which must be in increasing order.
 
         ::
 
@@ -186,8 +188,8 @@ class TriContourSet(ContourSet):
 
           *levels* [level0, level1, ..., leveln]
             A list of floating point numbers indicating the level
-            curves to draw; e.g., to draw just the zero contour pass
-            ``levels=[0]``
+            curves to draw, in increasing order; e.g., to draw just
+            the zero contour pass ``levels=[0]``
 
           *origin*: [ *None* | 'upper' | 'lower' | 'image' ]
             If *None*, the first value of *Z* will correspond to the

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -97,6 +97,12 @@ static PyObject* PyQuadContourGenerator_create_filled_contour(PyQuadContourGener
         return NULL;
     }
 
+    if (lower_level >= upper_level)
+    {
+        PyErr_SetString(PyExc_ValueError,
+            "filled contour levels must be increasing");
+    }
+
     PyObject* result;
     CALL_CPP("create_filled_contour",
              (result = self->ptr->create_filled_contour(lower_level,


### PR DESCRIPTION
Fix for issue #5477.  All level arrays passed to contour(f) and tricontour(f) must be in increasing order, otherwise a ValueError is raised.  Added tests and updated documentation.

I have also added extra checks in the C++ contourf and tricontourf generators in case anyone is using the contour generators directly without our python wrappers.

I have not updated api_changes as I cannot decide if this is an API change or a bug fix.