### PR TITLE
added modifier key tracking in MouseEvents

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1606,9 +1606,14 @@ class MouseEvent(LocationEvent):
     key : None, or str
         the key depressed when the mouse event triggered (see
         :class:`KeyEvent`)
+        Note: .key is only processed if the FigureCanvas received keyboard
+        focus. For safer retrieval of modifier keys use .modifiers instead
 
     step : scalar
         number of scroll steps (positive for 'up', negative for 'down')
+
+    modifiers : set
+        modifier keys depressed when mouse event is triggered
 
     Examples
     --------
@@ -1620,17 +1625,18 @@ class MouseEvent(LocationEvent):
         cid = fig.canvas.mpl_connect('button_press_event', on_press)
 
     """
-    x = None         # x position - pixels from left of canvas
-    y = None         # y position - pixels from right of canvas
-    button = None    # button pressed None, 1, 2, 3
-    dblclick = None  # whether or not the event is the result of a double click
-    inaxes = None    # the Axes instance if mouse us over axes
-    xdata = None     # x coord of mouse in data coords
-    ydata = None     # y coord of mouse in data coords
-    step = None      # scroll steps for scroll events
+    x = None          # x position - pixels from left of canvas
+    y = None          # y position - pixels from right of canvas
+    button = None     # button pressed None, 1, 2, 3
+    dblclick = None   # whether or not the event is the result of a double click
+    inaxes = None     # the Axes instance if mouse us over axes
+    xdata = None      # x coord of mouse in data coords
+    ydata = None      # y coord of mouse in data coords
+    step = None       # scroll steps for scroll events
+    modifiers = None  # depressed modifier keys
 
     def __init__(self, name, canvas, x, y, button=None, key=None,
-                 step=0, dblclick=False, guiEvent=None):
+                 step=0, dblclick=False, guiEvent=None, modifiers=None):
         """
         x, y in figure coords, 0,0 = bottom, left
         button pressed None, 1, 2, 3, 'up', 'down'
@@ -1640,6 +1646,7 @@ class MouseEvent(LocationEvent):
         self.key = key
         self.step = step
         self.dblclick = dblclick
+        self.modifiers = modifiers
 
     def __str__(self):
         return ("MPL MouseEvent: xy=(%d,%d) xydata=(%s,%s) button=%s " +
@@ -1921,7 +1928,7 @@ class FigureCanvasBase(object):
                                 step=step, guiEvent=guiEvent)
         self.callbacks.process(s, mouseevent)
 
-    def button_press_event(self, x, y, button, dblclick=False, guiEvent=None):
+    def button_press_event(self, x, y, button, dblclick=False, guiEvent=None, modifiers=None):
         """
         Backend derived classes should call this function on any mouse
         button press.  x,y are the canvas coords: 0,0 is lower, left.
@@ -1932,8 +1939,9 @@ class FigureCanvasBase(object):
         """
         self._button = button
         s = 'button_press_event'
+
         mouseevent = MouseEvent(s, self, x, y, button, self._key,
-                                dblclick=dblclick, guiEvent=guiEvent)
+                                dblclick=dblclick, guiEvent=guiEvent, modifiers=modifiers)
         self.callbacks.process(s, mouseevent)
 
     def button_release_event(self, x, y, button, guiEvent=None):

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -163,6 +163,10 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
                65406 : 'alt',
                65289 : 'tab',
                }
+    modifier_keys = [[gdk.MOD4_MASK, 'super'],
+                     [gdk.MOD1_MASK, 'alt'],
+                     [gdk.CONTROL_MASK, 'ctrl'],
+                     [gdk.SHIFT_MASK, 'shift']]
 
     # Setting this as a static constant prevents
     # this resulting expression from leaking
@@ -250,7 +254,9 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
                 del self.last_downclick[event.button] # we do not want to eat more than one event.
                 return False                          # eat.
             self.last_downclick[event.button] = current_time
-        FigureCanvasBase.button_press_event(self, x, y, event.button, dblclick=dblclick, guiEvent=event)
+        modifiers = {prefix for key_mask, prefix in modifier_keys if event.state & key_mask}
+        FigureCanvasBase.button_press_event(self, x, y, event.button,
+                                            dblclick=dblclick, guiEvent=event, modifiers=modifiers)
         return False  # finish event propagation?
 
     def button_release_event(self, widget, event):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -151,6 +151,10 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
                65439 : 'dec',
                65421 : 'enter',
                }
