### PR TITLE
[WiP] Brace arrowstyle

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3698,9 +3698,10 @@ class ArrowStyle(_Style):
             """
             *angle*
                 rotation in degrees (anti-clockwise)
+
             *bracetype*
-                'curly': a real }, with rounded corners made of quadratic
-                                   Bezier curves
+                'curly': a real curly bracket }, with rounded corners made of 
+                         quadratic Bezier curves
                 'straight': a simplified }, with the 7 control points p0...p6
                             simply linked with straight lines.
 
@@ -3732,22 +3733,18 @@ class ArrowStyle(_Style):
             v06 = 2*width * np.exp(1.j * angle * np.pi/180.)
             vtip = length * np.exp(1.j * (angle - 90.) * np.pi/180.)
 
-            # EXPOSE sym AND pad AS ARGUMENTS?
-            """
-            Remark: sym is not really useful here (one rapidly stumble into
-            weird behavior of the connection style).
-            """
-            sym = 0.5  # in [0., 1.]: p0--(sym)--tipstart----(1-sym)----p6
-            pad = min(sym/4., 0.1)  # min() to prevent issues with small sym
+            # Should pad be exposed?
+            # Might be useful in order to scale it accordingly to mutation_size
+            pad = 0.1
 
             p3 = x + 1.j*y
             # Define left side points recursively
             p2 = p3 - pad*v06 - 0.5*vtip
-            p1 = p2 - (sym - pad)*v06
+            p1 = p2 - (0.5 - pad)*v06  # Future: 0.5 <- symmetry param?
             p0 = p1 - pad*v06 - 0.5*vtip
             # Define right side points recursively
             p4 = p3 + pad*v06 - 0.5*vtip
-            p5 = p4 + (1. - sym - pad)*v06
+            p5 = p4 + (1. - 0.5 - pad)*v06  # Future: 0.5 <- symmetry param?
             p6 = p5 + pad*v06 - 0.5*vtip
 
             if bracetype == 'straight':

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3695,9 +3695,9 @@ class ArrowStyle(_Style):
             self.angleA, self.angleB = angleA, angleB
             self.scaleA, self.scaleB = scaleA, scaleB
 
-        # Declare it as a static method as it is also planned to be use to build
-        # a new type of patch that may be useful to annotate range of data.
-        # However, not sure the current arguments are the best suited for
+        # Declare it as a static method as it is also planned to be use to
+        # build a new type of patch that may be useful to annotate range of
+        # data. However, not sure the current arguments are the best suited for
         # that purpose. (Might be better to directly pass "length," p0 and p6.)
         #
         # Would it be better to define a module-level '_get_brace' function?
@@ -3709,12 +3709,12 @@ class ArrowStyle(_Style):
                 rotation in degrees (anti-clockwise)
 
             *bracetype*
-                'curly': a real curly bracket }, with rounded corners made of 
+                'curly': a real curly bracket }, with rounded corners made of
                          quadratic Bezier curves
                 'straight': a simplified }, with the 7 control points p0...p6
                             simply linked with straight lines.
 
-            Details of the basic design:
+            Details of the basic design::
                 p0                 p6   with vectors  (p0)-----v06---->(p6)
                   \____p2   p4____/                             |vtip
                   p1     \ /     p5                             v
@@ -3726,7 +3726,7 @@ class ArrowStyle(_Style):
                 * angle = arg(vector(p0 -> p6)) in degrees.
 
             Besides, if bracetype is 'curly', 3 supplementary control points
-            (p01, p24 and p56) are used:
+            (p01, p24 and p56) are used::
                  p0          p2__p24__p4          p6
                  | \    and    \  |  /    and    / |
                  |  \           \ | /           /  |
@@ -3769,7 +3769,7 @@ class ArrowStyle(_Style):
                 complex_pts = [p0, p1, p2, p3, p4, p5, p6]
 
                 vertices_brace = [(xy.real, xy.imag) for xy in complex_pts]
-                codes_brace = ([Path.MOVETO] + 
+                codes_brace = ([Path.MOVETO] +
                                [Path.LINETO]*(len(vertices_brace) - 1))
 
             elif bracetype == 'curly':
@@ -3952,7 +3952,8 @@ class ArrowStyle(_Style):
 
     class CurveABraceB(CurveA, BraceB):
             """
