### PR TITLE
[WIP] Run Travis on Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,6 @@ matrix:
   allow_failures:
     - python: "nightly"
 
-before_install:
-  - source ci/travis/travis_tools.sh
-  # Install into our own pristine virtualenv
-  - virtualenv --python=python venv
-  - source venv/bin/activate
-
 install:
   - |
     pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,20 +57,12 @@ before_install:
   - source venv/bin/activate
 
 install:
-  # Upgrade pip and setuptools. Mock has issues with the default version of
-  # setuptools
   - |
     pip install --upgrade pip
     pip install --upgrade setuptools
-  # Install only from travis wheelhouse
-  - if [ -z "$PRE" ]; then
-        wheelhouse_pip_install python-dateutil $NUMPY $PANDAS pyparsing!=2.0.4 pillow sphinx!=1.3.0 $MOCK;
-    else
-        pip install $PRE python-dateutil $NUMPY pyparsing!=2.0.4 pillow sphinx!=1.3.0;
-    fi
-  # Always install from pypi
-  - pip install $PRE pep8 cycler coveralls coverage
-  - 'pip install git+https://github.com/jenshnielsen/nose.git@matplotlibnose'
+    pip install --upgrade wheel
+    pip install $PRE pep8 cycler coveralls coverage python-dateutil $NUMPY pyparsing!=2.0.4 pillow sphinx!=1.3.0 $MOCK $PANDAS
+    pip install 'git+https://github.com/jenshnielsen/nose.git@matplotlibnose'
 
   # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
   # availible in the Ubuntu version used by Travis but we can manually install the deb from a later

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ addons:
       - gdb
       - mencoder
       - dvipng
+      - pgf
+      - lmodern
       - texlive-latex-base
       - texlive-latex-extra
       - texlive-fonts-recommended
       - texlive-latex-recommended
+      - texlive-xetex
       - graphviz
-#     - fonts-humor-sans
-#    sources:
-#      - debian-sid
 
 env:
   global:


### PR DESCRIPTION
This gives us better machines and a more up to date packages which allows us to install xelatex and run the pgf tests. This fails because #5727 is not merged and would have caught that issues. 

Unfortunatly the wheelhouse packages are not compatible with this (segfault) so I had to disable them. 
Neither does this support the caching of pip/wheel packages so we have to compile numpy from source every time.

Possible solutions to this which I can see are 

* Switch to using conda for dependencies. We probably still want a job that installed the latest version from pypi but most could be done with conda
* Update the wheelhouse to support 14.04
* Use numpy preinstalled by Travis. (Probably still wants a job that explicitly installs the earliest version we support and latest version from pypi
