### PR TITLE
Fix #6335: Queue boxes to update

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1025,7 +1025,7 @@ class Animation(object):
     def _end_redraw(self, evt):
         # Now that the redraw has happened, do the post draw flushing and
         # blit handling. Then re-enable all of the original events.
-        self._post_draw(None, self._blit)
+        self._post_draw(None, False)
         self.event_source.start()
         self._fig.canvas.mpl_disconnect(self._resize_id)
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -77,7 +77,7 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         FigureCanvasQTAggBase.__init__(self, figure)
         FigureCanvasAgg.__init__(self, figure)
         self._drawRect = None
-        self.blitbox = None
+        self.blitbox = []
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
 
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -135,8 +135,9 @@ class FigureCanvasQTAggBase(object):
                 stringBuffer = reg.to_string_argb()
                 qImage = QtGui.QImage(stringBuffer, w, h,
                                       QtGui.QImage.Format_ARGB32)
-                # Adjust the stringBuffer reference count to work around a memory
-                # leak bug in QImage() under PySide on Python 3.x
+                # Adjust the stringBuffer reference count to work
+                # around a memory leak bug in QImage() under PySide on
+                # Python 3.x
                 if QT_API == 'PySide' and six.PY3:
                     ctypes.c_long.from_address(id(stringBuffer)).value = 1
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -84,7 +84,7 @@ class FigureCanvasQTAggBase(object):
             print('FigureCanvasQtAgg.paintEvent: ', self,
                   self.get_width_height())
 
-        if self.blitbox is None:
+        if len(self.blitbox) == 0:
             # matplotlib is in rgba byte order.  QImage wants to put the bytes
             # into argb format and is in a 4 byte unsigned int.  Little endian
             # system is LSB first and expects the bytes in reverse order
@@ -123,31 +123,33 @@ class FigureCanvasQTAggBase(object):
             if refcnt != sys.getrefcount(stringBuffer):
                 _decref(stringBuffer)
         else:
-            bbox = self.blitbox
-            l, b, r, t = bbox.extents
-            w = int(r) - int(l)
-            h = int(t) - int(b)
-            t = int(b) + h
-            reg = self.copy_from_bbox(bbox)
-            stringBuffer = reg.to_string_argb()
-            qImage = QtGui.QImage(stringBuffer, w, h,
-                                  QtGui.QImage.Format_ARGB32)
-            # Adjust the stringBuffer reference count to work around a memory
-            # leak bug in QImage() under PySide on Python 3.x
-            if QT_API == 'PySide' and six.PY3:
-                ctypes.c_long.from_address(id(stringBuffer)).value = 1
-
-            pixmap = QtGui.QPixmap.fromImage(qImage)
             p = QtGui.QPainter(self)
-            p.drawPixmap(QtCore.QPoint(l, self.renderer.height-t), pixmap)
+
+            while len(self.blitbox):
+                bbox = self.blitbox.pop()
+                l, b, r, t = bbox.extents
+                w = int(r) - int(l)
+                h = int(t) - int(b)
+                t = int(b) + h
+                reg = self.copy_from_bbox(bbox)
+                stringBuffer = reg.to_string_argb()
+                qImage = QtGui.QImage(stringBuffer, w, h,
+                                      QtGui.QImage.Format_ARGB32)
+                # Adjust the stringBuffer reference count to work around a memory
+                # leak bug in QImage() under PySide on Python 3.x
+                if QT_API == 'PySide' and six.PY3:
+                    ctypes.c_long.from_address(id(stringBuffer)).value = 1
+
+                pixmap = QtGui.QPixmap.fromImage(qImage)
+                p.drawPixmap(QtCore.QPoint(l, self.renderer.height-t), pixmap)
 
             # draw the zoom rectangle to the QPainter
             if self._drawRect is not None:
                 p.setPen(QtGui.QPen(QtCore.Qt.black, 1, QtCore.Qt.DotLine))
                 x, y, w, h = self._drawRect
                 p.drawRect(x, y, w, h)
+
             p.end()
-            self.blitbox = None
 
     def draw(self):
         """
@@ -190,7 +192,7 @@ class FigureCanvasQTAggBase(object):
         if bbox is None and self.figure:
             bbox = self.figure.bbox
 
-        self.blitbox = bbox
+        self.blitbox.append(bbox)
         l, b, w, h = bbox.bounds
         t = b + h
         self.repaint(l, self.renderer.height-t, w, h)
@@ -218,7 +220,7 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
             print('FigureCanvasQtAgg: ', figure)
         super(FigureCanvasQTAgg, self).__init__(figure=figure)
         self._drawRect = None
-        self.blitbox = None
+        self.blitbox = []
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
 
 


### PR DESCRIPTION
This fixes the issue where multiple animating axes would not all get updated.  The reason this was broken is because `blit` sets a region to update, but there may be multiple blits between each opportunity to actually paint to the screen (on idle), so some will get thrown out.  This changes things so there is a list (queue) of bounding boxes to update instead.

There is still the issue with glitchiness on resizing that I haven't been able to solve as easily.

Fixes #6335 