### PR TITLE
fix a warning when the aspect is a number

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1249,7 +1249,7 @@ class _AxesBase(martist.Artist):
                     '1.2', name='normal', alternative='auto', obj_type='aspect')
                 self._aspect = 'auto'
             else:
-               raise ValueError("error in aspect")
+                raise ValueError("error in aspect")
 
         if adjustable is not None:
             self.set_adjustable(adjustable)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1239,15 +1239,17 @@ class _AxesBase(martist.Artist):
         .. deprecated:: 1.2
             the option 'normal' for aspect is deprecated. Use 'auto' instead.
         """
-        if aspect == 'normal':
-            cbook.warn_deprecated(
-                '1.2', name='normal', alternative='auto', obj_type='aspect')
-            self._aspect = 'auto'
-
-        elif aspect in ('equal', 'auto'):
-            self._aspect = aspect
-        else:
+        try:
             self._aspect = float(aspect)  # raise ValueError if necessary
+        except ValueError:
+            if aspect in ('equal', 'auto'):
+                self._aspect = aspect
+            elif aspect == 'normal':
+                cbook.warn_deprecated(
+                    '1.2', name='normal', alternative='auto', obj_type='aspect')
+                self._aspect = 'auto'
+            else:
+               raise ValueError("error in aspect")
 
         if adjustable is not None:
             self.set_adjustable(adjustable)


### PR DESCRIPTION
This PR fixes the following warning when using `plt.axes().set_aspect(1)`:

``` console
/usr/local/lib/python2.7/site-packages/matplotlib/axes/_base.py:1215: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if aspect == 'normal':
/usr/local/lib/python2.7/site-packages/matplotlib/axes/_base.py:1220: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  elif aspect in ('equal', 'auto'):
```
