### PR TITLE
DOC: Add Qt5 backend to documentation.

### DIFF
--- a/doc/api/backend_qt5agg_api.rst
+++ b/doc/api/backend_qt5agg_api.rst
@@ -1,0 +1,9 @@
+
+:mod:`matplotlib.backends.backend_qt5agg`
+=========================================
+
+.. automodule:: matplotlib.backends.backend_qt5agg
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/doc/api/index_backend_api.rst
+++ b/doc/api/index_backend_api.rst
@@ -9,6 +9,7 @@ backends
    backend_tools_api.rst
    backend_gtkagg_api.rst
    backend_qt4agg_api.rst
+   backend_qt5agg_api.rst
    backend_wxagg_api.rst
    backend_pdf_api.rst
 ..   backend_webagg.rst


### PR DESCRIPTION
I didn't really test building the docs, but it doesn't look like there should be any issues, and hopefully Travis will complain if it's really a problem.