### PR TITLE
WIP: Don't draw_idle in non-GUI backends

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2021,9 +2021,7 @@ class FigureCanvasBase(object):
         """
         :meth:`draw` only if idle; defaults to draw but backends can overrride
         """
-        if not self._is_idle_drawing:
-            with self._idle_draw_cntx():
-                self.draw(*args, **kwargs)
+        pass
 
     def draw_cursor(self, event):
         """

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2021,7 +2021,9 @@ class FigureCanvasBase(object):
         """
         :meth:`draw` only if idle; defaults to draw but backends can overrride
         """
-        pass
+        if is_interactive() and not self._is_idle_drawing:
+            with self._idle_draw_cntx():
+                self.draw(*args, **kwargs)
 
     def draw_cursor(self, event):
         """


### PR DESCRIPTION
Consider this a "proposed" PR, since I have a feeling the solution can't possibly be this easy.

While doing some timings on image drawing, I just discovered that running something like the following:

```python
import matplotlib
matplotlib.use('Agg')
from matplotlib import pyplot as plt

plt.plot([1,2,3])
plt.savefig("test.png")
```

results in the entire figure being drawn twice.  Once to save the file, and then again as the result of `draw_idle`.  It seems that `draw_idle` really shouldn't do anything in a non-GUI backend.

Making `draw_idle` a no-op in the canvas base class seems to address this, and all the GUI backends override `draw_idle` anyway.  This behavior seems to have been here for a very long time.

I can't seem to see how this breaks things, by @tacaswell has been down in the weeds of `draw_idle` more recently...  Maybe he has some ideas as to why this is necessary.
