### PR TITLE
Fix redundent set line props

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -184,10 +184,6 @@ class _process_plot_var_args(object):
         ret = self._grab_next_args(*args, **kwargs)
         return ret
 
-    def set_lineprops(self, line, **kwargs):
-        assert self.command == 'plot', 'set_lineprops only works with "plot"'
-        line.set(**kwargs)
-
     def set_patchprops(self, fill_poly, **kwargs):
         assert self.command == 'fill', 'set_patchprops only works with "fill"'
         fill_poly.set(**kwargs)
@@ -275,10 +271,10 @@ class _process_plot_var_args(object):
     def _makeline(self, x, y, kw, kwargs):
         kw = kw.copy()  # Don't modify the original kw.
         kwargs = kwargs.copy()
-        default_dict = self._getdefaults(None, kw, kwargs)
-        self._setdefaults(default_dict, kw, kwargs)
+        kw.update(kwargs)
+        default_dict = self._getdefaults(None, kw)
+        self._setdefaults(default_dict, kw)
         seg = mlines.Line2D(x, y, **kw)
-        self.set_lineprops(seg, **kwargs)
         return seg
 
     def _makefill(self, x, y, kw, kwargs):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -270,7 +270,6 @@ class _process_plot_var_args(object):
 
     def _makeline(self, x, y, kw, kwargs):
         kw = kw.copy()  # Don't modify the original kw.
-        kwargs = kwargs.copy()
         kw.update(kwargs)
         default_dict = self._getdefaults(None, kw)
         self._setdefaults(default_dict, kw)

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -332,8 +332,8 @@ class Line2D(Artist):
 
         self._dashSeq = None
 
-        self.set_linestyle(linestyle)
         self.set_drawstyle(drawstyle)
+        self.set_linestyle(linestyle)
         self.set_linewidth(linewidth)
 
         self._color = None

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1790,11 +1790,11 @@ def test_boxplot_sym():
 def test_boxplot_autorange_whiskers():
     x = np.ones(140)
     x = np.hstack([0, x, 2])
-    
+
     fig1, ax1 = plt.subplots()
     ax1.boxplot([x, x], bootstrap=10000, notch=1)
     ax1.set_ylim((-5, 5))
-    
+
     fig2, ax2 = plt.subplots()
     ax2.boxplot([x, x], bootstrap=10000, notch=1, autorange=True)
     ax2.set_ylim((-5, 5))
@@ -4235,6 +4235,19 @@ def test_axis_set_tick_params_labelsize_labelcolor():
     assert axis_1.yaxis.majorTicks[0]._color == 'k'
     assert axis_1.yaxis.majorTicks[0]._labelsize == 30.0
     assert axis_1.yaxis.majorTicks[0]._labelcolor == 'red'
+
+
+@cleanup
+def test_none_kwargs():
+    fig, ax = plt.subplots()
+    ln, = ax.plot(range(32), linestyle=None)
+    assert ln.get_linestyle() == '-'
+
+
+@cleanup
+def test_ls_ds_conflict():
+    assert_raises(ValueError, plt.plot, range(32),
+                  linestyle='steps-pre:', drawstyle='steps-post')
 
 
 @image_comparison(baseline_images=['date_timezone_x'], extensions=['png'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4250,6 +4250,12 @@ def test_ls_ds_conflict():
                   linestyle='steps-pre:', drawstyle='steps-post')
 
 
+@cleanup
+def test_ls_ds_conflict():
+    assert_raises(ValueError, plt.plot, range(32),
+                  linestyle='steps-pre:', drawstyle='steps-post')
+
+
 @image_comparison(baseline_images=['date_timezone_x'], extensions=['png'])
 def test_date_timezone_x():
     # Tests issue 5575


### PR DESCRIPTION
'quick' fix to #6173

Found one live :dragon_face:  and one sleeping :dragon: 

This is targeted at 1.5.x, but I would be very easily convinced that these changes are too big to apply to 1.5.x and needs to be targeted at v2.x or master.

There is also an issue that `ls` and `linestyle` are not properly aliased, but that should be fixed on master using https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/cbook.py#L2449