### PR TITLE
Add a 'useMathText' param to method 'ticklabel_format'

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2488,6 +2488,8 @@ class _AxesBase(martist.Artist):
                          C-style (English) formatting.  The
                          default setting is controlled by the
                          axes.formatter.use_locale rcparam.
+          *useMathText*  If True, render the offset and scientific 
+                         notation in mathtext                                
           ============   =========================================
 
         Only the major ticks are affected.
@@ -2501,6 +2503,7 @@ class _AxesBase(martist.Artist):
         scilimits = kwargs.pop('scilimits', None)
         useOffset = kwargs.pop('useOffset', None)
         useLocale = kwargs.pop('useLocale', None)
+        useMathText = kwargs.pop('useMathText', None)
         axis = kwargs.pop('axis', 'both').lower()
         if scilimits is not None:
             try:
@@ -2542,6 +2545,11 @@ class _AxesBase(martist.Artist):
                     self.xaxis.major.formatter.set_useLocale(useLocale)
                 if axis == 'both' or axis == 'y':
                     self.yaxis.major.formatter.set_useLocale(useLocale)
+            if useMathText is not None:
+                if axis == 'both' or axis =='x':
+                    self.xaxis.major.formatter.set_useMathText(useMathText)
+                if axis == 'both' or axis == 'y':
+                    self.yaxis.major.formatter.set_useMathText(useMathText)
         except AttributeError:
             raise AttributeError(
                 "This method only works with the ScalarFormatter.")

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2488,8 +2488,8 @@ class _AxesBase(martist.Artist):
                          C-style (English) formatting.  The
                          default setting is controlled by the
                          axes.formatter.use_locale rcparam.
-          *useMathText*  If True, render the offset and scientific 
-                         notation in mathtext                                
+          *useMathText*  If True, render the offset and scientific
+                         notation in mathtext
           ============   =========================================
 
         Only the major ticks are affected.
@@ -2546,7 +2546,7 @@ class _AxesBase(martist.Artist):
                 if axis == 'both' or axis == 'y':
                     self.yaxis.major.formatter.set_useLocale(useLocale)
             if useMathText is not None:
-                if axis == 'both' or axis =='x':
+                if axis == 'both' or axis == 'x':
                     self.xaxis.major.formatter.set_useMathText(useMathText)
                 if axis == 'both' or axis == 'y':
                     self.yaxis.major.formatter.set_useMathText(useMathText)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2465,32 +2465,32 @@ class _AxesBase(martist.Artist):
 
         Optional keyword arguments:
 
-          ============   =========================================
-          Keyword        Description
-          ============   =========================================
-          *style*        [ 'sci' (or 'scientific') | 'plain' ]
-                         plain turns off scientific notation
-          *scilimits*    (m, n), pair of integers; if *style*
-                         is 'sci', scientific notation will
-                         be used for numbers outside the range
-                         10`m`:sup: to 10`n`:sup:.
-                         Use (0,0) to include all numbers.
-          *useOffset*    [True | False | offset]; if True,
-                         the offset will be calculated as needed;
-                         if False, no offset will be used; if a
-                         numeric offset is specified, it will be
-                         used.
-          *axis*         [ 'x' | 'y' | 'both' ]
-          *useLocale*    If True, format the number according to
-                         the current locale.  This affects things
-                         such as the character used for the
-                         decimal separator.  If False, use
-                         C-style (English) formatting.  The
-                         default setting is controlled by the
-                         axes.formatter.use_locale rcparam.
-          *useMathText*  If True, render the offset and scientific
-                         notation in mathtext
-          ============   =========================================
+          ==============   =========================================
+          Keyword          Description
+          ==============   =========================================
+          *style*          [ 'sci' (or 'scientific') | 'plain' ]
+                           plain turns off scientific notation
+          *scilimits*      (m, n), pair of integers; if *style*
+                           is 'sci', scientific notation will
+                           be used for numbers outside the range
+                           10`m`:sup: to 10`n`:sup:.
+                           Use (0,0) to include all numbers.
+          *useOffset*      [True | False | offset]; if True,
+                           the offset will be calculated as needed;
+                           if False, no offset will be used; if a
+                           numeric offset is specified, it will be
+                           used.
+          *axis*           [ 'x' | 'y' | 'both' ]
+          *useLocale*      If True, format the number according to
+                           the current locale.  This affects things
+                           such as the character used for the
+                           decimal separator.  If False, use
+                           C-style (English) formatting.  The
+                           default setting is controlled by the
+                           axes.formatter.use_locale rcparam.
+          *useMathText*    If True, render the offset and scientific
+                           notation in mathtext
+          ==============   =========================================
 
         Only the major ticks are affected.
         If the method is called when the

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -452,7 +452,7 @@ class ScalarFormatter(Formatter):
         self._usetex = rcParams['text.usetex']
         if useMathText is None:
             useMathText = rcParams['axes.formatter.use_mathtext']
-        self._useMathText = useMathText
+        self.set_useMathText(useMathText)
         self.orderOfMagnitude = 0
         self.format = ''
         self._scientific = True
@@ -484,6 +484,17 @@ class ScalarFormatter(Formatter):
             self._useLocale = val
 
     useLocale = property(fget=get_useLocale, fset=set_useLocale)
+
+    def get_useMathText(self):
+        return self._useMathText
+
+    def set_useMathText(self, val):
+        if val is None:
+            self._useMathText = rcParams['axes.formatter.use_mathtext']
+        else:
+            self._useMathText = val
+
+    useMathText = property(fget=get_useMathText, fset=set_useMathText)
 
     def fix_minus(self, s):
         """use a unicode minus rather than hyphen"""


### PR DESCRIPTION
As discussed in #6330. Can anyone examine this?