### PR TITLE
MAINT: Updates to formatters in `matplotlib.ticker`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -28,6 +28,7 @@ John Hunter <jdh2358@gmail.com>
 Jorrit Wronski <jowr@mek.dtu.dk>
 Jouni K. Seppänen <jks@iki.fi>
 Joseph Fox-Rabinovitz <jfoxrabinovitz@gmail.com> Mad Physicist <madphysicist@users.noreply.github.com>
+Joseph Fox-Rabinovitz <jfoxrabinovitz@gmail.com> Joseph Fox-Rabinovitz <joseph.r.fox-rabinovitz@nasa.gov>
 Julien Schueller <julien.schueller@gmail.com> <schueller@porsche-l64.phimeca.lan>
 Julien Schueller <julien.schueller@gmail.com> <schueller@bx-l64.phimeca.lan>
 Kevin Davies <kdavies4@gmail.com> <daviesk24@yahoo.com>

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -371,6 +371,10 @@ def _percent_format_helper(xmax, decimals, symbol, x, display_range, expected):
     formatter = mticker.PercentFormatter(xmax, decimals, symbol)
     nose.tools.assert_equal(formatter.format_pct(x, display_range), expected)
 
+    # test str.format() style formatter with `pos`
+    tmp_form = mticker.StrMethodFormatter('{x:03d}-{pos:02d}')
+    nose.tools.assert_equal('002-01', tmp_form(2, 1))
+
 
 def test_percentformatter():
     test_cases = (

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -282,7 +282,7 @@ class Formatter(TickHelper):
         """
         Return a short string version of the tick value.
 
-        Defaults to the position-indepedent long value.
+        Defaults to the position-independent long value.
         """
         return self.format_data(value)
 
@@ -400,7 +400,7 @@ class FormatStrFormatter(Formatter):
     Use an old-style ('%' operator) format string to format the tick.
 
     The format string should have a single variable format (%) in it.
-    It will be applied to the value (not the postition) of the tick.
+    It will be applied to the value (not the position) of the tick.
     """
     def __init__(self, fmt):
         self.fmt = fmt
@@ -489,19 +489,16 @@ class OldScalarFormatter(Formatter):
 class ScalarFormatter(Formatter):
     """
     Format tick values as a number.
+
+    Tick value is interpreted as a plain old number. If
+    ``useOffset==True`` and the data range is much smaller than the data
+    average, then an offset will be determined such that the tick labels
+    are meaningful. Scientific notation is used for ``data < 10^-n`` or
+    ``data >= 10^m``, where ``n`` and ``m`` are the power limits set
+    using ``set_powerlimits((n,m))``. The defaults for these are
+    controlled by the ``axes.formatter.limits`` rc parameter.
     """
     def __init__(self, useOffset=None, useMathText=None, useLocale=None):
-        """
-        Tick value is interpreted as a plain old number. If
-        ``useOffset==True`` and the data range is much smaller than the
-        data average, then an offset will be determined such that the
-        tick labels are meaningful. Scientific notation is used for
-        ``data < 10^-n`` or ``data >= 10^m``, where ``n`` and ``m`` are
-        the power limits set using ``set_powerlimits((n,m))``. The
-        defaults for these are controlled by the
-        ``axes.formatter.limits`` rc parameter.
-        """
-
         # useOffset allows plotting small data ranges with large offsets: for
         # example: [1+1e-9,1+2e-9,1+3e-9] useMathText will render the offset
         # and scientific notation in mathtext
@@ -555,7 +552,9 @@ class ScalarFormatter(Formatter):
             return s.replace('-', '\u2212')
 
     def __call__(self, x, pos=None):
-        'Return the format for tick val *x* at position *pos*'
+        """
+        Return the format for tick value `x` at position `pos`.
+        """
         if len(self.locs) == 0:
             return ''
         else:
@@ -574,7 +573,7 @@ class ScalarFormatter(Formatter):
         """
         Sets size thresholds for scientific notation.
 
-        Limits is a two-element sequence containing the powers of 10
+        ``lims`` is a two-element sequence containing the powers of 10
         that determine the switchover threshold. Numbers below
         ``10**lims[0]`` and above ``10**lims[1]`` will be displayed in
         scientific notation.
@@ -997,8 +996,15 @@ class EngFormatter(Formatter):
     """
     Formats axis values using engineering prefixes to represent powers
     of 1000, plus a specified unit, e.g., 10 MHz instead of 1e7.
-    """
 
+    `unit` is a string containing the abbreviated name of the unit,
+    suitable for use with single-letter representations of powers of
+    1000. For example, 'Hz' or 'm'.
+
+    `places` is the percision with which to display the number,
+    specified in digits after the decimal point (there will be between
+    one and three digits before the decimal point).
+    """
     # The SI engineering prefixes
     ENG_PREFIXES = {
         -24: "y",
@@ -1021,17 +1027,6 @@ class EngFormatter(Formatter):
     }
 
     def __init__(self, unit="", places=None):
-        """
-        Initializes an engineering notation formatter.
-
-        `unit` is a string containing the abbreviated name of the unit,
-        suitable for use with single-letter representations of powers of
-        1000. For example, 'Hz' or 'm'.
-
-        `places` is the percision with which to display the number,
-        specified in digits after the decimal point (there will be
-        between one and three digits before the decimal point).
-        """
         self.unit = unit
         self.places = places
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2,11 +2,11 @@
 Tick locating and formatting
 ============================
 
-This module contains classes to support completely configurable tick locating
-and formatting.  Although the locators know nothing about major or minor
-ticks, they are used by the Axis class to support major and minor tick
-locating and formatting.  Generic tick locators and formatters are provided,
-as well as domain specific custom ones..
+This module contains classes to support completely configurable tick
+locating and formatting.  Although the locators know nothing about major
+or minor ticks, they are used by the Axis class to support major and
+minor tick locating and formatting.  Generic tick locators and
+formatters are provided, as well as domain specific custom ones..
 
 
 Default Formatter
@@ -35,8 +35,8 @@ Tick locating
 The Locator class is the base class for all tick locators.  The locators
 handle autoscaling of the view limits based on the data limits, and the
 choosing of tick locations.  A useful semi-automatic tick locator is
-MultipleLocator.  You initialize this with a base, e.g., 10, and it picks axis
-limits and ticks that are multiples of your base.
+MultipleLocator.  You initialize this with a base, e.g., 10, and it
+picks axis limits and ticks that are multiples of your base.
 
 The Locator subclasses defined here are
 
@@ -56,8 +56,9 @@ The Locator subclasses defined here are
     logarithmically ticks from min to max
 
 :class:`SymmetricalLogLocator`
-    locator for use with with the symlog norm, works like the `LogLocator` for
-    the part outside of the threshold and add 0 if inside the limits
+    locator for use with with the symlog norm, works like the
+    `LogLocator` for the part outside of the threshold and add 0 if
+    inside the limits
 
 :class:`MultipleLocator`
     ticks and range are a multiple of base;
@@ -790,8 +791,13 @@ class LogFormatter(Formatter):
         self.labelOnlyBase = labelOnlyBase
 
     def base(self, base):
-        """change the *base* for labeling - warning: should always match the
-           base used for :class:`LogLocator`"""
+        """
+        change the `base` for labeling.
+
+        .. warning::
+           Should always match the base used for :class:`LogLocator`
+
+        """
         self._base = base
 
     def label_minor(self, labelOnlyBase):
@@ -803,7 +809,9 @@ class LogFormatter(Formatter):
         self.labelOnlyBase = labelOnlyBase
 
     def __call__(self, x, pos=None):
-        """Return the format for tick val *x* at position *pos*"""
+        """
+        Return the format for tick val `x` at position `pos`.
+        """
         vmin, vmax = self.axis.get_view_interval()
         d = abs(vmax - vmin)
         b = self._base
@@ -834,7 +842,9 @@ class LogFormatter(Formatter):
         return value
 
     def format_data_short(self, value):
-        'return a short formatted string representation of a number'
+        """
+        Return a short formatted string representation of a number.
+        """
         return '%-12g' % value
 
     def pprint_val(self, x, d):
@@ -872,7 +882,7 @@ class LogFormatter(Formatter):
 
 class LogFormatterExponent(LogFormatter):
     """
-    Format values for log axis using ``exponent = log_base(value)``
+    Format values for log axis using ``exponent = log_base(value)``.
     """
     def __call__(self, x, pos=None):
         """

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -377,14 +377,22 @@ class FormatStrFormatter(Formatter):
 class StrMethodFormatter(Formatter):
     """
     Use a new-style format string (as used by `str.format()`)
-    to format the tick.  The field formatting must be labeled `x`.
+    to format the tick.
+
+    The field used for the value must be labeled `x` and the field used
+    for the position must be labeled `pos`.
     """
     def __init__(self, fmt):
         self.fmt = fmt
 
     def __call__(self, x, pos=None):
-        'Return the format for tick val *x* at position *pos*'
-        return self.fmt.format(x=x)
+        """
+        Return the formatted label string.
+
+        `x` and `pos` are passed to `str.format` as keyword arguments
+        with those exact names.
+        """
+        return self.fmt.format(x=x, pos=pos)
 
 
 class OldScalarFormatter(Formatter):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -564,7 +564,7 @@ class ScalarFormatter(Formatter):
     def set_scientific(self, b):
         """
         Turn scientific notation on or off.
-        
+
         .. seealso:: Method :meth:`set_powerlimits`
         """
         self._scientific = bool(b)


### PR DESCRIPTION
This PR is a split from #6251. Most of the changes are to docs, but there are two minor code changes:

  1. `__all__` has been moved to the top of the file and a couple of missing formatters were added to it.
  2. A second format (position) is permitted in the string for the new-style string formatter.

As the title suggests, only formatters were affected. Locators were left untouched.

I have retained the original commits until the PR is reviewed to make sure that I did the split correctly.