### PR TITLE
[MRG+1] Reproducible PS/PDF output (master)

### DIFF
--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -1,0 +1,6 @@
+Reproducible PS and PDF output
+------------------------------
+
+The ``SOURCE_DATE_EPOCH`` environment variable can now be used to set
+the timestamps value in the PS and PDF outputs, which are then
+reproducible.

--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -5,9 +5,10 @@ The ``SOURCE_DATE_EPOCH`` environment variable can now be used to set
 the timestamps value in the PS and PDF outputs. See
 https://reproducible-builds.org/specs/source-date-epoch/
 
-Matplotlib does its best to make PS and PDF outputs reproducible, but
-be aware that some unreproducibility issues can arise if you use
-different versions of Matplotlib and the tools it relies on. Although
-standard plots has been checked to be reproducible, external tools can
-also be a source of nondeterminism (``mathtext``, ``ps.usedistiller``,
-``ps.fonttype``, ``pdf.fonttype``...).
+The reproducibility of the output from the PS and PDF backends has so
+far been tested using various plot elements but only default values of
+options such as ``{ps,pdf}.fonttype`` that can affect the output at a
+low level, and not with the mathtext or usetex features. When
+matplotlib calls external tools (such as PS distillers or LaTeX) their
+versions need to be kept constant for reproducibility, and they may
+add sources of nondeterminism outside the control of matplotlib.

--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -2,5 +2,12 @@ Reproducible PS and PDF output
 ------------------------------
 
 The ``SOURCE_DATE_EPOCH`` environment variable can now be used to set
-the timestamps value in the PS and PDF outputs, which are then
-reproducible.
+the timestamps value in the PS and PDF outputs. See
+https://reproducible-builds.org/specs/source-date-epoch/
+
+Matplotlib does its best to make PS and PDF outputs reproducible, but
+be aware that some unreproducibility issues can arise if you use
+different versions of Matplotlib and the tools it relies on. Although
+standard plots has been checked to be reproducible, external tools can
+also be a source of nondeterminism (``mathtext``, ``ps.usedistiller``,
+``ps.fonttype``, ``pdf.fonttype``...).

--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -2,7 +2,7 @@ Reproducible PS and PDF output
 ------------------------------
 
 The ``SOURCE_DATE_EPOCH`` environment variable can now be used to set
-the timestamps value in the PS and PDF outputs. See
+the timestamp value in the PS and PDF outputs. See
 https://reproducible-builds.org/specs/source-date-epoch/
 
 The reproducibility of the output from the PS and PDF backends has so

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -17,6 +17,7 @@ import sys
 import time
 import warnings
 import zlib
+import collections
 from io import BytesIO
 from functools import total_ordering
 
@@ -24,7 +25,7 @@ import numpy as np
 from six import unichr
 
 
-from datetime import datetime
+from datetime import datetime, tzinfo, timedelta
 from math import ceil, cos, floor, pi, sin
 
 import matplotlib
@@ -135,6 +136,20 @@ def _string_escape(match):
     assert False
 
 
+# tzinfo class for UTC
+class UTCtimezone(tzinfo):
+    """UTC timezone"""
+
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
+
 def pdfRepr(obj):
     """Map Python objects to PDF syntax."""
 
@@ -202,10 +217,14 @@ def pdfRepr(obj):
     # A date.
     elif isinstance(obj, datetime):
         r = obj.strftime('D:%Y%m%d%H%M%S')
-        if time.daylight:
-            z = time.altzone
+        z = obj.utcoffset()
+        if z is not None:
+            z = z.seconds
         else:
-            z = time.timezone
+            if time.daylight:
+                z = time.altzone
+            else:
+                z = time.timezone
         if z == 0:
             r += 'Z'
         elif z < 0:
@@ -468,10 +487,19 @@ class PdfFile(object):
         self.writeObject(self.rootObject, root)
 
         revision = ''
+        # get source date from SOURCE_DATE_EPOCH, if set
+        # See https://reproducible-builds.org/specs/source-date-epoch/
+        source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
+        if source_date_epoch:
+            source_date = datetime.utcfromtimestamp(int(source_date_epoch))
+            source_date = source_date.replace(tzinfo=UTCtimezone())
+        else:
+            source_date = datetime.today()
+
         self.infoDict = {
             'Creator': 'matplotlib %s, http://matplotlib.org' % __version__,
             'Producer': 'matplotlib pdf backend%s' % revision,
-            'CreationDate': datetime.today()
+            'CreationDate': source_date
             }
 
         self.fontNames = {}     # maps filenames to internal font names
@@ -483,14 +511,15 @@ class PdfFile(object):
 
         self.alphaStates = {}   # maps alpha values to graphics state objects
         self.nextAlphaState = 1
-        self.hatchPatterns = {}
+        # reproducible writeHatches needs an ordered dict:
+        self.hatchPatterns = collections.OrderedDict()
         self.nextHatch = 1
         self.gouraudTriangles = []
 
-        self._images = {}
+        self._images = collections.OrderedDict()   # reproducible writeImages
         self.nextImage = 1
 
