### PR TITLE
Implements #4489 WIP

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -672,7 +672,13 @@ class Axes(_AxesBase):
 
         .. plot:: mpl_examples/pylab_examples/annotation_demo2.py
         """
-        a = mtext.Annotation(*args, **kwargs)
+
+        # # TODO: resolve this
+        # args = list(args)
+        # args[2] = self
+        # tuple(args)
+
+        a = mtext.Annotation(self, *args, **kwargs)
         a.set_transform(mtransforms.IdentityTransform())
         if 'clip_on' in kwargs:
             a.set_clip_path(self.patch)


### PR DESCRIPTION
This is work in progress to implement auto-placement of annotations, as mentioned in issue #4489. We're trying to migrate legend.py's find best position algorithm, and we're looking for critical feedback. So far, we've:

- Copied _find_best_position, _auto_legend_data and _get_anchored_bbox from legend.py
- Added a new instance variable of the axes for use in _find_best_position
- Used self.parent.bbox for _get_anchored_bbox
- Used Text.get_window_extent to get the bbox of the annotation for its width and height (Or so I assumed)
- Removed self.borderaxespad from _get_anchored_bbox's method body, since it doesn't exist and I couldn't find a suitable replacement (Not in this commit)

Current issues that we're having/foreseeing:
- Is this the correct way to get an annotation's bbox? Is there a more correct (or more appropriate for this situation) way to get the bbox?
- Are there any problems with removing borderaxespad from _get_anchored_bbox?
- _find_best_position appears to give display (pixel) coordinates for the best determined position. In which method should it be called, and which method should be used to update its position?
