### PR TITLE
MNT: trap inappropriate use of color kwarg in scatter; closes #6266

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3824,19 +3824,20 @@ class Axes(_AxesBase):
         # Process **kwargs to handle aliases, conflicts with explicit kwargs:
 
         facecolors = None
-        ec = kwargs.pop('edgecolor', None)
-        if ec is not None:
-            edgecolors = ec
-        fc = kwargs.pop('facecolor', None)
-        if fc is not None:
-            facecolors = fc
+        edgecolors = kwargs.pop('edgecolor', edgecolors)
         fc = kwargs.pop('facecolors', None)
+        fc = kwargs.pop('facecolor', fc)
         if fc is not None:
             facecolors = fc
-        # 'color' should be deprecated in scatter, or clearly defined;
-        # since it isn't, I am giving it low priority.
         co = kwargs.pop('color', None)
         if co is not None:
+            try:
+                mcolors.colorConverter.to_rgba_array(co)
+            except ValueError:
+                raise ValueError("'color' kwarg must be an mpl color"
+                                 " spec or sequence of color specs.\n"
+                                 "For a sequence of values to be"
+                                 " color-mapped, use the 'c' kwarg instead.")
             if edgecolors is None:
                 edgecolors = co
             if facecolors is None:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1285,6 +1285,13 @@ def test_scatter_2D():
     fig, ax = plt.subplots()
     ax.scatter(x, y, c=z, s=200, edgecolors='face')
 
+@cleanup
+def test_scatter_color():
+    # Try to catch cases where 'c' kwarg should have been used.
+    assert_raises(ValueError, plt.scatter, [1, 2], [1, 2],
+                  color=[0.1, 0.2])
+    assert_raises(ValueError, plt.scatter, [1, 2, 3], [1, 2, 3],
+                  color=[1, 2, 3])
 
 @cleanup
 def test_as_mpl_axes_api():


### PR DESCRIPTION
This slightly modifies and extends the special-casing of color-related
kwargs that would otherwise be passed in to a Collection instance.
Attempts to use 'color' in place of the 'c' kwarg for color-mapping
in scatter are now trapped with a ValueError in most cases.  There
are still cases that are impossible to trap: a sequence of 3 or 4
floats between 0 and 1 could be either a single color spec or a
sequence of values to be color-mapped.