### PR TITLE
Low-hanging performance improvements

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -750,8 +750,8 @@ class Axis(artist.Artist):
         # build a few default ticks; grow as necessary later; only
         # define 1 so properties set on ticks will be copied as they
         # grow
-        cbook.popall(self.majorTicks)
-        cbook.popall(self.minorTicks)
+        del self.majorTicks[:]
+        del self.minorTicks[:]
 
         self.majorTicks.extend([self._get_tick(major=True)])
         self.minorTicks.extend([self._get_tick(major=False)])

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1392,12 +1392,6 @@ class Stack(object):
                 self.push(thiso)
 
 
-def popall(seq):
-    'empty a list'
-    for i in xrange(len(seq)):
-        seq.pop()
-
-
 def finddir(o, match, case=False):
     """
     return all attributes of *o* which match string in match.  if case

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -93,6 +93,8 @@ from .transforms import IdentityTransform, Affine2D
 (TICKLEFT, TICKRIGHT, TICKUP, TICKDOWN,
  CARETLEFT, CARETRIGHT, CARETUP, CARETDOWN) = list(xrange(8))
 
+_empty_path = Path(np.empty((0, 2)))
+
 
 class MarkerStyle(object):
 
@@ -182,7 +184,7 @@ class MarkerStyle(object):
         self._recache()
 
     def _recache(self):
-        self._path = Path(np.empty((0, 2)))
+        self._path = _empty_path
         self._transform = IdentityTransform()
         self._alt_path = None
         self._alt_transform = None

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -278,7 +278,7 @@ def test_transform():
     # Check parent -> child links of TransformWrapper.
     assert_equal(obj.wrapper._child, obj.composite)
     # Check child -> parent links of TransformWrapper.
-    assert_equal(list(obj.wrapper._parents.values()), [obj.composite2])
+    assert_equal([v() for v in obj.wrapper._parents.values()], [obj.composite2])
     # Check input and output dimensions are set as expected.
     assert_equal(obj.wrapper.input_dims, obj.composite.input_dims)
     assert_equal(obj.wrapper.output_dims, obj.composite.output_dims)

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -278,7 +278,8 @@ def test_transform():
     # Check parent -> child links of TransformWrapper.
     assert_equal(obj.wrapper._child, obj.composite)
     # Check child -> parent links of TransformWrapper.
-    assert_equal([v() for v in obj.wrapper._parents.values()], [obj.composite2])
+    assert_equal(
+        [v() for v in obj.wrapper._parents.values()], [obj.composite2])
     # Check input and output dimensions are set as expected.
     assert_equal(obj.wrapper.input_dims, obj.composite.input_dims)
     assert_equal(obj.wrapper.output_dims, obj.composite.output_dims)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -106,14 +106,17 @@ class TransformNode(object):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        # turn the weakkey dictionary into a normal dictionary
-        d['_parents'] = dict(six.iteritems(self._parents))
+        # turn the dictionary with weak values into a normal dictionary
+        d['_parents'] = dict((k, v()) for (k, v) in
+                             six.iteritems(self._parents))
         return d
 
     def __setstate__(self, data_dict):
         self.__dict__ = data_dict
-        # turn the normal dictionary back into a WeakValueDictionary
-        self._parents = WeakValueDictionary(self._parents)
+        # turn the normal dictionary back into a dictionary with weak
+        # values
+        self._parents = dict((k, weakref.ref(v)) for (k, v) in
+                             six.iteritems(self._parents))
 
     def __copy__(self, *args):
         raise NotImplementedError(
@@ -1563,8 +1566,8 @@ class TransformWrapper(Transform):
             'child': self._child,
             'input_dims': self.input_dims,
             'output_dims': self.output_dims,
-            # turn the weakkey dictionary into a normal dictionary
-            'parents': dict(six.iteritems(self._parents))
+            # turn the weak-values dictionary into a normal dictionary
+            'parents': dict((k, v()) for (k, v) in six.iteritems(self._parents))
         }
 
     def __setstate__(self, state):
@@ -1574,7 +1577,7 @@ class TransformWrapper(Transform):
         self.input_dims = state['input_dims']
         self.output_dims = state['output_dims']
         # turn the normal dictionary back into a WeakValueDictionary
-        self._parents = WeakValueDictionary(state['parents'])
+        self._parents = dict((k, weakref.ref(v)) for (k, v) in state['parents'])
 
     def __repr__(self):
         return "TransformWrapper(%r)" % self._child

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1578,7 +1578,8 @@ class TransformWrapper(Transform):
         self.output_dims = state['output_dims']
         # turn the normal dictionary back into a dictionary with weak
         # values
-        self._parents = dict((k, weakref.ref(v)) for (k, v) in state['parents'])
+        self._parents = dict((k, weakref.ref(v)) for (k, v) in
+                             six.iteritems(state['parents']))
 
     def __repr__(self):
         return "TransformWrapper(%r)" % self._child

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1576,7 +1576,8 @@ class TransformWrapper(Transform):
         # The child may not be unpickled yet, so restore its information.
         self.input_dims = state['input_dims']
         self.output_dims = state['output_dims']
-        # turn the normal dictionary back into a WeakValueDictionary
+        # turn the normal dictionary back into a dictionary with weak
+        # values
         self._parents = dict((k, weakref.ref(v)) for (k, v) in state['parents'])
 
     def __repr__(self):

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1567,7 +1567,8 @@ class TransformWrapper(Transform):
             'input_dims': self.input_dims,
             'output_dims': self.output_dims,
             # turn the weak-values dictionary into a normal dictionary
-            'parents': dict((k, v()) for (k, v) in six.iteritems(self._parents))
+            'parents': dict((k, v()) for (k, v) in
+                            six.iteritems(self._parents))
         }
 
     def __setstate__(self, state):

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -40,7 +40,7 @@ from matplotlib._path import (affine_transform, count_bboxes_overlapping_bbox,
     update_path_extents)
 from numpy.linalg import inv
 
-from weakref import WeakValueDictionary
+import weakref
 import warnings
 try:
     set
@@ -92,10 +92,7 @@ class TransformNode(object):
                              other than to improve the readability of
                              ``str(transform)`` when DEBUG=True.
         """
