### PR TITLE
De-randomize doc builds

### DIFF
--- a/doc/pyplots/whats_new_98_4_fancy.py
+++ b/doc/pyplots/whats_new_98_4_fancy.py
@@ -8,7 +8,7 @@ fontsize = 0.4 * fig.dpi
 def make_boxstyles(ax):
     styles = mpatch.BoxStyle.get_styles()
 
-    for i, (stylename, styleclass) in enumerate(styles.items()):
+    for i, (stylename, styleclass) in enumerate(sorted(styles.items())):
         ax.text(0.5, (float(len(styles)) - 0.5 - i)/len(styles), stylename,
                   ha="center",
                   size=fontsize,

--- a/examples/api/filled_step.py
+++ b/examples/api/filled_step.py
@@ -1,4 +1,5 @@
 import itertools
+from collections import OrderedDict
 from functools import partial
 
 import numpy as np
@@ -174,9 +175,9 @@ label_cycle = cycler('label', ['set {n}'.format(n=n) for n in range(4)])
 hatch_cycle = cycler('hatch', ['/', '*', '+', '|'])
 
 # make some synthetic data
+np.random.seed(0)
 stack_data = np.random.randn(4, 12250)
-dict_data = {lab: d for lab, d in zip(list(c['label'] for c in label_cycle),
-                                      stack_data)}
+dict_data = OrderedDict(zip((c['label'] for c in label_cycle), stack_data))
 
 # work with plain arrays
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 4.5), tight_layout=True)

--- a/examples/color/named_colors.py
+++ b/examples/color/named_colors.py
@@ -33,8 +33,11 @@ hue = [color[0] for color in hsv]
 sat = [color[1] for color in hsv]
 val = [color[2] for color in hsv]
 
-# Sort by hue, saturation and value.
-ind = np.lexsort((val, sat, hue))
+# Get the color names by themselves.
+names = [color[0] for color in colors_]
+
+# Sort by hue, saturation, value and name.
+ind = np.lexsort((names, val, sat, hue))
 sorted_colors = [colors_[i] for i in ind]
 
 n = len(sorted_colors)

