### PR TITLE
use `locale.getpreferredencoding()` to prevent OS X locale issues

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1002,7 +1002,7 @@ def _open_file_or_url(fname):
         f.close()
     else:
         fname = os.path.expanduser(fname)
-        encoding = locale.getdefaultlocale()[1]
+        encoding = locale.getpreferredencoding(do_setlocale=False)
         if encoding is None:
             encoding = "utf-8"
         with io.open(fname, encoding=encoding) as f:
@@ -1043,7 +1043,8 @@ def _rc_params_in_file(fname, fail_on_error=False):
             warnings.warn(
                 ('Cannot decode configuration file %s with '
                  'encoding %s, check LANG and LC_* variables')
-                % (fname, locale.getdefaultlocale()[1] or 'utf-8 (default)'))
+                % (fname, locale.getpreferredencoding(do_setlocale=False) or
+                   'utf-8 (default)'))
             raise
 
     config = RcParams()


### PR DESCRIPTION
There is an issue on OS X when the locale is set to `UTF-8` (no language), which happens out of the box on some systems. This has been reported before in #3870 and #5481. Such a locale cannot be parsed by Python's `locale.getdefaultlocale()`, which will throw

    ValueError: unknown locale: UTF-8

when importing matplotlib.

[Python issue 18378](https://bugs.python.org/issue18378) deals with this matter. There you will find the suggestion that a project should use `locale.getpreferredencoding()` over `locale.getdefaultlocale()[1]`, which coincidentally also fixes the issue on OS X. The PR implements this change.