### PR TITLE
BF: protect against locale in sphinext text

### DIFF
--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -80,11 +80,11 @@ class TestTinyPages(object):
         # Plot 13 shows close-figs in action
         assert_true(file_same(range_4, plot_file(13)))
         # Plot 14 has included source
-        with open(pjoin(self.html_dir, 'some_plots.html'), 'rt') as fobj:
+        with open(pjoin(self.html_dir, 'some_plots.html'), 'rb') as fobj:
             html_contents = fobj.read()
-        assert_true('# Only a comment' in html_contents)
+        assert_true(b'# Only a comment' in html_contents)
         # check plot defined in external file.
         assert_true(file_same(range_4, pjoin(self.html_dir, 'range4.png')))
         assert_true(file_same(range_6, pjoin(self.html_dir, 'range6.png')))
         # check if figure caption made it into html file
-        assert_true('This is the caption for plot 15.' in html_contents)
+        assert_true(b'This is the caption for plot 15.' in html_contents)


### PR DESCRIPTION
The sphinxext tests were loading a text file with encoding not stated,
making the test sensitive to the default locale of the testing machine.

See:
https://travis-ci.org/matthew-brett/matplotlib-wheels/jobs/138518917#L8787

Read the text file as binary to avoid need for encoding.