### PR TITLE
[MRG+1] Add a common example to compare style sheets

### DIFF
--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -16,7 +16,6 @@ def plot_scatter(ax, prng, nb_samples=100):
         x, y = prng.normal(loc=mu, scale=sigma, size=(2, nb_samples))
         ax.plot(x, y, ls='none', marker=marker)
     ax.set_xlabel('X-label')
-    ax.set_ylabel('Y-label')
     return ax
 
 
@@ -104,15 +103,22 @@ def plot_figure(style_label=None):
     # across the different figures.
     prng = np.random.RandomState(96917002)
 
-    fig, axes = plt.subplots(ncols=3, nrows=2, num=style_label)
-    fig.suptitle(style_label)
+    # Tweak the figure size to be better suited for a row of numerous plots:
+    # double the width and halve the height. NB: use relative changes because
+    # some styles may have a figure size different from the default one.
+    (fig_width, fig_height) = plt.rcParams['figure.figsize']
+    fig_size = [fig_width * 2, fig_height / 2]
 
-    plot_scatter(axes[0, 0], prng)
-    plot_image_and_patch(axes[0, 1], prng)
-    plot_bar_graphs(axes[0, 2], prng)
-    plot_colored_circles(axes[1, 0], prng)
-    plot_colored_sinusoidal_lines(axes[1, 1])
-    plot_histograms(axes[1, 2], prng)
+    fig, axes = plt.subplots(ncols=6, nrows=1, num=style_label,
+                             figsize=fig_size, squeeze=True)
+    axes[0].set_ylabel(style_label)
+
+    plot_scatter(axes[0], prng)
+    plot_image_and_patch(axes[1], prng)
+    plot_bar_graphs(axes[2], prng)
+    plot_colored_circles(axes[3], prng)
+    plot_colored_sinusoidal_lines(axes[4])
+    plot_histograms(axes[5], prng)
 
     fig.tight_layout()
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -1,0 +1,119 @@
+"""
+This example demonstrates different available style sheets on a common example.
+
+The different plots are heavily similar to the other ones in the style sheet
+gallery.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+def plot_scatter(ax, prng, nb_samples=200):
+    """ Scatter plot.
+
+    NB: `plt.scatter` doesn't use default colors.
+    """
+    x, y = prng.normal(size=(2, nb_samples))
+    ax.plot(x, y, 'o')
+    return ax
+
+def plot_colored_sinusoidal_lines(ax):
+    """ Plot sinusoidal lines with colors from default color cycle.
+    """
+    L = 2*np.pi
+    x = np.linspace(0, L)
+    ncolors = len(plt.rcParams['axes.color_cycle'])
+    shift = np.linspace(0, L, ncolors, endpoint=False)
+    for s in shift:
+        ax.plot(x, np.sin(x + s), '-')
+    ax.margins(0)
+    return ax
+
+def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
+    """ Plot two bar graphs side by side, with letters as xticklabels.
+    """
+    x = np.arange(nb_samples)
+    ya, yb = prng.randint(min_value, max_value, size=(2, nb_samples))
+    width = 0.25
+    ax.bar(x, ya, width)
+    ax.bar(x + width, yb, width, color=plt.rcParams['axes.color_cycle'][2])
+    ax.set_xticks(x + width)
+    ax.set_xticklabels(['a', 'b', 'c', 'd', 'e'])
+    return ax
+
+def plot_colored_circles(ax, prng, nb_samples=15):
+    """ Plot circle patches.
+
+    NB: drawing a fixed amount of samples, rather than using the length of
+    the color cycle, because different styles may have different numbers of
+    colors.
+    """
+    max_idx = max(nb_samples, len(plt.rcParams['axes.color_cycle']))
+    for color in plt.rcParams['axes.color_cycle'][0:max_idx]:
+        ax.add_patch(plt.Circle(prng.normal(scale=3, size=2),
+                     radius=1.0, color=color))
+    # Force the limits to be the same accross the styles (because different
+    # styles may have different numbers of available colors).
+    ax.set_xlim([-5., 7.])
+    ax.set_ylim([-8.5, 3.5])
+    ax.set_aspect('equal', adjustable='box')  # to plot circles as circles
+    return ax
+
+def plot_image_and_patch(ax, prng, size=(20, 20)):
+    """ Plot an image with random values and superimpose a circular patch.
+    """
+    values = prng.random_sample(size=size)
+    ax.imshow(values, interpolation='none')
+    c = plt.Circle((5, 5), radius=5, label='patch')
+    ax.add_patch(c)
+
+def plot_histograms(ax, prng, nb_samples=10000):
+    """ Plot 4 histograms and a text annotation.
+    """
+    params = ((10, 10), (4, 12), (50, 12), (6, 55))
+    for values in (prng.beta(a, b, size=nb_samples) for a, b in params):
+        ax.hist(values, histtype="stepfilled", bins=30, alpha=0.8, normed=True)
+    # Add a small annotation
+    ax.annotate('Annotation', xy=(0.25, 4.25), xycoords='data',
+                xytext=(0.4, 10), textcoords='data',
+                bbox=dict(boxstyle="round", alpha=0.2),
+                arrowprops=dict(arrowstyle="->",
+                                connectionstyle=
+                                "angle,angleA=-95,angleB=35,rad=10"),
+                )
+    return ax
+
+def plot_figure(style_label=None):
+    """ 
+    Setup and plot the demonstration figure with the style `style_label`.
+    If `style_label`, fall back to the `default` style.
+    """
+    if style_label == None:
+        style_label = 'default'
+
+    # Use a dedicated RandomState instance to draw the same "random" values across
+    # the different figures
+    prng = np.random.RandomState(145236987)
+
+    fig, axes = plt.subplots(ncols=3, nrows=2, num=style_label)
+    fig.suptitle(style_label)
+
+    axes_list = axes.ravel()  # for convenience
+    plot_scatter(axes_list[0], prng)
+    plot_image_and_patch(axes_list[1], prng)
+    plot_bar_graphs(axes_list[2], prng)
+    plot_colored_circles(axes_list[3], prng)
+    plot_colored_sinusoidal_lines(axes_list[4])
+    plot_histograms(axes_list[5], prng)
+
+    return fig
+
+
+if __name__ == "__main__":
+
+    # Plot a demonstration figure for every available style sheet.
+    for style_label in plt.style.available:
+        with plt.style.context(style_label):
+            fig = plot_figure(style_label=style_label)
+
+    plt.show()
+

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -22,13 +22,13 @@ def plot_scatter(ax, prng, nb_samples=100):
 def plot_colored_sinusoidal_lines(ax):
     """Plot sinusoidal lines with colors following the style color cycle.
     """
-    L = 2*np.pi
+    L = 2 * np.pi
     x = np.linspace(0, L)
     nb_colors = len(plt.rcParams['axes.prop_cycle'])
     shift = np.linspace(0, L, nb_colors, endpoint=False)
     for s in shift:
         ax.plot(x, np.sin(x + s), '-')
-    ax.margins(0)
+    ax.set_xlim([x[0], x[-1]])
     return ax
 
 
@@ -57,7 +57,7 @@ def plot_colored_circles(ax, prng, nb_samples=15):
                                 radius=1.0, color=sty_dict['color']))
     # Force the limits to be the same across the styles (because different
     # styles may have different numbers of available colors).
-    ax.set_xlim([-4, 7])
+    ax.set_xlim([-4, 8])
     ax.set_ylim([-5, 6])
     ax.set_aspect('equal', adjustable='box')  # to plot circles as circles
     return ax
@@ -70,6 +70,9 @@ def plot_image_and_patch(ax, prng, size=(20, 20)):
     ax.imshow(values, interpolation='none')
     c = plt.Circle((5, 5), radius=5, label='patch')
     ax.add_patch(c)
+    # Remove ticks
+    ax.set_xticks([])
+    ax.set_yticks([])
 
 
 def plot_histograms(ax, prng, nb_samples=10000):

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -84,9 +84,9 @@ def plot_histograms(ax, prng, nb_samples=10000):
     ax.annotate('Annotation', xy=(0.25, 4.25), xycoords='data',
                 xytext=(0.4, 10), textcoords='data',
                 bbox=dict(boxstyle="round", alpha=0.2),
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle=
-                                "angle,angleA=-95,angleB=35,rad=10"),
+                arrowprops=dict(
+                          arrowstyle="->",
+                          connectionstyle="angle,angleA=-95,angleB=35,rad=10"),
                 )
     return ax
 
@@ -99,8 +99,8 @@ def plot_figure(style_label=None):
     if style_label is None:
         style_label = 'default'
 
-    # Use a dedicated RandomState instance to draw the same "random" values across
-    # the different figures
+    # Use a dedicated RandomState instance to draw the same "random" values
+    # across the different figures
     prng = np.random.RandomState(145236987)
 
     fig, axes = plt.subplots(ncols=3, nrows=2, num=style_label)

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -1,8 +1,12 @@
 """
