### PR TITLE
Drop prettyplotlib from the list of toolkits.

### DIFF
--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -102,16 +102,6 @@ tools. An example plot from the
 Miscellaneous Toolkits
 **********************
 
-
-.. _toolkit_prettyplotlib:
-
-prettyplotlib
-=============
-
-`prettyplotlib <https://olgabot.github.io/prettyplotlib>`_ is an extension
-to matplotlib which changes many of the defaults to make plots some
-consider more attractive.
-
 .. _toolkit_probscale:
 
 mpl-probscale


### PR DESCRIPTION
prettyplotlib has been deprecated by its author in favor of seaborn.