### PR TITLE
Fix FigureCanvasAgg.print_raw(...)

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -509,7 +509,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             fileobj.write(renderer._renderer.buffer_rgba())
         finally:
             if close:
-                filename_or_obj.close()
+                fileobj.close()
             renderer.dpi = original_dpi
     print_rgba = print_raw
 


### PR DESCRIPTION
The `finally` block in `FigureCanvasAgg.print_raw()` attempts to close a string instead of a file. This appears to cause any attempts to write .rgb or .rgba files to fail.