### PR TITLE
Clarify error when plot() args have bad shapes.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -220,9 +220,11 @@ class _process_plot_var_args(object):
         x = _check_1d(x)
         y = _check_1d(y)
         if x.shape[0] != y.shape[0]:
-            raise ValueError("x and y must have same first dimension")
+            raise ValueError("x and y must have same first dimension, but "
+                             "have shapes {} and {}".format(x.shape, y.shape))
         if x.ndim > 2 or y.ndim > 2:
-            raise ValueError("x and y can be no greater than 2-D")
+            raise ValueError("x and y can be no greater than 2-D, but have "
+                             "shapes {} and {}".format(x.shape, y.shape))
 
         if x.ndim == 1:
             x = x[:, np.newaxis]


### PR DESCRIPTION
When I see the error "x and y must have the same dimensions", typically the first thing I do is to re-run the thing with a print of the shapes just before the call to plot() (or do this via pdb), and then I think about what went wrong.  This is a minor patch that would save this step.