### PR TITLE
Replaced hardcoded MSBuild with VCBuild

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1118,9 +1118,8 @@ class FreeType(SetupPackage):
             FREETYPE_BUILD_CMD = """\
 call "%ProgramFiles%\\Microsoft SDKs\\Windows\\v7.0\\Bin\\SetEnv.Cmd" /Release /{xXX} /xp
 call "{vcvarsall}" {xXX}
-set MSBUILD=C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\MSBuild.exe
 rd /S /Q %FREETYPE%\\objs
-%MSBUILD% %FREETYPE%\\builds\\windows\\{vc20xx}\\freetype.sln /t:Clean;Build /p:Configuration="{config}";Platform={WinXX}
+vcbuild /platform:{WinXX} "%FREETYPE%\\builds\\windows\\{vc20xx}\\freetype.sln" "{config}|{WinXX}"
 echo Build completed, moving result"
 :: move to the "normal" path for the unix builds...
 mkdir %FREETYPE%\\objs\\.libs


### PR DESCRIPTION
This fixes for me strange problem with VC2008 Express Edition (9.00.21022) and x64 build:

> The project consists entirely of configurations that require support for platforms which are not installed on this machine. The project cannot be loaded.

And it is looks better than hardcoded MSBuild.exe path.