### PR TITLE
support for updating axis ticks for categorical data

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,11 +3,11 @@ Andrew Dawson <ajdawson@acm.org> <dawson@atm.ox.ac.uk>
 anykraus <kraus@mpip-mainz.mpg.de> <anykraus@users.noreply.github.com>
 Ariel Hernán Curiale <curiale@gmail.com>
 Ben Cohen <bj.cohen19@gmail.com> <ben@cohen-family.org>
-Ben Root <ben.v.root@gmail.com>
+Ben Root <ben.v.root@gmail.com> Benjamin Root <ben.v.root@gmail.com>
 Casper van der Wel <caspervdw@gmail.com>
-Christoph Gohlke <cgohlke@uci.edu> <cgohlke@uci.edu>
-Cimarron Mittelsteadt <cimarronm@gmail.com>
-Daniel Hyams <dhyams@gmail.com>
+Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
+Christoph Gohlke <cgohlke@uci.edu> C. Gohlke <cgohlke@uci.edu>
+Cimarron Mittelsteadt <cimarronm@gmail.com> Cimarron <cimarronm@gmail.com>
 Daniel Hyams <dhyams@gmail.com> Daniel Hyams <dhyams@gitdev.(none)>
 David Kua <david@kua.io> <david.kua@mail.utoronto.ca>
 endolith <endolith@gmail.com>

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,6 @@ install:
     # Install nose from a build which has partial
     # support for python36 and suport for coverage output suppressing
     pip install git+https://github.com/jenshnielsen/nose.git@matplotlibnose
