### PR TITLE
Fix svg determinism test

### DIFF
--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -151,6 +151,8 @@ def test_determinism():
     plots = []
     for i in range(3):
         check_call([sys.executable, '-R', '-c',
+                    'import matplotlib; '
+                    'matplotlib.use("svg"); '
                     'from matplotlib.tests.test_backend_svg '
                     'import _test_determinism;'
                     '_test_determinism("determinism.svg")'])


### PR DESCRIPTION
Make sure this test is running with the svg backend and not an interactive backend closes #5729 as suggested by @mdboom 