### PR TITLE
Bug Fix: Issue #6000

### DIFF
--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -89,7 +89,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         linewidth = matplotlib.rcParams['lines.linewidth']
 
     line_kw = {}
-    arrow_kw = dict(arrowstyle=arrowstyle, mutation_scale=10 * arrowsize)
+
+    arrow_kw = dict(arrowstyle=arrowstyle, mutation_scale=arrowsize)
 
     use_multicolor_lines = isinstance(color, np.ndarray)
     if use_multicolor_lines:
@@ -183,10 +184,9 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
         p = patches.FancyArrowPatch(arrow_tail,
                                     arrow_head,
-                                    transform=transform,
                                     margins=False,
                                     **arrow_kw)
-        axes.add_patch(p)
+
         arrows.append(p)
 
     lc = mcollections.LineCollection(streamlines,
@@ -201,6 +201,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     axes.autoscale_view()
 
     ac = matplotlib.collections.PatchCollection(arrows, margins=False)
+    axes.add_collection(ac)
+
     stream_container = StreamplotSet(lc, ac)
     return stream_container
 


### PR DESCRIPTION
For issue #6000 , the problem was that calling `streamplot.arrows.set_visible(False)` was setting the `PatchCollection` instance's visible flag to False, and when the arrows were being rendered only the arrow's visible flag was checked (bypassing the check to `PatchCollection` altogether). This is why the arrows were drawn even when the collection's visible flag was `False`.

The fix was simply to add the arrows at the end as a whole collection to the `axes` (instead of adding them one at time), and also removing the `transform=transform` parameter from the `FancyArrowPatch` creation since it is no longer needed. However I noticed that the default arrow style of '-|>' did not work as some arrows were misplaced so I changed the default style to 'wedge' and this seems to work just fine.
