### PR TITLE
key events handler return value to True to stop propagation

### DIFF
--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -300,14 +300,14 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         key = self._get_key(event)
         if _debug: print("hit", key)
         FigureCanvasBase.key_press_event(self, key, guiEvent=event)
-        return True  # stoping event propagation
+        return True  # stop event propagation
 
     def key_release_event(self, widget, event):
         if _debug: print('FigureCanvasGTK.%s' % fn_name())
         key = self._get_key(event)
         if _debug: print("release", key)
         FigureCanvasBase.key_release_event(self, key, guiEvent=event)
-        return True  # stoping event propagation
+        return True  # stop event propagation
 
     def motion_notify_event(self, widget, event):
         if _debug: print('FigureCanvasGTK.%s' % fn_name())

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -300,14 +300,14 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         key = self._get_key(event)
         if _debug: print("hit", key)
         FigureCanvasBase.key_press_event(self, key, guiEvent=event)
-        return False  # finish event propagation?
+        return True  # stoping event propagation
 
     def key_release_event(self, widget, event):
         if _debug: print('FigureCanvasGTK.%s' % fn_name())
         key = self._get_key(event)
         if _debug: print("release", key)
         FigureCanvasBase.key_release_event(self, key, guiEvent=event)
-        return False  # finish event propagation?
+        return True  # stoping event propagation
 
     def motion_notify_event(self, widget, event):
         if _debug: print('FigureCanvasGTK.%s' % fn_name())

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -251,14 +251,14 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         key = self._get_key(event)
         if _debug: print("hit", key)
         FigureCanvasBase.key_press_event(self, key, guiEvent=event)
-        return True  # stoping event propagation
+        return True  # stop event propagation
 
     def key_release_event(self, widget, event):
         if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         key = self._get_key(event)
         if _debug: print("release", key)
         FigureCanvasBase.key_release_event(self, key, guiEvent=event)
-        return True  # stoping event propagation
+        return True  # stop event propagation
 
     def motion_notify_event(self, widget, event):
         if _debug: print('FigureCanvasGTK3.%s' % fn_name())

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -251,14 +251,14 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         key = self._get_key(event)
         if _debug: print("hit", key)
         FigureCanvasBase.key_press_event(self, key, guiEvent=event)
-        return False  # finish event propagation?
+        return True  # stoping event propagation
 
     def key_release_event(self, widget, event):
         if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         key = self._get_key(event)
         if _debug: print("release", key)
         FigureCanvasBase.key_release_event(self, key, guiEvent=event)
-        return False  # finish event propagation?
+        return True  # stoping event propagation
 
     def motion_notify_event(self, widget, event):
         if _debug: print('FigureCanvasGTK3.%s' % fn_name())


### PR DESCRIPTION
Fixing https://github.com/matplotlib/matplotlib/issues/6349

Right now only stopping the key press and key release event from propagating after callback.
I am in doubt about the other events, should be stopped also?

@tacaswell how does it work in Qt? 