### PR TITLE
Adjust test tolerance to pass for me on OSX

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -29,8 +29,6 @@ from numpy.testing import assert_allclose, assert_array_equal
 import warnings
 from matplotlib.cbook import IgnoredKeywordWarning
 
-import sys
-on_win = (sys.platform == 'win32')
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2766,7 +2766,7 @@ def test_subplot_key_hash():
 @image_comparison(baseline_images=['specgram_freqs',
                                    'specgram_freqs_linear'],
                   remove_text=True, extensions=['png'],
-                  tol=0.07 if on_win else 0.03)
+                  tol=0.07)
 def test_specgram_freqs():
     '''test axes.specgram in default (psd) mode with sinusoidal stimuli'''
     n = 10000
@@ -2867,7 +2867,7 @@ def test_specgram_noise():
 @image_comparison(baseline_images=['specgram_magnitude_freqs',
                                    'specgram_magnitude_freqs_linear'],
                   remove_text=True, extensions=['png'],
-                  tol=0.07 if on_win else 0.03)
+                  tol=0.07)
 def test_specgram_magnitude_freqs():
     '''test axes.specgram in magnitude mode with sinusoidal stimuli'''
     n = 10000
@@ -2969,7 +2969,7 @@ def test_specgram_magnitude_noise():
 
 @image_comparison(baseline_images=['specgram_angle_freqs'],
                   remove_text=True, extensions=['png'],
-                  tol=0.007 if on_win else 0)
+                  tol=0.007)
 def test_specgram_angle_freqs():
     '''test axes.specgram in angle mode with sinusoidal stimuli'''
     n = 10000

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -113,7 +113,7 @@ def test_SimplePatchShadow_offset():
     assert_equal(pe._offset, (4, 5))
 
 
-@image_comparison(baseline_images=['collection'], tol=0.013 if on_win else 0)
+@image_comparison(baseline_images=['collection'], tol=0.015)
 def test_collection():
     x, y = np.meshgrid(np.linspace(0, 10, 150), np.linspace(-5, 5, 100))
     data = np.sin(x) + np.cos(y)

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -17,9 +17,6 @@ except ImportError:
     import mock
 from nose.tools import assert_equal
 
-import sys
-on_win = (sys.platform == 'win32')
-
 
 @image_comparison(baseline_images=['patheffect1'], remove_text=True)
 def test_patheffect1():

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -149,7 +149,7 @@ def test_text3d():
     ax.set_zlabel('Z axis')
 
 
-@image_comparison(baseline_images=['trisurf3d'], remove_text=True)
+@image_comparison(baseline_images=['trisurf3d'], remove_text=True, tol=0.03)
 def test_trisurf3d():
     n_angles = 36
     n_radii = 8


### PR DESCRIPTION
These are mainly the same as changed on windows. Rather than making more OS specific hacks I have changed them everywhere but I could be convinced otherwise. 
None of the changes are related to text/freetype as far as I can see but more likely to be related to floating point math and thus libraries, OS, compilers, CPU architecture ... 

Might want to backport to 2.x