### PR TITLE
Bug: Fixed regression of `drawstyle=None`

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -985,6 +985,8 @@ class Line2D(Artist):
         ACCEPTS: ['default' | 'steps' | 'steps-pre' | 'steps-mid' |
                   'steps-post']
         """
+        if drawstyle is None:
+            drawstyle = 'default'
         if drawstyle not in self.drawStyles:
             raise ValueError('Unrecognized drawstyle ' +
                              ' '.join(self.drawStyleKeys))

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -123,7 +123,7 @@ def test_drawstyle_variants():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
     for ds in ("default", "steps-mid", "steps-pre", "steps-post",
-               "steps"):
+               "steps", None):
         ax.plot(range(10), drawstyle=ds)
 
     fig.canvas.draw()


### PR DESCRIPTION
Minor fixup to #6145. Apparently this requires a separate PR since reopening the branch does not reopen the old PR.