### PR TITLE
explicitly select cell after figure on shift-enter

### DIFF
--- a/lib/matplotlib/backends/web_backend/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/nbagg_mpl.js
@@ -164,12 +164,9 @@ mpl.figure.prototype._key_event_extra = function(event, name) {
     // Check for shift+enter
     if (event.shiftKey && event.which == 13) {
         this.canvas_div.blur();
-        event.shiftKey = false;
-        // Send a "J" for go to next cell
-        event.which = 74;
-        event.keyCode = 74;
-        manager.command_mode();
-        manager.handle_keydown(event);
+        // select the cell after this one
+        var index = IPython.notebook.find_cell_index(this.cell_info[0]);
+        IPython.notebook.select(index + 1);
     }
 }
 


### PR DESCRIPTION
rather than triggering select-next via `j` keystroke without checking what cell is currently selected. Further, if the user has custom shortcuts hitting `j` can trigger any arbitrary action.

Fixes the apparent shift-enter skipping a cell discussed in jupyter/notebook#1124.

closes jupyter/notebook#1124

cc @tacaswell 