### PR TITLE
Make @cleanup *really* support generative tests.

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -130,7 +130,7 @@ def cleanup(style=None):
     # writing a decorator with optional arguments.
 
     def make_cleanup(func):
-        if inspect.isgenerator(func):
+        if inspect.isgeneratorfunction(func):
             @functools.wraps(func)
             def wrapped_callable(*args, **kwargs):
                 original_units_registry = matplotlib.units.registry.copy()


### PR DESCRIPTION
Generative tests were still not run after #5809.  If `f` is defined as `def f(): yield`, `isgeneratorfunction(f) == isgenerator(f()) == True`.