### PR TITLE
Animation error handling (Fixes #6416)

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -234,12 +234,14 @@ class MovieWriter(object):
             # frame format and dpi.
             self.fig.savefig(self._frame_sink(), format=self.frame_format,
                              dpi=self.dpi, **savefig_kwargs)
-        except RuntimeError:
+        except (RuntimeError, IOError):
             out, err = self._proc.communicate()
             verbose.report('MovieWriter -- Error '
                            'running proc:\n%s\n%s' % (out,
                                                       err), level='helpful')
-            raise
+            raise IOError('Error saving animation to file. '
+                          'Stdout: {0} StdError: {1}. It may help to re-run '
+                          'with --verbose-debug.'.format(out, err))
 
     def _frame_sink(self):
         'Returns the place to which frames should be written.'

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -686,37 +686,13 @@ class Animation(object):
         If nothing is passed, the value of the rcparam `animation.writer` is
         used.
 
-        *fps* is the frames per second in the movie. Defaults to None,
-        which will use the animation's specified interval to set the frames
-        per second. This argument is only valid if *writer* is not a
-        :class:`MovieWriter` instance.
-
         *dpi* controls the dots per inch for the movie frames. This combined
         with the figure's size in inches controls the size of the movie.
 
-        *codec* is the video codec to be used. Not all codecs are supported
-        by a given :class:`MovieWriter`. If none is given, this defaults to the
-        value specified by the rcparam `animation.codec`. This argument is only
-        valid if *writer* is not a :class:`MovieWriter` instance.
-
-        *bitrate* specifies the amount of bits used per second in the
-        compressed movie, in kilobits per second. A higher number means a
-        higher quality movie, but at the cost of increased file size. If no
-        value is given, this defaults to the value given by the rcparam
-        `animation.bitrate`. This argument is only valid if *writer* is not a
-        :class:`MovieWriter` instance.
-
-        *extra_args* is a list of extra string arguments to be passed to the
-        underlying movie utility. The default is None, which passes the
-        additional arguments in the 'animation.extra_args' rcParam. This
-        argument is only valid if *writer* is not a :class:`MovieWriter`
-        instance.
-
-        *metadata* is a dictionary of keys and values for metadata to include
-        in the output file. Some keys that may be of use include:
-        title, artist, genre, subject, copyright, srcform, comment. This
-        argument is only valid if *writer* is not a :class:`MovieWriter`
-        instance.
+        *savefig_kwargs* is a dictionary containing keyword arguments to be
+        passed on to the 'savefig' command which is called repeatedly to save
+        the individual frames. This can be used to set tight bounding boxes,
+        for example.
 
         *extra_anim* is a list of additional `Animation` objects that should
         be included in the saved movie file. These need to be from the same
@@ -724,10 +700,31 @@ class Animation(object):
         simply combined, so there should be a 1:1 correspondence between
         the frames from the different animations.
 
-        *savefig_kwargs* is a dictionary containing keyword arguments to be
-        passed on to the 'savefig' command which is called repeatedly to save
-        the individual frames. This can be used to set tight bounding boxes,
-        for example.
+        These remaining arguments are used to construct a :class:`MovieWriter`
+        instance when necessary and are only considered valid if *writer* is
+        not a :class:`MovieWriter` instance.
+
+        *fps* is the frames per second in the movie. Defaults to None,
+        which will use the animation's specified interval to set the frames
+        per second.
+
+        *codec* is the video codec to be used. Not all codecs are supported
+        by a given :class:`MovieWriter`. If none is given, this defaults to the
+        value specified by the rcparam `animation.codec`.
+
+        *bitrate* specifies the amount of bits used per second in the
+        compressed movie, in kilobits per second. A higher number means a
+        higher quality movie, but at the cost of increased file size. If no
+        value is given, this defaults to the value given by the rcparam
+        `animation.bitrate`.
+
+        *extra_args* is a list of extra string arguments to be passed to the
+        underlying movie utility. The default is None, which passes the
+        additional arguments in the 'animation.extra_args' rcParam.
+
+        *metadata* is a dictionary of keys and values for metadata to include
+        in the output file. Some keys that may be of use include:
+        title, artist, genre, subject, copyright, srcform, comment.
         '''
         # If the writer is None, use the rc param to find the name of the one
         # to use

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -234,14 +234,14 @@ class MovieWriter(object):
             # frame format and dpi.
             self.fig.savefig(self._frame_sink(), format=self.frame_format,
                              dpi=self.dpi, **savefig_kwargs)
-        except (RuntimeError, IOError):
+        except (RuntimeError, IOError) as e:
             out, err = self._proc.communicate()
             verbose.report('MovieWriter -- Error '
                            'running proc:\n%s\n%s' % (out,
                                                       err), level='helpful')
-            raise IOError('Error saving animation to file. '
-                          'Stdout: {0} StdError: {1}. It may help to re-run '
-                          'with --verbose-debug.'.format(out, err))
+            raise IOError('Error saving animation to file (cause: {0}) '
+                          'Stdout: {1} StdError: {2}. It may help to re-run '
+                          'with --verbose-debug.'.format(e, out, err))
 
     def _frame_sink(self):
         'Returns the place to which frames should be written.'

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -686,28 +686,35 @@ class Animation(object):
 
         *fps* is the frames per second in the movie. Defaults to None,
         which will use the animation's specified interval to set the frames
-        per second.
+        per second. This argument is only valid if *writer* is not a
+        :class:`MovieWriter` instance.
 
         *dpi* controls the dots per inch for the movie frames. This combined
         with the figure's size in inches controls the size of the movie.
 
         *codec* is the video codec to be used. Not all codecs are supported
         by a given :class:`MovieWriter`. If none is given, this defaults to the
-        value specified by the rcparam `animation.codec`.
+        value specified by the rcparam `animation.codec`. This argument is only
+        valid if *writer* is not a :class:`MovieWriter` instance.
 
         *bitrate* specifies the amount of bits used per second in the
         compressed movie, in kilobits per second. A higher number means a
         higher quality movie, but at the cost of increased file size. If no
         value is given, this defaults to the value given by the rcparam
-        `animation.bitrate`.
+        `animation.bitrate`. This argument is only valid if *writer* is not a
+        :class:`MovieWriter` instance.
 
         *extra_args* is a list of extra string arguments to be passed to the
         underlying movie utility. The default is None, which passes the
-        additional arguments in the 'animation.extra_args' rcParam.
+        additional arguments in the 'animation.extra_args' rcParam. This
+        argument is only valid if *writer* is not a :class:`MovieWriter`
+        instance.
 
         *metadata* is a dictionary of keys and values for metadata to include
         in the output file. Some keys that may be of use include:
-        title, artist, genre, subject, copyright, srcform, comment.
+        title, artist, genre, subject, copyright, srcform, comment. This
+        argument is only valid if *writer* is not a :class:`MovieWriter`
+        instance.
 
         *extra_anim* is a list of additional `Animation` objects that should
         be included in the saved movie file. These need to be from the same
@@ -720,6 +727,20 @@ class Animation(object):
         the individual frames. This can be used to set tight bounding boxes,
         for example.
         '''
+        # If the writer is None, use the rc param to find the name of the one
+        # to use
+        if writer is None:
+            writer = rcParams['animation.writer']
+        elif (not is_string_like(writer) and
+                any(arg is not None
+                    for arg in (fps, codec, bitrate, extra_args, metadata))):
+            raise RuntimeError('Passing in values for arguments for arguments '
+                               'fps, codec, bitrate, extra_args, or metadata '
+                               'is not supported when writer is an existing '
+                               'MovieWriter instance. These should instead be '
+                               'passed as arguments when creating the '
+                               'MovieWriter instance.')
+
         if savefig_kwargs is None:
             savefig_kwargs = {}
 
@@ -734,11 +755,6 @@ class Animation(object):
         if fps is None and hasattr(self, '_interval'):
             # Convert interval in ms to frames per second
             fps = 1000. / self._interval
-
-        # If the writer is None, use the rc param to find the name of the one
-        # to use
-        if writer is None:
-            writer = rcParams['animation.writer']
 
         # Re-use the savefig DPI for ours if none is given
         if dpi is None:


### PR DESCRIPTION
This addresses the remaining issues from #6416 
- raise an error when given arguments that would be ignored (because they are only used to create new instances of `MovieWriter`)
- Try to improve exception message when saving movie fails.

The latter can only be improved so much, because often the observed behavior is a `BrokenPipeError`, which keeps us from being able to grab anything from stderr. My solution here is to note that running with `--verbose-debug` may be helpful since in this case output is dumped straight to stdout.