### PR TITLE
Turn autoscale into a contextmanager.

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -11,6 +11,19 @@ sources of the changes you are experiencing.
 For new features that were added to matplotlib, please see
 :ref:`whats-new`.
 
+Changes in 2.1.0
+================
+
+Code changes
+------------
+
+autoscale is now a context manager
+``````````````````````````````````
+
+Instead of returning None, ``plt.autoscale`` and ``Axes.autoscale``
+now return a context manager, which allows one to restore the previous
+autoscaling status upon exiting the block.
+
 Changes in 2.0.0
 ================
 

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -23,6 +23,18 @@ revision, see the :ref:`github-stats`.
 .. contents:: Table of Contents
    :depth: 3
 
+.. _whats-new-2-1:
+
+new in matplotlib-2.1
+=====================
+
+autoscale is now a context manager
+----------------------------------
+
+Instead of returning None, ``plt.autoscale`` and ``Axes.autoscale``
+now return a context manager, which allows one to restore the previous
+autoscaling status upon exiting the block.
+
 .. _whats-new-1-5:
 
 new in matplotlib-1.5

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2109,13 +2109,8 @@ class _AxesBase(martist.Artist):
 
             with axes.autoscale(enable): ...
 
-        or::
-
-            @axes.autoscale(enable)
-            def func(): ...
-
         will keep the autoscale status to `enable` for the duration of the
-        block or function and then restore it to its original value.
+        block only.
         """
         orig_autoscale = self._autoscaleXon, self._autoscaleYon
         if enable is not None:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from matplotlib.externals import six
 from matplotlib.externals.six.moves import xrange
 
+from contextlib import contextmanager
 import itertools
 import warnings
 import math
@@ -2103,22 +2104,36 @@ class _AxesBase(martist.Artist):
             The *tight* setting is retained for future autoscaling
             until it is explicitly changed.
 
+        This returns a context-manager/decorator that allows temporarily
+        setting the autoscale status, i.e.::
 
-        Returns None.
+            with axes.autoscale(enable): ...
+
+        or::
+
+            @axes.autoscale(enable)
+            def func(): ...
+
+        will keep the autoscale status to `enable` for the duration of the
+        block or function and then restore it to its original value.
         """
-        if enable is None:
-            scalex = True
-            scaley = True
-        else:
-            scalex = False
-            scaley = False
+        orig_autoscale = self._autoscaleXon, self._autoscaleYon
+        if enable is not None:
             if axis in ['x', 'both']:
                 self._autoscaleXon = bool(enable)
-                scalex = self._autoscaleXon
             if axis in ['y', 'both']:
                 self._autoscaleYon = bool(enable)
-                scaley = self._autoscaleYon
-        self.autoscale_view(tight=tight, scalex=scalex, scaley=scaley)
+        self.autoscale_view(
+            tight=tight, scalex=self._autoscaleXon, scaley=self._autoscaleYon)
+
+        @contextmanager
+        def restore_autoscaling():
+            try:
+                yield
+            finally:
+                self._autoscaleXon, self._autoscaleYon = orig_autoscale
+
+        return restore_autoscaling()
 
     def autoscale_view(self, tight=None, scalex=True, scaley=True):
         """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4118,6 +4118,23 @@ def test_axisbg_warning():
             ("The axisbg attribute was deprecated in version 2.0.")))
 
 
+@cleanup
+def test_autoscale():
+    plt.plot([0, 1], [0, 1])
+    assert_equal(plt.xlim(), (0, 1))
+    plt.autoscale(False)
+    plt.plot([2, 3], [2, 3])
+    assert_equal(plt.xlim(), (0, 1))
+    plt.autoscale(True)
+    plt.plot([1, 2], [1, 2])
+    assert_equal(plt.xlim(), (0, 3))
+    with plt.autoscale(False):
+        plt.plot([3, 4], [3, 4])
+    assert_equal(plt.xlim(), (0, 3))
+    plt.plot([4, 5], [4, 5])
+    assert_equal(plt.xlim(), (0, 5))
+
+
 if __name__ == '__main__':
     import nose
     import sys

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4125,8 +4125,7 @@ def test_autoscale():
     plt.autoscale(False)
     plt.plot([2, 3], [2, 3])
     assert_equal(plt.xlim(), (0, 1))
-    plt.autoscale(True)
-    plt.plot([1, 2], [1, 2])
+    plt.autoscale(None)
     assert_equal(plt.xlim(), (0, 3))
     with plt.autoscale(False):
         plt.plot([3, 4], [3, 4])


### PR DESCRIPTION
See #5510.

Also clarify a bit the implementation of autoscale, and fix an issue about the
lack of effect of set_autoscalez_on for 3D axes, which was previously visible
by running::

```
from pylab import *
from mpl_toolkits import mplot3d

gcf().add_subplot(111, projection="3d")
plot([0, 1], [0, 1], [0, 1])
gca().set_autoscalex_on(False)
gca().set_autoscalez_on(False) # has no effect
plot([2, 3], [2, 3], [2, 3])
show()
```
