### PR TITLE
Fix for broken maplotlib.test function

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1550,7 +1550,7 @@ def test(verbosity=1, coverage=False):
 
         # store the old values before overriding
         plugins = _get_extra_test_plugins()
-        plugins.extend([plugin() for plugin in nose.plugins.builtin.plugins])
+        plugins.extend([plugin for plugin in nose.plugins.builtin.plugins])
 
         manager = PluginManager(plugins=[x() for x in plugins])
         config = nose.config.Config(verbosity=verbosity, plugins=manager)


### PR DESCRIPTION
So if I try to run `import matplotlib; matplotlib.test()`, I get this error:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-dc738b53f7b4> in <module>()
----> 1 mpl.test()

/home/paul/miniconda3/envs/mpldev/lib/python3.4/site-packages/matplotlib/__init__.py in test(verbosity, coverage)
   1553         plugins.extend([plugin() for plugin in nose.plugins.builtin.plugins])
   1554 
-> 1555         manager = PluginManager(plugins=[x() for x in plugins])
   1556         config = nose.config.Config(verbosity=verbosity, plugins=manager)
   1557 

/home/paul/miniconda3/envs/mpldev/lib/python3.4/site-packages/matplotlib/__init__.py in <listcomp>(.0)
   1553         plugins.extend([plugin() for plugin in nose.plugins.builtin.plugins])
   1554 
-> 1555         manager = PluginManager(plugins=[x() for x in plugins])
   1556         config = nose.config.Config(verbosity=verbosity, plugins=manager)
   1557 

TypeError: 'AttributeSelector' object is not callable
```

This was b/c we call some plugins in a list comprehension twice (https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/__init__.py#L1551)