-        self.markers = {}
+        self.markers = collections.OrderedDict()   # reproducible writeMarkers
         self.multi_byte_charprocs = {}
 
         self.paths = []

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -949,7 +949,8 @@ end"""
             rawcharprocs = ttconv.get_pdf_charprocs(
                 filename.encode(sys.getfilesystemencoding()), glyph_ids)
             charprocs = {}
-            for charname, stream in six.iteritems(rawcharprocs):
+            for charname in sorted(rawcharprocs):
+                stream = rawcharprocs[charname]
                 charprocDict = {'Length': len(stream)}
                 # The 2-byte characters are used as XObjects, so they
                 # need extra info in their dictionary

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -669,7 +669,8 @@ class PdfFile(object):
 
     def writeFonts(self):
         fonts = {}
-        for filename, Fx in six.iteritems(self.fontNames):
+        for filename in sorted(self.fontNames):
+            Fx = self.fontNames[filename]
             matplotlib.verbose.report('Embedding font %s' % filename, 'debug')
             if filename.endswith('.afm'):
                 # from pdf.use14corefonts

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -46,6 +46,7 @@ from matplotlib.ft2font import (FIXED_WIDTH, ITALIC, LOAD_NO_SCALE,
 from matplotlib.mathtext import MathTextParser
 from matplotlib.transforms import Affine2D, BboxBase
 from matplotlib.path import Path
+from matplotlib.dates import UTC
 from matplotlib import _path
 from matplotlib import _png
 from matplotlib import ttconv
@@ -134,20 +135,6 @@ def _string_escape(match):
     elif m == b'\r':
         return br'\r'
     assert False
-
-
-# tzinfo class for UTC
-class UTCtimezone(tzinfo):
-    """UTC timezone"""
-
-    def utcoffset(self, dt):
-        return timedelta(0)
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return timedelta(0)
 
 
 def pdfRepr(obj):
@@ -492,7 +479,7 @@ class PdfFile(object):
         source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
         if source_date_epoch:
             source_date = datetime.utcfromtimestamp(int(source_date_epoch))
-            source_date = source_date.replace(tzinfo=UTCtimezone())
+            source_date = source_date.replace(tzinfo=UTC)
         else:
             source_date = datetime.today()
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import StringIO
 
-import glob, math, os, shutil, sys, time
+import glob, math, os, shutil, sys, time, datetime
 def _fn_name(): return sys._getframe(1).f_code.co_name
 import io
 
@@ -1091,7 +1091,8 @@ class FigureCanvasPS(FigureCanvasBase):
             # See https://reproducible-builds.org/specs/source-date-epoch/
             source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
             if source_date_epoch:
-                source_date = time.asctime(time.gmtime(int(source_date_epoch)))
+                source_date = datetime.datetime.utcfromtimestamp(
+                    int(source_date_epoch) ).strftime("%a %b %e %T %Y")
             else:
                 source_date = time.ctime()
             print("%%CreationDate: "+source_date, file=fh)
@@ -1281,7 +1282,8 @@ class FigureCanvasPS(FigureCanvasBase):
             # See https://reproducible-builds.org/specs/source-date-epoch/
             source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
             if source_date_epoch:
-                source_date = time.asctime(time.gmtime(int(source_date_epoch)))
+                source_date = datetime.datetime.utcfromtimestamp(
+                    int(source_date_epoch) ).strftime("%a %b %e %T %Y")
             else:
                 source_date = time.ctime()
             print("%%CreationDate: "+source_date, file=fh)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1087,7 +1087,14 @@ class FigureCanvasPS(FigureCanvasBase):
             if title: print("%%Title: "+title, file=fh)
             print(("%%Creator: matplotlib version "
                          +__version__+", http://matplotlib.org/"), file=fh)
-            print("%%CreationDate: "+time.ctime(time.time()), file=fh)
+            # get source date from SOURCE_DATE_EPOCH, if set
+            # See https://reproducible-builds.org/specs/source-date-epoch/
+            source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
+            if source_date_epoch:
+                source_date = time.asctime(time.gmtime(int(source_date_epoch)))
+            else:
+                source_date = time.ctime()
+            print("%%CreationDate: "+source_date, file=fh)
             print("%%Orientation: " + orientation, file=fh)
             if not isEPSF: print("%%DocumentPaperSizes: "+papertype, file=fh)
             print("%%%%BoundingBox: %d %d %d %d" % bbox, file=fh)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1283,7 +1283,7 @@ class FigureCanvasPS(FigureCanvasBase):
             source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
             if source_date_epoch:
                 source_date = datetime.datetime.utcfromtimestamp(
-                    int(source_date_epoch) ).strftime("%a %b %e %T %Y")
+                    int(source_date_epoch) ).strftime("%a %b %d %H:%M:%S %Y")
             else:
                 source_date = time.ctime()
             print("%%CreationDate: "+source_date, file=fh)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1277,7 +1277,14 @@ class FigureCanvasPS(FigureCanvasBase):
             if title: print("%%Title: "+title, file=fh)
             print(("%%Creator: matplotlib version "
                          +__version__+", http://matplotlib.org/"), file=fh)
-            print("%%CreationDate: "+time.ctime(time.time()), file=fh)
+            # get source date from SOURCE_DATE_EPOCH, if set
+            # See https://reproducible-builds.org/specs/source-date-epoch/
+            source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
+            if source_date_epoch:
+                source_date = time.asctime(time.gmtime(int(source_date_epoch)))
+            else:
+                source_date = time.ctime()
+            print("%%CreationDate: "+source_date, file=fh)
             print("%%%%BoundingBox: %d %d %d %d" % bbox, file=fh)
             print("%%EndComments", file=fh)
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1092,7 +1092,7 @@ class FigureCanvasPS(FigureCanvasBase):
             source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
             if source_date_epoch:
                 source_date = datetime.datetime.utcfromtimestamp(
-                    int(source_date_epoch) ).strftime("%a %b %e %T %Y")
+                    int(source_date_epoch) ).strftime("%a %b %d %H:%M:%S %Y")
             else:
                 source_date = time.ctime()
             print("%%CreationDate: "+source_date, file=fh)

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -2,6 +2,9 @@
 Provides utilities to test output reproducibility.
 """
 
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
 import six
 
 import io

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -13,15 +13,18 @@ import re
 import sys
 from subprocess import check_output
 
