### PR TITLE
setup.py: Recommend installation command for pkgs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,10 +201,14 @@ if __name__ == '__main__':
     # Abort if any of the required packages can not be built.
     if required_failed:
         print_line()
-        print_message(
-            "The following required packages can not "
-            "be built: %s" %
-            ', '.join(x.name for x in required_failed))
+        message = ("The following required packages can not "
+                   "be built: %s" %
+                   ", ".join(x.name for x in required_failed))
+        for pkg in required_failed:
+            pkg_help = pkg.install_help_msg()
+            if pkg_help:
+                message += "\n* " + pkg_help
+        print_message(message)
         sys.exit(1)
 
     # Now collect all of the information we need to build all of the

--- a/setupext.py
+++ b/setupext.py
@@ -6,6 +6,7 @@ from distutils.core import Extension
 import glob
 import multiprocessing
 import os
+import platform
 import re
 import subprocess
 from subprocess import check_output
@@ -412,6 +413,14 @@ class CheckFailed(Exception):
 
 class SetupPackage(object):
     optional = False
+    pkg_names = {
+        "apt-get": None,
+        "yum": None,
+        "dnf": None,
+        "brew": None,
+        "port": None,
+        "windows_url": None
+        }
 
     def check(self):
         """
@@ -530,6 +539,56 @@ class SetupPackage(object):
         override this method.
         """
         pass
+
+    def install_help_msg(self):
+        """
+        Do not override this method !
+
+        Generate the help message to show if the package is not installed.
+        To use this in subclasses, simply add the dictionary `pkg_names` as
+        a class variable:
+
+        pkg_names = {
+            "apt-get": <Name of the apt-get package>,
+            "yum": <Name of the yum package>,
+            "dnf": <Name of the dnf package>,
+            "brew": <Name of the brew package>,
+            "port": <Name of the port package>,
+            "windows_url": <The url which has installation instructions>
+            }
+
+        All the dictionary keys are optional. If a key is not present or has
+        the value `None` no message is provided for that platform.
+        """
+        def _try_managers(*managers):
+            for manager in managers:
+                pkg_name = self.pkg_names.get(manager, None)
+                if pkg_name:
+                    try:
+                        # `shutil.which()` can be used when Python 2.7 support
+                        # is dropped. It is available in Python 3.3+
+                        _ = check_output(["which", manager],
+                                         stderr=subprocess.STDOUT)
+                        return ('Try installing {0} with `{1} install {2}`'
+                                .format(self.name, manager, pkg_name))
+                    except subprocess.CalledProcessError:
+                        pass
+
+        message = None
+        if sys.platform == "win32":
+            url = self.pkg_names.get("windows_url", None)
+            if url:
+                message = ('Please check {0} for instructions to install {1}'
+                           .format(url, self.name))
+        elif sys.platform == "darwin":
+            message = _try_managers("brew", "port")
+        elif sys.platform.startswith("linux"):
+            release = platform.linux_distribution()[0].lower()
+            if release in ('debian', 'ubuntu'):
+                message = _try_managers('apt-get')
+            elif release in ('centos', 'redhat', 'fedora'):
+                message = _try_managers('dnf', 'yum')
+        return message
 
 
 class OptionalPackage(SetupPackage):
@@ -953,6 +1012,14 @@ class LibAgg(SetupPackage):
 
 class FreeType(SetupPackage):
     name = "freetype"
+    pkg_names = {
+        "apt-get": "libfreetype6-dev",
+        "yum": "freetype-devel",
+        "dnf": "freetype-devel",
+        "brew": "freetype",
+        "port": "freetype",
+        "windows_url": "http://gnuwin32.sourceforge.net/packages/freetype.htm"
+        }
 
     def check(self):
         if options.get('local_freetype'):
@@ -1167,6 +1234,14 @@ class FT2Font(SetupPackage):
 
 class Png(SetupPackage):
     name = "png"
+    pkg_names = {
+        "apt-get": "libpng12-dev",
+        "yum": "libpng-devel",
+        "dnf": "libpng-devel",
+        "brew": "libpng",
+        "port": "libpng",
+        "windows_url": "http://gnuwin32.sourceforge.net/packages/libpng.htm"
+        }
 
     def check(self):
         if sys.platform == 'win32':


### PR DESCRIPTION
If a package is not found, provide a better error message
that also explains how to install the package or gives the
user a link explaining what to do to install the package.

The supported methods are:
 - Provide a link for windows
 - Provide a command using a package manager for the OS
   (For example: apt-get for Ubuntu/Debian, dnf and yum for
    Fedora/CentOS/RHEL, brew and port for OSX)

Fixes https://github.com/matplotlib/matplotlib/issues/6546