### PR TITLE
DOC: Incorrect rendering of dashes

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1075,7 +1075,7 @@ class Line2D(Artist):
 
         Parameters
         ----------
-        ls : { '-',  '--', '-.', ':'} and more see description
+        ls : { ``'-'``,  ``'--'``, ``'-.'``, ``':'``} and more see description
             The line style.
         """
         if not is_string_like(ls):


### PR DESCRIPTION
Without double-backticks, '--' renders as a single en-dash in sphinx. See parameters section: http://matplotlib.org/api/lines_api.html#matplotlib.lines.Line2D.set_linestyle