### PR TITLE
WIP: Parallel docs build

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import glob
+import multiprocessing
 import os
 import shutil
 import sys
@@ -45,7 +46,8 @@ def html(buildername='html'):
         options = ''
     if warnings_as_errors:
         options = options + ' -W'
-    if os.system('sphinx-build %s -b %s -d build/doctrees . build/%s' % (options, buildername, buildername)):
+    if os.system('sphinx-build -j %d %s -b %s -d build/doctrees . build/%s' % (
+            multiprocessing.cpu_count(), options, buildername, buildername)):
         raise SystemExit("Building HTML failed.")
 
     # Clean out PDF files from the _images directory
@@ -60,7 +62,7 @@ def htmlhelp():
     with open('build/htmlhelp/index.html', 'r+') as fh:
         content = fh.read()
         fh.seek(0)
-        content = re.sub(r'<script>.*?</script>', '', content, 
+        content = re.sub(r'<script>.*?</script>', '', content,
                          flags=re.MULTILINE| re.DOTALL)
         fh.write(content)
         fh.truncate()

--- a/doc/sphinxext/gen_gallery.py
+++ b/doc/sphinxext/gen_gallery.py
@@ -168,3 +168,6 @@ def setup(app):
         app.add_config_value('mpl_example_sections', [], True)
     except sphinx.errors.ExtensionError:
         pass # mpl_example_sections already defined
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -169,3 +169,6 @@ def setup(app):
         app.add_config_value('mpl_example_sections', [], True)
     except sphinx.errors.ExtensionError:
         pass # mpl_example_sections already defined
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata

--- a/doc/sphinxext/github.py
+++ b/doc/sphinxext/github.py
@@ -143,7 +143,7 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def setup(app):
     """Install the plugin.
-    
+
     :param app: Sphinx application context.
     """
     app.info('Initializing GitHub plugin')
@@ -152,4 +152,6 @@ def setup(app):
     app.add_role('ghuser', ghuser_role)
     app.add_role('ghcommit', ghcommit_role)
     app.add_config_value('github_project_url', None, 'env')
-    return
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata

--- a/doc/sphinxext/math_symbol_table.py
+++ b/doc/sphinxext/math_symbol_table.py
@@ -138,6 +138,9 @@ def setup(app):
         'math_symbol_table', math_symbol_table_directive,
         False, (0, 1, 0))
 
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata
+
 if __name__ == "__main__":
     # Do some verification of the tables
     from matplotlib import _mathtext_data

--- a/lib/matplotlib/sphinxext/mathmpl.py
+++ b/lib/matplotlib/sphinxext/mathmpl.py
@@ -119,3 +119,6 @@ def setup(app):
     app.add_role('math', math_role)
     app.add_directive('math', math_directive,
                       True, (0, 0, 0), **options_spec)
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata

--- a/lib/matplotlib/sphinxext/only_directives.py
+++ b/lib/matplotlib/sphinxext/only_directives.py
@@ -66,3 +66,6 @@ def setup(app):
     app.add_node(html_only, latex=(visit_ignore, depart_ignore))
     app.add_node(latex_only, latex=(visit_perform, depart_perform))
     app.add_node(latex_only, html=(visit_ignore, depart_ignore))
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -280,6 +280,9 @@ def setup(app):
 
     app.connect(str('doctree-read'), mark_plot_labels)
 
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata
+
 #------------------------------------------------------------------------------
 # Doctest handling
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow-on to #5589, that enables parallel doc building for all extensions.  This does seem to result in the docs actually being built in parallel -- though only using 186% of CPU time on average on a Core i7.  However, on my machine, it hangs indefinitely with the message "waiting for workers..." at the end, so it's still not a viable solution.  However, I'm putting this up here in case anyone else has any ideas.

Cc: @jschuller, @jenshnielsen, @birkenfeld