### PR TITLE
register IPython's eventloop integration in plt.install_repl_displayhook

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -121,7 +121,8 @@ def install_repl_displayhook():
     Install a repl display hook so that any stale figure are automatically
     redrawn when control is returned to the repl.
 
-    This works with both IPython terminals and vanilla python shells.
+    This works with IPython terminals and kernels,
+    as well as vanilla python shells.
     """
     global _IP_REGISTERED
     global _INSTALL_FIG_OBSERVER
@@ -154,6 +155,13 @@ def install_repl_displayhook():
 
             _IP_REGISTERED = post_execute
             _INSTALL_FIG_OBSERVER = False
+
+            # trigger IPython's eventloop integration, if available
+            from IPython.core.pylabtools import backend2gui
+
+            ipython_gui_name = backend2gui.get(get_backend())
+            if ipython_gui_name:
+                ip.enable_gui(ipython_gui_name)
         else:
             _INSTALL_FIG_OBSERVER = True
 


### PR DESCRIPTION
Registers eventloop integration for IPython on setup, avoiding hangs when IPython hasn't been told about matplotlib prior to plotting.

The IPython kernel (notebook, qtcosole) has always needed this to avoid hangs if plotting happens prior to `%matplotlib` magic, but it was less important for terminal IPython < 5.0. Terminal IPython 5.0's adoption of prompt_toolkit means that it has the same eventloop requirements of the kernel, so it's now important in both contexts to avoid hangs.

cc @tacaswell