### PR TITLE
DOC: Clarify fillbetween_x example.

### DIFF
--- a/examples/pylab_examples/fill_betweenx_demo.py
+++ b/examples/pylab_examples/fill_betweenx_demo.py
@@ -1,48 +1,46 @@
-"""
-Copy of fill_between.py but using fill_betweenx() instead.
-"""
 import matplotlib.mlab as mlab
 from matplotlib.pyplot import figure, show
 import numpy as np
 
 
-x = np.arange(0.0, 2, 0.01)
-y1 = np.sin(2*np.pi*x)
-y2 = 1.2*np.sin(4*np.pi*x)
+y = np.arange(0.0, 2, 0.01)
+x1 = np.sin(2*np.pi*y)
+x2 = 1.2*np.sin(4*np.pi*y)
 
 fig = figure()
 ax1 = fig.add_subplot(311)
 ax2 = fig.add_subplot(312, sharex=ax1)
 ax3 = fig.add_subplot(313, sharex=ax1)
 
-ax1.fill_betweenx(x, 0, y1)
-ax1.set_ylabel('(y1, 0)')
+ax1.fill_betweenx(y, 0, x1)
+ax1.set_ylabel('(x1, 0)')
 
-ax2.fill_betweenx(x, y1, 1)
-ax2.set_ylabel('(y1, 1)')
+ax2.fill_betweenx(y, x1, 1)
+ax2.set_ylabel('(x1, 1)')
 
-ax3.fill_betweenx(x, y1, y2)
-ax3.set_ylabel('(y1, y2)')
+ax3.fill_betweenx(y, x1, x2)
+ax3.set_ylabel('(x1, x2)')
 ax3.set_xlabel('x')
 
-# now fill between y1 and y2 where a logical condition is met.  Note
+# now fill between x1 and x2 where a logical condition is met.  Note
 # this is different than calling
-#   fill_between(x[where], y1[where],y2[where]
+#   fill_between(y[where], x1[where], x2[where])
 # because of edge effects over multiple contiguous regions.
+
 fig = figure()
 ax = fig.add_subplot(211)
-ax.plot(y1, x, y2, x, color='black')
-ax.fill_betweenx(x, y1, y2, where=y2 >= y1, facecolor='green')
-ax.fill_betweenx(x, y1, y2, where=y2 <= y1, facecolor='red')
+ax.plot(x1, y, x2, y, color='black')
+ax.fill_betweenx(y, x1, x2, where=x2 >= x1, facecolor='green')
+ax.fill_betweenx(y, x1, x2, where=x2 <= x1, facecolor='red')
 ax.set_title('fill between where')
 
 # Test support for masked arrays.
-y2 = np.ma.masked_greater(y2, 1.0)
+x2 = np.ma.masked_greater(x2, 1.0)
 ax1 = fig.add_subplot(212, sharex=ax)
-ax1.plot(y1, x, y2, x, color='black')
-ax1.fill_betweenx(x, y1, y2, where=y2 >= y1, facecolor='green')
-ax1.fill_betweenx(x, y1, y2, where=y2 <= y1, facecolor='red')
-ax1.set_title('Now regions with y2 > 1 are masked')
+ax1.plot(x1, y, x2, y, color='black')
+ax1.fill_betweenx(y, x1, x2, where=x2 >= x1, facecolor='green')
+ax1.fill_betweenx(y, x1, x2, where=x2 <= x1, facecolor='red')
+ax1.set_title('Now regions with x2 > 1 are masked')
 
 # This example illustrates a problem; because of the data
 # gridding, there are undesired unfilled triangles at the crossover


### PR DESCRIPTION
The example for fillbetween_x confusingly switches the variables for x and y in the code compared to what is plotted. This PR fixes that.