### PR TITLE
fixed issue #5456

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3147,16 +3147,16 @@ class Axes(_AxesBase):
            If True produces boxes with the Patch artist
 
         showmeans : bool, default = False
-           If True, will toggle one the rendering of the means
+           If True, will toggle on the rendering of the means
 
         showcaps : bool, default = True
-           If True, will toggle one the rendering of the caps
+           If True, will toggle on the rendering of the caps
 
         showbox : bool, default = True
-           If True, will toggle one the rendering of box
+           If True, will toggle on the rendering of the box
 
         showfliers : bool, default = True
-           If True, will toggle one the rendering of the fliers
+           If True, will toggle on the rendering of the fliers
 
         boxprops : dict or None (default)
            If provided, will set the plotting style of the boxes
@@ -3412,16 +3412,16 @@ class Axes(_AxesBase):
           If `True`, will produce a notched box plot
 
         showmeans : bool, default = False
-          If `True`, will toggle one the rendering of the means
+          If `True`, will toggle on the rendering of the means
 
         showcaps  : bool, default = True
-          If `True`, will toggle one the rendering of the caps
+          If `True`, will toggle on the rendering of the caps
 
         showbox  : bool, default = True
-          If `True`, will toggle one the rendering of box
+          If `True`, will toggle on the rendering of the box
 
         showfliers : bool, default = True
-          If `True`, will toggle one the rendering of the fliers
+          If `True`, will toggle on the rendering of the fliers
 
         boxprops : dict or None (default)
           If provided, will set the plotting style of the boxes
@@ -6225,7 +6225,6 @@ class Axes(_AxesBase):
             # we return patches, so put it back in the expected order
             patches.reverse()
 
-            # adopted from adjust_x/ylim part of the bar method
             if orientation == 'horizontal':
                 xmin0 = max(_saved_bounds[0]*0.9, minimum)
                 xmax = self.dataLim.intervalx[1]
@@ -6237,16 +6236,23 @@ class Axes(_AxesBase):
                 xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
             elif orientation == 'vertical':
-                ymin0 = max(_saved_bounds[1]*0.9, minimum)
-                ymax = self.dataLim.intervaly[1]
 
-                for m in n:
-                    if np.sum(m) > 0:  # make sure there are counts
-                        ymin = np.amin(m[m != 0])
-                        # filter out the 0 height bins
-                ymin = max(ymin*0.9, minimum) if not input_empty else minimum
-                ymin = min(ymin0, ymin)
-                self.dataLim.intervaly = (ymin, ymax)
+                # If norm, autoscale axis
+                # fixed bug for #4414
+                if normed:
+                    self.set_autoscaley_on(True)
+                else:
+                    ymin0 = max(_saved_bounds[1]*0.9, minimum)
+                    ymax = self.dataLim.intervaly[1]
+
+                    for m in n:
+                        if np.sum(m) > 0:  # make sure there are counts
+                            ymin = np.amin(m[m != 0])
+                            # filter out the 0 height bins
+                    ymin = max(ymin*0.9, minimum) if not input_empty else minimum
+                    ymin = min(ymin0, ymin)
+                    self.dataLim.intervaly = (ymin, ymax)
+
 
         if label is None:
             labels = [None]

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3147,16 +3147,16 @@ class Axes(_AxesBase):
            If True produces boxes with the Patch artist
 
         showmeans : bool, default = False
-           If True, will toggle on the rendering of the means
+           If True, will toggle one the rendering of the means
 
         showcaps : bool, default = True
-           If True, will toggle on the rendering of the caps
+           If True, will toggle one the rendering of the caps
 
         showbox : bool, default = True
-           If True, will toggle on the rendering of the box
+           If True, will toggle one the rendering of box
 
         showfliers : bool, default = True
-           If True, will toggle on the rendering of the fliers
+           If True, will toggle one the rendering of the fliers
 
         boxprops : dict or None (default)
            If provided, will set the plotting style of the boxes
@@ -3412,16 +3412,16 @@ class Axes(_AxesBase):
           If `True`, will produce a notched box plot
 
         showmeans : bool, default = False
-          If `True`, will toggle on the rendering of the means
+          If `True`, will toggle one the rendering of the means
 
         showcaps  : bool, default = True
-          If `True`, will toggle on the rendering of the caps
+          If `True`, will toggle one the rendering of the caps
 
         showbox  : bool, default = True
