### PR TITLE
eps text editable in illustrator by default

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1126,11 +1126,11 @@ defaultParams = {
 
     # Set the papersize/type
     'ps.papersize':     ['letter', validate_ps_papersize],
-    'ps.useafm':        [False, validate_bool],  # Set PYTHONINSPECT
+    'ps.useafm':        [True, validate_bool],  # Set PYTHONINSPECT
     # use ghostscript or xpdf to distill ps output
     'ps.usedistiller':  [False, validate_ps_distiller],
     'ps.distiller.res': [6000, validate_int],     # dpi
-    'ps.fonttype':      [3, validate_fonttype],  # 3 (Type3) or 42 (Truetype)
+    'ps.fonttype':      [42, validate_fonttype],  # 3 (Type3) or 42 (Truetype)
     # compression level from 0 to 9; 0 to disable
     'pdf.compression':  [6, validate_int],
     # ignore any color-setting commands from the frontend

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -481,13 +481,13 @@ backend      : %(backend)s
 
 # ps backend params
 #ps.papersize      : letter   # auto, letter, legal, ledger, A0-A10, B0-B10
-#ps.useafm         : False    # use of afm fonts, results in small files
+#ps.useafm         : True     # use of afm fonts, results in small files
 #ps.usedistiller   : False    # can be: None, ghostscript or xpdf
                                           # Experimental: may produce smaller files.
                                           # xpdf intended for production of publication quality files,
                                           # but requires ghostscript, xpdf and ps2eps
 #ps.distiller.res  : 6000      # dpi
-#ps.fonttype       : 3         # Output Type 3 (Type3) or Type 42 (TrueType)
+#ps.fonttype       : 42        # Output Type 3 (Type3) or Type 42 (TrueType)
 
 # pdf backend params
 #pdf.compression   : 6 # integer from 0 to 9


### PR DESCRIPTION
These ps.fonttype and ps.useafm defaults allow the exported
figure text to edited in Adobe Illustrator.
