### PR TITLE
Skip svg tex test if tex is not installed

### DIFF
--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -9,7 +9,7 @@ import xml.parsers.expat
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, knownfailureif
 import matplotlib
 
 needs_tex = knownfailureif(

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -10,6 +10,11 @@ import xml.parsers.expat
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
 from matplotlib.testing.decorators import image_comparison
+import matplotlib
+
+needs_tex = knownfailureif(
+    not matplotlib.checkdep_tex(),
+    "This test needs a TeX installation")
 
 
 @cleanup
@@ -173,6 +178,7 @@ def test_determinism_notex():
 
 
 @cleanup
+@needs_tex
 def test_determinism_tex():
     # unique filename to allow for parallel testing
     _test_determinism('determinism_tex.svg', usetex=True)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -345,7 +345,7 @@ class TextToPath(object):
                                                     1094995778)]:
                     try:
                         font.select_charmap(charmap_code)
-                    except ValueError:
+                    except (ValueError, RuntimeError):
                         pass
                     else:
                         break


### PR DESCRIPTION
This should fix failure on the 2.x branch after the merge of #5766 

This should be merged asap to make the 2.x branch pass again