### PR TITLE
Offset text colored by labelcolor param

### DIFF
--- a/doc/users/whats_new/offset_label_color.rst
+++ b/doc/users/whats_new/offset_label_color.rst
@@ -1,0 +1,4 @@
+Axis offset label now responds to `labelcolor`
+----------------------------------------------
+
+Axis offset labels are now colored the same as axis tick markers when `labelcolor` is altered.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -796,6 +796,8 @@ class Axis(artist.Artist):
             if which == 'minor' or which == 'both':
                 for tick in self.minorTicks:
                     tick._apply_params(**self._minor_tick_kw)
+            if 'labelcolor' in kwtrans:
+                self.offsetText.set_color(kwtrans['labelcolor'])
         self.stale = True
 
     @staticmethod

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4478,6 +4478,16 @@ def test_axisbelow():
 
 
 @cleanup
+def test_offset_label_color():
+    # Tests issue 6440
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    ax.plot([1.01e9, 1.02e9, 1.03e9])
+    ax.yaxis.set_tick_params(labelcolor='red')
+    assert ax.yaxis.get_offset_text().get_color() == 'red'
+
+
+@cleanup
 def test_large_offset():
     fig, ax = plt.subplots()
     ax.plot((1 + np.array([0, 1.e-12])) * 1.e27)


### PR DESCRIPTION
Addresses #6440.

Sets color of `offsetText` in `set_tick_params` to what the `labelcolor` dictates.
