### PR TITLE
docstring added

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -412,6 +412,12 @@ class Table(Artist):
         """ Given column indexs in either List, Tuple or int. Will be able to
         automatically set the columns into optimal sizes.
 
+        Here is the example of the input, which triger automatic adjustment on 
+        column to optimal size by given index numbers.
+        -1: the row labling
+        0: the 1st column
+        1: the 2nd column
+
         Args:
             col(List): list of indexs
             >>>table.auto_set_column_width([-1,0,1])

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -413,7 +413,7 @@ class Table(Artist):
         automatically set the columns into optimal sizes.
 
         Here is the example of the input, which triger automatic adjustment on
-        column to optimal size by given index numbers.
+        columns to optimal size by given index numbers.
         -1: the row labling
         0: the 1st column
         1: the 2nd column

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -412,7 +412,7 @@ class Table(Artist):
         """ Given column indexs in either List, Tuple or int. Will be able to
         automatically set the columns into optimal sizes.
 
-        Here is the example of the input, which triger automatic adjustment on 
+        Here is the example of the input, which triger automatic adjustment on
         column to optimal size by given index numbers.
         -1: the row labling
         0: the 1st column

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -409,7 +409,21 @@ class Table(Artist):
             cell.set_y(bottoms[row])
 
     def auto_set_column_width(self, col):
+        """ Given column indexs in either List, Tuple or int. Will be able to
+        automatically set the columns into optimal sizes.
 
+        Args:
+            col(List): list of indexs
+            >>>table.auto_set_column_width([-1,0,1])
+
+            col(Tuple): tuple of indexs
+            >>>table.auto_set_column_width((-1,0,1))
+
+            col(int): index integer
+            >>>table.auto_set_column_width(-1)
+            >>>table.auto_set_column_width(0)
+            >>>table.auto_set_column_width(1)
+        """
         # check for col possibility on iteration
         try:
             iter(col)


### PR DESCRIPTION
Table: auto_set_column_width not working [#6047](https://github.com/matplotlib/matplotlib/pull/6047)

doc string has added.
**method description**
```python
""" Given column indexs in either List, Tuple or int. Will be able to
       automatically set the columns into optimal sizes.
```
**method example**
```python
Args:
    col(List): list of indexs
    >>>table.auto_set_column_width([-1,0,1])

    col(Tuple): tuple of indexs
    >>>table.auto_set_column_width((-1,0,1))

    col(int): index integer
    >>>table.auto_set_column_width(-1)
    >>>table.auto_set_column_width(0)
    >>>table.auto_set_column_width(1)
"""
```