### PR TITLE
Gridspec-based suptitle (WIP, do not merge).

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1000,7 +1000,9 @@ class Axis(artist.Artist):
         else:
             interval_expanded = interval[1], interval[0]
 
-        if hasattr(self, '_get_pixel_distance_along_axis'):
+        # Don't call `_get_pixel_distance_along_axis` when there are no ticks,
+        # to support the "empty axes" trick used by suptitle.
+        if tick_tups:
             # normally, one does not want to catch all exceptions that
             # could possibly happen, but it is not clear exactly what
             # exceptions might arise from a user's projection (their
@@ -1048,6 +1050,19 @@ class Axis(artist.Artist):
             ticks_to_draw.append(tick)
 
         return ticks_to_draw
+
+    def _get_pixel_distance_along_axis(self, where, perturb):
+        """
+        Returns the amount, in data coordinates, that a single pixel
+        corresponds to in the locality given by "where", which is also given
+        in data coordinates, and is an x coordinate. "perturb" is the amount
+        to perturb the pixel.  Usually +0.5 or -0.5.
+
+        Implementing this routine for an axis is optional; if present, it will
+        ensure that no ticks are lost due to round-off at the extreme ends of
+        an axis.
+        """
+        return 0
 
     def _get_tick_bboxes(self, ticks, renderer):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -511,81 +511,22 @@ class Figure(Artist):
         """
         Add a centered title to the figure.
 
-        kwargs are :class:`matplotlib.text.Text` properties.  Using figure
-        coordinates, the defaults are:
-
-          x : 0.5
-            The x location of the text in figure coords
-
-          y : 0.98
-            The y location of the text in figure coords
-
-          horizontalalignment : 'center'
-            The horizontal alignment of the text
-
-          verticalalignment : 'top'
-            The vertical alignment of the text
-
-        If the `fontproperties` keyword argument is given then the
-        rcParams defaults for `fontsize` (`figure.titlesize`) and
-        `fontweight` (`figure.titleweight`) will be ignored in favour
-        of the `FontProperties` defaults.
-
-        A :class:`matplotlib.text.Text` instance is returned.
+        kwargs are :class:`matplotlib.text.Text` properties.  A
+        :class:`matplotlib.text.Text` instance is returned.
 
         Example::
 
           fig.suptitle('this is the figure title', fontsize=12)
         """
-        x = kwargs.pop('x', 0.5)
-        y = kwargs.pop('y', 0.98)
 
-        if ('horizontalalignment' not in kwargs) and ('ha' not in kwargs):
-            kwargs['horizontalalignment'] = 'center'
-        if ('verticalalignment' not in kwargs) and ('va' not in kwargs):
-            kwargs['verticalalignment'] = 'top'
-
-        if 'fontproperties' not in kwargs:
-            if 'fontsize' not in kwargs and 'size' not in kwargs:
-                kwargs['size'] = rcParams['figure.titlesize']
-            if 'fontweight' not in kwargs and 'weight' not in kwargs:
-                kwargs['weight'] = rcParams['figure.titleweight']
-
-        sup = self.text(x, y, t, **kwargs)
-        if self._suptitle is not None:
-            self._suptitle.set_text(t)
-            self._suptitle.set_position((x, y))
-            self._suptitle.update_from(sup)
-            sup.remove()
+        if self._suptitle is None:
+            gs = GridSpec(2, 1, height_ratios=[0, 1])
+            title_axes = self.add_subplot(gs[0], frameon=False)
+            title_axes.xaxis.set_major_locator(NullLocator())
+            title_axes.yaxis.set_major_locator(NullLocator())
         else:
-            self._suptitle = sup
-
-        self.stale = True
-        return self._suptitle
-
-    def suptitle2(self, text):
-        from .tight_layout import get_subplotspec_list
-        subplotspec_list = get_subplotspec_list(self.axes)
-        if None in subplotspec_list:
-            warnings.warn("This figure includes Axes that are not "
-                          "compatible with suptitle2, so its "
-                          "results might be incorrect.")
-
-        gs = GridSpec(2, 1, height_ratios=[0, 1])
-        title_axes = self.add_subplot(gs[0], frameon=False)
-        self._suptitle = title_axes.set_title(text)
-
-        class empty_axis:
-            @property
-            def _get_pixel_distance_along_axis(self):
-                raise AttributeError
-
-        title_axes.xaxis.__class__ = type(
-            "_", (empty_axis, type(title_axes.xaxis)), {})
-        title_axes.yaxis.__class__ = type(
-            "_", (empty_axis, type(title_axes.yaxis)), {})
-        title_axes.xaxis.set_major_locator(NullLocator())
-        title_axes.yaxis.set_major_locator(NullLocator())
+            title_axes = self._suptitle.axes
+        self._suptitle = title_axes.set_title(t, **kwargs)
 
         self.stale = True
         return self._suptitle


### PR DESCRIPTION
ref: #829, #5355

This is a proof of concept.

The idea is to use a technique similar to the one used by colorbars to
make `tight_layout` respect `suptitle`s, rather than crash into them.

Compare:

```
plt.subplots(2, 2); plt.gcf().suptitle("foo"); plt.tight_layout()
```

![suptitle](https://cloud.githubusercontent.com/assets/1322974/17502711/12d7d240-5d9f-11e6-872d-c14847d1fe8b.png)

and

```
plt.subplots(2, 2); plt.gcf().suptitle2("foo"); plt.tight_layout()
```

![suptitle2](https://cloud.githubusercontent.com/assets/1322974/17502715/1859c318-5d9f-11e6-9f24-bf75aea9aa7c.png)

Text-related kwargs can easily be supported; if any positioning-related
ones are used (`x`, `y`, `ha`, `va`), the old code path should probably
be used.

If there are axes that were not created (directly or indirectly) via
`GridSpec`, we can either move all of them (using a technique similar to
`colorbar.make_axes`, or again just go through the old code path
(because `tight_layout` won't work anyways).

Finally this could be generalized to all four sides of the figure, e.g.
to provide "global" x- and y-labels to multiple subplots simultaneously.

The hack of providing an `empty_axis` mixin class serves to pretend that
the Axises (...?) do not implement `_get_pixel_distance_along_axis`;
currently the implementation of this method leads to a warning being
raised for zero-sized axises.

---

More generally, I wonder whether we could just use the gridspec mechanism to solve a number of issues that are awaiting the implementation of a geometry manager (see corresponding issue label) -- unfortunately, #1109 seems to have stalled.
