### PR TITLE
Line2D._path obeys drawstyle.

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2403,12 +2403,14 @@ def pts_to_midstep(x, *args):
     # convert 2D array back to tuple
     return tuple(steps)
 
-STEP_LOOKUP_MAP = {'pre': pts_to_prestep,
+STEP_LOOKUP_MAP = {'default': lambda x, y: (x, y),
+                   'pre': pts_to_prestep,
                    'post': pts_to_poststep,
                    'mid': pts_to_midstep,
-                   'step-pre': pts_to_prestep,
-                   'step-post': pts_to_poststep,
-                   'step-mid': pts_to_midstep}
+                   'steps': pts_to_prestep,
+                   'steps-pre': pts_to_prestep,
+                   'steps-post': pts_to_poststep,
+                   'steps-mid': pts_to_midstep}
 
 
 def index_of(y):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -17,7 +17,7 @@ from matplotlib import verbose
 from . import artist, colors as mcolors
 from .artist import Artist
 from .cbook import (iterable, is_string_like, is_numlike, ls_mapper_r,
-                    pts_to_prestep, pts_to_poststep, pts_to_midstep)
+                    STEP_LOOKUP_MAP)
 
 from .path import Path
 from .transforms import Bbox, TransformedPath, IdentityTransform
@@ -244,14 +244,6 @@ class Line2D(Artist):
     # Need a list ordered with long names first:
     drawStyleKeys = (list(six.iterkeys(_drawStyles_l)) +
                      list(six.iterkeys(_drawStyles_s)))
-
-    _drawstyle_conv = {
-        'default': lambda x, y: (x, y),
-        'steps': pts_to_prestep,
-        'steps-pre': pts_to_prestep,
-        'steps-mid': pts_to_midstep,
-        'steps-post': pts_to_poststep
-    }
 
     # Referenced here to maintain API.  These are defined in
     # MarkerStyle
@@ -688,7 +680,7 @@ class Line2D(Artist):
             interpolation_steps = self._path._interpolation_steps
         else:
             interpolation_steps = 1
-        xy = self._drawstyle_conv[self._drawstyle](*self._xy.T)
+        xy = STEP_LOOKUP_MAP[self._drawstyle](*self._xy.T)
         self._path = Path(np.asarray(xy).T, None, interpolation_steps)
         self._transformed_path = None
         self._invalidx = False

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -237,12 +237,21 @@ class Line2D(Artist):
         'steps': '_draw_steps_pre',
     }
 
+    # drawStyles should now be deprecated.
     drawStyles = {}
     drawStyles.update(_drawStyles_l)
     drawStyles.update(_drawStyles_s)
     # Need a list ordered with long names first:
     drawStyleKeys = (list(six.iterkeys(_drawStyles_l)) +
                      list(six.iterkeys(_drawStyles_s)))
+
+    _drawstyle_conv = {
+        'default': lambda x, y: (x, y),
+        'steps': pts_to_prestep,
+        'steps-pre': pts_to_prestep,
+        'steps-mid': pts_to_midstep,
+        'steps-post': pts_to_poststep
+    }
 
     # Referenced here to maintain API.  These are defined in
     # MarkerStyle
@@ -470,8 +479,7 @@ class Line2D(Artist):
         # application has set the error flags such that an exception is raised
         # on overflow, we temporarily set the appropriate error flags here and
         # set them back when we are finished.
-        olderrflags = np.seterr(all='ignore')
-        try:
+        with np.errstate(all='ignore'):
             # Check for collision
             if self._linestyle in ['None', None]:
                 # If no line, return the nearby point(s)
@@ -480,19 +488,8 @@ class Line2D(Artist):
             else:
                 # If line, return the nearby segment(s)
                 ind = segment_hits(mouseevent.x, mouseevent.y, xt, yt, pixels)
-        finally:
-            np.seterr(**olderrflags)
 
         ind += self.ind_offset
-
-        # Debugging message
-        if False and self._label != '':
-            print("Checking line", self._label,
-                  "at", mouseevent.x, mouseevent.y)
-            print('xt', xt)
-            print('yt', yt)
-            #print 'dx,dy', (xt-mouseevent.x)**2., (yt-mouseevent.y)**2.
-            print('ind', ind)
 
         # Return the point(s) within radius
         return len(ind) > 0, dict(ind=ind)
@@ -691,7 +688,8 @@ class Line2D(Artist):
             interpolation_steps = self._path._interpolation_steps
         else:
             interpolation_steps = 1
-        self._path = Path(self._xy, None, interpolation_steps)
+        xy = self._drawstyle_conv[self._drawstyle](*self._xy.T)
+        self._path = Path(np.asarray(xy).T, None, interpolation_steps)
         self._transformed_path = None
         self._invalidx = False
         self._invalidy = False
@@ -764,8 +762,6 @@ class Line2D(Artist):
             tpath, affine = transf_path.get_transformed_path_and_affine()
             if len(tpath.vertices):
                 self._lineFunc = getattr(self, funcname)
-                funcname = self.drawStyles.get(self._drawstyle, '_draw_lines')
-                drawFunc = getattr(self, funcname)
                 gc = renderer.new_gc()
                 self._set_gc_clip(gc)
 
@@ -788,7 +784,7 @@ class Line2D(Artist):
                 if self.get_sketch_params() is not None:
                     gc.set_sketch_params(*self.get_sketch_params())
 
-                drawFunc(renderer, gc, tpath, affine.frozen())
+                self._draw_lines(renderer, gc, tpath, affine.frozen())
                 gc.restore()
 
         if self._marker and self._markersize > 0:
@@ -1233,27 +1229,6 @@ class Line2D(Artist):
 
     def _draw_lines(self, renderer, gc, path, trans):
         self._lineFunc(renderer, gc, path, trans)
-
-    def _draw_steps_pre(self, renderer, gc, path, trans):
-        steps = np.vstack(pts_to_prestep(*self._xy.T)).T
-
-        path = Path(steps)
-        path = path.transformed(self.get_transform())
-        self._lineFunc(renderer, gc, path, IdentityTransform())
-
-    def _draw_steps_post(self, renderer, gc, path, trans):
-        steps = np.vstack(pts_to_poststep(*self._xy.T)).T
-
-        path = Path(steps)
-        path = path.transformed(self.get_transform())
-        self._lineFunc(renderer, gc, path, IdentityTransform())
-
-    def _draw_steps_mid(self, renderer, gc, path, trans):
-        steps = np.vstack(pts_to_midstep(*self._xy.T)).T
-
-        path = Path(steps)
-        path = path.transformed(self.get_transform())
-        self._lineFunc(renderer, gc, path, IdentityTransform())
 
     def _draw_solid(self, renderer, gc, path, trans):
         gc.set_linestyle('solid')


### PR DESCRIPTION
For stepping drawstyles, `Line2D.draw` used to recompute a path at drawing time, because its `_path` attribute always assumed a linear drawstyle.  Instead, directly compute the correct path.

Also fixes #6447 (`Line2D.contains` did not take drawstyle into account) because that code relied on proximity of the mouse event with the underlying path.

Note that unfortunately, the drawstyle names remain inconsistent with those accepted by `fill_between` and `fill_betweenx`, which (seem to be the only functions to) rely on `cbook.STEP_LOOKUP_MAP`.  It may be a good opportunity to fix the discrepancy too...