### PR TITLE
Allow creating annotation arrows w/ default props.

### DIFF
--- a/doc/users/whats_new/annotation-default-arrow.rst
+++ b/doc/users/whats_new/annotation-default-arrow.rst
@@ -1,0 +1,5 @@
+Annotation can use a default arrow style
+----------------------------------------
+
+Annotations now use the default arrow style when setting `arrowprops={}`,
+rather than no arrow (the new behavior actually matches the documentation).

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -183,6 +183,16 @@ def test_basic_annotate():
                 xytext=(3, 3), textcoords='offset points')
 
 
+@cleanup
+def test_annotate_default_arrow():
+    # Check that we can make an annotation arrow with only default properties.
+    fig, ax = plt.subplots()
+    ann = ax.annotate("foo", (0, 1), xytext=(2, 3))
+    assert ann.arrow_patch is None
+    ann = ax.annotate("foo", (0, 1), xytext=(2, 3), arrowprops={})
+    assert ann.arrow_patch is not None
+
+
 @image_comparison(baseline_images=['polar_axes'])
 def test_polar_annotations():
     # you can specify the xypoint and the xytext in different

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -2151,7 +2151,7 @@ class Annotation(Text, _AnnotationBase):
 
         self.arrow = None
 
-        if arrowprops:
+        if arrowprops is not None:
             if "arrowstyle" in arrowprops:
                 arrowprops = self.arrowprops.copy()
                 self._arrow_relpos = arrowprops.pop("relpos", (0.5, 0.5))
@@ -2220,7 +2220,7 @@ class Annotation(Text, _AnnotationBase):
         ox0, oy0 = self._get_xy_display()
         ox1, oy1 = xy_pixel
 
-        if self.arrowprops:
+        if self.arrowprops is not None:
             x0, y0 = xy_pixel
             l, b, w, h = Text.get_window_extent(self, renderer).bounds
             r = l + w


### PR DESCRIPTION
`annotate(..., arrowprops={})` now uses an arrow with the default arrow
properties, rather than no arrow.  Note that this matches the docstring
of `annotate`, which indicates that "arrowprops, if not None, is a
dictionary of line properties (see matplotlib.lines.Line2D) for the
arrow that connects annotation to the point."

Comes down to checking for `None` instead of falsiness of `arrowprops`.