### PR TITLE
BUG: % crashes saving figure with tex enabled

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1140,7 +1140,7 @@ class PercentFormatter(Formatter):
     def __init__(self, xmax=100, decimals=None, symbol='%'):
         self.xmax = xmax + 0.0
         self.decimals = decimals
-        self.symbol = symbol
+        self.symbol = symbol.replace('%', r'\%') if rcParams['text.usetex'] else symbol
 
     def __call__(self, x, pos=None):
         """


### PR DESCRIPTION
This PR changes the default symbol used by `mpl.ticker.PercentFormatter` if `mpl.rcParams['text.usetex'] == True`. There is room for improvement, as evidenced by this question: http://stackoverflow.com/q/38731201/2988730.

Tests coming soon.