+import matplotlib
 from matplotlib import pyplot as plt
 
 
-def _determinism_save(objects='mhi', format="pdf"):
+def _determinism_save(objects='mhi', format="pdf", usetex=False):
     # save current value of SOURCE_DATE_EPOCH and set it
     # to a constant value, so that time difference is not
     # taken into account
     sde = os.environ.pop('SOURCE_DATE_EPOCH', None)
     os.environ['SOURCE_DATE_EPOCH'] = "946684800"
+
+    matplotlib.rcParams['text.usetex'] = usetex
 
     fig = plt.figure()
 
@@ -73,7 +76,7 @@ def _determinism_save(objects='mhi', format="pdf"):
         os.environ['SOURCE_DATE_EPOCH'] = sde
 
 
-def _determinism_check(objects='mhi', format="pdf", uid=""):
+def _determinism_check(objects='mhi', format="pdf", uid="", usetex=False):
     """
     Output three times the same graphs and checks that the outputs are exactly
     the same.
@@ -98,8 +101,8 @@ def _determinism_check(objects='mhi', format="pdf", uid=""):
                                'matplotlib.use(%r); '
                                'from matplotlib.testing.determinism '
                                'import _determinism_save;'
-                               '_determinism_save(%r,%r)'
-                               % (format, objects, format)])
+                               '_determinism_save(%r,%r,%r)'
+                               % (format, objects, format, usetex)])
         plots.append(result)
     for p in plots[1:]:
         assert_equal(p, plots[0])

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -60,7 +60,7 @@ def _test_determinism_save(filename, objects='mhi', format="pdf"):
         os.environ['SOURCE_DATE_EPOCH'] = sde
 
 
-def _test_determinism(objects='mhi', format="pdf"):
+def _test_determinism(objects='mhi', format="pdf", uid=""):
     """
     Output three times the same graphs and checks that the outputs are exactly
     the same.
@@ -73,11 +73,14 @@ def _test_determinism(objects='mhi', format="pdf"):
         default value is "mhi", so that the test includes all these objects.
     format : str
         format string. The default value is "pdf".
+    uid : str
+        some string to add to the filename used to store the output. Use it to
+        allow parallel execution of two tests with the same objects parameter.
     """
     import sys
     from subprocess import check_call
     from nose.tools import assert_equal
-    filename = 'determinism_O%s.%s' % (objects, format)
+    filename = 'determinism_O%s%s.%s' % (objects, uid, format)
     plots = []
     for i in range(3):
         check_call([sys.executable, '-R', '-c',

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -9,7 +9,7 @@ import re
 from matplotlib import pyplot as plt
 
 
-def _test_determinism_save(filename, objects='mhi', format="pdf"):
+def _determinism_save(filename, objects='mhi', format="pdf"):
     # save current value of SOURCE_DATE_EPOCH and set it
     # to a constant value, so that time difference is not
     # taken into account
@@ -60,7 +60,7 @@ def _test_determinism_save(filename, objects='mhi', format="pdf"):
         os.environ['SOURCE_DATE_EPOCH'] = sde
 
 
-def _test_determinism(objects='mhi', format="pdf", uid=""):
+def _determinism_check(objects='mhi', format="pdf", uid=""):
     """
     Output three times the same graphs and checks that the outputs are exactly
     the same.
@@ -87,8 +87,8 @@ def _test_determinism(objects='mhi', format="pdf", uid=""):
                     'import matplotlib; '
                     'matplotlib.use(%r); '
                     'from matplotlib.testing.determinism '
-                    'import _test_determinism_save;'
-                    '_test_determinism_save(%r,%r,%r)'
+                    'import _determinism_save;'
+                    '_determinism_save(%r,%r,%r)'
                     % (format, filename, objects, format)])
         with open(filename, 'rb') as fd:
             plots.append(fd.read())
@@ -97,7 +97,7 @@ def _test_determinism(objects='mhi', format="pdf", uid=""):
         assert_equal(p, plots[0])
 
 
