### PR TITLE
DOC: Switch to OO code style & ensure fixed y-range in `psd_demo3`

### DIFF
--- a/examples/pylab_examples/psd_demo3.py
+++ b/examples/pylab_examples/psd_demo3.py
@@ -8,11 +8,13 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.mlab as mlab
 
+prng = np.random.RandomState(123456)  # to ensure reproducibility
+
 fs = 1000
 t = np.linspace(0, 0.3, 301)
 A = np.array([2, 8]).reshape(-1, 1)
 f = np.array([150, 140]).reshape(-1, 1)
-xn = (A * np.sin(2 * np.pi * f * t)).sum(axis=0) + 5 * np.random.randn(*t.shape)
+xn = (A * np.sin(2 * np.pi * f * t)).sum(axis=0) + 5 * prng.randn(*t.shape)
 
 fig, (ax0, ax1) = plt.subplots(ncols=2)
 

--- a/examples/pylab_examples/psd_demo3.py
+++ b/examples/pylab_examples/psd_demo3.py
@@ -1,6 +1,8 @@
-# This is a ported version of a MATLAB example from the signal processing
-# toolbox that showed some difference at one time between Matplotlib's and
-# MATLAB's scaling of the PSD.
+"""This is a ported version of a MATLAB example from the signal
+processing toolbox that showed some difference at one time between
+Matplotlib's and MATLAB's scaling of the PSD.
+
+"""
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -12,25 +14,28 @@ A = np.array([2, 8]).reshape(-1, 1)
 f = np.array([150, 140]).reshape(-1, 1)
 xn = (A * np.sin(2 * np.pi * f * t)).sum(axis=0) + 5 * np.random.randn(*t.shape)
 
+fig, (ax0, ax1) = plt.subplots(ncols=2)
+
+fig.subplots_adjust(hspace=0.45, wspace=0.3)
 yticks = np.arange(-50, 30, 10)
+yrange = (yticks[0], yticks[-1])
 xticks = np.arange(0, 550, 100)
-plt.subplots_adjust(hspace=0.45, wspace=0.3)
-plt.subplot(1, 2, 1)
 
-plt.psd(xn, NFFT=301, Fs=fs, window=mlab.window_none, pad_to=1024,
+ax0.psd(xn, NFFT=301, Fs=fs, window=mlab.window_none, pad_to=1024,
         scale_by_freq=True)
-plt.title('Periodogram')
-plt.yticks(yticks)
-plt.xticks(xticks)
-plt.grid(True)
+ax0.set_title('Periodogram')
+ax0.set_yticks(yticks)
+ax0.set_xticks(xticks)
+ax0.grid(True)
+ax0.set_ylim(yrange)
 
-plt.subplot(1, 2, 2)
-plt.psd(xn, NFFT=150, Fs=fs, window=mlab.window_none, noverlap=75, pad_to=512,
+ax1.psd(xn, NFFT=150, Fs=fs, window=mlab.window_none, pad_to=512, noverlap=75,
         scale_by_freq=True)
-plt.title('Welch')
-plt.xticks(xticks)
-plt.yticks(yticks)
-plt.ylabel('')
-plt.grid(True)
+ax1.set_title('Welch')
+ax1.set_xticks(xticks)
+ax1.set_yticks(yticks)
+ax1.set_ylabel('')  # overwrite the y-label added by `psd`
+ax1.grid(True)
+ax1.set_ylim(yrange)
 
 plt.show()


### PR DESCRIPTION
In `psd_demo3.py` pylab example:
- adopt OO code style;
- fix the y-range to avoid discrepancies between the two subplots in the case of y-values in the 1st subplot that exceed the provided y-tick range (due to an “unfortunate” random draw) .