### PR TITLE
OSX virtualenv fixing by creating a simple alias

### DIFF
--- a/doc/faq/virtualenv_faq.rst
+++ b/doc/faq/virtualenv_faq.rst
@@ -120,7 +120,7 @@ Alternatively you can define an alias in your ``.bashrc`` using
 
 .. code:: bash
 
-  alias frameworkpython='PYTHONHOME=$VIRTUAL_ENV /usr/local/bin/python'
+  alias frameworkpython='[[ ! -z "$VIRTUAL_ENV" ]] && PYTHONHOME=$VIRTUAL_ENV /usr/local/bin/python || /usr/local/bin/python'
 
 This alias can then be used in all of your virtualenvs without having to
 fix every single one of them.

--- a/doc/faq/virtualenv_faq.rst
+++ b/doc/faq/virtualenv_faq.rst
@@ -77,7 +77,7 @@ The issue has been reported on the virtualenv bug tracker `here
 <https://github.com/pypa/virtualenv/issues/54>`__ and `here
 <https://github.com/pypa/virtualenv/issues/609>`__
 
-Until this is fixed, one of the following workarounds.
+Until this is fixed, one of the following workarounds must be used:
 
 ``PYTHONHOME`` Script
 ---------------------

--- a/doc/faq/virtualenv_faq.rst
+++ b/doc/faq/virtualenv_faq.rst
@@ -77,7 +77,12 @@ The issue has been reported on the virtualenv bug tracker `here
 <https://github.com/pypa/virtualenv/issues/54>`__ and `here
 <https://github.com/pypa/virtualenv/issues/609>`__
 
-Until this is fixed, a workaround is needed. The best known workaround,
+Until this is fixed, one of the following workarounds.
+
+``PYTHONHOME`` Script
+---------------------
+
+The best known workaround,
 borrowed  from the `WX wiki
 <http://wiki.wxpython.org/wxPythonVirtualenvOnMac>`_, is to  use the non
 virtualenv python along with the PYTHONHOME environment variable.  This can be
@@ -107,6 +112,21 @@ framework build within the virtualenv. To run a script you can do
 ``frameworkpython test.py`` where ``test.py`` is a script that requires a
 framework build. To run an interactive ``IPython`` session with the framework
 build within the virtual environment you can do ``frameworkpython -m IPython``
+
+``PYTHONHOME`` Alias
+--------------------
+
+Alternatively you can define an alias in your ``.bashrc`` using
+
+.. code:: bash
+
+  alias frameworkpython='PYTHONHOME=$VIRTUAL_ENV /usr/local/bin/python'
+
+This alias can then be used in all of your virtualenvs without having to
+fix every single one of them.
+
+PythonW Compiler
+----------------
 
 In addition
 `virtualenv-pythonw-osx <https://github.com/gldnspud/virtualenv-pythonw-osx>`_

--- a/doc/faq/virtualenv_faq.rst
+++ b/doc/faq/virtualenv_faq.rst
@@ -113,16 +113,22 @@ framework build within the virtualenv. To run a script you can do
 framework build. To run an interactive ``IPython`` session with the framework
 build within the virtual environment you can do ``frameworkpython -m IPython``
 
-``PYTHONHOME`` Alias
---------------------
+``PYTHONHOME`` Function
+-----------------------
 
-Alternatively you can define an alias in your ``.bashrc`` using
+Alternatively you can define a function in your ``.bashrc`` using
 
 .. code:: bash
 
-  alias frameworkpython='[[ ! -z "$VIRTUAL_ENV" ]] && PYTHONHOME=$VIRTUAL_ENV /usr/local/bin/python || /usr/local/bin/python'
+  function frameworkpython {
+      if [[ ! -z "$VIRTUAL_ENV" ]]; then
+          PYTHONHOME=$VIRTUAL_ENV /usr/local/bin/python "$@"
+      else
+          /usr/local/bin/python "$@"
+      fi
+  }
 
-This alias can then be used in all of your virtualenvs without having to
+This function can then be used in all of your virtualenvs without having to
 fix every single one of them.
 
 PythonW Compiler


### PR DESCRIPTION
Added simple solution of creating frameworkpython `alias`. to OSX virtualenv fixing.

The alias does exactly what the script does: it runs `python` with a variable `PYTHONHOME` set. The script is a bit overkill because virtualenv `source bin/activate` puts the root dir of the virtualenv already in a variable `$VIRTUAL_ENV`. So picking this one up and running the system wide Python interpreter can be easily done in a one line alias.