### PR TITLE
Fix for PyQt5.7 support.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -474,17 +474,17 @@ class FigureManagerQT(FigureManagerBase):
 
         self.window._destroying = False
 
-        self.toolbar = self._get_toolbar(self.canvas, self.window)
-        if self.toolbar is not None:
-            self.window.addToolBar(self.toolbar)
-            self.toolbar.message.connect(self._show_message)
-            tbs_height = self.toolbar.sizeHint().height()
-        else:
-            tbs_height = 0
-
         # add text label to status bar
         self.statusbar_label = QtWidgets.QLabel()
         self.window.statusBar().addWidget(self.statusbar_label)
+
+        self.toolbar = self._get_toolbar(self.canvas, self.window)
+        if self.toolbar is not None:
+            self.window.addToolBar(self.toolbar)
+            self.toolbar.message.connect(self.statusbar_label.setText)
+            tbs_height = self.toolbar.sizeHint().height()
+        else:
+            tbs_height = 0
 
         # resize the main window so it will display the canvas with the
         # requested size:
@@ -506,10 +506,6 @@ class FigureManagerQT(FigureManagerBase):
                 self.toolbar.update()
         self.canvas.figure.add_axobserver(notify_axes_change)
         self.window.raise_()
-
-    @QtCore.Slot()
-    def _show_message(self, s):
-        self.statusbar_label.setText(s)
 
     def full_screen_toggle(self):
         if self.window.isFullScreen():


### PR DESCRIPTION
Just getting rid of a slot with an incorrect signature (for which
PyQt5.7 is more strict).

Tested on PyQt5.6.1 and 5.7, PyQt4.11.4, PySide 1.2.4.

cf #6853.
@tacaswell you already suggested the correct fix a year ago :) (https://github.com/matplotlib/matplotlib/pull/4894#discussion_r36631084)

Given that without this fix, matplotlib doesn't work at all with PyQt5.7, I'm milestoning to 2.0; this should probably also be backported to 1.5.3 (1.5.2 if it gets retagged).