### PR TITLE
Reset the available animation movie writer on rcParam change

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -338,10 +338,11 @@ class MovieWriter(AbstractMovieWriter):
         Check to see if a MovieWriter subclass is actually available by
         running the commandline tool.
         '''
-        if not cls.bin_path():
+        bin_path = cls.bin_path()
+        if not bin_path:
             return False
         try:
-            p = subprocess.Popen(cls.bin_path(),
+            p = subprocess.Popen(bin_path,
                              shell=False,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,
@@ -642,12 +643,22 @@ class ImageMagickBase(object):
                 binpath = ''
         rcParams[cls.exec_key] = rcParamsDefault[cls.exec_key] = binpath
 
+    @classmethod
+    def isAvailable(cls):
+        '''
+        Check to see if a MovieWriter subclass is actually available by
+        running the commandline tool.
+        '''
+        bin_path = cls.bin_path()
+        if bin_path == "convert":
+            cls._init_from_registry()
+        return super(ImageMagickBase, cls).isAvailable()
 
 ImageMagickBase._init_from_registry()
 
 
 @writers.register('imagemagick')
-class ImageMagickWriter(MovieWriter, ImageMagickBase):
+class ImageMagickWriter(ImageMagickBase, MovieWriter, ):
     def _args(self):
         return ([self.bin_path(),
                  '-size', '%ix%i' % self.frame_size, '-depth', '8',
@@ -657,7 +668,7 @@ class ImageMagickWriter(MovieWriter, ImageMagickBase):
 
 
 @writers.register('imagemagick_file')
-class ImageMagickFileWriter(FileMovieWriter, ImageMagickBase):
+class ImageMagickFileWriter(ImageMagickBase, FileMovieWriter):
     supported_formats = ['png', 'jpeg', 'ppm', 'tiff', 'sgi', 'bmp',
                          'pbm', 'raw', 'rgba']
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -459,13 +459,16 @@ class FileMovieWriter(MovieWriter):
             try:
                 stdout = [s.decode() for s in self._proc._stdout_buff]
                 stderr = [s.decode() for s in self._proc._stderr_buff]
-                verbose.report("MovieWriter.finish: stdout: %s" % stdout, level='helpful')
-                verbose.report("MovieWriter.finish: stderr: %s" % stderr, level='helpful')
+                verbose.report("MovieWriter.finish: stdout: %s" % stdout,
+                               level='helpful')
+                verbose.report("MovieWriter.finish: stderr: %s" % stderr,
+                               level='helpful')
             except Exception as e:
                 pass
-            raise RuntimeError('Error creating movie, return code: '
-                               + str(self._proc.returncode)
-                               + ' Try setting mpl.verbose.set_level("helpful")')
+            msg = ('Error creating movie, return code: ' +
+                   str(self._proc.returncode) +
+                   ' Try setting mpl.verbose.set_level("helpful")')
+            raise RuntimeError(msg)
 
     def cleanup(self):
         MovieWriter.cleanup(self)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -656,7 +656,9 @@ class ImageMagickBase(object):
     @classmethod
     def isAvailable(cls):
         '''
