### PR TITLE
WX/WXagg backend add code that zooms properly on a Mac with a Retina display

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1574,7 +1574,11 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         self._idle = True
         self.statbar = None
         self.prevZoomRect = None
-        self.RetinaFix = 'wxMac' in wx.PlatformInfo
+        # for now, use alternate zoom-rectangle drawing on all
+        # Macs. N.B. In future versions of wx it may be possible to
+        # detect Retina displays with window.GetContentScaleFactor()
+        # and/or dc.GetContentScaleFactor() 
+        self.retinaFix = 'wxMac' in wx.PlatformInfo
 
     def get_canvas(self, frame, fig):
         return FigureCanvasWx(frame, -1, fig)
@@ -1676,7 +1680,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
     def press(self, event):
         if self._active == 'ZOOM':
-            if not self.RetinaFix:
+            if not self.retinaFix:
                 self.wxoverlay = wx.Overlay()
             else:
                 self.savedRetinaImage = self.canvas.copy_from_bbox(
@@ -1688,7 +1692,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         if self._active == 'ZOOM':
             # When the mouse is released we reset the overlay and it
             # restores the former content to the window.
-            if not self.RetinaFix:
+            if not self.retinaFix:
                 self.wxoverlay.Reset()
                 del self.wxoverlay
             else:
@@ -1698,7 +1702,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                     self.prevZoomRect = None
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
-        if self.RetinaFix:  # On Macs, use the following code
+        if self.retinaFix:  # On Macs, use the following code
             # wx.DCOverlay does not work properly on Retina displays.
             rubberBandColor = '#C0C0FF'
             if self.prevZoomRect:

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1699,17 +1699,17 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         if self.RetinaFix:  # On Macs, use the following code
-            # wx.DCOverlay does not work properly on Retina displays. 
+            # wx.DCOverlay does not work properly on Retina displays.
             rubberBandColor = '#C0C0FF'
             if self.prevZoomRect:
                 self.prevZoomRect.pop(0).remove()
             self.canvas.restore_region(self.savedRetinaImage)
-            X0,X1 = self.zoomStartX,event.xdata
-            Y0,Y1 = self.zoomStartY,event.ydata
+            X0, X1 = self.zoomStartX, event.xdata
+            Y0, Y1 = self.zoomStartY, event.ydata
             lineX = (X0, X0, X1, X1, X0)
             lineY = (Y0, Y1, Y1, Y0, Y0)
             self.prevZoomRect = self.canvas.figure.gca().plot(
-                lineX,lineY,'-',color=rubberBandColor)
+                lineX, lineY, '-', color=rubberBandColor)
             self.canvas.figure.gca().draw_artist(self.prevZoomRect[0])
             self.canvas.blit(self.canvas.figure.gca().bbox)
             return

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1368,6 +1368,7 @@ class FigureManagerWx(FigureManagerBase):
 
     def show(self):
         self.frame.Show()
+        self.canvas.draw()
 
     def destroy(self, *args):
         DEBUG_MSG("destroy()", 1, self)
@@ -1572,6 +1573,8 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         self.canvas = canvas
         self._idle = True
         self.statbar = None
+        self.prevZoomRect = None
+        self.RetinaFix = 'wxMac' in wx.PlatformInfo
 
     def get_canvas(self, frame, fig):
         return FigureCanvasWx(frame, -1, fig)
@@ -1673,16 +1676,42 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
     def press(self, event):
         if self._active == 'ZOOM':
-            self.wxoverlay = wx.Overlay()
+            if not self.RetinaFix:
+                self.wxoverlay = wx.Overlay()
+            else:
+                self.savedRetinaImage = self.canvas.copy_from_bbox(self.canvas.figure.gca().bbox)
+                self.zoomStartX = event.xdata
+                self.zoomStartY = event.ydata
 
     def release(self, event):
         if self._active == 'ZOOM':
             # When the mouse is released we reset the overlay and it
             # restores the former content to the window.