-def _test_source_date_epoch(format, string, keyword=b"CreationDate"):
+def _determinism_source_date_epoch(format, string, keyword=b"CreationDate"):
     """
     Test SOURCE_DATE_EPOCH support. Output a document with the envionment
     variable SOURCE_DATE_EPOCH set to 2000-01-01 00:00 UTC and check that the
@@ -121,8 +121,8 @@ def _test_source_date_epoch(format, string, keyword=b"CreationDate"):
                 'import matplotlib; '
                 'matplotlib.use(%r); '
                 'from matplotlib.testing.determinism '
-                'import _test_determinism_save;'
-                '_test_determinism_save(%r,%r,%r)'
+                'import _determinism_save;'
+                '_determinism_save(%r,%r,%r)'
                 % (format, filename, "", format)])
     find_keyword = re.compile(b".*" + keyword + b".*")
     with open(filename, 'rb') as fd:

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -1,0 +1,133 @@
+"""
+Provides utilities to test output reproducibility.
+"""
+
+import io
+import os
+
+from matplotlib import pyplot as plt
+
+
+def _test_determinism_save(filename, objects='mhi', format="pdf"):
+    # save current value of SOURCE_DATE_EPOCH and set it
+    # to a constant value, so that time difference is not
+    # taken into account
+    sde = os.environ.pop('SOURCE_DATE_EPOCH', None)
+    os.environ['SOURCE_DATE_EPOCH'] = "946684800"
+
+    fig = plt.figure()
+
+    if 'm' in objects:
+        # use different markers...
+        ax1 = fig.add_subplot(1, 6, 1)
+        x = range(10)
+        ax1.plot(x, [1] * 10, marker=u'D')
+        ax1.plot(x, [2] * 10, marker=u'x')
+        ax1.plot(x, [3] * 10, marker=u'^')
+        ax1.plot(x, [4] * 10, marker=u'H')
+        ax1.plot(x, [5] * 10, marker=u'v')
+
+    if 'h' in objects:
+        # also use different hatch patterns
+        ax2 = fig.add_subplot(1, 6, 2)
+        bars = ax2.bar(range(1, 5), range(1, 5)) + \
+            ax2.bar(range(1, 5), [6] * 4, bottom=range(1, 5))
+        ax2.set_xticks([1.5, 2.5, 3.5, 4.5])
+
+        patterns = ('-', '+', 'x', '\\', '*', 'o', 'O', '.')
+        for bar, pattern in zip(bars, patterns):
+            bar.set_hatch(pattern)
+
+    if 'i' in objects:
+        # also use different images
+        A = [[1, 2, 3], [2, 3, 1], [3, 1, 2]]
+        fig.add_subplot(1, 6, 3).imshow(A, interpolation='nearest')
+        A = [[1, 3, 2], [1, 2, 3], [3, 1, 2]]
+        fig.add_subplot(1, 6, 4).imshow(A, interpolation='bilinear')
+        A = [[2, 3, 1], [1, 2, 3], [2, 1, 3]]
+        fig.add_subplot(1, 6, 5).imshow(A, interpolation='bicubic')
+
+    x = range(5)
+    fig.add_subplot(1, 6, 6).plot(x, x)
+
+    fig.savefig(filename, format=format)
+
+    # Restores SOURCE_DATE_EPOCH
+    if sde is None:
+        os.environ.pop('SOURCE_DATE_EPOCH', None)
+    else:
+        os.environ['SOURCE_DATE_EPOCH'] = sde
+
+
+def _test_determinism(objects='mhi', format="pdf"):
+    """
+    Output three times the same graphs and checks that the outputs are exactly
+    the same.
+
+    Parameters
+    ----------
+    objects : str
+        contains characters corresponding to objects to be included in the test
+        document: 'm' for markers, 'h' for hatch patterns, 'i' for images. The
+        default value is "mhi", so that the test includes all these objects.
+    format : str
+        format string. The default value is "pdf".
+    """
+    import sys
+    from subprocess import check_call
+    from nose.tools import assert_equal
+    filename = 'determinism_O%s.%s' % (objects, format)
+    plots = []
+    for i in range(3):
+        check_call([sys.executable, '-R', '-c',
+                    'import matplotlib; '
+                    'matplotlib.use(%r); '
+                    'from matplotlib.testing.determinism '
+                    'import _test_determinism_save;'
+                    '_test_determinism_save(%r,%r,%r)'
+                    % (format, filename, objects, format)])
+        with open(filename, 'rb') as fd:
+            plots.append(fd.read())
+        os.unlink(filename)
+    for p in plots[1:]:
+        assert_equal(p, plots[0])
+
+def _test_source_date_epoch(format, string):
+    """
+    Test SOURCE_DATE_EPOCH support. Output a document with the envionment
+    variable SOURCE_DATE_EPOCH set to 2000-01-01 00:00 UTC and check that the
+    document contains the timestamp that corresponds to this date (given as an
+    argument).
+
+    Parameters
+    ----------
+    format : str
+        format string, such as "pdf".
+    string : str
+        timestamp string for 2000-01-01 00:00 UTC.
+    """
+    try:
+        # save current value of SOURCE_DATE_EPOCH
+        sde = os.environ.pop('SOURCE_DATE_EPOCH', None)
+        fig = plt.figure()
+        ax = fig.add_subplot(1, 1, 1)
+        x = [1, 2, 3, 4, 5]
+        ax.plot(x, x)
+        os.environ['SOURCE_DATE_EPOCH'] = "946684800"
+        with io.BytesIO() as output:
+            fig.savefig(output, format=format)
+            output.seek(0)
+            buff = output.read()
+            assert string in buff
+        os.environ.pop('SOURCE_DATE_EPOCH', None)
+        with io.BytesIO() as output:
+            fig.savefig(output, format=format)
+            output.seek(0)
+            buff = output.read()
+            assert string not in buff
+    finally:
+        # Restores SOURCE_DATE_EPOCH
+        if sde is None:
+            os.environ.pop('SOURCE_DATE_EPOCH', None)
+        else:
+            os.environ['SOURCE_DATE_EPOCH'] = sde

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -92,6 +92,7 @@ def _test_determinism(objects='mhi', format="pdf"):
     for p in plots[1:]:
         assert_equal(p, plots[0])
 
+
 def _test_source_date_epoch(format, string):
     """
     Test SOURCE_DATE_EPOCH support. Output a document with the envionment

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -14,7 +14,7 @@ def _test_determinism_save(filename, objects='mhi', format="pdf"):
     # to a constant value, so that time difference is not
     # taken into account
     sde = os.environ.pop('SOURCE_DATE_EPOCH', None)
-    os.environ['SOURCE_DATE_EPOCH'] = "976875010"
+    os.environ['SOURCE_DATE_EPOCH'] = "946684800"
 
     fig = plt.figure()
 
