### PR TITLE
Cleanup for drawstyles.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4732,7 +4732,7 @@ class Axes(_AxesBase):
             y1slice = y1[ind0:ind1]
             y2slice = y2[ind0:ind1]
             if step is not None:
-                step_func = STEP_LOOKUP_MAP[step]
+                step_func = STEP_LOOKUP_MAP["steps-" + step]
                 xslice, y1slice, y2slice = step_func(xslice, y1slice, y2slice)
 
             if not len(xslice):
@@ -4882,7 +4882,7 @@ class Axes(_AxesBase):
             x1slice = x1[ind0:ind1]
             x2slice = x2[ind0:ind1]
             if step is not None:
-                step_func = STEP_LOOKUP_MAP[step]
+                step_func = STEP_LOOKUP_MAP["steps-" + step]
                 yslice, x1slice, x2slice = step_func(yslice, x1slice, x2slice)
 
             if not len(yslice):

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -33,9 +33,11 @@ LINESTYLES = {'-': 'Solid',
               'none': 'None',
               }
 
-DRAWSTYLES = {'default': 'Default',
-              'steps': 'Steps',
-              }
+DRAWSTYLES = {
+    'default': 'Default',
+    'steps-pre': 'Steps (Pre)', 'steps': 'Steps (Pre)',
+    'steps-mid': 'Steps (Mid)',
+    'steps-post': 'Steps (Post)'}
 
 MARKERS = markers.MarkerStyle.markers
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2395,10 +2395,8 @@ def pts_to_midstep(x, *args):
     # convert 2D array back to tuple
     return tuple(steps)
 
+
 STEP_LOOKUP_MAP = {'default': lambda x, y: (x, y),
-                   'pre': pts_to_prestep,
-                   'post': pts_to_poststep,
-                   'mid': pts_to_midstep,
                    'steps': pts_to_prestep,
                    'steps-pre': pts_to_prestep,
                    'steps-post': pts_to_poststep,

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -987,8 +987,7 @@ class Line2D(Artist):
         if drawstyle is None:
             drawstyle = 'default'
         if drawstyle not in self.drawStyles:
-            raise ValueError('Unrecognized drawstyle ' +
-                             ' '.join(self.drawStyleKeys))
+            raise ValueError('Unrecognized drawstyle {!r}'.format(drawstyle))
         if self._drawstyle != drawstyle:
             self.stale = True
         self._drawstyle = drawstyle


### PR DESCRIPTION
1. Remove unused entries from `STEP_LOOKUP_MAP` (`plt.step` already
normalizes drawstyles to `step-*` format).

2. Clarify the error for invalid drawstyles.

3. Fix handling of `step-*` drawstyles by the Qt options editor.