### PR TITLE
MNT: do not use srand unless we have to

### DIFF
--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -838,10 +838,10 @@ class Sketch
 
     inline void rewind(unsigned path_id)
     {
-        srand(0);
         m_has_last = false;
         m_p = 0.0;
         if (m_scale != 0.0) {
+	    srand(0);
             m_segmented.rewind(path_id);
         } else {
             m_source->rewind(path_id);


### PR DESCRIPTION
Resetting the random number generator to seed at 0 is done as part
of rewinding the `Sketch` path convertor.  However, this causes
the seed to be reset on every call to `draw` if Agg is being used which
interferes with users how are using `rand` in their own code and
embedding python [1].

This moves the `srand` call inside the conditional that deals with paths
that really are sketched so you only get disrupted if you are really
using this feature.

1 http://stackoverflow.com/q/34422244/380231

@mdboom 