### PR TITLE
Fix inconsistency between `set_xlim` and `set_view_interval`

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2853,13 +2853,25 @@ class _AxesBase(martist.Artist):
                 ('Attempting to set identical left==right results\n'
                  'in singular transformations; automatically expanding.\n'
                  'left=%s, right=%s') % (left, right))
+
         left, right = mtransforms.nonsingular(left, right, increasing=False)
         left, right = self.xaxis.limit_range_for_scale(left, right)
 
-        self.viewLim.intervalx = (left, right)
         if auto is not None:
             self._autoscaleXon = bool(auto)
 
+        self._set_viewLim_intervalx(left, right, emit=emit)
+        return left, right
+
+    def _set_viewLim_intervalx(self, left, right, emit=True):
+        """
+        Set the data limits for the xaxis
+        This should be the only method who can change viewLim.intervalx directly.
+
+        *emit*: [ *True* | *False* ]
+            Notify observers of limit change
+        """
+        self.viewLim.intervalx = (left, right)
         if emit:
             self.callbacks.process('xlim_changed', self)
             # Call all of the other x-axes that are shared with this one
@@ -2871,7 +2883,6 @@ class _AxesBase(martist.Artist):
                             other.figure.canvas is not None):
                         other.figure.canvas.draw_idle()
         self.stale = True
-        return left, right
 
     def get_xscale(self):
         return self.xaxis.get_scale()
@@ -3115,10 +3126,21 @@ class _AxesBase(martist.Artist):
         bottom, top = mtransforms.nonsingular(bottom, top, increasing=False)
         bottom, top = self.yaxis.limit_range_for_scale(bottom, top)
 
-        self.viewLim.intervaly = (bottom, top)
         if auto is not None:
             self._autoscaleYon = bool(auto)
 
+        self._set_viewLim_intervaly(bottom, top, emit=emit)
+        return bottom, top
+
+    def _set_viewLim_intervaly(self, bottom, top, emit=True):
+        """
+        Set the data limits for the yaxis
+        This should be the only method who can change viewLim.intervaly directly.
+
+        *emit*: [ *True* | *False* ]
+            Notify observers of limit change
+        """
+        self.viewLim.intervaly = (bottom, top)
         if emit:
             self.callbacks.process('ylim_changed', self)
             # Call all of the other y-axes that are shared with this one
@@ -3130,7 +3152,6 @@ class _AxesBase(martist.Artist):
                             other.figure.canvas is not None):
                         other.figure.canvas.draw_idle()
         self.stale = True
-        return bottom, top
 
     def get_yscale(self):
         return self.yaxis.get_scale()

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1960,15 +1960,16 @@ class XAxis(Axis):
 
         """
         if ignore:
-            self.axes.viewLim.intervalx = vmin, vmax
+            left, right = vmin, vmax
         else:
             Vmin, Vmax = self.get_view_interval()
             if Vmin < Vmax:
-                self.axes.viewLim.intervalx = (min(vmin, vmax, Vmin),
-                                               max(vmin, vmax, Vmax))
+                left, right = (min(vmin, vmax, Vmin),
+                               max(vmin, vmax, Vmax))
             else:
-                self.axes.viewLim.intervalx = (max(vmin, vmax, Vmin),
-                                               min(vmin, vmax, Vmax))
+                left, right = (max(vmin, vmax, Vmin),
+                               min(vmin, vmax, Vmax))
+        self.axes._set_viewLim_intervalx(left, right)
 
     def get_minpos(self):
         return self.axes.dataLim.minposx
@@ -2299,16 +2300,16 @@ class YAxis(Axis):
 
         """
         if ignore:
-            self.axes.viewLim.intervaly = vmin, vmax
+            bottom, top = vmin, vmax
         else:
             Vmin, Vmax = self.get_view_interval()
             if Vmin < Vmax:
-                self.axes.viewLim.intervaly = (min(vmin, vmax, Vmin),
-                                               max(vmin, vmax, Vmax))
+                bottom, top = (min(vmin, vmax, Vmin),
+                               max(vmin, vmax, Vmax))
             else:
-                self.axes.viewLim.intervaly = (max(vmin, vmax, Vmin),
-                                               min(vmin, vmax, Vmax))
-        self.stale = True
+                bottom, top = (max(vmin, vmax, Vmin),
+                               min(vmin, vmax, Vmax))
+        self.axes._set_viewLim_intervaly(bottom, top)
 
     def get_minpos(self):
         return self.axes.dataLim.minposy


### PR DESCRIPTION
Fix bug:
`Axes.xaxis.set_view_interval` , `Axes.xaxis.set_view_interval` do not
update twin axis as `Axes.set_xlim` do.

Add function:
`Axes._set_viewLim_intervalx`, `Axes._set_viewLim_intervaly`, they aim at change `viewLim.intervalx(y)` and reduce the axes's callbacks and update the twin axis.

Refer the issue https://github.com/matplotlib/matplotlib/issues/6863