### PR TITLE
Fix Path deepcopy signature

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -297,13 +297,17 @@ class Path(object):
 
     copy = __copy__
 
-    def __deepcopy__(self):
+    def __deepcopy__(self, memo=None):
         """
         Returns a deepcopy of the `Path`.  The `Path` will not be
         readonly, even if the source `Path` is.
         """
+        try:
+            codes = self.codes.copy()
+        except AttributeError:
+            codes = None
         return self.__class__(
-            self.vertices.copy(), self.codes.copy(),
+            self.vertices.copy(), codes,
             _interpolation_steps=self._interpolation_steps)
 
     deepcopy = __deepcopy__

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import copy
 
 import six
 
@@ -170,6 +171,16 @@ def test_path_to_polygons():
                        [data])
     assert_array_equal(p.to_polygons(), [closed_data])
     assert_array_equal(p.to_polygons(closed_only=False), [data])
+
+
+def test_path_deepcopy():
+    # Should not raise any error
+    verts = [[0, 0], [1, 1]]
+    codes = [Path.MOVETO, Path.LINETO]
+    path1 = Path(verts)
+    path2 = Path(verts, codes)
+    copy.deepcopy(path1)
+    copy.deepcopy(path2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Problem**

`Path.__deepcopy__` does not accept a second(`memo`) parameter,
so the common usage of the `deepcopy` function fails.

**Solution**

Add second parameter.