### PR TITLE
FIX: do not mutate Series input to Normalize()

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -904,8 +904,11 @@ class Normalize(object):
             is_scalar = False
             result = ma.asarray(value)
             if result.dtype.kind == 'f':
-                if isinstance(value, np.ndarray):
-                    result = result.copy()
+                # this is overkill for lists of floats, but required
+                # to support pd.Series as input until we can reliable
+                # determine if result and value share memory in all cases
+                # (list, tuple, deque, ndarray, Series, ...)
+                result = result.copy()
             elif result.dtype.itemsize > 2:
                 result = result.astype(np.float)
             else:


### PR DESCRIPTION
This forces a copy in all cases.  For input sequences which are base
python (list, tuple, deque, ...) this will cause a second un-needed copy
of all of the data, but will force the required copy in the case where
the the input values is enough ndarray-like for `ma.asarray` to re-use
memory.

closes #5427