### PR TITLE
[MRG+1] Fillbetween

### DIFF
--- a/doc/users/whats_new/updated_fill_betweenx.rst
+++ b/doc/users/whats_new/updated_fill_betweenx.rst
@@ -1,0 +1,6 @@
+Interpolation in fill_betweenx
+------------------------------
+
+The ``interpolate`` parameter now exists for the method :func:`fill_betweenx`.
+This allows a user to interpolate the data and fill the areas in the crossover
+points, similarly to :func:`fill_between`.


### PR DESCRIPTION
As discussed in issue #6543. Added the interpolate argument just before the `**kwargs`.

I think I made a mistake, I wanted to target the 1.5.x. I'll be waiting for some input. :)

Should I edit the changelog as well?
