### PR TITLE
Revert "Fix #5524.  Use finfo.max instead of np.inf"

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1231,11 +1231,10 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         self.layers = 0.5 * (self._levels[:-1] + self._levels[1:])
         # ...except that extended layers must be outside the
         # normed range:
-        finfo = np.finfo(float)
         if self.extend in ('both', 'min'):
-            self.layers[0] = self.vmin - finfo.eps
+            self.layers[0] = -np.inf
         if self.extend in ('both', 'max'):
-            self.layers[-1] = self.vmax + finfo.eps
+            self.layers[-1] = np.inf
 
     def _process_colors(self):
         """


### PR DESCRIPTION
Reverts matplotlib/matplotlib#5534