### PR TITLE
FigureCanvasQT key auto repeat

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -76,8 +76,8 @@ class FigureCanvasQT(FigureCanvasQT5):
         w, h = self.get_width_height()
         self.resize(w, h)
 
-        # Key auto-repeat disabled by default
-        self._keyautorepeat = False
+        # Key auto-repeat enabled by default
+        self._keyautorepeat = True
 
     def wheelEvent(self, event):
         x = event.x()

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -76,6 +76,9 @@ class FigureCanvasQT(FigureCanvasQT5):
         w, h = self.get_width_height()
         self.resize(w, h)
 
+        # Key auto-repeat disabled by default
+        self._keyautorepeat = False
+
     def wheelEvent(self, event):
         x = event.x()
         # flipy so y=0 is bottom of canvas

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -137,7 +137,7 @@ def _create_qApp():
                 if display is None or not re.search(':\d', display):
                     raise RuntimeError('Invalid DISPLAY variable')
 
-            qApp = QtWidgets.QApplication([str(" ")])
+            qApp = QtWidgets.QApplication([six.text_type(" ")])
             qApp.lastWindowClosed.connect(qApp.quit)
         else:
             qApp = app

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -172,7 +172,7 @@ def new_figure_manager_given_figure(num, figure):
 
 class TimerQT(TimerBase):
     '''
-    Subclass of :class:`backend_bases.TimerBase` that uses Qt4 timer events.
+    Subclass of :class:`backend_bases.TimerBase` that uses Qt timer events.
 
     Attributes:
     * interval: The time between timer events in milliseconds. Default
@@ -226,10 +226,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
                # QtCore.Qt.XButton2: None,
                }
 
-    # Key auto-repeat disabled by default
-    _keypressautorepeat = False
-    _keyreleaseautorepeat = False
-
     def __init__(self, figure):
         if DEBUG:
             print('FigureCanvasQt qt5: ', figure)
@@ -245,6 +241,9 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         self.setMouseTracking(True)
         w, h = self.get_width_height()
         self.resize(w, h)
+
+        # Key auto-repeat enabled by default
+        self._keyautorepeat = True
 
     def enterEvent(self, event):
         FigureCanvasBase.enter_notify_event(self, guiEvent=event)
@@ -311,8 +310,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
                       'steps = %i ' % (event.delta(), steps))
 
     def keyPressEvent(self, event):
-        if not self._keypressautorepeat and event.isAutoRepeat():
-            return
         key = self._get_key(event)
         if key is None:
             return
@@ -320,20 +317,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         if DEBUG:
             print('key press', key)
 
-    @property
-    def keyPressAutoRepeat(self):
-        """
-        If True, enable auto-repeat for key press events.
-        """
-        return self._keypressautorepeat
-
-    @keyPressAutoRepeat.setter
-    def keyPressAutoRepeat(self, val):
-        self._keypressautorepeat = bool(val)
-
     def keyReleaseEvent(self, event):
-        if not self._keyreleaseautorepeat and event.isAutoRepeat():
-            return
         key = self._get_key(event)
         if key is None:
             return
@@ -342,15 +326,15 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('key release', key)
 
     @property
-    def keyReleaseAutoRepeat(self):
+    def keyAutoRepeat(self):
         """
-        If True, enable auto-repeat for key release events.
+        If True, enable auto-repeat for key events.
         """
-        return self._keyreleaseautorepeat
+        return self._keyautorepeat
 
-    @keyReleaseAutoRepeat.setter
-    def keyReleaseAutoRepeat(self, val):
-        self._keyreleaseautorepeat = bool(val)
+    @keyAutoRepeat.setter
+    def keyAutoRepeat(self, val):
+        self._keyautorepeat = bool(val)
 
     def resizeEvent(self, event):
         w = event.size().width()
@@ -374,6 +358,9 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         return QtCore.QSize(10, 10)
 
     def _get_key(self, event):
+        if not self._keyautorepeat and event.isAutoRepeat():
+            return
+
         event_key = event.key()
         event_mods = int(event.modifiers())  # actually a bitmask
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -359,7 +359,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
     def _get_key(self, event):
         if not self._keyautorepeat and event.isAutoRepeat():
-            return
+            return None
 
         event_key = event.key()
         event_mods = int(event.modifiers())  # actually a bitmask


### PR DESCRIPTION
Actually, with QtBackend, auto-repeat is disabled. But auto-repeat is sometime useful (By example for implementing moving an artist with arrow keys).

This add "keyPressAutoRepeat" and "keyReleaseAutoRepeat" properties to FigureCanvasQT.

If True, theses properties enable key auto-repeat for press and release events respectively.

With this auto-repeat is still disabled by default, but can be re-enabled now.