### PR TITLE
Fixed instances of {} formating for py2.6 compatibility.

### DIFF
--- a/examples/pylab_examples/barchart_demo2.py
+++ b/examples/pylab_examples/barchart_demo2.py
@@ -50,7 +50,7 @@ def format_score(scr, test):
     """
     md = testMeta[test]
     if md:
-        return '{}\n{}'.format(scr, md)
+        return '{0}\n{1}'.format(scr, md)
     else:
         return scr
 
@@ -86,7 +86,7 @@ def plot_student_results(student, scores, cohort_size):
     # Plot a solid vertical gridline to highlight the median position
     ax1.axvline(50, color='grey', alpha=0.25)
     # set X-axis tick marks at the deciles
-    cohort_label = ax1.text(.5, -.07, 'Cohort Size: {}'.format(cohort_size),
+    cohort_label = ax1.text(.5, -.07, 'Cohort Size: {0}'.format(cohort_size),
                             horizontalalignment='center', size='small',
                             transform=ax1.transAxes)
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1482,5 +1482,5 @@ def kwdoc(a):
 
 docstring.interpd.update(Artist=kwdoc(Artist))
 
-_get_axes_msg = """{} has been deprecated in mpl 1.5, please use the
+_get_axes_msg = """{0} has been deprecated in mpl 1.5, please use the
 axes property.  A removal date has not been set."""

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1048,7 +1048,7 @@ class Line2D(Artist):
                 ls = ls_mapper_r[ls]
             except KeyError:
                 raise ValueError(("You passed in an invalid linestyle, "
-                                  "`{}`.  See "
+                                  "`{0}`.  See "
                                   "docs of Line2D.set_linestyle for "
                                   "valid values.").format(ls))
 

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -710,7 +710,7 @@ class Quiver(mcollections.PolyCollection):
                                           # by a float first, as with 'mid'.
         elif self.pivot != 'tail':
             raise ValueError(("Quiver.pivot must have value in {{'middle', "
-                              "'tip', 'tail'}} not {}").format(self.pivot))
+                              "'tip', 'tail'}} not {0}").format(self.pivot))
 
         tooshort = length < self.minlength
         if tooshort.any():

--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -205,9 +205,9 @@ class RGBAxesBase(object):
         ny, nx = r.shape
         if not ((nx, ny) == g.shape == b.shape):
             raise ValueError('Input shapes do not match.'
-                             '\nr.shape = {}'
-                             '\ng.shape = {}'
-                             '\nb.shape = {}'
+                             '\nr.shape = {0}'
+                             '\ng.shape = {1}'
+                             '\nb.shape = {2}'
                              ''.format(r.shape, g.shape, b.shape))
 
         R = np.zeros([ny, nx, 3], dtype="d")


### PR DESCRIPTION
Found it in a few other places, too. I ignored the problem in tools/*.py, though.