### PR TITLE
WIP: Fix some animation confusion

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -420,8 +420,6 @@ class FFMpegBase(object):
 
     @property
     def output_args(self):
-        # The %dk adds 'k' as a suffix so that ffmpeg treats our bitrate as in
-        # kbps
         args = ['-vcodec', self.codec]
         # For h264, the default format is yuv444p, which is not compatible
         # with quicktime (and others). Specifying yuv420p fixes playback on
@@ -429,6 +427,8 @@ class FFMpegBase(object):
         # OSX). Also fixes internet explorer. This is as of 2015/10/29.
         if self.codec == 'h264' and '-pix_fmt' not in self.extra_args:
             args.extend(['-pix_fmt', 'yuv420p'])
+        # The %dk adds 'k' as a suffix so that ffmpeg treats our bitrate as in
+        # kbps
         if self.bitrate > 0:
             args.extend(['-b', '%dk' % self.bitrate])
         if self.extra_args:

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -133,8 +133,8 @@ class MovieWriter(object):
             automatically by the underlying utility.
         extra_args: list of strings or None
             A list of extra string arguments to be passed to the underlying
-            movie utiltiy. The default is None, which passes the additional
-            argurments in the 'animation.extra_args' rcParam.
+            movie utility. The default is None, which passes the additional
+            arguments in the 'animation.extra_args' rcParam.
         metadata: dict of string:string or None
             A dictionary of keys and values for metadata to include in the
             output file. Some keys that may be of use include:
@@ -702,8 +702,8 @@ class Animation(object):
         `animation.bitrate`.
 
         *extra_args* is a list of extra string arguments to be passed to the
-        underlying movie utiltiy. The default is None, which passes the
-        additional argurments in the 'animation.extra_args' rcParam.
+        underlying movie utility. The default is None, which passes the
+        additional arguments in the 'animation.extra_args' rcParam.
 
         *metadata* is a dictionary of keys and values for metadata to include
         in the output file. Some keys that may be of use include:
@@ -947,7 +947,7 @@ class Animation(object):
         directly into the HTML5 video tag. This respects the rc parameters
         for the writer as well as the bitrate. This also makes use of the
         ``interval`` to control the speed, and uses the ``repeat``
-        paramter to decide whether to loop.
+        parameter to decide whether to loop.
         '''
         VIDEO_TAG = r'''<video {size} {options}>
   <source type="video/mp4" src="data:video/mp4;base64,{video}">


### PR DESCRIPTION
This fixes #6416.

It refactors and expands checking for the 'tight' figure bounding boxes that break piping image data to animation writers. First ,refactor things so that the writers can specify whether they handle changing figure sizes. By default `MovieWriter` (i.e. pipe-based writers) sets the flag to `False`, while `MovieFileWriter` sets it to `True`; this seems to work appropriately for all of the various writers (on OSX at least, but I don't think this is a platform issue). It also adds handling of the `'savefig.bbox'` rcParam.

The issue of what to do about being given a `MovieWriter` instance and kwargs for creating one remains TBD.