### PR TITLE
Set maximum number of bins in ticking

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1431,7 +1431,7 @@ class MaxNLocator(Locator):
     def bin_boundaries(self, vmin, vmax):
         nbins = self._nbins
         if nbins == 'auto':
-            nbins = self.axis.get_tick_space()
+            nbins = min(self.axis.get_tick_space(), 9)
         scale, offset = scale_range(vmin, vmax, nbins)
         if self._integer:
             scale = max(1, scale)


### PR DESCRIPTION
Follow-on to #5588 based on @efiring's comment that now there can be too many ticks. (https://github.com/matplotlib/matplotlib/pull/5588#issuecomment-166185617)