### PR TITLE
Restore webagg backend following the merge of widget nbagg backend

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -262,7 +262,7 @@ class WebAggApplication(tornado.web.Application):
                 (url_prefix + r'/?', self.AllFiguresPage,
                  {'url_prefix': url_prefix}),
 
-                (url_prefix + r'/mpl.js', self.MplJs),
+                (url_prefix + r'/js/mpl.js', self.MplJs),
 
                 # Sends images and events to the browser, and receives
                 # events from the browser

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -531,7 +531,7 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
 
     @classmethod
     def get_static_file_path(cls):
-        return os.path.join(os.path.dirname(__file__), 'web_backend', 'js')
+        return os.path.join(os.path.dirname(__file__), 'web_backend')
 
     def _send_event(self, event_type, **kwargs):
         payload = {'type': event_type}

--- a/lib/matplotlib/backends/web_backend/all_figures.html
+++ b/lib/matplotlib/backends/web_backend/all_figures.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" href="{{ prefix }}/_static/jquery/css/themes/base/jquery-ui.min.css" >
     <script src="{{ prefix }}/_static/jquery/js/jquery-1.11.3.min.js"></script>
     <script src="{{ prefix }}/_static/jquery/js/jquery-ui.min.js"></script>
-    <script src="{{ prefix }}/_static/mpl_tornado.js"></script>
-    <script src="{{ prefix }}/mpl.js"></script>
+    <script src="{{ prefix }}/_static/js/mpl_tornado.js"></script>
+    <script src="{{ prefix }}/js/mpl.js"></script>
 
     <script>
       {% for (fig_id, fig_manager) in figures %}

--- a/lib/matplotlib/backends/web_backend/ipython_inline_figure.html
+++ b/lib/matplotlib/backends/web_backend/ipython_inline_figure.html
@@ -5,8 +5,8 @@
   // We can't proceed until these Javascript files are fetched, so
   // we fetch them synchronously
   $.ajaxSetup({async: false});
-  $.getScript("http://" + window.location.hostname + ":{{ port }}{{prefix}}/_static/mpl_tornado.js");
-  $.getScript("http://" + window.location.hostname + ":{{ port }}{{prefix}}/mpl.js");
+  $.getScript("http://" + window.location.hostname + ":{{ port }}{{prefix}}/_static/js/mpl_tornado.js");
+  $.getScript("http://" + window.location.hostname + ":{{ port }}{{prefix}}/js/mpl.js");
   $.ajaxSetup({async: true});
 
   function init_figure{{ fig_id }}(e) {

--- a/lib/matplotlib/backends/web_backend/single_figure.html
+++ b/lib/matplotlib/backends/web_backend/single_figure.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" href="{{ prefix }}/_static/jquery/css/themes/base/jquery-ui.min.css" >
     <script src="{{ prefix }}/_static/jquery/js/jquery-1.11.3.min.js"></script>
     <script src="{{ prefix }}/_static/jquery/js/jquery-ui.min.js"></script>
-    <script src="{{ prefix }}/_static/mpl_tornado.js"></script>
-    <script src="{{ prefix }}/mpl.js"></script>
+    <script src="{{ prefix }}/_static/js/mpl_tornado.js"></script>
+    <script src="{{ prefix }}/js/mpl.js"></script>
     <script>
       $(document).ready(
         function() {


### PR DESCRIPTION
The change of get_static_file_path to point to the js directory broke the serving of non javascript files in the webagg backend. This fixes that by changing it back and prefixing the js paths with js/ 

The nbagg backend is stil functional with this as all javascript is loaded from the nb extension