-This example demonstrates different available style sheets on a common example.
+======================
+Style sheets reference
+======================
 
-The different plots are heavily similar to the other ones in the style sheet
-gallery.
+This scripts demonstrates the different available style sheets on a
+common set of example plots: scatter plot, image, bar graph, patches,
+line plot and histogram,
+
 """
 
 import numpy as np

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -98,14 +98,9 @@ def plot_histograms(ax, prng, nb_samples=10000):
     return ax
 
 
-def plot_figure(style_label=None):
+def plot_figure(style_label=""):
     """Setup and plot the demonstration figure with a given style.
-
-    If `style_label` is None, fall back to the `default` style.
     """
-    if style_label is None:
-        style_label = 'default'
-
     # Use a dedicated RandomState instance to draw the same "random" values
     # across the different figures.
     prng = np.random.RandomState(96917002)

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -53,8 +53,9 @@ def plot_colored_circles(ax, prng, nb_samples=15):
     the color cycle, because different styles may have different numbers of
     colors.
     """
-    max_idx = max(nb_samples, len(plt.rcParams['axes.color_cycle']))
-    for color in plt.rcParams['axes.color_cycle'][0:max_idx]:
+    list_of_colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
+    max_idx = min(nb_samples, len(list_of_colors))
+    for color in list_of_colors[0:max_idx]:
         ax.add_patch(plt.Circle(prng.normal(scale=3, size=2),
                      radius=1.0, color=color))
     # Force the limits to be the same accross the styles (because different

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -134,8 +134,17 @@ def plot_figure(style_label=None):
 
 if __name__ == "__main__":
 
