### PR TITLE
Update installing_faq.rst

### DIFF
--- a/doc/faq/installing_faq.rst
+++ b/doc/faq/installing_faq.rst
@@ -246,8 +246,8 @@ You can now install matplotlib and all its dependencies with::
 
     pip install matplotlib
 
-Macports
-^^^^^^^^
+Macports Python
+^^^^^^^^^^^^^^^
 
 For Python 2.7::
 
@@ -259,8 +259,8 @@ For Python 3.4::
     sudo port install py34-pip
     sudo pip-3.4 install matplotlib
 
-Homebrew
-^^^^^^^^
+Homebrew Python
+^^^^^^^^^^^^^^^
 
 For Python 2.7::
 


### PR DESCRIPTION
clarifies that these instructions can be used when installing matplotlib for Python installed with Homebrew/Macports