### PR TITLE
Some general cleanups

### DIFF
--- a/examples/misc/rec_join_demo.py
+++ b/examples/misc/rec_join_demo.py
@@ -11,8 +11,7 @@ r.sort()
 r1 = r[-10:]
 
 # Create a new array
-r2 = np.empty(12, dtype=[('date', '|O4'), ('high', np.float),
-                         ('marker', np.float)])
+r2 = np.empty(12, dtype=[('date', '|O4'), ('high', float), ('marker', float)])
 r2 = r2.view(np.recarray)
 r2.date = r.date[-17:-5]
 r2.high = r.high[-17:-5]

--- a/examples/pylab_examples/demo_ribbon_box.py
+++ b/examples/pylab_examples/demo_ribbon_box.py
@@ -121,7 +121,7 @@ if 1:
                                interpolation="bicubic",
                                zorder=0.1,
                                )
-    gradient = np.zeros((2, 2, 4), dtype=np.float)
+    gradient = np.zeros((2, 2, 4), dtype=float)
     gradient[:, :, :3] = [1, 1, 0.]
     gradient[:, :, 3] = [[0.1, 0.3], [0.3, 0.5]]  # alpha channel
     patch_gradient.set_array(gradient)

--- a/examples/pylab_examples/dolphin.py
+++ b/examples/pylab_examples/dolphin.py
@@ -74,7 +74,7 @@ while i < len(parts):
     vertices.extend([[float(x) for x in y.split(',')] for y in
                      parts[i + 1:i + npoints + 1]])
     i += npoints + 1
-vertices = np.array(vertices, np.float)
+vertices = np.array(vertices, float)
 vertices[:, 1] -= 160
 
 dolphin_path = Path(vertices, codes)

--- a/examples/units/units_scatter.py
+++ b/examples/units/units_scatter.py
@@ -15,7 +15,7 @@ from matplotlib.pylab import figure, show
 # create masked array
 
 
-xsecs = secs*np.ma.MaskedArray((1, 2, 3, 4, 5, 6, 7, 8), (1, 0, 1, 0, 0, 0, 1, 0), np.float)
+xsecs = secs*np.ma.MaskedArray((1, 2, 3, 4, 5, 6, 7, 8), (1, 0, 1, 0, 0, 0, 1, 0), float)
 #xsecs = secs*np.arange(1,10.)
 
 fig = figure()

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -126,7 +126,6 @@ from matplotlib.rcsetup import (defaultParams,
                                 cycler)
 
 import numpy
-import numpy.ma
 from matplotlib.externals.six.moves.urllib.request import urlopen
 from matplotlib.externals.six.moves import reload_module as reload
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -126,6 +126,7 @@ from matplotlib.rcsetup import (defaultParams,
                                 cycler)
 
 import numpy
+import numpy.ma
 from matplotlib.externals.six.moves.urllib.request import urlopen
 from matplotlib.externals.six.moves import reload_module as reload
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5387,7 +5387,7 @@ class Axes(_AxesBase):
 
         if t and any(t.contains_branch_seperately(self.transData)):
             trans_to_data = t - self.transData
-            pts = np.vstack([x, y]).T.astype(np.float)
+            pts = np.vstack([x, y]).T.astype(float)
             transformed_pts = trans_to_data.transform(pts)
             x = transformed_pts[..., 0]
             y = transformed_pts[..., 1]
@@ -5537,7 +5537,7 @@ class Axes(_AxesBase):
 
         if t and any(t.contains_branch_seperately(self.transData)):
             trans_to_data = t - self.transData
-            pts = np.vstack([X, Y]).T.astype(np.float)
+            pts = np.vstack([X, Y]).T.astype(float)
             transformed_pts = trans_to_data.transform(pts)
             X = transformed_pts[..., 0]
             Y = transformed_pts[..., 1]

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2357,7 +2357,7 @@ class Axes(_AxesBase):
 
         # Try a second one
         try:
-            second = np.asarray(args[0], dtype=np.float)
+            second = np.asarray(args[0], dtype=float)
             x, y = y, second
             args = args[1:]
         except (IndexError, ValueError):
@@ -4739,7 +4739,7 @@ class Axes(_AxesBase):
                 continue
 
             N = len(xslice)
-            X = np.zeros((2 * N + 2, 2), np.float)
+            X = np.zeros((2 * N + 2, 2), float)
 
             if interpolate:
                 def get_interp_point(ind):
@@ -4889,7 +4889,7 @@ class Axes(_AxesBase):
                 continue
 
             N = len(yslice)
-            Y = np.zeros((2 * N + 2, 2), np.float)
+            Y = np.zeros((2 * N + 2, 2), float)
 
             # the purpose of the next two lines is for when x2 is a
             # scalar like 0 and we want the fill to go all the way
@@ -6203,7 +6203,7 @@ class Axes(_AxesBase):
 
             for m, c in zip(n, color):
                 if bottom is None:
-                    bottom = np.zeros(len(m), np.float)
+                    bottom = np.zeros(len(m), float)
                 if stacked:
                     height = m - bottom
                 else:
@@ -6222,14 +6222,14 @@ class Axes(_AxesBase):
 
         elif histtype.startswith('step'):
             # these define the perimeter of the polygon
-            x = np.zeros(4 * len(bins) - 3, np.float)
-            y = np.zeros(4 * len(bins) - 3, np.float)
+            x = np.zeros(4 * len(bins) - 3, float)
+            y = np.zeros(4 * len(bins) - 3, float)
 
             x[0:2*len(bins)-1:2], x[1:2*len(bins)-1:2] = bins, bins[:-1]
             x[2*len(bins)-1:] = x[1:2*len(bins)-1][::-1]
 
             if bottom is None:
-                bottom = np.zeros(len(bins)-1, np.float)
+                bottom = np.zeros(len(bins)-1, float)
 
             y[1:2*len(bins)-1:2], y[2:2*len(bins):2] = bottom, bottom
             y[2*len(bins)-1:] = y[1:2*len(bins)-1][::-1]

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -12,7 +12,6 @@ import math
 from operator import itemgetter
 
 import numpy as np
-from numpy import ma
 
 import matplotlib
 
@@ -1917,7 +1916,7 @@ class _AxesBase(martist.Artist):
 
         if iterable(xys) and not len(xys):
             return
-        if not ma.isMaskedArray(xys):
+        if not isinstance(xys, np.ma.MaskedArray):
             xys = np.asarray(xys)
         self.dataLim.update_from_data_xy(xys, self.ignore_existing_data_limits,
                                          updatex=updatex, updatey=updatey)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -34,16 +34,17 @@ graphics contexts must implement to serve as a matplotlib backend
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from contextlib import contextmanager
 
 from matplotlib.externals import six
 from matplotlib.externals.six.moves import xrange
 
