### PR TITLE
Fix #6323: Fix vertical alignment of TeX text

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -262,7 +262,10 @@ class Dvi(object):
                 e = 0           # zero depth
             else:               # glyph
                 x, y, font, g, w = elt
-                h, e = font._height_depth_of(g)
+                if g != 0:
+                    h, e = font._height_depth_of(g)
+                else:
+                    h, e = y, 0
             minx = min(minx, x)
             miny = min(miny, y - h)
             maxx = max(maxx, x + w)


### PR DESCRIPTION
For some reason, the minus sign is coming in as character code "0", and therefore it uses the wrong height and depth for that character, which I feel must be wrong.

Cc: @jkseppan as our resident DVI expert.  Any ideas why that may be the case?
- [ ] Needs a test.
