### PR TITLE
Lock calls to latex in texmanager

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -53,7 +53,7 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib import rcParams
 from matplotlib._png import read_png
-from matplotlib.cbook import mkdirs
+from matplotlib.cbook import mkdirs, Locked
 from matplotlib.compat.subprocess import Popen, PIPE, STDOUT
 import matplotlib.dviread as dviread
 import re
@@ -403,7 +403,8 @@ Could not rename old TeX cache dir "%s": a suitable configuration
                 'latex -interaction=nonstopmode %s > "%s"' %
                 (os.path.split(texfile)[-1], outfile))
             mpl.verbose.report(command, 'debug')
-            exit_status = os.system(command)
+            with Locked(self.texcache):
+                exit_status = os.system(command)
             try:
                 with open(outfile) as fh:
                     report = fh.read()


### PR DESCRIPTION
These seem to be one of the more common reasons for random failures in the test suite when running in parallel. 

This code should really be rewritten using subprocess rather than os.system but I would like this minimal version to go against 2.0. The Locked context manager is not on 1.5.x so this is tricky to backport further.
