### PR TITLE
Switch the cursor to a busy cursor while redrawing.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3201,6 +3201,11 @@ class NavigationToolbar2(object):
 
     def set_cursor(self, cursor):
         """Set the current cursor to one of the :class:`Cursors` enums values.
+
+        If required by the backend, this method should trigger an update in
+        the backend event loop after the cursor is set, as this method may be
+        called e.g. before a long-running task during which the GUI is not
+        updated.
         """
 
     def update(self):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2818,7 +2818,8 @@ class NavigationToolbar2(object):
         self._idPress = None
         self._idRelease = None
         self._active = None
-        self._lastCursor = None
+        # This cursor will be set after the initial draw.
+        self._lastCursor = cursors.POINTER
         self._init_toolbar()
         self._idDrag = self.canvas.mpl_connect(
             'motion_notify_event', self.mouse_move)
@@ -2904,14 +2905,13 @@ class NavigationToolbar2(object):
                 self.set_cursor(cursors.POINTER)
                 self._lastCursor = cursors.POINTER
         else:
-            if self._active == 'ZOOM':
-                if self._lastCursor != cursors.SELECT_REGION:
-                    self.set_cursor(cursors.SELECT_REGION)
-                    self._lastCursor = cursors.SELECT_REGION
+            if (self._active == 'ZOOM'
+                    and self._lastCursor != cursors.SELECT_REGION):
+                self.set_cursor(cursors.SELECT_REGION)
+                self._lastCursor = cursors.SELECT_REGION
             elif (self._active == 'PAN' and
                   self._lastCursor != cursors.MOVE):
                 self.set_cursor(cursors.MOVE)
-
                 self._lastCursor = cursors.MOVE
 
     def mouse_move(self, event):

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -24,7 +24,7 @@ import numpy as np
 
 class Cursors(object):
     """Simple namespace for cursor reference"""
-    HAND, POINTER, SELECT_REGION, MOVE = list(range(4))
+    HAND, POINTER, SELECT_REGION, MOVE, WAIT = list(range(5))
 cursors = Cursors()
 
 # Views positions tool

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -30,7 +30,7 @@ from collections import OrderedDict
 from math import radians, cos, sin
 from matplotlib import verbose, rcParams, __version__
 from matplotlib.backend_bases import (
-    _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
+    _Backend, FigureCanvasBase, FigureManagerBase, RendererBase, cursors)
 from matplotlib.cbook import maxdict
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, get_font
@@ -422,9 +422,14 @@ class FigureCanvasAgg(FigureCanvasBase):
         # acquire a lock on the shared font cache
         RendererAgg.lock.acquire()
 
+        toolbar = self.toolbar
         try:
+            if toolbar:
+                toolbar.set_cursor(cursors.WAIT)
             self.figure.draw(self.renderer)
         finally:
+            if toolbar:
+                toolbar.set_cursor(cursors.POINTER)
             RendererAgg.lock.release()
 
     def get_renderer(self, cleared=False):

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -429,7 +429,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             self.figure.draw(self.renderer)
         finally:
             if toolbar:
-                toolbar.set_cursor(cursors.POINTER)
+                toolbar.set_cursor(toolbar._lastCursor)
             RendererAgg.lock.release()
 
     def get_renderer(self, cleared=False):

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -400,7 +400,7 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
             self.window.draw_drawable (self.style.fg_gc[self.state],
                                        self._pixmap, x, y, x, y, w, h)
         if toolbar:
-            toolbar.set_cursor(cursors.POINTER)
+            toolbar.set_cursor(toolbar._lastCursor)
         return False  # finish event propagation?
 
     filetypes = FigureCanvasBase.filetypes.copy()

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -54,6 +54,7 @@ cursord = {
     cursors.HAND          : gdk.Cursor(gdk.HAND2),
     cursors.POINTER       : gdk.Cursor(gdk.LEFT_PTR),
     cursors.SELECT_REGION : gdk.Cursor(gdk.TCROSS),
+    cursors.WAIT          : gdk.Cursor(gdk.WATCH),
     }
 
 # ref gtk+/gtk/gtkwidget.h

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -624,6 +624,7 @@ class NavigationToolbar2GTK(NavigationToolbar2, gtk.Toolbar):
 
     def set_cursor(self, cursor):
         self.canvas.window.set_cursor(cursord[cursor])
