### PR TITLE
Add keymap (default: G) to toggle minor grid.

### DIFF
--- a/doc/api/api_changes/2016-08-02-toggle-grids.rst
+++ b/doc/api/api_changes/2016-08-02-toggle-grids.rst
@@ -1,0 +1,9 @@
+Improved toggling of the axes grids
+-----------------------------------
+The `g` key binding now switches the states of the `x` and `y` grids
+independently (by cycling through all four on/off combinations).
+
+The new `G` key binding switches the states of the minor grids.
+
+Both bindings are disabled if only a subset of the grid lines (in either
+direction) is visible, to avoid making irreversible changes to the figure.

--- a/doc/users/navigation_toolbar.rst
+++ b/doc/users/navigation_toolbar.rst
@@ -99,8 +99,8 @@ Close all plots                    **shift** + **w**
 Constrain pan/zoom to x axis       hold **x** when panning/zooming with mouse
 Constrain pan/zoom to y axis       hold **y** when panning/zooming with mouse
 Preserve aspect ratio              hold **CONTROL** when panning/zooming with mouse
-Toggle major grid                  **g** when mouse is over an axes
-Toggle major and minor grid        **G** when mouse is over an axes
+Toggle major grids                 **g** when mouse is over an axes
+Toggle minor grids                 **G** when mouse is over an axes
 Toggle x axis scale (log/linear)   **L** or **k**  when mouse is over an axes
 Toggle y axis scale (log/linear)   **l** when mouse is over an axes
 ================================== =================================================

--- a/doc/users/navigation_toolbar.rst
+++ b/doc/users/navigation_toolbar.rst
@@ -99,7 +99,8 @@ Close all plots                    **shift** + **w**
 Constrain pan/zoom to x axis       hold **x** when panning/zooming with mouse
 Constrain pan/zoom to y axis       hold **y** when panning/zooming with mouse
 Preserve aspect ratio              hold **CONTROL** when panning/zooming with mouse
-Toggle grid                        **g** when mouse is over an axes
+Toggle major grid                  **g** when mouse is over an axes
+Toggle major and minor grid        **G** when mouse is over an axes
 Toggle x axis scale (log/linear)   **L** or **k**  when mouse is over an axes
 Toggle y axis scale (log/linear)   **l** when mouse is over an axes
 ================================== =================================================

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2482,6 +2482,7 @@ def key_press_handler(event, canvas, toolbar=None):
     save_keys = rcParams['keymap.save']
     quit_keys = rcParams['keymap.quit']
     grid_keys = rcParams['keymap.grid']
+    grid_minor_keys = rcParams['keymap.grid_minor']
     toggle_yscale_keys = rcParams['keymap.yscale']
     toggle_xscale_keys = rcParams['keymap.xscale']
     all = rcParams['keymap.all_axes']
@@ -2525,13 +2526,28 @@ def key_press_handler(event, canvas, toolbar=None):
 
     # these bindings require the mouse to be over an axes to trigger
 
+    ax = event.inaxes
     # switching on/off a grid in current axes (default key 'g')
     if event.key in grid_keys:
-        event.inaxes.grid()
+        # If either major grid is on, turn all major and minor grids off.
+        if any(tick.gridOn
+               for tick in ax.xaxis.majorTicks + ax.yaxis.majorTicks):
+            ax.grid(False, which="both")
+        # Otherwise, turn the major grids on.
+        else:
+            ax.grid(True)
+        canvas.draw()
+    if event.key in grid_minor_keys:
+        # If either minor grid is on, turn all minor grids off.
+        if any(tick.gridOn
+               for tick in ax.xaxis.minorTicks + ax.yaxis.minorTicks):
+            ax.grid(False, which="minor")
+        # Otherwise, turn all major and minor grids on.
+        else:
+            ax.grid(True, which="both")
         canvas.draw()
     # toggle scaling of y-axes between 'log and 'linear' (default key 'l')
     elif event.key in toggle_yscale_keys:
-        ax = event.inaxes
         scale = ax.get_yscale()
         if scale == 'log':
             ax.set_yscale('linear')
@@ -2541,7 +2557,6 @@ def key_press_handler(event, canvas, toolbar=None):
             ax.figure.canvas.draw()
     # toggle scaling of x-axes between 'log and 'linear' (default key 'k')
     elif event.key in toggle_xscale_keys:
