### PR TITLE
Bug fix and general touch ups for hist3d_demo example (#1702)

### DIFF
--- a/examples/mplot3d/hist3d_demo.py
+++ b/examples/mplot3d/hist3d_demo.py
@@ -1,3 +1,6 @@
+# Note: np.meshgrid produces arrays in (ny, nx), so flatten is called with 'F'.
+# For numpy >= 1.7, this can be avoided by calling meshgrid with indexing='ij'.
+
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
 import numpy as np
@@ -7,12 +10,11 @@ ax = fig.add_subplot(111, projection='3d')
 x, y = np.random.rand(2, 100) * 4
 hist, xedges, yedges = np.histogram2d(x, y, bins=4)
 
-elements = (len(xedges) - 1) * (len(yedges) - 1)
 xpos, ypos = np.meshgrid(xedges[:-1] + 0.25, yedges[:-1] + 0.25)
+xpos = xpos.flatten('F')
+ypos = ypos.flatten('F')
+zpos = np.zeros_like(xpos)
 
-xpos = xpos.flatten()
-ypos = ypos.flatten()
-zpos = np.zeros(elements)
 dx = 0.5 * np.ones_like(zpos)
 dy = dx.copy()
 dz = hist.flatten()

--- a/examples/mplot3d/hist3d_demo.py
+++ b/examples/mplot3d/hist3d_demo.py
@@ -1,5 +1,6 @@
-# Note: np.meshgrid produces arrays in (ny, nx), so flatten is called with 'F'.
-# For numpy >= 1.7, this can be avoided by calling meshgrid with indexing='ij'.
+'''
+Demo of a histogram for 2 dimensional data as a bar graph in 3D.
+'''
 
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
@@ -8,13 +9,18 @@ import numpy as np
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
 x, y = np.random.rand(2, 100) * 4
-hist, xedges, yedges = np.histogram2d(x, y, bins=4)
+hist, xedges, yedges = np.histogram2d(x, y, bins=4, range=[[0, 4], [0, 4]])
 
+# Construct arrays for the anchor positions of the 16 bars.
+# Note: np.meshgrid gives arrays in (ny, nx) so we use 'F' to flatten xpos,
+# ypos in column-major order. For numpy >= 1.7, we could instead call meshgrid
+# with indexing='ij'.
 xpos, ypos = np.meshgrid(xedges[:-1] + 0.25, yedges[:-1] + 0.25)
 xpos = xpos.flatten('F')
 ypos = ypos.flatten('F')
 zpos = np.zeros_like(xpos)
 
+# Construct arrays with the dimensions for the 16 bars.
 dx = 0.5 * np.ones_like(zpos)
 dy = dx.copy()
 dz = hist.flatten()


### PR DESCRIPTION
- Fixes bug #1702 by using 'F' when flattening xpos, ypos
- Makes the bin ranges fixed, also as discussed on #1702
- Adds a docstring (as per MEP12) plus some clarifying comments