### PR TITLE
Using to_rgba rather than to_rgb in figure_edit

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -112,9 +112,9 @@ def figure_edit(axes, parent=None):
     curvelabels = sorted(linedict, key=cmp_key)
     for label in curvelabels:
         line = linedict[label]
-        color = rgb2hex(colorConverter.to_rgb(line.get_color()))
-        ec = rgb2hex(colorConverter.to_rgb(line.get_markeredgecolor()))
-        fc = rgb2hex(colorConverter.to_rgb(line.get_markerfacecolor()))
+        color = rgb2hex(colorConverter.to_rgba(line.get_color()))
+        ec = rgb2hex(colorConverter.to_rgba(line.get_markeredgecolor()))
+        fc = rgb2hex(colorConverter.to_rgba(line.get_markerfacecolor()))
         curvedata = [
             ('Label', label),
             sep,


### PR DESCRIPTION

OS: Windows 7 (64bit)
Python: Anaconda, Python 3.4.4 (64bit)
matplotlib: 1.5.1  (version used for this test)
matplotlib backend: Qt4Agg or Qt5Agg

If I set "markerfacecolor" as "none" (**not None**) for plotting, I get the following exception **when I push the editing button of toolbar**.

> Traceback (most recent call last):
>   File "C:\Users\dwlee\Anaconda\envs\py34\lib\site-packages\matplotlib\colors.py", line 309, in to_rgb
>     fl = float(argl)
> ValueError: could not convert string to float: 'none'
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "C:\Users\dwlee\Anaconda\envs\py34\lib\site-packages\matplotlib\backends\backend_qt5.py", line 645, in edit_parameters
>     figureoptions.figure_edit(axes, self)
>   File "C:\Users\dwlee\Anaconda\envs\py34\lib\site-packages\matplotlib\backends\qt_editor\figureoptions.py", line 89, in
>  figure_edit
>     fc = rgb2hex(colorConverter.to_rgb(line.get_markerfacecolor()))
>   File "C:\Users\dwlee\Anaconda\envs\py34\lib\site-packages\matplotlib\colors.py", line 331, in to_rgb
>     'to_rgb: Invalid rgb arg "%s"\n%s' % (str(arg), exc))
> ValueError: to_rgb: Invalid rgb arg "none" could not convert string to float: 'none'

Here is the example code for testing.

```
import numpy as np
import matplotlib.pyplot as plt

X = np.random.rand(100, 1000)
xs = np.mean(X, axis=1)
ys = np.std(X, axis=1)

fig = plt.figure()
ax = fig.add_subplot(111)
line, = ax.plot(xs, ys, 'o', markerfacecolor="none")

plt.show()
```

One solution is to use "to_rgba" of colorConverter in "matplotlib\backends\qt_editor\figureoptions.py" rather than "to_rgb". It is because "to_rgb" does not handle the "none" option as a transparent color, whereas "to_rgba" does.

```
# Before
color = rgb2hex(colorConverter.to_rgb(line.get_color()))
ec = rgb2hex(colorConverter.to_rgb(line.get_markeredgecolor()))
fc = rgb2hex(colorConverter.to_rgb(line.get_markerfacecolor()))

# Fixed
color = rgb2hex(colorConverter.to_rgba(line.get_color()))
ec = rgb2hex(colorConverter.to_rgba(line.get_markeredgecolor()))
fc = rgb2hex(colorConverter.to_rgba(line.get_markerfacecolor()))
```
