### PR TITLE
Strip spaces in properties doc after newline.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1205,7 +1205,7 @@ class ArtistInspector(object):
 
         match = self._get_valid_values_regex.search(docstring)
         if match is not None:
-            return match.group(1).replace('\n', ' ')
+            return re.sub("\n *", " ", match.group(1))
         return 'unknown'
 
     def _get_setters_and_targets(self):


### PR DESCRIPTION
Snippet of output of `pydoc pylab.plot`:

Before:
```
      linestyle or ls: ['solid' | 'dashed', 'dashdot', 'dotted' |                    (offset, on-off-dash-seq) |                    ``'-'`` | ``'--'`` | ``'-.'`` | ``':'`` | ``'None'`` |                    ``' '`` | ``''``]
```

After:
```
      linestyle or ls: ['solid' | 'dashed', 'dashdot', 'dotted' | (offset, on-off-dash-seq) | ``'-'`` | ``'--'`` | ``'-.'`` | ``':'`` | ``'None'`` | ``' '`` | ``''``]
```