### PR TITLE
Raise a meaningful error message in @image_comparison decorator

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -360,7 +360,12 @@ def _image_directories(func):
             # namespace package pip installed and run via the nose
             # multiprocess plugin or as a specific test this may be
             # missing. See https://github.com/matplotlib/matplotlib/issues/3314
-        assert mods.pop(0) == 'tests'
+        if mods[0] != 'tests':
+            raise ValueError(
+                "Test does not live in a submodule named 'tests'. Please make "
+                "sure that there is a parent directory named 'tests' and that "
+                "it contains a __init__.py file (can be empty).")
+        mods.pop(0)  # ignore the leading 'tests' part of the module name
         subdir = os.path.join(*mods)
 
         import imp

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -361,7 +361,7 @@ def _image_directories(func):
             # multiprocess plugin or as a specific test this may be
             # missing. See https://github.com/matplotlib/matplotlib/issues/3314
         if mods[0] != 'tests':
-            raise ValueError(
+            raise AssertionError(
                 "Test does not live in a submodule named 'tests'. Please make "
                 "sure that there is a parent directory named 'tests' and that "
                 "it contains a __init__.py file (can be empty).")


### PR DESCRIPTION
This PR makes the use of the `@image_comparison` decorator slightly more user-friendly in projects outside matplotlib. (Previously, an `AssertionError` with a fairly cryptic error message would be raised if a test that uses the `@image_comparison` decorator is not contained in a submodule named `tests`.)

Btw, is there any specific reason this assertion exists? Why not simply allow the tests to live in any directory?