### PR TITLE
Remove shebang lines from all examples. [MEP12]

### DIFF
--- a/examples/animation/dynamic_image.py
+++ b/examples/animation/dynamic_image.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 An animated image
 """

--- a/examples/animation/dynamic_image2.py
+++ b/examples/animation/dynamic_image2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 An animated image
 """

--- a/examples/api/agg_oo.py
+++ b/examples/api/agg_oo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- noplot -*-
 """
 A pure OO (look Ma, no pylab!) example using the agg backend

--- a/examples/api/barchart_demo.py
+++ b/examples/api/barchart_demo.py
@@ -1,5 +1,3 @@
-
-#!/usr/bin/env python
 # a bar plot with errorbars
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/api/collections_demo.py
+++ b/examples/api/collections_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''Demonstration of LineCollection, PolyCollection, and
 RegularPolyCollection with autoscaling.
 

--- a/examples/api/date_demo.py
+++ b/examples/api/date_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Show how to make date plots in matplotlib using date tick locators and
 formatters.  See major_minor_demo1.py for more information on

--- a/examples/api/joinstyle.py
+++ b/examples/api/joinstyle.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Illustrate the three different join styles
 """

--- a/examples/api/power_norm_demo.py
+++ b/examples/api/power_norm_demo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from matplotlib import pyplot as plt
 import matplotlib.colors as mcolors
 import numpy as np

--- a/examples/api/sankey_demo_old.py
+++ b/examples/api/sankey_demo_old.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 
 __author__ = "Yannick Copin <ycopin@ipnl.in2p3.fr>"

--- a/examples/api/two_scales.py
+++ b/examples/api/two_scales.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 
 Demonstrate how to do two plots on the same axes with different left

--- a/examples/event_handling/keypress_demo.py
+++ b/examples/event_handling/keypress_demo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Show how to connect to keypress events
 """

--- a/examples/event_handling/pick_event_demo.py
+++ b/examples/event_handling/pick_event_demo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 
 You can enable picking by setting the "picker" property of an artist

--- a/examples/event_handling/pipong.py
+++ b/examples/event_handling/pipong.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # A matplotlib based game of Pong illustrating one way to write interactive
 # animation which are easily ported to multiple backends
 # pipong.py was written by Paul Ivanov <http://pirsquared.org>

--- a/examples/event_handling/pong_gtk.py
+++ b/examples/event_handling/pong_gtk.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 
 # For detailed comments on animation and the techniques used here, see

--- a/examples/event_handling/test_mouseclicks.py
+++ b/examples/event_handling/test_mouseclicks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 import matplotlib

--- a/examples/misc/ftface_props.py
+++ b/examples/misc/ftface_props.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 """
 This is a demo script to show you how to use all the properties of an

--- a/examples/pylab_examples/accented_text.py
+++ b/examples/pylab_examples/accented_text.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 matplotlib supports accented characters via TeX mathtext
 

--- a/examples/pylab_examples/agg_buffer.py
+++ b/examples/pylab_examples/agg_buffer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Use backend agg to access the figure canvas as an RGB string and then
 convert it to an array and pass it to Pillow for rendering.

--- a/examples/pylab_examples/alignment_test.py
+++ b/examples/pylab_examples/alignment_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 You can precisely layout text in data or axes (0,1) coordinates.  This
 example shows you some of the alignment and rotation specifications to

--- a/examples/pylab_examples/anscombe.py
+++ b/examples/pylab_examples/anscombe.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 """
 Edward Tufte uses this example from Anscombe to show 4 datasets of x

--- a/examples/pylab_examples/arrow_demo.py
+++ b/examples/pylab_examples/arrow_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Arrow drawing example for the new fancy_arrow facilities.
 
 Code contributed by: Rob Knight <rob@spot.colorado.edu>

--- a/examples/pylab_examples/bar_stacked.py
+++ b/examples/pylab_examples/bar_stacked.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # a stacked bar plot with errorbars
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/cohere_demo.py
+++ b/examples/pylab_examples/cohere_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Compute the coherence of two signals
 """

--- a/examples/pylab_examples/color_demo.py
+++ b/examples/pylab_examples/color_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 matplotlib gives you 4 ways to specify colors,
 

