### PR TITLE
Change `savefig.dpi` and `figure.dpi` defaults

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1092,7 +1092,7 @@ defaultParams = {
 
     # figure size in inches: width by height
     'figure.figsize':    [[8.0, 6.0], validate_nseq_float(2)],
-    'figure.dpi':        [80, validate_float],   # DPI
+    'figure.dpi':        [100, validate_float],  # DPI
     'figure.facecolor':  ['0.75', validate_color],  # facecolor; scalar gray
     'figure.edgecolor':  ['w', validate_color],  # edgecolor; white
     'figure.frameon':    [True, validate_bool],
@@ -1113,7 +1113,7 @@ defaultParams = {
                                                      closedmax=False)],
 
     ## Saving figure's properties
-    'savefig.dpi':         [100, validate_dpi],   # DPI
+    'savefig.dpi':         ['figure', validate_dpi],  # DPI
     'savefig.facecolor':   ['w', validate_color],  # facecolor; white
     'savefig.edgecolor':   ['w', validate_color],  # edgecolor; white
     'savefig.frameon':     [True, validate_bool],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -390,7 +390,7 @@ backend      : %(backend)s
 #figure.titlesize : medium     # size of the figure title
 #figure.titleweight : normal   # weight of the figure title
 #figure.figsize   : 8, 6    # figure size in inches
-#figure.dpi       : 80      # figure dots per inch
+#figure.dpi       : 100     # figure dots per inch
 #figure.facecolor : 0.75    # figure facecolor; 0.75 is scalar gray
 #figure.edgecolor : white   # figure edgecolor
 #figure.autolayout : False  # When True, automatically adjust subplot
@@ -463,7 +463,7 @@ backend      : %(backend)s
 # the default savefig params can be different from the display params
 # e.g., you may want a higher resolution, or to make the figure
 # background white
-#savefig.dpi         : 100      # figure dots per inch
+#savefig.dpi         : figure   # figure dots per inch or 'figure'
 #savefig.facecolor   : white    # figure facecolor when saving
 #savefig.edgecolor   : white    # figure edgecolor when saving
 #savefig.format      : png      # png, ps, pdf, svg


### PR DESCRIPTION
Change the default values for `savefig.dpi` and `figure.dpi` as suggested in #305.

```
savefig.dpi: 100 -> 'figure'
figure.dpi: 80 -> 100
```