### PR TITLE
DOC: Fix `psd_demo_complex` similarly to `psd_demo3`

### DIFF
--- a/examples/pylab_examples/psd_demo_complex.py
+++ b/examples/pylab_examples/psd_demo_complex.py
@@ -22,7 +22,7 @@ fig, (ax0, ax1) = plt.subplots(ncols=2)
 fig.subplots_adjust(hspace=0.45, wspace=0.3)
 yticks = np.arange(-50, 30, 10)
 yrange = (yticks[0], yticks[-1])
-xticks = np.arange(-500, 550, 100)
+xticks = np.arange(-500, 550, 200)
 
 ax0.psd(xn, NFFT=301, Fs=fs, window=mlab.window_none, pad_to=1024,
         scale_by_freq=True)

--- a/examples/pylab_examples/psd_demo_complex.py
+++ b/examples/pylab_examples/psd_demo_complex.py
@@ -11,11 +11,13 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.mlab as mlab
 
+prng = np.random.RandomState(123456)  # to ensure reproducibility
+
 fs = 1000
 t = np.linspace(0, 0.3, 301)
 A = np.array([2, 8]).reshape(-1, 1)
 f = np.array([150, 140]).reshape(-1, 1)
-xn = (A * np.exp(2j * np.pi * f * t)).sum(axis=0) + 5 * np.random.randn(*t.shape)
+xn = (A * np.exp(2j * np.pi * f * t)).sum(axis=0) + 5 * prng.randn(*t.shape)
 
 fig, (ax0, ax1) = plt.subplots(ncols=2)
 

--- a/examples/pylab_examples/psd_demo_complex.py
+++ b/examples/pylab_examples/psd_demo_complex.py
@@ -1,7 +1,12 @@
-# This is a ported version of a MATLAB example from the signal processing
-# toolbox that showed some difference at one time between Matplotlib's and
-# MATLAB's scaling of the PSD.  This differs from psd_demo3.py in that
-# this uses a complex signal, so we can see that complex PSD's work properly
+"""This is a ported version of a MATLAB example from the signal
+processing toolbox that showed some difference at one time between
+Matplotlib's and MATLAB's scaling of the PSD.
+
+This differs from psd_demo3.py in that this uses a complex signal,
+so we can see that complex PSD's work properly
+
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.mlab as mlab
@@ -12,27 +17,28 @@ A = np.array([2, 8]).reshape(-1, 1)
 f = np.array([150, 140]).reshape(-1, 1)
 xn = (A * np.exp(2j * np.pi * f * t)).sum(axis=0) + 5 * np.random.randn(*t.shape)
 
+fig, (ax0, ax1) = plt.subplots(ncols=2)
+
+fig.subplots_adjust(hspace=0.45, wspace=0.3)
 yticks = np.arange(-50, 30, 10)
+yrange = (yticks[0], yticks[-1])
 xticks = np.arange(-500, 550, 100)
-plt.subplots_adjust(hspace=0.45, wspace=0.3)
-ax = plt.subplot(1, 2, 1)
 
-plt.psd(xn, NFFT=301, Fs=fs, window=mlab.window_none, pad_to=1024,
+ax0.psd(xn, NFFT=301, Fs=fs, window=mlab.window_none, pad_to=1024,
         scale_by_freq=True)
-plt.title('Periodogram')
-plt.yticks(yticks)
-plt.xticks(xticks)
-plt.grid(True)
-plt.xlim(-500, 500)
+ax0.set_title('Periodogram')
+ax0.set_yticks(yticks)
+ax0.set_xticks(xticks)
+ax0.grid(True)
+ax0.set_ylim(yrange)
 
-plt.subplot(1, 2, 2, sharex=ax, sharey=ax)
-plt.psd(xn, NFFT=150, Fs=fs, window=mlab.window_none, noverlap=75, pad_to=512,
+ax1.psd(xn, NFFT=150, Fs=fs, window=mlab.window_none, pad_to=512, noverlap=75,
         scale_by_freq=True)
-plt.title('Welch')
-plt.xticks(xticks)
-plt.yticks(yticks)
-plt.ylabel('')
-plt.grid(True)
-plt.xlim(-500, 500)
+ax1.set_title('Welch')
+ax1.set_xticks(xticks)
+ax1.set_yticks(yticks)
+ax1.set_ylabel('')  # overwrite the y-label added by `psd`
+ax1.grid(True)
+ax1.set_ylim(yrange)
 
 plt.show()


### PR DESCRIPTION
Reports on `psd_demo_complex` some fixes similar to the ones done in #6841 on `psd_demo3` (from which this example is derived):
- OO code style
- set a fixed y-range

NB: as the axes were not shared between the subplots in `psd_demo3`, I removed the sharing in this PR. It might be reintroduced if needed.

Besides, the 2nd commit halves the x-tick amount, because otherwise the x-tick labels overlap. Currently, the example looks like:
![fix_psd_demo_complex](https://cloud.githubusercontent.com/assets/17270724/17157094/84c16dce-538d-11e6-84f1-42ba678591a9.png)
vs the current one in the devdocs gallery:
![devdocs_psd_demo_complex](https://cloud.githubusercontent.com/assets/17270724/17157199/29c5a88a-538e-11e6-84dc-9da8b8339172.png)

_BTW, is it normal for the PNG in the devdocs gallery to be only 550x450 pixels?_
