### PR TITLE
Fix #5573: Use SVG in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,7 +114,7 @@ default_role = 'obj'
 # Plot directive configuration
 # ----------------------------
 
-plot_formats = [('png', 80), ('hires.png', 200), ('pdf', 50)]
+plot_formats = [('svg', 72), ('png', 80)]
 
 # Subdirectories in 'examples/' directory of package and titles for gallery
 mpl_example_sections = (

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -537,16 +537,7 @@ def clear_state(plot_rcparams, close=True):
     matplotlib.rcParams.update(plot_rcparams)
 
 
-def render_figures(code, code_path, output_dir, output_base, context,
-                   function_name, config, context_reset=False,
-                   close_figs=False):
-    """
-    Run a pyplot script and save the images in *output_dir*.
-
-    Save the images under *output_dir* with file names derived from
-    *output_base*
-    """
-    # -- Parse format list
+def get_plot_formats(config):
     default_dpi = {'png': 80, 'hires.png': 200, 'pdf': 200}
     formats = []
     plot_formats = config.plot_formats
@@ -562,10 +553,23 @@ def render_figures(code, code_path, output_dir, output_base, context,
                 formats.append((str(suffix), int(dpi)))
             else:
                 formats.append((fmt, default_dpi.get(fmt, 80)))
-        elif type(fmt) in (tuple, list) and len(fmt)==2:
+        elif type(fmt) in (tuple, list) and len(fmt) == 2:
             formats.append((str(fmt[0]), int(fmt[1])))
         else:
             raise PlotError('invalid image format "%r" in plot_formats' % fmt)
+    return formats
+
+
+def render_figures(code, code_path, output_dir, output_base, context,
+                   function_name, config, context_reset=False,
+                   close_figs=False):
+    """
+    Run a pyplot script and save the images in *output_dir*.
+
+    Save the images under *output_dir* with file names derived from
+    *output_base*
+    """
+    formats = get_plot_formats(config)
 
     # -- Try to determine if all images already exist
 
@@ -665,13 +669,8 @@ def run(arguments, content, options, state_machine, state, lineno):
     config = document.settings.env.config
     nofigs = 'nofigs' in options
 
-    plot_formats = config.plot_formats
-    if isinstance(plot_formats, six.string_types):
-        # String Sphinx < 1.3, Split on , to mimic
-        # Sphinx 1.3 and later. Sphinx 1.3 always
-        # returns a list.
-        plot_formats = plot_formats.split(',')
-    default_fmt = plot_formats[0][0]
+    formats = get_plot_formats(config)
+    default_fmt = formats[0][0]
 
     options.setdefault('include-source', config.plot_include_source)
     keep_context = 'context' in options

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -377,7 +377,7 @@ TEMPLATE = """
    {% endif %}
 
    {% for img in images %}
-   .. figure:: {{ build_dir }}/{{ img.basename }}.png
+   .. figure:: {{ build_dir }}/{{ img.basename }}.{{ default_fmt }}
       {% for option in options -%}
       {{ option }}
       {% endfor %}
@@ -541,8 +541,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
                    function_name, config, context_reset=False,
                    close_figs=False):
     """
-    Run a pyplot script and save the low and high res PNGs and a PDF
-    in *output_dir*.
+    Run a pyplot script and save the images in *output_dir*.
 
     Save the images under *output_dir* with file names derived from
     *output_base*
@@ -559,7 +558,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
     for fmt in plot_formats:
         if isinstance(fmt, six.string_types):
             if ':' in fmt:
-                suffix,dpi = fmt.split(':')
+                suffix, dpi = fmt.split(':')
                 formats.append((str(suffix), int(dpi)))
             else:
                 formats.append((fmt, default_dpi.get(fmt, 80)))
@@ -665,6 +664,14 @@ def run(arguments, content, options, state_machine, state, lineno):
     document = state_machine.document
     config = document.settings.env.config
     nofigs = 'nofigs' in options
+
+    plot_formats = config.plot_formats
+    if isinstance(plot_formats, six.string_types):
+        # String Sphinx < 1.3, Split on , to mimic
+        # Sphinx 1.3 and later. Sphinx 1.3 always
+        # returns a list.
+        plot_formats = plot_formats.split(',')
+    default_fmt = plot_formats[0][0]
 
     options.setdefault('include-source', config.plot_include_source)
     keep_context = 'context' in options
@@ -814,6 +821,7 @@ def run(arguments, content, options, state_machine, state, lineno):
 
         result = format_template(
             config.plot_template or TEMPLATE,
+            default_fmt=default_fmt,
             dest_dir=dest_dir_link,
             build_dir=build_dir_link,
             source_link=src_link,

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -343,7 +343,7 @@ class TextToPath(object):
                                                     1094995778)]:
                     try:
                         font.select_charmap(charmap_code)
-                    except ValueError:
+                    except (ValueError, RuntimeError):
                         pass
                     else:
                         break


### PR DESCRIPTION
This looks a lot better on hi-res displays, and I think will be a nice show-off for the style changes in 2.0.

I think what this PR needs is testing on various browsers and some manual looking for things where SVG breaks (though it all looks pretty good to me on spot-checking, and SVG is one of our better-tested backends).