### PR TITLE
Remove explicit children invalidation in update_position method

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -448,28 +448,16 @@ class XTick(Tick):
 
     def update_position(self, loc):
         'Set the location of tick in data coords with scalar *loc*'
-        x = loc
-
-        nonlinear = (hasattr(self.axes, 'yaxis') and
-                     self.axes.yaxis.get_scale() != 'linear' or
-                     hasattr(self.axes, 'xaxis') and
-                     self.axes.xaxis.get_scale() != 'linear')
-
         if self.tick1On:
-            self.tick1line.set_xdata((x,))
+            self.tick1line.set_xdata((loc,))
         if self.tick2On:
-            self.tick2line.set_xdata((x,))
+            self.tick2line.set_xdata((loc,))
         if self.gridOn:
-            self.gridline.set_xdata((x,))
+            self.gridline.set_xdata((loc,))
         if self.label1On:
-            self.label1.set_x(x)
+            self.label1.set_x(loc)
         if self.label2On:
-            self.label2.set_x(x)
-
-        if nonlinear:
-            self.tick1line._invalid = True
-            self.tick2line._invalid = True
-            self.gridline._invalid = True
+            self.label2.set_x(loc)
 
         self._loc = loc
         self.stale = True
@@ -582,28 +570,17 @@ class YTick(Tick):
         return l
 
     def update_position(self, loc):
-        'Set the location of tick in data coords with scalar loc'
-        y = loc
-
-        nonlinear = (hasattr(self.axes, 'yaxis') and
-                     self.axes.yaxis.get_scale() != 'linear' or
-                     hasattr(self.axes, 'xaxis') and
-                     self.axes.xaxis.get_scale() != 'linear')
-
+        'Set the location of tick in data coords with scalar *loc*'
         if self.tick1On:
-            self.tick1line.set_ydata((y,))
+            self.tick1line.set_ydata((loc,))
         if self.tick2On:
-            self.tick2line.set_ydata((y,))
+            self.tick2line.set_ydata((loc,))
         if self.gridOn:
-            self.gridline.set_ydata((y, ))
+            self.gridline.set_ydata((loc,))
         if self.label1On:
-            self.label1.set_y(y)
+            self.label1.set_y(loc)
         if self.label2On:
-            self.label2.set_y(y)
-        if nonlinear:
-            self.tick1line._invalid = True
-            self.tick2line._invalid = True
-            self.gridline._invalid = True
+            self.label2.set_y(loc)
 
         self._loc = loc
         self.stale = True


### PR DESCRIPTION
This invalidation actually does nothing as the `Line2D` does not have nor use the `_invalid` field. There are `_invalidx` and `_invalidy` fields for this purpose, but them are private members. Moreover, the `set_xdata` and `set_ydata` methods internally invalidate the state (what is more reasonable
then an external invalidation).