### PR TITLE
[MRG+2] Call _transform_vmin_vmax during SymLogNorm.__init__

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1054,6 +1054,8 @@ class SymLogNorm(Normalize):
         Normalize.__init__(self, vmin, vmax, clip)
         self.linthresh = float(linthresh)
         self._linscale_adj = (linscale / (1.0 - np.e ** -1))
+        if vmin is not None and vmax is not None:
+            self._transform_vmin_vmax()
 
     def __call__(self, value, clip=None):
         if clip is None:

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -224,8 +224,12 @@ def test_SymLogNorm():
     normed_vals = norm(vals)
     assert_array_almost_equal(normed_vals, expected)
     
-    # Ensure that a SymLogNorm object can be used in a colorbar
-    # without directly calling it on an array.
+
+@cleanup
+def test_SymLogNorm_colorbar():
+    """
+    Test un-called SymLogNorm in a colorbar.
+    """
     norm = mcolors.SymLogNorm(0.1, vmin=-1, vmax=1, linscale=1)
     fig = plt.figure()
     cbar = mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -22,6 +22,7 @@ from matplotlib import cycler
 import matplotlib
 import matplotlib.colors as mcolors
 import matplotlib.cm as cm
+import matplotlib.colorbar as mcolorbar
 import matplotlib.cbook as cbook
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import (image_comparison,
@@ -222,6 +223,13 @@ def test_SymLogNorm():
     norm = mcolors.SymLogNorm(3, vmin=-30, vmax=5, linscale=1.2)
     normed_vals = norm(vals)
     assert_array_almost_equal(normed_vals, expected)
+    
+    # Ensure that a SymLogNorm object can be used in a colorbar
+    # without directly calling it on an array.
+    norm = mcolors.SymLogNorm(0.1, vmin=-1, vmax=1, linscale=1)
+    fig = plt.figure()
+    cbar = mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
+    plt.close(fig)
 
 
 def _inverse_tester(norm_instance, vals):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -223,7 +223,7 @@ def test_SymLogNorm():
     norm = mcolors.SymLogNorm(3, vmin=-30, vmax=5, linscale=1.2)
     normed_vals = norm(vals)
     assert_array_almost_equal(normed_vals, expected)
-    
+
 
 @cleanup
 def test_SymLogNorm_colorbar():


### PR DESCRIPTION
A fix for #6750