+        gtk.main_iteration()
 
     def release(self, event):
         try: del self._pixmapBack

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -387,16 +387,20 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
     def expose_event(self, widget, event):
         """Expose_event for all GTK backends. Should not be overridden.
         """
+        toolbar = self.toolbar
+        if toolbar:
+            toolbar.set_cursor(cursors.WAIT)
         if GTK_WIDGET_DRAWABLE(self):
             if self._need_redraw:
                 x, y, w, h = self.allocation
                 self._pixmap_prepare (w, h)
                 self._render_figure(self._pixmap, w, h)
                 self._need_redraw = False
-
             x, y, w, h = event.area
             self.window.draw_drawable (self.style.fg_gc[self.state],
                                        self._pixmap, x, y, x, y, w, h)
+        if toolbar:
+            toolbar.set_cursor(cursors.POINTER)
         return False  # finish event propagation?
 
     filetypes = FigureCanvasBase.filetypes.copy()

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -51,6 +51,7 @@ cursord = {
     cursors.HAND          : Gdk.Cursor.new(Gdk.CursorType.HAND2),
     cursors.POINTER       : Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR),
     cursors.SELECT_REGION : Gdk.Cursor.new(Gdk.CursorType.TCROSS),
+    cursors.WAIT          : Gdk.Cursor.new(Gdk.CursorType.WATCH),
     }
 
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -500,7 +500,7 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
 
     def set_cursor(self, cursor):
         self.canvas.get_property("window").set_cursor(cursord[cursor])
-        #self.canvas.set_cursor(cursord[cursor])
+        Gtk.main_iteration()
 
     def release(self, event):
         try: del self._pixmapBack

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -6,6 +6,7 @@ import six
 from . import backend_cairo, backend_gtk3
 from .backend_cairo import cairo, HAS_CAIRO_CFFI
 from .backend_gtk3 import _BackendGTK3
+from matplotlib.backend_bases import cursors
 from matplotlib.figure import Figure
 
 
@@ -35,10 +36,15 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
     def on_draw_event(self, widget, ctx):
         """ GtkDrawable draw event, like expose_event in GTK 2.X
         """
+        toolbar = self.toolbar
+        if toolbar:
+            toolbar.set_cursor(cursors.WAIT)
         self._renderer.set_context(ctx)
         allocation = self.get_allocation()
         x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
         self._render_figure(w, h)
+        if toolbar:
+            toolbar.set_cursor(cursors.POINTER)
         return False  # finish event propagation?
 
 

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -44,7 +44,7 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
         x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
         self._render_figure(w, h)
         if toolbar:
-            toolbar.set_cursor(cursors.POINTER)
+            toolbar.set_cursor(toolbar._lastCursor)
         return False  # finish event propagation?
 
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -90,6 +90,7 @@ cursord = {
     cursors.HAND: QtCore.Qt.PointingHandCursor,
     cursors.POINTER: QtCore.Qt.ArrowCursor,
     cursors.SELECT_REGION: QtCore.Qt.CrossCursor,
+    cursors.WAIT: QtCore.Qt.WaitCursor,
     }
 
 

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -698,6 +698,7 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
 
     def set_cursor(self, cursor):
         self.window.configure(cursor=cursord[cursor])
+        self.window.update_idletasks()
 
     def _Button(self, text, file, command, extension='.gif'):
         img_file = os.path.join(

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -45,6 +45,7 @@ cursord = {
     cursors.HAND: "hand2",
     cursors.POINTER: "arrow",
     cursors.SELECT_REGION: "tcross",
+    cursors.WAIT: "watch",
     }
 
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1595,6 +1595,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def set_cursor(self, cursor):
         cursor = wxc.Cursor(cursord[cursor])
         self.canvas.SetCursor(cursor)
+        self.canvas.Update()
 
     def release(self, event):
         try:

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1474,6 +1474,7 @@ cursord = {
     cursors.HAND: wx.CURSOR_HAND,
     cursors.POINTER: wx.CURSOR_ARROW,
     cursors.SELECT_REGION: wx.CURSOR_CROSS,
+    cursors.WAIT: wx.CURSOR_WAIT,
 }
 
 


### PR DESCRIPTION
To test, plot e.g. `plot(rand(100000))` and zoom in manually (the
redraw should take some time).  The cursor should switch to a "busy"
cursor (e.g. spinwheel).  The switch doesn't seem to happen under the
Tk and WX backends, probably due to some event loop intricacies I don't
understand.
