### PR TITLE
Add xkcd font as one of the options

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -400,7 +400,7 @@ def xkcd(scale=1, length=100, randomness=2):
     from matplotlib import patheffects
     context = rc_context()
     try:
-        rcParams['font.family'] = ['Humor Sans', 'Comic Sans MS']
+        rcParams['font.family'] = ['xkcd', 'Humor Sans', 'Comic Sans MS']
         rcParams['font.size'] = 14.0
         rcParams['path.sketch'] = (scale, length, randomness)
         rcParams['path.effects'] = [


### PR DESCRIPTION
The official xkcd font https://github.com/ipython/xkcd-font
was missing from the list of what is looked for when the
user selects xkcd mode. Since it is the "official" font, it
has been added to the top of the list.