### PR TITLE
Patch for issue #6009

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -450,6 +450,26 @@ def test_percentformatter():
         yield (_percent_format_helper,) + case
 
 
+def test_EngFormatter_formatting():
+    """
+    Create two instances of EngFormatter with default parameters, with and
+    without a unit string ('s' for seconds). Test the formatting in some cases,
+    especially the case when no SI prefix is present, for values in [1, 1000).
+
+    Should not exception.
+    """
+    unitless = pef.EngFormatter()
+    nose.tools.assert_equal(unitless(0.1), u'100 m')
+    nose.tools.assert_equal(unitless(1), u'1')
+    nose.tools.assert_equal(unitless(999.9), u'999.9')
+    nose.tools.assert_equal(unitless(1001), u'1.001 k')
+
+    with_unit = pef.EngFormatter(unit=u's')
+    nose.tools.assert_equal(with_unit(0.1), u'100 ms')
+    nose.tools.assert_equal(with_unit(1), u'1 s')
+    nose.tools.assert_equal(with_unit(999.9), u'999.9 s')
+    nose.tools.assert_equal(with_unit(1001), u'1.001 ks')
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -458,13 +458,13 @@ def test_EngFormatter_formatting():
 
     Should not exception.
     """
-    unitless = pef.EngFormatter()
+    unitless = mticker.EngFormatter()
     nose.tools.assert_equal(unitless(0.1), u'100 m')
     nose.tools.assert_equal(unitless(1), u'1')
     nose.tools.assert_equal(unitless(999.9), u'999.9')
     nose.tools.assert_equal(unitless(1001), u'1.001 k')
 
-    with_unit = pef.EngFormatter(unit=u's')
+    with_unit = mticker.EngFormatter(unit=u's')
     nose.tools.assert_equal(with_unit(0.1), u'100 ms')
     nose.tools.assert_equal(with_unit(1), u'1 s')
     nose.tools.assert_equal(with_unit(999.9), u'999.9 s')

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -456,7 +456,7 @@ def test_EngFormatter_formatting():
     without a unit string ('s' for seconds). Test the formatting in some cases,
     especially the case when no SI prefix is present, for values in [1, 1000).
 
-    Should not exception.
+    Should not raise exceptions.
     """
     unitless = mticker.EngFormatter()
     nose.tools.assert_equal(unitless(0.1), u'100 m')

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1114,7 +1114,7 @@ class EngFormatter(Formatter):
         formatted = format_str % (mant, prefix)
 
         formatted = formatted.strip()
-        if (self.unit is not "") and (prefix is self.ENG_PREFIXES[0]):
+        if (self.unit != "") and (prefix == self.ENG_PREFIXES[0]):
             formatted = formatted + " "
 
         return formatted

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1033,7 +1033,7 @@ class EngFormatter(Formatter):
     suitable for use with single-letter representations of powers of
     1000. For example, 'Hz' or 'm'.
 
-    `places` is the percision with which to display the number,
+    `places` is the precision with which to display the number,
     specified in digits after the decimal point (there will be between
     one and three digits before the decimal point).
     """

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1112,11 +1112,11 @@ class EngFormatter(Formatter):
             format_str = ("%%.%if %%s" % self.places)
 
         formatted = format_str % (mant, prefix)
-        
+
         formatted = formatted.strip()
         if (self.unit is not "") and (prefix is self.ENG_PREFIXES[0]):
             formatted = formatted + " "
-        
+
         return formatted
 
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1112,8 +1112,12 @@ class EngFormatter(Formatter):
             format_str = ("%%.%if %%s" % self.places)
 
         formatted = format_str % (mant, prefix)
-
-        return formatted.strip()
+        
+        formatted = formatted.strip()
+        if (self.unit is not "") and (prefix is self.ENG_PREFIXES[0]):
+            formatted = formatted + " "
+        
+        return formatted
 
 
 class PercentFormatter(Formatter):


### PR DESCRIPTION
Here is a patch for issue #6009 about the EngFormatter in matplotlib.ticker.

It simply enforces a space when there is no SI prefix but yet a unit symbol. For example “10 seconds” should be formatted as “10 s” by the EngFormatter (previously “10s”).
