### PR TITLE
adding a new color and editing an existing color in fivethirtyeight.mplstyle

### DIFF
--- a/examples/style_sheets/plot_fivethirtyeight.py
+++ b/examples/style_sheets/plot_fivethirtyeight.py
@@ -13,6 +13,9 @@ with plt.style.context('fivethirtyeight'):
     plt.plot(x, np.sin(x) + x + np.random.randn(50))
     plt.plot(x, np.sin(x) + 0.5 * x + np.random.randn(50))
     plt.plot(x, np.sin(x) + 2 * x + np.random.randn(50))
+    plt.plot(x, np.sin(x) - 0.5 * x + np.random.randn(50))
+    plt.plot(x, np.sin(x) - 2 * x + np.random.randn(50))
+    plt.plot(x, np.sin(x) + np.random.randn(50))
 
 
 plt.show()

--- a/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
@@ -6,7 +6,7 @@ lines.solid_capstyle: butt
 
 legend.fancybox: true
 
-axes.prop_cycle: cycler('color', ['30a2da', 'fc4f30', 'e5ae38', '6d904f', '8b8b8b'])
+axes.prop_cycle: cycler('color', ['008fd5', 'fc4f30', 'e5ae38', '6d904f', '8b8b8b', '810f7c'])
 axes.facecolor: f0f0f0
 axes.labelsize: large
 axes.axisbelow: true


### PR DESCRIPTION
### Modifying the example script to show all the colors:

<img width="1041" alt="screen shot 2016-06-26 at 23 46 20" src="https://cloud.githubusercontent.com/assets/884032/16368096/6366e5f2-3bf8-11e6-8936-e7455c46a509.png">

### Adding this new color: 
A live example is here: http://fivethirtyeight.com/features/when-will-everyone-i-know-be-married/?ex_cid=538twitter
<img width="898" alt="screen shot 2016-06-26 at 23 45 15" src="https://cloud.githubusercontent.com/assets/884032/16368097/63758030-3bf8-11e6-8a03-01913f34fcfc.png">

### Replacing an existing blue with a slightly more accurate one

<img width="924" alt="screen shot 2016-06-26 at 23 44 30" src="https://cloud.githubusercontent.com/assets/884032/16368098/6377b2a6-3bf8-11e6-8eff-bd3e3de29486.png">
