### PR TITLE
Hide "inner" {x,y}labels in label_outer too.

### DIFF
--- a/examples/pylab_examples/subplots_demo.py
+++ b/examples/pylab_examples/subplots_demo.py
@@ -22,31 +22,32 @@ ax.set_title('Simple plot')
 
 # Two subplots, the axes array is 1-d
 f, axarr = plt.subplots(2, sharex=True)
+f.suptitle('Sharing X axis')
 axarr[0].plot(x, y)
-axarr[0].set_title('Sharing X axis')
 axarr[1].scatter(x, y)
 
 # Two subplots, unpack the axes array immediately
 f, (ax1, ax2) = plt.subplots(1, 2, sharey=True)
+f.suptitle('Sharing Y axis')
 ax1.plot(x, y)
-ax1.set_title('Sharing Y axis')
 ax2.scatter(x, y)
 
 # Three subplots sharing both x/y axes
-f, (ax1, ax2, ax3) = plt.subplots(3, sharex=True, sharey=True)
-ax1.plot(x, y)
-ax1.set_title('Sharing both axes')
-ax2.scatter(x, y)
-ax3.scatter(x, 2 * y ** 2 - 1, color='r')
-# Fine-tune figure; make subplots close to each other and hide x ticks for
-# all but bottom plot.
+f, axarr = plt.subplots(3, sharex=True, sharey=True)
+f.suptitle('Sharing both axes')
+axarr[0].plot(x, y)
+axarr[1].scatter(x, y)
+axarr[2].scatter(x, 2 * y ** 2 - 1, color='r')
+# Bring subplots close to each other.
 f.subplots_adjust(hspace=0)
-plt.setp([a.get_xticklabels() for a in f.axes[:-1]], visible=False)
+# Hide x labels and tick labels for all but bottom plot.
+for ax in axarr:
+    ax.label_outer()
 
 # row and column sharing
 f, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, sharex='col', sharey='row')
+f.suptitle('Sharing x per column, y per row')
 ax1.plot(x, y)
-ax1.set_title('Sharing x per column, y per row')
 ax2.scatter(x, y)
 ax3.scatter(x, 2 * y ** 2 - 1, color='r')
 ax4.plot(x, 2 * y ** 2 - 1, color='r')
@@ -61,9 +62,11 @@ axarr[1, 0].plot(x, y ** 2)
 axarr[1, 0].set_title('Axis [1,0]')
 axarr[1, 1].scatter(x, y ** 2)
 axarr[1, 1].set_title('Axis [1,1]')
-# Fine-tune figure; hide x ticks for top plots and y ticks for right plots
-plt.setp([a.get_xticklabels() for a in axarr[0, :]], visible=False)
-plt.setp([a.get_yticklabels() for a in axarr[:, 1]], visible=False)
+for ax in axarr.flat:
+    ax.set(xlabel='x-label', ylabel='y-label')
+# Hide x labels and tick labels for top plots and y ticks for right plots.
+for ax in axarr.flat:
+    ax.label_outer()
 
 # Four polar axes
 f, axarr = plt.subplots(2, 2, subplot_kw=dict(projection='polar'))

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -125,7 +125,7 @@ class SubplotBase(object):
     def is_last_col(self):
         return self.colNum == self.numCols - 1
 
-    # COVERAGE NOTE: Never used internally or from examples
+    # COVERAGE NOTE: Never used internally.
     def label_outer(self):
         """Only show "outer" labels and tick labels.
 

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -127,19 +127,23 @@ class SubplotBase(object):
 
     # COVERAGE NOTE: Never used internally or from examples
     def label_outer(self):
-        """
-        set the visible property on ticklabels so xticklabels are
-        visible only if the subplot is in the last row and yticklabels
-        are visible only if the subplot is in the first column
+        """Only show "outer" labels and tick labels.
+
+        x-labels are only kept for subplots on the last row; y-labels only for
+        subplots on the first column.
         """
         lastrow = self.is_last_row()
         firstcol = self.is_first_col()
         for label in self.get_xticklabels():
             label.set_visible(lastrow)
         self.get_xaxis().get_offset_text().set_visible(lastrow)
+        if not lastrow:
+            self.set_xlabel("")
         for label in self.get_yticklabels():
             label.set_visible(firstcol)
         self.get_yaxis().get_offset_text().set_visible(firstcol)
+        if not firstcol:
+            self.set_ylabel("")
 
     def _make_twin_axes(self, *kl, **kwargs):
         """


### PR DESCRIPTION
`ax.label_outer` used to hide only "inner" ticklabels; make it hide axes
labels too.  (I couldn't find a way to just switch label visibility, so
I just set the labels to the empty string instead.)