### PR TITLE
more explicit message for missing image

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -232,7 +232,13 @@ class ImageComparisonTest(CleanupTest):
                     shutil.copyfile(orig_expected_fname, expected_fname)
                 else:
                     will_fail = True
-                    fail_msg = 'Do not have baseline image %s' % expected_fname
+                    fail_msg = (
+                        "Do not have baseline image {0} because this "
+                        "file does not exist: {1}".format(
+                            expected_fname,
+                            orig_expected_fname
+                        )
+                    )
 
                 @knownfailureif(
                     will_fail, fail_msg,


### PR DESCRIPTION
Pointing out what exactly the problem is, is a nice feature of raised stuff; we all hate a `file not found` error without the exact file being specified.

If someone simple copies something from `lib/matplotlib/tests` and alters it for his or her need, he will be pointed to likely missing comparison files without the need to know about the exact workings of the `image_comparison` decorator.