### PR TITLE
Optimize 3D display

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -261,7 +261,7 @@ class Patch3D(Patch):
         self.set_3d_properties(zs, zdir)
 
     def set_3d_properties(self, verts, zs=0, zdir='z'):
-        verts = np.vstack([verts, np.ones(len(verts)) * zs])
+        verts = np.hstack([verts, np.ones((len(verts), 1)) * zs])
         self._segment3d = juggle_axes_vec(verts, zdir)
         self._facecolor3d = Patch.get_facecolor(self)
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -317,7 +317,7 @@ class PathPatch3D(Patch3D):
 
     def do_3d_projection(self, renderer):
         # pad ones
-        s = np.vstack(self._segments3d, np.ones(self._segments3d.shape[1]))
+        s = np.vstack(self._segment3d, np.ones(self._segment3d.shape[1]))
         vxyzis = proj3d.proj_transform_vec_clip(s, renderer.M)
         self._path2d = mpath.Path(vxyzis[0:2].T, self._code3d)
         # FIXME: coloring
@@ -348,6 +348,7 @@ def pathpatch_2d_to_3d(pathpatch, z=0, zdir='z'):
     mpath = trans.transform_path(path)
     pathpatch.__class__ = PathPatch3D
     pathpatch.set_3d_properties(mpath, z, zdir)
+
 
 class Patch3DCollection(PatchCollection):
     '''

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -317,7 +317,7 @@ class PathPatch3D(Patch3D):
 
     def do_3d_projection(self, renderer):
         # pad ones
-        s = np.vstack(self._segment3d, np.ones(self._segment3d.shape[1]))
+        s = np.vstack([self._segment3d, np.ones(self._segment3d.shape[1])])
         vxyzis = proj3d.proj_transform_vec_clip(s, renderer.M)
         self._path2d = mpath.Path(vxyzis[0:2].T, self._code3d)
         # FIXME: coloring

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -580,9 +580,6 @@ class Poly3DCollection(PolyCollection):
         self._sort_zpos = val
         self.stale = True
 
-    from profilehooks import profile
-
-    #@profile
     def do_3d_projection(self, renderer):
         '''
         Perform the 3D projection for this object.

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -233,7 +233,7 @@ class Line3DCollection(LineCollection):
         xys = np.reshape(xys.T, shape)
         segments_2d = xys[:, :, 0:2]
         LineCollection.set_segments(self, segments_2d)
-        minz = np.min(xys[:, :, 2])
+        minz = np.min(xys[:, :, 2]) if xys.size > 0 else 1e9
         return minz
 
     def draw(self, renderer, project=False):
@@ -262,7 +262,7 @@ class Patch3D(Patch):
 
     def set_3d_properties(self, verts, zs=0, zdir='z'):
         verts = np.hstack([verts, np.ones((len(verts), 1)) * zs])
-        self._segment3d = juggle_axes_vec(verts, zdir)
+        self._segment3d = juggle_axes_vec(verts.T, zdir)
         self._facecolor3d = Patch.get_facecolor(self)
 
     def get_path(self):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2340,15 +2340,9 @@ class Axes3D(Axes):
             if 'alpha' in kwargs:
                 p.set_alpha(kwargs['alpha'])
 
-        if len(verts) > 0 :
-            # the following has to be skipped if verts is empty
-            # NOTE: Bugs could still occur if len(verts) > 0,
-            #       but the "2nd dimension" is empty.
-            xs, ys = list(zip(*verts))
-        else :
-            xs, ys = [], []
+        verts = np.vstack(verts, verts_zs)
 
-        xs, ys, verts_zs = art3d.juggle_axes(xs, ys, verts_zs, zdir)
+        xs, ys, verts_zs = art3d.juggle_axes(verts, zdir)
         self.auto_scale_xyz(xs, ys, verts_zs, had_data)
 
         return patches

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2340,11 +2340,11 @@ class Axes3D(Axes):
             if 'alpha' in kwargs:
                 p.set_alpha(kwargs['alpha'])
 
-        verts = np.hstack([verts, np.asarray(verts_zs)[:, np.newaxis]])
+        verts = np.vstack([list(zip(*verts)), verts_zs])
 
-        xs, ys, verts_zs = art3d.juggle_axes_vec(verts.T, zdir)
+        xs, ys, verts_zs = art3d.juggle_axes_vec(verts, zdir)
         self.auto_scale_xyz(xs, ys, verts_zs, had_data)
