### PR TITLE
Fix example of streamplot `start_points` option

### DIFF
--- a/examples/images_contours_and_fields/streamplot_demo_start_points.py
+++ b/examples/images_contours_and_fields/streamplot_demo_start_points.py
@@ -14,13 +14,13 @@ U, V = np.mgrid[-3:3:100j, 0:0:100j]
 
 seed_points = np.array([[-2, 0, 1], [-2, 0, 1]])
 
-fig0, ax0 = plt.subplots()
-strm = ax0.streamplot(X, Y, U, V, color=U, linewidth=2,
-                      cmap=plt.cm.autumn, start_points=seed_points.T)
-fig0.colorbar(strm.lines)
+fig, ax = plt.subplots()
+strm = ax.streamplot(X, Y, U, V, color=U, linewidth=2,
+                     cmap=plt.cm.autumn, start_points=seed_points.T)
+fig.colorbar(strm.lines)
 
-ax0.plot(seed_points[0], seed_points[1], 'bo')
+ax.plot(seed_points[0], seed_points[1], 'bo')
 
-ax0.axis((-3, 3, -3, 3))
+ax.axis((-3, 3, -3, 3))
 
 plt.show()

--- a/examples/images_contours_and_fields/streamplot_demo_start_points.py
+++ b/examples/images_contours_and_fields/streamplot_demo_start_points.py
@@ -7,12 +7,12 @@ an array of seed points to the `start_points` keyword argument.
 import numpy as np
 import matplotlib.pyplot as plt
 
-X, Y = (np.linspace(-3, 3, 100),
-        np.linspace(-3, 3, 100))
+Y, X = np.mgrid[-3:3:100j, -3:3:100j]
+U = -1 - X**2 + Y
+V = 1 + X - Y**2
 
-U, V = np.mgrid[-3:3:100j, 0:0:100j]
-
-seed_points = np.array([[-2, 0, 1], [-2, 0, 1]])
+# 5 points along the first diagonal and a point in the left upper quadrant
+seed_points = np.array([[-2, -1, 0, 1, 2, -1], [-2, -1,  0, 1, 2, 2]])
 
 fig, ax = plt.subplots()
 strm = ax.streamplot(X, Y, U, V, color=U, linewidth=2,

--- a/examples/images_contours_and_fields/streamplot_demo_start_points.py
+++ b/examples/images_contours_and_fields/streamplot_demo_start_points.py
@@ -1,12 +1,8 @@
 """
-Demo of the `streamplot` function.
+Demo of the streamplot function with starting points.
 
-A streamplot, or streamline plot, is used to display 2D vector fields. This
-example shows a few features of the stream plot function:
-
-    * Varying the color along a streamline.
-    * Varying the density of streamlines.
-    * Varying the line width along a stream line.
+This example shows how to fix the streamlines that are plotted, by passing
+an array of seed points to the `start_points` keyword argument.
 """
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
1/ Change the docstring, which was copy-pasted from the other example `streamplot_demo_features`, for something that should be more relevant and descriptive.

2/ Change `fig0` and `ax0`, for only `fig` and `ax` as they are the only instances. My guess is that the previous names were just a copy-pasting result too.

3/ I don't know why, but the vector field in this example was different from the one used in all the other streamplot examples: it was mode of simple horizontal streamlines. I copy-pasted the vector field  from `streamplot_demo_features` and added a few new seeds. The result seems more demonstrative to me: in the former example, one of the starting points was used to draw a very (very) short streamline, which puzzled me when trying to understand what the example was demonstrating.

The new example looks like:
![modified_examples_streamplot_start_points](https://cloud.githubusercontent.com/assets/17270724/16533143/f1965678-3fd6-11e6-9c6c-62347168f2f1.png)
