### PR TITLE
use base64.encodestring on python2.7

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -27,7 +27,12 @@ import os
 import platform
 import sys
 import itertools
-import base64
+try:
+    # python3
+    from base64 import encodebytes
+except ImportError:
+    # python2
+    from base64 import encodestring as encodebytes
 import contextlib
 import tempfile
 from matplotlib.cbook import iterable, is_string_like
@@ -928,7 +933,7 @@ class Animation(object):
 
             # Now open and base64 encode
             with open(f.name, 'rb') as video:
-                vid64 = base64.encodebytes(video.read())
+                vid64 = encodebytes(video.read())
                 self._base64_video = vid64.decode('ascii')
                 self._video_size = 'width="{0}" height="{1}"'.format(
                         *writer.frame_size)


### PR DESCRIPTION
This PR fixes #5508.
I don't know the standard way to solve version compatibility issues in this project. So I chose explicit way.

I've tested a code below with IPython notebook on Python2.7.5 and Python3.4.2.
```python
get_ipython().enable_matplotlib("inline")

import os
import numpy as np
import matplotlib as mpl
import matplotlib.pyplot as plt
mpl.style.use('ggplot')

mpl.rcParams['animation.html'] = 'html5'
mpl.rcParams['animation.ffmpeg_path'] = os.path.expanduser("~/bin/ffmpeg")

fig = plt.figure()
x = np.arange(500)
frame_list = []

for a in range(10):
    frame = plt.plot(x, a * x ** 2, lw=2)
    frame_list.append(frame)

from matplotlib import animation
animation.ArtistAnimation(fig, frame_list, interval = 500)
```