--- a/examples/pylab_examples/colours.py
+++ b/examples/pylab_examples/colours.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- noplot -*-
 """
 Some simple functions to generate colours.

--- a/examples/pylab_examples/contour_corner_mask.py
+++ b/examples/pylab_examples/contour_corner_mask.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Illustrate the difference between corner_mask=False and corner_mask=True
 for masked contour plots.

--- a/examples/pylab_examples/contour_demo.py
+++ b/examples/pylab_examples/contour_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Illustrate simple contour plotting, contours on an image with
 a colorbar for the contours, and labelled contours.

--- a/examples/pylab_examples/contour_image.py
+++ b/examples/pylab_examples/contour_image.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 Test combinations of contouring, filled contouring, and image plotting.
 For contour labelling, see contour_demo.py.

--- a/examples/pylab_examples/contour_label_demo.py
+++ b/examples/pylab_examples/contour_label_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Illustrate some of the more advanced things that one can do with
 contour labels.

--- a/examples/pylab_examples/contourf_demo.py
+++ b/examples/pylab_examples/contourf_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/examples/pylab_examples/coords_demo.py
+++ b/examples/pylab_examples/coords_demo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 An example of how to interact with the plotting canvas by connecting
 to move and click events

--- a/examples/pylab_examples/coords_report.py
+++ b/examples/pylab_examples/coords_report.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # override the default reporting of coords
 
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/csd_demo.py
+++ b/examples/pylab_examples/csd_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Compute the cross spectral density of two signals
 """

--- a/examples/pylab_examples/custom_cmap.py
+++ b/examples/pylab_examples/custom_cmap.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap

--- a/examples/pylab_examples/custom_ticker1.py
+++ b/examples/pylab_examples/custom_ticker1.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 The new ticker code was designed to explicitly support user customized
 ticking.  The documentation

--- a/examples/pylab_examples/data_helper.py
+++ b/examples/pylab_examples/data_helper.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Some functions to load a return data for the plot demos
 
 from numpy import fromstring, argsort, take, array, resize

--- a/examples/pylab_examples/date_demo1.py
+++ b/examples/pylab_examples/date_demo1.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Show how to make date plots in matplotlib using date tick locators and
 formatters.  See major_minor_demo1.py for more information on

--- a/examples/pylab_examples/date_demo2.py
+++ b/examples/pylab_examples/date_demo2.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python
-
 """
 Show how to make date plots in matplotlib using date tick locators and
 formatters.  See major_minor_demo1.py for more information on
 controlling major and minor ticks
 """
+
 from __future__ import print_function
 import datetime
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/date_demo_convert.py
+++ b/examples/pylab_examples/date_demo_convert.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import datetime
 import matplotlib.pyplot as plt
 from matplotlib.dates import DayLocator, HourLocator, DateFormatter, drange

--- a/examples/pylab_examples/date_demo_rrule.py
+++ b/examples/pylab_examples/date_demo_rrule.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Show how to use an rrule instance to make a custom date ticker - here
 we put a tick mark on every 5th easter

--- a/examples/pylab_examples/equal_aspect_ratio.py
+++ b/examples/pylab_examples/equal_aspect_ratio.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Example: simple line plot.
 Show how to make a plot that has equal aspect ratio

--- a/examples/pylab_examples/eventcollection_demo.py
+++ b/examples/pylab_examples/eventcollection_demo.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
-# -*- Coding:utf-8 -*-
-'''Plot two curves, then use EventCollections to mark the locations of the x
-and y data points on the respective axes for each curve'''
+'''
+Plot two curves, then use EventCollections to mark the locations of the x
+and y data points on the respective axes for each curve
+'''
 
 import matplotlib.pyplot as plt
 from matplotlib.collections import EventCollection

--- a/examples/pylab_examples/eventplot_demo.py
+++ b/examples/pylab_examples/eventplot_demo.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
-# -*- Coding:utf-8 -*-
-'''an eventplot showing sequences of events with various line properties
-the plot is shown in both horizontal and vertical orientations'''
+'''
+An eventplot showing sequences of events with various line properties.
+The plot is shown in both horizontal and vertical orientations.
+'''
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/fill_between_demo.py
+++ b/examples/pylab_examples/fill_between_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/pylab_examples/finance_demo.py
+++ b/examples/pylab_examples/finance_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import matplotlib.pyplot as plt
 from matplotlib.dates import DateFormatter, WeekdayLocator,\
     DayLocator, MONDAY

--- a/examples/pylab_examples/ginput_manual_clabel.py
+++ b/examples/pylab_examples/ginput_manual_clabel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- noplot -*-
 
 from __future__ import print_function

