### PR TITLE
Minor improvements concerning #6353 and #6357 

### DIFF
--- a/examples/statistics/histogram_demo_features.py
+++ b/examples/statistics/histogram_demo_features.py
@@ -27,7 +27,7 @@ n, bins, patches = plt.hist(x, num_bins, normed=1)
 y = mlab.normpdf(bins, mu, sigma)
 plt.plot(bins, y, '--')
 plt.xlabel('Smarts')
-plt.ylabel('Probability')
+plt.ylabel('Probability density')
 plt.title(r'Histogram of IQ: $\mu=100$, $\sigma=15$')
 
 # Tweak spacing to prevent clipping of ylabel

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5801,9 +5801,11 @@ class Axes(_AxesBase):
         normed : boolean, optional
             If `True`, the first element of the return tuple will
             be the counts normalized to form a probability density, i.e.,
-            ``n/(len(x)`dbin)``, i.e., the integral of the histogram will sum
-            to 1. If *stacked* is also *True*, the sum of the histograms is
-            normalized to 1.
+            the integral of the histogram will sum to 1. So, the normalized
+            count *is not* the count in a bin divided by the total number
+            of observations, but it is the count in the bin divided by the
+            number of observations times the bin width. If `stacked` is
+            also `True`, the sum of the histograms is normalized to 1.
 
             Default is ``False``
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5804,7 +5804,7 @@ class Axes(_AxesBase):
             the area (or integral) under the histogram will sum to 1.
             This is achieved dividing the count by the number of observations
             times the bin width and *not* dividing by the total number
-            of observations. If `stacked` is also `True`, the sum of the 
+            of observations. If `stacked` is also `True`, the sum of the
             histograms is normalized to 1.
 
             Default is ``False``

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5801,11 +5801,11 @@ class Axes(_AxesBase):
         normed : boolean, optional
             If `True`, the first element of the return tuple will
             be the counts normalized to form a probability density, i.e.,
-            the integral of the histogram will sum to 1. So, the normalized
-            count *is not* the count in a bin divided by the total number
-            of observations, but it is the count in the bin divided by the
-            number of observations times the bin width. If `stacked` is
-            also `True`, the sum of the histograms is normalized to 1.
+            the area (or integral) under the histogram will sum to 1.
+            This is achieved dividing the count by the number of observations
+            times the bin width and *not* dividing by the total number
+            of observations. If `stacked` is also `True`, the sum of the 
+            histograms is normalized to 1.
 
             Default is ``False``
 


### PR DESCRIPTION
Related with #6353 and #6357, this commit corrects ylabel string in histogram_demo_features.py example but also tries to improve the documentation of hist in pyplot to clarify which one of the two common ways to normalize the counts is available through this option and which is not, in order to avoid future misunderstandings.