### PR TITLE
Assume that tickers respect view limits.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -252,23 +252,19 @@ class Tick(artist.Artist):
             self.stale = False
             return
 
-        midPoint = mtransforms.interval_contains(self.get_view_interval(),
-                                                 self.get_loc())
+        renderer.open_group(self.__name__)
+        if self.gridOn:
+            self.gridline.draw(renderer)
+        if self.tick1On:
+            self.tick1line.draw(renderer)
+        if self.tick2On:
+            self.tick2line.draw(renderer)
 
-        if midPoint:
-            renderer.open_group(self.__name__)
-            if self.gridOn:
-                self.gridline.draw(renderer)
-            if self.tick1On:
-                self.tick1line.draw(renderer)
-            if self.tick2On:
-                self.tick2line.draw(renderer)
-
-            if self.label1On:
-                self.label1.draw(renderer)
-            if self.label2On:
-                self.label2.draw(renderer)
-            renderer.close_group(self.__name__)
+        if self.label1On:
+            self.label1.draw(renderer)
+        if self.label2On:
+            self.label2.draw(renderer)
+        renderer.close_group(self.__name__)
 
         self.stale = False
 


### PR DESCRIPTION
Tickers may return positions epsilon-outside of the view limits and we
don't want to drop them.

Fixes #6641.