### PR TITLE
fixed bug 6028

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -68,21 +68,23 @@ import matplotlib._png as _png
 ##############################################################################
 # FONTS
 
-def get_unicode_index(symbol, nonMath=False):
+def get_unicode_index(symbol, non_math=False):
     """get_unicode_index(symbol, [bool]) -> integer
 
 Return the integer index (from the Unicode table) of symbol.  *symbol*
 can be a single unicode character, a TeX command (i.e. r'\pi'), or a
 Type1 symbol name (i.e. 'phi').
-If nonMath is True, the current symbol should be treated as a non-math symbol.
+If non_math is True, the current symbol should be treated as a non-math symbol.
 """
+    # for a non-math symbol, simply return its unicode index
+    if non_math:
+        return ord(symbol)
     # From UTF #25: U+2212 minus sign is the preferred
     # representation of the unary and binary minus sign rather than
     # the ASCII-derived U+002D hyphen-minus, because minus sign is
     # unambiguous and because it is rendered with a more desirable
     # length, usually longer than a hyphen.
-    # Hyphens in texts will not be affected.
-    if not nonMath and symbol == '-':
+    if symbol == '-':
         return 0x2212
     try:# This will succeed if symbol is a single unicode char
         return ord(symbol)
@@ -440,7 +442,7 @@ class Fonts(object):
         """
         return 0.
 
-    def get_metrics(self, font, font_class, sym, fontsize, dpi, nonMath=False):
+    def get_metrics(self, font, font_class, sym, fontsize, dpi, non_math=False):
         """
         *font*: one of the TeX font names::
 
@@ -454,7 +456,7 @@ class Fonts(object):
 
         *dpi*: current dots-per-inch
 
-        *nonMath*: whether sym is a nonMath character
+        *non_math*: whether sym is a non-math character
 
         Returns an object with the following attributes:
 
@@ -470,7 +472,7 @@ class Fonts(object):
             the glyph.  This corresponds to TeX's definition of
             "height".
         """
-        info = self._get_info(font, font_class, sym, fontsize, dpi, nonMath)
+        info = self._get_info(font, font_class, sym, fontsize, dpi, non_math)
         return info.metrics
 
     def set_canvas_size(self, w, h, d):
@@ -586,14 +588,14 @@ class TruetypeFonts(Fonts):
             return ((glyph.height/64.0/2.0) + (fontsize/3.0 * dpi/72.0))
         return 0.
 
-    def _get_info(self, fontname, font_class, sym, fontsize, dpi, nonMath=False):
+    def _get_info(self, fontname, font_class, sym, fontsize, dpi, non_math=False):
         key = fontname, font_class, sym, fontsize, dpi
         bunch = self.glyphd.get(key)
         if bunch is not None:
             return bunch
 
         font, num, symbol_name, fontsize, slanted = \
-            self._get_glyph(fontname, font_class, sym, fontsize, nonMath)
+            self._get_glyph(fontname, font_class, sym, fontsize, non_math)
 
         font.set_size(fontsize, dpi)
         glyph = font.load_char(
@@ -683,7 +685,7 @@ class BakomaFonts(TruetypeFonts):
 
     _slanted_symbols = set(r"\int \oint".split())
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize, nonMath=False):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, non_math=False):
         symbol_name = None
         font = None
         if fontname in self.fontmap and sym in latex_to_bakoma:
@@ -703,7 +705,7 @@ class BakomaFonts(TruetypeFonts):
 
         if symbol_name is None:
             return self._stix_fallback._get_glyph(
-                fontname, font_class, sym, fontsize, nonMath)
+                fontname, font_class, sym, fontsize, non_math)
 
         return font, num, symbol_name, fontsize, slanted
 
@@ -800,7 +802,7 @@ class UnicodeFonts(TruetypeFonts):
     def _map_virtual_font(self, fontname, font_class, uniindex):
         return fontname, uniindex
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize, nonMath=False):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, non_math=False):
         found_symbol = False
 
         if self.use_cmex:
@@ -811,7 +813,7 @@ class UnicodeFonts(TruetypeFonts):
 
         if not found_symbol:
             try:
-                uniindex = get_unicode_index(sym, nonMath)
+                uniindex = get_unicode_index(sym, non_math)
                 found_symbol = True
             except ValueError:
                 uniindex = ord('?')
@@ -904,11 +906,11 @@ class DejaVuFonts(UnicodeFonts):
             self.fontmap[key] = fullpath
             self.fontmap[name] = fullpath
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize, nonMath=False):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, non_math=False):
         """ Override prime symbol to use Bakoma """
         if sym == r'\prime':
             return self.bakoma._get_glyph(fontname,
-                    font_class, sym, fontsize, nonMath)
+                    font_class, sym, fontsize, non_math)
         else:
             # check whether the glyph is available in the display font
             uniindex = get_unicode_index(sym)
@@ -917,10 +919,10 @@ class DejaVuFonts(UnicodeFonts):
                 glyphindex = font.get_char_index(uniindex)
                 if glyphindex != 0:
                     return super(DejaVuFonts, self)._get_glyph('ex',
-                            font_class, sym, fontsize, nonMath)
+                            font_class, sym, fontsize, non_math)
             # otherwise return regular glyph
             return super(DejaVuFonts, self)._get_glyph(fontname,
-                    font_class, sym, fontsize, nonMath)
+                    font_class, sym, fontsize, non_math)
 
 
 class DejaVuSerifFonts(DejaVuFonts):
@@ -1128,7 +1130,7 @@ class StandardPsFonts(Fonts):
             self.fonts[cached_font.get_fontname()] = cached_font
         return cached_font
 
-    def _get_info (self, fontname, font_class, sym, fontsize, dpi, nonMath=False):
+    def _get_info (self, fontname, font_class, sym, fontsize, dpi, non_math=False):
         'load the cmfont, metrics and glyph with caching'
         key = fontname, sym, fontsize, dpi
         tup = self.glyphd.get(key)
@@ -1454,7 +1456,7 @@ class Char(Node):
     from width) must be converted into a :class:`Kern` node when the
     :class:`Char` is added to its parent :class:`Hlist`.
     """
