### PR TITLE
Use xkcd: prefix to avoid color name clashes.

### DIFF
--- a/doc/users/colors.rst
+++ b/doc/users/colors.rst
@@ -14,58 +14,9 @@ In almost all places in matplotlib where a color can be specified by the user it
 * valid css4/X11 color names
 * valid name from the `XKCD color survey
   <http://blog.xkcd.com/2010/05/03/color-survey-results/>`__ These
-  names are available both with and with out spaces.  In the case of name clashes
-  the css/X11 names have priority.  To ensure colors
-  from the XKCD mapping are used prefix the space-less name with
-  ``'XKCD'``.
+  names are prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``) to
+  prevent name clashes with the CSS4/X11 names.
 
 All string specifications of color are case-insensitive.
 
 Internally, mpl is moving to storing all colors as RGBA float quadruples.
-
-Name clash between CSS4/X11 and XKCD
-------------------------------------
-
-The color names in the XKCD survey include spaces (unlike css4/X11
-names).  Matplotlib exposes all of the XKCD colors both with and
-without spaces.
-
-There are 95 (out of 148 colors in the css color list) conflicts
-between the css4/X11 names and the XKCD names.  Given that these are
-the standard color names of the web, matplotlib should follow these
-conventions.  To accesses the XKCD colors which are shadowed by css4,
-prefix the colorname with ``'XKCD'``, for example ``'blue'`` maps to
-``'#0000FF'`` where as ``'XKCDblue'`` maps to ``'#0343DF'``.
-
-.. plot::
-
-   import matplotlib.pyplot as plt
-   import matplotlib._color_data as mcd
-
-   import matplotlib.patches as mpatch
-   overlap = (set(mcd.CSS4_COLORS) & set(mcd.XKCD_COLORS))
-
-   fig = plt.figure(figsize=[4.8, 16])
-   ax = fig.add_axes([0, 0, 1, 1])
-
-   j = 0
-
-   for n in sorted(overlap, reverse=True):
-       cn = mcd.CSS4_COLORS[n]
-       xkcd = mcd.XKCD_COLORS[n].upper()
-       if cn != xkcd:
-           print (n, cn, xkcd)
-
-       r1 = mpatch.Rectangle((0, j), 1, 1, color=cn)
-       r2 = mpatch.Rectangle((1, j), 1, 1, color=xkcd)
-       txt = ax.text(2, j+.5, '  ' + n, va='center', fontsize=10)
-       ax.add_patch(r1)
-       ax.add_patch(r2)
-       ax.axhline(j, color='k')
-       j += 1
-
-   ax.text(.5, j+.1, 'X11', ha='center')
-   ax.text(1.5, j+.1, 'XKCD', ha='center')
-   ax.set_xlim(0, 3)
-   ax.set_ylim(0, j + 1)
-   ax.axis('off')

--- a/doc/users/colors.rst
+++ b/doc/users/colors.rst
@@ -4,15 +4,16 @@
 Specifying Colors
 *****************
 
-In almost all places in matplotlib where a color can be specified by the user it can be provided as:
+In almost all places in matplotlib where a color can be specified by the user
+it can be provided as:
 
 * ``(r, g, b)`` tuples
 * ``(r, g, b, a)`` tuples
 * hex string, ex ``#OFOFOF``
 * float value between [0, 1] for gray level
 * One of ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``
-* valid css4/X11 color names
-* valid name from the `XKCD color survey
+* valid CSS4/X11 color names
+* valid name from the `xkcd color survey
   <http://blog.xkcd.com/2010/05/03/color-survey-results/>`__ These
   names are prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``) to
   prevent name clashes with the CSS4/X11 names.
@@ -20,3 +21,40 @@ In almost all places in matplotlib where a color can be specified by the user it
 All string specifications of color are case-insensitive.
 
 Internally, mpl is moving to storing all colors as RGBA float quadruples.
+
+There are 95 (out of 148 colors in the css color list) conflicts between the
+CSS4/X11 names and the xkcd names.  Given that the former are the standard
+color names of the web, matplotlib should follow them.  Thus, xkcd color names
+are prefixed with ``'xkcd:'``, for example ``'blue'`` maps to ``'#0000FF'``
+where as ``'xkcd:blue'`` maps to ``'#0343DF'``.
+
+.. plot::
+
+   import matplotlib.pyplot as plt
+   import matplotlib._color_data as mcd
+   import matplotlib.patches as mpatch
+
+   overlap = {name for name in mcd.CSS4_COLORS
+              if "xkcd:" + name in mcd.XKCD_COLORS}
+
+   fig = plt.figure(figsize=[4.8, 16])
+   ax = fig.add_axes([0, 0, 1, 1])
+
+   for j, n in enumerate(sorted(overlap, reverse=True)):
+       cn = mcd.CSS4_COLORS[n]
+       xkcd = mcd.XKCD_COLORS["xkcd:" + n].upper()
+       if cn != xkcd:
+           print(n, cn, xkcd)
+
+       r1 = mpatch.Rectangle((0, j), 1, 1, color=cn)
+       r2 = mpatch.Rectangle((1, j), 1, 1, color=xkcd)
+       txt = ax.text(2, j+.5, '  ' + n, va='center', fontsize=10)
+       ax.add_patch(r1)
+       ax.add_patch(r2)
+       ax.axhline(j, color='k')
+
+   ax.text(.5, j + .1, 'X11', ha='center')
+   ax.text(1.5, j + .1, 'XKCD', ha='center')
+   ax.set_xlim(0, 3)
+   ax.set_ylim(0, j + 1)
+   ax.axis('off')

--- a/lib/matplotlib/_color_data.py
+++ b/lib/matplotlib/_color_data.py
@@ -961,14 +961,9 @@ XKCD_COLORS = {
     'green': '#15b01a',
     'purple': '#7e1e9c'}
 
-# normalize to names with no spaces and provide versions with XKCD
-# prefix.
-for k in list(XKCD_COLORS):
-    XKCD_COLORS['xkcd'+k] = XKCD_COLORS[k]
-    _k = k.replace(' ', '')
-    if _k != k:
-        XKCD_COLORS[_k] = XKCD_COLORS[k]
-        XKCD_COLORS['xkcd'+_k] = XKCD_COLORS[k]
+
+# Normalize name to "xkcd:<name>" to avoid name collisions.
+XKCD_COLORS = {'xkcd:' + name: value for name, value in XKCD_COLORS.items()}
 
 
 # https://drafts.csswg.org/css-color-4/#named-colors

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -563,7 +563,7 @@ def test_xkcd():
         mcolors.colorConverter.to_rgb('blue'))
     assert x11_blue == '#0000ff'
     XKCD_blue = mcolors.rgb2hex(
-        mcolors.colorConverter.to_rgb('XKCDblue'))
+        mcolors.colorConverter.to_rgb('xkcd:blue'))
     assert XKCD_blue == '#0343df'
 
 
@@ -621,7 +621,7 @@ def test_cn():
     assert red == '#ff0000'
 
     matplotlib.rcParams['axes.prop_cycle'] = cycler('color',
-                                                    ['XKCDblue', 'r'])
+                                                    ['xkcd:blue', 'r'])
     XKCD_blue = mcolors.rgb2hex(mcolors.colorConverter.to_rgb('C0'))
     assert XKCD_blue == '#0343df'
     red = mcolors.rgb2hex(mcolors.colorConverter.to_rgb('C1'))


### PR DESCRIPTION
Split out of #6382.

Without the prefix, merging CSS4_COLORS and XKCD_COLORS becomes order-dependent.

It's also unclear why space-less names are needed, but I can put them back if someone feels strongly about it...