### PR TITLE
Fix #5456: Keep margins <= .5 in tight_layout

### DIFF
--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -253,3 +253,17 @@ def test_tight_layout_offsetboxes():
                 child.set_visible(False)
 
     plt.tight_layout()
+
+
+def test_long_label():
+  '''
+  Test for 5456. When the label was too long we'd get a ValueError that
+  bottom cannot be >= top
+  '''
+  try:
+    fig, ax = plt.subplots()
+    ax.set_ylabel('a'*50000)
+    plt.tight_layout()
+  except ValueError:
+    assert False, "ValueError raised from long label"
+  

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -1,12 +1,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import matplotlib
 from matplotlib.externals import six
 import warnings
 
 import numpy as np
 
-from matplotlib.testing.decorators import image_comparison, knownfailureif
+from matplotlib.testing.decorators import (image_comparison, knownfailureif,
+                                           cleanup)
 import matplotlib.pyplot as plt
 from nose.tools import assert_raises
 from numpy.testing import assert_array_equal
@@ -255,10 +257,12 @@ def test_tight_layout_offsetboxes():
     plt.tight_layout()
 
 
+@cleanup
+@knownfailureif(not matplotlib.checkdep_tex(),
+                "This test needs a Tex installation")
 def test_long_label():
     '''
-    Test for 5456. When the label was too long we'd get a ValueError that
-    bottom cannot be >= top
+    Test for 5456. No ValueError when using very long label.
     '''
     try:
         fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -258,8 +258,6 @@ def test_tight_layout_offsetboxes():
 
 
 @cleanup
-@knownfailureif(not matplotlib.checkdep_tex(),
-                "This test needs a Tex installation")
 def test_long_label():
     '''
     Test for 5456. No ValueError when using very long label.

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -256,14 +256,13 @@ def test_tight_layout_offsetboxes():
 
 
 def test_long_label():
-  '''
-  Test for 5456. When the label was too long we'd get a ValueError that
-  bottom cannot be >= top
-  '''
-  try:
-    fig, ax = plt.subplots()
-    ax.set_ylabel('a'*50000)
-    plt.tight_layout()
-  except ValueError:
-    assert False, "ValueError raised from long label"
-  
+    '''
+    Test for 5456. When the label was too long we'd get a ValueError that
+    bottom cannot be >= top
+    '''
+    try:
+        fig, ax = plt.subplots()
+        ax.set_ylabel('a'*50000)
+        plt.tight_layout()
+    except ValueError:
+        assert False, "ValueError raised from long label"

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -165,22 +165,28 @@ def auto_adjust_subplotpars(fig, renderer,
 
     # margins can be negative for axes with aspect applied. And we
     # append + [0] to make minimum margins 0
+    # We must also ensure that maximum margins are .5 so that we do not
+    # end up with bottom >= top or left >= right
 
     if not margin_left:
         margin_left = max([sum(s) for s in hspaces[::cols + 1]] + [0])
         margin_left += pad_inches / fig_width_inch
+        margin_left = 0.5 if margin_left > 0.5 else margin_left
 
     if not margin_right:
         margin_right = max([sum(s) for s in hspaces[cols::cols + 1]] + [0])
         margin_right += pad_inches / fig_width_inch
+        margin_right = 0.499 if margin_right > 0.5 else margin_right
 
     if not margin_top:
         margin_top = max([sum(s) for s in vspaces[:cols]] + [0])
         margin_top += pad_inches / fig_height_inch
+        margin_top = 0.499 if margin_top > 0.5 else margin_top
 
     if not margin_bottom:
         margin_bottom = max([sum(s) for s in vspaces[-cols:]] + [0])
         margin_bottom += pad_inches / fig_height_inch
+        margin_bottom = 0.5 if margin_bottom > 0.5 else margin_bottom
 
     kwargs = dict(left=margin_left,
                   right=1 - margin_right,

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -171,22 +171,22 @@ def auto_adjust_subplotpars(fig, renderer,
     if not margin_left:
         margin_left = max([sum(s) for s in hspaces[::cols + 1]] + [0])
         margin_left += pad_inches / fig_width_inch
-        margin_left = 0.5 if margin_left > 0.5 else margin_left
+        margin_left = min(0.5, margin_left)
 
     if not margin_right:
         margin_right = max([sum(s) for s in hspaces[cols::cols + 1]] + [0])
         margin_right += pad_inches / fig_width_inch
-        margin_right = 0.499 if margin_right > 0.5 else margin_right
+        margin_right = min(0.499, margin_right)
 
     if not margin_top:
         margin_top = max([sum(s) for s in vspaces[:cols]] + [0])
         margin_top += pad_inches / fig_height_inch
-        margin_top = 0.499 if margin_top > 0.5 else margin_top
+        margin_top = min(0.499, margin_top)
 
     if not margin_bottom:
         margin_bottom = max([sum(s) for s in vspaces[-cols:]] + [0])
         margin_bottom += pad_inches / fig_height_inch
-        margin_bottom = 0.5 if margin_bottom > 0.5 else margin_bottom
+        margin_bottom = min(0.5, margin_bottom)
 
     kwargs = dict(left=margin_left,
                   right=1 - margin_right,


### PR DESCRIPTION
For #5456 added a check to keep margins < .5 to prevent an Exception
