### PR TITLE
Added missing side tick rcParams

### DIFF
--- a/doc/users/whats_new/ticks_rcparams.rst
+++ b/doc/users/whats_new/ticks_rcparams.rst
@@ -5,6 +5,11 @@ The parameters ``xtick.top``, ``xtick.bottom``, ``ytick.left``
 and ``ytick.right`` were added to control where the ticks
 are drawn.
 
+Furthermore, the parameters ``xtick.major.top``, ``xtick.major.bottom``,
+``xtick.minor.top``, ``xtick.minor.bottom``, ``ytick.major.left``,
+``ytick.major.right``, ``ytick.minor.left``, and ``ytick.minor.right`` were
+added to control were ticks are drawn.
+
 ``hist.bins`` to control the default number of bins to use in
 `~matplotlib.axes.Axes.hist`.  This can be an `int`, a list of floats, or
 ``'auto'`` if numpy >= 1.11 is installed.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -566,11 +566,26 @@ class _AxesBase(martist.Artist):
         if self.yaxis is not None:
             self._ycid = self.yaxis.callbacks.connect('units finalize',
                                                       self.relim)
-        self.tick_params(top=rcParams['xtick.top'],
-                         bottom=rcParams['xtick.bottom'],
-                         left=rcParams['ytick.left'],
-                         right=rcParams['ytick.right'],
-                         which='both')
+
+        self.tick_params(top=rcParams['xtick.top'] and
+                         rcParams['xtick.minor.top'],
+                         bottom=rcParams['xtick.bottom'] and
+                         rcParams['xtick.minor.bottom'],
+                         left=rcParams['ytick.left'] and
+                         rcParams['ytick.minor.left'],
+                         right=rcParams['ytick.right'] and
+                         rcParams['ytick.minor.right'],
+                         which='minor')
+
+        self.tick_params(top=rcParams['xtick.top'] and
+                         rcParams['xtick.major.top'],
+                         bottom=rcParams['xtick.bottom'] and
+                         rcParams['xtick.major.bottom'],
+                         left=rcParams['ytick.left'] and
+                         rcParams['ytick.major.left'],
+                         right=rcParams['ytick.right'] and
+                         rcParams['ytick.major.right'],
+                         which='major')
 
     def __setstate__(self, state):
         self.__dict__ = state

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -567,25 +567,19 @@ class _AxesBase(martist.Artist):
             self._ycid = self.yaxis.callbacks.connect('units finalize',
                                                       self.relim)
 
-        self.tick_params(top=rcParams['xtick.top'] and
-                         rcParams['xtick.minor.top'],
-                         bottom=rcParams['xtick.bottom'] and
-                         rcParams['xtick.minor.bottom'],
-                         left=rcParams['ytick.left'] and
-                         rcParams['ytick.minor.left'],
-                         right=rcParams['ytick.right'] and
-                         rcParams['ytick.minor.right'],
-                         which='minor')
+        self.tick_params(
+            top=rcParams['xtick.top'] and rcParams['xtick.minor.top'],
+            bottom=rcParams['xtick.bottom'] and rcParams['xtick.minor.bottom'],
+            left=rcParams['ytick.left'] and rcParams['ytick.minor.left'],
+            right=rcParams['ytick.right'] and rcParams['ytick.minor.right'],
+            which='minor')
 
-        self.tick_params(top=rcParams['xtick.top'] and
-                         rcParams['xtick.major.top'],
-                         bottom=rcParams['xtick.bottom'] and
-                         rcParams['xtick.major.bottom'],
-                         left=rcParams['ytick.left'] and
-                         rcParams['ytick.major.left'],
-                         right=rcParams['ytick.right'] and
-                         rcParams['ytick.major.right'],
-                         which='major')
+        self.tick_params(
+            top=rcParams['xtick.top'] and rcParams['xtick.major.top'],
+            bottom=rcParams['xtick.bottom'] and rcParams['xtick.major.bottom'],
+            left=rcParams['ytick.left'] and rcParams['ytick.major.left'],
+            right=rcParams['ytick.right'] and rcParams['ytick.major.right'],
+            which='major')
 
     def __setstate__(self, state):
         self.__dict__ = state

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -243,6 +243,10 @@ xtick.minor.pad      : 4      # distance to the minor tick label in points
 xtick.color          : k      # color of the tick labels
 xtick.labelsize      : medium # fontsize of the tick labels
 xtick.direction      : in     # direction: in, out, or inout
