### PR TITLE
Handle non-empty data outside range in Axes.hist

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6320,25 +6320,34 @@ class Axes(_AxesBase):
 
             # adopted from adjust_x/ylim part of the bar method
             if orientation == 'horizontal':
-                xmin0 = max(_saved_bounds[0]*0.9, minimum)
                 xmax = self.dataLim.intervalx[1]
-                for m in n:
-                    if np.sum(m) > 0:  # make sure there are counts
-                        xmin = np.amin(m[m != 0])
-                        # filter out the 0 height bins
-                xmin = max(xmin*0.9, minimum) if not input_empty else minimum
-                xmin = min(xmin0, xmin)
+                # no data or all bins have 0 counts
+                if input_empty or np.sum(m) == 0:
+                    xmin = minimum
+                # some data
+                else:
+                    xmin0 = max(_saved_bounds[0]*0.9, minimum)
+                    for m in n:
+                        if np.sum(m) > 0:  # make sure there are counts
+                            xmin = np.amin(m[m != 0])
+                            # filter out the 0 height bins
+                    xmin = max(xmin*0.9, minimum)
+                    xmin = min(xmin0, xmin)
                 self.dataLim.intervalx = (xmin, xmax)
             elif orientation == 'vertical':
-                ymin0 = max(_saved_bounds[1]*0.9, minimum)
                 ymax = self.dataLim.intervaly[1]
-
-                for m in n:
-                    if np.sum(m) > 0:  # make sure there are counts
-                        ymin = np.amin(m[m != 0])
-                        # filter out the 0 height bins
-                ymin = max(ymin*0.9, minimum) if not input_empty else minimum
-                ymin = min(ymin0, ymin)
+                # no data or all bins have 0 counts
+                if input_empty or np.sum(m) == 0:
+                    ymin = minimum
+                # some data
+                else:
+                    ymin0 = max(_saved_bounds[1]*0.9, minimum)
+                    for m in n:
+                        if np.sum(m) > 0:  # make sure there are counts
+                            ymin = np.amin(m[m != 0])
+                            # filter out the 0 height bins
+                    ymin = max(ymin*0.9, minimum)
+                    ymin = min(ymin0, ymin)
                 self.dataLim.intervaly = (ymin, ymax)
 
         if label is None:


### PR DESCRIPTION
This PR fixes #6805 by handling a non-empty dataset that lies completely outside the `range`.
