### PR TITLE
Prf maybe

### DIFF
--- a/src/_path.h
+++ b/src/_path.h
@@ -77,7 +77,7 @@ struct XY
 // Input 2D polygon _pgon_ with _numverts_ number of vertices and test point
 // _point_, returns 1 if inside, 0 if outside.
 template <class PathIterator, class PointArray, class ResultArray>
-void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &inside_flag)
+void point_in_path_impl(const PointArray &points, PathIterator &path, ResultArray &inside_flag)
 {
     bool yflag1;
     double vtx0, vty0, vtx1, vty1;
@@ -89,14 +89,28 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
 
     size_t n = points.size();
 
+    std::vector<double> _x(n);
+    std::vector<double> _y(n);
+
     std::vector<bool> yflag0(n);
     std::vector<bool> subpath_flag(n);
+
 
     path.rewind(0);
 
     for (i = 0; i < n; ++i) {
         inside_flag[i] = false;
     }
+    for (i = 0; i < n; ++i) {
+
+	tx = points[i][0];
+	ty = points[i][1];
+
+	_x[i] = tx;
+	_y[i] = ty;
+
+    }
+
 
     unsigned code = 0;
     do {
@@ -135,8 +149,10 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
             }
 
             for (i = 0; i < n; ++i) {
-                tx = points[i][0];
-                ty = points[i][1];
+
+                tx = _x[i];
+                ty = _y[i];
+
 
                 if (!(std::isfinite(tx) && std::isfinite(ty))) {
                     continue;
@@ -183,8 +199,8 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
 
         all_done = true;
         for (i = 0; i < n; ++i) {
-            tx = points[i][0];
-            ty = points[i][1];
+            tx = _x[i];
+            ty = _y[i];
 
             if (!(std::isfinite(tx) && std::isfinite(ty))) {
                 continue;

--- a/src/_path.h
+++ b/src/_path.h
@@ -94,6 +94,7 @@ void point_in_path_impl(const PointArray &points, PathIterator &path, ResultArra
 
     std::vector<bool> yflag0(n);
     std::vector<bool> subpath_flag(n);
+    std::vector<bool> both_finite(n);
 
 
     path.rewind(0);
@@ -102,12 +103,13 @@ void point_in_path_impl(const PointArray &points, PathIterator &path, ResultArra
         inside_flag[i] = false;
     }
     for (i = 0; i < n; ++i) {
-
 	tx = points[i][0];
 	ty = points[i][1];
 
 	_x[i] = tx;
 	_y[i] = ty;
+
+	both_finite[i] = (std::isfinite(tx) && std::isfinite(ty));
 
     }
 
@@ -126,14 +128,13 @@ void point_in_path_impl(const PointArray &points, PathIterator &path, ResultArra
         sy = vty0 = vty1 = y;
 
         for (i = 0; i < n; ++i) {
-            ty = points[i][1];
+	    if (! both_finite[i]){
+		 continue;
+	    }
+	    // get test bit for above/below X axis
+	    yflag0[i] = (vty0 >= ty);
+	    subpath_flag[i] = false;
 
-            if (std::isfinite(ty)) {
-                // get test bit for above/below X axis
-                yflag0[i] = (vty0 >= ty);
-
-                subpath_flag[i] = false;
-            }
         }
 
         do {
@@ -149,14 +150,12 @@ void point_in_path_impl(const PointArray &points, PathIterator &path, ResultArra
             }
 
             for (i = 0; i < n; ++i) {
-
+		if (! both_finite[i]){
+		    continue;
+		}
                 tx = _x[i];
                 ty = _y[i];
 
-
-                if (!(std::isfinite(tx) && std::isfinite(ty))) {
-                    continue;
-                }
 
                 yflag1 = (vty1 >= ty);
                 // Check if endpoints straddle (are on opposite sides) of
@@ -199,12 +198,11 @@ void point_in_path_impl(const PointArray &points, PathIterator &path, ResultArra
 
         all_done = true;
         for (i = 0; i < n; ++i) {
-            tx = _x[i];
+	    if (!both_finite[i]){
+		continue;
+	    }
+	    tx = _x[i];
             ty = _y[i];
-
-            if (!(std::isfinite(tx) && std::isfinite(ty))) {
-                continue;
-            }
 
             yflag1 = (vty1 >= ty);
             if (yflag0[i] != yflag1) {


### PR DESCRIPTION
Partially addresses #6444 at the cost of more memory usage.

The bottle neck seems to be the `[][]` calls.

With this patch the exaple in #6444 runs in 160ms so this does not fully address the issue.

Might also be worth looking at change the `std:vector<bool>` to `std:vector<int>` to see if that gets any performance gains?

This diff from @mdboom also gets comparable speed up at the cost of breaking the single point tests (which can be fixed)


```diff
diff --git a/src/.clang-format b/src/.clang-format
index d54ffce..de76f7f 100644
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,4 +1,4 @@
----
+ ---
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 ConstructorInitializerIndentWidth: 4
diff --git a/src/_path.h b/src/_path.h
index 6b1b3d1..5554c12 100644
--- a/src/_path.h
+++ b/src/_path.h
@@ -112,7 +112,7 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
         sy = vty0 = vty1 = y;
 
         for (i = 0; i < n; ++i) {
-            ty = points[i][1];
+            ty = points(i, 1);
 
             if (std::isfinite(ty)) {
                 // get test bit for above/below X axis
@@ -135,8 +135,8 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
             }
 
             for (i = 0; i < n; ++i) {
-                tx = points[i][0];
-                ty = points[i][1];
+                tx = points(i, 0);
+                ty = points(i, 1);
 
                 if (!(std::isfinite(tx) && std::isfinite(ty))) {
                     continue;
@@ -183,8 +183,8 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
 
         all_done = true;
         for (i = 0; i < n; ++i) {
-            tx = points[i][0];
-            ty = points[i][1];
+            tx = points(i, 0);
+            ty = points(i, 1);
 
             if (!(std::isfinite(tx) && std::isfinite(ty))) {
                 continue;
@@ -242,18 +242,18 @@ template <class PathIterator>
 inline bool point_in_path(
     double x, double y, const double r, PathIterator &path, agg::trans_affine &trans)
 {
-    std::vector<double> point;
-    std::vector<std::vector<double> > points;
-    point.push_back(x);
-    point.push_back(y);
-    points.push_back(point);
+    // std::vector<double> point;
+    // std::vector<std::vector<double> > points;
+    // point.push_back(x);
+    // point.push_back(y);
+    // points.push_back(point);
 
-    int result[1];
-    result[0] = 0;
+    // int result[1];
+    // result[0] = 0;
 
-    points_in_path(points, r, path, trans, result);
+    // points_in_path(points, r, path, trans, result);
 
-    return (bool)result[0];
+    // return (bool)result[0];
 }
 
 template <class PathIterator, class PointArray, class ResultArray>
@@ -285,18 +285,18 @@ template <class PathIterator>
 inline bool point_on_path(
     double x, double y, const double r, PathIterator &path, agg::trans_affine &trans)
 {
-    std::vector<double> point;
-    std::vector<std::vector<double> > points;
-    point.push_back(x);
-    point.push_back(y);
-    points.push_back(point);
+    // std::vector<double> point;
+    // std::vector<std::vector<double> > points;
+    // point.push_back(x);
+    // point.push_back(y);
+    // points.push_back(point);
 
-    int result[1];
-    result[0] = 0;
+    // int result[1];
+    // result[0] = 0;
 
-    points_on_path(points, r, path, trans, result);
+    // points_on_path(points, r, path, trans, result);
 
-    return (bool)result[0];
+    // return (bool)result[0];
 }
 
 struct extent_limits

```