### PR TITLE
[MRG+1] Give a better error message on missing PostScript fonts 

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1876,6 +1876,12 @@ class RendererPdf(RendererBase):
                 pdfname = self.file.fontName(dvifont.texname)
                 if dvifont.texname not in self.file.dviFontInfo:
                     psfont = self.tex_font_mapping(dvifont.texname)
+                    if psfont.filename is None:
+                        self.file.broken = True
+                        raise ValueError(
+                            ("No usable font file found for %s (%s). "
+                             "The font may lack a Type-1 version.")
+                            % (psfont.psname, dvifont.texname))
                     self.file.dviFontInfo[dvifont.texname] = Bunch(
                         fontfile=psfont.filename,
                         basefont=psfont.psname,

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -5,12 +5,22 @@ from matplotlib.externals import six
 
 import numpy as np
 from io import BytesIO
+import os
+import tempfile
 import xml.parsers.expat
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+from nose.tools import raises
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
 from matplotlib.testing.decorators import image_comparison, knownfailureif
 import matplotlib
+from matplotlib import dviread
+
 
 needs_tex = knownfailureif(
     not matplotlib.checkdep_tex(),
@@ -181,6 +191,23 @@ def test_determinism_notex():
 def test_determinism_tex():
     # unique filename to allow for parallel testing
     _test_determinism('determinism_tex.svg', usetex=True)
+
+
+@cleanup
+@needs_tex
+@raises(ValueError)
+@patch('matplotlib.dviread.PsfontsMap.__getitem__')
+def test_missing_psfont(mock):
+    """An error is raised if a TeX font lacks a Type-1 equivalent"""
+    from matplotlib import rc
+    psfont = dviread.PsFont(texname='texfont', psname='Some Font',
+                            effects=None, encoding=None, filename=None)
+    mock.configure_mock(return_value=psfont)
+    rc('text', usetex=True)
+    fig, ax = plt.subplots()
+    ax.text(0.5, 0.5, 'hello')
+    with tempfile.NamedTemporaryFile(suffix='.svg') as tmpfile:
+        fig.savefig(tmpfile.name)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -335,6 +335,12 @@ class TextToPath(object):
             font_bunch = self.tex_font_map[dvifont.texname]
 
             if font_and_encoding is None:
+                if font_bunch.filename is None:
+                    raise ValueError(
+                        ("No usable font file found for %s (%s). "
+                         "The font may lack a Type-1 version.")
+                        % (font_bunch.psname, dvifont.texname))
+
                 font = get_font(font_bunch.filename)
 
                 for charmap_name, charmap_code in [("ADOBE_CUSTOM",


### PR DESCRIPTION
For #4167; does not fix the problem, as it would need supporting a whole different kind of font, but gives a more useful error message.
