### PR TITLE
TST: Enable grid within test_rc_grid test.

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4007,12 +4007,15 @@ def test_rc_spines():
 def test_rc_grid():
     fig = plt.figure()
     rc_dict0 = {
+        'axes.grid': True,
         'axes.grid.axis': 'both'
     }
     rc_dict1 = {
+        'axes.grid': True,
         'axes.grid.axis': 'x'
     }
     rc_dict2 = {
+        'axes.grid': True,
         'axes.grid.axis': 'y'
     }
     dict_list = [rc_dict0, rc_dict1, rc_dict2]


### PR DESCRIPTION
The provided settings only state which direction to use the grid, but never actually enabled it.

Fixes #5535.