### PR TITLE
qt: raise each new window

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -490,6 +490,7 @@ class FigureManagerQT(FigureManagerBase):
             if self.toolbar is not None:
                 self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
+        self.window.raise_()
 
     @QtCore.Slot()
     def _show_message(self, s):


### PR DESCRIPTION
This is an attempt to make progress on #596 with a one-line change to the qt backend that adds a call to `raise_()`.  It raises and grabs focus.  I would prefer that it not grab focus, but at least on OSX I don't know how to avoid it.  The present behavior on OSX is so annoying that I am willing to accept the focus grab.  Contrary to what I thought, my test of the qt4 backend on Linux without this change shows that at least on my XFCE desktop, the window is already being raised, including the focus grab; so the changeset here is just making OSX behave like this Linux desktop.

I also tried the approach of using the `WindowStaysOnTopHint`, but the problem is that it really *stays* on top, and that's no good either.