### PR TITLE
Bug #4414

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3147,16 +3147,16 @@ class Axes(_AxesBase):
            If True produces boxes with the Patch artist
 
         showmeans : bool, default = False
-           If True, will toggle one the rendering of the means
+           If True, will toggle on the rendering of the means
 
         showcaps : bool, default = True
-           If True, will toggle one the rendering of the caps
+           If True, will toggle on the rendering of the caps
 
         showbox : bool, default = True
-           If True, will toggle one the rendering of box
+           If True, will toggle on the rendering of the box
 
         showfliers : bool, default = True
-           If True, will toggle one the rendering of the fliers
+           If True, will toggle on the rendering of the fliers
 
         boxprops : dict or None (default)
            If provided, will set the plotting style of the boxes
@@ -3412,16 +3412,16 @@ class Axes(_AxesBase):
           If `True`, will produce a notched box plot
 
         showmeans : bool, default = False
-          If `True`, will toggle one the rendering of the means
+          If `True`, will toggle on the rendering of the means
 
         showcaps  : bool, default = True
-          If `True`, will toggle one the rendering of the caps
+          If `True`, will toggle on the rendering of the caps
 
         showbox  : bool, default = True
-          If `True`, will toggle one the rendering of box
+          If `True`, will toggle on the rendering of the box
 
         showfliers : bool, default = True
-          If `True`, will toggle one the rendering of the fliers
+          If `True`, will toggle on the rendering of the fliers
 
         boxprops : dict or None (default)
           If provided, will set the plotting style of the boxes
@@ -6225,7 +6225,6 @@ class Axes(_AxesBase):
             # we return patches, so put it back in the expected order
             patches.reverse()
 
-            # adopted from adjust_x/ylim part of the bar method
             if orientation == 'horizontal':
                 xmin0 = max(_saved_bounds[0]*0.9, minimum)
                 xmax = self.dataLim.intervalx[1]
@@ -6237,16 +6236,22 @@ class Axes(_AxesBase):
                 xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
             elif orientation == 'vertical':
-                ymin0 = max(_saved_bounds[1]*0.9, minimum)
-                ymax = self.dataLim.intervaly[1]
 
-                for m in n:
-                    if np.sum(m) > 0:  # make sure there are counts
-                        ymin = np.amin(m[m != 0])
-                        # filter out the 0 height bins
-                ymin = max(ymin*0.9, minimum) if not input_empty else minimum
-                ymin = min(ymin0, ymin)
-                self.dataLim.intervaly = (ymin, ymax)
+                # If norm, autoscale axis
+                if normed:
+                    self.set_autoscaley_on(True)
+                else:
+                    ymin0 = max(_saved_bounds[1]*0.9, minimum)
+                    ymax = self.dataLim.intervaly[1]
+
+                    for m in n:
+                        if np.sum(m) > 0:  # make sure there are counts
+                            ymin = np.amin(m[m != 0])
+                            # filter out the 0 height bins
+                    ymin = max(ymin*0.9, minimum) if not input_empty else minimum
+                    ymin = min(ymin0, ymin)
+                    self.dataLim.intervaly = (ymin, ymax)
+
 
         if label is None:
             labels = [None]

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3147,16 +3147,16 @@ class Axes(_AxesBase):
            If True produces boxes with the Patch artist
 
         showmeans : bool, default = False
-           If True, will toggle one the rendering of the means
+           If True, will toggle on the rendering of the means
 
         showcaps : bool, default = True
-           If True, will toggle one the rendering of the caps
+           If True, will toggle on the rendering of the caps
 
         showbox : bool, default = True
-           If True, will toggle one the rendering of box
+           If True, will toggle on the rendering of the box
 
         showfliers : bool, default = True
-           If True, will toggle one the rendering of the fliers
+           If True, will toggle on the rendering of the fliers
 
         boxprops : dict or None (default)
            If provided, will set the plotting style of the boxes
@@ -3412,16 +3412,16 @@ class Axes(_AxesBase):
           If `True`, will produce a notched box plot
 
         showmeans : bool, default = False
