### PR TITLE
A method added to Colormap classes to reverse the colormap

### DIFF
--- a/doc/users/whats_new/reversed_colormap.rst
+++ b/doc/users/whats_new/reversed_colormap.rst
@@ -1,0 +1,7 @@
+Colormap reversed method
+------------------------
+
+The methods :meth:`~matplotlib.colors.LinearSegmentedColormap.reversed` and
+:meth:`~matplotlib.colors.ListedColormap.reversed` return a reversed
+instance of the Colormap. This implements a way for any Colormap to be
+reversed.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -669,18 +669,13 @@ class Colormap(object):
         """
         Make a reversed instance of the Colormap.
 
-        NOTE: Function not implemented for base class.
+        .. note :: Function not implemented for base class.
 
         Parameters
         ----------
         name : str, optional
             The name for the reversed colormap. If it's None the
             name will be the name of the parent colormap + "_r".
-
-        Raises
-        ------
-        NotImplementedError
-            Function not implemented for base class.
 
         Notes
         -----

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -587,6 +587,17 @@ def test_pandas_iterable():
     cm2 = mcolors.ListedColormap(s, N=5)
     assert_sequence_equal(cm1.colors, cm2.colors)
 
+def test_colormap_reversing():
+    """Check the generated _lut data of a colormap and corresponding
+    reversed colormap if they are almost the same."""
+    for name in six.iterkeys(cm.cmap_d):
+        cmap = plt.get_cmap(name)
+        cmap_r = cmap.reversed()
+        if not cmap_r._isinit:
+            cmap._init()
+            cmap_r._init()
+        assert_array_almost_equal(cmap._lut[:-3], cmap_r._lut[-4::-1])
+
 
 if __name__ == '__main__':
     import nose

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -587,6 +587,7 @@ def test_pandas_iterable():
     cm2 = mcolors.ListedColormap(s, N=5)
     assert_sequence_equal(cm1.colors, cm2.colors)
 
+
 def test_colormap_reversing():
     """Check the generated _lut data of a colormap and corresponding
     reversed colormap if they are almost the same."""


### PR DESCRIPTION
This implements a solution for issue #4271

* method added to both `ListedColormap` and `LinearSegmentedColormap`
* The parent class `Colormap` raises `NotImplementedError`
* A test was added to `test_colors.py`

This PR succeeds PR #5899. Following is the initial comment copy/pasted from the previous PR:

A few things that I ran into while implementing this:

* Functions to reverse Colormap data already existed in [matplotlib.cm](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/cm.py) but they are inconvenient for a user. After seeing that I changed my implementation to resemble them more. Perhaps the old functions should eventually be deprecated?
* The documentation for [LinearSegmentedColormap](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/colors.py#L669) does not mention that input data can be functions. It is mentioned briefly in the doc for [makeMappingArray](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/colors.py#L429) but should probably be mentioned in the doc for LinearSegmentedColormap.
* The data is specified as "list of tuples" [LinearSegmentedColormap](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/colors.py#L669) and [ListedColormap](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/colors.py#L788) "a list of matplotlib color specifications, or an equivalent Nx3 or Nx4 floating point array (*N* rgb or rgba values)". I would suggest that this would be changed to *array_like* and that the data is then copied into a numpy array for internal use.


![figure_1](https://cloud.githubusercontent.com/assets/2393374/12513671/5c951e46-c11f-11e5-9fd6-b2001bde3d9b.png)
![figure_2](https://cloud.githubusercontent.com/assets/2393374/12513672/5cadf006-c11f-11e5-83db-59c78c6888e5.png)
![figure_3](https://cloud.githubusercontent.com/assets/2393374/12513674/5cd1be28-c11f-11e5-9754-c1931267d43c.png)
![figure_4](https://cloud.githubusercontent.com/assets/2393374/12513673/5cc7e074-c11f-11e5-8f37-060f33a94391.png)
![figure_5](https://cloud.githubusercontent.com/assets/2393374/12513675/5ce18e3e-c11f-11e5-9d92-04c101699571.png)
![figure_6](https://cloud.githubusercontent.com/assets/2393374/12513676/5ce6cd40-c11f-11e5-8236-2a002a3db95d.png)