### PR TITLE
Set _text to '' if Text.set_text argument is None

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1208,7 +1208,10 @@ class Text(Artist):
 
         ACCEPTS: string or anything printable with '%s' conversion.
         """
-        self._text = '%s' % (s,)
+        if s is not None:
+            self._text = '%s' % (s,)
+        else:
+            self._text = ''
         self.stale = True
 
     @staticmethod


### PR DESCRIPTION
This is a fix for mpld3/mpld3#275.

Given the argument `None`, the method `Text.set_text`--as currently implemented--sets the value of the attribute `_text` to the string `"None"`:

``` python
    In [1]: from matplotlib.text import Text

    In [2]: t = Text()

    In [3]: t._text
    Out[3]: ''

    In [4]: t.set_text(None)

    In [5]: t._text
    Out[5]: 'None'
```

This PR sets `_text` to its default value, the empty string `''`.
