### PR TITLE
Updating animation file writer to allow keywork arguments when using `with` construct

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -137,7 +137,7 @@ class AbstractMovieWriter(six.with_metaclass(abc.ABCMeta)):
     '''
 
     @abc.abstractmethod
-    def setup(self, fig, outfile, dpi, *args, **kwargs):
+    def setup(self, fig, outfile, dpi):
         '''
         Perform setup for writing the movie file.
 
@@ -246,7 +246,7 @@ class MovieWriter(AbstractMovieWriter):
         width_inches, height_inches = self.fig.get_size_inches()
         return width_inches * self.dpi, height_inches * self.dpi
 
-    def setup(self, fig, outfile, dpi, *args, **kwargs):
+    def setup(self, fig, outfile, dpi):
         '''
         Perform setup for writing the movie file.
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -137,7 +137,7 @@ class AbstractMovieWriter(six.with_metaclass(abc.ABCMeta)):
     '''
 
     @abc.abstractmethod
-    def setup(self, fig, outfile, dpi, *args):
+    def setup(self, fig, outfile, dpi, *args, **kwargs):
         '''
         Perform setup for writing the movie file.
 
@@ -163,13 +163,13 @@ class AbstractMovieWriter(six.with_metaclass(abc.ABCMeta)):
         'Finish any processing for writing the movie.'
 
     @contextlib.contextmanager
-    def saving(self, fig, outfile, dpi, *args):
+    def saving(self, fig, outfile, dpi, *args, **kwargs):
         '''
         Context manager to facilitate writing the movie file.
 
         All arguments are passed on to `setup`.
         '''
-        self.setup(fig, outfile, dpi, *args)
+        self.setup(fig, outfile, dpi, *args, **kwargs)
         yield
         self.finish()
 
@@ -246,7 +246,7 @@ class MovieWriter(AbstractMovieWriter):
         width_inches, height_inches = self.fig.get_size_inches()
         return width_inches * self.dpi, height_inches * self.dpi
 
-    def setup(self, fig, outfile, dpi, *args):
+    def setup(self, fig, outfile, dpi, *args, **kwargs):
         '''
         Perform setup for writing the movie file.
 


### PR DESCRIPTION
Previously, in order to pass configurations to [`saving()`](https://github.com/matplotlib/matplotlib/blob/b4bed4950e8195936de25eb1fbaa1745b055c776/lib/matplotlib/animation.py#L166) and subsequently [`setup()`](https://github.com/matplotlib/matplotlib/blob/b4bed4950e8195936de25eb1fbaa1745b055c776/lib/matplotlib/animation.py#L140), the caller had to provide positional arguments. There is nothing explicitly wrong with that approach though the [`saving()`](https://github.com/matplotlib/matplotlib/blob/b4bed4950e8195936de25eb1fbaa1745b055c776/lib/matplotlib/animation.py#L166) method is currently [advertised](https://github.com/matplotlib/matplotlib/blob/b4bed4950e8195936de25eb1fbaa1745b055c776/lib/matplotlib/animation.py#L170) as taking the same parameters as `setup()`. For example, if you wanted to disable temporary file clearing for a [FileMovieWriter](https://github.com/matplotlib/matplotlib/blob/b4bed4950e8195936de25eb1fbaa1745b055c776/lib/matplotlib/animation.py#L356), you previously would not have been able to structure it like this:
```python
with recorder.saving(fig, capFile, capDPI, tempPrefix, clear_temp = False):
```
Instead, you would have to know the order of the arguments and make the call like so:
```python
with recorder.saving(fig, capFile, capDPI, tempPrefix, False):
```
This is a small change but I think it makes code easier to read and more tolerant to future API change.