+from contextlib import contextmanager
+import importlib
+import io
 import os
 import sys
-import warnings
 import time
-import io
+import warnings
 
 import numpy as np
 import matplotlib.cbook as cbook
@@ -64,14 +65,6 @@ import matplotlib.textpath as textpath
 from matplotlib.path import Path
 from matplotlib.cbook import mplDeprecation, warn_deprecated
 import matplotlib.backend_tools as tools
-
-try:
-    from importlib import import_module
-except:
-    # simple python 2.6 implementation (no relative imports)
-    def import_module(name):
-        __import__(name)
-        return sys.modules[name]
 
 try:
     from PIL import Image
@@ -135,7 +128,7 @@ def get_registered_canvas_class(format):
         return None
     backend_class = _default_backends[format]
     if cbook.is_string_like(backend_class):
-        backend_class = import_module(backend_class).FigureCanvas
+        backend_class = importlib.import_module(backend_class).FigureCanvas
         _default_backends[format] = backend_class
     return backend_class
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -327,7 +327,7 @@ class RendererBase(object):
 
         if edgecolors is None:
             edgecolors = facecolors
-        linewidths = np.array([gc.get_linewidth()], np.float_)
+        linewidths = np.array([gc.get_linewidth()], float)
 
         return self.draw_path_collection(
             gc, master_transform, paths, [], offsets, offsetTrans, facecolors,

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -12,10 +12,7 @@ import glob, math, os, shutil, sys, time
 def _fn_name(): return sys._getframe(1).f_code.co_name
 import io
 
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5 #Deprecated in 2.5
+from hashlib import md5
 
 from tempfile import mkstemp
 from matplotlib import verbose, __version__, rcParams, checkdep_ghostscript
@@ -44,10 +41,6 @@ from matplotlib.backends.backend_mixed import MixedModeRenderer
 import numpy as np
 import binascii
 import re
-try:
-    set
-except NameError:
-    from sets import Set as set
 
 if sys.platform.startswith('win'): cmd_split = '&'
 else: cmd_split = ';'

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -31,7 +31,6 @@ import warnings
 from weakref import ref, WeakKeyDictionary
 
 import numpy as np
-import numpy.ma as ma
 
 
 class MatplotlibDeprecationWarning(UserWarning):
@@ -677,7 +676,7 @@ def is_string_like(obj):
     if isinstance(obj, six.string_types):
         return True
     # numpy strings are subclass of str, ma strings are not
-    if ma.isMaskedArray(obj):
+    if isinstance(obj, np.ma.MaskedArray):
         if obj.ndim == 0 and obj.dtype.kind in 'SU':
             return True
         else:
@@ -1728,7 +1727,7 @@ def delete_masked_points(*args):
     for i, x in enumerate(args):
         if (not is_string_like(x)) and iterable(x) and len(x) == nrecs:
             seqlist[i] = True
-            if ma.isMA(x):
+            if isinstance(x, np.ma.MaskedArray):
                 if x.ndim > 1:
                     raise ValueError("Masked arrays must be 1-D")
             else:
@@ -1739,8 +1738,8 @@ def delete_masked_points(*args):
         if seqlist[i]:
             if x.ndim > 1:
                 continue  # Don't try to get nan locations unless 1-D.
-            if ma.isMA(x):
-                masks.append(~ma.getmaskarray(x))  # invert the mask
+            if isinstance(x, np.ma.MaskedArray):
+                masks.append(~np.ma.getmaskarray(x))  # invert the mask
                 xd = x.data
             else:
                 xd = x
@@ -1758,7 +1757,7 @@ def delete_masked_points(*args):
                 if seqlist[i]:
                     margs[i] = x.take(igood, axis=0)
     for i, x in enumerate(margs):
-        if seqlist[i] and ma.isMA(x):
+        if seqlist[i] and isinstance(x, np.ma.MaskedArray):
             margs[i] = x.filled()
     return margs
 
@@ -2344,7 +2343,7 @@ def pts_to_poststep(x, *args):
     # do normalization
     vertices = _step_validation(x, *args)
     # create the output array
-    steps = ma.zeros((vertices.shape[0], 2 * len(x) - 1), np.float)
+    steps = np.zeros((vertices.shape[0], 2 * len(x) - 1), np.float)
     # do the to step conversion logic
     steps[0, ::2], steps[0, 1:-1:2] = vertices[0, :], vertices[0, 1:]
     steps[1:, 0::2], steps[1:, 1::2] = vertices[1:, :], vertices[1:, :-1]
@@ -2385,7 +2384,7 @@ def pts_to_midstep(x, *args):
     # do normalization
     vertices = _step_validation(x, *args)
     # create the output array
-    steps = ma.zeros((vertices.shape[0], 2 * len(x)), np.float)
+    steps = np.zeros((vertices.shape[0], 2 * len(x)), np.float)
     steps[0, 1:-1:2] = 0.5 * (vertices[0, :-1] + vertices[0, 1:])
     steps[0, 2::2] = 0.5 * (vertices[0, :-1] + vertices[0, 1:])
     steps[0, 0] = vertices[0, 0]

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2303,7 +2303,7 @@ def pts_to_prestep(x, *args):
     # do normalization
     vertices = _step_validation(x, *args)
     # create the output array
-    steps = np.zeros((vertices.shape[0], 2 * len(x) - 1), np.float)
+    steps = np.zeros((vertices.shape[0], 2 * len(x) - 1), float)
     # do the to step conversion logic
     steps[0, 0::2], steps[0, 1::2] = vertices[0, :], vertices[0, :-1]
     steps[1:, 0::2], steps[1:, 1:-1:2] = vertices[1:, :], vertices[1:, 1:]
@@ -2343,7 +2343,7 @@ def pts_to_poststep(x, *args):
     # do normalization
     vertices = _step_validation(x, *args)
     # create the output array
-    steps = np.zeros((vertices.shape[0], 2 * len(x) - 1), np.float)
+    steps = np.zeros((vertices.shape[0], 2 * len(x) - 1), float)
     # do the to step conversion logic
     steps[0, ::2], steps[0, 1:-1:2] = vertices[0, :], vertices[0, 1:]
     steps[1:, 0::2], steps[1:, 1::2] = vertices[1:, :], vertices[1:, :-1]
@@ -2384,7 +2384,7 @@ def pts_to_midstep(x, *args):
     # do normalization
     vertices = _step_validation(x, *args)
     # create the output array
-    steps = np.zeros((vertices.shape[0], 2 * len(x)), np.float)
+    steps = np.zeros((vertices.shape[0], 2 * len(x)), float)
     steps[0, 1:-1:2] = 0.5 * (vertices[0, :-1] + vertices[0, 1:])
     steps[0, 2::2] = 0.5 * (vertices[0, :-1] + vertices[0, 1:])
     steps[0, 0] = vertices[0, 0]

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -76,7 +76,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
     (i.e., a call to set_array has been made), at draw time a call to
     scalar mappable will be made to set the face colors.
     """
-    _offsets = np.array([], np.float_)
+    _offsets = np.array([], float)
     # _offsets must be a Nx2 array!
     _offsets.shape = (0, 2)
     _transOffset = transforms.IdentityTransform()
@@ -129,7 +129,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self.set_zorder(zorder)
 
         self._uniform_offsets = None
-        self._offsets = np.array([[0, 0]], np.float_)
+        self._offsets = np.array([[0, 0]], float)
         if offsets is not None:
             offsets = np.asanyarray(offsets)
             offsets.shape = (-1, 2)             # Make it Nx2
@@ -197,7 +197,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             offsets = transOffset.transform_non_affine(offsets)
             transOffset = transOffset.get_affine()
 
-        offsets = np.asanyarray(offsets, np.float_)
+        offsets = np.asanyarray(offsets, float)
         if isinstance(offsets, np.ma.MaskedArray):
             offsets = offsets.filled(np.nan)
             # get_path_collection_extents handles nan but not masked arrays
@@ -239,7 +239,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 ys = self.convert_yunits(offsets[:, 1])
                 offsets = list(zip(xs, ys))
 
-        offsets = np.asanyarray(offsets, np.float_)
+        offsets = np.asanyarray(offsets, float)
         offsets.shape = (-1, 2)             # Make it Nx2
 
         if not transform.is_affine:
@@ -428,7 +428,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         ACCEPTS: float or sequence of floats
         """
-        offsets = np.asanyarray(offsets, np.float_)
+        offsets = np.asanyarray(offsets, float)
         offsets.shape = (-1, 2)             # Make it Nx2
         #This decision is based on how they are initialized above
         if self._uniform_offsets is None:
@@ -1162,7 +1162,7 @@ class LineCollection(Collection):
 
         for seg in segments:
             if not isinstance(seg, np.ma.MaskedArray):
-                seg = np.asarray(seg, np.float_)
+                seg = np.asarray(seg, float)
             _segments.append(seg)
 
         if self._uniform_offsets is not None:
@@ -1752,7 +1752,7 @@ class QuadMesh(Collection):
         # By converting to floats now, we can avoid that on every draw.
         self._coordinates = self._coordinates.reshape(
             (meshHeight + 1, meshWidth + 1, 2))
-        self._coordinates = np.array(self._coordinates, np.float_)
+        self._coordinates = np.array(self._coordinates, float)
 
     def get_paths(self):
         if self._paths is None:
@@ -1850,7 +1850,7 @@ class QuadMesh(Collection):
                 ys = self.convert_yunits(self._offsets[:, 1])
                 offsets = list(zip(xs, ys))
 
-        offsets = np.asarray(offsets, np.float_)
+        offsets = np.asarray(offsets, float)
         offsets.shape = (-1, 2)                 # Make it Nx2
 
         self.update_scalarmappable()

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -15,7 +15,6 @@ from matplotlib.externals import six
 from matplotlib.externals.six.moves import zip
 import warnings
 import numpy as np
-import numpy.ma as ma
 import matplotlib as mpl
 import matplotlib.cbook as cbook
 import matplotlib.colors as mcolors
@@ -199,7 +198,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             transOffset = transOffset.get_affine()
 
         offsets = np.asanyarray(offsets, np.float_)
-        if np.ma.isMaskedArray(offsets):
+        if isinstance(offsets, np.ma.MaskedArray):
             offsets = offsets.filled(np.nan)
             # get_path_collection_extents handles nan but not masked arrays
         offsets.shape = (-1, 2)                     # Make it Nx2
@@ -252,7 +251,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             # This might have changed an ndarray into a masked array.
             transOffset = transOffset.get_affine()
 
-        if np.ma.isMaskedArray(offsets):
+        if isinstance(offsets, np.ma.MaskedArray):
             offsets = offsets.filled(np.nan)
             # Changing from a masked array to nan-filled ndarray
             # is probably most efficient at this point.
@@ -875,14 +874,14 @@ class PolyCollection(_CollectionWithSizes):
 
     def set_verts(self, verts, closed=True):
         '''This allows one to delay initialization of the vertices.'''
-        if np.ma.isMaskedArray(verts):
-            verts = verts.astype(np.float_).filled(np.nan)
+        if isinstance(verts, np.ma.MaskedArray):
+            verts = verts.astype(float).filled(np.nan)
             # This is much faster than having Path do it one at a time.
         if closed:
             self._paths = []
             for xy in verts:
                 if len(xy):
-                    if np.ma.isMaskedArray(xy):
+                    if isinstance(xy, np.ma.MaskedArray):
                         xy = np.ma.concatenate([xy, xy[0:1]])
                     else:
                         xy = np.asarray(xy)
@@ -1162,7 +1161,7 @@ class LineCollection(Collection):
         _segments = []
 
         for seg in segments:
-            if not np.ma.isMaskedArray(seg):
+            if not isinstance(seg, np.ma.MaskedArray):
                 seg = np.asarray(seg, np.float_)
             _segments.append(seg)
 
@@ -1779,7 +1778,7 @@ class QuadMesh(Collection):
         """
         Path = mpath.Path
 
-        if ma.isMaskedArray(coordinates):
+        if isinstance(coordinates, np.ma.MaskedArray):
             c = coordinates.data
         else:
             c = coordinates
@@ -1800,7 +1799,7 @@ class QuadMesh(Collection):
         with its own color.  This is useful for experiments using
         `draw_qouraud_triangle`.
         """
-        if ma.isMaskedArray(coordinates):
+        if isinstance(coordinates, np.ma.MaskedArray):
             p = coordinates.data
         else:
             p = coordinates

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -891,12 +891,12 @@ class Normalize(object):
                 # (list, tuple, deque, ndarray, Series, ...)
                 result = result.copy()
             elif result.dtype.itemsize > 2:
-                result = result.astype(np.float)
+                result = result.astype(float)
             else:
                 result = result.astype(np.float32)
         else:
             is_scalar = True
-            result = ma.array([value]).astype(np.float)
+            result = ma.array([value]).astype(float)
         return result, is_scalar
 
     def __call__(self, value, clip=None):
@@ -1121,7 +1121,7 @@ class SymLogNorm(Normalize):
         Calculates vmin and vmax in the transformed system.
         """
         vmin, vmax = self.vmin, self.vmax
-        arr = np.array([vmax, vmin]).astype(np.float)
+        arr = np.array([vmax, vmin]).astype(float)
         self._upper, self._lower = self._transform(arr)
 
     def inverse(self, value):

--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -263,7 +263,7 @@ def _parse_yahoo_historical(fh, adjusted=True, asobject=False,
 
     if not asobject:
         # 2-D sequence; formerly list of tuples, now ndarray
-        ret = np.zeros((len(d), 6), dtype=np.float)
+        ret = np.zeros((len(d), 6), dtype=float)
         ret[:, 0] = d['d']
         if ochl:
             ret[:, 1] = d['open']

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -48,10 +48,6 @@ License   : matplotlib license (PSF compatible)
 
 import json
 import os, sys, warnings
-try:
-    set
-except NameError:
-    from sets import Set as set
 from collections import Iterable
 import matplotlib
 from matplotlib import afm

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -516,7 +516,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             self._A = cbook.safe_masked_invalid(A, copy=True)
 
         if (self._A.dtype != np.uint8 and
-                not np.can_cast(self._A.dtype, np.float)):
+                not np.can_cast(self._A.dtype, float)):
             raise TypeError("Image data can not convert to float")
 
         if (self._A.ndim not in (2, 3) or

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -628,31 +628,31 @@ class Line2D(Artist):
         if always or self._invalidx:
             xconv = self.convert_xunits(self._xorig)
             if isinstance(self._xorig, np.ma.MaskedArray):
-                x = np.ma.asarray(xconv, np.float_).filled(np.nan)
+                x = np.ma.asarray(xconv, float).filled(np.nan)
             else:
-                x = np.asarray(xconv, np.float_)
+                x = np.asarray(xconv, float)
             x = x.ravel()
         else:
             x = self._x
         if always or self._invalidy:
             yconv = self.convert_yunits(self._yorig)
             if isinstance(self._yorig, np.ma.MaskedArray):
-                y = np.ma.asarray(yconv, np.float_).filled(np.nan)
+                y = np.ma.asarray(yconv, float).filled(np.nan)
             else:
-                y = np.asarray(yconv, np.float_)
+                y = np.asarray(yconv, float)
             y = y.ravel()
         else:
             y = self._y
 
         if len(x) == 1 and len(y) > 1:
-            x = x * np.ones(y.shape, np.float_)
+            x = x * np.ones(y.shape, float)
         if len(y) == 1 and len(x) > 1:
-            y = y * np.ones(x.shape, np.float_)
+            y = y * np.ones(x.shape, float)
 
         if len(x) != len(y):
             raise RuntimeError('xdata and ydata must be the same length')
 
-        self._xy = np.empty((len(x), 2), dtype=np.float_)
+        self._xy = np.empty((len(x), 2), dtype=float)
         self._xy[:, 0] = x
         self._xy[:, 1] = y
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -12,7 +12,6 @@ from matplotlib.externals import six
 import warnings
 
 import numpy as np
-from numpy import ma
 from matplotlib import verbose
 from . import artist, colors as mcolors
 from .artist import Artist
@@ -628,8 +627,8 @@ class Line2D(Artist):
     def recache(self, always=False):
         if always or self._invalidx:
             xconv = self.convert_xunits(self._xorig)
-            if ma.isMaskedArray(self._xorig):
-                x = ma.asarray(xconv, np.float_).filled(np.nan)
+            if isinstance(self._xorig, np.ma.MaskedArray):
+                x = np.ma.asarray(xconv, np.float_).filled(np.nan)
             else:
                 x = np.asarray(xconv, np.float_)
             x = x.ravel()
@@ -637,8 +636,8 @@ class Line2D(Artist):
             x = self._x
         if always or self._invalidy:
             yconv = self.convert_yunits(self._yorig)
-            if ma.isMaskedArray(self._yorig):
-                y = ma.asarray(yconv, np.float_).filled(np.nan)
+            if isinstance(self._yorig, np.ma.MaskedArray):
+                y = np.ma.asarray(yconv, np.float_).filled(np.nan)
             else:
                 y = np.asarray(yconv, np.float_)
             y = y.ravel()

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -22,10 +22,6 @@ from matplotlib.externals import six
 import os, sys
 from matplotlib.externals.six import unichr
 from math import ceil
-try:
-    set
-except NameError:
-    from sets import Set as set
 import unicodedata
 from warnings import warn
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -175,7 +175,6 @@ import os
 import warnings
 
 import numpy as np
-from matplotlib import verbose
 
 import matplotlib.cbook as cbook
 from matplotlib import docstring
@@ -516,7 +515,7 @@ def detrend_linear(y):
     if not y.ndim:
         return np.array(0., dtype=y.dtype)
 
-    x = np.arange(y.size, dtype=np.float_)
+    x = np.arange(y.size, dtype=float)
 
     C = np.cov(x, y, bias=1)
     b = C[0, 1]/C[0, 0]
@@ -1828,7 +1827,7 @@ def center_matrix(M, dim=0):
     If *dim* = 1 operate on columns instead of rows.  (*dim* is
     opposite to the numpy axis kwarg.)
     """
-    M = np.asarray(M, np.float_)
+    M = np.asarray(M, float)
     if dim:
         M = (M - M.mean(axis=0)) / M.std(axis=0)
     else:
@@ -1886,9 +1885,9 @@ def rk4(derivs, y0, t):
     try:
         Ny = len(y0)
     except TypeError:
-        yout = np.zeros((len(t),), np.float_)
+        yout = np.zeros((len(t),), float)
     else:
-        yout = np.zeros((len(t), Ny), np.float_)
+        yout = np.zeros((len(t), Ny), float)
 
     yout[0] = y0
     i = 0
@@ -1968,9 +1967,9 @@ def dist_point_to_segment(p, s0, s1):
     This algorithm from
     http://softsurfer.com/Archive/algorithm_0102/algorithm_0102.htm#Distance%20to%20Ray%20or%20Segment
     """
-    p = np.asarray(p, np.float_)
-    s0 = np.asarray(s0, np.float_)
-    s1 = np.asarray(s1, np.float_)
+    p = np.asarray(p, float)
+    s0 = np.asarray(s0, float)
+    s1 = np.asarray(s1, float)
     v = s1 - s0
     w = p - s0
 
@@ -2032,7 +2031,7 @@ def movavg(x, n):
     """
     Compute the len(*n*) moving average of *x*.
     """
-    w = np.empty((n,), dtype=np.float_)
+    w = np.empty((n,), dtype=float)
     w[:] = 1.0/n
     return np.convolve(x, w, mode='valid')
 
@@ -3519,10 +3518,10 @@ def slopes(x, y):
     Icelandic Meteorological Office, March 2006 halldor at vedur.is)
     """
     # Cast key variables as float.
-    x = np.asarray(x, np.float_)
-    y = np.asarray(y, np.float_)
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
 
-    yp = np.zeros(y.shape, np.float_)
+    yp = np.zeros(y.shape, float)
 
     dx = x[1:] - x[:-1]
     dy = y[1:] - y[:-1]
@@ -3576,18 +3575,18 @@ def stineman_interp(xi, x, y, yp=None):
     """
 
     # Cast key variables as float.
-    x = np.asarray(x, np.float_)
-    y = np.asarray(y, np.float_)
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
     if x.shape != y.shape:
         raise ValueError("'x' and 'y' must be of same shape")
 
     if yp is None:
         yp = slopes(x, y)
     else:
-        yp = np.asarray(yp, np.float_)
+        yp = np.asarray(yp, float)
 
-    xi = np.asarray(xi, np.float_)
-    yi = np.zeros(xi.shape, np.float_)
+    xi = np.asarray(xi, float)
+    yi = np.zeros(xi.shape, float)
 
     # calculate linear slopes
     dx = x[1:] - x[:-1]
@@ -3764,7 +3763,7 @@ class GaussianKDE(object):
                 dim, self.dim)
             raise ValueError(msg)
 
-        result = np.zeros((num_m,), dtype=np.float)
+        result = np.zeros((num_m,), dtype=float)
 
         if num_m >= self.num_dp:
             # there are more points than data, so loop over data
@@ -3817,7 +3816,7 @@ def poly_below(xmin, xs, ys):
       xv, yv = poly_below(0, x, y)
       ax.fill(xv, yv)
     """
-    if isinstance(xs, np.ma.MaskedArray) or isinstance(ys, np.ma.MaskedArray):
+    if any(isinstance(var, np.ma.MaskedArray) for var in [xs, ys]):
         numpy = np.ma
     else:
         numpy = np
@@ -3846,9 +3845,7 @@ def poly_between(x, ylower, yupper):
     Return value is *x*, *y* arrays for use with
     :meth:`matplotlib.axes.Axes.fill`.
     """
-    if (isinstance(ylower, np.ma.MaskedArray) or
-            isinstance(yupper, np.ma.MaskedArray) or
-            isinstance(x, np.ma.MaskedArray)):
+    if any(isinstance(var, np.ma.MaskedArray) for var in [ylower, yupper, x]):
         numpy = np.ma
     else:
         numpy = np

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -182,7 +182,6 @@ from matplotlib import docstring
 from matplotlib.path import Path
 import math
 
-ma = np.ma
 
 if six.PY3:
     long = int
@@ -1570,7 +1569,7 @@ def entropy(y, bins):
       Sanalytic = 0.5 * ( 1.0 + log(2*pi*sigma**2.0) )
     """
     n, bins = np.histogram(y, bins)
-    n = n.astype(np.float_)
+    n = n.astype(float)
 
     n = np.take(n, np.nonzero(n)[0])         # get the positive
 
@@ -2980,13 +2979,7 @@ def csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
         return None
 
     if use_mrecords and np.any(rowmasks):
-        try:
-            from numpy.ma import mrecords
-        except ImportError:
-            raise RuntimeError('numpy 1.05 or later is required for masked '
-                               'array support')
-        else:
-            r = mrecords.fromrecords(rows, names=names, mask=rowmasks)
+        r = np.ma.mrecords.fromrecords(rows, names=names, mask=rowmasks)
     else:
         r = np.rec.fromrecords(rows, names=names)
     return r
@@ -3824,8 +3817,8 @@ def poly_below(xmin, xs, ys):
       xv, yv = poly_below(0, x, y)
       ax.fill(xv, yv)
     """
-    if ma.isMaskedArray(xs) or ma.isMaskedArray(ys):
-        numpy = ma
+    if isinstance(xs, np.ma.MaskedArray) or isinstance(ys, np.ma.MaskedArray):
+        numpy = np.ma
     else:
         numpy = np
 
@@ -3853,9 +3846,10 @@ def poly_between(x, ylower, yupper):
     Return value is *x*, *y* arrays for use with
     :meth:`matplotlib.axes.Axes.fill`.
     """
-    if (ma.isMaskedArray(ylower) or ma.isMaskedArray(yupper) or
-            ma.isMaskedArray(x)):
-        numpy = ma
+    if (isinstance(ylower, np.ma.MaskedArray) or
+            isinstance(yupper, np.ma.MaskedArray) or
+            isinstance(x, np.ma.MaskedArray)):
+        numpy = np.ma
     else:
         numpy = np
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -133,7 +133,7 @@ class Path(object):
         if isinstance(vertices, np.ma.MaskedArray):
             vertices = vertices.astype(float).filled(np.nan)
         else:
-            vertices = np.asarray(vertices, np.float_)
+            vertices = np.asarray(vertices, float)
 
         if (vertices.ndim != 2) or (vertices.shape[1] != 2):
             msg = "'vertices' must be a 2D list or array with shape Nx2"
@@ -189,7 +189,7 @@ class Path(object):
         if isinstance(verts, np.ma.MaskedArray):
             verts = verts.astype(float).filled(np.nan)
         else:
-            verts = np.asarray(verts, np.float_)
+            verts = np.asarray(verts, float)
         pth._vertices = verts
         pth._codes = codes
         pth._readonly = internals.pop('readonly', False)
@@ -775,7 +775,7 @@ class Path(object):
                              [0.0, -1.0],
 
                              [0.0, -1.0]],