-            An arrow with a head at its begin point, and a brace at its end point.
+            An arrow with a head at its begin point, and a brace at its end
+            point.
             """
 
             def __init__(self, lengthA=.4, widthA=.2, fillA=False,
@@ -4015,7 +4016,6 @@ class ArrowStyle(_Style):
 
     _style_list["<-{"] = CurveABraceB
 
-
     # Would like to avoid creating yet another class that is exactly the same
     # as CurveABraceB but just with fillA = True. Tried to do something like:
     # _style_list["<|-{"] = CurveABraceB(fillA=True)
@@ -4047,7 +4047,6 @@ class ArrowStyle(_Style):
 
 # \WARNING
 ##########################################################################
-
 
     class BarAB(_Bracket):
         """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3695,15 +3695,15 @@ class ArrowStyle(_Style):
             self.angleA, self.angleB = angleA, angleB
             self.scaleA, self.scaleB = scaleA, scaleB
 
-        # Declare it as a class method as it is also planned to be use to build
+        # Declare it as a static method as it is also planned to be use to build
         # a new type of patch that may be useful to annotate range of data.
         # However, not sure the current arguments are the best suited for
         # that purpose. (Might be better to directly pass "length," p0 and p6.)
         #
         # Would it be better to define a module-level '_get_brace' function?
         #
-        @classmethod
-        def _get_brace(self, x, y, width, length, angle, bracetype):
+        @staticmethod
+        def _get_brace(x, y, width, length, angle, bracetype):
             """
             *angle*
                 rotation in degrees (anti-clockwise)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3946,7 +3946,7 @@ class ArrowStyle(_Style):
     _style_list["-{"] = BraceB
 
 ##########################################################################
-# WARNING: ABSOLUTELY NOT WARRANTY IT DOES WORK PROPERLY! 
+# WARNING: ABSOLUTELY NOT WARRANTY IT DOES WORK PROPERLY!
 # I am struggling understanding how to use super() in the case of multiple
 # inheritance...
 
@@ -4005,7 +4005,7 @@ class ArrowStyle(_Style):
                 # [_path_and_pathB, path_A_aka_arrow_head]
                 # but it seems the class is working fine...
                 # Anyway, it has to be this way, as _fillable also has to be a
-                # list to make the arrow head fillable (which the path and 
+                # list to make the arrow head fillable (which the path and
                 # the brace are not).
                 _complete_path, _fillable = self.transmuteA(_path_and_pathB,
                                                       mutation_size,

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3848,7 +3848,7 @@ class ArrowStyle(_Style):
 
     class BraceAB(_Brace):
         """
-        An arrow with a brace(}) at both ends.
+        An arrow with braces at both head and tail ("}-{").
         """
 
         def __init__(self,
@@ -3889,7 +3889,7 @@ class ArrowStyle(_Style):
 
     class BraceA(_Brace):
         """
-        An arrow with a brace(}) at its end.
+        An arrow with a brace at its head ("}-").
         """
 
         def __init__(self, widthA=1., lengthA=0.4, angleA=None,
@@ -3918,7 +3918,7 @@ class ArrowStyle(_Style):
 
     class BraceB(_Brace):
         """
