### PR TITLE
Enable cache on Travis

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1398,13 +1398,12 @@ if USE_FONTCONFIG and sys.platform != 'win32':
 else:
     _fmcache = None
 
-    if not 'TRAVIS' in os.environ:
-        cachedir = get_cachedir()
-        if cachedir is not None:
-            if six.PY3:
-                _fmcache = os.path.join(cachedir, 'fontList.py3k.cache')
-            else:
-                _fmcache = os.path.join(cachedir, 'fontList.cache')
+    cachedir = get_cachedir()
+    if cachedir is not None:
+        if six.PY3:
+            _fmcache = os.path.join(cachedir, 'fontList.py3k.cache')
+        else:
+            _fmcache = os.path.join(cachedir, 'fontList.cache')
 
     fontManager = None
 


### PR DESCRIPTION
This check was removed on master as a part of #5276 which was backported as 56a932c4e167a0e7e10ce8457f0f14d1965c0f87

But the backport missed this line. Given that we warn about creating the cache this check is really annoying as it will show up over and over again every time you are calling matplotlib from a project that uses matplotlib on Travis