### PR TITLE
Fix #5524: Use large, but finite, values for contour extensions

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1232,9 +1232,9 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         # ...except that extended layers must be outside the
         # normed range:
         if self.extend in ('both', 'min'):
-            self.layers[0] = -np.inf
+            self.layers[0] = -1e150
         if self.extend in ('both', 'max'):
-            self.layers[-1] = np.inf
+            self.layers[-1] = 1e150
 
     def _process_colors(self):
         """


### PR DESCRIPTION
This follows @efiring's suggestion in #5524.