### PR TITLE
Update setupext.py to solve issue #5846

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -17,7 +17,8 @@ from textwrap import fill
 import versioneer
 
 
-PY3 = (sys.version_info[0] >= 3)
+PY3min = (sys.version_info[0] >= 3)
+PY32min = (PY3min and sys.version_info[1] >= 2 or sys.version_info[0] > 3)
 
 
 # This is the version of FreeType to use when building a local
@@ -28,13 +29,13 @@ LOCAL_FREETYPE_VERSION = '2.6.1'
 LOCAL_FREETYPE_HASH = '348e667d728c597360e4a87c16556597'
 
 if sys.platform != 'win32':
-    if sys.version_info[0] < 3:
+    if not PY3min:
         from commands import getstatusoutput
     else:
         from subprocess import getstatusoutput
 
 
-if PY3:
+if PY3min:
     import configparser
 else:
     import ConfigParser as configparser
@@ -51,7 +52,10 @@ options = {
 
 setup_cfg = os.environ.get('MPLSETUPCFG', 'setup.cfg')
 if os.path.exists(setup_cfg):
-    config = configparser.SafeConfigParser()
+    if PY32min:
+        config = configparser.ConfigParser()
+    else:
+        config = configparser.SafeConfigParser()
     config.read(setup_cfg)
 
     if config.has_option('status', 'suppress'):
@@ -495,12 +499,17 @@ class OptionalPackage(SetupPackage):
     def get_config(cls):
         """
         Look at `setup.cfg` and return one of ["auto", True, False] indicating
-        if the package is at default state ("auto"), forced by the user (True)
-        or opted-out (False).
+        if the package is at default state ("auto"), forced by the user (case
+        insensitively defined as 1, true, yes, on for True) or opted-out (case
+        insensitively defined as 0, false, no, off for False).
         """
+        conf = "auto"
         if config is not None and config.has_option(cls.config_category, cls.name):
-            return config.get(cls.config_category, cls.name)
-        return "auto"
+            try:
+                conf = config.getboolean(cls.config_category, cls.name)
+            except ValueError:
+                conf = config.get(cls.config_category, cls.name)
+        return conf
 
     def check(self):
         """
@@ -1393,7 +1402,7 @@ class BackendTkAgg(OptionalBackendPackage):
 
     def check_requirements(self):
         try:
-            if PY3:
+            if PY3min:
                 import tkinter as Tkinter
             else:
                 import Tkinter
@@ -1444,7 +1453,7 @@ class BackendTkAgg(OptionalBackendPackage):
             return self.tcl_tk_cache
 
         # By this point, we already know that Tkinter imports correctly
-        if PY3:
+        if PY3min:
             import tkinter as Tkinter
         else:
             import Tkinter
@@ -1485,7 +1494,7 @@ class BackendTkAgg(OptionalBackendPackage):
 
     def parse_tcl_config(self, tcl_lib_dir, tk_lib_dir):
         try:
-            if PY3:
+            if PY3min:
                 import tkinter as Tkinter
             else:
                 import Tkinter


### PR DESCRIPTION
Also avoids deprecated class SafeConfigParser in module configparser for Python 3.2 or higher. This time, I extended the get_config method documentation too. Sorry for the mess with the pull requests and thanks for all the comments!