### PR TITLE
Fix to csv2rec bug for review

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2838,7 +2838,8 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
         # try and return a datetime object
         d = dateparser(x, dayfirst=dayfirst, yearfirst=yearfirst)
         return d
-    mydateparser = with_default_value(mydateparser, datetime.datetime(1,1,1,0,0,0))
+
+    mydateparser = with_default_value(mydateparser, datetime.datetime(1, 1, 1))
 
     myfloat = with_default_value(float, np.nan)
     myint = with_default_value(int, -1)

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2833,7 +2833,13 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
             raise ValueError('invalid bool')
 
     dateparser = dateutil.parser.parse
-    mydateparser = with_default_value(dateparser, datetime.date(1, 1, 1))
+
+    def mydateparser(x):
+        # try and return a datetime object
+        d = dateparser(x, dayfirst=dayfirst, yearfirst=yearfirst)
+        return d
+    mydateparser = with_default_value(mydateparser, datetime.datetime(1,1,1,0,0,0))
+
     myfloat = with_default_value(float, np.nan)
     myint = with_default_value(int, -1)
     mystr = with_default_value(str, '')

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -8,6 +8,7 @@ import tempfile
 from numpy.testing import assert_allclose, assert_array_equal
 import numpy.ma.testutils as matest
 import numpy as np
+import datetime as datetime
 from nose.tools import (assert_equal, assert_almost_equal, assert_not_equal,
                         assert_true, assert_raises)
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -346,6 +346,50 @@ class csv_testcase(CleanupTestCase):
         assert len(array) == 2
         assert len(array.dtype) == 3
 
+    def test_csv2rec_usdate(self):
+        self.fd.write('01/11/14\n' +
+                '03/05/76 12:00:01 AM\n' +
+                '07/09/83 5:17:34 PM\n' +
+                '06/20/2054 2:31:45 PM\n' +
+                '10/31/00 11:50:23 AM\n')
+        expected = [datetime.datetime(2014, 1, 11, 0, 0),
+                datetime.datetime(1976, 3, 5, 0, 0, 1),
+                datetime.datetime(1983, 7, 9, 17, 17, 34),
+                datetime.datetime(2054, 6, 20, 14, 31, 45),
+                datetime.datetime(2000, 10, 31, 11, 50, 23)]
+        self.fd.seek(0)
+        array = mlab.csv2rec(self.fd, names='a')
+        assert_array_equal(array['a'].tolist(), expected)
+
+    def test_csv2rec_dayfirst(self):
+        self.fd.write('11/01/14\n' +
+                '05/03/76 12:00:01 AM\n' +
+                '09/07/83 5:17:34 PM\n' +
+                '20/06/2054 2:31:45 PM\n' +
+                '31/10/00 11:50:23 AM\n')
+        expected = [datetime.datetime(2014, 1, 11, 0, 0),
+                datetime.datetime(1976, 3, 5, 0, 0, 1),
+                datetime.datetime(1983, 7, 9, 17, 17, 34),
+                datetime.datetime(2054, 6, 20, 14, 31, 45),
+                datetime.datetime(2000, 10, 31, 11, 50, 23)]
+        self.fd.seek(0)
+        array = mlab.csv2rec(self.fd, names='a', dayfirst = True)
+        assert_array_equal(array['a'].tolist(), expected)
+
+    def test_csv2rec_yearfirst(self):
+        self.fd.write('14/01/11\n' +
+                '76/03/05 12:00:01 AM\n' +
+                '83/07/09 5:17:34 PM\n' +
+                '2054/06/20 2:31:45 PM\n' +
+                '00/10/31 11:50:23 AM\n')
+        expected = [datetime.datetime(2014, 1, 11, 0, 0),
+                datetime.datetime(1976, 3, 5, 0, 0, 1),
+                datetime.datetime(1983, 7, 9, 17, 17, 34),
+                datetime.datetime(2054, 6, 20, 14, 31, 45),
+                datetime.datetime(2000, 10, 31, 11, 50, 23)]
+        self.fd.seek(0)
+        array = mlab.csv2rec(self.fd, names='a', yearfirst = True)
+        assert_array_equal(array['a'].tolist(), expected)
 
 class window_testcase(CleanupTestCase):
     def setUp(self):

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -374,7 +374,7 @@ class csv_testcase(CleanupTestCase):
                 datetime.datetime(2054, 6, 20, 14, 31, 45),
                 datetime.datetime(2000, 10, 31, 11, 50, 23)]
         self.fd.seek(0)
-        array = mlab.csv2rec(self.fd, names='a', dayfirst = True)
+        array = mlab.csv2rec(self.fd, names='a', dayfirst=True)
         assert_array_equal(array['a'].tolist(), expected)
 
     def test_csv2rec_yearfirst(self):
@@ -389,7 +389,7 @@ class csv_testcase(CleanupTestCase):
                 datetime.datetime(2054, 6, 20, 14, 31, 45),
                 datetime.datetime(2000, 10, 31, 11, 50, 23)]
         self.fd.seek(0)
-        array = mlab.csv2rec(self.fd, names='a', yearfirst = True)
+        array = mlab.csv2rec(self.fd, names='a', yearfirst=True)
         assert_array_equal(array['a'].tolist(), expected)
 
 class window_testcase(CleanupTestCase):

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -392,6 +392,7 @@ class csv_testcase(CleanupTestCase):
         array = mlab.csv2rec(self.fd, names='a', yearfirst=True)
         assert_array_equal(array['a'].tolist(), expected)
 
+
 class window_testcase(CleanupTestCase):
     def setUp(self):
         np.random.seed(0)


### PR DESCRIPTION
Datetime strings in csv files in dayfirst or yearfirst format with
nonzero hour&minute&second will not be properly represented. Date
strings will, presuming the csv file contains no strings in that column
that have nonzero hour/minute/second components in a datetime string. Refer to issue #6184 for further information.