### PR TITLE
Small fixes to docs

### DIFF
--- a/doc/users/customizing.rst
+++ b/doc/users/customizing.rst
@@ -94,4 +94,4 @@ A sample matplotlibrc file
 
     `(download) <../_static/matplotlibrc>`__
 
-.. literalinclude:: ../../lib/matplotlib/mpl-data/matplotlibrc
+.. literalinclude:: ../_static/matplotlibrc

--- a/doc/users/customizing.rst
+++ b/doc/users/customizing.rst
@@ -70,8 +70,8 @@ locations, in the following order:
 
 4. :file:`{INSTALL}/matplotlib/mpl-data/matplotlibrc`, where
    :file:`{INSTALL}` is something like
-   :file:`/usr/lib/python2.5/site-packages` on Linux, and maybe
-   :file:`C:\\Python25\\Lib\\site-packages` on Windows. Every time you
+   :file:`/usr/lib/python3.5/site-packages` on Linux, and maybe
+   :file:`C:\\Python35\\Lib\\site-packages` on Windows. Every time you
    install matplotlib, this file will be overwritten, so if you want
    your customizations to be saved, please move this file to your
    user-specific matplotlib directory.

--- a/examples/tests/backend_driver.py
+++ b/examples/tests/backend_driver.py
@@ -202,7 +202,6 @@ files['pylab'] = [
     'masked_demo.py',
     'mathtext_demo.py',
     'mathtext_examples.py',
-    'matplotlib_icon.py',
     'matshow.py',
     'mri_demo.py',
     'mri_with_eeg.py',


### PR DESCRIPTION
1. #6530 missed the fact that there was a link to the old location of matplotlibrc in the docs change that to point to static so we are only looking for it in one location.
2. Change python version in same file to something that we support
3. Remove no longer existing matplotlib_icon.py from backend driver