### PR TITLE
adding default toggled state for toggle tools

### DIFF
--- a/examples/user_interfaces/toolmanager.py
+++ b/examples/user_interfaces/toolmanager.py
@@ -45,19 +45,20 @@ class ListTools(ToolBase):
 
 
 class GroupHideTool(ToolToggleBase):
-    '''Hide lines with a given gid'''
+    '''Show lines with a given gid'''
     default_keymap = 'G'
-    description = 'Hide by gid'
+    description = 'Show by gid'
+    default_toggled = True
 
     def __init__(self, *args, **kwargs):
         self.gid = kwargs.pop('gid')
         ToolToggleBase.__init__(self, *args, **kwargs)
 
     def enable(self, *args):
-        self.set_lines_visibility(False)
+        self.set_lines_visibility(True)
 
     def disable(self, *args):
-        self.set_lines_visibility(True)
+        self.set_lines_visibility(False)
 
     def set_lines_visibility(self, state):
         gr_lines = []
@@ -75,7 +76,7 @@ plt.plot([3, 2, 1], gid='mygroup')
 
 # Add the custom tools that we created
 fig.canvas.manager.toolmanager.add_tool('List', ListTools)
-fig.canvas.manager.toolmanager.add_tool('Hide', GroupHideTool, gid='mygroup')
+fig.canvas.manager.toolmanager.add_tool('Show', GroupHideTool, gid='mygroup')
 
 
 # Add an existing tool to new group `foo`.
@@ -87,6 +88,6 @@ fig.canvas.manager.toolmanager.remove_tool('forward')
 
 # To add a custom tool to the toolbar at specific location inside
 # the navigation group
-fig.canvas.manager.toolbar.add_tool('Hide', 'navigation', 1)
+fig.canvas.manager.toolbar.add_tool('Show', 'navigation', 1)
 
 plt.show()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3229,6 +3229,9 @@ class ToolContainerBase(object):
         if toggle:
             self.toolmanager.toolmanager_connect('tool_trigger_%s' % tool.name,
                                                  self._tool_toggled_cbk)
+            # If initially toggled
+            if tool.toggled:
+                self.toggle_toolitem(tool.name, True)
 
     def _remove_tool_cbk(self, event):
         """Captures the 'tool_removed_event' signal and removes the tool"""

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -282,7 +282,11 @@ class ToolManager(object):
             else:
                 self._toggled.setdefault(tool_obj.radio_group, None)
 
+            # If initially toggled
+            if tool_obj.toggled:
+                self._handle_toggle(tool_obj, None, None, None)
         tool_obj.set_figure(self.figure)
+
         self._tool_added_event(tool_obj)
         return tool_obj
 
@@ -311,7 +315,7 @@ class ToolManager(object):
         # radio_group None is not mutually exclusive
         # just keep track of toggled tools in this group
         if radio_group is None:
-            if tool.toggled:
+            if tool.name in self._toggled[None]:
                 self._toggled[None].remove(tool.name)
             else:
                 self._toggled[None].add(tool.name)

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -147,6 +147,14 @@ class ToolToggleBase(ToolBase):
     Toggleable tool
 
     Every time it is triggered, it switches between enable and disable
+
+    Parameters
+    ----------
+    ``*args``
+        Variable length argument to be used by the Tool
+    ``**kwargs``
+        `toggled` if present and True, sets the initial state ot the Tool
+        Arbitrary keyword arguments to be consumed by the Tool
     """
 
     radio_group = None
@@ -159,9 +167,12 @@ class ToolToggleBase(ToolBase):
     cursor = None
     """Cursor to use when the tool is active"""
 
+    default_toggled = False
+    """Default of toggled state"""
+
     def __init__(self, *args, **kwargs):
+        self._toggled = kwargs.pop('toggled', self.default_toggled)
         ToolBase.__init__(self, *args, **kwargs)
-        self._toggled = False
 
     def trigger(self, sender, event, data=None):
         """Calls `enable` or `disable` based on `toggled` value"""
@@ -205,10 +216,20 @@ class ToolToggleBase(ToolBase):
     def set_figure(self, figure):
         toggled = self.toggled
         if toggled:
-            self.trigger(self, None)
+            if self.figure:
+                self.trigger(self, None)
+            else:
+                # if no figure the internal state is not changed
+                # we change it here so next call to trigger will change it back
+                self._toggled = False
         ToolBase.set_figure(self, figure)
-        if figure and toggled:
-            self.trigger(self, None)
+        if toggled:
+            if figure:
+                self.trigger(self, None)
+            else:
+                # if there is no figure, triggen wont change the internal state
+                # we change it back
+                self._toggled = True
 
 
 class SetCursorBase(ToolBase):


### PR DESCRIPTION
So far toggle tools start their life in the **untoggled** state, most of the time this is what we want but sometimes it is desirable to initialize a ToogleTool in a **toggled** state without firing the `tool_trigger_xxx` event

With the changes in this PR, the initial state can be changed by class attribute during Tool definition `default_toggle = True` or at the moment of adding the tool to the Toolmanager `toolmanager.add_tool('Name', ToolCls, toggle=True)`