--- a/examples/pylab_examples/arrow_demo.py
+++ b/examples/pylab_examples/arrow_demo.py
@@ -214,7 +214,7 @@ def make_arrow_plot(data, size=4, display='length', shape='right',
         plt.text(x, y, label, size=label_text_size, ha='center', va='center',
              color=labelcolor or fc)
 
-    for p in positions.keys():
+    for p in sorted(positions):
         draw_arrow(p)
 
 # test data

--- a/examples/pylab_examples/boxplot_demo2.py
+++ b/examples/pylab_examples/boxplot_demo2.py
@@ -16,6 +16,7 @@ numDists = 5
 randomDists = ['Normal(1,1)', ' Lognormal(1,1)', 'Exp(1)', 'Gumbel(6,4)',
                'Triangular(2,9,11)']
 N = 500
+np.random.seed(0)
 norm = np.random.normal(1, 1, N)
 logn = np.random.lognormal(1, 1, N)
 expo = np.random.exponential(1, N)

--- a/examples/pylab_examples/demo_tight_layout.py
+++ b/examples/pylab_examples/demo_tight_layout.py
@@ -1,16 +1,18 @@
 
 import matplotlib.pyplot as plt
+import itertools
 import warnings
 
-import random
-fontsizes = [8, 16, 24, 32]
+
+fontsizes = itertools.cycle([8, 16, 24, 32])
 
 
 def example_plot(ax):
     ax.plot([1, 2])
-    ax.set_xlabel('x-label', fontsize=random.choice(fontsizes))
-    ax.set_ylabel('y-label', fontsize=random.choice(fontsizes))
-    ax.set_title('Title', fontsize=random.choice(fontsizes))
+    ax.set_xlabel('x-label', fontsize=next(fontsizes))
+    ax.set_ylabel('y-label', fontsize=next(fontsizes))
+    ax.set_title('Title', fontsize=next(fontsizes))
+
 
 fig, ax = plt.subplots()
 example_plot(ax)

--- a/examples/pylab_examples/spectrum_demo.py
+++ b/examples/pylab_examples/spectrum_demo.py
@@ -1,6 +1,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+np.random.seed(0)
+
 dt = 0.01
 Fs = 1/dt
 t = np.arange(0, 10, dt)

--- a/examples/pylab_examples/system_monitor.py
+++ b/examples/pylab_examples/system_monitor.py
@@ -3,23 +3,23 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def get_memory():
+def get_memory(t):
     "Simulate a function that returns system memory"
-    return 100*(0.5 + 0.5*np.sin(0.5*np.pi*time.time()))
+    return 100 * (0.5 + 0.5 * np.sin(0.5 * np.pi * t))
 
 
-def get_cpu():
+def get_cpu(t):
     "Simulate a function that returns cpu usage"
-    return 100*(0.5 + 0.5*np.sin(0.2*np.pi*(time.time() - 0.25)))
+    return 100 * (0.5 + 0.5 * np.sin(0.2 * np.pi * (t - 0.25)))
 
 
-def get_net():
+def get_net(t):
     "Simulate a function that returns network bandwidth"
-    return 100*(0.5 + 0.5*np.sin(0.7*np.pi*(time.time() - 0.1)))
+    return 100 * (0.5 + 0.5 * np.sin(0.7 * np.pi * (t - 0.1)))
 
 
-def get_stats():
-    return get_memory(), get_cpu(), get_net()
+def get_stats(t):
+    return get_memory(t), get_cpu(t), get_net(t)
 
 fig, ax = plt.subplots()
 ind = np.arange(1, 4)
@@ -28,7 +28,7 @@ ind = np.arange(1, 4)
 plt.show(block=False)
 
 
-pm, pc, pn = plt.bar(ind, get_stats())
+pm, pc, pn = plt.bar(ind, get_stats(0))
 centers = ind + 0.5*pm.get_width()
 pm.set_facecolor('r')
 pc.set_facecolor('g')
@@ -42,7 +42,7 @@ ax.set_title('System Monitor')
 
 start = time.time()
 for i in range(200):  # run for a little while
-    m, c, n = get_stats()
+    m, c, n = get_stats(i / 10.0)
 
     # update the animated artists
     pm.set_height(m)

--- a/examples/pylab_examples/xcorr_demo.py
+++ b/examples/pylab_examples/xcorr_demo.py
@@ -1,6 +1,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+np.random.seed(0)
+
 x, y = np.random.randn(2, 100)
 fig = plt.figure()
 ax1 = fig.add_subplot(211)

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1690,7 +1690,7 @@ def unpack_labeled_data(replace_names=None, replace_all_args=False,
                 arg_names = []
             elif len(_arg_names) > 1 and (positional_parameter_names is None):
                 # we got no manual parameter names but more than an 'ax' ...
-                if len(set(replace_names) - set(_arg_names[1:])) == 0:
+                if len(replace_names - set(_arg_names[1:])) == 0:
                     # all to be replaced arguments are in the list
                     arg_names = _arg_names[1:]
                 else:
@@ -1838,7 +1838,7 @@ def unpack_labeled_data(replace_names=None, replace_all_args=False,
                 _repl = "* All arguments with the following names: '{names}'."
             if replace_all_args:
                 _repl += "\n* All positional arguments."
-            _repl = _repl.format(names="', '".join(replace_names))
+            _repl = _repl.format(names="', '".join(sorted(replace_names)))
         inner.__doc__ = (pre_doc +
                          _DATA_DOC_APPENDIX.format(replaced=_repl))
         if not python_has_wrapped:

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1267,8 +1267,7 @@ class ArtistInspector(object):
 
         if s in self.aliasd:
             return s + ''.join([' or %s' % x
-                                for x
-                                in six.iterkeys(self.aliasd[s])])
+                                for x in sorted(self.aliasd[s])])
         else:
             return s
 
@@ -1284,8 +1283,7 @@ class ArtistInspector(object):
 
         if s in self.aliasd:
             aliases = ''.join([' or %s' % x
-                               for x
-                               in six.iterkeys(self.aliasd[s])])
+                               for x in sorted(self.aliasd[s])])
         else:
             aliases = ''
         return ':meth:`%s <%s>`%s' % (s, target, aliases)


### PR DESCRIPTION
Based on some issues I've found trying to get consistency out of #5743, this disables some needless randomness in the documentation (by setting seeds, or dropping it altogether). There are still a few things that remain:
 * The hash in the inheritance diagrams changes; I guess this is a "bug" in the Sphinx extension, but I have not really looked much deeper.
 * There are some dictionaries in attributes and/or default parameters that don't stay sorted. I would assume that's also deep in Sphinx and I can't do anything about it.
 * Something is weird with the size of the background of the labels in [`boxplot_demo2.py`](); I guess the font size and bbox calculation are not always done in the same order.
 * The location of some tick marks is ever so slightly different in 41 images (including thumbnails and duplicates, so not quite so many actual examples.) I don't know why this is, maybe rounding differences?