### PR TITLE
FIX: only apply alpha once for images

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -458,7 +458,6 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
         gc = renderer.new_gc()
         self._set_gc_clip(gc)
-        gc.set_alpha(self.get_alpha())
         gc.set_url(self.get_url())
         gc.set_gid(self.get_gid())
 


### PR DESCRIPTION
The alpha of the image pixels is folded in as part of the image
rendering process, it does not need to be done a second time in the gc.

Fixes #6540 

attn @mdboom 