### PR TITLE
BUG: PcolorImage handles non-contiguous arrays, provides data readout

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5522,8 +5522,9 @@ class Axes(_AxesBase):
         .. seealso::
 
             :func:`~matplotlib.pyplot.pcolor`
-                For an explanation of the grid orientation and the
-                expansion of 1-D *X* and/or *Y* to 2-D arrays.
+                For an explanation of the grid orientation
+                (:ref:`Grid Orientation <axes-pcolor-grid-orientation>`)
+                and the expansion of 1-D *X* and/or *Y* to 2-D arrays.
         """
         if not self._hold:
             self.cla()
@@ -5637,10 +5638,10 @@ class Axes(_AxesBase):
         (*nr*-1, *nc*-1).  All cells are rectangles of the same size.
         This is the fastest version.
 
-        *x*, *y* are 1D arrays of length *nc* +1 and *nr* +1, respectively,
-        giving the x and y boundaries of the cells.  Hence the cells are
-        rectangular but the grid may be nonuniform.  The speed is
-        intermediate.  (The grid is checked, and if found to be
+        *x*, *y* are monotonic 1D arrays of length *nc* +1 and *nr* +1,
+        respectively, giving the x and y boundaries of the cells.  Hence
+        the cells are rectangular but the grid may be nonuniform.  The
+        speed is intermediate.  (The grid is checked, and if found to be
         uniform the fast version is used.)
 
         *X* and *Y* are 2D arrays with shape (*nr* +1, *nc* +1) that specify
@@ -5654,7 +5655,7 @@ class Axes(_AxesBase):
 
         Note that the column index corresponds to the x-coordinate,
         and the row index corresponds to y; for details, see
-        the "Grid Orientation" section below.
+        :ref:`Grid Orientation <axes-pcolor-grid-orientation>`.
 
         Optional keyword arguments:
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -985,6 +985,15 @@ class PcolorImage(AxesImage):
                     self.is_grayscale = True
             else:
                 raise ValueError("3D arrays must have RGB or RGBA as last dim")
+
+        # For efficient cursor readout, ensure x and y are increasing.
+        if x[-1] < x[0]:
+            x = x[::-1]
+            A = A[:, ::-1]
+        if y[-1] < y[0]:
+            y = y[::-1]
+            A = A[::-1]
+
         self._A = A
         self._Ax = x
         self._Ay = y
@@ -993,6 +1002,19 @@ class PcolorImage(AxesImage):
 
     def set_array(self, *args):
         raise NotImplementedError('Method not supported')
+
+    def get_cursor_data(self, event):
+        """Get the cursor data for a given event"""
+        x, y = event.xdata, event.ydata
+        if (x < self._Ax[0] or x > self._Ax[-1] or
+                y < self._Ay[0] or y > self._Ay[-1]):
+            return None
+        j = np.searchsorted(self._Ax, x) - 1
+        i = np.searchsorted(self._Ay, y) - 1
+        try:
+            return self._A[i, j]
+        except:
+            return None
 
 
 class FigureImage(_ImageBase):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -839,8 +839,8 @@ class NonUniformImage(AxesImage):
         """
         Set the grid for the pixel centers, and the pixel values.
 
-          *x* and *y* are 1-D ndarrays of lengths N and M, respectively,
-             specifying pixel centers
+          *x* and *y* are monotonic 1-D ndarrays of lengths N and M,
+             respectively, specifying pixel centers
 
           *A* is an (M,N) ndarray or masked array of values to be
             colormapped, or a (M,N,3) RGB array, or a (M,N,4) RGBA
@@ -959,6 +959,19 @@ class PcolorImage(AxesImage):
         return False
 
     def set_data(self, x, y, A):
+        """
+        Set the grid for the rectangle boundaries, and the data values.
+
+          *x* and *y* are monotonic 1-D ndarrays of lengths N+1 and M+1,
+             respectively, specifying rectangle boundaries.  If None,
+             they will be created as uniform arrays from 0 through N
+             and 0 through M, respectively.
+
+          *A* is an (M,N) ndarray or masked array of values to be
+            colormapped, or a (M,N,3) RGB array, or a (M,N,4) RGBA
+            array.
+
+        """
         A = cbook.safe_masked_invalid(A, copy=True)
         if x is None:
             x = np.arange(0, A.shape[1]+1, dtype=np.float64)

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -411,9 +411,9 @@ static PyObject *image_pcolor2(PyObject *self, PyObject *args, PyObject *kwds)
 
     if (!PyArg_ParseTuple(args,
                           "O&O&O&II(ffff)O&:pcolor2",
-                          &x.converter,
+                          &x.converter_contiguous,
                           &x,
-                          &y.converter,
+                          &y.converter_contiguous,
                           &y,
                           &d.converter_contiguous,
                           &d,


### PR DESCRIPTION
Closes #6905, and fixes a bug in the underlying `_image.pcolor2` function.  It requires that all three input arrays be contiguous, so I appended `_contiguous` to the converters for `x` and `y`.

To verify both the data cursor and the ability to handle non-contiguous inputs, 
```python
import numpy as np
import matplotlib.pyplot as plt

x = np.arange(4) ** 1.5
y = np.arange(3) ** 1.5

# comment out for contiguous inputs
x = x[::-1]
y = y[::-1]

z = x[:-1] - y[:-1, np.newaxis]

fig, ax = plt.subplots()
pci = ax.pcolorfast(x, y, z)
print(type(pci))
print(pci._A.shape)
print(pci._A)
print(pci._Ax)
print(pci._Ay)

plt.show()
```