### PR TITLE
Fix issue with Sphinx 1.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,31 +62,30 @@ before_install:
   - export PATH=/usr/lib/ccache:$PATH
 
 install:
-  - ccache -s
-  # Upgrade pip and setuptools. Mock has issues with the default version of
-  # setuptools
   - |
+    ccache -s
+    # Upgrade pip and setuptools and wheel to get as clean an install as possible
     pip install --upgrade pip
     pip install --upgrade wheel
     pip install --upgrade setuptools
-  # Install only from travis wheelhouse
-  - if [ -z "$PRE" ]; then
+    # Install only from travis wheelhouse
+    if [ -z "$PRE" ]; then
         wheelhouse_pip_install $NUMPY $PANDAS;
     else
         pip install $PRE $NUMPY $PANDAS;
     fi
-  # Always install from pypi
-  - pip install $PRE pep8 cycler coveralls coverage python-dateutil pyparsing!=2.0.4 pillow sphinx!=1.3.0 $MOCK
-  - 'pip install git+https://github.com/jenshnielsen/nose.git@matplotlibnose'
+    # Always install from pypi
+    pip install $PRE pep8 cycler coveralls coverage python-dateutil pyparsing!=2.0.4
+    pip install pillow sphinx!=1.3.0 $MOCK numpydoc ipython colorspacious
+    # Install nose from a build which has partial
+    # support for python36 and suport for coverage output suppressing
+    pip install git+https://github.com/jenshnielsen/nose.git@matplotlibnose
 
-  # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
-  # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
-  # version since is it basically just a .ttf file
-  # The current Travis Ubuntu image is to old to search .local/share/fonts so we store fonts in .fonts
-
-  - |
+    # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
+    # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
+    # version since is it basically just a .ttf file
+    # The current Travis Ubuntu image is to old to search .local/share/fonts so we store fonts in .fonts
     if [[ $BUILD_DOCS == true ]]; then
-      pip install $PRE numpydoc ipython colorspacious
       wget https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O Felipa-Regular.ttf
       wget http://mirrors.kernel.org/ubuntu/pool/universe/f/fonts-humor-sans/fonts-humor-sans_1.0-1_all.deb
       mkdir -p tmp
@@ -99,8 +98,7 @@ install:
       # Use the special local version of freetype for testing
       cp ci/travis/setup.cfg .
     fi;
-
-  - pip install -e .
+    pip install -e .
 
 script:
   # The number of processes is hardcoded, because using too many causes the

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,33 +134,33 @@ after_failure:
     fi
 
 after_success:
