### PR TITLE
ENH: webagg: Handle ioloop shutdown correctly

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -15,14 +15,15 @@ from __future__ import (absolute_import, division, print_function,
 
 from matplotlib.externals import six
 
-import datetime
 import errno
 import json
 import os
 import random
 import sys
+import signal
 import socket
 import threading
+from contextlib import contextmanager
 
 try:
     import tornado
@@ -323,9 +324,6 @@ class WebAggApplication(tornado.web.Application):
         if cls.started:
             return
 
-        # Set the flag to True *before* blocking on IOLoop.instance().start()
-        cls.started = True
-
         """
         IOLoop.running() was removed as of Tornado 2.4; see for example
         https://groups.google.com/forum/#!topic/python-tornado/QLMzkpQBGOY
@@ -333,15 +331,31 @@ class WebAggApplication(tornado.web.Application):
         launched. We may end up with two concurrently running loops in that
         unlucky case with all the expected consequences.
         """
-        print("Press Ctrl+C to stop WebAgg server")
-        sys.stdout.flush()
-        try:
-            tornado.ioloop.IOLoop.instance().start()
-        except KeyboardInterrupt:
+        ioloop = tornado.ioloop.IOLoop.instance()
+
+        def shutdown():
+            ioloop.stop()
             print("Server is stopped")
             sys.stdout.flush()
-        finally:
             cls.started = False
+
+        @contextmanager
+        def catch_sigint():
+            old_handler = signal.signal(
+                signal.SIGINT,
+                lambda sig, frame: ioloop.add_callback_from_signal(shutdown))
+            try:
+                yield
+            finally:
+                signal.signal(signal.SIGINT, old_handler)
+
+        # Set the flag to True *before* blocking on ioloop.start()
+        cls.started = True
+
+        print("Press Ctrl+C to stop WebAgg server")
+        sys.stdout.flush()
+        with catch_sigint():
+            ioloop.start()
 
 
 def ipython_inline_display(figure):


### PR DESCRIPTION
This change correctly triggers the `ioloop.stop()` method, allowing the user to call `plt.show()`, then resume control with a SIGINT, then call `plt.show()` again.

Without this change, any attempt to call `plt.show()` after killing the webagg server the first time would result in an error because the ioloop instance hadn't been properly stopped.

The motivation for using a signal handler comes from [this SO answer](http://stackoverflow.com/a/22314390/10601), which is the only solution I could find that worked as intended.