### PR TITLE
BUG: copy image data so it can't be modified prior to drawing

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1516,8 +1516,8 @@ def issubclass_safe(x, klass):
         return False
 
 
-def safe_masked_invalid(x):
-    x = np.asanyarray(x)
+def safe_masked_invalid(x, copy=False):
+    x = np.array(x, subok=True, copy=copy)
     try:
         xm = np.ma.masked_invalid(x, copy=False)
         xm.shrink_mask()

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -442,7 +442,7 @@ class _AxesImageBase(martist.Artist, cm.ScalarMappable):
         if hasattr(A, 'getpixel'):
             self._A = pil_to_array(A)
         else:
-            self._A = cbook.safe_masked_invalid(A)
+            self._A = cbook.safe_masked_invalid(A, copy=True)
 
         if (self._A.dtype != np.uint8 and
                 not np.can_cast(self._A.dtype, np.float)):
@@ -798,9 +798,9 @@ class NonUniformImage(AxesImage):
             colormapped, or a (M,N,3) RGB array, or a (M,N,4) RGBA
             array.
         """
-        x = np.asarray(x, np.float32)
-        y = np.asarray(y, np.float32)
-        A = cbook.safe_masked_invalid(A)
+        x = np.array(x, np.float32)
+        y = np.array(y, np.float32)
+        A = cbook.safe_masked_invalid(A, copy=True)
         if len(x.shape) != 1 or len(y.shape) != 1\
            or A.shape[0:2] != (y.shape[0], x.shape[0]):
             raise TypeError("Axes don't match array shape")
@@ -887,7 +887,8 @@ class PcolorImage(martist.Artist, cm.ScalarMappable):
         # it needs to be remade if the bbox or viewlim change,
         # so caching does help with zoom/pan/resize.
         self.update(kwargs)
-        self.set_data(x, y, A)
+        if A is not None:
+            self.set_data(x, y, A)
 
     def make_image(self, magnification=1.0):
         if self._A is None:
@@ -938,15 +939,15 @@ class PcolorImage(martist.Artist, cm.ScalarMappable):
         self.stale = False
 
     def set_data(self, x, y, A):
-        A = cbook.safe_masked_invalid(A)
+        A = cbook.safe_masked_invalid(A, copy=True)
         if x is None:
             x = np.arange(0, A.shape[1]+1, dtype=np.float64)
         else:
-            x = np.asarray(x, np.float64).ravel()
+            x = np.array(x, np.float64).ravel()
         if y is None:
             y = np.arange(0, A.shape[0]+1, dtype=np.float64)
         else:
-            y = np.asarray(y, np.float64).ravel()
+            y = np.array(y, np.float64).ravel()
 
         if A.shape[:2] != (y.size-1, x.size-1):
             print(A.shape)
@@ -1044,7 +1045,8 @@ class FigureImage(martist.Artist, cm.ScalarMappable):
 
     def set_data(self, A):
         """Set the image array."""
-        cm.ScalarMappable.set_array(self, cbook.safe_masked_invalid(A))
+        cm.ScalarMappable.set_array(self,
+                                    cbook.safe_masked_invalid(A, copy=True))
         self.stale = True
 
     def set_array(self, A):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -12,7 +12,8 @@ import numpy as np
 
 from matplotlib.testing.decorators import (image_comparison,
                                            knownfailureif, cleanup)
-from matplotlib.image import BboxImage, imread, NonUniformImage
+from matplotlib.image import (BboxImage, imread, NonUniformImage,
+                              AxesImage, FigureImage, PcolorImage)
 from matplotlib.transforms import Bbox
 from matplotlib import rcParams
 import matplotlib.pyplot as plt
@@ -461,6 +462,50 @@ def test_nonuniformimage_setnorm():
     ax = plt.gca()
     im = NonUniformImage(ax)
     im.set_norm(plt.Normalize())
+
+
+@cleanup
+def test_nonuniformimage_setdata():
+    ax = plt.gca()
+    im = NonUniformImage(ax)
+    x = np.arange(3, dtype=np.float64)
+    y = np.arange(4, dtype=np.float64)
+    z = np.arange(12, dtype=np.float64).reshape((4, 3))
+    im.set_data(x, y, z)
+    x[0] = y[0] = z[0, 0] = 9.9
+    assert im._A[0, 0] == im._Ax[0] == im._Ay[0] == 0, 'value changed'
+
+
+@cleanup
+def test_axesimage_setdata():
+    ax = plt.gca()
+    im = AxesImage(ax)
+    z = np.arange(12, dtype=np.float64).reshape((4, 3))
+    im.set_data(z)
+    z[0, 0] = 9.9
+    assert im._A[0, 0] == 0, 'value changed'
+
+
+@cleanup
+def test_figureimage_setdata():
+    fig = plt.gcf()
+    im = FigureImage(fig)
+    z = np.arange(12, dtype=np.float64).reshape((4, 3))
+    im.set_data(z)
+    z[0, 0] = 9.9
+    assert im._A[0, 0] == 0, 'value changed'
+
+
+@cleanup
+def test_pcolorimage_setdata():
+    ax = plt.gca()
+    im = PcolorImage(ax)
+    x = np.arange(3, dtype=np.float64)
+    y = np.arange(4, dtype=np.float64)
+    z = np.arange(6, dtype=np.float64).reshape((3, 2))
+    im.set_data(x, y, z)
+    x[0] = y[0] = z[0, 0] = 9.9
+    assert im._A[0, 0] == im._Ax[0] == im._Ay[0] == 0, 'value changed'
 
 
 @cleanup


### PR DESCRIPTION
Closes #6419.  Also fixes another small bug that I tripped over in testing: PcolorImage was not handling the case where the `A` array is None in the constructor.