+    # Setup a list of all available styles, in alphabetical order but
+    # the `default` and `classic` ones, which will be forced resp. in
+    # first and second position.
+    style_list = list(plt.style.available)  # *new* list: avoids side effects.
+    style_list.remove('classic')  # `classic` is in the list: first remove it.
+    style_list.sort()
+    style_list.insert(0, u'default')
+    style_list.insert(1, u'classic')
+
     # Plot a demonstration figure for every available style sheet.
-    for style_label in plt.style.available:
+    for style_label in style_list:
         with plt.style.context(style_label):
             fig = plot_figure(style_label=style_label)
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -3,7 +3,7 @@
 Style sheets reference
 ======================
 
-This scripts demonstrates the different available style sheets on a
+This script demonstrates the different available style sheets on a
 common set of example plots: scatter plot, image, bar graph, patches,
 line plot and histogram,
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 
 
 def plot_scatter(ax, prng, nb_samples=100):
-    """ Scatter plot.
+    """Scatter plot.
     """
     for mu, sigma, marker in [(-.5, 0.75, 'o'), (0.75, 1., 's')]:
         x, y = prng.normal(loc=mu, scale=sigma, size=(2, nb_samples))
@@ -21,7 +21,7 @@ def plot_scatter(ax, prng, nb_samples=100):
 
 
 def plot_colored_sinusoidal_lines(ax):
-    """ Plots sinusoidal lines with colors following the style color cycle.
+    """Plot sinusoidal lines with colors following the style color cycle.
     """
     L = 2*np.pi
     x = np.linspace(0, L)
@@ -34,7 +34,7 @@ def plot_colored_sinusoidal_lines(ax):
 
 
 def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
-    """ Plots two bar graphs side by side, with letters as xticklabels.
+    """Plot two bar graphs side by side, with letters as x-tick labels.
     """
     x = np.arange(nb_samples)
     ya, yb = prng.randint(min_value, max_value, size=(2, nb_samples))
@@ -47,7 +47,7 @@ def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
 
 
 def plot_colored_circles(ax, prng, nb_samples=15):
-    """ Plots circle patches.
+    """Plot circle patches.
 
     NB: draws a fixed amount of samples, rather than using the length of
     the color cycle, because different styles may have different numbers
@@ -65,7 +65,7 @@ def plot_colored_circles(ax, prng, nb_samples=15):
 
 
 def plot_image_and_patch(ax, prng, size=(20, 20)):
-    """ Plots an image with random values and superimposes a circular patch.
+    """Plot an image with random values and superimpose a circular patch.
     """
     values = prng.random_sample(size=size)
     ax.imshow(values, interpolation='none')
