### PR TITLE
Docstring fix & small adjustements in `demo_affine_image`

### DIFF
--- a/examples/api/demo_affine_image.py
+++ b/examples/api/demo_affine_image.py
@@ -1,11 +1,12 @@
 """
 For the backends that supports draw_image with optional affine
 transform (e.g., agg, ps backend), the image of the output should
-have its boundary matches the red dashed rectangle.
+have its boundary matches the red dashed rectangle. The extent of
+the image without affine transform is additionally displayed with
+a black solid rectangle.
 """
 
 import numpy as np
-import matplotlib.cm as cm
 import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
@@ -21,6 +22,25 @@ def get_image():
     return Z
 
 
+def plot_extent(im, rect_lw=1.5, ls="-", color="Black", transform=None):
+    """Draws a rectangle denoting the extent of an image `im` altered by a
+    transform `transform`. Additional segment markers going through then
+    origin are also plotted.
+
+    `rect_lw` is the linewidth parameter used to the rectangle.
+    """
+    x1, x2, y1, y2 = im.get_extent()
+    ax = im.axes
+    if transform is None:  # then no specific transform will be applied
+        transform = ax.transData
+    # Plot the extent rectangle
+    ax.plot([x1, x2, x2, x1, x1], [y1, y1, y2, y2, y1], ls=ls, lw=rect_lw,
+            color=color, transform=transform)
+    # Plot the segments parallel to the rectangle sides & going through (0, 0)
+    ax.plot([x1, x2], [0, 0], ls=ls, color=color, transform=transform)
+    ax.plot([0, 0], [y1, y2], ls=ls, color=color, transform=transform)
+
+
 if 1:
 
     fig, ax1 = plt.subplots(1, 1)
@@ -29,16 +49,15 @@ if 1:
                      origin='lower',
                      extent=[-2, 4, -3, 2], clip_on=True)
 
-    # image rotation
+    # Image rotation
     trans_data2 = mtransforms.Affine2D().rotate_deg(30) + ax1.transData
     im1.set_transform(trans_data2)
 
-    # display intended extent of the image
-    x1, x2, y1, y2 = im1.get_extent()
-    x3, y3 = x2, y1
-
-    ax1.plot([x1, x2, x2, x1, x1], [y1, y1, y2, y2, y1], "--r", lw=3,
-             transform=trans_data2)
+    # Plot the extent of the image:
+    # 1/ With the affine transform.
+    plot_extent(im1, ls="--", rect_lw=3, color="Red", transform=trans_data2)
+    # 2/ Without the affine transform (see `plot_extent` defaults).
+    plot_extent(im1)
 
     ax1.set_xlim(-3, 5)
     ax1.set_ylim(-4, 4)

--- a/examples/api/demo_affine_image.py
+++ b/examples/api/demo_affine_image.py
@@ -1,7 +1,7 @@
 """
 For the backends that supports draw_image with optional affine
 transform (e.g., agg, ps backend), the image of the output should
-have its boundary matches the red rectangles.
+have its boundary matches the red dashed rectangle.
 """
 
 import numpy as np
@@ -23,14 +23,13 @@ def get_image():
 
 if 1:
 
-    # image rotation
-
     fig, ax1 = plt.subplots(1, 1)
     Z = get_image()
     im1 = ax1.imshow(Z, interpolation='none',
                      origin='lower',
                      extent=[-2, 4, -3, 2], clip_on=True)
 
+    # image rotation
     trans_data2 = mtransforms.Affine2D().rotate_deg(30) + ax1.transData
     im1.set_transform(trans_data2)
 
@@ -38,8 +37,10 @@ if 1:
     x1, x2, y1, y2 = im1.get_extent()
     x3, y3 = x2, y1
 
-    ax1.plot([x1, x2, x2, x1, x1], [y1, y1, y2, y2, y1], "--",
+    ax1.plot([x1, x2, x2, x1, x1], [y1, y1, y2, y2, y1], "--r", lw=3,
              transform=trans_data2)
 
     ax1.set_xlim(-3, 5)
     ax1.set_ylim(-4, 4)
+
+    plt.show()


### PR DESCRIPTION
1/ Makes the red rectangle announced in the docstring red in the plot. The docstring has also been precised a bit.

2/ I think the comment about the image rotation was misplaced so I moved it where it seemed relevant to me.

3/ Finally, I've made the line width of the rectangle a bit bigger to be more visible and added a call to `plt.show()`

The example should now looks like:
![modified_demo_affine_image](https://cloud.githubusercontent.com/assets/17270724/16533777/6632f1ae-3fdb-11e6-9b28-9ce547b12eef.png)

**Remark 1**: the colormap is not `viridis` because the colormap seems to default to `gnuplot2` in my conda env. I guess I had tweaked sthg and didn't remember it.

**Remark 2**: the red rectangle does not seem to be perfectly centered on the image: the 2 upper sides are mostly over the image, while the 2 lower sides are mostly out of it. Is it expected? 