### PR TITLE
API: default locator on colorbars to AutoLocator

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -576,7 +576,10 @@ class ColorbarBase(cm.ScalarMappable):
                 elif isinstance(self.norm, colors.LogNorm):
                     locator = ticker.LogLocator()
                 else:
-                    locator = ticker.MaxNLocator()
+                    if mpl.rcParams['_internal.classic_mode']:
+                        locator = ticker.MaxNLocator()
+                    else:
+                        locator = ticker.AutoLocator()
             else:
                 b = self._boundaries[self._inside]
                 locator = ticker.FixedLocator(b, nbins=10)


### PR DESCRIPTION
This brings them inline with the default locator on the x and y axis.

Noted in https://stackoverflow.com/questions/37053874/