### PR TITLE
FIX: create _dashSeq and _dashOfset before use

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -332,6 +332,10 @@ class Line2D(Artist):
         self._linestyles = None
         self._drawstyle = None
         self._linewidth = None
+
+        self._dashSeq = None
+        self._dashOffset = 0
+
         self.set_linestyle(linestyle)
         self.set_drawstyle(drawstyle)
         self.set_linewidth(linewidth)
@@ -348,9 +352,6 @@ class Line2D(Artist):
         self.set_markevery(markevery)
         self.set_antialiased(antialiased)
         self.set_markersize(markersize)
-
-        self._dashSeq = None
-        self._dashOffset = 0
 
         self._markeredgecolor = None
         self._markeredgewidth = None


### PR DESCRIPTION
closes #5850

This will need to be back-ported to 1.5.x.

I did it this way because on the 2.x branch we add `_dashOffset` which is not on 1.5.x and backporting (and dealing with the conflict then) is more reliable that remembering to fix up the second one when merging up).