### PR TITLE
Prevent forced alpha in figureoptions.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -209,8 +209,8 @@ def figure_edit(axes, parent=None):
             line.set_drawstyle(drawstyle)
             line.set_linewidth(linewidth)
             rgba = mcolors.to_rgba(color)
-            line.set_color(rgba[:3])
-            line.set_alpha(rgba[-1])
+            line.set_alpha(None)
+            line.set_color(rgba)
             if marker is not 'none':
                 line.set_marker(marker)
                 line.set_markersize(markersize)


### PR DESCRIPTION
Forcing the alpha value sets it not only for the line color but also the
marker faces and edges (i.e., editing the alpha value of the markers
in the options editor had no effect).  Instead, just remove any forced
alpha and use the alpha values that have been set in the editor.

A later idea may be to make alpha not override alpha values passed in
together with the color as quadruplets.

See discussion starting at https://github.com/matplotlib/matplotlib/pull/6383#issuecomment-227039674