### PR TITLE
FIX: do invalid masking in to_rgba not set_data

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -263,9 +263,7 @@ class ScalarMappable(object):
         except AttributeError:
             # e.g., x is not an ndarray; so try mapping it
             pass
-
-        # This is the normal case, mapping a scalar array:
-        x = ma.asarray(x)
+        x = cbook.safe_masked_invalid(x)
         if norm:
             x = self.norm(x)
         rgba = self.cmap(x, alpha=alpha, bytes=bytes)
@@ -273,6 +271,7 @@ class ScalarMappable(object):
         # transparent so we copy that over to the alpha channel
         if x.ndim == 2 and x.dtype.kind == 'f':
             rgba[:, :, 3][x < 0.0] = 0
+
         return rgba
 
     def set_array(self, A):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -503,9 +503,9 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         """
         # check if data is PIL Image without importing Image
         if hasattr(A, 'getpixel'):
-            self._A = pil_to_array(A)
-        else:
-            self._A = cbook.safe_masked_invalid(A)
+            A = pil_to_array(A)
+
+        self._A = A
 
         if (self._A.dtype != np.uint8 and
                 not np.can_cast(self._A.dtype, np.float)):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -505,7 +505,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         if hasattr(A, 'getpixel'):
             A = pil_to_array(A)
 
-        self._A = A
+        self._A = np.asanyarray(A)
 
         if (self._A.dtype != np.uint8 and
                 not np.can_cast(self._A.dtype, np.float)):


### PR DESCRIPTION
The way that color mapping used to work was:

 - mask invalid
 - normalize
 - cmap (which uses the mask information fill in 'bad' values)
 - interpolate

The new order is:

 - mask invalid
 - interpolate (converting mask -> nan)
 - normalize (which passes through nan)
 - cmap

which results in cmap seeing the `nan` which it seems to map to
0.

This does the masking on the interpolated array just prior to
normalizing and removes it on the way in.

Fixes #6069