### PR TITLE
Fix issue #4597. Make use of mkdtemp when creating temporary config directory.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -553,16 +553,14 @@ def _create_tmp_config_dir():
         # Some restricted platforms (such as Google App Engine) do not provide
         # gettempdir.
         return None
-
     try:
         username = getpass.getuser()
     except KeyError:
         username = str(os.getuid())
-    tempdir = os.path.join(tempdir, 'matplotlib-%s' % username)
+
+    tempdir = tempfile.mkdtemp(prefix='matplotlib-%s-' % username, dir=tempdir)
 
     os.environ['MPLCONFIGDIR'] = tempdir
-
-    mkdirs(tempdir)
 
     return tempdir
 


### PR DESCRIPTION
Original issue [here](https://github.com/matplotlib/matplotlib/issues/4597).

I have made use of the appropriate prefix in mkdtemp that will also add username before appending the eight alphanumeric characters. For example, calling this function created the dir _matplotlib-kanwar-8d6h5lxj_ inside my temp directory.

I am unsure as to how to add test cases for this since the change here was basically refactoring the code. Please suggest.