### PR TITLE
Index.html template. Only insert snippet if found

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -29,7 +29,11 @@ function getSnippet(id, url) {
     // Synchronous request, wait till we have it all
     req.open('GET', url, false);
     req.send(null);
-    element.innerHTML = req.responseText;
+    if (req.status == 200) {
+      element.innerHTML = req.responseText;
+    } else {
+      element.innerHTML = "<mark>Could not find Snippet to insert at " + url + "</mark>"
+    }
   }
 }
 </script>


### PR DESCRIPTION
If you build a local copy of the documentation for preview such as 
http://jenshnielsen.github.io/matplotlib/ the main `index.html` page rendering is broken because 
`versions.html` is not found. This results in a github 404 page being inserted into the page which breaks the formatting of the webpage. 

This PR changes the javascript function to insert an error message rather than the 404 page if the Snippet is not found. 