### PR TITLE
Remove fixed colours from xkcd style.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -403,7 +403,6 @@ def xkcd(scale=1, length=100, randomness=2):
         rcParams['grid.linewidth'] = 0.0
         rcParams['axes.grid'] = False
         rcParams['axes.unicode_minus'] = False
-        rcParams['axes.prop_cycle'] = cycler('color', ['b', 'r', 'c', 'm'])
         rcParams['axes.edgecolor'] = 'black'
         rcParams['xtick.major.size'] = 8
         rcParams['xtick.major.width'] = 3


### PR DESCRIPTION
I think the intent there was to limit the number of colours, but looking at something like https://xkcd.com/657/ I think the Category10 colours are quite fine.

At the moment, using the short names is causing an inconsistency between lines and patches in [the example](http://matplotlib.org/devdocs/examples/showcase/xkcd.html).