### PR TITLE
Don't warn when legend() finds no labels.

### DIFF
--- a/doc/api/api_changes/2016-09-28-AL_emptylegend.rst
+++ b/doc/api/api_changes/2016-09-28-AL_emptylegend.rst
@@ -1,0 +1,5 @@
+Removal of warning on empty legends
+```````````````````````````````````
+
+``plt.legend`` used to issue a warning when no labeled artist could be found.
+This warning has been removed.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -531,8 +531,6 @@ class Axes(_AxesBase):
         elif len(args) == 0:
             handles, labels = self.get_legend_handles_labels(handlers)
             if not handles:
-                warnings.warn("No labelled objects found. "
-                              "Use label='...' kwarg on individual plots.")
                 return None
 
         # One argument. User defined labels - automatic handle detection.


### PR DESCRIPTION
There's no warning when calling `plot([])`, so I don't see why there should be
one when calling `legend()` with no labeled artists either (except for catching
basic bugs where someone forgets to pass `label=...`, but such errors are
pretty obvious visually anyways and the warning doesn't help when only *some*
labels are missing).

Typical use case: making a complicated plot with a lot of elements which each
may or may not have a label; now I need to separately keep track of whether I
actually *did* add a label before deciding whether to call `legend()` at the
end.