### PR TITLE
FIX: deal with negative canvas dimension in Qt

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -172,6 +172,9 @@ class FigureCanvasQTAggBase(object):
             QtCore.QTimer.singleShot(0, self.__draw_idle_agg)
 
     def __draw_idle_agg(self, *args):
+        if self.height() < 0 or self.width() < 0:
+            self._agg_draw_pending = False
+            return
         try:
             FigureCanvasAgg.draw(self)
             self.update()


### PR DESCRIPTION
In some cases Qt may report having a negative height (and presumably
width) in the case of minimizing windows / widgets.  This causes issues
at the Agg layer when the re-size triggers a re-draw which tries to get
a renderer with a negative dimension (segfaults or OutOfMemory errors).

reported via https://stackoverflow.com/questions/35977326/a-figurecanvasqtagg-nested-in-a-qmdisubwindow-segfaults-when-i-minimize-the-qmdi