-                            dtype=np.float_)
+                            dtype=float)
 
         codes = [cls.CURVE4] * 26
         codes[0] = cls.MOVETO
@@ -821,7 +821,7 @@ class Path(object):
 
                  [0.0, -1.0]],
 
-                np.float_)
+                float)
 
             codes = cls.CURVE4 * np.ones(14)
             codes[0] = cls.MOVETO
@@ -881,7 +881,7 @@ class Path(object):
 
         if is_wedge:
             length = n * 3 + 4
-            vertices = np.zeros((length, 2), np.float_)
+            vertices = np.zeros((length, 2), float)
             codes = cls.CURVE4 * np.ones((length, ), cls.code_type)
             vertices[1] = [xA[0], yA[0]]
             codes[0:2] = [cls.MOVETO, cls.LINETO]
@@ -890,7 +890,7 @@ class Path(object):
             end = length - 2
         else:
             length = n * 3 + 1
-            vertices = np.empty((length, 2), np.float_)
+            vertices = np.empty((length, 2), float)
             codes = cls.CURVE4 * np.ones((length, ), cls.code_type)
             vertices[0] = [xA[0], yA[0]]
             codes[0] = cls.MOVETO

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -21,7 +21,6 @@ import math
 from weakref import WeakValueDictionary
 
 import numpy as np
