### PR TITLE
Warning message prior to fc-list command

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -276,7 +276,7 @@ def get_fontconfig_fonts(fontext='ttf'):
 
     fontfiles = {}
     try:
-        warnings.warn('Running fc-list. This could take a few minutes.')
+        warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')
         pipe = subprocess.Popen(['fc-list', '--format=%{file}\\n'],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -276,6 +276,7 @@ def get_fontconfig_fonts(fontext='ttf'):
 
     fontfiles = {}
     try:
+        warnings.warn('Running fc-list. This could take a few minutes.')
         pipe = subprocess.Popen(['fc-list', '--format=%{file}\\n'],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)


### PR DESCRIPTION
When the font cache is first created, `fc-list` may take up to several minutes on some machines. No indication is given that this is being done. This adds a warning so the user is aware.

https://github.com/matplotlib/matplotlib/issues/2919