-          If `True`, will toggle on the rendering of the box
+          If `True`, will toggle one the rendering of box
 
         showfliers : bool, default = True
-          If `True`, will toggle on the rendering of the fliers
+          If `True`, will toggle one the rendering of the fliers
 
         boxprops : dict or None (default)
           If provided, will set the plotting style of the boxes
@@ -6225,6 +6225,7 @@ class Axes(_AxesBase):
             # we return patches, so put it back in the expected order
             patches.reverse()
 
+            # adopted from adjust_x/ylim part of the bar method
             if orientation == 'horizontal':
                 xmin0 = max(_saved_bounds[0]*0.9, minimum)
                 xmax = self.dataLim.intervalx[1]
@@ -6236,23 +6237,16 @@ class Axes(_AxesBase):
                 xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
             elif orientation == 'vertical':
+                ymin0 = max(_saved_bounds[1]*0.9, minimum)
+                ymax = self.dataLim.intervaly[1]
 
-                # If norm, autoscale axis
-                # fixed bug for #4414
-                if normed:
-                    self.set_autoscaley_on(True)
-                else:
-                    ymin0 = max(_saved_bounds[1]*0.9, minimum)
-                    ymax = self.dataLim.intervaly[1]
-
-                    for m in n:
-                        if np.sum(m) > 0:  # make sure there are counts
-                            ymin = np.amin(m[m != 0])
-                            # filter out the 0 height bins
-                    ymin = max(ymin*0.9, minimum) if not input_empty else minimum
-                    ymin = min(ymin0, ymin)
-                    self.dataLim.intervaly = (ymin, ymax)
-
+                for m in n:
+                    if np.sum(m) > 0:  # make sure there are counts
+                        ymin = np.amin(m[m != 0])
+                        # filter out the 0 height bins
+                ymin = max(ymin*0.9, minimum) if not input_empty else minimum
+                ymin = min(ymin0, ymin)
+                self.dataLim.intervaly = (ymin, ymax)
 
         if label is None:
             labels = [None]

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -169,18 +169,33 @@ def auto_adjust_subplotpars(fig, renderer,
     if not margin_left:
         margin_left = max([sum(s) for s in hspaces[::cols + 1]] + [0])
         margin_left += pad_inches / fig_width_inch
+        # bugfix for bug-#5456
+        # simple check for the error
+        if margin_left > 0.5:
+            margin_left = 0.05
 
     if not margin_right:
         margin_right = max([sum(s) for s in hspaces[cols::cols + 1]] + [0])
         margin_right += pad_inches / fig_width_inch
+        # bugfix for bug-#5456
+        # simple check for the error
+        if margin_right > 0.5:
+            margin_right = 0.05
 
     if not margin_top:
         margin_top = max([sum(s) for s in vspaces[:cols]] + [0])
         margin_top += pad_inches / fig_height_inch
+         # bugfix for bug-#5456
+        if margin_top > 0.5:
+            margin_top = 0.05
 
     if not margin_bottom:
         margin_bottom = max([sum(s) for s in vspaces[-cols:]] + [0])
         margin_bottom += pad_inches / fig_height_inch
+
+        # bugfix for bug-#5456
+        if margin_bottom > 0.5:
+            margin_bottom = 0.05
 
     kwargs = dict(left=margin_left,
                   right=1 - margin_right,


### PR DESCRIPTION
# bugfix for bug-#5456

This is a simple fix by adding a value check. 
If you need testing cases, please let me know 

In this scenario, bottom and top are the margins(white space) that are set between the figure and the top/bottom of the image. If the y-axis label is set to a long string, it causes the calculations of these margins in tight_layout() to be greater than their max length 0.5, which then raises the ValueError as mentioned before. The size of the figure should be in the range 0.0-1.0 for both x and y lengths. If one of the margins exceed 0.5, then the image produced would have too much empty space on one half. If margins top and bottom exceed 0.5, then the figure will be left with no space to be displayed, which causes the program to crash.

Also, We fixed the same problem that appear in horizontal label.
Through investigation, it was discovered that a similar bug happens when the label assigned to the x-axis exceeds the allotted space for the figure. Namely, the error that occurs is ValueError: left cannot be >= right and crashes the python program. We have implemented the same fix to apply for the x-axis as well.

Our initial commit for bug #5456 passed the check..
For the commit and revert of bug #4414, please ignore the commit of 2a02dfc and 7902d5d
Those will be committed by my teammates.