-from numpy import ma
 
 from matplotlib import _path
 from matplotlib.cbook import simple_linear_interpolation, maxdict
@@ -131,8 +130,8 @@ class Path(object):
             Makes the path behave in an immutable way and sets the vertices
             and codes as read-only arrays.
         """
-        if ma.isMaskedArray(vertices):
-            vertices = vertices.astype(np.float_).filled(np.nan)
+        if isinstance(vertices, np.ma.MaskedArray):
+            vertices = vertices.astype(float).filled(np.nan)
         else:
             vertices = np.asarray(vertices, np.float_)
 
@@ -187,8 +186,8 @@ class Path(object):
         """
         internals = internals or {}
         pth = cls.__new__(cls)
-        if ma.isMaskedArray(verts):
-            verts = verts.astype(np.float_).filled(np.nan)
+        if isinstance(verts, np.ma.MaskedArray):
+            verts = verts.astype(float).filled(np.nan)
         else:
             verts = np.asarray(verts, np.float_)
         pth._vertices = verts

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -440,7 +440,7 @@ class MollweideAxes(GeoAxes):
             clat = np.pi/2 - np.abs(latitude)
             ihigh = clat < 0.087 # within 5 degrees of the poles
             ilow = ~ihigh
-            aux = np.empty(latitude.shape, dtype=np.float)
+            aux = np.empty(latitude.shape, dtype=float)
 
             if ilow.any():  # Newton-Raphson iteration
                 pi_sin_l = np.pi * np.sin(latitude[ilow])
