### PR TITLE
Allow image comparison outside tests module

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -364,7 +364,9 @@ def _image_directories(func):
 
         import imp
         def find_dotted_module(module_name, path=None):
-            """A version of imp which can handle dots in the module name"""
+            """A version of imp which can handle dots in the module name.
+               As for imp.find_module(), the return value is a 3-element
+               tuple (file, pathname, description)."""
             res = None
             for sub_mod in module_name.split('.'):
                 try:

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -359,7 +359,13 @@ def _image_directories(func):
             # namespace package pip installed and run via the nose
             # multiprocess plugin or as a specific test this may be
             # missing. See https://github.com/matplotlib/matplotlib/issues/3314
-        assert mods.pop(0) == 'tests'
+        if mods.pop(0) != 'tests':
+            warnings.warn(("Module '%s' does not live in a parent module "
+                "named 'tests'. This is probably ok, but we may not be able "
+                "to guess the correct subdirectory containing the baseline "
+                "images. If things go wrong please make sure that there is "
+                "a parent directory named 'tests' and that it contains a "
+                "__init__.py file (can be empty).") % module_name)
         subdir = os.path.join(*mods)
 
         import imp


### PR DESCRIPTION
This is a replacement for PR #5518 (which should be closed if this is accepted). For now this PR simply removes the `assert` statement so that the `@image_comparison` decorator can be used in situations where the test does not live in a parent directory called `tests` (this does not apply to matplotlib but will be useful for third-party users).

In the medium term it would be good to re-think and refactor the code in `_image_directories` because isn't very easy to read at a glance if you don't know what's going on already, and the logic seems somewhat fragile (see #3314 for example).