### PR TITLE
Mnt cn passthrough

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -167,10 +167,6 @@ class _process_plot_var_args(object):
         else:
             prop_cycler = cycler(*args, **kwargs)
 
-        # Make sure the cycler always has at least one color
-        if 'color' not in prop_cycler.keys:
-            prop_cycler = prop_cycler * cycler('color', ['k'])
-
         self.prop_cycler = itertools.cycle(prop_cycler)
         # This should make a copy
         self._prop_keys = prop_cycler.keys
@@ -200,6 +196,8 @@ class _process_plot_var_args(object):
         """
         Return the next color in the cycle.
         """
+        if 'color' not in self._prop_keys:
+            return 'k'
         return six.next(self.prop_cycler)['color']
 
     def set_lineprops(self, line, **kwargs):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -164,9 +164,6 @@ class _process_plot_var_args(object):
     def set_prop_cycle(self, *args, **kwargs):
         if not (args or kwargs) or (len(args) == 1 and args[0] is None):
             prop_cycler = rcParams['axes.prop_cycle']
-            if prop_cycler is None and 'axes.color_cycle' in rcParams:
-                clist = rcParams['axes.color_cycle']
-                prop_cycler = cycler('color', clist)
         else:
             prop_cycler = cycler(*args, **kwargs)
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -127,7 +127,7 @@ def to_rgba(c, alpha=None):
     if _is_nth_color(c):
         from matplotlib import rcParams
         prop_cycler = rcParams['axes.prop_cycle']
-        colors = prop_cycler._transpose().get('color', 'k')
+        colors = prop_cycler.by_key().get('color', ['k'])
         c = colors[int(c[1]) % len(colors)]
     try:
         rgba = _colors_full_map.cache[c, alpha]

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -126,11 +126,7 @@ def to_rgba(c, alpha=None):
     # Special-case nth color syntax because it should not be cached.
     if _is_nth_color(c):
         from matplotlib import rcParams
-        from matplotlib.rcsetup import cycler
         prop_cycler = rcParams['axes.prop_cycle']
-        if prop_cycler is None and 'axes.color_cycle' in rcParams:
-            clist = rcParams['axes.color_cycle']
-            prop_cycler = cycler('color', clist)
         colors = prop_cycler._transpose().get('color', 'k')
         c = colors[int(c[1]) % len(colors)]
     try:

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -69,13 +69,13 @@ def test_linestylecycle_basic():
     ax.set_prop_cycle(cycler('ls', ['-', '--', ':']))
     xs = np.arange(10)
     ys = 0.25 * xs + 2
-    ax.plot(xs, ys, label='solid', lw=4)
+    ax.plot(xs, ys, label='solid', lw=4, color='k')
     ys = 0.45 * xs + 3
-    ax.plot(xs, ys, label='dashed', lw=4)
+    ax.plot(xs, ys, label='dashed', lw=4, color='k')
     ys = 0.65 * xs + 4
-    ax.plot(xs, ys, label='dotted', lw=4)
+    ax.plot(xs, ys, label='dotted', lw=4, color='k')
     ys = 0.85 * xs + 5
-    ax.plot(xs, ys, label='solid2', lw=4)
+    ax.plot(xs, ys, label='solid2', lw=4, color='k')
     ax.legend(loc='upper left')
 
 
@@ -130,8 +130,8 @@ def test_property_collision_plot():
     ax.set_prop_cycle('linewidth', [2, 4])
     for c in range(1, 4):
         ax.plot(np.arange(10), c * np.arange(10), lw=0.1, color='k')
-    ax.plot(np.arange(10), 4 * np.arange(10))
-    ax.plot(np.arange(10), 5 * np.arange(10))
+    ax.plot(np.arange(10), 4 * np.arange(10), color='k')
+    ax.plot(np.arange(10), 5 * np.arange(10), color='k')
 
 
 @image_comparison(baseline_images=['property_collision_fill'],


### PR DESCRIPTION
This is an attempt to close #6380

The first 4 commits on this are relatively un-controversial.  They

 - remove unreachable code
 - switch to using the public cycler API
 - remove the implicit cycler added in `_base.py` however this changes the 'default' line color back to 'C0' which resolves to 'b' in the global prop_cycler so change the tests to specify 'k' as the color to keep the test passing.

The 5th commit makes `to_rgba` take in a cycler to use for local CN look up.  In the cases where we are going through `_process_plot_format` in `_get_lines` we can easily get the `Axes` property cycler in, however in many other cases where we want to use `CN` (such as in `Line2D` which gets it's default color from rcparam, which may be `'CN'` and actually calls `to_rgba` at some later point) may not even be associated with an `Axes` object so when `CN` gets resolved so it has to use the global property cycler.  With the 5th commit we have the situation where if the user lets the color be `'C0'` via the call or via the rcparams, there will be different results.

Having typed this out I am inclined to rip that commit off, but leaving for comment.

I would be comfertable doing the beta having with the first 4 commits merged, but not the 5th.