### PR TITLE
Tick label rotation via `set_tick_params`

### DIFF
--- a/doc/users/whats_new/tick_params_rotation.rst
+++ b/doc/users/whats_new/tick_params_rotation.rst
@@ -1,0 +1,10 @@
+`Axis.set_tick_params` now responds to 'rotation'
+-------------------------------------------------
+
+Bulk setting of tick label rotation is now possible via :func:`set_tick_params` using the `rotation` keyword. 
+
+Example
+```````
+::
+
+    ax.xaxis.set_tick_params(which='both', rotation=90)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2665,6 +2665,9 @@ class _AxesBase(martist.Artist):
             Boolean or ['on' | 'off'], controls whether to draw the
             respective tick labels.
 
+        *labelrotation*
+            Tick label rotation.
+
         Example::
 
             ax.tick_params(direction='out', length=6, width=2, colors='r')

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -73,6 +73,7 @@ class Tick(artist.Artist):
                  pad=None,
                  labelsize=None,
                  labelcolor=None,
+                 labelrotation=0,
                  zorder=None,
                  gridOn=None,  # defaults to axes.grid depending on
                                # axes.grid.which
@@ -138,6 +139,8 @@ class Tick(artist.Artist):
         if labelsize is None:
             labelsize = rcParams['%s.labelsize' % name]
         self._labelsize = labelsize
+
+        self._labelrotation = labelrotation
 
         if zorder is None:
             if major:
@@ -333,7 +336,7 @@ class Tick(artist.Artist):
                 self.tick1line.set_markeredgewidth(v)
                 self.tick2line.set_markeredgewidth(v)
         label_list = [k for k in six.iteritems(kw)
-                      if k[0] in ['labelsize', 'labelcolor']]
+                      if k[0] in ['labelsize', 'labelcolor', 'labelrotation']]
         if label_list:
             label_kw = dict([(k[5:], v) for (k, v) in label_list])
             self.label1.set(**label_kw)
@@ -798,7 +801,8 @@ class Axis(artist.Artist):
                    'labelsize', 'labelcolor', 'zorder', 'gridOn',
                    'tick1On', 'tick2On', 'label1On', 'label2On']
         kwkeys1 = ['length', 'direction', 'left', 'bottom', 'right', 'top',
-                   'labelleft', 'labelbottom', 'labelright', 'labeltop']
+                   'labelleft', 'labelbottom', 'labelright', 'labeltop',
+                   'rotation']
         kwkeys = kwkeys0 + kwkeys1
         kwtrans = dict()
         if to_init_kw:
@@ -806,6 +810,8 @@ class Axis(artist.Artist):
                 kwtrans['size'] = kw.pop('length')
             if 'direction' in kw:
                 kwtrans['tickdir'] = kw.pop('direction')
+            if 'rotation' in kw:
+                kwtrans['labelrotation'] = kw.pop('rotation')
             if 'left' in kw:
                 kwtrans['tick1On'] = _string_to_bool(kw.pop('left'))
             if 'bottom' in kw:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -73,7 +73,6 @@ class Tick(artist.Artist):
                  pad=None,
                  labelsize=None,
                  labelcolor=None,
-                 labelrotation=0,
                  zorder=None,
                  gridOn=None,  # defaults to axes.grid depending on
                                # axes.grid.which
@@ -82,6 +81,7 @@ class Tick(artist.Artist):
                  label1On=True,
                  label2On=False,
                  major=True,
+                 labelrotation=0,
                  ):
         """
         bbox is the Bound2D bounding box in display coords of the Axes

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4549,6 +4549,18 @@ def test_bar_color_cycle():
             assert ccov(ln.get_color()) == ccov(br.get_facecolor())
 
 
+@cleanup
+def test_tick_param_label_rotation():
+    fix, ax = plt.subplots()
+    plt.plot([0, 1], [0, 1])
+    ax.xaxis.set_tick_params(which='both', rotation=75)
+    ax.yaxis.set_tick_params(which='both', rotation=90)
+    for text in ax.get_xticklabels(which='both'):
+        assert text.get_rotation() == 75
+    for text in ax.get_yticklabels(which='both'):
+        assert text.get_rotation() == 90
+
+
 if __name__ == '__main__':
     import nose
     import sys


### PR DESCRIPTION
Addresses #6795.

Implemented @tacaswell's suggestion so that commands such as `ax.xaxis.set_tick_params(which='both', rotation=90)` are now possible.

Added related test and whats_new entry.