### PR TITLE
Set size of static figure to match widget on hidp displays

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -122,8 +122,12 @@ class NavigationIPy(NavigationToolbar2WebAgg):
     def export(self):
         buf = io.BytesIO()
         self.canvas.figure.savefig(buf, format='png', dpi='figure')
-        data = "<img src='data:image/png;base64,{0}'/>"
-        data = data.format(b64encode(buf.getvalue()).decode('utf-8'))
+        # Figure width in pixels
+        pwidth = self.canvas.figure.get_figwidth()*self.canvas.figure.get_dpi()
+        # Scale size to match widget on HiPD monitors
+        width = pwidth/self.canvas._dpi_ratio
+        data = "<img src='data:image/png;base64,{0}' width={1}/>"
+        data = data.format(b64encode(buf.getvalue()).decode('utf-8'), width)
         display(HTML(data))
 
 


### PR DESCRIPTION
This was lost in the trasition to the widget based backend but used to work.

Without this fix the static figure will be double the size of the original widget on a Mac Retina monitor