### PR TITLE
Merge pull request #5815 from mdboom/fix-minimizing-raster-layer

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -3,25 +3,30 @@ from __future__ import (absolute_import, division, print_function,
 
 from matplotlib.externals import six
 import sys
+import io
+import os
 
 import numpy as np
 
-from matplotlib.testing.decorators import image_comparison, knownfailureif, cleanup
+from matplotlib.testing.decorators import (image_comparison,
+                                           knownfailureif, cleanup)
 from matplotlib.image import BboxImage, imread, NonUniformImage
 from matplotlib.transforms import Bbox
 from matplotlib import rcParams
 import matplotlib.pyplot as plt
-from nose.tools import assert_raises
-from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-import io
-import os
+from numpy.testing import assert_array_equal
+
+
+import nose
 
 try:
     from PIL import Image
+    del Image
     HAS_PIL = True
 except ImportError:
     HAS_PIL = False
+
 
 @image_comparison(baseline_images=['image_interps'])
 def test_image_interps():

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from matplotlib.externals import six
+import sys
 
 import numpy as np
 
@@ -463,6 +464,10 @@ def test_minimized_rasterized():
     # in Postscript, the best way to detect it is to generate SVG
     # and then parse the output to make sure the two colorbar images
     # are the same size.
+    if sys.version_info[:2] < (2, 7):
+        raise nose.SkipTest("xml.etree.ElementTree.Element.iter "
+                            "added in py 2.7")
+
     from xml.etree import ElementTree
 
     np.random.seed(0)

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -210,10 +210,10 @@ agg::rect_i RendererAgg::get_content_extents()
         }
     }
 
-    r.x1 = std::max(0, r.x1 - 1);
-    r.y1 = std::max(0, r.y1 - 1);
-    r.x2 = std::max(r.x2 + 1, (int)width);
-    r.y2 = std::max(r.y2 + 1, (int)height);
+    r.x1 = std::max(0, r.x1);
+    r.y1 = std::max(0, r.y1);
+    r.x2 = std::min(r.x2 + 1, (int)width);
+    r.y2 = std::min(r.y2 + 1, (int)height);
 
     return r;
 }


### PR DESCRIPTION
Properly minimize the rasterized layers
Conflicts:
	lib/matplotlib/tests/test_image.py

One too-many tests where cherry-picked

The backport of https://github.com/matplotlib/matplotlib/pull/5815 is not passing locally for me, I am getting

```
2:30 $ python tests.py --processes=8 --process-timeout=300 matplotlib.tests.test_image:test_rasterize_dpi.test
.F
======================================================================
FAIL: matplotlib.tests.test_image.test_rasterize_dpi.test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tcaswell/source/other_source/nose/build/lib/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/tcaswell/source/my_source/matplotlib/lib/matplotlib/testing/decorators.py", line 53, in failer
    result = f(*args, **kwargs)
  File "/home/tcaswell/source/my_source/matplotlib/lib/matplotlib/testing/decorators.py", line 220, in do_test
    '(RMS %(rms).3f)'%err)
matplotlib.testing.exceptions.ImageComparisonFailure: images not close: /home/tcaswell/source/my_source/matplotlib/result_images/test_image/rasterize_10dpi_svg.png vs. /home/tcaswell/source/my_source/matplotlib/result_images/test_image/rasterize_10dpi-expected_svg.png (RMS 5.661)

----------------------------------------------------------------------
Ran 2 tests in 0.357s

FAILED (failures=1)


```