-
     # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
     pip install $PRE pytest 'pytest-cov>=2.3.1' pytest-timeout pytest-xdist pytest-faulthandler
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1499,7 +1499,6 @@ default_test_modules = [
     'matplotlib.tests.test_backend_svg',
     'matplotlib.tests.test_basic',
     'matplotlib.tests.test_bbox_tight',
-    'matplotlib.tests.test_category',
     'matplotlib.tests.test_cbook',
     'matplotlib.tests.test_coding_standards',
     'matplotlib.tests.test_collections',

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -642,7 +642,7 @@ class Axis(artist.Artist):
         self.offsetText = self._get_offset_text()
         self.majorTicks = []
         self.minorTicks = []
-        self.unit_data = []
+        self.unit_data = None
         self.pickradius = pickradius
 
         # Initialize here for testing; later add API
@@ -695,14 +695,14 @@ class Axis(artist.Artist):
 
     @property
     def unit_data(self):
-        """Holds data that a ConversionInterface subclass relys on
+        """Holds data that a ConversionInterface subclass uses
         to convert between labels and indexes
         """
         return self._unit_data
 
     @unit_data.setter
-    def unit_data(self, data):
-        self._unit_data = data
+    def unit_data(self, unit_data):
+        self._unit_data = unit_data
 
     def get_children(self):
         children = [self.label, self.offsetText]

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -9,6 +9,7 @@ import six
 
 import numpy as np
 
+import matplotlib.cbook as cbook
 import matplotlib.units as units
 import matplotlib.ticker as ticker
 
@@ -22,10 +23,12 @@ NP_NEW = (LooseVersion(np.version.version) >= LooseVersion('1.7'))
 def to_array(data, maxlen=100):
     if NP_NEW:
         return np.array(data, dtype=np.unicode)
+    if cbook.is_scalar_or_string(data):
+        data = [data]
     try:
         vals = np.array(data, dtype=('|S', maxlen))
     except UnicodeEncodeError:
-        # pure hack
+        # this yields gibberish
         vals = np.array([convert_to_string(d) for d in data])
     return vals
 
@@ -36,40 +39,44 @@ class StrCategoryConverter(units.ConversionInterface):
         """Uses axis.unit_data map to encode
         data as floats
         """
-        vmap = dict(axis.unit_data)
+        vmap = dict(zip(axis.unit_data.seq, axis.unit_data.locs))
 
         if isinstance(value, six.string_types):
             return vmap[value]
 
         vals = to_array(value)
-        for lab, loc in axis.unit_data:
+        for lab, loc in vmap.items():
             vals[vals == lab] = loc
 
         return vals.astype('float')
 
     @staticmethod
     def axisinfo(unit, axis):
-        seq, locs = zip(*axis.unit_data)
-        majloc = StrCategoryLocator(locs)
-        majfmt = StrCategoryFormatter(seq)
+        majloc = StrCategoryLocator(axis.unit_data.locs)
+        majfmt = StrCategoryFormatter(axis.unit_data.seq)
         return units.AxisInfo(majloc=majloc, majfmt=majfmt)
 
     @staticmethod
     def default_units(data, axis):
         # the conversion call stack is:
         # default_units->axis_info->convert
-        axis.unit_data = map_categories(data, axis.unit_data)
+        if axis.unit_data is None:
+            axis.unit_data = UnitData(data)
+        else:
+            axis.unit_data.update(data)
         return None
 
 
 class StrCategoryLocator(ticker.FixedLocator):
     def __init__(self, locs):
-        super(StrCategoryLocator, self).__init__(locs, None)
+        self.locs = locs
+        self.nbins = None
 
 
 class StrCategoryFormatter(ticker.FixedFormatter):
     def __init__(self, seq):
-        super(StrCategoryFormatter, self).__init__(seq)
+        self.seq = seq
+        self.offset_string = ''
 
 
 def convert_to_string(value):
@@ -77,8 +84,8 @@ def convert_to_string(value):
     np.array(...,dtype=unicode) for all later versions of numpy"""
 
     if isinstance(value, six.string_types):
-        return value
-    if np.isfinite(value):
+        pass
+    elif np.isfinite(value):
         value = np.asarray(value, dtype=str)[np.newaxis][0]
     elif np.isnan(value):
         value = 'nan'
@@ -91,59 +98,38 @@ def convert_to_string(value):
     return value
 
 
-def map_categories(data, old_map=None):
-    """Create mapping between unique categorical
-    values and numerical identifier.
-
-    Paramters
-    ---------
-    data: iterable
-        sequence of values
-    old_map: list of tuple, optional
-        if not `None`, than old_mapping will be updated with new values and
-        previous mappings will remain unchanged)
-    sort: bool, optional
-        sort keys by ASCII value
-
-    Returns
-    -------
-    list of tuple
-        [(label, ticklocation),...]
-
-    """
-
-    # code typical missing data in the negative range because
-    # everything else will always have positive encoding
-    # question able if it even makes sense
+class UnitData(object):
+    # debatable makes sense to special code missing values
     spdict = {'nan': -1.0, 'inf': -2.0, '-inf': -3.0}
 
-    if isinstance(data, six.string_types):
-        data = [data]
+    def __init__(self, data):
+        """Create mapping between unique categorical values
+        and numerical identifier
+        Paramters
+        ---------
+        data: iterable
+            sequence of values
+        """
+        self.seq, self.locs = [], []
+        self._set_seq_locs(data, 0)
 
-    # will update this post cbook/dict support
-    strdata = to_array(data)
-    uniq = np.unique(strdata)
+    def update(self, new_data):
+        # so as not to conflict with spdict
+        value = max(max(self.locs) + 1, 0)
+        self._set_seq_locs(new_data, value)
 
-    if old_map:
-        olabs, okeys = zip(*old_map)
-        svalue = max(okeys) + 1
-    else:
-        old_map, olabs, okeys = [], [], []
-        svalue = 0
-
-    category_map = old_map[:]
-
-    new_labs = [u for u in uniq if u not in olabs]
-    missing = [nl for nl in new_labs if nl in spdict.keys()]
-
-    category_map.extend([(m, spdict[m]) for m in missing])
-
-    new_labs = [nl for nl in new_labs if nl not in missing]
-
-    new_locs = np.arange(svalue, svalue + len(new_labs), dtype='float')
-    category_map.extend(list(zip(new_labs, new_locs)))
-    return category_map
-
+    def _set_seq_locs(self, data, value):
+        # magic to make it work under np1.6
+        strdata = to_array(data)
+        # np.unique makes dateframes work
+        new_s = [d for d in np.unique(strdata) if d not in self.seq]
+        for ns in new_s:
+            self.seq.append(convert_to_string(ns))
+            if ns in UnitData.spdict.keys():
+                self.locs.append(UnitData.spdict[ns])
+            else:
+                self.locs.append(value)
+                value += 1
 
 # Connects the convertor to matplotlib
 units.registry[str] = StrCategoryConverter()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py31, py32
+envlist = py27, py34, py35
 
 [testenv]
 changedir = /tmp
@@ -15,3 +15,4 @@ deps =
     nose
     mock
     numpy
+    pytest


### PR DESCRIPTION
Now supports updating axis:
```python
fig, ax = plt.subplots()
ax.plot(['a', 'c', 'e'], label="plot 1")
ax.plot(['a', 'b', 'd'], label="plot 2")
ax.plot(['b', 'e', 'd'], label="plot3")
ax.legend()
```
![unknown](https://cloud.githubusercontent.com/assets/1300499/17359883/b4bbfedc-5936-11e6-8183-81613b057f39.png)

Which as a sidenote, it didn't work before because apparently FixedLocator  [converts to an array](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/ticker.py#L1348) as soon as it's passed in (and also apparently it doesn't need to...)

UnitData was also changed into an object to facilitate the updating and as a precursor to adding more functionality. And the tests should now be py.test compliant @Kojoley 