### PR TITLE
Don't force anncoords to fig coords upon dragging.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1750,30 +1750,12 @@ class DraggableAnnotation(DraggableBase):
 
     def save_offset(self):
         ann = self.annotation
-        x, y = ann.xyann
-        if isinstance(ann.anncoords, tuple):
-            xcoord, ycoord = ann.anncoords
-            x1, y1 = ann._get_xy(self.canvas.renderer, x, y, xcoord)
-            x2, y2 = ann._get_xy(self.canvas.renderer, x, y, ycoord)
-            ox0, oy0 = x1, y2
-        else:
-            ox0, oy0 = ann._get_xy(self.canvas.renderer, x, y, ann.anncoords)
-
-        self.ox, self.oy = ox0, oy0
-        self.annotation.anncoords = "figure pixels"
-        self.update_offset(0, 0)
+        self.ox, self.oy = ann.get_transform().transform(ann.xyann)
 
     def update_offset(self, dx, dy):
         ann = self.annotation
-        ann.xyann = self.ox + dx, self.oy + dy
-        x, y = ann.xyann
-
-    def finalize_offset(self):
-        loc_in_canvas = self.annotation.xyann
-        self.annotation.anncoords = "axes fraction"
-        pos_axes_fraction = self.annotation.axes.transAxes.inverted()
-        pos_axes_fraction = pos_axes_fraction.transform_point(loc_in_canvas)
-        self.annotation.xyann = tuple(pos_axes_fraction)
+        ann.xyann = ann.get_transform().inverted().transform(
+            (self.ox + dx, self.oy + dy))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See #6783.

Minimal example:

    from matplotlib import pyplot as plt

    plt.annotate("foo", (.5, .5),
                (15, 15), textcoords="offset points",
                arrowprops={"arrowstyle": "->"},
                bbox={"ec": "k"}).draggable()
    plt.show()

Panning the axes shows that the annotation uses offset coordinates: it moves
"with" the point it points to.  However, (before this patch is applied,) after
dragging the annotation somewhere else, it switches to figure coordinates: when
panning the axes, the text box stops physically moving; instead it's the arrow
that moves to follow the point.

The fix actually makes the code simpler...