### PR TITLE
Text class: changed __str__ method and added __repr__ method

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -182,8 +182,11 @@ class Text(Artist):
 
     _cached = maxdict(50)
 
-    def __str__(self):
+    def __repr__(self):
         return "Text(%g,%g,%s)" % (self._x, self._y, repr(self._text))
+
+    def __str__(self):
+        return self._text
 
     def __init__(self,
                  x=0, y=0, text='',

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -185,9 +185,6 @@ class Text(Artist):
     def __repr__(self):
         return "Text(%g,%g,%s)" % (self._x, self._y, repr(self._text))
 
-    def __str__(self):
-        return self._text
-
     def __init__(self,
                  x=0, y=0, text='',
                  color=None,           # defaults to rc params


### PR DESCRIPTION
This should address #6042 

According to the [Python docs for `__repr__` and `__str__`](https://docs.python.org/3.5/reference/datamodel.html#object.__repr__): `print()` will output what is returned by `__str__`, while `__repr__` should return a string that looks like a valid python expression. The text class currently has a `__str__` but no `__repr__`. This changes the existing `__str__` method into `__repr__` (which returns `Text(x_coord, y_coord, "string")`) and adds a new `__str__` method that returns `self._text`, which achieves the behavior requested in #6042 .

This would result in the following behavior:

    >>> text
    Text(x_coord,y_coord,"String in self._text")
    >>> print(text)
    String in self._text

Thoughts?