### PR TITLE
Bring back the module level 'backend'

### DIFF
--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -51,7 +51,8 @@ def pylab_setup(name=None):
 
     # the last argument is specifies whether to use absolute or relative
     # imports. 0 means only perform absolute imports.
-    backend_mod = __import__(backend_name, globals(), locals(), [backend_name], 0)
+    backend_mod = __import__(backend_name, globals(), locals(),
+                             [backend_name], 0)
 
     # Things we pull in from all backends
     new_figure_manager = backend_mod.new_figure_manager
@@ -76,7 +77,8 @@ or with matplotlib.use()""" %
 
     show = getattr(backend_mod, 'show', do_nothing_show)
 
-    draw_if_interactive = getattr(backend_mod, 'draw_if_interactive', do_nothing)
+    draw_if_interactive = getattr(backend_mod, 'draw_if_interactive',
+                                  do_nothing)
 
     matplotlib.verbose.report('backend %s version %s' %
                               (name, backend_version))

--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -40,10 +40,12 @@ def pylab_setup(name=None):
     '''
     # Import the requested backend into a generic module object
     if name is None:
+        # validates, to match all_backends
+        name = matplotlib.get_backend()
         # need to keep a global reference to the backend for compatibility
         # reasons. See https://github.com/matplotlib/matplotlib/issues/6092
         global backend
-        name = backend
+        backend = name
     if name.startswith('module://'):
         backend_name = name[9:]
     else:

--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -8,7 +8,10 @@ import inspect
 import warnings
 
 
-def pylab_setup(backend=None):
+backend = matplotlib.get_backend()
+
+
+def pylab_setup(name=None):
     '''return new_figure_manager, draw_if_interactive and show for pyplot
 
     This provides the backend-specific functions that are used by
@@ -16,7 +19,7 @@ def pylab_setup(backend=None):
 
     Parameters
     ----------
-    backend : str, optional
+    name : str, optional
         The name of the backend to use.  If `None`, falls back to
         ``matplotlib.get_backend()`` (which return ``rcParams['backend']``)
 
@@ -26,30 +29,31 @@ def pylab_setup(backend=None):
         The module which contains the backend of choice
 
     new_figure_manager : function
-        Create a new figure manage (roughly maps to GUI window)
+        Create a new figure manager (roughly maps to GUI window)
 
     draw_if_interactive : function
         Redraw the current figure if pyplot is interactive
 
     show : function
-        Show (and possible block) any unshown figures.
+        Show (and possibly block) any unshown figures.
 
     '''
     # Import the requested backend into a generic module object
-    if backend is None:
-        backend = matplotlib.get_backend()  # validates, to match all_backends
-
-    if backend.startswith('module://'):
-        backend_name = backend[9:]
+    if name is None:
+        # need to keep a global reference to the backend for compatibility
+        # reasons. See https://github.com/matplotlib/matplotlib/issues/6092
+        global backend
+        name = backend
+    if name.startswith('module://'):
+        backend_name = name[9:]
     else:
-        backend_name = 'backend_' + backend
+        backend_name = 'backend_' + name
         backend_name = backend_name.lower()  # until we banish mixed case
         backend_name = 'matplotlib.backends.%s' % backend_name.lower()
 
     # the last argument is specifies whether to use absolute or relative
     # imports. 0 means only perform absolute imports.
-    backend_mod = __import__(backend_name, globals(), locals(),
-                             [backend_name], 0)
+    backend_mod = __import__(backend_name, globals(), locals(), [backend_name], 0)
 
     # Things we pull in from all backends
     new_figure_manager = backend_mod.new_figure_manager
@@ -65,20 +69,18 @@ def pylab_setup(backend=None):
 Your currently selected backend, '%s' does not support show().
 Please select a GUI backend in your matplotlibrc file ('%s')
 or with matplotlib.use()""" %
-                          (backend, matplotlib.matplotlib_fname()))
+                          (name, matplotlib.matplotlib_fname()))
 
     def do_nothing(*args, **kwargs):
         pass
 
-    backend_version = getattr(backend_mod, 'backend_version',
-                              'unknown')
+    backend_version = getattr(backend_mod, 'backend_version', 'unknown')
 
     show = getattr(backend_mod, 'show', do_nothing_show)
 
-    draw_if_interactive = getattr(backend_mod, 'draw_if_interactive',
-                                  do_nothing)
+    draw_if_interactive = getattr(backend_mod, 'draw_if_interactive', do_nothing)
 
     matplotlib.verbose.report('backend %s version %s' %
-                              (backend, backend_version))
+                              (name, backend_version))
 
     return backend_mod, new_figure_manager, draw_if_interactive, show

--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -42,10 +42,6 @@ def pylab_setup(name=None):
     if name is None:
         # validates, to match all_backends
         name = matplotlib.get_backend()
-        # need to keep a global reference to the backend for compatibility
-        # reasons. See https://github.com/matplotlib/matplotlib/issues/6092
-        global backend
-        backend = name
     if name.startswith('module://'):
         backend_name = name[9:]
     else:
@@ -85,4 +81,8 @@ or with matplotlib.use()""" %
     matplotlib.verbose.report('backend %s version %s' %
                               (name, backend_version))
 
+    # need to keep a global reference to the backend for compatibility
+    # reasons. See https://github.com/matplotlib/matplotlib/issues/6092
+    global backend
+    backend = name
     return backend_mod, new_figure_manager, draw_if_interactive, show


### PR DESCRIPTION
The removal of the module level 'backend' broke ipython's pylab code.  @tacaswell can you have a look?  Renamed the `pylab_setup()` kwarg to `name`, so that `backend` could be a global in this function.

Closes #6092