### PR TITLE
str.formatter invalid

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -707,7 +707,7 @@ class AutoDateFormatter(ticker.Formatter):
         elif six.callable(fmt):
             result = fmt(x, pos)
         else:
-            raise TypeError('Unexpected type passed to {!r}.'.formatter(self))
+            raise TypeError('Unexpected type passed to {0!r}.'.format(self))
 
         return result
 


### PR DESCRIPTION
A TypeError in AutoDateFormatter introduced in be0aafbc
uses invalid str.formatter instead of str.format.