-          If `True`, will toggle one the rendering of the means
+          If `True`, will toggle on the rendering of the means
 
         showcaps  : bool, default = True
-          If `True`, will toggle one the rendering of the caps
+          If `True`, will toggle on the rendering of the caps
 
         showbox  : bool, default = True
-          If `True`, will toggle one the rendering of box
+          If `True`, will toggle on the rendering of the box
 
         showfliers : bool, default = True
-          If `True`, will toggle one the rendering of the fliers
+          If `True`, will toggle on the rendering of the fliers
 
         boxprops : dict or None (default)
           If provided, will set the plotting style of the boxes
@@ -6225,7 +6225,6 @@ class Axes(_AxesBase):
             # we return patches, so put it back in the expected order
             patches.reverse()
 
-            # adopted from adjust_x/ylim part of the bar method
             if orientation == 'horizontal':
                 xmin0 = max(_saved_bounds[0]*0.9, minimum)
                 xmax = self.dataLim.intervalx[1]
@@ -6237,16 +6236,23 @@ class Axes(_AxesBase):
                 xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
             elif orientation == 'vertical':
-                ymin0 = max(_saved_bounds[1]*0.9, minimum)
-                ymax = self.dataLim.intervaly[1]
 
-                for m in n:
-                    if np.sum(m) > 0:  # make sure there are counts
-                        ymin = np.amin(m[m != 0])
-                        # filter out the 0 height bins
-                ymin = max(ymin*0.9, minimum) if not input_empty else minimum
-                ymin = min(ymin0, ymin)
-                self.dataLim.intervaly = (ymin, ymax)
+                # If norm, autoscale axis
+                # fixed bug for #4414
+                if normed:
+                    self.set_autoscaley_on(True)
+                else:
+                    ymin0 = max(_saved_bounds[1]*0.9, minimum)
+                    ymax = self.dataLim.intervaly[1]
+
+                    for m in n:
+                        if np.sum(m) > 0:  # make sure there are counts
+                            ymin = np.amin(m[m != 0])
+                            # filter out the 0 height bins
+                    ymin = max(ymin*0.9, minimum) if not input_empty else minimum
+                    ymin = min(ymin0, ymin)
+                    self.dataLim.intervaly = (ymin, ymax)
+
 
         if label is None:
             labels = [None]

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3147,16 +3147,16 @@ class Axes(_AxesBase):
            If True produces boxes with the Patch artist
 
         showmeans : bool, default = False
-           If True, will toggle on the rendering of the means
+           If True, will toggle one the rendering of the means
 
         showcaps : bool, default = True
-           If True, will toggle on the rendering of the caps
+           If True, will toggle one the rendering of the caps
 
         showbox : bool, default = True
-           If True, will toggle on the rendering of the box
+           If True, will toggle one the rendering of box
 
         showfliers : bool, default = True
-           If True, will toggle on the rendering of the fliers
+           If True, will toggle one the rendering of the fliers
 
         boxprops : dict or None (default)
            If provided, will set the plotting style of the boxes
@@ -3412,16 +3412,16 @@ class Axes(_AxesBase):
           If `True`, will produce a notched box plot
 
         showmeans : bool, default = False
-          If `True`, will toggle on the rendering of the means
+          If `True`, will toggle one the rendering of the means
 
         showcaps  : bool, default = True
-          If `True`, will toggle on the rendering of the caps
+          If `True`, will toggle one the rendering of the caps
 
         showbox  : bool, default = True
-          If `True`, will toggle on the rendering of the box
+          If `True`, will toggle one the rendering of box
 
         showfliers : bool, default = True
-          If `True`, will toggle on the rendering of the fliers
+          If `True`, will toggle one the rendering of the fliers
 
         boxprops : dict or None (default)
           If provided, will set the plotting style of the boxes
@@ -6225,6 +6225,7 @@ class Axes(_AxesBase):
             # we return patches, so put it back in the expected order
             patches.reverse()
 
