### PR TITLE
STYLE: make default Figure suptitle large, like Axes title.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1180,7 +1180,7 @@ defaultParams = {
 
     ## figure props
     # figure title
-    'figure.titlesize':   ['medium', validate_fontsize],
+    'figure.titlesize':   ['large', validate_fontsize],
     'figure.titleweight': ['normal', six.text_type],
 
     # figure size in inches: width by height

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -418,7 +418,7 @@ backend      : $TEMPLATE_BACKEND
 
 ### FIGURE
 # See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
-#figure.titlesize : medium     # size of the figure title
+#figure.titlesize : large      # size of the figure title (Figure.suptitle())
 #figure.titleweight : normal   # weight of the figure title
 #figure.figsize   : 6.4, 4.8   # figure size in inches
 #figure.dpi       : 100      # figure dots per inch


### PR DESCRIPTION
The present default is for the suptitle to be "medium", like the axis labels and tick labels, while the Axes title is "large".  I think the Figure suptitle should be at least as large and prominent as the Axes title, so this PR changes its default to "large"  This does not require changing any of the subplot positioning parameters.