### PR TITLE
Fix #5646: bump the font manager version

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1040,7 +1040,7 @@ class FontManager(object):
     # Increment this version number whenever the font cache data
     # format or behavior has changed and requires a existing font
     # cache files to be rebuilt.
-    __version__ = 101
+    __version__ = 200
 
     def __init__(self, size=None, weight='normal'):
         self._version = self.__version__


### PR DESCRIPTION
See #5646 for the reason we need to do this for 2.0.