### PR TITLE
Fix read mode when loading cached AFM fonts

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1119,7 +1119,7 @@ class StandardPsFonts(Fonts):
         cached_font = self.fonts.get(basename)
         if cached_font is None:
             fname = os.path.join(self.basepath, basename + ".afm")
-            with open(fname, 'r') as fd:
+            with open(fname, 'rb') as fd:
                 cached_font = AFM(fd)
             cached_font.fname = fname
             self.fonts[basename] = cached_font


### PR DESCRIPTION
This fixes a typo to read cached AFM fonts as a byte string, as needed by the AFM class in `afm.py`. This bug is triggered when testing PR #5161.

cc: @mdboom 