+xtick.major.top      : True   # draw x axis top major ticks
+xtick.major.bottom   : True   # draw x axis bottom major ticks
+xtick.minor.top      : True   # draw x axis top minor ticks
+xtick.minor.bottom   : True   # draw x axis bottom minor ticks
 
 ytick.left           : True   # draw ticks on the left side
 ytick.right          : True   # draw ticks on the right side
@@ -256,7 +260,10 @@ ytick.minor.pad      : 4      # distance to the minor tick label in points
 ytick.color          : k      # color of the tick labels
 ytick.labelsize      : medium # fontsize of the tick labels
 ytick.direction      : in     # direction: in, out, or inout
-
+ytick.major.left     : True   # draw y axis left major ticks
+ytick.major.right    : True   # draw y axis right major ticks
+ytick.minor.left     : True   # draw y axis left minor ticks
+ytick.minor.right    : True   # draw y axis right minor ticks
 
 ### GRIDS
 grid.color       :   k       # grid color

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1174,12 +1174,10 @@ defaultParams = {
     'xtick.minor.pad':   [3.4, validate_float],    # distance to label in points
     'xtick.color':       ['k', validate_color],  # color of the xtick labels
     'xtick.minor.visible':   [False, validate_bool],    # visiablility of the x axis minor ticks
-
-    'xtick.minor.top':   [True, validate_bool],        # visability of the x axis top minor ticks
-    'xtick.minor.bottom':    [True, validate_bool],    # visability of the x axis bottom minor ticks
-    'xtick.major.top':   [True, validate_bool],        # visability of the x axis top major ticks
-    'xtick.major.bottom':    [True, validate_bool],    # visability of the x axis bottom major ticks
-
+    'xtick.minor.top':   [True, validate_bool],  # draw x axis top minor ticks
+    'xtick.minor.bottom':    [True, validate_bool],    # draw x axis bottom minor ticks
+    'xtick.major.top':   [True, validate_bool],  # draw x axis top major ticks
+    'xtick.major.bottom':    [True, validate_bool],    # draw x axis bottom major ticks
 
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
@@ -1195,11 +1193,10 @@ defaultParams = {
     'ytick.minor.pad':   [3.4, validate_float],     # distance to label in points
     'ytick.color':       ['k', validate_color],   # color of the ytick labels
     'ytick.minor.visible':   [False, validate_bool],    # visiablility of the y axis minor ticks
-
-    'ytick.minor.left':   [True, validate_bool],  # visability of the y axis top minor ticks
-    'ytick.minor.right':    [True, validate_bool],    # visability of the y axis bottom minor ticks
-    'ytick.major.left':   [True, validate_bool],        # visability of the y axis top major ticks
-    'ytick.major.right':    [True, validate_bool],    # visability of the y axis bottom major ticks
+    'ytick.minor.left':   [True, validate_bool],  # draw y axis left minor ticks
+    'ytick.minor.right':    [True, validate_bool],    # draw y axis right minor ticks
+    'ytick.major.left':   [True, validate_bool],  # draw y axis left major ticks
+    'ytick.major.right':    [True, validate_bool],    # draw y axis right major ticks
 
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1175,6 +1175,12 @@ defaultParams = {
     'xtick.color':       ['k', validate_color],  # color of the xtick labels
     'xtick.minor.visible':   [False, validate_bool],    # visiablility of the x axis minor ticks
 
+    'xtick.minor.top':   [True, validate_bool],        # visability of the x axis top minor ticks
+    'xtick.minor.bottom':    [True, validate_bool],    # visability of the x axis bottom minor ticks
+    'xtick.major.top':   [True, validate_bool],        # visability of the x axis top major ticks
+    'xtick.major.bottom':    [True, validate_bool],    # visability of the x axis bottom major ticks
+
+
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
     'xtick.direction':   ['out', six.text_type],            # direction of xticks
@@ -1189,6 +1195,11 @@ defaultParams = {
     'ytick.minor.pad':   [3.4, validate_float],     # distance to label in points
     'ytick.color':       ['k', validate_color],   # color of the ytick labels
     'ytick.minor.visible':   [False, validate_bool],    # visiablility of the y axis minor ticks
+
+    'ytick.minor.left':   [True, validate_bool],  # visability of the y axis top minor ticks
+    'ytick.minor.right':    [True, validate_bool],    # visability of the y axis bottom minor ticks
+    'ytick.major.left':   [True, validate_bool],        # visability of the y axis top major ticks
+    'ytick.major.right':    [True, validate_bool],    # visability of the y axis bottom major ticks
 
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4129,6 +4129,30 @@ def test_rc_tick():
 
 
 @cleanup
+def test_rc_major_minor_tick():
+    d = {'xtick.top': True, 'ytick.right': True,  # Enable all ticks
+         'xtick.bottom': True, 'ytick.left': True,
+         # Selectively disable
+         'xtick.minor.bottom': False, 'xtick.major.bottom': False,
+         'ytick.major.left': False, 'ytick.minor.left': False}
+    with plt.rc_context(rc=d):
+        fig = plt.figure()
+        ax1 = fig.add_subplot(1, 1, 1)
+        xax = ax1.xaxis
+        yax = ax1.yaxis
+        # tick1On bottom/left
+        assert xax._major_tick_kw['tick1On'] == False
+        assert xax._major_tick_kw['tick2On'] == True
+        assert xax._minor_tick_kw['tick1On'] == False
+        assert xax._minor_tick_kw['tick2On'] == True
+
+        assert yax._major_tick_kw['tick1On'] == False
+        assert yax._major_tick_kw['tick2On'] == True
+        assert yax._minor_tick_kw['tick1On'] == False
+        assert yax._minor_tick_kw['tick2On'] == True
+
+
+@cleanup
 def test_bar_negative_width():
     fig, ax = plt.subplots()
     res = ax.bar(range(1, 5), range(1, 5), width=-1)

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -373,6 +373,10 @@ backend      : $TEMPLATE_BACKEND
 #xtick.labelsize      : medium # fontsize of the tick labels
 #xtick.direction      : out    # direction: in, out, or inout
 #xtick.minor.visible  : False  # visibility of minor ticks on x-axis
+#xtick.major.top      : True   # draw x axis top major ticks
+#xtick.major.bottom   : True   # draw x axis bottom major ticks
+#xtick.minor.top      : True   # draw x axis top minor ticks
+#xtick.minor.bottom   : True   # draw x axis bottom minor ticks
 
 #ytick.left           : True   # draw ticks on the left side
 #ytick.right          : False  # draw ticks on the right side
@@ -386,6 +390,10 @@ backend      : $TEMPLATE_BACKEND
 #ytick.labelsize      : medium # fontsize of the tick labels
 #ytick.direction      : out    # direction: in, out, or inout
 #ytick.minor.visible  : False  # visibility of minor ticks on y-axis
+#xtick.major.left     : True   # draw y axis left major ticks
+#xtick.major.right    : True   # draw y axis right major ticks
+#xtick.minor.left     : True   # draw y axis left minor ticks
+#xtick.minor.right    : True   # draw y axis right minor ticks
 
 
 ### GRIDS


### PR DESCRIPTION
Addresses #6691.

Adds `<x/y>tick.<major/minor>.*` for configuring which side ticks are drawn via rcParams.

Per this change, similar tags like `xtick.top` and `xtick.minor.top` are `and`'ed to get the actual tick draw status.