### PR TITLE
Show significant digits by default in QLineEdit.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/formlayout.py
@@ -296,6 +296,7 @@ class FormWidget(QtWidgets.QWidget):
                     field.setCheckState(QtCore.Qt.Unchecked)
             elif isinstance(value, float):
                 field = QtWidgets.QLineEdit(repr(value), self)
+                field.setCursorPosition(0)
                 field.setValidator(QtGui.QDoubleValidator(field))
                 dialog = self.get_dialog()
                 dialog.register_float_field(field)


### PR DESCRIPTION
After creating a new plot with
```
xlim([123.4567890123456789, 456.78901234567890123])
```
and clicking the green-tick-button, this is how the xlims used to be displayed:
![screenshot_20160120_231826](https://cloud.githubusercontent.com/assets/1322974/12474052/aa13160e-bfcc-11e5-9122-d3943e070a5c.png)
and how they'd be displayed after the patch:
![screenshot_20160120_232005](https://cloud.githubusercontent.com/assets/1322974/12474053/aa44ace6-bfcc-11e5-8f0b-46d2385c3b8f.png)