+    modifier_keys = [[gdk.MOD4_MASK, 'super'],
+                     [gdk.MOD1_MASK, 'alt'],
+                     [gdk.CONTROL_MASK, 'ctrl'],
+                     [gdk.SHIFT_MASK, 'shift']]
 
     # Setting this as a static constant prevents
     # this resulting expression from leaking
@@ -212,7 +216,8 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         x = event.x
         # flipy so y=0 is bottom of canvas
         y = self.get_allocation().height - event.y
-        FigureCanvasBase.button_press_event(self, x, y, event.button, guiEvent=event)
+        modifiers = {prefix for key_mask, prefix in modifier_keys if event.state & key_mask}
+        FigureCanvasBase.button_press_event(self, x, y, event.button, guiEvent=event, modifiers=modifiers)
         return False  # finish event propagation?
 
     def button_release_event(self, widget, event):

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -237,17 +237,23 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     def mousePressEvent(self, event):
         x, y = self.mouseEventCoords(event.pos())
         button = self.buttond.get(event.button())
+        modifiers = {name for name, mod_key, qt_key in MODIFIER_KEYS
+                        if event.modifiers() & mod_key}
         if button is not None:
             FigureCanvasBase.button_press_event(self, x, y, button,
-                                                guiEvent=event)
+                                                guiEvent=event,
+                                                modifiers=modifiers)
 
     def mouseDoubleClickEvent(self, event):
         x, y = self.mouseEventCoords(event.pos())
         button = self.buttond.get(event.button())
+        modifiers = {name for name, mod_key, qt_key in MODIFIER_KEYS
+                        if event.modifiers() & mod_key}
         if button is not None:
             FigureCanvasBase.button_press_event(self, x, y,
                                                 button, dblclick=True,
-                                                guiEvent=event)
+                                                guiEvent=event,
+                                                modifiers=modifiers)
 
     def mouseMoveEvent(self, event):
         x, y = self.mouseEventCoords(event)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1004,6 +1004,19 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
 
         return key
 
+    def _get_modifiers(self, evt):
+        """
+        Extracts modifier keys from a wx MouseEvent
+        """
+        MOD_KEYS = {"AltDown": "alt",
+                    "CmdDown": "ctrl",
+                    "ControlDown": "ctrl",
+                    "ShiftDown": "shift"
+                    }
+        modifiers = {prefix for attr, prefix in MOD_KEYS
+                     if getattr(evt, attr)()}
+        return modifiers
+
     def _onKeyDown(self, evt):
         """Capture key press."""
         key = self._get_key(evt)
@@ -1034,7 +1047,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
         self._set_capture(True)
-        FigureCanvasBase.button_press_event(self, x, y, 3, guiEvent=evt)
+        modifiers = self._get_modifiers(evt)
+        FigureCanvasBase.button_press_event(self, x, y, 3,
+                                            guiEvent=evt,
+                                            modifiers=modifiers)
 
     def _onRightButtonDClick(self, evt):
         """Start measuring on an axis."""
@@ -1042,8 +1058,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
         self._set_capture(True)
+        modifiers = self._get_modifiers(evt)
         FigureCanvasBase.button_press_event(self, x, y, 3,
-                                            dblclick=True, guiEvent=evt)
+                                            dblclick=True, guiEvent=evt,
+                                            modifiers=modifiers)
 
     def _onRightButtonUp(self, evt):
         """End measuring on an axis."""
@@ -1059,7 +1077,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
         self._set_capture(True)
-        FigureCanvasBase.button_press_event(self, x, y, 1, guiEvent=evt)
+        modifiers = self._get_modifiers(evt)
+        FigureCanvasBase.button_press_event(self, x, y, 1,
+                                            guiEvent=evt,
+                                            modifiers=modifiers)
 
     def _onLeftButtonDClick(self, evt):
         """Start measuring on an axis."""
@@ -1067,8 +1088,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
         self._set_capture(True)
+        modifiers = self._get_modifiers(evt)
         FigureCanvasBase.button_press_event(self, x, y, 1,
-                                            dblclick=True, guiEvent=evt)
+                                            dblclick=True, guiEvent=evt,
+                                            modifiers=modifiers)
 
     def _onLeftButtonUp(self, evt):
         """End measuring on an axis."""
