### PR TITLE
ENH: add musecond scale to AutoDateFormatter

### DIFF
--- a/doc/users/whats_new/rcparams.rst
+++ b/doc/users/whats_new/rcparams.rst
@@ -1,25 +1,27 @@
 Configuration (rcParams)
 ------------------------
 
-+----------------------------+--------------------------------------------------+
-| Parameter                  | Description                                      |
-+============================+==================================================+
-|`date.autoformatter.year`   | foramt string for 'year' scale dates             |
-+----------------------------+--------------------------------------------------+
-|`date.autoformatter.month`  | format string for 'month' scale dates            |
-+----------------------------+--------------------------------------------------+
-|`date.autoformatter.day`    | format string for 'day' scale dates              |
-+----------------------------+--------------------------------------------------+
-|`date.autoformatter.hour`   | format string for 'hour' scale times             |
-+----------------------------+--------------------------------------------------+
-|`date.autoformatter.minute` | format string for 'minute' scale times           |
-+----------------------------+--------------------------------------------------+
-|`date.autoformatter.second` | format string for 'second' scale times           |
-+----------------------------+--------------------------------------------------+
-|`scatter.marker`            | default marker for scatter plot                  |
-+----------------------------+--------------------------------------------------+
-|`svg.hashsalt`              | see note                                         |
-+----------------------------+--------------------------------------------------+
++---------------------------------+--------------------------------------------------+
+| Parameter                       | Description                                      |
++=================================+==================================================+
+|`date.autoformatter.year`        | foramt string for 'year' scale dates             |
++---------------------------------+--------------------------------------------------+
+|`date.autoformatter.month`       | format string for 'month' scale dates            |
++---------------------------------+--------------------------------------------------+
+|`date.autoformatter.day`         | format string for 'day' scale dates              |
++---------------------------------+--------------------------------------------------+
+|`date.autoformatter.hour`        | format string for 'hour' scale times             |
++---------------------------------+--------------------------------------------------+
+|`date.autoformatter.minute`      | format string for 'minute' scale times           |
++---------------------------------+--------------------------------------------------+
+|`date.autoformatter.second`      | format string for 'second' scale times           |
++---------------------------------+--------------------------------------------------+
+|`date.autoformatter.microsecond` | format string for 'microsecond' scale times      |
++---------------------------------+--------------------------------------------------+
+|`scatter.marker`                 | default marker for scatter plot                  |
++---------------------------------+--------------------------------------------------+
+|`svg.hashsalt`                   | see note                                         |
++---------------------------------+--------------------------------------------------+
 
 Added ``svg.hashsalt`` key to rcParams
 ```````````````````````````````````````

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -634,7 +634,9 @@ class AutoDateFormatter(ticker.Formatter):
             1.0: rcParams['date.autoformat.day'],
             1. / HOURS_PER_DAY: rcParams['date.autoformat.hour'],
             1. / (MINUTES_PER_DAY): rcParams['date.autoformat.minute'],
-            1. / (SEC_PER_DAY): rcParams['date.autoformat.second']}
+            1. / (SEC_PER_DAY): rcParams['date.autoformat.second'],
+            1. / (MUSECONDS_PER_DAY): rcParams['date.autoformat.microsecond'],
+            }
 
 
     The algorithm picks the key in the dictionary that is >= the
@@ -693,7 +695,9 @@ class AutoDateFormatter(ticker.Formatter):
                        1. / (MINUTES_PER_DAY):
                            rcParams['date.autoformatter.minute'],
                        1. / (SEC_PER_DAY):
-                           rcParams['date.autoformatter.second']}
+                           rcParams['date.autoformatter.second'],
+                       1. / (MUSECONDS_PER_DAY):
+                           rcParams['date.autoformatter.microsecond']}
 
     def __call__(self, x, pos=None):
         locator_unit_scale = float(self._locator._get_unit())

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1097,7 +1097,8 @@ defaultParams = {
     'date.autoformatter.day': ['%Y-%m-%d', six.text_type],
     'date.autoformatter.hour': ['%H:%M', six.text_type],
     'date.autoformatter.minute': ['%H:%M:%S', six.text_type],
-    'date.autoformatter.second': ['%H:%M:%S.%f', six.text_type],
+    'date.autoformatter.second': ['%H:%M:%S', six.text_type],
+    'date.autoformatter.microsecond': ['%H:%M:%S.%f', six.text_type],
 
     #legend properties
     'legend.fancybox': [True, validate_bool],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -355,7 +355,8 @@ backend      : $TEMPLATE_BACKEND
 # date.autoformatter.day      : %Y-%m-%d
 # date.autoformatter.hour     : %H:%M
 # date.autoformatter.minute   : %H:%M:%S
-# date.autoformatter.second   : %H:%M:%S.%f
+# date.autoformatter.second   : %H:%M:%S
+# date.autoformatter.microsecond   : %H:%M:%S.%f
 
 ### TICKS
 # see http://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick


### PR DESCRIPTION
The lack of this scale is pointed out in #6365 and was the big
difference between pandas AutoDateFormatter and the stock upstream
version.


```python
import numpy as np
import matplotlib.pyplot as plt
import datetime

# generating time stamps with a resolution of 1s
x = np.array([datetime.datetime(2016, 5, 4, 12, 0, i) for i in range(60)])
# generating some random y-values
y = np.random.randn(x.shape[0]).cumsum()

# plot
plt.plot(x, y)
plt.show()

```

![so](https://cloud.githubusercontent.com/assets/199813/15201805/cd1e728a-17c2-11e6-8060-a61e9d732142.png)

Still not great, but better.  I think the decision to reduce the default figure size proportional to the increased figure size has made all of the text effectively bigger (as a fraction of figure size).


attn @puggie