@@ -100,16 +100,16 @@ def _test_determinism(objects='mhi', format="pdf", uid=""):
 def _test_source_date_epoch(format, string, keyword=b"CreationDate"):
     """
     Test SOURCE_DATE_EPOCH support. Output a document with the envionment
-    variable SOURCE_DATE_EPOCH set to 2000-12-15 10:10:10 UTC and check that
-    the document contains the timestamp that corresponds to this date (given as
-    an argument).
+    variable SOURCE_DATE_EPOCH set to 2000-01-01 00:00 UTC and check that the
+    document contains the timestamp that corresponds to this date (given as an
+    argument).
 
     Parameters
     ----------
     format : str
         format string, such as "pdf".
     string : str
-        timestamp string for 2000-12-15 10:10:10 UTC.
+        timestamp string for 2000-01-01 00:00 UTC.
     keyword : str
         a string to look at when searching for the timestamp in the document
         (used in case the test fails).

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -100,9 +100,9 @@ def _test_determinism(objects='mhi', format="pdf", uid=""):
 def _test_source_date_epoch(format, string, keyword=b"CreationDate"):
     """
     Test SOURCE_DATE_EPOCH support. Output a document with the envionment
-    variable SOURCE_DATE_EPOCH set to 2000-12-15 10:10:10 UTC and check that the
-    document contains the timestamp that corresponds to this date (given as an
-    argument).
+    variable SOURCE_DATE_EPOCH set to 2000-12-15 10:10:10 UTC and check that
+    the document contains the timestamp that corresponds to this date (given as
+    an argument).
 
     Parameters
     ----------

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -14,7 +14,7 @@ def _test_determinism_save(filename, objects='mhi', format="pdf"):
     # to a constant value, so that time difference is not
     # taken into account
     sde = os.environ.pop('SOURCE_DATE_EPOCH', None)
-    os.environ['SOURCE_DATE_EPOCH'] = "946684800"
+    os.environ['SOURCE_DATE_EPOCH'] = "976875010"
 
     fig = plt.figure()
 
@@ -100,7 +100,7 @@ def _test_determinism(objects='mhi', format="pdf", uid=""):
 def _test_source_date_epoch(format, string, keyword=b"CreationDate"):
     """
     Test SOURCE_DATE_EPOCH support. Output a document with the envionment
-    variable SOURCE_DATE_EPOCH set to 2000-01-01 00:00 UTC and check that the
+    variable SOURCE_DATE_EPOCH set to 2000-12-15 10:10:10 UTC and check that the
     document contains the timestamp that corresponds to this date (given as an
     argument).
 
@@ -109,7 +109,7 @@ def _test_source_date_epoch(format, string, keyword=b"CreationDate"):
     format : str
         format string, such as "pdf".
     string : str
-        timestamp string for 2000-01-01 00:00 UTC.
+        timestamp string for 2000-12-15 10:10:10 UTC.
     keyword : str
         a string to look at when searching for the timestamp in the document
         (used in case the test fails).

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -16,6 +16,8 @@ from subprocess import check_output
 import matplotlib
 from matplotlib import pyplot as plt
 
+from nose.plugins.skip import SkipTest
+
 
 def _determinism_save(objects='mhi', format="pdf", usetex=False):
     # save current value of SOURCE_DATE_EPOCH and set it
@@ -105,7 +107,11 @@ def _determinism_check(objects='mhi', format="pdf", uid="", usetex=False):
                                % (format, objects, format, usetex)])
         plots.append(result)
     for p in plots[1:]:
-        assert_equal(p, plots[0])
+        if usetex:
+            if p != plots[0]:
+                raise SkipTest("failed, maybe due to ghostscript timestamps")
+        else:
+            assert_equal(p, plots[0])
 
 
 def _determinism_source_date_epoch(format, string, keyword=b"CreationDate"):

--- a/lib/matplotlib/testing/determinism.py
+++ b/lib/matplotlib/testing/determinism.py
@@ -78,7 +78,7 @@ def _determinism_save(objects='mhi', format="pdf", usetex=False):
         os.environ['SOURCE_DATE_EPOCH'] = sde
 
 
-def _determinism_check(objects='mhi', format="pdf", uid="", usetex=False):
+def _determinism_check(objects='mhi', format="pdf", usetex=False):
     """
     Output three times the same graphs and checks that the outputs are exactly
     the same.
@@ -91,9 +91,6 @@ def _determinism_check(objects='mhi', format="pdf", uid="", usetex=False):
         default value is "mhi", so that the test includes all these objects.
     format : str
         format string. The default value is "pdf".
-    uid : str
-        some string to add to the filename used to store the output. Use it to
-        allow parallel execution of two tests with the same objects parameter.
     """
     from nose.tools import assert_equal
     plots = []
@@ -127,7 +124,7 @@ def _determinism_source_date_epoch(format, string, keyword=b"CreationDate"):
         format string, such as "pdf".
     string : str
         timestamp string for 2000-01-01 00:00 UTC.
-    keyword : str
+    keyword : bytes
         a string to look at when searching for the timestamp in the document
         (used in case the test fails).
     """

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -109,6 +109,137 @@ def test_composite_image():
         assert len(pdf._file._images.keys()) == 2
 
 
