### PR TITLE
Don't convert vmin, vmax to floats.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -918,8 +918,6 @@ class Normalize(object):
         elif vmin > vmax:
             raise ValueError("minvalue must be less than or equal to maxvalue")
         else:
-            vmin = float(vmin)
-            vmax = float(vmax)
             if clip:
                 mask = np.ma.getmask(result)
                 result = np.ma.array(np.clip(result.filled(vmax), vmin, vmax),
@@ -938,8 +936,7 @@ class Normalize(object):
     def inverse(self, value):
         if not self.scaled():
             raise ValueError("Not invertible until scaled")
-        vmin = float(self.vmin)
-        vmax = float(self.vmax)
+        vmin, vmax = self.vmin, self.vmax
 
         if cbook.iterable(value):
             val = np.ma.asarray(value)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -194,6 +194,11 @@ def test_Normalize():
     _scalar_tester(norm, vals)
     _mask_tester(norm, vals)
 
+    # Don't lose precision on longdoubles (float128 on Linux).
+    vals = np.array([1.2345678901, 9.8765432109], dtype=np.longdouble)
+    norm = mcolors.Normalize(vals.min(), vals.max())
+    assert_array_equal(np.asarray(norm(vals)), [0, 1])
+
 
 def test_SymLogNorm():
     """

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -194,10 +194,15 @@ def test_Normalize():
     _scalar_tester(norm, vals)
     _mask_tester(norm, vals)
 
-    # Don't lose precision on longdoubles (float128 on Linux).
+    # Don't lose precision on longdoubles (float128 on Linux):
+    # for array inputs...
     vals = np.array([1.2345678901, 9.8765432109], dtype=np.longdouble)
     norm = mcolors.Normalize(vals.min(), vals.max())
     assert_array_equal(np.asarray(norm(vals)), [0, 1])
+    # and for scalar ones.
+    eps = np.finfo(np.longdouble).resolution
+    norm = plt.Normalize(1, 1 + 100 * eps)
+    assert_equal(norm(1 + 50 * eps), .5)
 
 
 def test_SymLogNorm():


### PR DESCRIPTION
They may be float128's in which case precision would be lost; this can
result in `Normalize` returning values (barely) outside of `[0, 1]`.

(The cast to `float` was introduced in 28e1d2, referring to bug 2997687
on SF; it may be worth checking what it was about.)

See #6698.