@@ -456,7 +456,7 @@ class MollweideAxes(GeoAxes):
                 d = 0.5 * (3 * np.pi * e**2) ** (1.0/3)
                 aux[ihigh] = (np.pi/2 - d) * np.sign(latitude[ihigh])
 
-            xy = np.empty(ll.shape, dtype=np.float)
+            xy = np.empty(ll.shape, dtype=float)
             xy[:,0] = (2.0 * np.sqrt(2.0) / np.pi) * longitude * np.cos(aux)
             xy[:,1] = np.sqrt(2.0) * np.sin(aux)
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -40,7 +40,7 @@ class PolarTransform(Transform):
         self._use_rmin = use_rmin
 
     def transform_non_affine(self, tr):
-        xy = np.empty(tr.shape, np.float_)
+        xy = np.empty(tr.shape, float)
         if self._axis is not None:
             if self._use_rmin:
                 rmin = self._axis.viewLim.ymin
@@ -522,7 +522,7 @@ cbook.simple_linear_interpolation on the data before passing to matplotlib.""")
         """
         # Make sure we take into account unitized data
         angles = self.convert_yunits(angles)
-        angles = np.asarray(angles, np.float_)
+        angles = np.asarray(angles, float)
         self.set_xticks(angles * (np.pi / 180.0))
         if labels is not None:
             self.set_xticklabels(labels)
