### PR TITLE
FIX: handle arbitrary iterables in setp

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1437,7 +1437,12 @@ def setp(obj, *args, **kwargs):
       >>> setp(lines, linewidth=2, color='r')        # python style
     """
 
-    insp = ArtistInspector(obj)
+    if not cbook.iterable(obj):
+        objs = [obj]
+    else:
+        objs = list(cbook.flatten(obj))
+
+    insp = ArtistInspector(objs[0])
 
     if len(kwargs) == 0 and len(args) == 0:
         print('\n'.join(insp.pprint_setters()))
@@ -1446,11 +1451,6 @@ def setp(obj, *args, **kwargs):
     if len(kwargs) == 0 and len(args) == 1:
         print(insp.pprint_setters(prop=args[0]))
         return
-
-    if not cbook.iterable(obj):
-        objs = [obj]
-    else:
-        objs = cbook.flatten(obj)
 
     if len(args) % 2:
         raise ValueError('The set args must be string, value pairs')

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import warnings
 from matplotlib.externals import six
+from itertools import chain
 
 import io
 
@@ -13,6 +14,7 @@ import matplotlib.lines as mlines
 import matplotlib.path as mpath
 import matplotlib.transforms as mtrans
 import matplotlib.collections as mcollections
+import matplotlib.artist as martist
 from matplotlib.testing.decorators import image_comparison, cleanup
 
 from nose.tools import (assert_true, assert_false)
@@ -186,6 +188,12 @@ def test_properties():
         ln.properties()
         assert len(w) == 0
 
+
+@cleanup
+def test_setp():
+    lines1 = plt.plot(range(3))
+    lines2 = plt.plot(range(3))
+    martist.setp(chain(lines1, lines2), 'lw', 5)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
closes #6212

Alternative / complimentary to #6217

I had this half done when @madphysicist said they would work on it, fixes the same problem but in a different place.