@@ -74,7 +74,7 @@ def plot_image_and_patch(ax, prng, size=(20, 20)):
 
 
 def plot_histograms(ax, prng, nb_samples=10000):
-    """ Plots 4 histograms and a text annotation.
+    """Plot 4 histograms and a text annotation.
     """
     params = ((10, 10), (4, 12), (50, 12), (6, 55))
     for a, b in params:
@@ -93,8 +93,8 @@ def plot_histograms(ax, prng, nb_samples=10000):
 
 
 def plot_figure(style_label=None):
-    """
-    Sets up and plots the demonstration figure with the style `style_label`.
+    """Setup and plot the demonstration figure with a given style.
+
     If `style_label` is None, fall back to the `default` style.
     """
     if style_label is None:

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -8,13 +8,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def plot_scatter(ax, prng, nb_samples=200):
+def plot_scatter(ax, prng, nb_samples=100):
     """ Scatter plot.
-
-    NB: `plt.scatter` doesn't use default colors.
     """
-    x, y = prng.normal(size=(2, nb_samples))
-    ax.plot(x, y, 'o')
+    for mu, sigma, marker in [(-.5, 0.75, 'o'), (0.75, 1., 's')]:
+        x, y = prng.normal(loc=mu, scale=sigma, size=(2, nb_samples))
+        ax.plot(x, y, marker=marker, ls='')
     ax.set_xlabel('X-label')
     ax.set_ylabel('Y-label')
     return ax
@@ -25,8 +24,8 @@ def plot_colored_sinusoidal_lines(ax):
     """
     L = 2*np.pi
     x = np.linspace(0, L)
-    ncolors = len(plt.rcParams['axes.color_cycle'])
-    shift = np.linspace(0, L, ncolors, endpoint=False)
+    nb_colors = len(plt.rcParams['axes.prop_cycle'])
+    shift = np.linspace(0, L, nb_colors, endpoint=False)
     for s in shift:
         ax.plot(x, np.sin(x + s), '-')
     ax.margins(0)
@@ -40,7 +39,7 @@ def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
     ya, yb = prng.randint(min_value, max_value, size=(2, nb_samples))
     width = 0.25
     ax.bar(x, ya, width)
-    ax.bar(x + width, yb, width, color=plt.rcParams['axes.color_cycle'][2])
+    ax.bar(x + width, yb, width, color='C2')
     ax.set_xticks(x + width)
     ax.set_xticklabels(['a', 'b', 'c', 'd', 'e'])
     return ax
@@ -53,15 +52,13 @@ def plot_colored_circles(ax, prng, nb_samples=15):
     the color cycle, because different styles may have different numbers of
     colors.
     """
-    list_of_colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
-    max_idx = min(nb_samples, len(list_of_colors))
-    for color in list_of_colors[0:max_idx]:
+    for sty_dict, j in zip(plt.rcParams['axes.prop_cycle'], range(nb_samples)):
         ax.add_patch(plt.Circle(prng.normal(scale=3, size=2),
-                     radius=1.0, color=color))
-    # Force the limits to be the same accross the styles (because different
+                                radius=1.0, color=sty_dict['color']))
+    # Force the limits to be the same across the styles (because different
     # styles may have different numbers of available colors).
-    ax.set_xlim([-5., 7.])
-    ax.set_ylim([-8.5, 3.5])
+    ax.set_xlim([-4, 7])
+    ax.set_ylim([-5, 6])
     ax.set_aspect('equal', adjustable='box')  # to plot circles as circles
     return ax
 
@@ -79,9 +76,10 @@ def plot_histograms(ax, prng, nb_samples=10000):
     """ Plot 4 histograms and a text annotation.
     """
     params = ((10, 10), (4, 12), (50, 12), (6, 55))
-    for values in (prng.beta(a, b, size=nb_samples) for a, b in params):
+    for a, b in params:
+        values = prng.beta(a, b, size=nb_samples)
         ax.hist(values, histtype="stepfilled", bins=30, alpha=0.8, normed=True)