--- a/examples/pylab_examples/hyperlinks.py
+++ b/examples/pylab_examples/hyperlinks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- noplot -*-
 
 """

--- a/examples/pylab_examples/image_clip_path.py
+++ b/examples/pylab_examples/image_clip_path.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 import matplotlib.cm as cm
 import matplotlib.mlab as mlab

--- a/examples/pylab_examples/image_demo.py
+++ b/examples/pylab_examples/image_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 import matplotlib.cm as cm
 import matplotlib.mlab as mlab

--- a/examples/pylab_examples/leftventricle_bulleye.py
+++ b/examples/pylab_examples/leftventricle_bulleye.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 This example demonstrates how to create the 17 segment model for the left
 ventricle recommended by the American Heart Association (AHA).

--- a/examples/pylab_examples/major_minor_demo2.py
+++ b/examples/pylab_examples/major_minor_demo2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Automatic tick selection for major and minor ticks.
 

--- a/examples/pylab_examples/mathtext_demo.py
+++ b/examples/pylab_examples/mathtext_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Use matplotlib's internal LaTeX parser and layout engine.  For true
 latex rendering, see the text.usetex option

--- a/examples/pylab_examples/movie_demo.py
+++ b/examples/pylab_examples/movie_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- noplot -*-
 
 from __future__ import print_function

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
-
 """
 This now uses the imshow command instead of pcolor which *is much
 faster*
 """
+
 from __future__ import division, print_function
 
 import numpy as np

--- a/examples/pylab_examples/multi_image.py
+++ b/examples/pylab_examples/multi_image.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 Make a set of images with a single colormap, norm, and colorbar.
 

--- a/examples/pylab_examples/multicolored_line.py
+++ b/examples/pylab_examples/multicolored_line.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
 '''
 Color parts of a line based on its properties, e.g., slope.
 '''
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection

--- a/examples/pylab_examples/polar_legend.py
+++ b/examples/pylab_examples/polar_legend.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import numpy as np
 from matplotlib.pyplot import figure, show, rc
 

--- a/examples/pylab_examples/quadmesh_demo.py
+++ b/examples/pylab_examples/quadmesh_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 pcolormesh uses a QuadMesh, a faster generalization of pcolor, but
 with some restrictions.

--- a/examples/pylab_examples/symlog_demo.py
+++ b/examples/pylab_examples/symlog_demo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/pylab_examples/tex_unicode_demo.py
+++ b/examples/pylab_examples/tex_unicode_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 This demo is tex_demo.py modified to have unicode. See that file for

--- a/examples/pylab_examples/text_handles.py
+++ b/examples/pylab_examples/text_handles.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
-# Controlling the properties of axis text using handles
+"""
+Controlling the properties of axis text using handles
 
-# See examples/text_themes.py for a more elegant, pythonic way to control
-# fonts.  After all, if we were slaves to MATLAB , we wouldn't be
-# using python!
+See examples/text_themes.py for a more elegant, pythonic way to control
+fonts.  After all, if we were slaves to MATLAB , we wouldn't be
+using python!
+"""
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/text_rotation_relative_to_line.py
+++ b/examples/pylab_examples/text_rotation_relative_to_line.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Text objects in matplotlib are normally rotated with respect to the
 screen coordinate system (i.e., 45 degrees rotation plots text along a

--- a/examples/pylab_examples/titles_demo.py
+++ b/examples/pylab_examples/titles_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 matplotlib can display plot titles centered, flush with the left side of
 a set of axes, and flush with the right side of a set of axes.

--- a/examples/pylab_examples/toggle_images.py
+++ b/examples/pylab_examples/toggle_images.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ toggle between two images by pressing "t"
 
 The basic idea is to load two images (they can be different shapes) and plot

--- a/examples/pylab_examples/webapp_demo.py
+++ b/examples/pylab_examples/webapp_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- noplot -*-
 """
 This example shows how to use the agg backend directly to create

--- a/examples/pylab_examples/zorder_demo.py
+++ b/examples/pylab_examples/zorder_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The default drawing order for axes is patches, lines, text.  This
 order is determined by the zorder attribute.  The following defaults

--- a/examples/tests/backend_driver.py
+++ b/examples/tests/backend_driver.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function, division
 """
 This is used to drive many of the examples across the backends, for

--- a/examples/units/bar_unit_demo.py
+++ b/examples/units/bar_unit_demo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 from basic_units import cm, inch
 import matplotlib.pyplot as plt

--- a/examples/user_interfaces/embedding_in_gtk.py
+++ b/examples/user_interfaces/embedding_in_gtk.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 show how to add a matplotlib FigureCanvasGTK or FigureCanvasGTKAgg widget to a
 gtk.Window

--- a/examples/user_interfaces/embedding_in_gtk2.py
+++ b/examples/user_interfaces/embedding_in_gtk2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 show how to add a matplotlib FigureCanvasGTK or FigureCanvasGTKAgg widget and
 a toolbar to a gtk.Window

--- a/examples/user_interfaces/embedding_in_gtk3.py
+++ b/examples/user_interfaces/embedding_in_gtk3.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 demonstrate adding a FigureCanvasGTK3Agg widget to a Gtk.ScrolledWindow
 using GTK3 accessed via pygobject

--- a/examples/user_interfaces/embedding_in_gtk3_panzoom.py
+++ b/examples/user_interfaces/embedding_in_gtk3_panzoom.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 demonstrate NavigationToolbar with GTK3 accessed via pygobject
 """

