### PR TITLE
FIX: apply tick.side rcparam to major&minor ticks

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -576,7 +576,8 @@ class _AxesBase(martist.Artist):
         self.tick_params(top=rcParams['xtick.top'],
                          bottom=rcParams['xtick.bottom'],
                          left=rcParams['ytick.left'],
-                         right=rcParams['ytick.right'])
+                         right=rcParams['ytick.right'],
+                         which='both')
 
     def __setstate__(self, state):
         self.__dict__ = state

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4064,9 +4064,13 @@ def test_rc_tick():
         # tick1On bottom/left
         assert xax._major_tick_kw['tick1On'] == False
         assert xax._major_tick_kw['tick2On'] == True
+        assert xax._minor_tick_kw['tick1On'] == False
+        assert xax._minor_tick_kw['tick2On'] == True
 
         assert yax._major_tick_kw['tick1On'] == True
         assert yax._major_tick_kw['tick2On'] == False
+        assert yax._minor_tick_kw['tick1On'] == True
+        assert yax._minor_tick_kw['tick2On'] == False
 
 
 @cleanup


### PR DESCRIPTION
Extends
cbb3dc84fdb4e4cedf1d171fbc9bf12790e34489
to also apply to minor ticks

closes #6408