### PR TITLE
Fix cycler validation

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -726,15 +726,7 @@ def cycler(*args, **kwargs):
         if not isinstance(args[0], Cycler):
             raise TypeError("If only one positional argument given, it must "
                             " be a Cycler instance.")
-
-        c = args[0]
-        unknowns = c.keys - (set(_prop_validators.keys()) |
-                             set(_prop_aliases.keys()))
-        if unknowns:
-            # This is about as much validation I can do
-            raise TypeError("Unknown artist properties: %s" % unknowns)
-        else:
-            return Cycler(c)
+        return validate_cycler(args[0])
     elif len(args) == 2:
         pairs = [(args[0], args[1])]
     elif len(args) > 2:
@@ -788,6 +780,17 @@ def validate_cycler(s):
         cycler_inst = s
     else:
         raise ValueError("object was not a string or Cycler instance: %s" % s)
+
+    unknowns = cycler_inst.keys - (set(_prop_validators.keys()) |
+                                   set(_prop_aliases.keys()))
+    if unknowns:
+        raise ValueError("Unknown artist properties: %s" % unknowns)
+
+    # Not a full validation, but it'll at least normalize property names
+    # A fuller validation would require v0.10 of cycler.
+    for prop in cycler_inst.keys:
+        norm_prop = _prop_aliases.get(prop, prop)
+        cycler_inst.change_key(prop, norm_prop)
 
     return cycler_inst
 

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -32,7 +32,7 @@ def test_colorcycle_basic():
 def test_marker_cycle():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('color', ['r', 'g', 'y']) +
+    ax.set_prop_cycle(cycler('c', ['r', 'g', 'y']) +
                       cycler('marker', ['.', '*', 'x']))
     xs = np.arange(10)
     ys = 0.25 * xs + 2
@@ -48,7 +48,7 @@ def test_marker_cycle():
     fig = plt.figure()
     ax = fig.add_subplot(111)
     # Test keyword arguments, numpy arrays, and generic iterators
-    ax.set_prop_cycle(color=np.array(['r', 'g', 'y']),
+    ax.set_prop_cycle(c=np.array(['r', 'g', 'y']),
                       marker=iter(['.', '*', 'x']))
     xs = np.arange(10)
     ys = 0.25 * xs + 2
@@ -67,7 +67,7 @@ def test_marker_cycle():
 def test_linestylecycle_basic():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('linestyle', ['-', '--', ':']))
+    ax.set_prop_cycle(cycler('ls', ['-', '--', ':']))
     xs = np.arange(10)
     ys = 0.25 * xs + 2
     ax.plot(xs, ys, label='solid', lw=4)
@@ -85,7 +85,7 @@ def test_linestylecycle_basic():
 def test_fillcycle_basic():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('color',  ['r', 'g', 'y']) +
+    ax.set_prop_cycle(cycler('c',  ['r', 'g', 'y']) +
                       cycler('hatch', ['xx', 'O', '|-']) +
                       cycler('linestyle', ['-', '--', ':']))
     xs = np.arange(10)
@@ -131,7 +131,7 @@ def test_valid_input_forms():
     ax.set_prop_cycle(None)
     ax.set_prop_cycle(cycler('linewidth', [1, 2]))
     ax.set_prop_cycle('color', 'rgywkbcm')
-    ax.set_prop_cycle('linewidth', (1, 2))
+    ax.set_prop_cycle('lw', (1, 2))
     ax.set_prop_cycle('linewidth', [1, 2])
     ax.set_prop_cycle('linewidth', iter([1, 2]))
     ax.set_prop_cycle('linewidth', np.array([1, 2]))
@@ -181,6 +181,11 @@ def test_invalid_input_forms():
             'linewidth', {'1': 1, '2': 2})
     assert_raises((TypeError, ValueError), ax.set_prop_cycle,
             linewidth=1, color='r')
+    assert_raises((TypeError, ValueError), ax.set_prop_cycle, 'foobar', [1, 2])
+    assert_raises((TypeError, ValueError), ax.set_prop_cycle,
+            foobar=[1, 2])
+    assert_raises((TypeError, ValueError), ax.set_prop_cycle,
+            cycler(foobar=[1, 2]))
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -186,6 +186,8 @@ def test_invalid_input_forms():
             foobar=[1, 2])
     assert_raises((TypeError, ValueError), ax.set_prop_cycle,
             cycler(foobar=[1, 2]))
+    assert_raises(ValueError, ax.set_prop_cycle,
+            cycler(color='rgb', c='cmy'))
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -322,6 +322,10 @@ def test_validators():
                      ("cycler('c', 'rgb') * cycler('linestyle', ['-', '--'])",
                       (cycler('color', 'rgb') *
                           cycler('linestyle', ['-', '--']))),
+                     (cycler('ls', ['-', '--']),
+                      cycler('linestyle', ['-', '--'])),
+                     (cycler(mew=[2, 5]),
+                      cycler('markeredgewidth', [2, 5])),
                     ),
          # This is *so* incredibly important: validate_cycler() eval's
          # an arbitrary string! I think I have it locked down enough,
@@ -343,6 +347,7 @@ def test_validators():
                   ('cycler("waka", [1, 2, 3])', ValueError),  # not a property
                   ('cycler(c=[1, 2, 3])', ValueError),  # invalid values
                   ("cycler(lw=['a', 'b', 'c'])", ValueError),  # invalid values
+                  (cycler('waka', [1, 3, 5]), ValueError),  # not a property
                  )
         },
         {'validator': validate_hatch,

--- a/setupext.py
+++ b/setupext.py
@@ -1384,7 +1384,7 @@ class Cycler(SetupPackage):
         return "using cycler version %s" % cycler.__version__
 
     def get_install_requires(self):
-        return ['cycler']
+        return ['cycler>=0.9']
 
 
 class Dateutil(SetupPackage):


### PR DESCRIPTION
This should fix the cycler normalization/validation bugs we have seen such as #5875. This does require a minimum version of Cycler v0.9 to get the `change_key()` feature. We could go a few steps further and get full validation of property values for Cycler objects, but that will require Cycler v0.10, I think, so that I can introspect the cycler object better -- not out of the question, but I figure I would get this first step done first.