--- a/examples/user_interfaces/embedding_in_qt4.py
+++ b/examples/user_interfaces/embedding_in_qt4.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 
 # embedding_in_qt4.py --- Simple Qt4 application embedding matplotlib canvases
 #

--- a/examples/user_interfaces/embedding_in_qt5.py
+++ b/examples/user_interfaces/embedding_in_qt5.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 
 # embedding_in_qt5.py --- Simple Qt5 application embedding matplotlib canvases
 #

--- a/examples/user_interfaces/embedding_in_tk.py
+++ b/examples/user_interfaces/embedding_in_tk.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import matplotlib
 matplotlib.use('TkAgg')
 

--- a/examples/user_interfaces/embedding_in_tk2.py
+++ b/examples/user_interfaces/embedding_in_tk2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import matplotlib
 matplotlib.use('TkAgg')
 

--- a/examples/user_interfaces/embedding_in_tk_canvas.py
+++ b/examples/user_interfaces/embedding_in_tk_canvas.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- noplot -*-
 
 import matplotlib as mpl

--- a/examples/user_interfaces/embedding_in_wx2.py
+++ b/examples/user_interfaces/embedding_in_wx2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 An example of how to use wx or wxagg in an application with the new
 toolbar - comment out the setA_toolbar line for no toolbar

--- a/examples/user_interfaces/embedding_in_wx3.py
+++ b/examples/user_interfaces/embedding_in_wx3.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Copyright (C) 2003-2004 Andrew Straw, Jeremy O'Donoghue and others
 

--- a/examples/user_interfaces/embedding_in_wx4.py
+++ b/examples/user_interfaces/embedding_in_wx4.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 An example of how to use wx or wxagg in an application with a custom
 toolbar

--- a/examples/user_interfaces/embedding_in_wx5.py
+++ b/examples/user_interfaces/embedding_in_wx5.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # matplotlib requires wxPython 2.8+
 # set the wxPython version in lib\site-packages\wx.pth file
 # or if you have wxversion installed un-comment the lines below

--- a/examples/user_interfaces/fourier_demo_wx.py
+++ b/examples/user_interfaces/fourier_demo_wx.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 
 # matplotlib requires wxPython 2.8+

--- a/examples/user_interfaces/gtk_spreadsheet.py
+++ b/examples/user_interfaces/gtk_spreadsheet.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Example of embedding matplotlib in an application and interacting with
 a treeview to store data.  Double click on an entry to update plot

--- a/examples/user_interfaces/histogram_demo_canvasagg.py
+++ b/examples/user_interfaces/histogram_demo_canvasagg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 This is an example that shows you how to work directly with the agg
 figure canvas to create a figure using the pythonic API.

--- a/examples/user_interfaces/interactive.py
+++ b/examples/user_interfaces/interactive.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Multithreaded interactive interpreter with GTK and Matplotlib support.
 
 WARNING:

--- a/examples/user_interfaces/interactive2.py
+++ b/examples/user_interfaces/interactive2.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 
 #  GTK Interactive Console

--- a/examples/user_interfaces/mpl_with_glade.py
+++ b/examples/user_interfaces/mpl_with_glade.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 import matplotlib
 matplotlib.use('GTK')

--- a/examples/user_interfaces/mpl_with_glade_316.py
+++ b/examples/user_interfaces/mpl_with_glade_316.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from gi.repository import Gtk
 
 from matplotlib.figure import Figure

--- a/examples/user_interfaces/svg_histogram.py
+++ b/examples/user_interfaces/svg_histogram.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-#-*- encoding:utf-8 -*-
-
 """
 Demonstrate how to create an interactive histogram, in which bars
 are hidden or shown by cliking on legend markers.
@@ -27,7 +24,7 @@ a PatchCollection, or be assigned a class="hist_##" attribute.
 CSS could also be used more extensively to replace repetitive markup
 troughout the generated SVG.
 
-__author__="david.huard@gmail.com"
+Author: david.huard@gmail.com
 
 """
 

--- a/examples/widgets/cursor.py
+++ b/examples/widgets/cursor.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from matplotlib.widgets import Cursor
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The SpanSelector is a mouse widget to select a xmin/xmax range and plot the
 detail view of the selected region in the lower axes


### PR DESCRIPTION
I'm planning a hacknight soon with my local PyLadies group to contribute some work on example clean up, but deleting shebang lines seemed like one aspect of MEP12 that could be easily done in bulk ahead of time.  I believe this gets rid of every single shebang in the examples folder.  You might even say it takes care of... the whole shebang. [:sunglasses:](http://www.youtube.com/watch?v=6YMPAH67f4o) 

This commit also includes a handful of other tweaks to file headers.  Nothing exhaustive, just things I noticed while the files were open.