### PR TITLE
Issue #6105: Adds targetfig parameter to the subplot2grid function

### DIFF
--- a/doc/users/whats_new/uptade_subplot2grid.rst
+++ b/doc/users/whats_new/uptade_subplot2grid.rst
@@ -1,0 +1,13 @@
+New Firgure Parameter for subplot2grid
+--------------------------------------
+
+A ``fig`` parameter now exists for the method :func:`subplot2grid`.  This allows
+for the figure that the subplots will be created in to be specified.  If ``fig``
+is ``None`` (default) then the method will use the current figure retrieved by
+:func:`gcf`.
+
+Example
+```````
+::
+
+    subplot2grid(shape, loc, rowspan=1, colspan=1, fig=myfig)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1147,7 +1147,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
     return fig, axs
 
 
-def subplot2grid(shape, loc, rowspan=1, colspan=1, **kwargs):
+def subplot2grid(shape, loc, rowspan=1, colspan=1, targetfig=None, **kwargs):
     """
     Create a subplot in a grid.  The grid is specified by *shape*, at
     location of *loc*, spanning *rowspan*, *colspan* cells in each
@@ -1162,7 +1162,11 @@ def subplot2grid(shape, loc, rowspan=1, colspan=1, **kwargs):
       subplot(subplotspec)
     """
 
-    fig = gcf()
+    if targetfig is None:
+        fig = gcf()
+    else:
+        fig = targetfig
+
     s1, s2 = shape
     subplotspec = GridSpec(s1, s2).new_subplotspec(loc,
                                                    rowspan=rowspan,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1147,7 +1147,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
     return fig, axs
 
 
-def subplot2grid(shape, loc, rowspan=1, colspan=1, targetfig=None, **kwargs):
+def subplot2grid(shape, loc, rowspan=1, colspan=1, fig=None, **kwargs):
     """
     Create a subplot in a grid.  The grid is specified by *shape*, at
     location of *loc*, spanning *rowspan*, *colspan* cells in each
@@ -1162,10 +1162,8 @@ def subplot2grid(shape, loc, rowspan=1, colspan=1, targetfig=None, **kwargs):
       subplot(subplotspec)
     """
 
-    if targetfig is None:
+    if fig is None:
         fig = gcf()
-    else:
-        fig = targetfig
 
     s1, s2 = shape
     subplotspec = GridSpec(s1, s2).new_subplotspec(loc,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1151,7 +1151,8 @@ def subplot2grid(shape, loc, rowspan=1, colspan=1, fig=None, **kwargs):
     """
     Create a subplot in a grid.  The grid is specified by *shape*, at
     location of *loc*, spanning *rowspan*, *colspan* cells in each
-    direction.  The index for loc is 0-based. ::
+    direction.  The index for loc is 0-based.  The current figure will
+    be used unless *fig* is specified. ::
 
       subplot2grid(shape, loc, rowspan=1, colspan=1)
 


### PR DESCRIPTION
As mentioned in issue #6105.  A simple implementation.  I named the argument targetfig to be consistent with another function in pyplot, subplot_tool.

Feedback needed.