### PR TITLE
Install basemap from git trying to fix build issue with docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ install:
     # We have to install it after matplotlib to avoid pulling in MPL as
     # a dependency
     if [[ $BUILD_DOCS == true ]]; then
-      pip install https://github.com/matplotlib/basemap/tarball/master
+      pip install git+https://github.com/matplotlib/basemap.git
     fi;
 
 script:


### PR DESCRIPTION
Trying to fix the failure to build basemap as part of the docs build. Not at all sure why this fails and it works on my matplotlib branch. Perhaps a caching issue?