### PR TITLE
Fix issue #4414

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6244,16 +6244,21 @@ class Axes(_AxesBase):
                 xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
             elif orientation == 'vertical':
-                ymin0 = max(_saved_bounds[1]*0.9, minimum)
-                ymax = self.dataLim.intervaly[1]
+                 # If norm, autoscale axis
+                if normed:
+                    self.set_autoscaley_on(True)
+                else:
+                    ymin0 = max(_saved_bounds[1]*0.9, minimum)
+                    ymax = self.dataLim.intervaly[1]
+                    
+                    for m in n:
+                        if np.sum(m) > 0: # make sure there are counts
+                            ymin = np.amin(m[m != 0])
+                            # filter out the 0 height bins
+                    ymin = max(ymin*0.9, minimum) if not input_empty else minimum
+                    ymin = min(ymin0, ymin)
+                    self.dataLim.intervaly = (ymin, ymax)
 
-                for m in n:
-                    if np.sum(m) > 0:  # make sure there are counts
-                        ymin = np.amin(m[m != 0])
-                        # filter out the 0 height bins
-                ymin = max(ymin*0.9, minimum) if not input_empty else minimum
-                ymin = min(ymin0, ymin)
-                self.dataLim.intervaly = (ymin, ymax)
 
         if label is None:
             labels = [None]


### PR DESCRIPTION
Here is an attempt fix to bug #6169 
The bugfix code involves an if statement method that checks the histtype and normed parameters to sets the y limit accordingly. If the histtype property were not given, then the algorithm would simply scale the graph as if it were a bargraph. However, this is not the case with histtype = “stepfilled”. Since histtype = “stepfilled” is given, it will not scale according to the data, which is why it is imperative to determine the method of scaling before any calculations. The best way to do this is by using an if statement when histtype=’stepfilled’ to check the value of the normed property, and scale accordingly(i.e. Manually calculate dimensions if data not normalized normed=False vs. Auto scale if data is normalized normed=True).