### PR TITLE
Remove reference to changelog from frontpage

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -147,9 +147,7 @@ but it is a good idea to ping us on the mailing list too.</p>
 
 <p>To keep up to date with what's going on in matplotlib, see
 the <a href="{{ pathto('users/whats_new.html', 1) }}">what's new
-page</a>, the more detailed <a href="{{ pathto('_static/CHANGELOG', 1)
-}}">changelog</a> or browse
-the <a href="https://github.com/matplotlib/matplotlib">source
+page</a> or browse the <a href="https://github.com/matplotlib/matplotlib">source
 code</a>.  Anything that could require changes to your existing code
 is logged in the <a href="{{ pathto('api/api_changes.html', 1) }}">api
 changes</a> file.</p>


### PR DESCRIPTION
Fixes link checker issue in documentation as discussed with @tacaswell 