@@ -712,7 +712,7 @@ PolarAxes.RadialLocator = RadialLocator
 
 #             vertices = self.transform(vertices)
 
-#             result = np.zeros((len(vertices) * 3 - 2, 2), np.float_)
+#             result = np.zeros((len(vertices) * 3 - 2, 2), float)
 #             codes = mpath.Path.CURVE4 * np.ones((len(vertices) * 3 - 2, ), mpath.Path.code_type)
 #             result[0] = vertices[0]
 #             codes[0] = mpath.Path.MOVETO
@@ -769,7 +769,7 @@ PolarAxes.RadialLocator = RadialLocator
 #             if interpolate > 1.0:
 #                 vertices = self.interpolate(vertices, interpolate)
 
-#             result = np.zeros((len(vertices) * 3 - 2, 2), np.float_)
+#             result = np.zeros((len(vertices) * 3 - 2, 2), float)
 #             codes = mpath.Path.CURVE4 * np.ones((len(vertices) * 3 - 2, ), mpath.Path.code_type)
 #             result[0] = vertices[0]
 #             codes[0] = mpath.Path.MOVETO

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -133,7 +133,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
                 if t is not None:
                     trajectories.append(t)
     else:
-        sp2 = np.asanyarray(start_points, dtype=np.float).copy()
+        sp2 = np.asanyarray(start_points, dtype=float).copy()
 
         # Check if start_points are outside the data boundaries
         for xs, ys in sp2:

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -361,8 +361,8 @@ def save_diff_image(expected, actual, output):
     actualImage = _png.read_png(actual)
     actualImage, expectedImage = crop_to_same(
         actual, actualImage, expected, expectedImage)
-    expectedImage = np.array(expectedImage).astype(np.float)
-    actualImage = np.array(actualImage).astype(np.float)
+    expectedImage = np.array(expectedImage).astype(float)
+    actualImage = np.array(actualImage).astype(float)
     assert expectedImage.ndim == actualImage.ndim
     assert expectedImage.shape == actualImage.shape
     absDiffImage = abs(expectedImage - actualImage)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -157,12 +157,12 @@ def test_LogNorm():
 
 
 def test_PowerNorm():
-    a = np.array([0, 0.5, 1, 1.5], dtype=np.float)
+    a = np.array([0, 0.5, 1, 1.5], dtype=float)
     pnorm = mcolors.PowerNorm(1)
     norm = mcolors.Normalize()
     assert_array_almost_equal(norm(a), pnorm(a))
 
-    a = np.array([-0.5, 0, 2, 4, 8], dtype=np.float)
+    a = np.array([-0.5, 0, 2, 4, 8], dtype=float)
     expected = [0, 0, 1/16, 1/4, 1]
     pnorm = mcolors.PowerNorm(2, vmin=0, vmax=8)
     assert_array_almost_equal(pnorm(a), expected)
@@ -171,7 +171,7 @@ def test_PowerNorm():
     assert_array_almost_equal(a[1:], pnorm.inverse(pnorm(a))[1:])
 
     # Clip = True
-    a = np.array([-0.5, 0, 1, 8, 16], dtype=np.float)
+    a = np.array([-0.5, 0, 1, 8, 16], dtype=float)
     expected = [0, 0, 0, 1, 1]
     pnorm = mcolors.PowerNorm(2, vmin=2, vmax=8, clip=True)
     assert_array_almost_equal(pnorm(a), expected)
@@ -179,7 +179,7 @@ def test_PowerNorm():
     assert_equal(pnorm(a[-1]), expected[-1])
 
     # Clip = True at call time
