### PR TITLE
Issue #6429 fix

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1971,6 +1971,9 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
     CFMachPortRef port;
     CFRunLoopSourceRef source;
     NSDictionary* dictionary = [notification userInfo];
+    if (! [[dictionary valueForKey:@"NSApplicationName"]
+           isEqualToString:@"Python"])
+        return;
     NSNumber* psnLow = [dictionary valueForKey: @"NSApplicationProcessSerialNumberLow"];
     NSNumber* psnHigh = [dictionary valueForKey: @"NSApplicationProcessSerialNumberHigh"];
     ProcessSerialNumber psn;


### PR DESCRIPTION
Simple fix for issue #6429 to prevent macosx backend from trying to add a quartz tap on anything but the main Python app. A better approach might be to add the tap without having to wait on the launch notification avoiding having to parse through any child subprocesses