### PR TITLE
FIX: cross figure legends with patches

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3159,8 +3159,8 @@ class Axes(_AxesBase):
             ``shownotches`` is also True. Otherwise, means will be shown
             as points.
 
-        Additional Options
-        ---------------------
+        Other Parameters
+        ----------------
         The following boolean options toggle the drawing of individual
         components of the boxplots:
             - showcaps: the caps on the ends of whiskers

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -179,7 +179,6 @@ class Patch(artist.Artist):
         self.set_linewidth(other.get_linewidth())
         self.set_linestyle(other.get_linestyle())
         self.set_transform(other.get_data_transform())
-        self.set_figure(other.get_figure())
         self.set_alpha(other.get_alpha())
 
     def get_extents(self):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -241,6 +241,15 @@ def test_legend_stackplot():
 
 
 @cleanup
+def test_cross_figure_patch_legend():
+    fig, ax = plt.subplots()
+    fig2, ax2 = plt.subplots()
+
+    brs = ax.bar(range(3), range(3))
+    fig2.legend(brs, 'foo')
+
+
+@cleanup
 def test_nanscatter():
     fig, ax = plt.subplots()
 


### PR DESCRIPTION
Found via https://github.com/biocore/qiime/issues/2117

The `update_props` method on `Patch` was setting the figure along
with the style.  This was setting the new patch for the legend to have
the same figure as the original handle, but this is later attempted to
be set to the figure the legend is in when the patch is added to the
legend.

This fix should not break anything as if the patch is going to be drawn
it should be added to the draw tree which _should_ in turn set the
correct figure.