### PR TITLE
Fix #5948: Don't clip closed paths

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -208,10 +208,7 @@ def test_clipping_of_log():
                                  simplify=False)
 
     tpoints, tcodes = list(zip(*result))
-    # Because y coordinate -99 is outside the clip zone, the first
-    # line segment is effectively removed. That means that the closepoly
-    # operation must be replaced by a move to the first point.
-    assert np.allclose(tcodes, [M, M, L, L, L, C])
+    assert np.allclose(tcodes, [M, L, L, L, C])
 
 
 class NonAffineForTest(mtrans.Transform):

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -488,7 +488,7 @@ RendererAgg::draw_path(GCAgg &gc, PathIterator &path, agg::trans_affine &trans, 
 
     transformed_path_t tpath(path, trans);
     nan_removed_t nan_removed(tpath, true, path.has_curves());
-    clipped_t clipped(nan_removed, clip, width, height);
+    clipped_t clipped(nan_removed, clip && !path.has_curves(), width, height);
     snapped_t snapped(clipped, gc.snap_mode, path.total_vertices(), snapping_linewidth);
     simplify_t simplified(snapped, simplify, path.simplify_threshold());
     curve_t curve(simplified);
@@ -1014,7 +1014,7 @@ inline void RendererAgg::_draw_path_collection_generic(GCAgg &gc,
 
             transformed_path_t tpath(path, trans);
             nan_removed_t nan_removed(tpath, true, has_curves);
-            clipped_t clipped(nan_removed, do_clip, width, height);
+            clipped_t clipped(nan_removed, do_clip && !has_curves, width, height);
             snapped_t snapped(
                 clipped, gc.snap_mode, path.total_vertices(), points_to_pixels(gc.linewidth));
             if (has_curves) {

--- a/src/_path.h
+++ b/src/_path.h
@@ -885,7 +885,7 @@ void convert_path_to_polygons(PathIterator &path,
 
     transformed_path_t tpath(path, trans);
     nan_removal_t nan_removed(tpath, true, path.has_curves());
-    clipped_t clipped(nan_removed, do_clip, width, height);
+    clipped_t clipped(nan_removed, do_clip && !path.has_curves(), width, height);
     simplify_t simplified(clipped, simplify, path.simplify_threshold());
     curve_t curve(simplified);
 
@@ -950,7 +950,7 @@ void cleanup_path(PathIterator &path,
 
     transformed_path_t tpath(path, trans);
     nan_removal_t nan_removed(tpath, remove_nans, path.has_curves());
-    clipped_t clipped(nan_removed, do_clip, rect);
+    clipped_t clipped(nan_removed, do_clip && !path.has_curves(), rect);
     snapped_t snapped(clipped, snap_mode, path.total_vertices(), stroke_width);
     simplify_t simplified(snapped, do_simplify, path.simplify_threshold());
 
@@ -1156,7 +1156,7 @@ int convert_to_string(PathIterator &path,
 
     transformed_path_t tpath(path, trans);
     nan_removal_t nan_removed(tpath, true, path.has_curves());
-    clipped_t clipped(nan_removed, do_clip, clip_rect);
+    clipped_t clipped(nan_removed, do_clip && !path.has_curves(), clip_rect);
     simplify_t simplified(clipped, simplify, path.simplify_threshold());
 
     *buffersize = path.total_vertices() * (precision + 5) * 4;

--- a/src/path_cleanup.cpp
+++ b/src/path_cleanup.cpp
@@ -43,7 +43,7 @@ class PathCleanupIterator
         : m_transform(trans),
           m_transformed(m_path_iter, m_transform),
           m_nan_removed(m_transformed, remove_nans, m_path_iter.has_curves()),
-          m_clipped(m_nan_removed, do_clip, rect),
+          m_clipped(m_nan_removed, do_clip && !m_path_iter.has_curves(), rect),
           m_snapped(m_clipped, snap_mode, m_path_iter.total_vertices(), stroke_width),
           m_simplify(m_snapped,
                      do_simplify && m_path_iter.should_simplify(),


### PR DESCRIPTION
The issue is that the clipping algorithm may create a moveto command if the polygon is clipped outside of the image.  A subsequent "close poly" command will then close the polygon to that last moveto command, rather than the original moveto location.  

I'm not sure there's a good solution to this:  One needs the closepoly command to actually close the poly (if you just to a lineto to the original point, the line isn't "joined" at the corner properly...  not getting that detail right has been the source of other bugs in the past.)  The only correct solution I can think of is to "rotate" the order of the vertices so that the closepoly always ends up outside of the clipping box.  But that just sounds hard to do efficiently.

In the meantime, I think the best fix is to just turn off clipping for all paths that have a closepoly on the grounds that large polygons are less likely to require clipping anyway vs. the many-vertex line plots that are quite common.