-        ax = event.inaxes
         scalex = ax.get_xscale()
         if scalex == 'log':
             ax.set_xscale('linear')

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -400,8 +400,7 @@ class ToolEnableNavigation(ToolBase):
 
 
 class _ToolGridBase(ToolBase):
-    """Common functionality between ToolGrid and ToolMinorGrid.
-    """
+    """Common functionality between ToolGrid and ToolMinorGrid."""
 
     _cycle = [(False, False), (True, False), (True, True), (False, True)]
 
@@ -420,7 +419,8 @@ class _ToolGridBase(ToolBase):
 
     @staticmethod
     def _get_uniform_grid_state(ticks):
-        """Check whether all grid lines are in the same visibility state.
+        """
+        Check whether all grid lines are in the same visibility state.
 
         Returns True/False if all grid lines are on or off, None if they are
         not all in the same state.
@@ -443,7 +443,7 @@ class ToolGrid(_ToolGridBase):
         x_state, y_state = map(self._get_uniform_grid_state,
                                [ax.xaxis.majorTicks, ax.yaxis.majorTicks])
         cycle = self._cycle
-        # Bail out if major grids are not in a uniform state.
+        # Bail out (via ValueError) if major grids are not in a uniform state.
         x_state, y_state = (
             cycle[(cycle.index((x_state, y_state)) + 1) % len(cycle)])
         return x_state, y_state, "major"
@@ -463,7 +463,7 @@ class ToolMinorGrid(_ToolGridBase):
         x_state, y_state = map(self._get_uniform_grid_state,
                                [ax.xaxis.minorTicks, ax.yaxis.minorTicks])
         cycle = self._cycle
-        # Bail out if minor grids are not in a uniform state.
+        # Bail out (via ValueError) if minor grids are not in a uniform state.
         x_state, y_state = (
             cycle[(cycle.index((x_state, y_state)) + 1) % len(cycle)])
         return x_state, y_state, "both"

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1313,6 +1313,7 @@ defaultParams = {
     'keymap.quit':         [['ctrl+w', 'cmd+w', 'q'], validate_stringlist],
     'keymap.quit_all':     [['W', 'cmd+W', 'Q'], validate_stringlist],
     'keymap.grid':         [['g'], validate_stringlist],
+    'keymap.grid_minor':   [['G'], validate_stringlist],
     'keymap.yscale':       [['l'], validate_stringlist],
     'keymap.xscale':       [['k', 'L'], validate_stringlist],
     'keymap.all_axes':     [['a'], validate_stringlist],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -584,8 +584,8 @@ backend      : $TEMPLATE_BACKEND
 #keymap.zoom : o                     # zoom mnemonic
 #keymap.save : s                     # saving current figure
 #keymap.quit : ctrl+w, cmd+w         # close the current figure
-#keymap.grid : g                     # switching on/off a grid in current axes
-#keymap.grid_minor : G               # switching on/off a grid in current axes
+#keymap.grid : g                     # switching on/off major grids in current axes
+#keymap.grid_minor : G               # switching on/off minor grids in current axes
 #keymap.yscale : l                   # toggle scaling of y-axes ('log'/'linear')
 #keymap.xscale : L, k                # toggle scaling of x-axes ('log'/'linear')
 #keymap.all_axes : a                 # enable all axes

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -585,6 +585,7 @@ backend      : $TEMPLATE_BACKEND
 #keymap.save : s                     # saving current figure
 #keymap.quit : ctrl+w, cmd+w         # close the current figure
 #keymap.grid : g                     # switching on/off a grid in current axes
+#keymap.grid_minor : G               # switching on/off a grid in current axes
 #keymap.yscale : l                   # toggle scaling of y-axes ('log'/'linear')
 #keymap.xscale : L, k                # toggle scaling of x-axes ('log'/'linear')
 #keymap.all_axes : a                 # enable all axes


### PR DESCRIPTION
If either minor grid is on, turn both of them off.  Otherwise, turn all
major and minor grids on (it usually doesn't make sense to have the
minor grids only).

Also change the behavior of `keymap.grid` ("g") to synchronize the grid
state of both axes.  Otherwise, if starting from only grids in one
direction (`plt.plot(); plt.grid(axis="x")`), "g" switches between only
`x` grid and only `y` grid, which is unlikely to be the expected
behavior.

See #6616.