### PR TITLE
FIX: minimum number of bins in 'auto' is 3

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1549,7 +1549,7 @@ class MaxNLocator(Locator):
     def _raw_ticks(self, vmin, vmax):
         nbins = self._nbins
         if nbins == 'auto':
-            nbins = max(min(self.axis.get_tick_space(), 9), 1)
+            nbins = max(min(self.axis.get_tick_space(), 9), 3)
         scale, offset = scale_range(vmin, vmax, nbins)
         if self._integer:
             scale = max(1, scale)


### PR DESCRIPTION
This is to prevent plots with only one visible tick.

Use 3 instead of 2 because ticks may fall out of the visible range so 2
bins would be 3 ticks which may be one visible and 2 off either end.

closes #5784