### PR TITLE
Use shorter float repr in figure options dialog.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -46,8 +46,8 @@ def figure_edit(axes, parent=None):
     has_curve = len(axes.get_lines()) > 0
 
     # Get / General
-    xmin, xmax = axes.get_xlim()
-    ymin, ymax = axes.get_ylim()
+    xmin, xmax = map(float, axes.get_xlim())
+    ymin, ymax = map(float, axes.get_ylim())
     general = [('Title', axes.get_title()),
                sep,
                (None, "<b>X-Axis</b>"),


### PR DESCRIPTION
On Python3, native float repr is as short as possible.  Moreover, no precision
is lost as {x,y}lims are already internally represented as numpy floats of the
same size as the native floats.

See #4839.