-    def __init__(self, c, state, nonMath=False):
+    def __init__(self, c, state, non_math=False):
         Node.__init__(self)
         self.c = c
         self.font_output = state.font_output
@@ -1462,7 +1464,7 @@ class Char(Node):
         self.font_class = state.font_class
         self.fontsize = state.fontsize
         self.dpi = state.dpi
-        self.nonMath = nonMath
+        self.non_math = non_math
         # The real width, height and depth will be set during the
         # pack phase, after we know the real fontsize
         self._update_metrics()
@@ -1472,7 +1474,7 @@ class Char(Node):
 
     def _update_metrics(self):
         metrics = self._metrics = self.font_output.get_metrics(
-            self.font, self.font_class, self.c, self.fontsize, self.dpi, self.nonMath)
+            self.font, self.font_class, self.c, self.fontsize, self.dpi, self.non_math)
         if self.c == ' ':
             self.width = metrics.advance
         else:
@@ -2594,7 +2596,7 @@ class Parser(object):
     def non_math(self, s, loc, toks):
         #~ print "non_math", toks
         s = toks[0].replace(r'\$', '$')
-        symbols = [Char(c, self.get_state(), nonMath=True) for c in s]
+        symbols = [Char(c, self.get_state(), non_math=True) for c in s]
         hlist = Hlist(symbols)
         # We're going into math now, so set font to 'it'
         self.push_state()

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1128,7 +1128,7 @@ class StandardPsFonts(Fonts):
             self.fonts[cached_font.get_fontname()] = cached_font
         return cached_font
 
-    def _get_info (self, fontname, font_class, sym, fontsize, dpi):
+    def _get_info (self, fontname, font_class, sym, fontsize, dpi, nonMath=False):
         'load the cmfont, metrics and glyph with caching'
         key = fontname, sym, fontsize, dpi
         tup = self.glyphd.get(key)

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -68,19 +68,21 @@ import matplotlib._png as _png
 ##############################################################################
 # FONTS
 
-def get_unicode_index(symbol):
-    """get_unicode_index(symbol) -> integer
+def get_unicode_index(symbol, nonMath=False):
+    """get_unicode_index(symbol, [bool]) -> integer
 
 Return the integer index (from the Unicode table) of symbol.  *symbol*
 can be a single unicode character, a TeX command (i.e. r'\pi'), or a
 Type1 symbol name (i.e. 'phi').
