### PR TITLE
FIX: do not always reset scales from figureoptions

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -120,8 +120,12 @@ def figure_edit(axes, parent=None):
         # Set / General
         title, xmin, xmax, xlabel, xscale, ymin, ymax, ylabel, yscale, \
             generate_legend = general
-        axes.set_xscale(xscale)
-        axes.set_yscale(yscale)
+
+        if axes.get_xscale() != xscale:
+            axes.set_xscale(xscale)
+        if axes.get_yscale() != yscale:
+            axes.set_yscale(yscale)
+
         axes.set_title(title)
         axes.set_xlim(xmin, xmax)
         axes.set_xlabel(xlabel)


### PR DESCRIPTION
Only try to set the axis scales if they have been changed.

closes #6276

The `set_yscale` and `set_xscale` Axes methods call out to
`Axis_set_scale` which resets the default locator/formatters (which
makes sense when flipping between log/linear).

Putting the cut-out in `figureoption` is the less disruptive change,
even if the case could be made that the no-op short-circuit should be
done in Axis or Axes.