-            self.wxoverlay.Reset()
-            del self.wxoverlay
+            if not self.RetinaFix:
+                self.wxoverlay.Reset()
+                del self.wxoverlay
+            else:
+                del self.savedRetinaImage
+                if self.prevZoomRect:
+                    self.prevZoomRect.pop(0).remove()
+                    self.prevZoomRect = None
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
+        if self.RetinaFix:
+            # wx.DCOverlay does not work properly on Macs with Retina displays
+            # for Macs, use the following code instead.
+            rubberBandColor = '#C0C0FF' # or load from config?
+            if self.prevZoomRect:
+                self.prevZoomRect.pop(0).remove()
+            self.canvas.restore_region(self.savedRetinaImage)
+            X0,X1,Y0,Y1 = self.zoomStartX,event.xdata,self.zoomStartY,event.ydata
+            lineX = (X0, X0, X1, X1, X0)
+            lineY = (Y0, Y1, Y1, Y0, Y0)
+            self.prevZoomRect = self.canvas.figure.gca().plot(lineX,lineY,'-',color=rubberBandColor)
+            self.canvas.figure.gca().draw_artist(self.prevZoomRect[0])
+            self.canvas.blit(self.canvas.figure.gca().bbox)
+            return
+        
         # Use an Overlay to draw a rubberband-like bounding box.
 
         dc = wx.ClientDC(self.canvas)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1577,7 +1577,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         # for now, use alternate zoom-rectangle drawing on all
         # Macs. N.B. In future versions of wx it may be possible to
         # detect Retina displays with window.GetContentScaleFactor()
-        # and/or dc.GetContentScaleFactor() 
+        # and/or dc.GetContentScaleFactor()
         self.retinaFix = 'wxMac' in wx.PlatformInfo
 
     def get_canvas(self, frame, fig):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1679,7 +1679,8 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             if not self.RetinaFix:
                 self.wxoverlay = wx.Overlay()
             else:
-                self.savedRetinaImage = self.canvas.copy_from_bbox(self.canvas.figure.gca().bbox)
+                self.savedRetinaImage = self.canvas.copy_from_bbox(
+                    self.canvas.figure.gca().bbox)
                 self.zoomStartX = event.xdata
                 self.zoomStartY = event.ydata
 
@@ -1697,21 +1698,22 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                     self.prevZoomRect = None
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
-        if self.RetinaFix:
-            # wx.DCOverlay does not work properly on Macs with Retina displays
-            # for Macs, use the following code instead.
-            rubberBandColor = '#C0C0FF' # or load from config?
+        if self.RetinaFix:  # On Macs, use the following code
+            # wx.DCOverlay does not work properly on Retina displays. 
+            rubberBandColor = '#C0C0FF'
             if self.prevZoomRect:
                 self.prevZoomRect.pop(0).remove()
             self.canvas.restore_region(self.savedRetinaImage)
-            X0,X1,Y0,Y1 = self.zoomStartX,event.xdata,self.zoomStartY,event.ydata
+            X0,X1 = self.zoomStartX,event.xdata
+            Y0,Y1 = self.zoomStartY,event.ydata
             lineX = (X0, X0, X1, X1, X0)
             lineY = (Y0, Y1, Y1, Y0, Y0)
-            self.prevZoomRect = self.canvas.figure.gca().plot(lineX,lineY,'-',color=rubberBandColor)
+            self.prevZoomRect = self.canvas.figure.gca().plot(
+                lineX,lineY,'-',color=rubberBandColor)
             self.canvas.figure.gca().draw_artist(self.prevZoomRect[0])
             self.canvas.blit(self.canvas.figure.gca().bbox)
             return
-        
+
         # Use an Overlay to draw a rubberband-like bounding box.
 
         dc = wx.ClientDC(self.canvas)


### PR DESCRIPTION
This uses a slower method for drawing the zoom rubberband box on all Macs (perhaps not needed in Phoenix?) because I don't know a way to detect if a Retina display is present. 

Note that the added self.canvas.draw() call in the FigureManagerWx.show() method comes from the version in the Canopy dist for 1.5.0. 