### PR TITLE
adding str to force string in format

### DIFF
--- a/examples/user_interfaces/toolmanager.py
+++ b/examples/user_interfaces/toolmanager.py
@@ -41,7 +41,7 @@ class ListTools(ToolBase):
         print("{0:12} {1:45}".format("Group", "Active"))
         print('-' * 80)
         for group, active in self.toolmanager.active_toggle.items():
-            print("{0:12} {1:45}".format(group, active))
+            print("{0:12} {1:45}".format(str(group), str(active)))
 
 
 class GroupHideTool(ToolToggleBase):


### PR DESCRIPTION
When running the example `toolmanager` with python 3.5 and using the option `m` to list the shortcuts

The following error appears.
```
Traceback (most recent call last):
  File "/home/fede/workspace/matplotlib/lib/matplotlib/backends/backend_gtk3.py", line 253, in key_press_event
    FigureCanvasBase.key_press_event(self, key, guiEvent=event)
  File "/home/fede/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 1847, in key_press_event
    self.callbacks.process(s, event)
  File "/home/fede/workspace/matplotlib/lib/matplotlib/cbook.py", line 549, in process
    proxy(*args, **kwargs)
  File "/home/fede/workspace/matplotlib/lib/matplotlib/cbook.py", line 416, in __call__
    return mtd(*args, **kwargs)
  File "/home/fede/workspace/matplotlib/lib/matplotlib/backend_managers.py", line 369, in _key_press
    self.trigger_tool(name, canvasevent=event)
  File "/home/fede/workspace/matplotlib/lib/matplotlib/backend_managers.py", line 341, in trigger_tool
    self._trigger_tool(name, sender, canvasevent, data)
  File "/home/fede/workspace/matplotlib/lib/matplotlib/backend_managers.py", line 360, in _trigger_tool
    tool.trigger(sender, canvasevent, data)
  File "examples/user_interfaces/toolmanager.py", line 44, in trigger
    print("{0:12} {1:45}".format(group, active))
TypeError: non-empty format string passed to object.__format__
```

This PR corrects this problem by forcing a string casting on the key value to be displayed