### PR TITLE
A feeble attempt to plug a theoretical security hole

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -746,17 +746,16 @@ def validate_cycler(s):
             # might come from the internet (future plans), this
             # could be downright dangerous.
             # I locked it down by only having the 'cycler()' function
-            # available. Imports and defs should not
-            # be possible. However, it is entirely possible that
-            # a security hole could open up via attributes to the
-            # function (this is why I decided against allowing the
-            # Cycler class object just to reduce the number of
-            # degrees of freedom (but maybe it is safer to use?).
-            # One possible hole I can think of (in theory) is if
-            # someone managed to hack the cycler module. But, if
-            # someone does that, this wouldn't make anything
-            # worse because we have to import the module anyway.
-            s = eval(s, {'cycler': cycler})
+            # available.
+            # UPDATE: Partly plugging a security hole.
+            # I really should have read this:
+            # http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+            # We should replace this eval with a combo of PyParsing and
+            # ast.literal_eval()
+            if '.__' in s.replace(' ', ''):
+                raise ValueError("'%s' seems to have dunder methods. Raising"
+                                 " an exception for your safety")
+            s = eval(s, {'cycler': cycler, '__builtins__': {}})
         except BaseException as e:
             raise ValueError("'%s' is not a valid cycler construction: %s" %
                              (s, e))


### PR DESCRIPTION
I introduced a security hole when I implemented the property cycle support last year. I should have read this blog posting: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html that would have scared me off of the current implementation.

What this PR does is tries to plug two possible holes. First, it neuters `__builtins__`, which is a good step, but as Ned points out in his post, it is insufficient. Second, I reject any cycler strings that have the substring of `'.__'` in it, as it could be a dunder method access, which is key to the other holes that Ned demonstrates. I don't like that because I can see possible valid uses of that combo of three characters in a property cycler.

@tacaswell and I have discussed some future directions to fix this permanently that should go into v2.0. Essentially, use PyParsing and `ast.literal_eval()` instead of the unsafe `eval()`. That would take some time, and given that v2.0 is still in the works, I would suggest releasing v1.5.2 as a security fix release.