### PR TITLE
Nicer axes names in selector for figure options.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -618,23 +618,12 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             else:
                 titles = []
                 for axes in allaxes:
-                    title = axes.get_title()
-                    ylabel = axes.get_ylabel()
-                    label = axes.get_label()
-                    if title:
-                        fmt = "%(title)s"
-                        if ylabel:
-                            fmt += ": %(ylabel)s"
-                        fmt += " (%(axes_repr)s)"
-                    elif ylabel:
-                        fmt = "%(axes_repr)s (%(ylabel)s)"
-                    elif label:
-                        fmt = "%(axes_repr)s (%(label)s)"
-                    else:
-                        fmt = "%(axes_repr)s"
-                    titles.append(fmt % dict(title=title,
-                                         ylabel=ylabel, label=label,
-                                         axes_repr=repr(axes)))
+                    name = (axes.get_title() or
+                            " - ".join(filter(None, [axes.get_xlabel(),
+                                                     axes.get_ylabel()])) or
+                            "<anonymous {} (id: {:#x})>".format(
+                                type(axes).__name__, id(axes)))
+                    titles.append(name)
                 item, ok = QtWidgets.QInputDialog.getItem(
                     self.parent, 'Customize', 'Select axes:', titles, 0, False)
                 if ok:


### PR DESCRIPTION
Replace the old label, which included the legthy repr of the axes
object, to a nicer label which emphasizes the title or axes labels
(depending on what is present).  Also drops the use of the label of the
Axes object itself, for which I haven't found any other reference or use
in general.  (Another option would be to use solely `Axes.get_label()`
when defined, as this doesn't seem to have any other use.)

See #5468.