### PR TITLE
Fixed outdated link to thirdpartypackages, and simplified the page

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -166,8 +166,8 @@ changes</a> file.</p>
 
 <h1>Third party packages</h1>
 
-<p>A large number of third party <a href="{{ pathto('mpl_toolkits/index') }}">packages</a>
-    extend and build on Matplotlib functionality.  This includes several higher-level plotting interfaces;
+<p>A large number of <a href="{{ pathto('thirdpartypackages/index') }}">third party packages</a>
+    extend and build on Matplotlib functionality, including several higher-level plotting interfaces
     <a href="http://web.stanford.edu/~mwaskom/software/seaborn">seaborn</a>,
     <a href="http://holoviews.org">holoviews</a>,
     <a href="http://ggplot.yhathq.com">ggplot</a>, and

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -5,15 +5,133 @@
 *********************
 
 Several external packages that extend or build on Matplotlib functionality
-exist. Below we list a number of these. Please submit an issue or pull request
+exist. Below we list a number of these. Note that they are each
+maintained and distributed separately from Matplotlib, and will need
+to be installed individually.
+
+Please submit an issue or pull request
 on Github if you have created a package that you would like to have included.
 We are also happy to host third party packages within the `Matplotlib Github
 Organization <https://github.com/matplotlib>`_.
 
+.. _hl_plotting:
+
+High-Level Plotting
+*******************
+
+Several projects provide higher-level interfaces for creating
+matplotlib plots.
+
+.. _toolkit_seaborn:
+
+seaborn
+=======
+
+`seaborn <http://web.stanford.edu/~mwaskom/software/seaborn>`_ is a high
+level interface for drawing statistical graphics with matplotlib. It
+aims to make visualization a central part of exploring and
+understanding complex datasets.
+
+.. image:: /_static/seaborn.png
+    :height: 157px
+
+.. _toolkit_ggplot:
+
+ggplot
+======
+
+`ggplot <https://github.com/yhat/ggplot>`_ is a port of the R ggplot2 package
+to python based on matplotlib.
+
+.. image:: /_static/ggplot.png
+    :height: 195px
+
+.. _toolkit_holoviews:
+
+holoviews
+=========
+
+`holoviews <http://holoviews.org>`_ makes it easier to visualize data
+interactively, especially in a `Jupyter notebook
+<http://jupyter.org>`_, by providing a set of declarative
+plotting objects that store your data and associated metadata.  Your
+data is then immediately visualizable alongside or overlaid with other
+data, either statically or with automatically provided widgets for
+parameter exploration.
+
+.. image:: /_static/holoviews.png
+    :height: 354px
+
+
+.. _toolkits-mapping:
+
+Mapping Toolkits
+****************
+
+Two independent mapping toolkits are available.
+
+.. _toolkit_basemap:
+
+Basemap
+=======
+
+Plots data on map projections, with continental and political
+boundaries. See `basemap <http://matplotlib.org/basemap>`_
+docs.
+
+.. image:: /_static/basemap_contour1.png
+    :height: 400px
+
+
+
+Cartopy
+=======
+`Cartopy <http://scitools.org.uk/cartopy/docs/latest>`_ builds on top of
+matplotlib to provide object oriented map projection definitions and close
+integration with Shapely for powerful yet easy-to-use vector data processing
+tools. An example plot from the
+`Cartopy gallery <http://scitools.org.uk/cartopy/docs/latest/gallery.html>`_:
+
+.. image:: /_static/cartopy_hurricane_katrina_01_00.png
+    :height: 400px
+
+
+.. _toolkits-misc:
 .. _toolkits-general:
 
-General Toolkits
-****************
+Miscellaneous Toolkits
+**********************
+
+
+.. _toolkit_prettyplotlib:
+
+prettyplotlib
+=============
+
+`prettyplotlib <https://olgabot.github.io/prettyplotlib>`_ is an extension
+to matplotlib which changes many of the defaults to make plots some
+consider more attractive.
+
+.. _toolkit_probscale:
+
+mpl-probscale
+=============
+`mpl-probscale <http://phobson.github.io/mpl-probscale/index.html>`_
+is a small extension that allows matplotlib users to specify probabilty
+scales. Simply importing the ``probscale`` module registers the scale
+with matplotlib, making it accessible via e.g.,
+``ax.set_xscale('prob')`` or ``plt.yscale('prob')``.
+
+.. image:: /_static/probscale_demo.png
+
+iTerm2 terminal backend
+=======================
+
+`matplotlib_iterm2 <https://github.com/oselivanov/matplotlib_iterm2>`_ is an
+external matplotlib backend using iTerm2 nightly build inline image display
+feature.
+
+.. image:: /_static/matplotlib_iterm2_demo.png
 
 
 .. _toolkit_mpldatacursor:
@@ -47,117 +165,3 @@ mplstereonet
 ===============
 
 `mplstereonet <https://github.com/joferkington/mplstereonet>`_ provides stereonets for plotting and analyzing orientation data in Matplotlib.
-
-
-.. _hl_plotting:
-
-High-Level Plotting
-*******************
-
-Several projects have started to provide a higher-level interface to
-matplotlib.  These are independent projects.
-
-.. _toolkit_seaborn:
-
-seaborn
-=======
-
-`seaborn <http://web.stanford.edu/~mwaskom/software/seaborn>`_ is a high
-level interface for drawing statistical graphics with matplotlib. It
-aims to make visualization a central part of exploring and
-understanding complex datasets.
-
-.. image:: /_static/seaborn.png
-    :height: 157px
-
-.. _toolkit_ggplot:
-
-ggplot
-======
-
-`ggplot <https://github.com/yhat/ggplot>`_ is a port of the R ggplot2
-to python based on matplotlib.
-
-.. image:: /_static/ggplot.png
-    :height: 195px
-
-.. _toolkit_holoviews:
-
-holoviews
-=========
-
-
-`holoviews <http://holoviews.org>`_ makes it easier to visualize data
-interactively, especially in a `Jupyter notebook
-<http://jupyter.org>`_, by providing a set of declarative
-plotting objects that store your data and associated metadata.  Your
-data is then immediately visualizable alongside or overlaid with other
-data, either statically or with automatically provided widgets for
-parameter exploration.
-
-.. image:: /_static/holoviews.png
-    :height: 354px
-
-.. _toolkit_prettyplotlib:
-
-prettyplotlib
-=============
-
-`prettyplotlib <https://olgabot.github.io/prettyplotlib>`_ is an extension
-to matplotlib which changes many of the defaults to make plots some
-consider more attractive.
-
-.. _toolkit_probscale:
-
-mpl-probscale
-=============
-`mpl-probscale <http://phobson.github.io/mpl-probscale/index.html>`_
-is a small extension that allows matplotlib users to specify probabilty
-scales. Simply importing the ``probscale`` module registers the scale
-with matplotlib, making it accessible via e.g.,
-``ax.set_xscale('prob')`` or ``plt.yscale('prob')``.
-
-.. image:: /_static/probscale_demo.png
-
-iTerm2 terminal backend
-=======================
-
-`matplotlib_iterm2 <https://github.com/oselivanov/matplotlib_iterm2>`_ is an
-external matplotlib backend using iTerm2 nightly build inline image display
-feature.
-
-.. image:: /_static/matplotlib_iterm2_demo.png
-
-
-.. _toolkits-mapping:
-
-Mapping Toolkits
-****************
-
-
-.. _toolkit_basemap:
-
-Basemap
-=======
-
-Plots data on map projections, with continental and political
-boundaries, see `basemap <http://matplotlib.org/basemap>`_
-docs.
-
-.. image:: /_static/basemap_contour1.png
-    :height: 400px
-
-
-
-Cartopy
-=======
-
-An alternative mapping library written for matplotlib ``v1.2`` and beyond.
-`Cartopy <http://scitools.org.uk/cartopy/docs/latest>`_ builds on top of
-matplotlib to provide object oriented map projection definitions and close
-integration with Shapely for powerful yet easy-to-use vector data processing
-tools. An example plot from the
-`Cartopy gallery <http://scitools.org.uk/cartopy/docs/latest/gallery.html>`_:
-
-.. image:: /_static/cartopy_hurricane_katrina_01_00.png
-    :height: 400px


### PR DESCRIPTION
This PR replaces https://github.com/matplotlib/matplotlib/pull/6088, which has been superseded by events.  PR #6088 can now be closed.  The updated web pages should be essentially the same as produced by that PR:

  http://homepages.inf.ed.ac.uk/jbednar/mpl2/index.html

  http://homepages.inf.ed.ac.uk/jbednar/mpl2/thirdpartypackages/index.html