### PR TITLE
Avoid duplicate cmap in image options.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -137,7 +137,7 @@ def figure_edit(axes, parent=None):
     for label in imagelabels:
         image = imagedict[label]
         cmap = image.get_cmap()
-        if cmap not in cm.cmap_d:
+        if cmap not in cm.cmap_d.values():
             cmaps = [(cmap, cmap.name)] + cmaps
         imagedata = [
             ('Label', label),


### PR DESCRIPTION
The previous implementation (#5469) was incorrect and would yield a double entry
in the cmap combobox.