### PR TITLE
Missing `cleanup` decorator in `test_subplots.test_exceptions`

### DIFF
--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -108,7 +108,7 @@ def test_exceptions():
     assert_raises(ValueError, plt.subplots, 2, 2, sharex='blah')
     assert_raises(ValueError, plt.subplots, 2, 2, sharey='blah')
     # We filter warnings in this test which are genuine since
-    # the pount of this test is to ensure that this raises.
+    # the point of this test is to ensure that this raises.
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore',
                                 message='.*sharex\ argument\ to\ subplots',

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -102,7 +102,7 @@ def test_shared():
     check_visible(axs, [False, False, True, True], [True, False, True, False])
 
 
-
+@cleanup
 def test_exceptions():
     # TODO should this test more options?
     assert_raises(ValueError, plt.subplots, 2, 2, sharex='blah')

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -129,16 +129,6 @@ def test_subplots_offsettext():
     axes[1, 1].plot(y, x)
 
 
-@cleanup
-def test_subplots():
-    # things to test
-    # - are axes actually shared?
-    # - are tickmarks correctly hidden?
-    test_shared()
-    # - are exceptions thrown correctly
-    test_exceptions()
-
-
 if __name__ == "__main__":
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
`pytest` fails in `test_subplots.test_subplots_offsettext` because of missing cleanup, while `nose` is fine