### PR TITLE
Fix ImportError: No module named 'StringIO' on Python 3

### DIFF
--- a/examples/misc/svg_filter_line.py
+++ b/examples/misc/svg_filter_line.py
@@ -52,8 +52,8 @@ ax.set_xlim(0., 1.)
 ax.set_ylim(0., 1.)
 
 # save the figure as a string in the svg format.
-from StringIO import StringIO
-f = StringIO()
+from io import BytesIO
+f = BytesIO()
 plt.savefig(f, format="svg")
 
 

--- a/examples/misc/svg_filter_pie.py
+++ b/examples/misc/svg_filter_pie.py
@@ -42,8 +42,8 @@ for w in pies[0]:
 
 
 # save
-from StringIO import StringIO
-f = StringIO()
+from io import BytesIO
+f = BytesIO()
 plt.savefig(f, format="svg")
 
 import xml.etree.cElementTree as ET

--- a/examples/user_interfaces/svg_histogram.py
+++ b/examples/user_interfaces/svg_histogram.py
@@ -35,7 +35,7 @@ __author__="david.huard@gmail.com"
 import numpy as np
 import matplotlib.pyplot as plt
 import xml.etree.ElementTree as ET
-from StringIO import StringIO
+from io import BytesIO
 import json
 
 plt.rcParams['svg.embed_char_paths'] = 'none'
@@ -76,7 +76,7 @@ for i, t in enumerate(leg.get_texts()):
     t.set_gid('leg_text_%d' % i)
 
 # Save SVG in a fake file object.
-f = StringIO()
+f = BytesIO()
 plt.savefig(f, format="svg")
 
 # Create XML tree from the SVG file.

--- a/examples/user_interfaces/svg_tooltip.py
+++ b/examples/user_interfaces/svg_tooltip.py
@@ -24,7 +24,7 @@ the appearance by the CSS.
 
 import matplotlib.pyplot as plt
 import xml.etree.ElementTree as ET
-from StringIO import StringIO
+from io import BytesIO
 
 ET.register_namespace("", "http://www.w3.org/2000/svg")
 
@@ -72,7 +72,7 @@ ax.set_xlim(-30, 30)
 ax.set_ylim(-30, 30)
 ax.set_aspect('equal')
 
-f = StringIO()
+f = BytesIO()
 plt.savefig(f, format="svg")
 
 # --- Add interactivity ---


### PR DESCRIPTION
Several examples use the `StringIO` module, which fails to import on Python 3. 
This PR uses `io.BytesIO` instead. Tested with Python 2.7 and 3.5 on Windows. 
Please review. Not sure if it would be better to use `io.StringIO` or `six.StringIO` instead.