### PR TITLE
Don't fallback to old ipython_console_highlighting

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,11 +40,12 @@ exclude_patterns = ['api/api_changes/*', 'users/whats_new/*']
 try:
     from IPython.sphinxext import ipython_console_highlighting
 except ImportError:
-    extensions.append('matplotlib.sphinxext.ipython_console_highlighting')
+    raise ImportError(
+        "IPython must be installed to build the matplotlib docs")
 else:
-    print("Using IPython's ipython_console_highlighting directive")
     extensions.append('IPython.sphinxext.ipython_console_highlighting')
     extensions.append('IPython.sphinxext.ipython_directive')
+
 try:
     import numpydoc
 except ImportError:


### PR DESCRIPTION
@QuLogic [pointed out](https://github.com/matplotlib/matplotlib/pull/3992#issuecomment-167027402) that since the ipython_console_highlighting sphinx extension was completely removed from matplotlib, the build script should no longer fall back to using it.