### PR TITLE
Force Qt validator to use C locale.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/formlayout.py
@@ -298,6 +298,7 @@ class FormWidget(QtWidgets.QWidget):
                 field = QtWidgets.QLineEdit(repr(value), self)
                 field.setCursorPosition(0)
                 field.setValidator(QtGui.QDoubleValidator(field))
+                field.validator().setLocale(QtCore.QLocale("C"))
                 dialog = self.get_dialog()
                 dialog.register_float_field(field)
                 field.textChanged.connect(lambda text: dialog.update_buttons())


### PR DESCRIPTION
PR for #6082: Cannot interactively edit axes limits using Qt5 backend

I found that this was a locale issue: I am on a French locale, where the decimal separator is ",".
On Qt4 (http://doc.qt.io/qt-4.8/qdoublevalidator.html),
> QDoubleValidator uses its locale() to interpret the number. For example, in the German locale, "1,234" will be accepted as the fractional number 1.234. In Arabic locales, QDoubleValidator will accept Arabic digits.
In addition, QDoubleValidator is always guaranteed to accept a number formatted according to the "C" locale.

On Qt5 (http://doc.qt.io/qt-5/qdoublevalidator.html), the second provision has been removed.

Thus, on the French locale, "1.23" is considered an invalid input and rejected by QDoubleValidator.  In fact, I can input instead "1,23", but this causes an exception later when Python tries to convert this to a float.  (To reproduce this, set the locale appropriately and edit the axes parameters of a default plot.)

Given that matplotlib is not really localized anyways (except for `axes.formatter.use_locale`), this patch sets the validator's locale to C in all cases.  Note that despite what the Qt docs indicate, this does *not* seem to prevent input of localized ("1,23") values, which still lead to an exception.