### PR TITLE
Cleanup clang warnings

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -898,6 +898,11 @@ class Numpy(SetupPackage):
         ext.define_macros.append(('NPY_NO_DEPRECATED_API',
                                   'NPY_1_7_API_VERSION'))
 
+        # Allow the numpy NPY_INTP_FMT macro to be used in C++.
+        # On gcc this translates to PRIdPTR which needs
+        # __STDC_FORMAT_MACROS to be usable in c++
+        ext.define_macros.append(('__STDC_FORMAT_MACROS', 1))
+
     def get_setup_requires(self):
         return ['numpy>=1.6']
 

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -449,14 +449,14 @@ PyRendererAgg_draw_gouraud_triangle(PyRendererAgg *self, PyObject *args, PyObjec
 
     if (points.dim(0) != 3 || points.dim(1) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "points must be a 3x2 array, got %dx%d",
+                     "points must be a 3x2 array, got %ldx%ld",
                      points.dim(0), points.dim(1));
         return NULL;
     }
 
     if (colors.dim(0) != 3 || colors.dim(1) != 4) {
         PyErr_Format(PyExc_ValueError,
-                     "colors must be a 3x4 array, got %dx%d",
+                     "colors must be a 3x4 array, got %ldx%ld",
                      colors.dim(0), colors.dim(1));
         return NULL;
     }
