### PR TITLE
Skip test broken with numpy 1.11

### DIFF
--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.noseclasses import KnownFailureTest
 import matplotlib.pyplot as plt
 import matplotlib.path as mpath
 import matplotlib.patches as mpatches
@@ -90,6 +91,8 @@ def test_bbox_inches_tight_clipping():
                   remove_text=True, savefig_kwarg={'bbox_inches': 'tight'})
 def test_bbox_inches_tight_raster():
     """Test rasterization with tight_layout"""
+    if tuple(map(int, np.__version__.split('.'))) >= (1, 11, 0):
+        raise KnownFailureTest("Fall out from a fixed numpy bug")
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.plot([1.0, 2.0], rasterized=True)


### PR DESCRIPTION
This test is broken with numpy 1.11 on the 1.5.x branch but fixed on the 2.x and master brach. We don't catch this on Travis because the python 'nightly' build is the only one to run Numpy 1.11. The others install from the wheelhouse which only has numpy 1.10 see #6472 for a fix to this. 

This is a bit tricky as it should be reverted once merged to 2.x to prevent the tests being knownfail there. 