+@cleanup
+def test_source_date_epoch():
+    # Test SOURCE_DATE_EPOCH support
+    try:
+        # save current value of SOURCE_DATE_EPOCH
+        sde = os.environ.pop('SOURCE_DATE_EPOCH',None)
+        fig = plt.figure()
+        ax = fig.add_subplot(1, 1, 1)
+        x = [1, 2, 3, 4, 5]
+        ax.plot(x, x)
+        os.environ['SOURCE_DATE_EPOCH'] = "946684800"
+        with io.BytesIO() as pdf:
+            fig.savefig(pdf, format="pdf")
+            pdf.seek(0)
+            buff = pdf.read()
+            assert b"/CreationDate (D:20000101000000Z)" in buff
+        os.environ.pop('SOURCE_DATE_EPOCH',None)
+        with io.BytesIO() as pdf:
+            fig.savefig(pdf, format="pdf")
+            pdf.seek(0)
+            buff = pdf.read()
+            assert not b"/CreationDate (D:20000101000000Z)" in buff
+    finally:
+        # Restores SOURCE_DATE_EPOCH
+        if sde == None:
+            os.environ.pop('SOURCE_DATE_EPOCH',None)
+        else:
+            os.environ['SOURCE_DATE_EPOCH'] = sde
+
+
+def _test_determinism_save(filename, objects=''):
+    # save current value of SOURCE_DATE_EPOCH and set it
+    # to a constant value, so that time difference is not
+    # taken into account
+    sde = os.environ.pop('SOURCE_DATE_EPOCH',None)
+    os.environ['SOURCE_DATE_EPOCH'] = "946684800"
+
+    fig = plt.figure()
+
+    if 'm' in objects:
+        # use different markers, to be recorded in the PdfFile object
+        ax1 = fig.add_subplot(1, 6, 1)
+        x = range(10)
+        ax1.plot(x, [1] * 10, marker=u'D')
+        ax1.plot(x, [2] * 10, marker=u'x')
+        ax1.plot(x, [3] * 10, marker=u'^')
+        ax1.plot(x, [4] * 10, marker=u'H')
+        ax1.plot(x, [5] * 10, marker=u'v')
+
+    if 'h' in objects:
+        # also use different hatch patterns
+        ax2 = fig.add_subplot(1, 6, 2)
+        bars = ax2.bar(range(1, 5), range(1, 5)) + \
+               ax2.bar(range(1, 5), [6] * 4, bottom=range(1, 5))
+        ax2.set_xticks([1.5, 2.5, 3.5, 4.5])
+
+        patterns = ('-', '+', 'x', '\\', '*', 'o', 'O', '.')
+        for bar, pattern in zip(bars, patterns):
+            bar.set_hatch(pattern)
+
+    if 'i' in objects:
+        # also use different images
+        A = [[1, 2, 3], [2, 3, 1], [3, 1, 2]]
+        fig.add_subplot(1, 6, 3).imshow(A, interpolation='nearest')
+        A = [[1, 3, 2], [1, 2, 3], [3, 1, 2]]
+        fig.add_subplot(1, 6, 4).imshow(A, interpolation='bilinear')
+        A = [[2, 3, 1], [1, 2, 3], [2, 1, 3]]
+        fig.add_subplot(1, 6, 5).imshow(A, interpolation='bicubic')
+
+    x=range(5)
+    fig.add_subplot(1, 6, 6).plot(x,x)
+
+    fig.savefig(filename, format="pdf")
+
+    # Restores SOURCE_DATE_EPOCH
+    if sde == None:
+        os.environ.pop('SOURCE_DATE_EPOCH',None)
+    else:
+        os.environ['SOURCE_DATE_EPOCH'] = sde
+
+
+def _test_determinism(objects=''):
+    import sys
+    from subprocess import check_call
+    from nose.tools import assert_equal
+    filename = 'determinism_O%s.pdf' % objects
+    plots = []
+    for i in range(3):
+        check_call([sys.executable, '-R', '-c',
+                    'import matplotlib; '
+                    'matplotlib.use("pdf"); '
+                    'from matplotlib.tests.test_backend_pdf '
+                    'import _test_determinism_save;'
+                    '_test_determinism_save(%r,%r)' % (filename,objects)])
+        with open(filename, 'rb') as fd:
+            plots.append(fd.read())
+        os.unlink(filename)
+    for p in plots[1:]:
+        assert_equal(p,plots[0])
+
+
+@cleanup
+def test_determinism_plain():
+    """Test for reproducible PDF output: simple figure"""
+    _test_determinism()
+
+
+@cleanup
+def test_determinism_images():
+    """Test for reproducible PDF output: figure with different images"""
+    _test_determinism('i')
+
+
+@cleanup
+def test_determinism_hatches():
+    """Test for reproducible PDF output: figure with different hatches"""
+    _test_determinism('h')
+
+
+@cleanup
+def test_determinism_markers():
+    """Test for reproducible PDF output: figure with different markers"""
+    _test_determinism('m')
+
+
+@cleanup
+def test_determinism_all():
+    """Test for reproducible PDF output"""
+    _test_determinism('mhi')
+
+
 @image_comparison(baseline_images=['hatching_legend'],
                   extensions=['pdf'])
 def test_hatching_legend():

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -12,7 +12,8 @@ import numpy as np
 from matplotlib import cm, rcParams
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib import pyplot as plt
-from matplotlib.testing.determinism import _test_source_date_epoch, _test_determinism
+from matplotlib.testing.determinism import (_test_source_date_epoch,
+                                            _test_determinism)
 from matplotlib.testing.decorators import (image_comparison, knownfailureif,
                                            cleanup)
 
@@ -91,8 +92,8 @@ def test_multipage_keep_empty():
 
 @cleanup
 def test_composite_image():
-    #Test that figures can be saved with and without combining multiple images
-    #(on a single set of axes) into a single composite image.
+    # Test that figures can be saved with and without combining multiple images
+    # (on a single set of axes) into a single composite image.
     X, Y = np.meshgrid(np.arange(-5, 5, 1), np.arange(-5, 5, 1))
     Z = np.sin(Y ** 2)
     fig = plt.figure()