+If nonMath is True, the current symbol should be treated as a non-math symbol.
 """
     # From UTF #25: U+2212 minus sign is the preferred
     # representation of the unary and binary minus sign rather than
     # the ASCII-derived U+002D hyphen-minus, because minus sign is
     # unambiguous and because it is rendered with a more desirable
     # length, usually longer than a hyphen.
-    if symbol == '-':
+    # Hyphens in texts will not be affected.
+    if not nonMath and symbol == '-':
         return 0x2212
     try:# This will succeed if symbol is a single unicode char
         return ord(symbol)
@@ -438,7 +440,7 @@ class Fonts(object):
         """
         return 0.
 
-    def get_metrics(self, font, font_class, sym, fontsize, dpi):
+    def get_metrics(self, font, font_class, sym, fontsize, dpi, nonMath=False):
         """
         *font*: one of the TeX font names::
 
@@ -451,6 +453,8 @@ class Fonts(object):
         *fontsize*: font size in points
 
         *dpi*: current dots-per-inch
+
+        *nonMath*: whether sym is a nonMath character
 
         Returns an object with the following attributes:
 
@@ -466,7 +470,7 @@ class Fonts(object):
             the glyph.  This corresponds to TeX's definition of
             "height".
         """
-        info = self._get_info(font, font_class, sym, fontsize, dpi)
+        info = self._get_info(font, font_class, sym, fontsize, dpi, nonMath)
         return info.metrics
 
     def set_canvas_size(self, w, h, d):
@@ -582,14 +586,14 @@ class TruetypeFonts(Fonts):
             return ((glyph.height/64.0/2.0) + (fontsize/3.0 * dpi/72.0))
         return 0.
 
-    def _get_info(self, fontname, font_class, sym, fontsize, dpi):
+    def _get_info(self, fontname, font_class, sym, fontsize, dpi, nonMath=False):
         key = fontname, font_class, sym, fontsize, dpi
         bunch = self.glyphd.get(key)
         if bunch is not None:
             return bunch
 
         font, num, symbol_name, fontsize, slanted = \
-            self._get_glyph(fontname, font_class, sym, fontsize)
+            self._get_glyph(fontname, font_class, sym, fontsize, nonMath)
 
         font.set_size(fontsize, dpi)
         glyph = font.load_char(
@@ -679,7 +683,7 @@ class BakomaFonts(TruetypeFonts):
 
     _slanted_symbols = set(r"\int \oint".split())
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, nonMath=False):
         symbol_name = None
         font = None
         if fontname in self.fontmap and sym in latex_to_bakoma:
@@ -699,7 +703,7 @@ class BakomaFonts(TruetypeFonts):
 
         if symbol_name is None:
             return self._stix_fallback._get_glyph(
-                fontname, font_class, sym, fontsize)
+                fontname, font_class, sym, fontsize, nonMath)
 
         return font, num, symbol_name, fontsize, slanted
 
@@ -796,7 +800,7 @@ class UnicodeFonts(TruetypeFonts):
     def _map_virtual_font(self, fontname, font_class, uniindex):
         return fontname, uniindex
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, nonMath=False):
         found_symbol = False
 
         if self.use_cmex:
@@ -807,7 +811,7 @@ class UnicodeFonts(TruetypeFonts):
 
         if not found_symbol:
             try:
-                uniindex = get_unicode_index(sym)
+                uniindex = get_unicode_index(sym, nonMath)
                 found_symbol = True
             except ValueError:
                 uniindex = ord('?')
@@ -900,11 +904,11 @@ class DejaVuFonts(UnicodeFonts):
             self.fontmap[key] = fullpath
             self.fontmap[name] = fullpath
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, nonMath=False):
         """ Override prime symbol to use Bakoma """
         if sym == r'\prime':
             return self.bakoma._get_glyph(fontname,
-                    font_class, sym, fontsize)
+                    font_class, sym, fontsize, nonMath)
         else:
             # check whether the glyph is available in the display font
             uniindex = get_unicode_index(sym)
@@ -913,10 +917,10 @@ class DejaVuFonts(UnicodeFonts):
                 glyphindex = font.get_char_index(uniindex)
                 if glyphindex != 0:
                     return super(DejaVuFonts, self)._get_glyph('ex',
-                            font_class, sym, fontsize)
+                            font_class, sym, fontsize, nonMath)
             # otherwise return regular glyph
             return super(DejaVuFonts, self)._get_glyph(fontname,
-                    font_class, sym, fontsize)
+                    font_class, sym, fontsize, nonMath)
 
 
 class DejaVuSerifFonts(DejaVuFonts):
