### PR TITLE
Add a locator to AutoDateFormatters example code

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -642,7 +642,8 @@ class AutoDateFormatter(ticker.Formatter):
     dictionary by doing::
 
 
-    >>> formatter = AutoDateFormatter()
+    >>> locator = AutoDateLocator()
+    >>> formatter = AutoDateFormatter(locator)
     >>> formatter.scaled[1/(24.*60.)] = '%M:%S' # only show min and sec
 
     A custom :class:`~matplotlib.ticker.FuncFormatter` can also be used.


### PR DESCRIPTION
AutoDateFormatter.\__init\__ always needs a locator, so add one to the
example in the documentation.