@@ -114,6 +115,7 @@ def test_composite_image():
 def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PDF output"""
     _test_source_date_epoch("pdf", b"/CreationDate (D:20000101000000Z)")
+
 
 @cleanup
 def test_determinism_plain():

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -114,7 +114,7 @@ def test_composite_image():
 @cleanup
 def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PDF output"""
-    _test_source_date_epoch("pdf", b"/CreationDate (D:20001215101010Z)")
+    _test_source_date_epoch("pdf", b"/CreationDate (D:20000101000000Z)")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -114,7 +114,7 @@ def test_composite_image():
 @cleanup
 def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PDF output"""
-    _test_source_date_epoch("pdf", b"/CreationDate (D:20000101000000Z)")
+    _test_source_date_epoch("pdf", b"/CreationDate (D:20001215101010Z)")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -12,8 +12,8 @@ import numpy as np
 from matplotlib import cm, rcParams
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib import pyplot as plt
-from matplotlib.testing.determinism import (_test_source_date_epoch,
-                                            _test_determinism)
+from matplotlib.testing.determinism import (_determinism_source_date_epoch,
+                                            _determinism_check)
 from matplotlib.testing.decorators import (image_comparison, knownfailureif,
                                            cleanup)
 
@@ -114,37 +114,37 @@ def test_composite_image():
 @cleanup
 def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PDF output"""
-    _test_source_date_epoch("pdf", b"/CreationDate (D:20000101000000Z)")
+    _determinism_source_date_epoch("pdf", b"/CreationDate (D:20000101000000Z)")
 
 
 @cleanup
 def test_determinism_plain():
     """Test for reproducible PDF output: simple figure"""
-    _test_determinism('', format="pdf")
+    _determinism_check('', format="pdf")
 
 
 @cleanup
 def test_determinism_images():
     """Test for reproducible PDF output: figure with different images"""
-    _test_determinism('i', format="pdf")
+    _determinism_check('i', format="pdf")
 
 
 @cleanup
 def test_determinism_hatches():
     """Test for reproducible PDF output: figure with different hatches"""
-    _test_determinism('h', format="pdf")
+    _determinism_check('h', format="pdf")
 
 
 @cleanup
 def test_determinism_markers():
     """Test for reproducible PDF output: figure with different markers"""
-    _test_determinism('m', format="pdf")
+    _determinism_check('m', format="pdf")
 
 
 @cleanup
 def test_determinism_all():
     """Test for reproducible PDF output"""
