### PR TITLE
Remove unused broken doc example axes_zoom_effect

### DIFF
--- a/doc/users/plotting/examples/axes_zoom_effect.py
+++ b/doc/users/plotting/examples/axes_zoom_effect.py
@@ -1,1 +1,0 @@
-../../../../examples/pylab_examples/axes_zoom_effect.py


### PR DESCRIPTION
doc/users/plotting/examples/axes_zoom_effect.py was literally:
'../../../../examples/pylab_examples/axes_zoom_effect.py'
and therefore was a SyntaxError if used as a Python file.

Closes  #5705.