### PR TITLE
image comparison decorator shouldn't require matplotlib.tests

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -5,6 +5,7 @@ import warnings
 from contextlib import contextmanager
 
 from matplotlib.cbook import is_string_like, iterable
+from matplotlib import rcParams, rcdefaults, use
 
 
 def _is_list_like(obj):
@@ -70,3 +71,37 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
                                  % expected_warning.__name__)
         assert not extra_warnings, ("Caused unexpected warning(s): %r."
                                     % extra_warnings)
+
+
+def setup():
+    # The baseline images are created in this locale, so we should use
+    # it during all of the tests.
+    import locale
+    import warnings
+    from matplotlib.backends import backend_agg, backend_pdf, backend_svg
+
+    try:
+        locale.setlocale(locale.LC_ALL, str('en_US.UTF-8'))
+    except locale.Error:
+        try:
+            locale.setlocale(locale.LC_ALL, str('English_United States.1252'))
+        except locale.Error:
+            warnings.warn(
+                "Could not set locale to English/United States. "
+                "Some date-related tests may fail")
+
+    use('Agg', warn=False)  # use Agg backend for these tests
+
+    # These settings *must* be hardcoded for running the comparison
+    # tests and are not necessarily the default values as specified in
+    # rcsetup.py
+    rcdefaults()  # Start with all defaults
+    rcParams['font.family'] = 'Bitstream Vera Sans'
+    rcParams['text.hinting'] = False
+    rcParams['text.hinting_factor'] = 8
+
+    # Clear the font caches.  Otherwise, the hinting mode can travel
+    # from one test to another.
+    backend_agg.RendererAgg._fontd.clear()
+    backend_pdf.RendererPdf.truetype_font_cache.clear()
+    backend_svg.RendererSVG.fontd.clear()

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -16,8 +16,8 @@ import numpy as np
 
 import matplotlib as mpl
 import matplotlib.style
-import matplotlib.tests
 import matplotlib.units
+import matplotlib.testing
 from matplotlib import cbook
 from matplotlib import ticker
 from matplotlib import pyplot as plt
@@ -84,7 +84,7 @@ class CleanupTest(object):
     def setup_class(cls):
         cls.original_units_registry = matplotlib.units.registry.copy()
         cls.original_settings = mpl.rcParams.copy()
-        matplotlib.tests.setup()
+        matplotlib.testing.setup()
 
     @classmethod
     def teardown_class(cls):
@@ -371,7 +371,7 @@ def switch_backend(backend):
         def backend_switcher(*args, **kwargs):
             try:
                 prev_backend = mpl.get_backend()
-                matplotlib.tests.setup()
+                matplotlib.testing.setup()
                 plt.switch_backend(backend)
                 result = func(*args, **kwargs)
             finally:

--- a/lib/matplotlib/tests/__init__.py
+++ b/lib/matplotlib/tests/__init__.py
@@ -21,7 +21,6 @@ if not os.path.exists(os.path.join(
         'test data.')
 
 
-
 def assert_str_equal(reference_str, test_str,
                      format_str=('String {str1} and {str2} do not '
                                  'match:\n{differences}')):

--- a/lib/matplotlib/tests/__init__.py
+++ b/lib/matplotlib/tests/__init__.py
@@ -6,8 +6,7 @@ from matplotlib.externals import six
 import difflib
 import os
 
-from matplotlib import rcParams, rcdefaults, use
-
+from matplotlib.testing import setup
 
 _multiprocess_can_split_ = True
 
@@ -21,39 +20,6 @@ if not os.path.exists(os.path.join(
         'You may need to install matplotlib from source to get the '
         'test data.')
 
-
-def setup():
-    # The baseline images are created in this locale, so we should use
-    # it during all of the tests.
-    import locale
-    import warnings
-    from matplotlib.backends import backend_agg, backend_pdf, backend_svg
-
-    try:
-        locale.setlocale(locale.LC_ALL, str('en_US.UTF-8'))
-    except locale.Error:
-        try:
-            locale.setlocale(locale.LC_ALL, str('English_United States.1252'))
-        except locale.Error:
-            warnings.warn(
-                "Could not set locale to English/United States. "
-                "Some date-related tests may fail")
-
-    use('Agg', warn=False)  # use Agg backend for these tests
-
-    # These settings *must* be hardcoded for running the comparison
-    # tests and are not necessarily the default values as specified in
-    # rcsetup.py
-    rcdefaults()  # Start with all defaults
-    rcParams['font.family'] = 'Bitstream Vera Sans'
-    rcParams['text.hinting'] = False
-    rcParams['text.hinting_factor'] = 8
-
-    # Clear the font caches.  Otherwise, the hinting mode can travel
-    # from one test to another.
-    backend_agg.RendererAgg._fontd.clear()
-    backend_pdf.RendererPdf.truetype_font_cache.clear()
-    backend_svg.RendererSVG.fontd.clear()
 
 
 def assert_str_equal(reference_str, test_str,


### PR DESCRIPTION
Don't have image comparison decorator depend on matplotlib.tests, which
may be missing.