### PR TITLE
Fix canonical name for "None" linestyle.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -30,7 +30,7 @@ LINESTYLES = {'-': 'Solid',
               '--': 'Dashed',
               '-.': 'DashDot',
               ':': 'Dotted',
-              'none': 'None',
+              'None': 'None',
               }
 
 DRAWSTYLES = {'default': 'Default',


### PR DESCRIPTION
The canonical "empty" linestyle is "None", not "none".  The previous
implementation would raise an error after running

    plot([1, 2], ls="none")

and opening the figure options editor.