### PR TITLE
Fix: Pandas indexing Error in collections

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -151,7 +151,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         except TypeError:
             if cbook.iterable(val) and len(val):
                 try:
-                    float(val[0])
+                    float(cbook.safe_first_element(val))
                 except (TypeError, ValueError):
                     pass  # raise below
                 else:
@@ -164,7 +164,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if not cbook.iterable(val):
             val = (val,)
         try:
-            bool(val[0])
+            bool(cbook.safe_first_element(val))
         except (TypeError, IndexError):
             raise TypeError('val must be a bool or nonzero sequence of them')
         return val

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -11,11 +11,12 @@ import io
 from nose.tools import assert_equal
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
+from nose.plugins.skip import SkipTest
 
 import matplotlib.pyplot as plt
 import matplotlib.collections as mcollections
 import matplotlib.transforms as mtransforms
-from matplotlib.collections import EventCollection
+from matplotlib.collections import Collection, EventCollection
 from matplotlib.testing.decorators import cleanup, image_comparison
 
 
@@ -615,6 +616,25 @@ def test_size_in_xy():
 
     ax.set_xlim(0, 30)
     ax.set_ylim(0, 30)
+
+
+def test_pandas_indexing():
+    try:
+        import pandas as pd
+    except ImportError:
+        raise SkipTest("Pandas not installed")
+
+    # Should not fail break when faced with a
+    # non-zero indexed series
+    index = [11, 12, 13]
+    ec = fc = pd.Series(['red', 'blue', 'green'], index=index)
+    lw = pd.Series([1, 2, 3], index=index)
+    aa = pd.Series([True, False, True], index=index)
+
+    Collection(edgecolors=ec)
+    Collection(facecolors=fc)
+    Collection(linewidths=lw)
+    Collection(antialiaseds=aa)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Specifically, when creating collection objects,
`linewidths` and `antialiaseds` can be non zero indexed
pandas series.

Related to: PR #5556