### PR TITLE
TST Remove plt.show() from test_axes.test_dash_offset

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4249,7 +4249,6 @@ def test_dash_offset():
     y = np.ones_like(x)
     for j in range(0, 100, 2):
         ax.plot(x, j*y, ls=(j, (10, 10)), lw=5, color='k')
-    plt.show()
 
 
 @cleanup


### PR DESCRIPTION
Remove the call to `plt.show()` in `test_axes.test_dash_offset` (as suggested in PR #5433). Previously, when running `test_axes` in an IPython session, a figure window was opened, waiting for the user to close it before running the remaining tests...