### PR TITLE
Add badges to sidebar

### DIFF
--- a/doc/_templates/badgesidebar.html
+++ b/doc/_templates/badgesidebar.html
@@ -1,0 +1,10 @@
+
+<a href="http://depsy.org/package/python/matplotlib">
+  <img src="http://depsy.org/api/package/pypi/matplotlib/badge.svg">
+</a>
+
+<br/>
+
+Travis-CI: <img src="https://travis-ci.org/matplotlib/matplotlib.svg?branch=master"/>
+
+<br/>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -185,9 +185,11 @@ html_index = 'index.html'
 #html_sidebars = {}
 
 # Custom sidebar templates, maps page names to templates.
-html_sidebars = {'index': 'indexsidebar.html',
-                 }
-
+html_sidebars = {
+    'index': ['badgesidebar.html', 'indexsidebar.html'],
+    '**': ['badgesidebar.html', 'localtoc.html',
+           'relations.html', 'sourcelink.html', 'searchbox.html']
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
This adds Depsy and Travis badges to the sidebar on the matplotlib website.

I'm not sure this is the greatest approach from a visual perspective, but it at least illustrates how to add content to the Sphinx sidebar (which was kind of non-obvious).