### PR TITLE
Fix tutorial pyplot scales (issue #6775)

### DIFF
--- a/doc/pyplots/pyplot_scales.py
+++ b/doc/pyplots/pyplot_scales.py
@@ -31,7 +31,7 @@ plt.grid(True)
 # symmetric log
 plt.subplot(223)
 plt.plot(x, y - y.mean())
-plt.yscale('symlog', linthreshy=0.05)
+plt.yscale('symlog', linthreshy=0.01)
 plt.title('symlog')
 plt.grid(True)
 

--- a/doc/pyplots/pyplot_scales.py
+++ b/doc/pyplots/pyplot_scales.py
@@ -1,6 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
+from matplotlib.ticker import NullFormatter  # useful for `logit` scale
+
 # make up some data in the interval ]0, 1[
 y = np.random.normal(loc=0.5, scale=0.4, size=1000)
 y = y[(y > 0) & (y < 1)]
@@ -39,5 +41,12 @@ plt.plot(x, y)
 plt.yscale('logit')
 plt.title('logit')
 plt.grid(True)
+# Format the minor tick labels of the y-axis into empty string with
+# the `NullFormatter`, to avoid cumbering it with too many labels.
+plt.gca().yaxis.set_minor_formatter(NullFormatter())
+# Adjust the subplot layout, because the logit one may take more space than
+# usual, due to y-tick labels like "1 - 10^3"
+plt.subplots_adjust(top=0.92, bottom=0.08, left=0.10, right=0.95, hspace=0.25,
+                    wspace=0.35)
 
 plt.show()


### PR DESCRIPTION
Fix #6775.

The issue reports among other things a poor choice of x-ticks. However, this seems to be OK in the devdocs version ([http://matplotlib.org/devdocs/users/pyplot_tutorial.html]())

I suppressed the minor y tick labels in the case of the logit scale, to keep only the major ones. To do so, I used a `NullFormatter`: _is it OK for a pyplot tutorial_? First I wanted to simply use `plt.minorticks_off` but it hides the nice feature of the logit scale, which is to be log in some range and linear in another range.

Furthermore, I slightly tweaked the `linthreshy` value in the case of the symlog case, to avoid overlapping some of the y tick labels.

The current PR should produce things similar to
![example_with_plt_subplots_adjust](https://cloud.githubusercontent.com/assets/17270724/16902313/028cc4f8-4c5c-11e6-8688-04f58c301649.png)
I precise “similar” because depending on the random samples, the tick range of the axes may be different.

PS: I got weird crashes when trying to use `plt.tight_layout` to adjust the subplots. I'll see if it comes from my machine or is a real issue, and I will open report another issue in the latter case. And for the moment, I have simply defined by hand some correct values in `plt.subplots_adjust`.
