### PR TITLE
Fix the resetting of color cycles

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1123,7 +1123,13 @@ class _AxesBase(martist.Artist):
         """
         cbook.warn_deprecated(
                 '1.5', name='set_color_cycle', alternative='set_prop_cycle')
-        self.set_prop_cycle('color', clist)
+        if clist is None:
+            # Calling set_color_cycle() or set_prop_cycle() with None
+            # effectively resets the cycle, but you can't do
+            # set_prop_cycle('color', None). So we are special-casing this.
+            self.set_prop_cycle(None)
+        else:
+            self.set_prop_cycle('color', clist)
 
     def ishold(self):
         """return the HOLD status of the axes"""

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -1,3 +1,5 @@
+import warnings
+
 from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 import numpy as np
@@ -145,6 +147,30 @@ def test_valid_input_forms():
                       color=np.array(['k', 'w']),
                       ls=np.array(['-', '--']))
     assert True
+
+
+@cleanup
+def test_cycle_reset():
+    fig, ax = plt.subplots()
+
+    # Can't really test a reset because only a cycle object is stored
+    # but we can test the first item of the cycle.
+    prop = next(ax._get_lines.prop_cycler)
+    ax.set_prop_cycle(linewidth=[10, 9, 4])
+    assert prop != next(ax._get_lines.prop_cycler)
+    ax.set_prop_cycle(None)
+    got = next(ax._get_lines.prop_cycler)
+    assert prop == got, "expected %s, got %s" % (prop, got)
+
+    fig, ax = plt.subplots()
+    # Need to double-check the old set/get_color_cycle(), too
+    with warnings.catch_warnings():
+        prop = next(ax._get_lines.prop_cycler)
+        ax.set_color_cycle(['c', 'm', 'y', 'k'])
+        assert prop != next(ax._get_lines.prop_cycler)
+        ax.set_color_cycle(None)
+        got = next(ax._get_lines.prop_cycler)
+        assert prop == got, "expected %s, got %s" % (prop, got)
 
 
 @cleanup


### PR DESCRIPTION
Targeting v1.5.x as a fix, but will also need to go into master and v2.0. This fixes a regression introduced by me in 1.5.0.

In the process of creating the unit tests, I discovered another possible bug in the hatching validation. Haven't figured it out yet, but it will also need to be fixed.