### PR TITLE
DOC: add function name to deprecation warning

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -207,7 +207,8 @@ class Artist(object):
 
         ACCEPTS: an :class:`~matplotlib.axes.Axes` instance
         """
-        warnings.warn(_get_axes_msg, mplDeprecation, stacklevel=1)
+        warnings.warn(_get_axes_msg.format('set_axes'), mplDeprecation,
+                      stacklevel=1)
         self.axes = axes
 
     def get_axes(self):
@@ -218,7 +219,8 @@ class Artist(object):
         This has been deprecated in mpl 1.5, please use the
         axes property.  Will be removed in 1.7 or 2.0.
         """
-        warnings.warn(_get_axes_msg, mplDeprecation, stacklevel=1)
+        warnings.warn(_get_axes_msg.format('get_axes'), mplDeprecation,
+                      stacklevel=1)
         return self.axes
 
     @property
@@ -1480,5 +1482,5 @@ def kwdoc(a):
 
 docstring.interpd.update(Artist=kwdoc(Artist))
 
-_get_axes_msg = """This has been deprecated in mpl 1.5, please use the
+_get_axes_msg = """{} has been deprecated in mpl 1.5, please use the
 axes property.  A removal date has not been set."""


### PR DESCRIPTION
There was a mailing list question and I have seen confusion of this else where.  This just makes the warning more explicit.