### PR TITLE
RF: fix annoying parens bug

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -812,7 +812,7 @@ def run(arguments, content, options, state_machine, state, lineno):
             options=opts,
             images=images,
             source_code=source_code,
-            html_show_formats=config.plot_html_show_formats and not nofigs,
+            html_show_formats=config.plot_html_show_formats and len(images),
             caption=caption)
 
         total_lines.extend(result.split("\n"))


### PR DESCRIPTION
When there are no images generated but plots are configured to show
different plot formats, the plot directive generates an annoying empty
parens in the output.  Fix.