### PR TITLE
Added get_status() function to the CheckButtons widget

### DIFF
--- a/doc/users/whats_new/CheckButtons_widget_get_status.rst
+++ b/doc/users/whats_new/CheckButtons_widget_get_status.rst
@@ -1,0 +1,4 @@
+CheckButtons widget get_status function
+---------------------------------------
+
+A :func:`get_status` function has been added the the :class:`matplotlib.widgets.CheckButtons` class. This :func:`get_status` function allows user to query the status (True/False) of all of the buttons in the CheckButtons object. 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -258,13 +258,15 @@ def test_lasso_selector():
     check_lasso_selector(useblit=False, lineprops=dict(color='red'))
     check_lasso_selector(useblit=True, button=1)
 
+
 @cleanup
 def test_CheckButtons():
     ax = get_ax()
-    check = widgets.CheckButtons(ax,('a','b','c'),(True,False,True))
-    assert check.get_status() == [True,False,True]
+    check = widgets.CheckButtons(ax, ('a', 'b', 'c'), (True, False, True))
+    assert check.get_status() == [True, False, True]
     check.set_active(0)
-    assert check.get_status() == [False,False,True]
+    assert check.get_status() == [False, False, True]
+
     def clicked_function():
         pass
     cid = check.on_clicked(clicked_function)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -257,3 +257,15 @@ def test_lasso_selector():
     check_lasso_selector()
     check_lasso_selector(useblit=False, lineprops=dict(color='red'))
     check_lasso_selector(useblit=True, button=1)
+
+@cleanup
+def test_CheckButtons():
+    ax = get_ax()
+    check = widgets.CheckButtons(ax,('a','b','c'),(True,False,True))
+    assert check.get_status() == [True,False,True]
+    check.set_active(0)
+    assert check.get_status() == [False,False,True]
+    def clicked_function():
+        pass
+    cid = check.on_clicked(clicked_function)
+    check.disconnect(cid)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -474,7 +474,7 @@ class Slider(AxesWidget):
 
 class CheckButtons(AxesWidget):
     """
-    A GUI neutral radio button.
+    A GUI neutral set of check buttons.
 
     For the check buttons to remain responsive you must keep a
     reference to this object.
@@ -602,6 +602,12 @@ class CheckButtons(AxesWidget):
             return
         for cid, func in six.iteritems(self.observers):
             func(self.labels[index].get_text())
+            
+    def get_status(self):
+        """
+        returns a tuple of the status (True/False) of all of the check buttons
+        """
+        return [l1.get_visible() for (l1,l2) in self.lines]
 
     def on_clicked(self, func):
         """

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -607,7 +607,7 @@ class CheckButtons(AxesWidget):
         """
         returns a tuple of the status (True/False) of all of the check buttons
         """
-        return [l1.get_visible() for (l1,l2) in self.lines]
+        return [l1.get_visible() for (l1, l2) in self.lines]
 
     def on_clicked(self, func):
         """

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -602,7 +602,7 @@ class CheckButtons(AxesWidget):
             return
         for cid, func in six.iteritems(self.observers):
             func(self.labels[index].get_text())
-            
+
     def get_status(self):
         """
         returns a tuple of the status (True/False) of all of the check buttons


### PR DESCRIPTION
This allows the user to query the status of a CheckButtons instance using 
`check.get_status()` as discussed in issue https://github.com/matplotlib/matplotlib/issues/5930#issuecomment-184837486

Here is an adaptation of the [CheckButtons example](http://matplotlib.org/examples/widgets/check_buttons.html) to show this functionality:
```python
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.widgets import CheckButtons

t = np.arange(0.0, 2.0, 0.01)
s0 = np.sin(2*np.pi*t)
s1 = np.sin(4*np.pi*t)
s2 = np.sin(6*np.pi*t)

fig, ax = plt.subplots()
l0, = ax.plot(t, s0, visible=False, lw=2)
l1, = ax.plot(t, s1, lw=2)
l2, = ax.plot(t, s2, lw=2)
plt.subplots_adjust(left=0.2)

rax = plt.axes([0.05, 0.4, 0.1, 0.15])
check = CheckButtons(rax, ('2 Hz', '4 Hz', '6 Hz'), (False, True, True))

def func(label):
    status = check.get_status()

    l0.set_visible(status[0])
    l1.set_visible(status[1])
    l2.set_visible(status[2])
   
    print status
    plt.draw()
    
check.on_clicked(func)

plt.show()
```

I also fixed a typo in the CheckButtons docstring that referred to them as "radio button".