### PR TITLE
ENH: Figure.show() raises figure with qt backends

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -529,6 +529,8 @@ class FigureManagerQT(FigureManagerBase):
 
     def show(self):
         self.window.show()
+        self.window.activateWindow()
+        self.window.raise_()
 
     def destroy(self, *args):
         # check for qApp first, as PySide deletes it in its atexit handler


### PR DESCRIPTION
This is an increment of progress addressing #6378, which follows on a long discussion in #596.  The intention is to make Figure.show() activate and raise the figure, if it is managed by pyplot. It is presently specific to the qt*agg backends.  I think that the Tkagg backend already behaves this way.  If so, that leaves the gtk\* and wxagg backends needing similar modifications.

Ideally we would also have the option of separate control over focus and stack position, but this seems to be more difficult.  For example, with qt, using the window.raise_() method without activation (focus) doesn't work, at least on OSX.  It flashes the raised window, and then puts it right back behind the one that was on top. 

I suspect we are faced here with a fundamental conflict between "perfect", or even "very good", and "a little better".  This PR is taking the latter approach because in the years since the issue was raised, we seem to have made little progress in arriving at the wonderful universal window management API we would all like.
