### PR TITLE
Only render markers on a line when markersize > 0

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -780,7 +780,7 @@ class Line2D(Artist):
                 drawFunc(renderer, gc, tpath, affine.frozen())
                 gc.restore()
 
-        if self._marker:
+        if self._marker and self._markersize > 0:
             gc = renderer.new_gc()
             self._set_gc_clip(gc)
             rgbaFace = self._get_rgba_face()


### PR DESCRIPTION
Fixes issue #6294 by only rendering markers when their size is larger than zero.