@@ -1450,7 +1454,7 @@ class Char(Node):
     from width) must be converted into a :class:`Kern` node when the
     :class:`Char` is added to its parent :class:`Hlist`.
     """
-    def __init__(self, c, state):
+    def __init__(self, c, state, nonMath=False):
         Node.__init__(self)
         self.c = c
         self.font_output = state.font_output
@@ -1458,6 +1462,7 @@ class Char(Node):
         self.font_class = state.font_class
         self.fontsize = state.fontsize
         self.dpi = state.dpi
+        self.nonMath = nonMath
         # The real width, height and depth will be set during the
         # pack phase, after we know the real fontsize
         self._update_metrics()
@@ -1467,7 +1472,7 @@ class Char(Node):
 
     def _update_metrics(self):
         metrics = self._metrics = self.font_output.get_metrics(
-            self.font, self.font_class, self.c, self.fontsize, self.dpi)
+            self.font, self.font_class, self.c, self.fontsize, self.dpi, self.nonMath)
         if self.c == ' ':
             self.width = metrics.advance
         else:
@@ -2589,7 +2594,7 @@ class Parser(object):
     def non_math(self, s, loc, toks):
         #~ print "non_math", toks
         s = toks[0].replace(r'\$', '$')
-        symbols = [Char(c, self.get_state()) for c in s]
+        symbols = [Char(c, self.get_state(), nonMath=True) for c in s]
         hlist = Hlist(symbols)
         # We're going into math now, so set font to 'it'
         self.push_state()

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -68,16 +68,16 @@ import matplotlib._png as _png
 ##############################################################################
 # FONTS
 
-def get_unicode_index(symbol, non_math=False):
+def get_unicode_index(symbol, math=True):
     """get_unicode_index(symbol, [bool]) -> integer
 
 Return the integer index (from the Unicode table) of symbol.  *symbol*
 can be a single unicode character, a TeX command (i.e. r'\pi'), or a
 Type1 symbol name (i.e. 'phi').
-If non_math is True, the current symbol should be treated as a non-math symbol.
+If math is False, the current symbol should be treated as a non-math symbol.
 """
     # for a non-math symbol, simply return its unicode index
-    if non_math:
+    if not math:
         return ord(symbol)
     # From UTF #25: U+2212 minus sign is the preferred
     # representation of the unary and binary minus sign rather than
@@ -442,7 +442,7 @@ class Fonts(object):
         """
         return 0.
 
-    def get_metrics(self, font, font_class, sym, fontsize, dpi, non_math=False):
+    def get_metrics(self, font, font_class, sym, fontsize, dpi, math=True):
         """
         *font*: one of the TeX font names::
 
@@ -456,7 +456,7 @@ class Fonts(object):
 
         *dpi*: current dots-per-inch
 
-        *non_math*: whether sym is a non-math character
+        *math*: whether sym is a math character
 
         Returns an object with the following attributes:
 
@@ -472,7 +472,7 @@ class Fonts(object):
             the glyph.  This corresponds to TeX's definition of
             "height".
         """
-        info = self._get_info(font, font_class, sym, fontsize, dpi, non_math)
+        info = self._get_info(font, font_class, sym, fontsize, dpi, math)
         return info.metrics
 
     def set_canvas_size(self, w, h, d):
@@ -588,14 +588,14 @@ class TruetypeFonts(Fonts):
             return ((glyph.height/64.0/2.0) + (fontsize/3.0 * dpi/72.0))
         return 0.
 
-    def _get_info(self, fontname, font_class, sym, fontsize, dpi, non_math=False):
+    def _get_info(self, fontname, font_class, sym, fontsize, dpi, math=True):
         key = fontname, font_class, sym, fontsize, dpi
         bunch = self.glyphd.get(key)
         if bunch is not None:
             return bunch
 
         font, num, symbol_name, fontsize, slanted = \
-            self._get_glyph(fontname, font_class, sym, fontsize, non_math)
+            self._get_glyph(fontname, font_class, sym, fontsize, math)
 
         font.set_size(fontsize, dpi)
         glyph = font.load_char(
@@ -685,7 +685,7 @@ class BakomaFonts(TruetypeFonts):
 
     _slanted_symbols = set(r"\int \oint".split())
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize, non_math=False):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, math=True):
         symbol_name = None
         font = None
         if fontname in self.fontmap and sym in latex_to_bakoma:
