### PR TITLE
'closes' and 'lows' misplaced in candlestick chart

### DIFF
--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -1051,7 +1051,7 @@ def candlestick2_ochl(ax, opens, closes, highs, lows,  width=4,
         (lineCollection, barCollection)
     """
 
-    candlestick2_ohlc(ax, opens, highs, closes, lows, width=width,
+    candlestick2_ohlc(ax, opens, highs, lows, closes, width=width,
                      colorup=colorup, colordown=colordown,
                      alpha=alpha)
 
@@ -1139,8 +1139,8 @@ def candlestick2_ohlc(ax, opens, highs, lows, closes, width=4,
     ax.autoscale_view()
 
     # add these last
-    ax.add_collection(barCollection)
     ax.add_collection(rangeCollection)
+    ax.add_collection(barCollection)
     return rangeCollection, barCollection
 
 


### PR DESCRIPTION
This two function: _candlestick2_ohlc()_ and _candlestick2_ochl()_, their parameter of open/high/low/close should **preserve the order** in the document. 

for _candlestick2_ohlc()_, 'closes' and 'lows' are misplaced (exchanged) in candlestick2_ochl function, both in 1.5.1 and 2.* ( i don't know 1.4.* or below).  

This bug will cause mistakes while ploting, see my answer to this question on stackoverflow: http://stackoverflow.com/a/38684513/4117822. Could any one VOTE-UP for me here? T_T


before:
![rrdsi](https://cloud.githubusercontent.com/assets/17794885/17278387/11fecfc4-578f-11e6-877e-bc0a5ca6b47f.png)

after:
![index](https://cloud.githubusercontent.com/assets/17794885/17278390/21d38f20-578f-11e6-9381-975cf9de55a6.png)
