### PR TITLE
FIX: use b'' when escaping array as strings in ps

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -165,15 +165,16 @@ def _num_to_str(val):
 def _nums_to_str(*args):
     return ' '.join(map(_num_to_str,args))
 
+
 def quote_ps_string(s):
     "Quote dangerous characters of S for use in a PostScript string constant."
-    s=s.replace("\\", "\\\\")
-    s=s.replace("(", "\\(")
-    s=s.replace(")", "\\)")
-    s=s.replace("'", "\\251")
-    s=s.replace("`", "\\301")
-    s=re.sub(r"[^ -~\n]", lambda x: r"\%03o"%ord(x.group()), s)
-    return s
+    s = s.replace(b"\\", b"\\\\")
+    s = s.replace(b"(", b"\\(")
+    s = s.replace(b")", b"\\)")
+    s = s.replace(b"'", b"\\251")
+    s = s.replace(b"`", b"\\301")
+    s = re.sub(br"[^ -~\n]", lambda x: br"\%03o" % ord(x.group()), s)
+    return s.decode('ascii')
 
 
 def seq_allequal(seq1, seq2):


### PR DESCRIPTION
The function quote_ps_string is used to sanitize the result of
np.tostring (which really returns bytes) to make sure no 'special'
ps characters make it through.

We were trying to use unicode to replace in a byte string

We also need to decode bytes to unicode to put the string into the
ps file.

closes #6226