### PR TITLE
Add missing cleanup decorator to test_bar_color_cycle

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4555,6 +4555,7 @@ def test_large_offset():
     fig.canvas.draw()
 
 
+@cleanup
 def test_bar_color_cycle():
     ccov = mcolors.colorConverter.to_rgb
     fig, ax = plt.subplots()


### PR DESCRIPTION
Should fix the issue noted in #6707 This cleanup decorator is there on 2.x so no need to backport. I guess it was lost during a merge conflict or similar