### PR TITLE
DOC: add FAQ about np.datetime64

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -14,6 +14,35 @@ How-To
 Plotting: howto
 ===============
 
+.. _howto-datetime64:
+
+Plot `numpy.datetime64` values
+------------------------------
+
+For matplotlib to plot dates (or any scalar with units) a converter
+to float needs to be registered with the `matplolib.units` module.  The
+current best converters for `datetime64` values are in `pandas`.  Simply
+importing `pandas` ::
+
+  import pandas as pd
+
+should be sufficient as `pandas` will try to install the converters
+on import.  If that does not work, or you need to reset `munits.registry`
+you can explicitly install the `pandas` converters by ::
+
+  from pandas.tseries import converter as pdtc
+  pdtc.register()
+
+If you only want to use the `pandas` converter for `datetime64` values ::
+
+  from pandas.tseries import converter as pdtc
+  import matplotlib.units as munits
+  import numpy as np
+
+  munits.registry[np.datetime64] = pdtc.DatetimeConverter()
+
+
+
 .. _howto-findobj:
 
 Find all objects in a figure of a certain type


### PR DESCRIPTION
I would appreciate if someone else checked to make sure I am not lying here, but with up-to-date everything, datetime64 seems to 'just work' so long as `pandas` has been imported.