### PR TITLE
fix for latex call on PS backend (Issue #5895)

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1452,6 +1452,10 @@ def convert_psfrags(tmpfile, psfrags, font_preamble, custom_preamble,
     # multiple
     if sys.platform == 'win32': precmd = '%s &&'% os.path.splitdrive(tmpdir)[0]
     else: precmd = ''
+    #Replace \\ for / so latex does not think there is a function call
+    latexfile = latexfile.replace("\\", "/")
+    # Replace ~ so Latex does not think it is line break
+    latexfile = latexfile.replace("~", "\\string~")
     command = '%s cd "%s" && latex -interaction=nonstopmode "%s" > "%s"'\
                 %(precmd, tmpdir, latexfile, outfile)
     verbose.report(command, 'debug')


### PR DESCRIPTION
If the ~ character appears on the path of the file, latex might recognize it as a line break, and therefore fail. By replacing the ~ for \\string~ we can avoid this.