-        An arrow with a brace({) at its end.
+        An arrow with a brace at its tail ("-{").
         """
 
         def __init__(self, widthB=1., lengthB=0.4, angleB=None,
@@ -3946,7 +3946,7 @@ class ArrowStyle(_Style):
     _style_list["-{"] = BraceB
 
 ##########################################################################
-# WARNING: ABSOLUTELY NOT WARRANTY IT DOES WORK PROPERLY!
+# WARNING: ABSOLUTELY NO WARRANTY IT DOES WORK PROPERLY!
 # I am struggling understanding how to use super() in the case of multiple
 # inheritance...
 
@@ -3956,7 +3956,7 @@ class ArrowStyle(_Style):
             """
 
             def __init__(self, lengthA=.4, widthA=.2, fillA=False,
-                               widthB=1., lengthB=0.4,
+                               lengthB=0.4, widthB=1.,
                                angleB=None, bracetypeB='curly'):
                 """
                 *lengthA*
@@ -3965,11 +3965,11 @@ class ArrowStyle(_Style):
                 *widthA*
                   width of the arrow head
 
-                *widthB*
-                  width of the brace
-
                 *lengthB*
                   length of the brace
+
+                *widthB*
+                  width of the brace
 
                 *angleB*
                   angle between the brace and the line
@@ -3980,11 +3980,11 @@ class ArrowStyle(_Style):
 
                 # Initialize every possible attributes.
                 super(ArrowStyle.CurveABraceB, self).__init__()
-                # Set manually the relevant parameters related to CurveA.
+                # Manually set the relevant parameters related to CurveA.
                 self.head_length = lengthA
                 self.head_width = widthA
                 self.fillbegin = fillA
-                # Set manually the relevant parameters related to BraceB
+                # Manually set the relevant parameters related to BraceB
                 self.widthB = widthB
                 self.lengthB = lengthB
                 self.angleB = angleB
@@ -3996,16 +3996,16 @@ class ArrowStyle(_Style):
                 self.transmuteB = super(ArrowStyle.BraceB, self).transmute
 
             def transmute(self, path, mutation_size, linewidth):
-                # Concatenate the path for the brace to the path from args.
+                # Concatenate the brace path to the path from args.
                 _path_and_pathB, _unused_fillable = self.transmuteB(path,
                                                              mutation_size,
                                                              linewidth)
 
-                # NB: _complete_path is actually be a list of 2 paths:
+                # NB: *_complete_path* is actually a list of 2 paths:
                 # [_path_and_pathB, path_A_aka_arrow_head]
                 # but it seems the class is working fine...
-                # Anyway, it has to be this way, as _fillable also has to be a
-                # list to make the arrow head fillable (which the path and
+                # Anyway, it has to be this way, as *_fillable* also has to be
+                # a list to make the arrow head fillable (and the path and
                 # the brace are not).
                 _complete_path, _fillable = self.transmuteA(_path_and_pathB,
                                                       mutation_size,
@@ -4017,10 +4017,12 @@ class ArrowStyle(_Style):
 
 
     # Would like to avoid creating yet another class that is exactly the same
-    # as CurveABraceB but just with fillA = True, by doing something like:
+    # as CurveABraceB but just with fillA = True. Tried to do something like:
     # _style_list["<|-{"] = CurveABraceB(fillA=True)
     # but then it raises this error:
     # NameError: global name 'ArrowStyle' is not defined
+    # I guess it is wrong anyway, as this new item would be an instance, while
+    # the others aren't.
     #
     # So in the meantime, here is a workaround:
     class _CurveFilledABraceB(CurveABraceB):
@@ -4034,7 +4036,7 @@ class ArrowStyle(_Style):
                                angleB=None, bracetypeB='curly'):
                 super(ArrowStyle._CurveFilledABraceB, self).__init__(
                                 lengthA=lengthA, widthA=widthA, fillA=fillA,
-                                widthB=widthB, lengthB=lengthB,
+                                lengthB=lengthB, widthB=widthB,
                                 angleB=angleB, bracetypeB=bracetypeB)
 
     _style_list["<|-{"] = _CurveFilledABraceB


### PR DESCRIPTION
**[2017-03-08] Edit:** Removing for the `need_review` flag for the moment as the code is actually not totally finished. I would qualify the PR of “WiP”, eventhough I am not currently actively working on it… This PR (or a “rebirth” version) might be part of the  arrow plotting overhaul that @dstansby is willing to initiate :).

### Generalities

PR that was mentioned in #6112 , about adding a new arrowstyle with curly brackets for head or tail. It is mainly targeted for use with `FancyArrowPatch` (as the other arrowstyles), with the style names "}-" for `BraceA`, "-{" for `BraceB`, and "}-{" for `BraceAB`. I implemented it for myself as I missed a few times such a feature and had to use Inkscape to add this kind of annotation to my figures. 

Since #6112 , I finally got working what I really wanted: arrowstyle "<-{", aka `CurveABraceB`. It seems to do what I want (an arrow with a normal head and a brace at the other side) but unfortunately, I have difficulties to understand how `super()` works (especially with multpile inheritance), so the review of `__init__` in  `CurveABraceB` is liketo to end up with changes. (See the last ~100 lines of the commit)

Furthermore, supplementary variations with straight braces are accessible by initializing the instance with one or two args to "straight". However, I didn't set dedicated stylenames for these versions, as the list of stylenames is already slightly long.

Here are some examples of what is currently achievable with these new arrowstyles:
![test_brace_arrowstyles](https://cloud.githubusercontent.com/assets/17270724/13555429/8a6017e0-e3c0-11e5-88b7-cee0a44ac497.png)
### Interrogations (some details are in the commit comments)

The computation of the brace (with lines and quadratic Bezier curves) is done in the method `_get_brace`.  I tried to explain the construction of the brace as clearly as I could: the docstring may appear a bit long... Besides , I internally use a parameter `pad` that one may want to expose as an argument.

I have used a @staticmethod decorator for `_get_brace`, because I may implement a new patch `BracePatch` that would also use it. For example, such a patch might be used to annotate a range of data. Unfortunately, I don't know when I will have time to try this.

It is planned to update the relevant unit test once review will have been done.
### Appendix

The code used to generate to previous figure, adapted from the documentation:

``` python
import matplotlib.patches as mpatches
import matplotlib.pyplot as plt

plt.ion()

#styles = mpatches.ArrowStyle.get_styles()
styles = {"}-": mpatches.ArrowStyle.BraceA(),
          "}-{": mpatches.ArrowStyle.BraceAB(),
          "-{": mpatches.ArrowStyle.BraceB(),
          "<-{": mpatches.ArrowStyle.CurveABraceB(),
          "<|-{": mpatches.ArrowStyle._CurveFilledABraceB(),
          # The same arrowstyles, but with "straight braces
          "--straight }-": mpatches.ArrowStyle.BraceA(bracetypeA='straight'),
          "--straight }-{": mpatches.ArrowStyle.BraceAB(bracetypeA='straight',
                                              bracetypeB='straight'),
          "--straight -{": mpatches.ArrowStyle.BraceB(bracetypeB='straight'),
          "--straight <-{": mpatches.ArrowStyle.CurveABraceB(
                                              bracetypeB='straight'),
          "--straight <|-{": mpatches.ArrowStyle._CurveFilledABraceB(
                                              bracetypeB='straight')
        }

ncol = 2
nrow = (len(styles) + 1) // ncol
figheight = (nrow + 0.5)
fig1 = plt.figure("Test_brace_arrowstyles", (2*4.*ncol/1.5, 2*figheight/1.5))
fig1.clf()
fontsize = 2*0.2 * 70

ax = fig1.add_axes([0, 0, 1, 1], frameon=False, aspect=1.)
ax.set_xlim(0, 4*ncol)
ax.set_ylim(0, figheight)

def to_texstring(s):
    s = s.replace("<", r"$<$")
    s = s.replace(">", r"$>$")
    s = s.replace("|", r"$|$")
    s = s.replace("{", r"$\{$")
    s = s.replace("}", r"$\}$")
    s = s.replace("--", "")  # trick, used to sort the 'straight' versions
    return s

# Sort with reverse = True to force straight into the second column
for i, (stylename, styleclass) in enumerate(sorted(styles.items(),
                                                   reverse=True)):

    x = 3.2 + (i//nrow)*4
    y = (figheight - 0.7 - i % nrow)  # /figheight
    p = mpatches.Circle((x, y), 0.2, fc="w", lw=1) # WEIRD: Had to add lw=1
    ax.add_patch(p)

    ax.annotate(to_texstring(stylename), (x, y),
                (x - 1.2, y),
                #xycoords="figure fraction", textcoords="figure fraction",
                ha="right", va="center",
                size=fontsize,
                arrowprops=dict(arrowstyle=styleclass,
                                patchB=p,
                                shrinkA=2*5,  # doubled to avoid collisions
                                shrinkB=2*5,  # with the textbox or the circle
                                fc="CornFlowerBlue", ec="k",
                                connectionstyle="arc3,rad=-0.05",
                                ),
                bbox=dict(boxstyle="square", fc="w"))

ax.xaxis.set_visible(False)
ax.yaxis.set_visible(False)

plt.draw()
plt.show()

```
