### PR TITLE
fixed font_manager.is_opentype_cff_font()

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1352,7 +1352,7 @@ def is_opentype_cff_font(filename):
         if result is None:
             with open(filename, 'rb') as fd:
                 tag = fd.read(4)
-            result = (tag == 'OTTO')
+            result = (tag == b'OTTO')
             _is_opentype_cff_font_cache[filename] = result
         return result
     return False


### PR DESCRIPTION
`font_manager.is_opentype_cff_font()` gives false result because compares bytes to str. This won't cause trouble in Py2, but in Py3 results in calling `EmbedTTFType3`, and makes impossible to use CFF fonts. With setting the literal to type of bytes, it works fine.