-        # Parents are stored in a WeakValueDictionary, so that if the
-        # parents are deleted, references from the children won't keep
-        # them alive.
-        self._parents = WeakValueDictionary()
+        self._parents = {}
 
         # TransformNodes start out as invalid until their values are
         # computed for the first time.
@@ -156,8 +153,11 @@ class TransformNode(object):
             self._invalid = value
 
             for parent in list(six.itervalues(self._parents)):
-                parent._invalidate_internal(value=value,
-                                            invalidating_node=self)
+                # Dereference the weak reference
+                parent = parent()
+                if parent is not None:
+                    parent._invalidate_internal(
+                        value=value, invalidating_node=self)
 
     def set_children(self, *children):
         """
@@ -166,8 +166,11 @@ class TransformNode(object):
         Should be called from the constructor of any transforms that
         depend on other transforms.
         """
+        # Parents are stored as weak references, so that if the
+        # parents are destroyed, references from the children won't
+        # keep them alive.
         for child in children:
-            child._parents[id(self)] = self
+            child._parents[id(self)] = weakref.ref(self)
 
     if DEBUG:
         _set_children = set_children

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -116,7 +116,7 @@ class TransformNode(object):
         # turn the normal dictionary back into a dictionary with weak
         # values
         self._parents = dict((k, weakref.ref(v)) for (k, v) in
-                             six.iteritems(self._parents))
+                             six.iteritems(self._parents) if v is not None)
 
     def __copy__(self, *args):
         raise NotImplementedError(
@@ -1580,7 +1580,7 @@ class TransformWrapper(Transform):
         # turn the normal dictionary back into a dictionary with weak
         # values
         self._parents = dict((k, weakref.ref(v)) for (k, v) in
-                             six.iteritems(state['parents']))
+                             six.iteritems(state['parents']) if v is not None)
 
     def __repr__(self):
         return "TransformWrapper(%r)" % self._child


### PR DESCRIPTION
Instantiating Paths is expensive, but they aren't mutable, so just reuse
when possible.

WeakValueDictionaries are expensive to construct.  We can fix that by
handling the weakrefs ourself.

And `cbook.popall` has no reason to exist.  Maybe someone's using it and it should stay, but no one *should* be using it.

On my benchmark of:

```
plt.subplots(8, 8)
plt.savefig("test.png")
```

I get a speedup from 5.04s to 3.81s.