### PR TITLE
Fix deprecation warning with dateutil 2.5

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -827,7 +827,7 @@ class RRuleLocator(DateLocator):
             # The magic number!
             stop = _from_ordinalf(3652059.9999999)
 
-        self.rule.set(dtstart=start, until=stop, count=self.MAXTICKS + 1)
+        self.rule.set(dtstart=start, until=stop)
 
         # estimate the number of ticks very approximately so we don't
         # have to do a very expensive (and potentially near infinite)


### PR DESCRIPTION
Count cannot be used together with until in future versions of dateutil. The matplotlib code already checks that there are no more then MAXTICKS generated so it looks like this has always been redundant