### PR TITLE
Correct link to favicon

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -169,8 +169,6 @@ color: #11557C;">new updates</a></p>
 
 {% block relbar1 %}
 
-<link rel="shortcut icon" href="/_static/favicon.ico">
-
 <!-- The "Fork me on github" ribbon -->
 <img style="float: right; margin-bottom: -40px; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" usemap="#ribbonmap"/>
 <map name="ribbonmap">

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,6 +213,8 @@ html_use_opensearch = 'False'
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Matplotlibdoc'
 
+# Path to favicon
+html_favicon = '_static/favicon.ico'
 
 # Options for LaTeX output
 # ------------------------


### PR DESCRIPTION
Discovered as part of #6044 we are bundling a favicon but the link to it is wrong resulting in a 404 on the main webpage. This fixes it by using the build in sphinx support for favicon, that generates the correct relative links, and removing the additional wrong link inserted into the template. 

Confusingly the link must be [relative to the root](http://www.sphinx-doc.org/en/stable/config.html#confval-html_favicon) and not to the _static dir as for the css above.
Sphinx correctly ensures that no additional _static is inserted. 