@@ -1086,7 +1109,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
         self._set_capture(True)
-        FigureCanvasBase.button_press_event(self, x, y, 2, guiEvent=evt)
+        modifiers = self._get_modifiers(evt)
+        FigureCanvasBase.button_press_event(self, x, y, 2,
+                                            guiEvent=evt,
+                                            modifiers=modifiers)
 
     def _onMiddleButtonDClick(self, evt):
         """Start measuring on an axis."""
@@ -1094,8 +1120,10 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
         self._set_capture(True)
+        modifiers = self._get_modifiers(evt)
         FigureCanvasBase.button_press_event(self, x, y, 2,
-                                            dblclick=True, guiEvent=evt)
+                                            dblclick=True, guiEvent=evt,
+                                            modifiers=modifiers)
 
     def _onMiddleButtonUp(self, evt):
         """End measuring on an axis."""

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2332,21 +2332,23 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     location = [self convertPoint: location fromView: nil];
     x = location.x * device_scale;
     y = location.y * device_scale;
+
+    unsigned int modifier = [event modifierFlags];
+    PyObject* modifiers = PySet_New(NULL);
+    if (modifier & NSControlKeyMask)
+        PySet_Add(modifiers, PyString_FromString("ctrl"));
+    if (modifier & NSAlternateKeyMask)
+        PySet_Add(modifiers, PyString_FromString("alt"));
+    if (modifier & NSShiftKeyMask)
+        PySet_Add(modifiers, PyString_FromString("shift"));
+    if (modifier & NSCommandKeyMask)
+        PySet_Add(modifiers, PyString_FromString("cmd"));
+
     switch ([event type])
     {    case NSLeftMouseDown:
-         {   unsigned int modifier = [event modifierFlags];
-             if (modifier & NSControlKeyMask)
-                 /* emulate a right-button click */
-                 num = 3;
-             else if (modifier & NSAlternateKeyMask)
-                 /* emulate a middle-button click */
-                 num = 2;
-             else
-             {
-                 num = 1;
-                 if ([NSCursor currentCursor]==[NSCursor openHandCursor])
+         {   if ([NSCursor currentCursor]==[NSCursor openHandCursor])
                      [[NSCursor closedHandCursor] set];
-             }
+             num = 1;
              break;
          }
          case NSOtherMouseDown: num = 2; break;
@@ -2357,7 +2359,8 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
       dblclick = 1;
     }
     gstate = PyGILState_Ensure();
-    result = PyObject_CallMethod(canvas, "button_press_event", "iiii", x, y, num, dblclick);
+    result = PyObject_CallMethod(canvas, "button_press_event", "iiii",
+                                 x, y, num, dblclick, Py_None, modifiers);
     if(result)
         Py_DECREF(result);
     else
@@ -2445,7 +2448,18 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     if ([event clickCount] == 2) {
       dblclick = 1;
     }
-    result = PyObject_CallMethod(canvas, "button_press_event", "iiii", x, y, num, dblclick);
+    unsigned int modifier = [event modifierFlags];
+    PyObject* modifiers = PySet_New(NULL);
+    if (modifier & NSControlKeyMask)
+        PySet_Add(modifiers, PyString_FromString("ctrl"));
+    if (modifier & NSAlternateKeyMask)
+        PySet_Add(modifiers, PyString_FromString("alt"));
+    if (modifier & NSShiftKeyMask)
+        PySet_Add(modifiers, PyString_FromString("shift"));
+    if (modifier & NSCommandKeyMask)
+        PySet_Add(modifiers, PyString_FromString("cmd"));
+    result = PyObject_CallMethod(canvas, "button_press_event", "iiii",
+                                 x, y, num, dblclick, Py_None, modifiers);
     if(result)
         Py_DECREF(result);
     else


### PR DESCRIPTION
Problem:
Currently, modifier keys in MouseEvents are only recognized if the FigureCanvas received a KeyEvent with the MouseEvent. However, in situations where the FigureCanvas does not receive keyboard focus, no KeyEvent is received, and thus the modifier-key is lost.

Solution
Modifier-key info should be carried in the MouseEvent created by a button_press_event. Add a modifiers field to mouse_events to track modifier-key status. I have updated the qt5 backend to account for this, but this can easily be extended to other backends. 
