### PR TITLE
Able to give a variable amount of alpha values into set_alpha in collections

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -276,15 +276,11 @@ class ScalarMappable(object):
         if norm:
             x = self.norm(x)
 
-        try:
-            np_alpha = ma.asarray(alpha)
-            if np_alpha.ndim == 1 and np_alpha.shape == x.shape:
-                rgba = self.cmap(x, bytes=bytes)
-                rgba[0:, 3] = np_alpha
-                return rgba
-        except AttributeError:
-            # e.g., alpha is not an array;
-            pass
+        np_alpha = ma.asarray(alpha)
+        if np_alpha.ndim == 1 and np_alpha.shape == x.shape:
+            rgba = self.cmap(x, bytes=bytes)
+            rgba[0:, 3] = np_alpha
+            return rgba
 
         rgba = self.cmap(x, alpha=alpha, bytes=bytes)
         return rgba

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -275,6 +275,17 @@ class ScalarMappable(object):
         x = ma.asarray(x)
         if norm:
             x = self.norm(x)
+
+        try:
+            alpha = ma.asarray(alpha)
+            if alpha.ndim == 1 and alpha.shape == x.shape:
+                rgba = self.cmap(x, bytes=bytes)
+                rgba[0:, 3] = alpha
+                return rgba
+        except AttributeError:
+            # e.g., alpha is not an array;
+            pass
+
         rgba = self.cmap(x, alpha=alpha, bytes=bytes)
         return rgba
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -277,10 +277,10 @@ class ScalarMappable(object):
             x = self.norm(x)
 
         try:
-            alpha = ma.asarray(alpha)
-            if alpha.ndim == 1 and alpha.shape == x.shape:
+            np_alpha = ma.asarray(alpha)
+            if np_alpha.ndim == 1 and np_alpha.shape == x.shape:
                 rgba = self.cmap(x, bytes=bytes)
-                rgba[0:, 3] = alpha
+                rgba[0:, 3] = np_alpha
                 return rgba
         except AttributeError:
             # e.g., alpha is not an array;

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -678,14 +678,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
         ACCEPTS: float or None
         """
         if alpha is not None:
-            try:
-                # Check if alpha is an array of matching size
-                np_alpha = ma.asarray(alpha)
-                if np_alpha.ndim == 1:
-                    artist.Artist.set_alpha(self, np_alpha)
-                    return
-            except AttributeError:
-                pass
+            # Check if alpha is an array of matching size
+            np_alpha = ma.asarray(alpha)
+            if np_alpha.ndim == 1:
+                artist.Artist.set_alpha(self, np_alpha)
+                return
             try:
                 float(alpha)
             except TypeError:

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -680,9 +680,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if alpha is not None:
             try:
                 # Check if alpha is an array of matching size
-                alpha = ma.asarray(alpha)
-                if alpha.ndim == 1:
-                    artist.Artist.set_alpha(self, alpha)
+                np_alpha = ma.asarray(alpha)
+                if np_alpha.ndim == 1:
+                    artist.Artist.set_alpha(self, np_alpha)
                     return
             except AttributeError:
                 pass

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -679,6 +679,14 @@ class Collection(artist.Artist, cm.ScalarMappable):
         """
         if alpha is not None:
             try:
+                # Check if alpha is an array of matching size
+                alpha = ma.asarray(alpha)
+                if alpha.ndim == 1:
+                    artist.Artist.set_alpha(self, alpha)
+                    return
+            except AttributeError:
+                pass
+            try:
                 float(alpha)
             except TypeError:
                 raise TypeError('alpha must be a float or None')


### PR DESCRIPTION
From issue #3643

Multiple alpha values can be given to `collection.set_alpha`.  The behaviour of this differs depending on what the colour input is.  
If there is only one face/edge colour then the given alpha values will alternate over all collection items.  
If there are more face/edge colours than alphas, set_alpha will apply to as many colours as there are alphas.  This is to avoid the situation of (for example) having 6 colours and 5 alphas, then set_alpha would need to create 30 different combinations.  I decided against this and instead, in this situation the first 5 colours will have the alpha values applied to them and the sixth color will have no alpha applied to it.