### PR TITLE
Register figureoptions edits in views history.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -39,6 +39,7 @@ import six
 from six.moves import xrange
 
 from contextlib import contextmanager
+from functools import partial
 import importlib
 import io
 import itertools
@@ -2833,6 +2834,13 @@ class NavigationToolbar2(object):
         self.mode = ''  # a mode string for the status bar
         self.set_history_buttons()
 
+        @partial(canvas.mpl_connect, 'draw_event')
+        def define_home(event):
+            self.push_current()
+            # The decorator sets `define_home` to the callback cid, so we can
+            # disconnect it after the first use.
+            canvas.mpl_disconnect(define_home)
+
     def set_message(self, s):
         """Display a message on toolbar or in status bar."""
 
@@ -2982,11 +2990,6 @@ class NavigationToolbar2(object):
             return
 
         x, y = event.x, event.y
-
-        # push the current view to define home if stack is empty
-        if self._views.empty():
-            self.push_current()
-
         self._xypress = []
         for i, a in enumerate(self.canvas.figure.get_axes()):
             if (x is not None and y is not None and a.in_axes(event) and
@@ -3022,11 +3025,6 @@ class NavigationToolbar2(object):
             return
 
         x, y = event.x, event.y
-
-        # push the current view to define home if stack is empty
-        if self._views.empty():
-            self.push_current()
-
         self._xypress = []
         for i, a in enumerate(self.canvas.figure.get_axes()):
             if (x is not None and y is not None and a.in_axes(event) and

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -248,6 +248,7 @@ def figure_edit(axes, parent=None):
         # Redraw
         figure = axes.get_figure()
         figure.canvas.draw()
+        figure.canvas.toolbar.push_current()
 
     data = formlayout.fedit(datalist, title="Figure options", parent=parent,
                             icon=get_icon('qt4_editor_options.svg'),

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -47,6 +47,7 @@ def figure_edit(axes, parent=None):
     sep = (None, None)  # separator
 
     # Get / General
+    # Cast to builtin floats as they have nicer reprs.
     xmin, xmax = map(float, axes.get_xlim())
     ymin, ymax = map(float, axes.get_ylim())
     general = [('Title', axes.get_title()),
@@ -177,6 +178,9 @@ def figure_edit(axes, parent=None):
 
     def apply_callback(data):
         """This function will be called to apply changes"""
+        orig_xlim = axes.get_xlim()
+        orig_ylim = axes.get_ylim()
+
         general = data.pop(0)
         curves = data.pop(0) if has_curve else []
         images = data.pop(0) if has_image else []
@@ -248,7 +252,8 @@ def figure_edit(axes, parent=None):
         # Redraw
         figure = axes.get_figure()
         figure.canvas.draw()
-        figure.canvas.toolbar.push_current()
+        if not (axes.get_xlim() == orig_xlim and axes.get_ylim() == orig_ylim):
+            figure.canvas.toolbar.push_current()
 
     data = formlayout.fedit(datalist, title="Figure options", parent=parent,
                             icon=get_icon('qt4_editor_options.svg'),


### PR DESCRIPTION
Changing axes limits in views history is now taken into account by the
views history navigation.  The home position is now defined the first
time the figure canvas is drawn (rather than the first time an edit
button is selected), via a one-shot callback.
