### PR TITLE
FIX: always use at least 2 ticks and recompute

### DIFF
--- a/examples/axes_grid/inset_locator_demo.py
+++ b/examples/axes_grid/inset_locator_demo.py
@@ -32,6 +32,9 @@ plt.yticks(visible=False)
 ax2.set_aspect(1.)
 
 axins = zoomed_inset_axes(ax2, 0.5, loc=1)  # zoom = 0.5
+# fix the number of ticks on the inset axes
+axins.yaxis.get_major_locator().set_params(nbins=7)
+axins.xaxis.get_major_locator().set_params(nbins=7)
 
 plt.xticks(visible=False)
 plt.yticks(visible=False)

--- a/examples/axes_grid/inset_locator_demo2.py
+++ b/examples/axes_grid/inset_locator_demo2.py
@@ -34,6 +34,9 @@ axins.imshow(Z2, extent=extent, interpolation="nearest",
 x1, x2, y1, y2 = -1.5, -0.9, -2.5, -1.9
 axins.set_xlim(x1, x2)
 axins.set_ylim(y1, y2)
+# fix the number of ticks on the inset axes
+axins.yaxis.get_major_locator().set_params(nbins=7)
+axins.xaxis.get_major_locator().set_params(nbins=7)
 
 plt.xticks(visible=False)
 plt.yticks(visible=False)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2004,7 +2004,7 @@ class XAxis(Axis):
             # is no more than 3:1
             size = tick.label1.get_size() * 3
             size *= np.cos(np.deg2rad(tick.label1.get_rotation()))
-            self._tick_space = np.floor(length / size)
+            return np.floor(length / size)
         return self._tick_space
 
 
@@ -2346,5 +2346,5 @@ class YAxis(Axis):
             # Having a spacing of at least 2 just looks good.
             size = tick.label1.get_size() * 2.0
             size *= np.cos(np.deg2rad(tick.label1.get_rotation()))
-            self._tick_space = np.floor(length / size)
+            return np.floor(length / size)
         return self._tick_space

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -664,7 +664,6 @@ class Axis(artist.Artist):
         # Initialize here for testing; later add API
         self._major_tick_kw = dict()
         self._minor_tick_kw = dict()
-        self._tick_space = None
 
         self.cla()
         self._set_scale('linear')
@@ -796,7 +795,6 @@ class Axis(artist.Artist):
                 for tick in self.minorTicks:
                     tick._apply_params(**self._minor_tick_kw)
         self.stale = True
-        self._tick_space = None
 
     @staticmethod
     def _translate_tick_kw(kw, to_init_kw=True):
@@ -1996,16 +1994,14 @@ class XAxis(Axis):
         self.stale = True
 
     def get_tick_space(self):
-        if self._tick_space is None:
-            ends = self.axes.transAxes.transform([[0, 0], [1, 0]])
-            length = ((ends[1][0] - ends[0][0]) / self.axes.figure.dpi) * 72.0
-            tick = self._get_tick(True)
-            # There is a heuristic here that the aspect ratio of tick text
-            # is no more than 3:1
-            size = tick.label1.get_size() * 3
-            size *= np.cos(np.deg2rad(tick.label1.get_rotation()))
-            return np.floor(length / size)
-        return self._tick_space
+        ends = self.axes.transAxes.transform([[0, 0], [1, 0]])
+        length = ((ends[1][0] - ends[0][0]) / self.axes.figure.dpi) * 72.0
+        tick = self._get_tick(True)
+        # There is a heuristic here that the aspect ratio of tick text
+        # is no more than 3:1
+        size = tick.label1.get_size() * 3
+        size *= np.cos(np.deg2rad(tick.label1.get_rotation()))
+        return np.floor(length / size)
 
 
 class YAxis(Axis):
@@ -2339,12 +2335,10 @@ class YAxis(Axis):
         self.stale = True
 
     def get_tick_space(self):
-        if self._tick_space is None:
-            ends = self.axes.transAxes.transform([[0, 0], [0, 1]])
-            length = ((ends[1][1] - ends[0][1]) / self.axes.figure.dpi) * 72.0
-            tick = self._get_tick(True)
-            # Having a spacing of at least 2 just looks good.
-            size = tick.label1.get_size() * 2.0
-            size *= np.cos(np.deg2rad(tick.label1.get_rotation()))
-            return np.floor(length / size)
-        return self._tick_space
+        ends = self.axes.transAxes.transform([[0, 0], [0, 1]])
+        length = ((ends[1][1] - ends[0][1]) / self.axes.figure.dpi) * 72.0
+        tick = self._get_tick(True)
+        # Having a spacing of at least 2 just looks good.
+        size = tick.label1.get_size() * 2.0
+        size *= np.cos(np.deg2rad(tick.label1.get_rotation()))
+        return np.floor(length / size)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4276,6 +4276,19 @@ def test_remove_shared_axes():
     assert assert_array_equal(ax_lst[0][1].get_xlim(), orig_xlim)
 
 
+@cleanup
+def test_adjust_numtick_aspect():
+    fig, ax = plt.subplots()
+    ax.yaxis.get_major_locator().set_params(nbins='auto')
+    ax.set_xlim(0, 1000)
+    ax.set_aspect('equal')
+    fig.canvas.draw()
+    assert len(ax.yaxis.get_major_locator()()) == 2
+    ax.set_ylim(0, 1000)
+    fig.canvas.draw()
+    assert len(ax.yaxis.get_major_locator()()) > 2
+
+
 @image_comparison(baseline_images=["auto_numticks"], style='default',
                   extensions=['png'])
 def test_auto_numticks():

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1434,7 +1434,7 @@ class MaxNLocator(Locator):
     def bin_boundaries(self, vmin, vmax):
         nbins = self._nbins
         if nbins == 'auto':
-            nbins = min(self.axis.get_tick_space(), 9)
+            nbins = max(min(self.axis.get_tick_space(), 9), 1)
         scale, offset = scale_range(vmin, vmax, nbins)
         if self._integer:
             scale = max(1, scale)

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -101,7 +101,8 @@ def test_inset_locator():
     axins = zoomed_inset_axes(ax, 6, loc=1)  # zoom = 6
     axins.imshow(Z2, extent=extent, interpolation="nearest",
                  origin="lower")
-
+    axins.yaxis.get_major_locator().set_params(nbins=7)
+    axins.xaxis.get_major_locator().set_params(nbins=7)
     # sub region of the original image
     x1, x2, y1, y2 = -1.5, -0.9, -2.5, -1.9
     axins.set_xlim(x1, x2)


### PR DESCRIPTION
For extreme aspect-ratio plots the auto ntick logic would decide that
no ticks will fit, leading to divide by 0 issue.

 - This changes the logic in Axis.get_tick_space to have a floor of 1.
 - also does not cache the number of ticks so that if the on-screen
   aspect ratio changes the number of ticks will update correctly.

I tried to add a test for this, but something about the testing framework is causing trouble

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
ax.set_aspect('equal')
ax.set_xlim(0, 1000)
fig.canvas.draw()
print(ax.yaxis.get_major_locator()())
print(ax.xaxis.get_major_locator()())
assert len(ax.yaxis.get_major_locator()()) == 2
ax.set_ylim(0, 1000)
fig.canvas.draw()
assert len(ax.yaxis.get_major_locator()()) > 2
```

runs correctly as a script for me and interactively, but as part of the test suite give 6 ticks in the first case.