### PR TITLE
ttconv: Also replace carriage return with spaces.

### DIFF
--- a/extern/ttconv/ttutil.cpp
+++ b/extern/ttconv/ttutil.cpp
@@ -76,7 +76,7 @@ void TTStreamWriter::putline(const char *a)
 void replace_newlines_with_spaces(char *a) {
   char* i = a;
   while (*i != 0) {
-    if (*i == '\n')
+    if (*i == '\r' || *i == '\n')
       *i = ' ';
     i++;
   }


### PR DESCRIPTION
Multi-line strings will cause issues in comments since the secondary lines will not be comments. This replacement is already done for newline characters (\n), but not carriage return (\r) which is prevalent on Windows.

I went with the simpler route of just replacing with a space instead of trying to compress `\r\n` because that would require shifting the entire string and would be a more involved change.

I assume that changing `ttconv` is alright even though it's external since I can't find an upstream and there are already comments to the effect that it has already been modified.

Fixes #5862.