### PR TITLE
Fix mlab.rec_join.

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2613,7 +2613,7 @@ def rec_join(key, r1, r2, jointype='inner', defaults=None, r1postfix='1',
 
     if jointype != 'inner' and defaults is not None:
         # fill in the defaults enmasse
-        newrec_fields = list(six.iterkeys(newrec.dtype.fields.keys))
+        newrec_fields = list(six.iterkeys(newrec.dtype.fields))
         for k, v in six.iteritems(defaults):
             if k in newrec_fields:
                 newrec[k] = v


### PR DESCRIPTION
`examples/misc/rec_lab_demo.py` was broken on Python3.

Any plans to just deprecate most of `mlab`?  I can see why it's there but nowadays `pandas` and friends are much more appropriate for this kind of stuff.