@@ -705,7 +705,7 @@ class BakomaFonts(TruetypeFonts):
 
         if symbol_name is None:
             return self._stix_fallback._get_glyph(
-                fontname, font_class, sym, fontsize, non_math)
+                fontname, font_class, sym, fontsize, math)
 
         return font, num, symbol_name, fontsize, slanted
 
@@ -802,7 +802,7 @@ class UnicodeFonts(TruetypeFonts):
     def _map_virtual_font(self, fontname, font_class, uniindex):
         return fontname, uniindex
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize, non_math=False):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, math=True):
         found_symbol = False
 
         if self.use_cmex:
@@ -813,7 +813,7 @@ class UnicodeFonts(TruetypeFonts):
 
         if not found_symbol:
             try:
-                uniindex = get_unicode_index(sym, non_math)
+                uniindex = get_unicode_index(sym, math)
                 found_symbol = True
             except ValueError:
                 uniindex = ord('?')
@@ -906,11 +906,11 @@ class DejaVuFonts(UnicodeFonts):
             self.fontmap[key] = fullpath
             self.fontmap[name] = fullpath
 
-    def _get_glyph(self, fontname, font_class, sym, fontsize, non_math=False):
+    def _get_glyph(self, fontname, font_class, sym, fontsize, math=True):
         """ Override prime symbol to use Bakoma """
         if sym == r'\prime':
             return self.bakoma._get_glyph(fontname,
-                    font_class, sym, fontsize, non_math)
+                    font_class, sym, fontsize, math)
         else:
             # check whether the glyph is available in the display font
             uniindex = get_unicode_index(sym)
@@ -919,10 +919,10 @@ class DejaVuFonts(UnicodeFonts):
                 glyphindex = font.get_char_index(uniindex)
                 if glyphindex != 0:
                     return super(DejaVuFonts, self)._get_glyph('ex',
-                            font_class, sym, fontsize, non_math)
+                            font_class, sym, fontsize, math)
             # otherwise return regular glyph
             return super(DejaVuFonts, self)._get_glyph(fontname,
-                    font_class, sym, fontsize, non_math)
+                    font_class, sym, fontsize, math)
 
 
 class DejaVuSerifFonts(DejaVuFonts):
@@ -1130,7 +1130,7 @@ class StandardPsFonts(Fonts):
             self.fonts[cached_font.get_fontname()] = cached_font
         return cached_font
 
-    def _get_info (self, fontname, font_class, sym, fontsize, dpi, non_math=False):
+    def _get_info (self, fontname, font_class, sym, fontsize, dpi, math=True):
         'load the cmfont, metrics and glyph with caching'
         key = fontname, sym, fontsize, dpi
         tup = self.glyphd.get(key)
@@ -1456,7 +1456,7 @@ class Char(Node):
     from width) must be converted into a :class:`Kern` node when the
     :class:`Char` is added to its parent :class:`Hlist`.
     """
-    def __init__(self, c, state, non_math=False):
+    def __init__(self, c, state, math=True):
         Node.__init__(self)
         self.c = c
         self.font_output = state.font_output
@@ -1464,7 +1464,7 @@ class Char(Node):
         self.font_class = state.font_class
         self.fontsize = state.fontsize
         self.dpi = state.dpi
-        self.non_math = non_math
+        self.math = math
         # The real width, height and depth will be set during the
         # pack phase, after we know the real fontsize
         self._update_metrics()
@@ -1474,7 +1474,7 @@ class Char(Node):
 
     def _update_metrics(self):
         metrics = self._metrics = self.font_output.get_metrics(
-            self.font, self.font_class, self.c, self.fontsize, self.dpi, self.non_math)
+            self.font, self.font_class, self.c, self.fontsize, self.dpi, self.math)
         if self.c == ' ':
             self.width = metrics.advance
         else:
@@ -2596,7 +2596,7 @@ class Parser(object):
     def non_math(self, s, loc, toks):
         #~ print "non_math", toks
         s = toks[0].replace(r'\$', '$')
-        symbols = [Char(c, self.get_state(), non_math=True) for c in s]
+        symbols = [Char(c, self.get_state(), math=False) for c in s]
         hlist = Hlist(symbols)
         # We're going into math now, so set font to 'it'
         self.push_state()


### PR DESCRIPTION
The problem was that hyphen-minus was converted to minus signs without differentiating those in math expressions and those in texts. I fixed it by adding an optional parameter nonMath so that hyphens in texts won't be converted.