-  |
-  if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' && $BUILD_DOCS == true && $TRAVIS_BRANCH == 'master' ]]; then
-    cd $TRAVIS_BUILD_DIR
-    echo "Uploading documentation"
-    openssl aes-256-cbc -K $encrypted_cc802e084cd0_key -iv $encrypted_cc802e084cd0_iv -in ci/travis/matplotlibDeployKey.enc -out ci/travis/matplotlibDeployKey -d
-    eval `ssh-agent -s`
-    chmod 600 ci/travis/matplotlibDeployKey
-    ssh-add ci/travis/matplotlibDeployKey
-    cd ..
-    git clone git@github.com:matplotlib/devdocs.git
-    cd devdocs
-    git checkout --orphan gh-pages
-    git reset --hard first_commit
-    cp -R ../matplotlib/doc/build/html/. .
-    touch .nojekyll
-    git config --global user.email "MatplotlibTravisBot@nomail"
-    git config --global user.name "MatplotlibTravisBot"
-    git config --global push.default simple
-    git add .
-    git commit -m "Docs build of $TRAVIS_COMMIT"
-    git push --set-upstream origin gh-pages --force
-  else
-    echo "Will only deploy docs build from matplotlib master branch"
-  fi
-  if [[ $TRAVIS_PULL_REQUEST == false ]] && \
-     [[ $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' ]] && \
-     [[ $TRAVIS_BRANCH == 'master' ]]; then
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' && $BUILD_DOCS == true && $TRAVIS_BRANCH == 'master' ]]; then
+      cd $TRAVIS_BUILD_DIR
+      echo "Uploading documentation"
+      openssl aes-256-cbc -K $encrypted_cc802e084cd0_key -iv $encrypted_cc802e084cd0_iv -in ci/travis/matplotlibDeployKey.enc -out ci/travis/matplotlibDeployKey -d
+      eval `ssh-agent -s`
+      chmod 600 ci/travis/matplotlibDeployKey
+      ssh-add ci/travis/matplotlibDeployKey
+      cd ..
+      git clone git@github.com:matplotlib/devdocs.git
+      cd devdocs
+      git checkout --orphan gh-pages
+      git reset --hard first_commit
+      cp -R ../matplotlib/doc/build/html/. .
+      touch .nojekyll
+      git config --global user.email "MatplotlibTravisBot@nomail"
+      git config --global user.name "MatplotlibTravisBot"
+      git config --global push.default simple
+      git add .
+      git commit -m "Docs build of $TRAVIS_COMMIT"
+      git push --set-upstream origin gh-pages --force
+    else
+      echo "Will only deploy docs build from matplotlib master branch"
+    fi
+    if [[ $TRAVIS_PULL_REQUEST == false ]] && \
+       [[ $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' ]] && \
+       [[ $TRAVIS_BRANCH == 'master' ]]; then
       cd $TRAVIS_BUILD_DIR
       python ci/travis/travis_after_all.py
       export $(cat .to_export_back)
@@ -172,7 +172,7 @@ after_success:
           echo "Some Failed; no OSX build"
         fi
       fi
-  fi
-  if [[ $NOSE_ARGS="--with-coverage" ]]; then
-     coveralls
-  fi
+    fi
+    if [[ $NOSE_ARGS="--with-coverage" ]]; then
+      coveralls
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,9 +104,9 @@ script:
   # The number of processes is hardcoded, because using too many causes the
   # Travis VM to run out of memory (since so many copies of inkscape and
   # ghostscript are running at the same time).
-  - echo Testing using $NPROC processes
-  - echo The following args are passed to nose $NOSE_ARGS
   - |
+    echo Testing using $NPROC processes
+    echo The following args are passed to nose $NOSE_ARGS
     if [[ $BUILD_DOCS == false ]]; then
       export MPL_REPO_DIR=$PWD  # needed for pep8-conformance test of the examples
       gdb -return-child-result -batch -ex r -ex bt --args python tests.py $NOSE_ARGS $TEST_ARGS
@@ -122,16 +122,16 @@ script:
     fi
 
 after_failure:
-  |
-  if [[ $BUILD_DOCS == false && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' ]]; then
-    gem install travis-artifacts
-    cd $TRAVIS_BUILD_DIR/../tmp_test_dir
-    tar cjf result_images.tar.bz2 result_images
-    travis-artifacts upload --path result_images.tar.bz2
-    echo https://s3.amazonaws.com/matplotlib-test-results/artifacts/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/result_images.tar.bz2
-  else
-    echo "The result images will only be uploaded if they are on the matplotlib/matplotlib repo - this is for security reasons to prevent arbitrary PRs echoing security details."
-  fi
+  - |
+    if [[ $BUILD_DOCS == false && $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' ]]; then
+      gem install travis-artifacts
+      cd $TRAVIS_BUILD_DIR/../tmp_test_dir
+      tar cjf result_images.tar.bz2 result_images
+      travis-artifacts upload --path result_images.tar.bz2
+      echo https://s3.amazonaws.com/matplotlib-test-results/artifacts/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/result_images.tar.bz2
+    else
+      echo "The result images will only be uploaded if they are on the matplotlib/matplotlib repo - this is for security reasons to prevent arbitrary PRs echoing security details."
+    fi
 
 after_success:
   |

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,12 +71,12 @@ install:
     pip install --upgrade setuptools
   # Install only from travis wheelhouse
   - if [ -z "$PRE" ]; then
-        wheelhouse_pip_install python-dateutil $NUMPY $PANDAS pyparsing!=2.0.4 pillow sphinx!=1.3.0 $MOCK;
+        wheelhouse_pip_install $NUMPY $PANDAS;
     else
-        pip install $PRE python-dateutil $NUMPY pyparsing!=2.0.4 pillow sphinx!=1.3.0;
+        pip install $PRE $NUMPY $PANDAS;
     fi
   # Always install from pypi
-  - pip install $PRE pep8 cycler coveralls coverage
+  - pip install $PRE pep8 cycler coveralls coverage python-dateutil pyparsing!=2.0.4 pillow sphinx!=1.3.0 $MOCK
   - 'pip install git+https://github.com/jenshnielsen/nose.git@matplotlibnose'
 
   # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,23 +55,28 @@ matrix:
     - python: "nightly"
 
 before_install:
-  - source ci/travis/travis_tools.sh
-  # Install into our own pristine virtualenv
-  - virtualenv --python=python venv
-  - source venv/bin/activate
-  - export PATH=/usr/lib/ccache:$PATH
+  - |
+    # Install into our own pristine virtualenv
+    source ci/travis/travis_tools.sh
+    virtualenv --python=python venv
+    source venv/bin/activate
+    export PATH=/usr/lib/ccache:$PATH
 
 install:
   - |
+    # Setup environment
     ccache -s
     # Upgrade pip and setuptools and wheel to get as clean an install as possible
     pip install --upgrade pip
     pip install --upgrade wheel
     pip install --upgrade setuptools
-    # Install only from travis wheelhouse
+  - |
+    # Install dependencies
     if [ -z "$PRE" ]; then
+        # Install only from travis wheelhouse
         wheelhouse_pip_install $NUMPY $PANDAS;
     else
+        # Fall back to pypi for non suported python versions
         pip install $PRE $NUMPY $PANDAS;
     fi
     # Always install from pypi
@@ -98,6 +103,8 @@ install:
       # Use the special local version of freetype for testing
       cp ci/travis/setup.cfg .
     fi;
+  - |
+    # Install matplotlib
     pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,8 +115,10 @@ script:
       python make.py html --small --warningsaserrors
       # We don't build the LaTeX docs here, so linkchecker will complain
       touch build/html/Matplotlib.pdf
+      # Linkchecker only works with python 2.7 for the time being
       deactivate
       source ~/virtualenv/python2.7/bin/activate
+      pip install pip --upgrade
       pip install linkchecker
       linkchecker build/html/index.html
     fi

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -958,7 +958,7 @@ def find_tex_file(filename, format=None):
     """
     Call :program:`kpsewhich` to find a file in the texmf tree. If
     *format* is not None, it is used as the value for the
-    :option:`--format` option.
+    `--format` option.
 
     Apparently most existing TeX distributions on Unix-like systems
     use kpathsea. I hear MikTeX (a popular distribution on Windows)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3011,15 +3011,21 @@ class ConnectionStyle(_Style):
 
         def __init__(self, armA=0., armB=0., fraction=0.3, angle=None):
             """
-            *armA* : minimum length of armA
+            Parameters
+            ----------
+            armA : float
+                minimum length of armA
 
-            *armB* : minimum length of armB
+            armB : float
+                minimum length of armB
 
-            *fraction* : a fraction of the distance between two points that
-                         will be added to armA and armB.
+            fraction : float
+                a fraction of the distance between two points that
+                will be added to armA and armB.
 
-            *angle* : angle of the connecting line (if None, parallel to A
-                      and B)
+            angle : float or None
+                angle of the connecting line (if None, parallel
+                to A and B)
             """
             self.armA = armA
             self.armB = armB


### PR DESCRIPTION
Fixes #5869 by rewriting the offending doc string as numpy doc

I also updated .travis.yaml. This originally started with the aim to ensure that the latest version of Sphinx and other dependencies is always installed by only installing Numpy and Pandas from the wheel house. (The wheel house requires manually rebuilding the wheel when a new version is released to pypi and was thus using an older version of Sphinx) The speed benefits are limited since other packages than numpy and pandas are fast to install and we now have the pip wheel cache on Travis anyway. 

I took the opportunity to refactor the Travis config a bit more to collect all the pip installs one place and group relevant sections. 