+            # adopted from adjust_x/ylim part of the bar method
             if orientation == 'horizontal':
                 xmin0 = max(_saved_bounds[0]*0.9, minimum)
                 xmax = self.dataLim.intervalx[1]
@@ -6236,23 +6237,16 @@ class Axes(_AxesBase):
                 xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
             elif orientation == 'vertical':
+                ymin0 = max(_saved_bounds[1]*0.9, minimum)
+                ymax = self.dataLim.intervaly[1]
 
-                # If norm, autoscale axis
-                # fixed bug for #4414
-                if normed:
-                    self.set_autoscaley_on(True)
-                else:
-                    ymin0 = max(_saved_bounds[1]*0.9, minimum)
-                    ymax = self.dataLim.intervaly[1]
-
-                    for m in n:
-                        if np.sum(m) > 0:  # make sure there are counts
-                            ymin = np.amin(m[m != 0])
-                            # filter out the 0 height bins
-                    ymin = max(ymin*0.9, minimum) if not input_empty else minimum
-                    ymin = min(ymin0, ymin)
-                    self.dataLim.intervaly = (ymin, ymax)
-
+                for m in n:
+                    if np.sum(m) > 0:  # make sure there are counts
+                        ymin = np.amin(m[m != 0])
+                        # filter out the 0 height bins
+                ymin = max(ymin*0.9, minimum) if not input_empty else minimum
+                ymin = min(ymin0, ymin)
+                self.dataLim.intervaly = (ymin, ymax)
 
         if label is None:
             labels = [None]

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -169,18 +169,33 @@ def auto_adjust_subplotpars(fig, renderer,
     if not margin_left:
         margin_left = max([sum(s) for s in hspaces[::cols + 1]] + [0])
         margin_left += pad_inches / fig_width_inch
+        # bugfix for bug-#5456
+        # simple check for the error
+        if margin_left > 0.5:
+            margin_left = 0.05
 
     if not margin_right:
         margin_right = max([sum(s) for s in hspaces[cols::cols + 1]] + [0])
         margin_right += pad_inches / fig_width_inch
+        # bugfix for bug-#5456
+        # simple check for the error
+        if margin_right > 0.5:
+            margin_right = 0.05
 
     if not margin_top:
         margin_top = max([sum(s) for s in vspaces[:cols]] + [0])
         margin_top += pad_inches / fig_height_inch
+         # bugfix for bug-#5456
+        if margin_top > 0.5:
+            margin_top = 0.05
 
     if not margin_bottom:
         margin_bottom = max([sum(s) for s in vspaces[-cols:]] + [0])
         margin_bottom += pad_inches / fig_height_inch
+
+        # bugfix for bug-#5456
+        if margin_bottom > 0.5:
+            margin_bottom = 0.05
 
     kwargs = dict(left=margin_left,
                   right=1 - margin_right,


### PR DESCRIPTION
Based on the previous class definition of hist(), if only histtype=’stepfilled’ is passed, then normed will default to false and together it causes the histogram to calculate its y-axis limits based on the graphing data. If only normed=True is passed, then histtype will default to ‘bar’ and together it causes the histogram to scale it’s y-axis limits after normalizing graph data. However, when both are provided, the y-axis limits are calculated instead of being scaled, because the previous code does not check if normed=True, which should override the manual calculations of y-axis limits. 

The bugfix code involves an if statement in the matplotlib/lib/matplotlib/axes/_axes.py hist(...) method that checks the histtype and normed parameters to sets the y limit accordingly. As mentioned above, if the histtype property were not given, then the algorithm would simply scale the graph as if it were a bargraph. However, this is not the case with histtype = “stepfilled”. Since histtype = “stepfilled” is given, it will not scale according to the data, which is why it is imperative to determine the method of scaling before any calculations. The best way to do this is by using an if statement when histtype=’stepfilled’ to check the value of the normed property, and scale accordingly(i.e. Manually calculate dimensions if data not normalized normed=False vs. Auto scale if data is normalized normed=True).
https://github.com/matplotlib/matplotlib/issues/4414