### PR TITLE
Guard against too-large figures

### DIFF
--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -11,6 +11,8 @@ from distutils.version import LooseVersion as V
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
+from nose.tools import assert_raises
+
 from matplotlib.image import imread
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
@@ -288,6 +290,13 @@ def test_agg_filter():
 
     ax.xaxis.set_visible(False)
     ax.yaxis.set_visible(False)
+
+
+@cleanup
+def test_too_large_image():
+    fig = plt.figure(figsize=(300, 1000))
+    buff = io.BytesIO()
+    assert_raises(ValueError, fig.savefig, buff)
 
 
 if __name__ == "__main__":

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -177,6 +177,15 @@ static int PyRendererAgg_init(PyRendererAgg *self, PyObject *args, PyObject *kwd
         return -1;
     }
 
+    if (width >= 1 << 16 || height >= 1 << 16) {
+        PyErr_Format(
+            PyExc_ValueError,
+            "Image size of %dx%d pixels is too large. "
+            "It must be less than 2^16 in each direction.",
+            width, height);
+        return -1;
+    }
+
     CALL_CPP_INIT("RendererAgg", self->x = new RendererAgg(width, height, dpi))
 
     return 0;


### PR DESCRIPTION
Agg buffers must have a max size of 2^16 pixels in each dimension.  This guards against that (and related segfaults from allocating too much memory).

Fixes https://github.com/ipython/ipython/issues/9676