### PR TITLE
Reproducible PS/PDF output

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1087,7 +1087,14 @@ class FigureCanvasPS(FigureCanvasBase):
             if title: print("%%Title: "+title, file=fh)
             print(("%%Creator: matplotlib version "
                          +__version__+", http://matplotlib.org/"), file=fh)
-            print("%%CreationDate: "+time.ctime(time.time()), file=fh)
+            # get source date from SOURCE_DATE_EPOCH, if set
+            # See https://reproducible-builds.org/specs/source-date-epoch/
+            source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
+            if source_date_epoch:
+                source_date = time.asctime(time.gmtime(int(source_date_epoch)))
+            else:
+                source_date = time.ctime()
+            print("%%CreationDate: "+source_date, file=fh)
             print("%%Orientation: " + orientation, file=fh)
             if not isEPSF: print("%%DocumentPaperSizes: "+papertype, file=fh)
             print("%%%%BoundingBox: %d %d %d %d" % bbox, file=fh)


### PR DESCRIPTION
Several software packages use matplotlib in their building process (mainly to produce PS or PDF documents). To make their build reproducible, it would be great to make matplotlib output reproducible.

To allow reproducible PS and PDF output:
* honour SOURCE_DATE_EPOCH for timestamps in PS and PDF files.
  See https://reproducible-builds.org/specs/source-date-epoch/
* get keys sorted so that hatch patterns, images and markers are included with
  a reproducible order in the PDF file. Another solution is to use `sorted(six.iteritems(self.hatchPatterns))` in `writeHatches` (and similar ordering in `writeImages` and `writeMarkers`), but this consumes more memory. 

This patch has been submitted in debian bug [#827361](https://bugs.debian.org/827361)

See also https://reproducible-builds.org/