### PR TITLE
fix deprecation warning for stopiteration

### DIFF
--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -306,8 +306,7 @@ class Type1Font(object):
                  b'/FontMatrix': replace(fontmatrix),
                  b'/UniqueID': suppress}
 
-        while True:
-            token, value = next(tokens)
+        for token, value in tokens:
             if token is cls._name and value in table:
                 for value in table[value](itertools.chain([(token, value)],
                                                           tokens)):


### PR DESCRIPTION
see pep 479 https://www.python.org/dev/peps/pep-0479/

This is being raised during the tests as a PendingDeprecationWaring on 3.5 and a DeprecationWaring on 3.6 and may result in a RunTimeError in 3.7 