### PR TITLE
Fix image plotting in Cairo backends

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -74,13 +74,13 @@ class ArrayWrapper:
        array.array interface.
     """
     def __init__(self, myarray):
-            self.__array = myarray
-            self.__data = myarray.ctypes.data
-            self.__size = len(myarray.flatten())
-            self.itemsize = myarray.itemsize
+        self.__array = myarray
+        self.__data = myarray.ctypes.data
+        self.__size = len(myarray.flatten())
+        self.itemsize = myarray.itemsize
 
     def buffer_info(self):
-            return (self.__data, self.__size)
+        return (self.__data, self.__size)
 
 
 class RendererCairo(RendererBase):


### PR DESCRIPTION
WIP solution to #6562

Call cairo.ImageSurface.create_for_data with an array that both py2cairo and cairocffi knows how to get a pointer too and size of.

This seems to correctly resolve the issue for the `Cairo` backend but not the GTK(3)Cairo backends.

Current status

- [x] Python2.7, Cairo backend, cairocffi
- [x] Python2.7, Cairo backend, py2cairo
- [x] Python3.5, Cairo backend, cairocffi
- [ ] Python2.7, GTKCairo backend, cairocffi
- [x] Python2.7, GTKCairo backend, py2cairo
- [x] Python2.7, GTK3Cairo backend, cairocffi
- [x] Python2.7, GTK3Cairo backend, py2cairo
- [x] Python3.5, GTK3Cairo backend, cairocffi
- [ ] Python3.5, Cairo backend, py3cairo non functional with latests release of py3cairo
- [ ] Python3.5, GTKCairo backend, cairocffi python 3 NOT Supported by GTK2
- [ ] Python3.5, GTKCairo backend, py3cairo python 3 NOT Supported by GTK2
- [ ] Python3.5, GTK3Cairo backend, py3cairo non functional with latests release of py3cairo