### PR TITLE
Correct MEP numbers in headers of documentation

### DIFF
--- a/doc/devel/MEP/MEP13.rst
+++ b/doc/devel/MEP/MEP13.rst
@@ -1,5 +1,5 @@
 =================================
-MEP12: Use properties for Artists
+MEP13: Use properties for Artists
 =================================
 
 .. contents::

--- a/doc/devel/MEP/MEP14.rst
+++ b/doc/devel/MEP/MEP14.rst
@@ -1,5 +1,5 @@
 ====================
-MEP13: Text handling
+MEP14: Text handling
 ====================
 
 .. contents::


### PR DESCRIPTION
The numbering is offset by one here i.e. MEP12 was duplicated in the index