### PR TITLE
Fixed Issue 4346

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -340,7 +340,7 @@ class Tick(artist.Artist):
                 # -> points. grab the integer from the `Text` object
                 # instead of saving the string representation
                 v = getattr(self.label1, 'get_' + k)()
-                setattr(self, '_' + k, v)
+                setattr(self, '_label' + k, v)
 
 
 class XTick(Tick):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4336,20 +4336,12 @@ def test_pandas_indexing_hist():
     axes.hist(ser_2)
 
 @cleanup
-def test_axis_set_tick_params_two_calls():
+def test_axis_set_tick_params_labelsize_labelcolor():
     # Tests fix for issue 4346
     axis_1 = plt.subplot()
     axis_1.yaxis.set_tick_params(labelsize=30, labelcolor='red', direction='out')
 
     # Expected values after setting the ticks
-    assert axis_1.yaxis.majorTicks[0]._size == 4.0
-    assert axis_1.yaxis.majorTicks[0]._color == 'k'
-    assert axis_1.yaxis.majorTicks[0]._labelsize == 30.0
-    assert axis_1.yaxis.majorTicks[0]._labelcolor == 'red'
-
-    # This second call to set_tick_params should not change any parameters
-    axis_1.yaxis.set_tick_params()
-
     assert axis_1.yaxis.majorTicks[0]._size == 4.0
     assert axis_1.yaxis.majorTicks[0]._color == 'k'
     assert axis_1.yaxis.majorTicks[0]._labelsize == 30.0

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4335,6 +4335,25 @@ def test_pandas_indexing_hist():
     fig, axes = plt.subplots()
     axes.hist(ser_2)
 
+@cleanup
+def test_axis_set_tick_params_two_calls():
+    # Tests fix for issue 4346
+    axis_1 = plt.subplot()
+    axis_1.yaxis.set_tick_params(labelsize=30, labelcolor='red', direction='out')
+
+    # Expected values after setting the ticks
+    assert axis_1.yaxis.majorTicks[0]._size == 4.0
+    assert axis_1.yaxis.majorTicks[0]._color == 'k'
+    assert axis_1.yaxis.majorTicks[0]._labelsize == 30.0
+    assert axis_1.yaxis.majorTicks[0]._labelcolor == 'red'
+
+    # This second call to set_tick_params should not change any parameters
+    axis_1.yaxis.set_tick_params()
+
+    assert axis_1.yaxis.majorTicks[0]._size == 4.0
+    assert axis_1.yaxis.majorTicks[0]._color == 'k'
+    assert axis_1.yaxis.majorTicks[0]._labelsize == 30.0
+    assert axis_1.yaxis.majorTicks[0]._labelcolor == 'red'
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
This is a fix for issue #4346 

The problem was that when handling parameters labelsize and labelcolor, _apply_params was calling setattr on _size and _color instead of _labelsize and _labelcolor.  This is all fine and dandy until something is used that calls _apply_params because _apply_params calls apply_tickdir which will change the padding.

When _size changes, its value gets added to the tick padding thus causing the issue seen in #4346.  This also explains why the issue only became apparent when setting major (or both) ticks, it is because minor ticks don't have _size added to their padding values.