### PR TITLE
Fixed memory leak in contour

### DIFF
--- a/src/_contour.cpp
+++ b/src/_contour.cpp
@@ -396,7 +396,7 @@ void QuadContourGenerator::append_contour_line_to_vertices(
         line(i, 0) = point->x;
         line(i, 1) = point->y;
     }
-    if (PyList_Append(vertices_list, line.pyobj())) {
+    if (PyList_Append(vertices_list, line.pyobj_steal())) {
         Py_XDECREF(vertices_list);
         throw "Unable to add contour line to vertices_list";
     }
@@ -470,8 +470,8 @@ void QuadContourGenerator::append_contour_to_vertices_and_codes(
                 child.clear_parent();  // To indicate it can be deleted.
             }
 
-            if (PyList_Append(vertices_list, vertices.pyobj()) ||
-                PyList_Append(codes_list, codes.pyobj())) {
+            if (PyList_Append(vertices_list, vertices.pyobj_steal()) ||
+                PyList_Append(codes_list, codes.pyobj_steal())) {
                 Py_XDECREF(vertices_list);
                 Py_XDECREF(codes_list);
                 contour.delete_contour_lines();

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -525,9 +525,16 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         return (T *)m_data;
     }
 
+    // Return a new reference.
     PyObject *pyobj()
     {
         Py_XINCREF(m_arr);
+        return (PyObject *)m_arr;
+    }
+
+    // Steal a reference.
+    PyObject *pyobj_steal()
+    {
         return (PyObject *)m_arr;
     }
 


### PR DESCRIPTION
Fixed memory leak in contour as reported in #6940.  PR is based on v2.x branch, but fix needs to be in all active branches.

Problem is down to my stupidity when adding numpy arrays to python lists to return from contour/contourf calls.  New contouring C++ code uses our numpy `array_view` wrappers, which are in charge of their own reference counting, and native Python/C API list functions for which I am explicitly responsible for reference counting.  Consider code:

    numpy::array_view<double, 2> line(dims);   // ref count 1
    PyObject* pyline = line.pyobj();  // ref count 2
    PyList_SetItem(pylist, pyline);  // ref count remains 2 as PyList_SetItem steals reference
    return pylist;  // line goes out of scope so ref count 1 for the one and only reference in the list

This is fine, but I am using `PyList_Append` instead of `PyList_SetItem` as I don't know the length of the list when it is created.  It turns out that `PyList_Append` increments the reference count whereas `PyList_SetItem` steals a reference.  I assume I used to know this but have since forgotten it and have just rediscovered it.

There are 2 options for the fix.  Either
1. keep using `array_view.pyobj()` but store the returned object and decrement the reference count myself, or
2. use a new function `array_view.pyobj_steal()` that returns a stolen reference.

I've opted for the second option as that keeps all the explicit array reference counting within the `array_view` class.