### PR TITLE
Don't forget to disconnect callbacks for dragging.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1695,6 +1695,12 @@ class DraggableBase(object):
         """disconnect the callbacks"""
         for cid in self.cids:
             self.canvas.mpl_disconnect(cid)
+        try:
+            c1 = self._c1
+        except AttributeError:
+            pass
+        else:
+            self.canvas.mpl_disconnect(c1)
 
     def artist_picker(self, artist, evt):
         return self.ref_artist.contains(evt)


### PR DESCRIPTION
Copy-pasted from https://github.com/matplotlib/matplotlib/issues/6785#issuecomment-233279977:

> There's at least another issue with the `DraggableBase` code: the mouse move callback (`._c1`) does not get disconnected when `.disconnect()` is called (I tried explicitly calling `.disconnect()` to work around the above-mentioned issue, but I then get a crash upon moving the mouse because `on_motion` becomes invalid).