-    a = np.array([-0.5, 0, 1, 8, 16], dtype=np.float)
+    a = np.array([-0.5, 0, 1, 8, 16], dtype=float)
     expected = [0, 0, 0, 1, 1]
     pnorm = mcolors.PowerNorm(2, vmin=2, vmax=8, clip=False)
     assert_array_almost_equal(pnorm(a, clip=True), expected)
@@ -189,7 +189,7 @@ def test_PowerNorm():
 
 def test_Normalize():
     norm = mcolors.Normalize()
-    vals = np.arange(-10, 10, 1, dtype=np.float)
+    vals = np.arange(-10, 10, 1, dtype=float)
     _inverse_tester(norm, vals)
     _scalar_tester(norm, vals)
     _mask_tester(norm, vals)
@@ -200,7 +200,7 @@ def test_SymLogNorm():
     Test SymLogNorm behavior
     """
     norm = mcolors.SymLogNorm(3, vmax=5, linscale=1.2)
-    vals = np.array([-30, -1, 2, 6], dtype=np.float)
+    vals = np.array([-30, -1, 2, 6], dtype=float)
     normed_vals = norm(vals)
     expected = [0., 0.53980074, 0.826991, 1.02758204]
     assert_array_almost_equal(normed_vals, expected)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -488,7 +488,7 @@ def test_jpeg_alpha():
     plt.figure(figsize=(1, 1), dpi=300)
     # Create an image that is all black, with a gradient from 0-1 in
     # the alpha channel from left to right.
-    im = np.zeros((300, 300, 4), dtype=np.float)
+    im = np.zeros((300, 300, 4), dtype=float)
     im[..., 3] = np.linspace(0.0, 1.0, 300)
 
     plt.figimage(im)

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -316,9 +316,9 @@ class csv_testcase(CleanupTestCase):
 
     def test_recarray_csv_roundtrip(self):
         expected = np.recarray((99,),
-                               [(str('x'), np.float),
-                                (str('y'), np.float),
-                                (str('t'), np.float)])
+                               [(str('x'), float),
+                                (str('y'), float),
+                                (str('t'), float)])
         # initialising all values: uninitialised memory sometimes produces
         # floats that do not round-trip to string and back.
         expected['x'][:] = np.linspace(-1e9, -1, 99)
@@ -334,8 +334,8 @@ class csv_testcase(CleanupTestCase):
         assert_allclose(expected['t'], actual['t'])
 
     def test_rec2csv_bad_shape_ValueError(self):
-        bad = np.recarray((99, 4), [(str('x'), np.float),
-                                    (str('y'), np.float)])
+        bad = np.recarray((99, 4), [(str('x'), float),
+                                    (str('y'), float)])
 
         # the bad recarray should trigger a ValueError for having ndim > 1.
         assert_raises(ValueError, mlab.rec2csv, bad, self.fd)
@@ -2869,7 +2869,7 @@ class gaussian_kde_tests():
         np.testing.assert_array_almost_equal(kde(x1), y_expected, decimal=6)
 
     def test_gaussian_kde_covariance_caching(self):
-        x1 = np.array([-7, -5, 1, 4, 5], dtype=np.float)
+        x1 = np.array([-7, -5, 1, 4, 5], dtype=float)
         xs = np.linspace(-10, 10, num=5)
         # These expected values are from scipy 0.10, before some changes to
         # gaussian_kde. They were not compared with any external reference.

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -636,7 +636,7 @@ Could not rename old TeX cache dir "%s": a suitable configuration
         if Z is None:
             alpha = self.get_grey(tex, fontsize, dpi)
 
-            Z = np.zeros((alpha.shape[0], alpha.shape[1], 4), np.float)
+            Z = np.zeros((alpha.shape[0], alpha.shape[1], 4), float)
 
             Z[:, :, 0] = r
             Z[:, :, 1] = g

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -399,8 +399,7 @@ class Text(Artist):
 
         # the corners of the unrotated bounding box
         cornersHoriz = np.array(
-            [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)],
-            np.float_)
+            [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)], float)
         cornersHoriz[:, 1] -= descent
 
         # now rotate the bbox

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -784,7 +784,7 @@ class Bbox(BboxBase):
         :meth:`from_bounds` and :meth:`from_extents`.
         """
         BboxBase.__init__(self, **kwargs)
-        points = np.asarray(points, np.float_)
+        points = np.asarray(points, float)
         if points.shape != (2, 2):
             raise ValueError('Bbox points must be of the form '
                              '"[[x0, y0], [x1, y1]]".')
@@ -812,7 +812,7 @@ class Bbox(BboxBase):
         (staticmethod) Create a new unit :class:`Bbox` from (0, 0) to
         (1, 1).
         """
-        return Bbox(np.array([[0.0, 0.0], [1.0, 1.0]], np.float))
+        return Bbox(np.array([[0.0, 0.0], [1.0, 1.0]], float))
 
     @staticmethod
     def null():
@@ -820,7 +820,7 @@ class Bbox(BboxBase):
         (staticmethod) Create a new null :class:`Bbox` from (inf, inf) to
         (-inf, -inf).
         """
-        return Bbox(np.array([[np.inf, np.inf], [-np.inf, -np.inf]], np.float))
+        return Bbox(np.array([[np.inf, np.inf], [-np.inf, -np.inf]], float))
 
     @staticmethod
     def from_bounds(x0, y0, width, height):
@@ -840,7 +840,7 @@ class Bbox(BboxBase):
 
         The *y*-axis increases upwards.
         """
-        points = np.array(args, dtype=np.float_).reshape(2, 2)
+        points = np.array(args, dtype=float).reshape(2, 2)
         return Bbox(points)
 
     def __format__(self, fmt):
@@ -994,7 +994,7 @@ class Bbox(BboxBase):
 
     def _set_bounds(self, bounds):
         l, b, w, h = bounds
-        points = np.array([[l, b], [l + w, b + h]], np.float_)
+        points = np.array([[l, b], [l + w, b + h]], float)
         if np.any(self._points != points):
             self._points = points
             self.invalidate()
@@ -1758,7 +1758,7 @@ class Affine2DBase(AffineBase):
           b d f
           0 0 1
         """
-        return np.array([[a, c, e], [b, d, f], [0.0, 0.0, 1.0]], np.float_)
+        return np.array([[a, c, e], [b, d, f], [0.0, 0.0, 1.0]], float)
 
     def transform_affine(self, points):
         mtx = self.get_matrix()
@@ -1818,7 +1818,7 @@ class Affine2D(Affine2DBase):
         if matrix is None:
             matrix = np.identity(3)
         elif DEBUG:
-            matrix = np.asarray(matrix, np.float_)
+            matrix = np.asarray(matrix, float)
             assert matrix.shape == (3, 3)
         self._mtx = matrix
         self._invalid = 0
@@ -1846,8 +1846,7 @@ class Affine2D(Affine2DBase):
         .
         """
         return Affine2D(
-            np.array([a, c, e, b, d, f, 0.0, 0.0, 1.0], np.float_)
-            .reshape((3, 3)))
+            np.array([a, c, e, b, d, f, 0.0, 0.0, 1.0], float).reshape((3, 3)))
 
     def get_matrix(self):
         """
@@ -1916,9 +1915,8 @@ class Affine2D(Affine2DBase):
         """
         a = np.cos(theta)
         b = np.sin(theta)
-        rotate_mtx = np.array(
-            [[a, -b, 0.0], [b, a, 0.0], [0.0, 0.0, 1.0]],
-            np.float_)
+        rotate_mtx = np.array([[a, -b, 0.0], [b, a, 0.0], [0.0, 0.0, 1.0]],
+                              float)
         self._mtx = np.dot(rotate_mtx, self._mtx)
         self.invalidate()
         return self
@@ -1962,8 +1960,7 @@ class Affine2D(Affine2DBase):
         and :meth:`scale`.
         """
         translate_mtx = np.array(
-            [[1.0, 0.0, tx], [0.0, 1.0, ty], [0.0, 0.0, 1.0]],
-            np.float_)
+            [[1.0, 0.0, tx], [0.0, 1.0, ty], [0.0, 0.0, 1.0]], float)
         self._mtx = np.dot(translate_mtx, self._mtx)
         self.invalidate()
         return self
@@ -1982,8 +1979,7 @@ class Affine2D(Affine2DBase):
         if sy is None:
             sy = sx
         scale_mtx = np.array(
-            [[sx, 0.0, 0.0], [0.0, sy, 0.0], [0.0, 0.0, 1.0]],
-            np.float_)
+            [[sx, 0.0, 0.0], [0.0, sy, 0.0], [0.0, 0.0, 1.0]], float)
         self._mtx = np.dot(scale_mtx, self._mtx)
         self.invalidate()
         return self
@@ -2002,8 +1998,7 @@ class Affine2D(Affine2DBase):
         rotX = np.tan(xShear)
         rotY = np.tan(yShear)
         skew_mtx = np.array(
-                [[1.0, rotX, 0.0], [rotY, 1.0, 0.0], [0.0, 0.0, 1.0]],
-                np.float_)
+            [[1.0, rotX, 0.0], [rotY, 1.0, 0.0], [0.0, 0.0, 1.0]], float)
         self._mtx = np.dot(skew_mtx, self._mtx)
         self.invalidate()
         return self
@@ -2530,9 +2525,9 @@ class BboxTransform(Affine2DBase):
             if DEBUG and (x_scale == 0 or y_scale == 0):
                 raise ValueError("Transforming from or to a singular bounding box.")
             self._mtx = np.array([[x_scale, 0.0    , (-inl*x_scale+outl)],
-                                   [0.0    , y_scale, (-inb*y_scale+outb)],
-                                   [0.0    , 0.0    , 1.0        ]],
-                                  np.float_)
+                                   [0.0   , y_scale, (-inb*y_scale+outb)],
+                                   [0.0   , 0.0    , 1.0        ]],
+                                 float)
             self._inverted = None
             self._invalid = 0
         return self._mtx
@@ -2570,9 +2565,9 @@ class BboxTransformTo(Affine2DBase):
             if DEBUG and (outw == 0 or outh == 0):
                 raise ValueError("Transforming to a singular bounding box.")
             self._mtx = np.array([[outw,  0.0, outl],
-                                   [ 0.0, outh, outb],
-                                   [ 0.0,  0.0,  1.0]],
-                                  np.float_)
+                                  [ 0.0, outh, outb],
+                                  [ 0.0,  0.0,  1.0]],
+                                  float)
             self._inverted = None
             self._invalid = 0
         return self._mtx
@@ -2596,7 +2591,7 @@ class BboxTransformToMaxOnly(BboxTransformTo):
             self._mtx = np.array([[xmax,  0.0, 0.0],
                                   [ 0.0, ymax, 0.0],
                                   [ 0.0,  0.0, 1.0]],
-                                 np.float_)
+                                 float)
             self._inverted = None
             self._invalid = 0
         return self._mtx
@@ -2631,9 +2626,9 @@ class BboxTransformFrom(Affine2DBase):
             x_scale = 1.0 / inw
             y_scale = 1.0 / inh
             self._mtx = np.array([[x_scale, 0.0    , (-inl*x_scale)],
-                                   [0.0    , y_scale, (-inb*y_scale)],
-                                   [0.0    , 0.0    , 1.0        ]],
-                                  np.float_)
+                                  [0.0    , y_scale, (-inb*y_scale)],
+                                  [0.0    , 0.0    , 1.0        ]],
+                                 float)
             self._inverted = None
             self._invalid = 0
         return self._mtx
@@ -2660,9 +2655,9 @@ class ScaledTranslation(Affine2DBase):
         if self._invalid:
             xt, yt = self._scale_trans.transform_point(self._t)
             self._mtx = np.array([[1.0, 0.0, xt],
-                                   [0.0, 1.0, yt],
-                                   [0.0, 0.0, 1.0]],
-                                  np.float_)
+                                  [0.0, 1.0, yt],
+                                  [0.0, 0.0, 1.0]],
+                                 float)
             self._invalid = 0
             self._inverted = None
         return self._mtx

--- a/unit/virtualenv.py
+++ b/unit/virtualenv.py
@@ -24,15 +24,6 @@ from distutils.util import strtobool
 import struct
 import subprocess
 
-if sys.version_info < (2, 5):
-    print('ERROR: %s' % sys.exc_info()[1])
-    print('ERROR: this script requires Python 2.5 or greater.')
-    sys.exit(101)
-
-try:
-    set
-except NameError:
-    from sets import Set as set
 try:
     basestring
 except NameError:


### PR DESCRIPTION
- Remove some very old compatibility layers (sets module, md5 module, etc.)
- Use `astype(float)` instead of `astype(np.float)` and `astype(np.float_)`
- Use `isinstance(..., MaskedArray)` instead of `isMaskedArray` / `isMA`.

Some other cleanup ideas:
- Get rid of `if debug` prints (mostly present in backend implementations just to indicate that a method has been called): I think that a tool such as https://pypi.python.org/pypi/hunter is typically more appropriate anyways.
- Reimplement the verbose class on top of the stdlib `logging` and read off an environment variable such as `MPLVERBOSITY` instead of command-line arguments which are likely to be set for other purposes.