### PR TITLE
API: bar now color cycles

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1983,6 +1983,8 @@ class Axes(_AxesBase):
         if not self._hold:
             self.cla()
         color = kwargs.pop('color', None)
+        if color is None:
+            color = self._get_patches_for_fill.get_next_color()
         edgecolor = kwargs.pop('edgecolor', None)
         linewidth = kwargs.pop('linewidth', None)
 
@@ -2062,14 +2064,11 @@ class Axes(_AxesBase):
         if len(linewidth) < nbars:
             linewidth *= nbars
 
-        if color is None:
-            color = [None] * nbars
-        else:
-            color = list(mcolors.to_rgba_array(color))
-            if len(color) == 0:  # until to_rgba_array is changed
-                color = [[0, 0, 0, 0]]
-            if len(color) < nbars:
-                color *= nbars
+        color = list(mcolors.to_rgba_array(color))
+        if len(color) == 0:  # until to_rgba_array is changed
+            color = [[0, 0, 0, 0]]
+        if len(color) < nbars:
+            color *= nbars
 
         if edgecolor is None:
             edgecolor = [None] * nbars

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1980,6 +1980,7 @@ class Axes(_AxesBase):
 
         .. plot:: mpl_examples/pylab_examples/bar_stacked.py
         """
+        kwargs = cbook.normalize_kwargs(kwargs, mpatches._patch_alias_map)
         if not self._hold:
             self.cla()
         color = kwargs.pop('color', None)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -55,6 +55,14 @@ docstring.interpd.update(Patch="""
 
           """)
 
+_patch_alias_map = {
+        'antialiased': ['aa'],
+        'edgecolor': ['ec'],
+        'facecolor': ['fc'],
+        'linewidth': ['lw'],
+        'linestyle': ['ls']
+    }
+
 
 class Patch(artist.Artist):
     """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -29,7 +29,7 @@ import matplotlib.patches as mpatches
 from numpy.testing import assert_allclose, assert_array_equal
 import warnings
 from matplotlib.cbook import IgnoredKeywordWarning
-
+import matplotlib.colors as mcolors
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have
@@ -4490,6 +4490,17 @@ def test_large_offset():
     fig, ax = plt.subplots()
     ax.plot((1 + np.array([0, 1.e-12])) * 1.e27)
     fig.canvas.draw()
+
+
+def test_bar_color_cycle():
+    ccov = mcolors.colorConverter.to_rgb
+    fig, ax = plt.subplots()
+    for j in range(5):
+        ln, = ax.plot(range(3))
+        brs = ax.bar(range(3), range(3))
+        for br in brs:
+            print(ln.get_color(), br.get_facecolor())
+            assert ccov(ln.get_color()) == ccov(br.get_facecolor())
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -34,7 +34,7 @@ def test_bbox_inches_tight():
     # the bottom values for stacked bar chart
     fig, ax = plt.subplots(1, 1)
     for row in xrange(rows):
-        plt.bar(ind, data[row], width, bottom=yoff)
+        ax.bar(ind, data[row], width, bottom=yoff, color='b')
         yoff = yoff + data[row]
         cellText.append([''])
     plt.xticks([])


### PR DESCRIPTION
repeated calls to `ax.bar` will advance the patch color cycle.

closes #5854


attn @story645 