### PR TITLE
Fix Boxplot docs to conform to numpydoc

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3159,8 +3159,8 @@ class Axes(_AxesBase):
             ``shownotches`` is also True. Otherwise, means will be shown
             as points.
 
-        Additional Options
-        ---------------------
+        Other Parameters
+        ----------------
         The following boolean options toggle the drawing of individual
         components of the boxplots:
             - showcaps: the caps on the ends of whiskers

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3161,22 +3161,26 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        The following boolean options toggle the drawing of individual
-        components of the boxplots:
-            - showcaps: the caps on the ends of whiskers
-              (default is True)
-            - showbox: the central box (default is True)
-            - showfliers: the outliers beyond the caps (default is True)
-            - showmeans: the arithmetic means (default is False)
-
-        The remaining options can accept dictionaries that specify the
-        style of the individual artists:
-            - capprops
-            - boxprops
-            - whiskerprops
-            - flierprops
-            - medianprops
-            - meanprops
+        showcaps : bool, optional (True)
+            Show the caps on the ends of whiskers.
+        showbox : bool, optional (True)
+            Show the central box.
+        showfliers : bool, optional (True)
+            Show the outliers beyond the caps.
+        showmeans : bool, optional (False)
+            Show the arithmetic means.
+        capprops : dict, optional (None)
+            Specifies the style of the caps.
+        boxprops : dict, optional (None)
+            Specifies the style of the box.
+        whiskerprops : dict, optional (None)
+            Specifies the style of the whiskers.
+        flierprops : dict, optional (None)
+            Specifies the style of the fliers.
+        medianprops : dict, optional (None)
+            Specifies the style of the median.
+        meanprops : dict, optional (None)
+            Specifies the style of the mean.
 
         Returns
         -------


### PR DESCRIPTION
*  Additional Options is not a valid numpy doc section so this whole section gets dropped [here](http://matplotlib.org/devdocs/api/axes_api.html#matplotlib.axes.Axes.boxplot) I have converted this to Other Parameters which is valid. 
* The section below does not confirm to numpy doc so I have converted the parameters to numpydoc format. This makes it slightly more verbose but renders correctly. I could be convinced to drop this if needed.