### PR TITLE
Fix: pandas series of strings

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -715,6 +715,17 @@ def is_sequence_of_strings(obj):
     return True
 
 
+def is_hashable(obj):
+    """
+    Returns true if *obj* can be hashed
+    """
+    try:
+        hash(obj)
+    except TypeError:
+        return False
+    return True
+
+
 def is_writable_file_like(obj):
     'return true if *obj* looks like a file object with a *write* method'
     return hasattr(obj, 'write') and six.callable(obj.write)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -532,7 +532,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             The line style.
         """
         try:
-            if cbook.is_string_like(ls):
+            if cbook.is_string_like(ls) and cbook.is_hashable(ls):
                 ls = cbook.ls_mapper.get(ls, ls)
                 dashes = [mlines.get_dash_pattern(ls)]
             elif cbook.iterable(ls):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -821,7 +821,8 @@ class ListedColormap(Colormap):
         if N is None:
             N = len(self.colors)
         else:
-            if cbook.is_string_like(self.colors):
+            if (cbook.is_string_like(self.colors) and
+                    cbook.is_hashable(self.colors)):
                 self.colors = [self.colors] * N
                 self.monochrome = True
             elif cbook.iterable(self.colors):

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -48,6 +48,14 @@ def test_is_sequence_of_strings():
     assert cbook.is_sequence_of_strings(y)
 
 
+def test_is_hashable():
+    s = 'string'
+    assert cbook.is_hashable(s)
+
+    lst = ['list', 'of', 'stings']
+    assert not cbook.is_hashable(lst)
+
+
 def test_restrict_dict():
     d = {'foo': 'bar', 1: 2}
     d1 = cbook.restrict_dict(d, ['foo', 1])

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -629,11 +629,13 @@ def test_pandas_indexing():
     index = [11, 12, 13]
     ec = fc = pd.Series(['red', 'blue', 'green'], index=index)
     lw = pd.Series([1, 2, 3], index=index)
+    ls = pd.Series(['solid', 'dashed', 'dashdot'], index=index)
     aa = pd.Series([True, False, True], index=index)
 
     Collection(edgecolors=ec)
     Collection(facecolors=fc)
     Collection(linewidths=lw)
+    Collection(linestyles=ls)
     Collection(antialiaseds=aa)
 
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -6,9 +6,11 @@ import itertools
 from distutils.version import LooseVersion as V
 
 from nose.tools import assert_raises, assert_equal, assert_true
+from nose.tools import assert_sequence_equal
 
 import numpy as np
 from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
+from nose.plugins.skip import SkipTest
 
 import matplotlib.colors as mcolors
 import matplotlib.cm as cm
@@ -561,6 +563,22 @@ def _azimuth2math(azimuth, elevation):
     theta = np.radians((90 - azimuth) % 360)
     phi = np.radians(90 - elevation)
     return theta, phi
+
+
+def test_pandas_iterable():
+    try:
+        import pandas as pd
+    except ImportError:
+        raise SkipTest("Pandas not installed")
+
+    # Using a list or series yields equivalent
+    # color maps, i.e the series isn't seen as
+    # a single color
+    lst = ['red', 'blue', 'green']
+    s = pd.Series(lst)
+    cm1 = mcolors.ListedColormap(lst, N=5)
+    cm2 = mcolors.ListedColormap(s, N=5)
+    assert_sequence_equal(cm1.colors, cm2.colors)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
*Problem*
Pandas series of strings exhibits string like behaviour
and it was being treated as a single string.

*Solution*
When requiring and identifying a single string, make sure
that the object can be hashed. This screens out the
series and lets them get rightly handled as sequences.