### PR TITLE
Change default value for the number of columns when generating a legend from qt_editor

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -158,7 +158,7 @@ def figure_edit(axes, parent=None):
 
         if generate_legend:
             draggable = None
-            ncol = None
+            ncol = 1
             if axes.legend_ is not None:
                 old_legend = axes.get_legend()
                 draggable = old_legend._draggable is not None


### PR DESCRIPTION
This is a correction related to the issue #5636 to make the legend generation working with more than two plots, due to the bad initialization of the number of columns. I hope without side effects...