### PR TITLE
FIX: suppress warning in Artist.properties

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1276,7 +1276,9 @@ class ArtistInspector(object):
                 continue
 
             try:
-                val = func()
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore')
+                    val = func()
             except:
                 continue
             else:

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
+import warnings
 from matplotlib.externals import six
 
 import io
@@ -9,6 +9,7 @@ import numpy as np
 
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
+import matplotlib.lines as mlines
 import matplotlib.path as mpath
 import matplotlib.transforms as mtrans
 import matplotlib.collections as mcollections
@@ -174,6 +175,16 @@ def test_remove():
     assert_true(im not in ax.mouseover_set)
     assert_true(fig.stale)
     assert_true(ax.stale)
+
+
+@cleanup
+def test_properties():
+    ln = mlines.Line2D([], [])
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        ln.properties()
+        assert len(w) == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Calling `get_axes` currently raises a deprecating warning, eat this.

The Artist.properties function will be completely re-written in 2.1 with
traitlets so this is a reasonable stop-gap for now.

closes #5089