### PR TITLE
fix the swab bug to compile on solaris system

### DIFF
--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -18,9 +18,13 @@ typedef unsigned __int8   uint8_t;
 #    undef _XOPEN_SOURCE
 #endif
 
+// Prevent multiple conflicting definitions of swab from stdlib.h and unistd.h
 #if defined(__sun) || defined(sun)
 #if defined(_XPG4)
 #undef _XPG4
+#endif
+#if defined(_XPG3)
+#undef _XPG3
 #endif
 #endif
 

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -18,6 +18,12 @@ typedef unsigned __int8   uint8_t;
 #    undef _XOPEN_SOURCE
 #endif
 
+#if defined(__sun) || defined(sun)
+#if defined(_XPG4)
+#undef _XPG4
+#endif
+#endif
+
 #include <Python.h>
 
 #if PY_MAJOR_VERSION >= 3

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -25,6 +25,13 @@
 #    undef _XOPEN_SOURCE
 #endif
 
+
+#if defined(__sun) || defined(sun)
+#if defined(_XPG4)
+#undef _XPG4
+#endif
+#endif
+
 #include <Python.h>
 #include <numpy/ndarrayobject.h>
 

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -25,9 +25,13 @@
 #    undef _XOPEN_SOURCE
 #endif
 
+// Prevent multiple conflicting definitions of swab from stdlib.h and unistd.h
 #if defined(__sun) || defined(sun)
 #if defined(_XPG4)
 #undef _XPG4
+#endif
+#if defined(_XPG3)
+#undef _XPG3
 #endif
 #endif
 

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -25,7 +25,6 @@
 #    undef _XOPEN_SOURCE
 #endif
 
-
 #if defined(__sun) || defined(sun)
 #if defined(_XPG4)
 #undef _XPG4


### PR DESCRIPTION
on smartos will met below error when try to build:

In file included from /opt/local/include/python2.7/Python.h:44:0,

                 from src/mplutils.h:21,

                 from src/ft2font_wrapper.cpp:1:

/usr/include/unistd.h:521:75: error: declaration of C function 'void swab(const void*, void*, ssize_t)' conflicts with

In file included from /opt/local/include/python2.7/Python.h:42:0,

                 from src/mplutils.h:21,

                 from src/ft2font_wrapper.cpp:1:

/usr/include/stdlib.h:170:13: error: previous declaration 'void swab(const char*, char*, ssize_t)' here

error: command 'gcc' failed with exit status 1

Signed-off-by: Frank Yu <flyxiaoyu@gmail.com>