### PR TITLE
Raise lock timeout as actual exception

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2577,10 +2577,11 @@ else:
         return np.copyto(a, values, where=mask)
 
 _lockstr = """\
-LOCKERROR: matplotlib is trying to acquire the lock {!r}
+LOCKERROR: matplotlib is trying to acquire the lock
+    {!r}
 and has failed.  This maybe due to any other process holding this
 lock.  If you are sure no other matplotlib process in running try
-removing this folder(s) and trying again.
+removing these folders and trying again.
 """
 
 
@@ -2598,6 +2599,9 @@ class Locked(object):
     """
     LOCKFN = '.matplotlib_lock'
 
+    class TimeoutError(RuntimeError):
+        pass
+
     def __init__(self, path):
         self.path = path
         self.end = "-" + str(os.getpid())
@@ -2607,18 +2611,17 @@ class Locked(object):
 
     def __enter__(self):
         retries = 50
-        sleeptime = 1
+        sleeptime = 0.1
         while retries:
             files = glob.glob(self.pattern)
             if files and not files[0].endswith(self.end):
                 time.sleep(sleeptime)
-                sleeptime *= 1.1
                 retries -= 1
             else:
                 break
         else:
             err_str = _lockstr.format(self.pattern)
-            raise RuntimeError(err_str)
+            raise self.TimeoutError(err_str)
 
         if not files:
             try:

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2580,7 +2580,7 @@ _lockstr = """\
 LOCKERROR: matplotlib is trying to acquire the lock
     {!r}
 and has failed.  This maybe due to any other process holding this
-lock.  If you are sure no other matplotlib process in running try
+lock.  If you are sure no other matplotlib process is running try
 removing these folders and trying again.
 """
 

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1446,6 +1446,8 @@ else:
             else:
                 fontManager.default_size = None
                 verbose.report("Using fontManager instance from %s" % _fmcache)
+        except cbook.Locked.TimeoutError:
+            raise
         except:
             _rebuild()
     else:


### PR DESCRIPTION
Fix #3655.

I haven't been able to directly reproduce #3655, so this is all based on theory, but given the symptoms and what we know about it, I'm reasonably certain about what is happening.

If a lock directory accidentally remains on disk in the `~/.cache/matplotlib` directory from a previous run, it will wait around 90 seconds waiting for the lock to go away, and then timeout.  When it times out, it simply tries again (once), and ultimately fails silently to write the file to disk.

The solution here is to:

1. Make the timeout much shorter -- this only needs to live for the time it takes to write a ~1MB json file to disk
2. Make the timeout a custom exception so we can handle it specially and let it bubble all the way out to the user (we still want to handle any other exception as a problem with font files and forcing a rebuild)