-    # Add a small annotation
+    # Add a small annotation.
     ax.annotate('Annotation', xy=(0.25, 4.25), xycoords='data',
                 xytext=(0.4, 10), textcoords='data',
                 bbox=dict(boxstyle="round", alpha=0.2),
@@ -95,25 +93,24 @@ def plot_histograms(ax, prng, nb_samples=10000):
 def plot_figure(style_label=None):
     """
     Setup and plot the demonstration figure with the style `style_label`.
-    If `style_label`, fall back to the `default` style.
+    If `style_label` is None, fall back to the `default` style.
     """
     if style_label is None:
         style_label = 'default'
 
     # Use a dedicated RandomState instance to draw the same "random" values
-    # across the different figures
-    prng = np.random.RandomState(145236987)
+    # across the different figures.
+    prng = np.random.RandomState(96917002)
 
     fig, axes = plt.subplots(ncols=3, nrows=2, num=style_label)
     fig.suptitle(style_label)
 
-    axes_list = axes.ravel()  # for convenience
-    plot_scatter(axes_list[0], prng)
-    plot_image_and_patch(axes_list[1], prng)
-    plot_bar_graphs(axes_list[2], prng)
-    plot_colored_circles(axes_list[3], prng)
-    plot_colored_sinusoidal_lines(axes_list[4])
-    plot_histograms(axes_list[5], prng)
+    plot_scatter(axes[0, 0], prng)
+    plot_image_and_patch(axes[0, 1], prng)
+    plot_bar_graphs(axes[0, 2], prng)
+    plot_colored_circles(axes[1, 0], prng)
+    plot_colored_sinusoidal_lines(axes[1, 1])
+    plot_histograms(axes[1, 2], prng)
 
     return fig
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -4,6 +4,7 @@ This example demonstrates different available style sheets on a common example.
 The different plots are heavily similar to the other ones in the style sheet
 gallery.
 """
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -13,14 +14,14 @@ def plot_scatter(ax, prng, nb_samples=100):
     """
     for mu, sigma, marker in [(-.5, 0.75, 'o'), (0.75, 1., 's')]:
         x, y = prng.normal(loc=mu, scale=sigma, size=(2, nb_samples))
-        ax.plot(x, y, marker=marker, ls='')
+        ax.plot(x, y, ls='none', marker=marker)
     ax.set_xlabel('X-label')
     ax.set_ylabel('Y-label')
     return ax
 
 
 def plot_colored_sinusoidal_lines(ax):
-    """ Plot sinusoidal lines with colors from default color cycle.
+    """ Plots sinusoidal lines with colors following the style color cycle.
     """
     L = 2*np.pi
     x = np.linspace(0, L)
@@ -33,7 +34,7 @@ def plot_colored_sinusoidal_lines(ax):
 
 
 def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
-    """ Plot two bar graphs side by side, with letters as xticklabels.
+    """ Plots two bar graphs side by side, with letters as xticklabels.
     """
     x = np.arange(nb_samples)
     ya, yb = prng.randint(min_value, max_value, size=(2, nb_samples))
@@ -46,11 +47,11 @@ def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
 
 
 def plot_colored_circles(ax, prng, nb_samples=15):
-    """ Plot circle patches.
+    """ Plots circle patches.
 
-    NB: drawing a fixed amount of samples, rather than using the length of
-    the color cycle, because different styles may have different numbers of
-    colors.
+    NB: draws a fixed amount of samples, rather than using the length of
+    the color cycle, because different styles may have different numbers
+    of colors.
     """
     for sty_dict, j in zip(plt.rcParams['axes.prop_cycle'], range(nb_samples)):
         ax.add_patch(plt.Circle(prng.normal(scale=3, size=2),
@@ -64,7 +65,7 @@ def plot_colored_circles(ax, prng, nb_samples=15):
 
 
 def plot_image_and_patch(ax, prng, size=(20, 20)):
-    """ Plot an image with random values and superimpose a circular patch.
+    """ Plots an image with random values and superimposes a circular patch.
     """
     values = prng.random_sample(size=size)
     ax.imshow(values, interpolation='none')
@@ -73,7 +74,7 @@ def plot_image_and_patch(ax, prng, size=(20, 20)):
 
 
 def plot_histograms(ax, prng, nb_samples=10000):
-    """ Plot 4 histograms and a text annotation.
+    """ Plots 4 histograms and a text annotation.
     """
     params = ((10, 10), (4, 12), (50, 12), (6, 55))
     for a, b in params:
@@ -81,7 +82,8 @@ def plot_histograms(ax, prng, nb_samples=10000):
         ax.hist(values, histtype="stepfilled", bins=30, alpha=0.8, normed=True)
     # Add a small annotation.
     ax.annotate('Annotation', xy=(0.25, 4.25), xycoords='data',
-                xytext=(0.4, 10), textcoords='data',
+                xytext=(0.9, 0.9), textcoords='axes fraction',
+                va="top", ha="right",
                 bbox=dict(boxstyle="round", alpha=0.2),
                 arrowprops=dict(
                           arrowstyle="->",
@@ -92,7 +94,7 @@ def plot_histograms(ax, prng, nb_samples=10000):
 
 def plot_figure(style_label=None):
     """
-    Setup and plot the demonstration figure with the style `style_label`.
+    Sets up and plots the demonstration figure with the style `style_label`.
     If `style_label` is None, fall back to the `default` style.
     """
     if style_label is None:
@@ -111,6 +113,8 @@ def plot_figure(style_label=None):
     plot_colored_circles(axes[1, 0], prng)
     plot_colored_sinusoidal_lines(axes[1, 1])
     plot_histograms(axes[1, 2], prng)
+
+    fig.tight_layout()
 
     return fig
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -7,6 +7,7 @@ gallery.
 import numpy as np
 import matplotlib.pyplot as plt
 
+
 def plot_scatter(ax, prng, nb_samples=200):
     """ Scatter plot.
 
@@ -14,7 +15,10 @@ def plot_scatter(ax, prng, nb_samples=200):
     """
     x, y = prng.normal(size=(2, nb_samples))
     ax.plot(x, y, 'o')
+    ax.set_xlabel('X-label')
+    ax.set_ylabel('Y-label')
     return ax
+
 
 def plot_colored_sinusoidal_lines(ax):
     """ Plot sinusoidal lines with colors from default color cycle.
@@ -28,6 +32,7 @@ def plot_colored_sinusoidal_lines(ax):
     ax.margins(0)
     return ax
 
+
 def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
     """ Plot two bar graphs side by side, with letters as xticklabels.
     """
@@ -39,6 +44,7 @@ def plot_bar_graphs(ax, prng, min_value=5, max_value=25, nb_samples=5):
     ax.set_xticks(x + width)
     ax.set_xticklabels(['a', 'b', 'c', 'd', 'e'])
     return ax
+
 
 def plot_colored_circles(ax, prng, nb_samples=15):
     """ Plot circle patches.
@@ -58,6 +64,7 @@ def plot_colored_circles(ax, prng, nb_samples=15):
     ax.set_aspect('equal', adjustable='box')  # to plot circles as circles
     return ax
 
+
 def plot_image_and_patch(ax, prng, size=(20, 20)):
     """ Plot an image with random values and superimpose a circular patch.
     """
@@ -65,6 +72,7 @@ def plot_image_and_patch(ax, prng, size=(20, 20)):
     ax.imshow(values, interpolation='none')
     c = plt.Circle((5, 5), radius=5, label='patch')
     ax.add_patch(c)
+
 
 def plot_histograms(ax, prng, nb_samples=10000):
     """ Plot 4 histograms and a text annotation.
@@ -82,12 +90,13 @@ def plot_histograms(ax, prng, nb_samples=10000):
                 )
     return ax
 
+
 def plot_figure(style_label=None):
-    """ 
+    """
     Setup and plot the demonstration figure with the style `style_label`.
     If `style_label`, fall back to the `default` style.
     """
-    if style_label == None:
+    if style_label is None:
         style_label = 'default'
 
     # Use a dedicated RandomState instance to draw the same "random" values across
@@ -116,4 +125,3 @@ if __name__ == "__main__":
             fig = plot_figure(style_label=style_label)
 
     plt.show()
-


### PR DESCRIPTION
This new example aims at producing a reference to compare the different styles, like for example `colormaps_reference.py` does for the colormaps. A separate figure is plotted for each available style sheet, so this may result in a big number of figures.

The different subplots give an idea of the chosen style in various situations. There are taken from other examples in the `style_sheets` section, some of them slightly adapted. The sample data are "randomly" produced with a constant seed passed to the pseudo-random number generator instance.