### PR TITLE
Fix for ylabel title in example tex_unicode_demo.py

### DIFF
--- a/examples/pylab_examples/tex_unicode_demo.py
+++ b/examples/pylab_examples/tex_unicode_demo.py
@@ -18,7 +18,7 @@ s = np.cos(2*2*np.pi*t) + 2
 plt.plot(t, s)
 
 plt.xlabel(r'\textbf{time (s)}')
-plt.ylabel(r'\textit{Velocity (\u00B0/sec)}', fontsize=16)
+plt.ylabel('\\textit{Velocity (\u00B0/sec)}', fontsize=16)
 plt.title(r"\TeX\ is Number \
           $\displaystyle\sum_{n=1}^\infty\frac{-e^{i\pi}}{2^n}$!",
           fontsize=16, color='r')

--- a/examples/pylab_examples/tex_unicode_demo.py
+++ b/examples/pylab_examples/tex_unicode_demo.py
@@ -19,8 +19,7 @@ plt.plot(t, s)
 
 plt.xlabel(r'\textbf{time (s)}')
 plt.ylabel('\\textit{Velocity (\u00B0/sec)}', fontsize=16)
-plt.title(r"\TeX\ is Number \
-          $\displaystyle\sum_{n=1}^\infty\frac{-e^{i\pi}}{2^n}$!",
-          fontsize=16, color='r')
+plt.title(r'\TeX\ is Number $\displaystyle\sum_{n=1}^\infty'
+          r'\frac{-e^{i\pi}}{2^n}$!', fontsize=16, color='r')
 plt.grid(True)
 plt.show()


### PR DESCRIPTION
The example is about using Unicode characters with TeX. However, the example uses a raw string type for the Unicode escape sequence:

    plt.ylabel(r'\textit{Velocity (\u00B0/sec)}', fontsize=16)

That means that the escape sequence appears literally instead of the degree sign.
Proposed fix is a normal string with doubling of the backslash for the TeX macro
`\textit`:

    plt.ylabel('\\textit{Velocity (\u00B0/sec)}', fontsize=16)