### PR TITLE
Revert "Build the docs with python 3.4 which should fix the Traitlets…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       env: PANDAS=pandas NOSE_ARGS=--with-coverage
     - python: 3.5
       env: TEST_ARGS=--pep8
-    - python: 3.4
+    - python: 3.5
       env: BUILD_DOCS=true
     - python: "nightly"
       env: PRE=--pre


### PR DESCRIPTION
…/IPython issue"

This reverts commit 26a1da9e46da9de60c1491ebc2ca391352995848.

A new version of Ipython has been released which should fix this and allow us to build with 3.5 again