-        
+
         return patches
 
     def bar3d(self, x, y, z, dx, dy, dz, color=None,

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2342,9 +2342,9 @@ class Axes3D(Axes):
 
         verts = np.hstack([verts, np.asarray(verts_zs)[:, np.newaxis]])
 
-        xs, ys, verts_zs = art3d.juggle_axes_vec(verts, zdir)
+        xs, ys, verts_zs = art3d.juggle_axes_vec(verts.T, zdir)
         self.auto_scale_xyz(xs, ys, verts_zs, had_data)
-
+        
         return patches
 
     def bar3d(self, x, y, z, dx, dy, dz, color=None,

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2342,7 +2342,7 @@ class Axes3D(Axes):
 
         verts = np.vstack(verts, verts_zs)
 
-        xs, ys, verts_zs = art3d.juggle_axes(verts, zdir)
+        xs, ys, verts_zs = art3d.juggle_axes_vec(verts, zdir)
         self.auto_scale_xyz(xs, ys, verts_zs, had_data)
 
         return patches

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2340,7 +2340,7 @@ class Axes3D(Axes):
             if 'alpha' in kwargs:
                 p.set_alpha(kwargs['alpha'])
 
-        verts = np.vstack(verts, verts_zs)
+        verts = np.hstack([verts, np.asarray(verts_zs)[:, np.newaxis]])
 
         xs, ys, verts_zs = art3d.juggle_axes_vec(verts, zdir)
         self.auto_scale_xyz(xs, ys, verts_zs, had_data)

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -214,6 +214,9 @@ def proj_points(points, M):
     return list(zip(*proj_trans_points(points, M)))
 
 def proj_trans_points(points, M):
+    """
+    Apply transformation matrix M on a set of points
+    """
     xs, ys, zs = list(zip(*points))
     return proj_transform(xs, ys, zs, M)
 

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -162,8 +162,7 @@ def proj_transform_vec(vec, M):
 def proj_transform_vec_clip(vec, M):
     vecw = np.dot(M, vec)
     # Determine clipping before rescaling
-    tis = np.logical_and(vecw[0] >= 0, vecw[0] <= 1,
-                         vecw[1] >= 0, vecw[1] <= 1)
+    tis = (vecw[0] >= 0) * (vecw[0] <= 1) * (vecw[1] >= 0) * (vecw[1] <= 1)
     # clip here..
     # Can anybody comment on this piece of code? I don't understand it...
     if np.sometrue(tis):

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -156,20 +156,22 @@ def persp_transformation(zfront, zback):
 
 def proj_transform_vec(vec, M):
     vecw = np.dot(M, vec)
-    w = vecw[3]
-    # clip here..
-    txs, tys, tzs = vecw[0]/w, vecw[1]/w, vecw[2]/w
-    return txs, tys, tzs
+    vecw /= vecw[3]
+    return vecw[0:3]
 
 def proj_transform_vec_clip(vec, M):
     vecw = np.dot(M, vec)
-    w = vecw[3]
+    # Determine clipping before rescaling
+    tis = np.logical_and(vecw[0] >= 0, vecw[0] <= 1,
+                         vecw[1] >= 0, vecw[1] <= 1)
     # clip here..
-    txs, tys, tzs = vecw[0]/w, vecw[1]/w, vecw[2]/w
-    tis = (vecw[0] >= 0) * (vecw[0] <= 1) * (vecw[1] >= 0) * (vecw[1] <= 1)
+    # Can anybody comment on this piece of code? I don't understand it...
     if np.sometrue(tis):
-        tis =  vecw[1] < 1
-    return txs, tys, tzs, tis
+        tis = vecw[1] < 1
+    vecw /= vecw[3]
+    # Integrating tis in the numpy array for optimization purposes
+    vecw[3, :] = tis
+    return vecw
 
 def inv_transform(xs, ys, zs, M):
     iM = linalg.inv(M)


### PR DESCRIPTION
While printing 3D objects, I noticed that the display was pretty slow. The reason is that matplotlib relies a lot on list of objects instead of using big numpy arrays to fasten 3D projections.

This PR aims at solving part of this problem. I replaced some airthmetic on list of vectors by artihmetic on big matrices. This impacts mainly 3D display.

I work on neuroimaging data. I noticed an approximate 25% speedup optimization on 3D display (depending on the complexity of the figure). Refreshment in interactive plotting is also faster. Example script:

``` python
from matplotlib import pyplot as plt
from mpl_toolkits.mplot3d import Axes3D
from nibabel import gifti


surf_mesh = '/path/to/spm12b/canonical/cortex_20484.surf.gii'

coords, faces = gifti.read(surf_mesh).getArraysFromIntent(1008)[0].data, \
                gifti.read(surf_mesh).getArraysFromIntent(1009)[0].data

limits = [coords.min(), coords.max()]

cmap = 'coolwarm'

fig = plt.figure()
ax = fig.add_subplot(111, projection='3d', xlim=limits, ylim=limits)
ax.view_init(elev=0, azim=0)
ax.set_axis_off()

p3dcollec = ax.plot_trisurf(coords[:, 0], coords[:, 1], coords[:, 2],
                            triangles=faces, linewidth=0.,
                            antialiased=False,
                            color='white')

fig.savefig('brain.png')
plt.close(fig)
```

Possible other optimizations:
- For display, matplotlib relies on a list of Path objects. This could be made faster with numpy arrays.
- Poly3DCollection and others: a lot of unnecessary asarray and paddings of ones to obtain quaternions are done. This could be simplified by keeping a quaternion numpy array in the object and using appropriate numpy views but requires a deeper refactoring.
- not plotting unseen triangle: For the moment, all polygons are drawn. if there are a lot, isn't it worth to compute which one are hidden by others and remove them?

@agramfort and @juhuntenburg, do you notice significant running time reduction with this PR?
