### PR TITLE
Fix #5687: Don't pass unicode to QApplication()

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -137,7 +137,7 @@ def _create_qApp():
                 if display is None or not re.search(':\d', display):
                     raise RuntimeError('Invalid DISPLAY variable')
 
-            qApp = QtWidgets.QApplication([six.text_type(" ")])
+            qApp = QtWidgets.QApplication([str(" ")])
             qApp.lastWindowClosed.connect(qApp.quit)
         else:
             qApp = app


### PR DESCRIPTION
PySide QApplication constructor cannot handle unicode text
(segfaults), so we instead pass an empty list to the constructor.

Fixes #5687 