### PR TITLE
STY: Fix grid and tick direction in bmh style.

### DIFF
--- a/lib/matplotlib/mpl-data/stylelib/bmh.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/bmh.mplstyle
@@ -19,5 +19,11 @@ axes.titlesize: x-large
 axes.labelsize: large
 axes.prop_cycle: cycler('color', ['348ABD', 'A60628', '7A68A6', '467821', 'D55E00', 'CC79A7', '56B4E9', '009E73', 'F0E442', '0072B2'])
 
+grid.color: b2b2b2
+grid.linestyle: --
+grid.linewidth: 0.5
+
 legend.fancybox: True
 
+xtick.direction: in
+ytick.direction: in

--- a/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
@@ -35,6 +35,6 @@ savefig.edgecolor: f0f0f0
 savefig.facecolor: f0f0f0
 
 figure.subplot.left: 0.08
-figure.subplot.right: 0.95 
+figure.subplot.right: 0.95
 figure.subplot.bottom: 0.07
 figure.facecolor: f0f0f0


### PR DESCRIPTION
Fixes #5982.

I don't believe the other styles need any changes.
 * The dark background and grayscale styles are simply a colour change, so the ticks/grid/linewidth/etc. don't really need to change.
 * The fivethirtyeight style looks the same as before, except for the location of ticks.
 * The ggplot style also looks almost the same except for the edge around the scatter plot. _However_, I don't think ggplot actually uses a line around scatter markers, so it's more correct this way.