### PR TITLE
Fix save button in GUIs

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -732,6 +732,8 @@ class Animation(object):
         # Re-use the savefig DPI for ours if none is given
         if dpi is None:
             dpi = rcParams['savefig.dpi']
+            if dpi == 'figure':
+                dpi = self._fig.dpi
 
         if codec is None:
             codec = rcParams['animation.codec']

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2141,6 +2141,8 @@ class FigureCanvasBase(object):
 
         if dpi is None:
             dpi = rcParams['savefig.dpi']
+            if dpi == 'figure':
+                dpi = self.figure.dpi
 
         origDPI = self.figure.dpi
         origfacecolor = self.figure.get_facecolor()


### PR DESCRIPTION
The save button in GUIs currently raises an exception that `'figure' can not be converted to float` because the special value of `savefig.dpi` == `figure` is not handled everywhere.

This bug was introduced in #4286, but not really easily triggered until we changed the default in #5659.

This should probably be backported (I didn't realise the bug is also on 1.5.x until further inspection).