-        Check to see if a MovieWriter subclass is actually available by
+        Check to see if a ImageMagickWriter is actually available
+
+        Done by first checking the windows registry (if applicable) and then
         running the commandline tool.
         '''
         bin_path = cls.bin_path()
@@ -667,8 +669,12 @@ class ImageMagickBase(object):
 ImageMagickBase._init_from_registry()
 
 
+# Note: the base classes need to be in that order to get
+# isAvailable() from ImageMagickBase called and not the
+# one from MovieWriter. The latter is then called by the
+# former.
 @writers.register('imagemagick')
-class ImageMagickWriter(ImageMagickBase, MovieWriter, ):
+class ImageMagickWriter(ImageMagickBase, MovieWriter):
     def _args(self):
         return ([self.bin_path(),
                  '-size', '%ix%i' % self.frame_size, '-depth', '8',
@@ -677,6 +683,10 @@ class ImageMagickWriter(ImageMagickBase, MovieWriter, ):
                 + self.output_args)
 
 
+# Note: the base classes need to be in that order to get
+# isAvailable() from ImageMagickBase called and not the
+# one from MovieWriter. The latter is then called by the
+# former.
 @writers.register('imagemagick_file')
 class ImageMagickFileWriter(ImageMagickBase, FileMovieWriter):
     supported_formats = ['png', 'jpeg', 'ppm', 'tiff', 'sgi', 'bmp',

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -456,9 +456,16 @@ class FileMovieWriter(MovieWriter):
         # Check error code for creating file here, since we just run
         # the process here, rather than having an open pipe.
         if self._proc.returncode:
+            try:
+                stdout = [s.decode() for s in self._proc._stdout_buff]
+                stderr = [s.decode() for s in self._proc._stderr_buff]
+                verbose.report("MovieWriter.finish: stdout: %s" % stdout, level='helpful')
+                verbose.report("MovieWriter.finish: stderr: %s" % stderr, level='helpful')
+            except Exception as e:
+                pass
             raise RuntimeError('Error creating movie, return code: '
                                + str(self._proc.returncode)
-                               + ' Try running with --verbose-debug')
+                               + ' Try setting mpl.verbose.set_level("helpful")')
 
     def cleanup(self):
         MovieWriter.cleanup(self)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -802,6 +802,21 @@ def validate_hist_bins(s):
     raise ValueError("'hist.bins' must be 'auto', an int or " +
                      "a sequence of floats")
 
+def validate_animation_writer_path(p):
+    # Make sure it's a string and then figure out if the animations
+    # are already loaded and reset the writers (which will validate
+    # the path on next call)
+    if not isinstance(p, six.text_type):
+        raise ValueError("path must be a (unicode) string")
+    from sys import modules
+    # set dirty, so that the next call to the registry will re-evaluate
+    # the state.
+    # only set dirty if already loaded. If not loaded, the load will
+    # trigger the checks.
+    if "matplotlib.animation" in modules:
+        modules["matplotlib.animation"].writers.set_dirty()
+    return p
+
 
 # a map from key -> value, converter
 defaultParams = {
@@ -1222,20 +1237,20 @@ defaultParams = {
     # Controls image format when frames are written to disk
     'animation.frame_format': ['png', validate_movie_frame_fmt],
     # Path to FFMPEG binary. If just binary name, subprocess uses $PATH.
-    'animation.ffmpeg_path':  ['ffmpeg', six.text_type],
+    'animation.ffmpeg_path':  ['ffmpeg', validate_animation_writer_path],
 
     # Additional arguments for ffmpeg movie writer (using pipes)
     'animation.ffmpeg_args':   [[], validate_stringlist],
     # Path to AVConv binary. If just binary name, subprocess uses $PATH.
-    'animation.avconv_path':   ['avconv', six.text_type],
+    'animation.avconv_path':   ['avconv', validate_animation_writer_path],
     # Additional arguments for avconv movie writer (using pipes)
     'animation.avconv_args':   [[], validate_stringlist],
     # Path to MENCODER binary. If just binary name, subprocess uses $PATH.
-    'animation.mencoder_path': ['mencoder', six.text_type],
+    'animation.mencoder_path': ['mencoder', validate_animation_writer_path],
     # Additional arguments for mencoder movie writer (using pipes)
     'animation.mencoder_args': [[], validate_stringlist],
      # Path to convert binary. If just binary name, subprocess uses $PATH
-    'animation.convert_path':  ['convert', six.text_type],
+    'animation.convert_path':  ['convert', validate_animation_writer_path],
      # Additional arguments for mencoder movie writer (using pipes)
 
     'animation.convert_args':  [[], validate_stringlist],

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -179,7 +179,7 @@ def test_movie_writer_registry():
     animation.writers.list()  # resets
     assert_false(animation.writers._dirty)
     assert_false(animation.writers.is_available("ffmpeg"))
-    # something which is garanteered to be available in path
+    # something which is guaranteed to be available in path
     # and exits immediately
     bin = u"true" if sys.platform != 'win32' else u"where"
     mpl.rcParams['animation.ffmpeg_path'] = bin

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -4,10 +4,13 @@ from __future__ import (absolute_import, division, print_function,
 from matplotlib.externals import six
 
 import os
+import sys
 import tempfile
 import numpy as np
 from numpy.testing import assert_equal
 from nose import with_setup
+from nose.tools import assert_false, assert_true
+import matplotlib as mpl
 from matplotlib import pyplot as plt
 from matplotlib import animation
 from matplotlib.testing.noseclasses import KnownFailureTest
@@ -161,6 +164,29 @@ def test_no_length_frames():
 
     anim = animation.FuncAnimation(fig, animate, init_func=init,
                                    frames=iter(range(5)))
+
+
+def test_movie_writer_registry():
+    ffmpeg_path = mpl.rcParams['animation.ffmpeg_path']
+    # Not sure about the first state as there could be some writer
+    # which set rcparams
+    #assert_false(animation.writers._dirty)
+    assert_true(len(animation.writers._registered) > 0)
+    animation.writers.list()  # resets dirty state
+    assert_false(animation.writers._dirty)
+    mpl.rcParams['animation.ffmpeg_path'] = u"not_available_ever_xxxx"
+    assert_true(animation.writers._dirty)
+    animation.writers.list()  # resets
+    assert_false(animation.writers._dirty)
+    assert_false(animation.writers.is_available("ffmpeg"))
+    # something which is garanteered to be available in path
+    bin = u"python"
+    mpl.rcParams['animation.ffmpeg_path'] = bin
+    assert_true(animation.writers._dirty)
+    animation.writers.list()  # resets
+    assert_false(animation.writers._dirty)
+    assert_true(animation.writers.is_available("ffmpeg"))
+    mpl.rcParams['animation.ffmpeg_path'] = ffmpeg_path
 
 
 if __name__ == "__main__":

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -180,7 +180,8 @@ def test_movie_writer_registry():
     assert_false(animation.writers._dirty)
     assert_false(animation.writers.is_available("ffmpeg"))
     # something which is garanteered to be available in path
-    bin = u"python"
+    # and exits immediately
+    bin = u"true" if sys.platform != 'win32' else u"where"
     mpl.rcParams['animation.ffmpeg_path'] = bin
     assert_true(animation.writers._dirty)
     animation.writers.list()  # resets


### PR DESCRIPTION
If one of the rcParams for a path to a program, which was called by a
movie writer, is changed, the the available movie writer in the
registry should be reevaluated if they are (still/became) available.

This also fixes the problem that you have to set the path to a movie
writer before importing mpl.animation, as before the state was
fixed on import time.

Closes: https://github.com/matplotlib/matplotlib/issues/5616