### PR TITLE
Fix DeprecationWarning in stackplot.py

### DIFF
--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, division, print_function,
 from matplotlib.externals import six
 from matplotlib.externals.six.moves import xrange
 
+from cycler import cycler
 import numpy as np
 
 __all__ = ['stackplot']
@@ -63,7 +64,7 @@ def stackplot(axes, x, *args, **kwargs):
 
     colors = kwargs.pop('colors', None)
     if colors is not None:
-        axes.set_color_cycle(colors)
+        axes.set_prop_cycle(cycler('color', colors))
 
     baseline = kwargs.pop('baseline', 'zero')
     # Assume data passed has not been 'stacked', so stack it here.


### PR DESCRIPTION
In matplotlib 1.5.0, plt.stackplot() raises a DeprecationWarning ("The set_color_cycle attribute was deprecated in version 1.5. Use set_prop_cycle instead"):

The simple replacement in the attached pull request seems to fix this.