### PR TITLE
Simplify get_legend_handler method

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -33,7 +33,8 @@ import numpy as np
 
 from matplotlib import rcParams
 from matplotlib.artist import Artist, allow_rasterization
-from matplotlib.cbook import (is_string_like, iterable, silent_list, safezip)
+from matplotlib.cbook import (is_string_like, iterable, silent_list, safezip,
+                              is_hashable)
 from matplotlib.font_manager import FontProperties
 from matplotlib.lines import Line2D
 from matplotlib.patches import Patch, Rectangle, Shadow, FancyBboxPatch
@@ -565,19 +566,19 @@ class Legend(Artist):
         method-resolution-order. If no matching key is found, it
         returns None.
         """
-        legend_handler_keys = list(six.iterkeys(legend_handler_map))
-        if orig_handle in legend_handler_keys:
-            handler = legend_handler_map[orig_handle]
-        else:
+        if is_hashable(orig_handle):
+            try:
+                return legend_handler_map[orig_handle]
+            except KeyError:
+                pass
 
-            for handle_type in type(orig_handle).mro():
-                if handle_type in legend_handler_map:
-                    handler = legend_handler_map[handle_type]
-                    break
-            else:
-                handler = None
+        for handle_type in type(orig_handle).mro():
+            try:
+                return legend_handler_map[handle_type]
+            except KeyError:
+                pass
 
-        return handler
+        return None
 
     def _init_legend_box(self, handles, labels, markerfirst=True):
         """


### PR DESCRIPTION
I have simplified the `get_legend_handler` method. There is no need to create list from keys of `legend_handler_map` and no need in two dictionary lookups (`if key in dict: return dict[key]`).
Loop can be optimized even more, but will result in a code bloat, which does not worth of saving few cpu cycles.
