### PR TITLE
Remove POSSIBLY obsolete hist() code for updating dataLim

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6378,14 +6378,6 @@ class Axes(_AxesBase):
                     p.update(kwargs)
                     p.set_label('_nolegend_')
 
-        if binsgiven:
-            if orientation == 'vertical':
-                self.update_datalim(
-                    [(bins[0], 0), (bins[-1], 0)], updatey=False)
-            else:
-                self.update_datalim(
-                    [(0, bins[0]), (0, bins[-1])], updatex=False)
-
         if nx == 1:
             return n[0], bins, cbook.silent_list('Patch', patches[0])
         else:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1200,18 +1200,18 @@ def test_hist_step_log_bottom():
 
 @cleanup
 def test_hist_datalims_binsgiven():
-    """
-    Checks that the hist function updates axes' dataLim to minimum and maximum
-    bins if the latter are given explicitly as a sequence.
-    """
+    # Checks that the hist function updates axes' dataLim to minimum and maximum
+    # bins if the latter are given explicitly as a sequence.
     # Helper function that runs actual tests
     @cleanup
-    def do_test(histtype, orientation):
+    def do_test(histtype, orientation, stacked):
         # Random values between -1 and 1
-        x = 2*np.random.randn(10)-1
+        x1 = 2*np.random.randn(10)-1
+	# Random values between -5 and 5
+        x2 = 10*np.random.randn(10)-5
         # Plot histogram with explicitly given bins from -3 to 3
-        plt.hist(x, bins=[-3, -2, -1, 0, 1, 2, 3], histtype=histtype,
-                 orientation=orientation)
+        plt.hist([x1, x2], bins=[-3, -2, -1, 0, 1, 2, 3], histtype=histtype,
+                 orientation=orientation, stacked=stacked)
         # Check that dataLim is given by bin range and not by data range
         if orientation == "horizontal":
             assert_equal(plt.gca().dataLim.y0, -3)
@@ -1223,8 +1223,10 @@ def test_hist_datalims_binsgiven():
     np.random.seed(0)
     histtypes = [ "bar", "step", "stepfilled" ]
     orientations = [ "horizontal", "vertical" ]
-    for histtype, orientation in product(histtypes, orientations):
-        yield do_test, histtype, orientation
+    stacked = [ True, False ]
+    all_combinations = product(histtypes, orientations, stacked)
+    for histtype, orientation, stacked in all_combinations:
+        yield do_test, histtype, orientation, stacked
 
 
 def contour_dat():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -12,6 +12,8 @@ from nose.plugins.skip import SkipTest
 
 import datetime
 
+from itertools import product
+
 import pytz
 
 import numpy as np
@@ -1194,6 +1196,35 @@ def test_hist_step_log_bottom():
     ax.hist(data, bins=10, log=True, histtype='stepfilled',
             alpha=0.5, color='y', bottom=np.arange(10))
     ax.set_ylim(9e-3, 1e3)
+
+
+@cleanup
+def test_hist_datalims_binsgiven():
+    """
+    Checks that the hist function updates axes' dataLim to minimum and maximum
+    bins if the latter are given explicitly as a sequence.
+    """
+    # Helper function that runs actual tests
+    @cleanup
+    def do_test(histtype, orientation):
+        # Random values between -1 and 1
+        x = 2*np.random.randn(10)-1
+        # Plot histogram with explicitly given bins from -3 to 3
+        plt.hist(x, bins=[-3, -2, -1, 0, 1, 2, 3], histtype=histtype,
+                 orientation=orientation)
+        # Check that dataLim is given by bin range and not by data range
+        if orientation == "horizontal":
+            assert_equal(plt.gca().dataLim.y0, -3)
+            assert_equal(plt.gca().dataLim.y1, 3)
+        elif orientation == "vertical":
+            assert_equal(plt.gca().dataLim.x0, -3)
+            assert_equal(plt.gca().dataLim.x1, 3)
+    # Test generation
+    np.random.seed(0)
+    histtypes = [ "bar", "step", "stepfilled" ]
+    orientations = [ "horizontal", "vertical" ]
+    for histtype, orientation in product(histtypes, orientations):
+        yield do_test, histtype, orientation
 
 
 def contour_dat():


### PR DESCRIPTION
As part of #6669, I'm trying to understand what each piece of code in the ``hist`` function does.

I came across [a code segment](https://github.com/matplotlib/matplotlib/blob/80a3f3e10c0f04ffbc9c5f0a32954e79b1c3ec61/lib/matplotlib/axes/_axes.py#L6381) for setting the axes' ``dataLim`` to the minimum and maximum bin if bins are given as an explicit sequence. It was introduced as a fix for [Debian bug #503148](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=503148) - the previous behaviour was to use the minimum and maximum *non-empty* bins for ``dataLim``, which obviously went against the user's wishes if bins were given explicitly.

But as the tests I introduced in a431582 show, even if the code is removed,``dataLim`` seems to get set just fine by other parts of the ``hist`` function *nowadays*.

Can anybody come up with a test case that requires this code fragment to exist? Otherwise I suggest it should be removed, because that would make implementing #6669 slightly easier.