### PR TITLE
Allow show to be interrupted

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -6026,6 +6026,7 @@ show(PyObject* self)
     NSWindow *window;
     while ((window = [enumerator nextObject])) {
         [window orderFront:nil];
+        [[window contentView] setNeedsDisplay: YES];
     }
     [pool release];
     Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
This is a comprehensive bug fix for issue #5251  . In particular, with this PR the backend is using the same code everywhere for the event loop, and the call to show() can be interrupted.
