### PR TITLE
Win: add mgs as a name for ghostscript executable

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -351,7 +351,8 @@ def checkdep_dvipng():
 
 def checkdep_ghostscript():
     if sys.platform == 'win32':
-        gs_execs = ['gswin32c', 'gswin64c', 'gs']
+        # mgs is the name in miktex
+        gs_execs = ['gswin32c', 'gswin64c', 'mgs', 'gs']
     else:
         gs_execs = ['gs']
     for gs_exec in gs_execs:


### PR DESCRIPTION
mgs.exe is available in miktex and is:

MiKTeX GPL Ghostscript 9.05 (2012-02-08)
Copyright (C) 2010 Artifex Software, Inc.  All rights reserved.
This software comes with NO WARRANTY: see the file PUBLIC for details.