### PR TITLE
Correct regex in filterwarnings

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1097,8 +1097,8 @@ class Figure(Artist):
             # instead treated as a bool for sharex.
             if isinstance(sharex, int):
                 warnings.warn(
-                    "sharex argument to add_subplots() was an integer. "
-                    "Did you intend to use add_subplot() (without 's')?")
+                    "sharex argument to subplots() was an integer. "
+                    "Did you intend to use subplot() (without 's')?")
 
             raise ValueError("sharex [%s] must be one of %s" %
                              (sharex, share_values))

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -110,7 +110,7 @@ def test_exceptions():
     # the pount of this test is to ensure that this raises.
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore',
-                                message='.*sharex\ argument\ to\ add_subplots',
+                                message='.*sharex\ argument\ to\ subplots',
                                 category=UserWarning)
         assert_raises(ValueError, plt.subplots, 2, 2, -1)
         assert_raises(ValueError, plt.subplots, 2, 2, 0)

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -110,11 +110,10 @@ def test_exceptions():
     # the pount of this test is to ensure that this raises.
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore',
-                                message='.*sharex\ argument\ to\ subplots',
+                                message='.*sharex\ argument\ to\ add_subplots',
                                 category=UserWarning)
         assert_raises(ValueError, plt.subplots, 2, 2, -1)
-        # uncomment this for 1.5
-        # assert_raises(ValueError, plt.subplots, 2, 2, 0)
+        assert_raises(ValueError, plt.subplots, 2, 2, 0)
         assert_raises(ValueError, plt.subplots, 2, 2, 5)
 
 


### PR DESCRIPTION
The method name has changed, also enable an assert which should have been enabled earlier