@@ -490,21 +490,21 @@ PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args, PyObje
 
     if (points.size() != 0 && (points.dim(1) != 3 || points.dim(2) != 2)) {
         PyErr_Format(PyExc_ValueError,
-                     "points must be a Nx3x2 array, got %dx%dx%d",
+                     "points must be a Nx3x2 array, got %ldx%ldx%ld",
                      points.dim(0), points.dim(1), points.dim(2));
         return NULL;
     }
 
     if (colors.size() != 0 && (colors.dim(1) != 3 || colors.dim(2) != 4)) {
         PyErr_Format(PyExc_ValueError,
-                     "colors must be a Nx3x4 array, got %dx%dx%d",
+                     "colors must be a Nx3x4 array, got %ldx%ldx%ld",
                      colors.dim(0), colors.dim(1), colors.dim(2));
         return NULL;
     }
 
     if (points.size() != colors.size()) {
         PyErr_Format(PyExc_ValueError,
-                     "points and colors arrays must be the same length, got %d and %d",
+                     "points and colors arrays must be the same length, got %ld and %ld",
                      points.dim(0), colors.dim(0));
         return NULL;
     }

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -449,14 +449,14 @@ PyRendererAgg_draw_gouraud_triangle(PyRendererAgg *self, PyObject *args, PyObjec
 
     if (points.dim(0) != 3 || points.dim(1) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "points must be a 3x2 array, got %ldx%ld",
+                     "points must be a 3x2 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      points.dim(0), points.dim(1));
         return NULL;
     }
 
     if (colors.dim(0) != 3 || colors.dim(1) != 4) {
         PyErr_Format(PyExc_ValueError,
-                     "colors must be a 3x4 array, got %ldx%ld",
+                     "colors must be a 3x4 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      colors.dim(0), colors.dim(1));
         return NULL;
     }
@@ -490,21 +490,21 @@ PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args, PyObje
 
     if (points.size() != 0 && (points.dim(1) != 3 || points.dim(2) != 2)) {
         PyErr_Format(PyExc_ValueError,
-                     "points must be a Nx3x2 array, got %ldx%ldx%ld",
+                     "points must be a Nx3x2 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      points.dim(0), points.dim(1), points.dim(2));
         return NULL;
     }
 
     if (colors.size() != 0 && (colors.dim(1) != 3 || colors.dim(2) != 4)) {
         PyErr_Format(PyExc_ValueError,
-                     "colors must be a Nx3x4 array, got %ldx%ldx%ld",
+                     "colors must be a Nx3x4 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      colors.dim(0), colors.dim(1), colors.dim(2));
         return NULL;
     }
 
     if (points.size() != colors.size()) {
         PyErr_Format(PyExc_ValueError,
-                     "points and colors arrays must be the same length, got %ld and %ld",
+                     "points and colors arrays must be the same length, got %"NPY_INTP_FMT" and %"NPY_INTP_FMT,
                      points.dim(0), colors.dim(0));
         return NULL;
     }

--- a/src/_image_resample.h
+++ b/src/_image_resample.h
@@ -908,8 +908,8 @@ void resample(
 
     if (params.interpolation != NEAREST &&
         params.is_affine &&
-        abs(params.affine.sx) == 1.0 &&
-        abs(params.affine.sy) == 1.0 &&
+        fabs(params.affine.sx) == 1.0 &&
+        fabs(params.affine.sy) == 1.0 &&
         params.affine.shx == 0.0 &&
         params.affine.shy == 0.0) {
         params.interpolation = NEAREST;

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -273,7 +273,7 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         } else {
             PyErr_Format(
                 PyExc_ValueError,
-                "If 3-dimensional, array must be RGBA.  Got %d planes.",
+                "If 3-dimensional, array must be RGBA.  Got %ld planes.",
                 PyArray_DIM(input_array, 2));
             goto error;
         }

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -273,7 +273,7 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         } else {
             PyErr_Format(
                 PyExc_ValueError,
-                "If 3-dimensional, array must be RGBA.  Got %ld planes.",
+                "If 3-dimensional, array must be RGBA.  Got %" NPY_INTP_FMT " planes.",
                 PyArray_DIM(input_array, 2));
             goto error;
         }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -214,7 +214,7 @@ static PyObject *Py_update_path_extents(PyObject *self, PyObject *args, PyObject
 
     if (minpos.dim(0) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "minpos must be of length 2, got %d",
+                     "minpos must be of length 2, got %ld",
                      minpos.dim(0));
         return NULL;
     }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -214,7 +214,7 @@ static PyObject *Py_update_path_extents(PyObject *self, PyObject *args, PyObject
 
     if (minpos.dim(0) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "minpos must be of length 2, got %ld",
+                     "minpos must be of length 2, got %"NPY_INTP_FMT,
                      minpos.dim(0));
         return NULL;
     }

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -535,7 +535,7 @@ int convert_points(PyObject *obj, void *pointsp)
 
     if (points->dim(1) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "Points must be Nx2 array, got %dx%d",
+                     "Points must be Nx2 array, got %ldx%ld",
                      points->dim(0), points->dim(1));
         return 0;
     }
@@ -559,7 +559,7 @@ int convert_transforms(PyObject *obj, void *transp)
 
     if (trans->dim(1) != 3 || trans->dim(2) != 3) {
         PyErr_Format(PyExc_ValueError,
-                     "Transforms must be Nx3x3 array, got %dx%dx%d",
+                     "Transforms must be Nx3x3 array, got %ldx%ldx%ld",
                      trans->dim(0), trans->dim(1), trans->dim(2));
         return 0;
     }
@@ -583,7 +583,7 @@ int convert_bboxes(PyObject *obj, void *bboxp)
 
     if (bbox->dim(1) != 2 || bbox->dim(2) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "Bbox array must be Nx2x2 array, got %dx%dx%d",
+                     "Bbox array must be Nx2x2 array, got %ldx%ldx%ld",
                      bbox->dim(0), bbox->dim(1), bbox->dim(2));
         return 0;
     }
@@ -607,7 +607,7 @@ int convert_colors(PyObject *obj, void *colorsp)
 
     if (colors->dim(1) != 4) {
         PyErr_Format(PyExc_ValueError,
-                     "Colors array must be Nx4 array, got %dx%d",
+                     "Colors array must be Nx4 array, got %ldx%ld",
                      colors->dim(0), colors->dim(1));
         return 0;
     }

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -535,7 +535,7 @@ int convert_points(PyObject *obj, void *pointsp)
 
     if (points->dim(1) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "Points must be Nx2 array, got %ldx%ld",
+                     "Points must be Nx2 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      points->dim(0), points->dim(1));
         return 0;
     }
@@ -559,7 +559,7 @@ int convert_transforms(PyObject *obj, void *transp)
 
     if (trans->dim(1) != 3 || trans->dim(2) != 3) {
         PyErr_Format(PyExc_ValueError,
-                     "Transforms must be Nx3x3 array, got %ldx%ldx%ld",
+                     "Transforms must be Nx3x3 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      trans->dim(0), trans->dim(1), trans->dim(2));
         return 0;
     }
@@ -583,7 +583,7 @@ int convert_bboxes(PyObject *obj, void *bboxp)
 
     if (bbox->dim(1) != 2 || bbox->dim(2) != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "Bbox array must be Nx2x2 array, got %ldx%ldx%ld",
+                     "Bbox array must be Nx2x2 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      bbox->dim(0), bbox->dim(1), bbox->dim(2));
         return 0;
     }
@@ -607,7 +607,7 @@ int convert_colors(PyObject *obj, void *colorsp)
 
     if (colors->dim(1) != 4) {
         PyErr_Format(PyExc_ValueError,
-                     "Colors array must be Nx4 array, got %ldx%ld",
+                     "Colors array must be Nx4 array, got %"NPY_INTP_FMT"x%"NPY_INTP_FMT,
                      colors->dim(0), colors->dim(1));
         return 0;
     }


### PR DESCRIPTION
This fixes a bunch of warnings that I am seeing with clang on OSX 10.11

@mdboom Some of these seems to be in the code from the new image rewrite 