### PR TITLE
Fix typo in margins handling.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2250,7 +2250,7 @@ class _AxesBase(martist.Artist):
                     x0, x1 = mtransforms.nonsingular(
                         x0, x1, increasing=False, expander=0.05)
 
-                if (margin > 0 and do_lower_margin or do_upper_margin):
+                if margin > 0 and (do_lower_margin or do_upper_margin):
                     if axis.get_scale() == 'linear':
                         delta = (x1 - x0) * margin
                         if do_lower_margin:


### PR DESCRIPTION
This does not change the semantics of the code but should make things
clearer and offer a negligible optimization: previously, the margins
correction would be computed even if `margin == 0` as long as
`do_upper_margin` was set.