### PR TITLE
DOC: clean up of demo_annotation_box.py

### DIFF
--- a/examples/pylab_examples/demo_annotation_box.py
+++ b/examples/pylab_examples/demo_annotation_box.py
@@ -1,18 +1,21 @@
 import matplotlib.pyplot as plt
-from matplotlib.offsetbox import TextArea, DrawingArea, OffsetImage, \
-    AnnotationBbox
+import numpy as np
+
+from matplotlib.patches import Circle
+from matplotlib.offsetbox import (TextArea, DrawingArea, OffsetImage,
+                                  AnnotationBbox)
 from matplotlib.cbook import get_sample_data
 
-import numpy as np
 
 if 1:
     fig, ax = plt.subplots()
 
-    offsetbox = TextArea("Test 1", minimumdescent=False)
-
+    # Define a 1st position to annotate (display it with a marker)
     xy = (0.5, 0.7)
-
     ax.plot(xy[0], xy[1], ".r")
+
+    # Annotate the 1st position with a text box ('Test 1')
+    offsetbox = TextArea("Test 1", minimumdescent=False)
 
     ab = AnnotationBbox(offsetbox, xy,
                         xybox=(-20, 40),
@@ -21,6 +24,7 @@ if 1:
                         arrowprops=dict(arrowstyle="->"))
     ax.add_artist(ab)
 
+    # Annotate the 1st position with another text box ('Test')
     offsetbox = TextArea("Test", minimumdescent=False)
 
     ab = AnnotationBbox(offsetbox, xy,
@@ -31,12 +35,14 @@ if 1:
                         arrowprops=dict(arrowstyle="->"))
     ax.add_artist(ab)
 
-    from matplotlib.patches import Circle
+    # Define a 2nd position to annotate (don't display with a marker this time)
+    xy = [0.3, 0.55]
+
+    # Annotate the 2nd position with a circle patch
     da = DrawingArea(20, 20, 0, 0)
     p = Circle((10, 10), 10)
     da.add_artist(p)
 
-    xy = [0.3, 0.55]
     ab = AnnotationBbox(da, xy,
                         xybox=(1.02, xy[1]),
                         xycoords='data',
@@ -46,6 +52,7 @@ if 1:
 
     ax.add_artist(ab)
 
+    # Annotate the 2nd position with an image (a generated array of pixels)
     arr = np.arange(100).reshape((10, 10))
     im = OffsetImage(arr, zoom=2)
     im.image.axes = ax
@@ -59,11 +66,9 @@ if 1:
 
     ax.add_artist(ab)
 
-    # another image
-
-    from matplotlib._png import read_png
+    # Annotate the 2nd position with another image (a Grace Hopper portrait)
     fn = get_sample_data("grace_hopper.png", asfileobj=False)
-    arr_img = read_png(fn)
+    arr_img = plt.imread(fn, format='png')
 
     imagebox = OffsetImage(arr_img, zoom=0.2)
     imagebox.image.axes = ax
@@ -73,14 +78,15 @@ if 1:
                         xycoords='data',
                         boxcoords="offset points",
                         pad=0.5,
-                        arrowprops=dict(arrowstyle="->",
-                                        connectionstyle="angle,angleA=0,angleB=90,rad=3")
+                        arrowprops=dict(
+                            arrowstyle="->",
+                            connectionstyle="angle,angleA=0,angleB=90,rad=3")
                         )
 
     ax.add_artist(ab)
 
+    # Fix the display limits to see everything
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
 
-    plt.draw()
     plt.show()


### PR DESCRIPTION
Clean up of `pylab_examples/demo_annotation_box.py`:
- moves all imports to the head of the script;
- reorganizes and adds comments to make the different steps more obvious;
- removes the final `plt.draw` call;
- loads Grace Hopper's portrait with `plt.imread` instead of `_png.read_png`, which (at least) avoids an additional import (besides, is the `_png` supposed to be exposed in a pylab example?).