### PR TITLE
colors: ensure masked array data is an ndarray

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -925,7 +925,7 @@ class Normalize(object):
                 result = np.ma.array(np.clip(result.filled(vmax), vmin, vmax),
                                      mask=mask)
             # ma division is very slow; we can take a shortcut
-            resdat = result.data
+            resdat = np.asarray(result.data)
             resdat -= vmin
             resdat /= (vmax - vmin)
             result = np.ma.array(resdat, mask=result.mask, copy=False)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -925,6 +925,8 @@ class Normalize(object):
                 result = np.ma.array(np.clip(result.filled(vmax), vmin, vmax),
                                      mask=mask)
             # ma division is very slow; we can take a shortcut
+            # use np.asarray so data passed in as an ndarray subclass are
+            # interpreted as an ndarray. See issue #6622.
             resdat = np.asarray(result.data)
             resdat -= vmin
             resdat /= (vmax - vmin)


### PR DESCRIPTION
This fixes compatibility for imshow plots with array data that is a unit-aware ndarray subclass, for example data from yt.units or astropy.units.

Take for example the following script:

```
import numpy as np
import matplotlib.pyplot as plt
from yt.units import km

arr = np.random.random((400, 400))*km

plt.imshow(a)
plt.show()
```

This produces the following traceback right now: https://gist.github.com/ngoldbaum/27effb41173859132fed08a0ad5485ee

This is not isolated to yt's units - if one tries the same thing with astropy's units the same issue arises. Pint does not have this issue because Pint's `Quantity` class is not an ndarray subclass, so when it is converted to a masked array in `matplotlib.image`, the units are stripped.

This function seems to expect `result.data` to be an instance of the base ndarray class. This patch just enforces that expectation explicitly.