### PR TITLE
Silence labeled data warning in tests

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -61,9 +61,10 @@ def _plot_args_replacer(args, data):
         except ValueError:
             pass
         else:
-            msg = "Second argument is ambiguous: could be a color spec " \
+            msg = "Second argument '{}' is ambiguous: could be a color spec " \
                   "but is in data. Using as data.\nEither rename the " \
-                  "entry in data or use three arguments to plot."
+                  "entry in data or use three arguments " \
+                  "to plot.".format(args[1])
             warnings.warn(msg, RuntimeWarning, stacklevel=3)
         return ["x", "y"]
     elif len(args) == 3:

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -1,6 +1,7 @@
 import warnings
 
 from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.pyplot as plt
 import numpy as np
 from nose.tools import assert_raises
@@ -160,6 +161,7 @@ def test_cycle_reset():
     fig, ax = plt.subplots()
     # Need to double-check the old set/get_color_cycle(), too
     with warnings.catch_warnings():
+        warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
         prop = next(ax._get_lines.prop_cycler)
         ax.set_color_cycle(['c', 'm', 'y', 'k'])
         assert prop != next(ax._get_lines.prop_cycler)

--- a/lib/matplotlib/tests/test_labeled_data_unpacking.py
+++ b/lib/matplotlib/tests/test_labeled_data_unpacking.py
@@ -395,10 +395,10 @@ def test_positional_parameter_names_as_function():
         return "{args} | {kwargs}".format(args=args, kwargs=kwargs)
 
     # the normal case...
-    data = {"x": "X", "y1": "Y"}
-    assert_equal(funcy(None, "x", "y1", data=data),
+    data = {"x": "X", "hy1": "Y"}
+    assert_equal(funcy(None, "x", "hy1", data=data),
                  "('X', 'Y') | {}")
-    assert_equal(funcy(None, "x", "y1", "c", data=data),
+    assert_equal(funcy(None, "x", "hy1", "c", data=data),
                  "('X', 'Y', 'c') | {}")
 
     # no arbitrary long args with data

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -14,7 +14,8 @@ def test_Type1Font():
     font = t1f.Type1Font(filename)
     slanted = font.transform({'slant': 1})
     condensed = font.transform({'extend': 0.5})
-    rawdata = open(filename, 'rb').read()
+    with open(filename, 'rb') as f:
+        rawdata = f.read()
     assert_equal(font.parts[0], rawdata[0x0006:0x10c5])
     assert_equal(font.parts[1], rawdata[0x10cb:0x897f])
     assert_equal(font.parts[2], rawdata[0x8985:0x8ba6])


### PR DESCRIPTION
Continuing to fix various warnings in the test suite. 

This suppresses a warning in the labeled data test and improves the error message a bit.