### PR TITLE
Add parameter checks to DayLocator initiator

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1241,12 +1241,8 @@ class DayLocator(RRuleLocator):
 
         Default is to tick every day of the month: ``bymonthday=range(1,32)``
         """
-        if interval < 1:
-            raise ValueError("The interval parameter must be an integer "
-                             "greater than or equal to one.")
-        if not isinstance(interval, int):
-            raise ValueError("The interval parameter must be an integer "
-                             "greater than or equal to one.")
+        if not interval == int(interval) or interval < 1:
+            raise ValueError("interval must be an integer greater than 0")
         if bymonthday is None:
             bymonthday = range(1, 32)
         elif isinstance(bymonthday, np.ndarray):

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -821,19 +821,6 @@ class RRuleLocator(DateLocator):
 
         self.rule.set(dtstart=start, until=stop)
 
-        # estimate the number of ticks very approximately so we don't
-        # have to do a very expensive (and potentially near infinite)
-        # 'between' calculation, only to find out it will fail.
-        nmax, nmin = date2num((vmax, vmin))
-        estimate = (nmax - nmin) / (self._get_unit() * self._get_interval())
-        # This estimate is only an estimate, so be really conservative
-        # about bailing...
-        if estimate > self.MAXTICKS * 2:
-            raise RuntimeError(
-                'RRuleLocator estimated to generate %d ticks from %s to %s: '
-                'exceeds Locator.MAXTICKS * 2 (%d) ' % (estimate, vmin, vmax,
-                                                        self.MAXTICKS * 2))
-
         dates = self.rule.between(vmin, vmax, True)
         if len(dates) == 0:
             return date2num([vmin, vmax])
@@ -1254,6 +1241,12 @@ class DayLocator(RRuleLocator):
 
         Default is to tick every day of the month: ``bymonthday=range(1,32)``
         """
+        if interval < 1:
+            raise ValueError("The interval parameter must be an integer "
+                             "greater than or equal to one.")
+        if not isinstance(interval, int):
+            raise ValueError("The interval parameter must be an integer "
+                             "greater than or equal to one.")
         if bymonthday is None:
             bymonthday = range(1, 32)
         elif isinstance(bymonthday, np.ndarray):

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -442,7 +442,6 @@ def test_date2num_dst():
 
     _test_date2num_dst(date_range, tz_convert)
 
-
 def test_date2num_dst_pandas():
     # Test for github issue #3896, but in date2num around DST transitions
     # with a timezone-aware pandas date_range object.
@@ -455,6 +454,13 @@ def test_date2num_dst_pandas():
         return pd.DatetimeIndex.tz_convert(*args).astype(datetime.datetime)
 
     _test_date2num_dst(pd.date_range, tz_convert)
+
+def test_DayLocator():
+   assert_raises(ValueError, mdates.DayLocator, interval=-1)
+   assert_raises(ValueError, mdates.DayLocator, interval=-1.5)
+   assert_raises(ValueError, mdates.DayLocator, interval=0)
+   assert_raises(ValueError, mdates.DayLocator, interval=1.3)
+   mdates.DayLocator(interval=1.0)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -442,6 +442,7 @@ def test_date2num_dst():
 
     _test_date2num_dst(date_range, tz_convert)
 
+
 def test_date2num_dst_pandas():
     # Test for github issue #3896, but in date2num around DST transitions
     # with a timezone-aware pandas date_range object.
@@ -454,6 +455,7 @@ def test_date2num_dst_pandas():
         return pd.DatetimeIndex.tz_convert(*args).astype(datetime.datetime)
 
     _test_date2num_dst(pd.date_range, tz_convert)
+
 
 def test_DayLocator():
    assert_raises(ValueError, mdates.DayLocator, interval=-1)


### PR DESCRIPTION
Check that interval parameter is an integer greater than zero.

Delete unuseful 'optimization' meant to prevent exceeding the
MAXTICKS variable. During testing it seemed ineffective. The
following Locator.raise_if_exceeds exception was triggered first
anyways.

resolves #6935