### PR TITLE
FIX: do not short-cut all white-space strings

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -740,7 +740,7 @@ class Text(Artist):
             self._renderer = renderer
         if not self.get_visible():
             return
-        if self.get_text().strip() == '':
+        if self.get_text() == '':
             return
 
         renderer.open_group('text', self.get_gid())
@@ -949,7 +949,7 @@ class Text(Artist):
         if dpi is not None:
             dpi_orig = self.figure.dpi
             self.figure.dpi = dpi
-        if self.get_text().strip() == '':
+        if self.get_text() == '':
             tx, ty = self._get_xy_display()
             return Bbox.from_bounds(tx, ty, 0, 0)
 
@@ -2211,7 +2211,7 @@ class Annotation(Text, _AnnotationBase):
                     self.arrow_patch.set_patchA(self._bbox_patch)
                 else:
                     pad = renderer.points_to_pixels(4)
-                    if self.get_text().strip() == "":
+                    if self.get_text() == "":
                         self.arrow_patch.set_patchA(None)
                         return
 


### PR DESCRIPTION
When drawing text, assume that all user input is valid input and do not
consider an all white space string to be equivalent to an empty string.

Closes #2698