-    _test_determinism(format="pdf")
+    _determinism_check(format="pdf")
 
 
 @image_comparison(baseline_images=['hatching_legend'],

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -179,13 +179,9 @@ def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PS output"""
     _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
 
-@cleanup
-@needs_tex
-@needs_ghostscript
-def test_source_date_epoch_tex():
-    """Test SOURCE_DATE_EPOCH support for PS/tex output"""
-    matplotlib.rcParams['text.usetex'] = True
-    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
+# SOURCE_DATE_EPOCH support is not tested with text.usetex, because the produced
+# timestamp comes from ghostscript: %%CreationDate: D:20000101000000Z00\'00\',
+# and this could change with another ghostscript version.
 
 @cleanup
 def test_determinism_all():

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -198,7 +198,7 @@ def test_determinism_all():
 def test_determinism_all_tex():
     """Test for reproducible PS/tex output"""
     matplotlib.rcParams['text.usetex'] = True
-    _test_determinism(format="ps")
+    _test_determinism(format="ps",uid="_tex")
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -181,9 +181,9 @@ def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PS output"""
     # SOURCE_DATE_EPOCH support is not tested with text.usetex,
     # because the produced timestamp comes from ghostscript:
-    # %%CreationDate: D:20000101000000Z00\'00\', and this could change
+    # %%CreationDate: D:20001215101010Z00\'00\', and this could change
     # with another ghostscript version.
-    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
+    _test_source_date_epoch("ps", b"%%CreationDate: Fri Dec 15 10:10:10 2000")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -198,8 +198,7 @@ def test_determinism_all():
 @needs_ghostscript
 def test_determinism_all_tex():
     """Test for reproducible PS/tex output"""
-    matplotlib.rcParams['text.usetex'] = True
-    _determinism_check(format="ps", uid="_tex")
+    _determinism_check(format="ps", uid="_tex", usetex=True)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -180,8 +180,24 @@ def test_source_date_epoch():
     _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
 
 @cleanup
+@needs_tex
+@needs_ghostscript
+def test_source_date_epoch_tex():
+    """Test SOURCE_DATE_EPOCH support for PS/tex output"""
+    matplotlib.rcParams['text.usetex'] = True
+    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
+
+@cleanup
 def test_determinism_all():
     """Test for reproducible PS output"""
+    _test_determinism(format="ps")
+
+@cleanup
+@needs_tex
+@needs_ghostscript
+def test_determinism_all_tex():
+    """Test for reproducible PS/tex output"""
+    matplotlib.rcParams['text.usetex'] = True
     _test_determinism(format="ps")
 
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -11,6 +11,7 @@ import six
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import patheffects
+from matplotlib.testing.determinism import _test_source_date_epoch, _test_determinism
 from matplotlib.testing.decorators import cleanup, knownfailureif
 
 
@@ -172,6 +173,17 @@ def test_tilde_in_tempfilename():
             except Exception as e:
                 # do not break if this is not removeable...
                 print(e)
+
+@cleanup
+def test_source_date_epoch():
+    """Test SOURCE_DATE_EPOCH support for PS output"""
+    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
+
+@cleanup
+def test_determinism_all():
+    """Test for reproducible PS output"""
+    _test_determinism(format="ps")
+
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -11,7 +11,8 @@ import six
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import patheffects
-from matplotlib.testing.determinism import _test_source_date_epoch, _test_determinism
+from matplotlib.testing.determinism import (_test_source_date_epoch,
+                                            _test_determinism)
 from matplotlib.testing.decorators import cleanup, knownfailureif
 
 
@@ -161,7 +162,7 @@ def test_tilde_in_tempfilename():
         plt.rc('text', usetex=True)
         plt.plot([1, 2, 3, 4])
         plt.xlabel(r'\textbf{time} (s)')
-        #matplotlib.verbose.set_level("debug")
+        # matplotlib.verbose.set_level("debug")
         output_eps = os.path.join(base_tempdir, 'tex_demo.eps')
         # use the PS backend to write the file...
         plt.savefig(output_eps, format="ps")
@@ -174,19 +175,22 @@ def test_tilde_in_tempfilename():
                 # do not break if this is not removeable...
                 print(e)
 
+
 @cleanup
 def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PS output"""
+    # SOURCE_DATE_EPOCH support is not tested with text.usetex,
+    # because the produced timestamp comes from ghostscript:
+    # %%CreationDate: D:20000101000000Z00\'00\', and this could change
+    # with another ghostscript version.
     _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
 
-# SOURCE_DATE_EPOCH support is not tested with text.usetex, because the produced
-# timestamp comes from ghostscript: %%CreationDate: D:20000101000000Z00\'00\',
-# and this could change with another ghostscript version.
 
 @cleanup
 def test_determinism_all():
     """Test for reproducible PS output"""
     _test_determinism(format="ps")
+
 
 @cleanup
 @needs_tex
@@ -195,7 +199,6 @@ def test_determinism_all_tex():
     """Test for reproducible PS/tex output"""
     matplotlib.rcParams['text.usetex'] = True
     _test_determinism(format="ps")
-
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -183,7 +183,7 @@ def test_source_date_epoch():
     # because the produced timestamp comes from ghostscript:
     # %%CreationDate: D:20000101000000Z00\'00\', and this could change
     # with another ghostscript version.
-    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
+    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan 01 00:00:00 2000")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -181,9 +181,9 @@ def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PS output"""
     # SOURCE_DATE_EPOCH support is not tested with text.usetex,
     # because the produced timestamp comes from ghostscript:
-    # %%CreationDate: D:20001215101010Z00\'00\', and this could change
+    # %%CreationDate: D:20000101000000Z00\'00\', and this could change
     # with another ghostscript version.
-    _test_source_date_epoch("ps", b"%%CreationDate: Fri Dec 15 10:10:10 2000")
+    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan  1 00:00:00 2000")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -11,8 +11,8 @@ import six
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import patheffects
-from matplotlib.testing.determinism import (_test_source_date_epoch,
-                                            _test_determinism)
+from matplotlib.testing.determinism import (_determinism_source_date_epoch,
+                                            _determinism_check)
 from matplotlib.testing.decorators import cleanup, knownfailureif
 
 
@@ -183,13 +183,14 @@ def test_source_date_epoch():
     # because the produced timestamp comes from ghostscript:
     # %%CreationDate: D:20000101000000Z00\'00\', and this could change
     # with another ghostscript version.
-    _test_source_date_epoch("ps", b"%%CreationDate: Sat Jan 01 00:00:00 2000")
+    _determinism_source_date_epoch(
+        "ps", b"%%CreationDate: Sat Jan 01 00:00:00 2000")
 
 
 @cleanup
 def test_determinism_all():
     """Test for reproducible PS output"""
-    _test_determinism(format="ps")
+    _determinism_check(format="ps")
 
 
 @cleanup
@@ -198,7 +199,7 @@ def test_determinism_all():
 def test_determinism_all_tex():
     """Test for reproducible PS/tex output"""
     matplotlib.rcParams['text.usetex'] = True
-    _test_determinism(format="ps", uid="_tex")
+    _determinism_check(format="ps", uid="_tex")
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -198,7 +198,7 @@ def test_determinism_all():
 def test_determinism_all_tex():
     """Test for reproducible PS/tex output"""
     matplotlib.rcParams['text.usetex'] = True
-    _test_determinism(format="ps",uid="_tex")
+    _test_determinism(format="ps", uid="_tex")
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -198,7 +198,7 @@ def test_determinism_all():
 @needs_ghostscript
 def test_determinism_all_tex():
     """Test for reproducible PS/tex output"""
-    _determinism_check(format="ps", uid="_tex", usetex=True)
+    _determinism_check(format="ps", usetex=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a rebase of #6595 to the master branch.

Several software packages use matplotlib in their building process (mainly to produce PS or PDF documents). To make their build reproducible, it would be great to make matplotlib output reproducible.

To allow reproducible PS and PDF output:
- honour SOURCE_DATE_EPOCH for timestamps in PS and PDF files.
  See https://reproducible-builds.org/specs/source-date-epoch/
- get keys sorted so that hatch patterns, images and markers are included with
  a reproducible order in the PDF file. Another solution is to sort `self.hatchPatterns` in `writeHatches` (and similar ordering in `writeImages` and `writeMarkers`), but this consumes more memory. 

This patch has been submitted in debian bug [#827361](https://bugs.debian.org/827361)

See also https://reproducible-builds.org/
