### PR TITLE
Colours like 'XeYYYY' don't get recognised properly if X, Y's are numbers

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -171,7 +171,11 @@ def _to_rgba_no_colorcycle(c, alpha=None):
             return tuple(color)
         # string gray.
         try:
-            return (float(c),) * 3 + (alpha if alpha is not None else 1.,)
+            fc = float(c)
+            if fc <= 1:
+                return (float(fc),) * 3 + (alpha if alpha is not None else 1.,)
+            else:
+                raise ValueError
         except ValueError:
             pass
         raise ValueError("Invalid RGBA argument: {!r}".format(orig_c))

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -171,11 +171,7 @@ def _to_rgba_no_colorcycle(c, alpha=None):
             return tuple(color)
         # string gray.
         try:
-            fc = float(c)
-            if fc <= 1:
-                return (float(fc),) * 3 + (alpha if alpha is not None else 1.,)
-            else:
-                raise ValueError
+            return (float(c),) * 3 + (alpha if alpha is not None else 1.,)
         except ValueError:
             pass
         raise ValueError("Invalid RGBA argument: {!r}".format(orig_c))

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -369,9 +369,6 @@ def validate_color(s):
         pass
 
     if isinstance(s, six.string_types):
-        if len(s) == 7 or len(s) == 9:
-            if is_color_like(s):
-                return s
         if len(s) == 6 or len(s) == 8:
             stmp = '#' + s
             if is_color_like(stmp):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -367,12 +367,19 @@ def validate_color(s):
             return 'None'
     except AttributeError:
         pass
+
+    if isinstance(s, six.string_types):
+        if len(s) == 7 or len(s) == 9:
+            if is_color_like(s):
+                return s
+        if len(s) == 6 or len(s) == 8:
+            stmp = '#' + s
+            if is_color_like(stmp):
+                return stmp
+
     if is_color_like(s):
         return s
-    stmp = '#' + s
 
-    if is_color_like(stmp):
-        return stmp
     # If it is still valid, it must be a tuple.
     colorarg = s
     msg = ''

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -618,8 +618,9 @@ def test_cn():
     matplotlib.rcParams['axes.prop_cycle'] = cycler('color', ['8e4585', 'r'])
 
     assert mcolors.to_hex("C0") == '#8e4585'
-    # if '8e4585' gets parsed as a float before it gets detected as a hex colour it will be interpreted as a very
-    # large number. this mustn't happen.
+    # if '8e4585' gets parsed as a float before it gets detected as a hex
+    # colour it will be interpreted as a very large number.
+    # this mustn't happen.
     assert mcolors.to_rgb("C0")[0] != np.inf
 
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
 from nose.plugins.skip import SkipTest
 
-from cycler import cycler
+from matplotlib import cycler
 import matplotlib
 import matplotlib.colors as mcolors
 import matplotlib.cm as cm
@@ -614,6 +614,13 @@ def test_cn():
                                                     ['xkcd:blue', 'r'])
     assert mcolors.to_hex("C0") == '#0343df'
     assert mcolors.to_hex("C1") == '#ff0000'
+
+    matplotlib.rcParams['axes.prop_cycle'] = cycler('color', ['8e4585', 'r'])
+
+    assert mcolors.to_hex("C0") == '#8e4585'
+    # if '8e4585' gets parsed as a float before it gets detected as a hex colour it will be interpreted as a very
+    # large number. this mustn't happen.
+    assert mcolors.to_rgb("C0")[0] != np.inf
 
 
 def test_conversions():


### PR DESCRIPTION
`'8e1245'` gets recognised as `8*10^(1245)`. While this is intended behaviour, all around `matplotlib` there seems to be some ambiguity as to whether hex colours should have a trailing hash (e.g.: `hex2color` fails **without** hash while colours in a `cycler` in a stylesheet fail **with** a hash).

This patch doesn't fix cases such as `0e1123` because they get interpreted as `0.0` so it probably needs a more fundamental decision.

Thoughts?