### PR TITLE
Fixes #5522, bug in custom scale example

### DIFF
--- a/examples/api/custom_scale_example.py
+++ b/examples/api/custom_scale_example.py
@@ -103,7 +103,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
         input_dims = 1
         output_dims = 1
         is_separable = True
-
+        has_inverse = True
         def __init__(self, thresh):
             mtransforms.Transform.__init__(self)
             self.thresh = thresh
@@ -138,6 +138,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
         input_dims = 1
         output_dims = 1
         is_separable = True
+        has_inverse = True
 
         def __init__(self, thresh):
             mtransforms.Transform.__init__(self)

--- a/examples/api/custom_scale_example.py
+++ b/examples/api/custom_scale_example.py
@@ -104,6 +104,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
         output_dims = 1
         is_separable = True
         has_inverse = True
+
         def __init__(self, thresh):
             mtransforms.Transform.__init__(self)
             self.thresh = thresh


### PR DESCRIPTION
Added the property has_inverse = True to the custom scale example so that if axhline is later called on this axis an error is not produced.