### PR TITLE
Bugfix for test_triage tool on Python 2

### DIFF
--- a/tools/test_triage.py
+++ b/tools/test_triage.py
@@ -24,6 +24,8 @@ Keys:
     R:          Reject test.  Copy the expected result to the source tree.
 """
 
+from __future__ import unicode_literals
+
 import os
 import shutil
 import sys


### PR DESCRIPTION
Just a little Unicode problem...