### PR TITLE
Value checking the numpoints argument to be a whole number.

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -286,6 +286,13 @@ class Legend(Artist):
             ncol = 1
         self._ncol = ncol
 
+        if (
+            not isinstance(self.numpoints, int) and
+            not isinstance(self.numpoints, float) and
+            not self.numpoints.is_integer()
+        ):
+            raise ValueError("numpoints must be a whole number; it was %f"
+                % numpoints)
         if self.numpoints <= 0:
             raise ValueError("numpoints must be > 0; it was %d" % numpoints)
 


### PR DESCRIPTION
Referencing issue #6921, if you accidentally provide a decimal fraction as numpoints, you get a strange error in another file (https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/legend_handler.py#L151) not reflecting the real problem. This can be fixed by checking for whole numbers.

I included checking for whole floats as well, in case the value gets calculated through some floating point formula. If that doesn't make any sense, I can remove it again.
