### PR TITLE
DOC: clearing out some instances of using pylab in the docs

### DIFF
--- a/doc/faq/installing_faq.rst
+++ b/doc/faq/installing_faq.rst
@@ -23,9 +23,10 @@ complexities. Open up a UNIX shell or a DOS command prompt and cd into a
 directory containing a minimal example in a file. Something like
 :file:`simple_plot.py` for example::
 
-  from pylab import *
-  plot([1,2,3])
-  show()
+  import matplotlib.pyplot as plt
+  fig, ax = plt.subplots()
+  ax.plot([1,2,3])
+  plt.show()
 
 and run it with::
 

--- a/doc/pyplots/boxplot_demo.py
+++ b/doc/pyplots/boxplot_demo.py
@@ -4,62 +4,60 @@
 # Example boxplot code
 #
 
-from pylab import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+np.random.seed(0)
 
 # fake up some data
-spread= rand(50) * 100
-center = ones(25) * 50
-flier_high = rand(10) * 100 + 100
-flier_low = rand(10) * -100
-data =concatenate((spread, center, flier_high, flier_low), 0)
+spread = np.random.rand(50) * 100
+center = np.ones(25) * 50
+flier_high = np.random.rand(10) * 100 + 100
+flier_low = np.random.rand(10) * -100
+data = np.concatenate((spread, center, flier_high, flier_low), 0)
 
-# basic plot
-boxplot(data)
-#savefig('box1')
+fig1, ax1 = plt.subplots()
+ax1.set_title('Basic Plot')
+ax1.boxplot(data)
 
-# notched plot
-figure()
-boxplot(data,1)
-#savefig('box2')
+fig2, ax2 = plt.subplots()
+ax2.set_title('Notched boxes')
+ax2.boxplot(data, notch=True)
 
-# change outlier point symbols
-figure()
-boxplot(data,0,'gD')
-#savefig('box3')
+green_diamond = dict(markerfacecolor='g', marker='D')
+fig3, ax3 = plt.subplots()
+ax3.set_title('Changed Outlier Symbols')
+ax3.boxplot(data, flierprops=green_diamond)
 
-# don't show outlier points
-figure()
-boxplot(data,0,'')
-#savefig('box4')
+fig4, ax4 = plt.subplots()
+ax4.set_title('Hide Outlier Points')
+ax4.boxplot(data, showfliers=False)
 
-# horizontal boxes
-figure()
-boxplot(data,0,'rs',0)
-#savefig('box5')
+red_square = dict(markerfacecolor='r', marker='s')
+fig5, ax5 = plt.subplots()
+ax5.set_title('Horizontal Boxes')
+ax5.boxplot(data, vert=False, flierprops=red_square)
 
-# change whisker length
-figure()
-boxplot(data,0,'rs',0,0.75)
-#savefig('box6')
+fig6, ax6 = plt.subplots()
+ax6.set_title('Shorter Whisker Length')
+ax6.boxplot(data, flierprops=red_square, vert=False, whis=0.75)
 
 # fake up some more data
-spread= rand(50) * 100
-center = ones(25) * 40
-flier_high = rand(10) * 100 + 100
-flier_low = rand(10) * -100
-d2 = concatenate( (spread, center, flier_high, flier_low), 0 )
+spread = np.random.rand(50) * 100
+center = np.ones(25) * 40
+flier_high = np.random.rand(10) * 100 + 100
+flier_low = np.random.rand(10) * -100
+d2 = np.concatenate((spread, center, flier_high, flier_low), 0)
 data.shape = (-1, 1)
 d2.shape = (-1, 1)
-#data = concatenate( (data, d2), 1 )
+
 # Making a 2-D array only works if all the columns are the
 # same length.  If they are not, then use a list instead.
 # This is actually more efficient because boxplot converts
 # a 2-D array into a list of vectors internally anyway.
 data = [data, d2, d2[::2,0]]
-# multiple box plots on one figure
-figure()
-boxplot(data)
-#savefig('box7')
+fig7, ax7 = plt.subplots()
+ax7.set_title('Multiple Samples with Different sizes')
+ax7.boxplot(data)
 
-show()
-
+plt.show()

--- a/doc/pyplots/whats_new_98_4_fill_between.py
+++ b/doc/pyplots/whats_new_98_4_fill_between.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 import matplotlib.mlab as mlab
-from pylab import figure, show
+import matplotlib.pyplot as plt
 import numpy as np
 
 x = np.arange(0.0, 2, 0.01)
 y1 = np.sin(2*np.pi*x)
 y2 = 1.2*np.sin(4*np.pi*x)
 
-fig = figure()
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots()
 ax.plot(x, y1, x, y2, color='black')
 ax.fill_between(x, y1, y2, where=y2>y1, facecolor='green')
 ax.fill_between(x, y1, y2, where=y2<=y1, facecolor='red')
 ax.set_title('fill between where')
 
-show()
+plt.show()

--- a/doc/pyplots/whats_new_99_mplot3d.py
+++ b/doc/pyplots/whats_new_99_mplot3d.py
@@ -1,17 +1,18 @@
-from mpl_toolkits.mplot3d import Axes3D
-from matplotlib import cm
-import pylab
 import random
-import numpy as np
 
-fig = pylab.figure()
-ax = Axes3D(fig)
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
+
 X = np.arange(-5, 5, 0.25)
 Y = np.arange(-5, 5, 0.25)
 X, Y = np.meshgrid(X, Y)
 R = np.sqrt(X**2 + Y**2)
 Z = np.sin(R)
-ax.plot_surface(X, Y, Z, rstride=1, cstride=1, cmap=cm.jet)
 
-pylab.show()
+fig = plt.figure()
+ax = Axes3D(fig)
+ax.plot_surface(X, Y, Z, rstride=1, cstride=1, cmap=cm.viridis)
 
+plt.show()

--- a/examples/api/colorbar_only.py
+++ b/examples/api/colorbar_only.py
@@ -2,11 +2,11 @@
 Make a colorbar as a separate figure.
 '''
 
-from matplotlib import pyplot
+import matplotlib.pyplot as plt
 import matplotlib as mpl
 
 # Make a figure and axes with dimensions as desired.
-fig = pyplot.figure(figsize=(8, 3))
+fig = plt.figure(figsize=(8, 3))
 ax1 = fig.add_axes([0.05, 0.80, 0.9, 0.15])
 ax2 = fig.add_axes([0.05, 0.475, 0.9, 0.15])
 ax3 = fig.add_axes([0.05, 0.15, 0.9, 0.15])
@@ -71,4 +71,4 @@ cb3 = mpl.colorbar.ColorbarBase(ax3, cmap=cmap,
                                 orientation='horizontal')
 cb3.set_label('Custom extension lengths, some other units')
 
-pyplot.show()
+plt.show()

--- a/examples/units/units_scatter.py
+++ b/examples/units/units_scatter.py
@@ -9,28 +9,25 @@ The example below shows support for unit conversions over masked
 arrays.
 """
 import numpy as np
+import matplotlib.pyplot as plt
 from basic_units import secs, hertz, minutes
-from matplotlib.pylab import figure, show
 
 # create masked array
+data = (1, 2, 3, 4, 5, 6, 7, 8)
+mask = (1, 0, 1, 0, 0, 0, 1, 0)
+xsecs = secs * np.ma.MaskedArray(data, mask, float)
 
-
-xsecs = secs*np.ma.MaskedArray((1, 2, 3, 4, 5, 6, 7, 8), (1, 0, 1, 0, 0, 0, 1, 0), float)
-#xsecs = secs*np.arange(1,10.)
-
-fig = figure()
-ax1 = fig.add_subplot(3, 1, 1)
+fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, sharex=True)
 ax1.scatter(xsecs, xsecs)
-#ax1.set_ylabel('seconds')
+ax1.yaxis.set_units(secs)
 ax1.axis([0, 10, 0, 10])
 
-ax2 = fig.add_subplot(3, 1, 2, sharex=ax1)
 ax2.scatter(xsecs, xsecs, yunits=hertz)
 ax2.axis([0, 10, 0, 1])
 
-ax3 = fig.add_subplot(3, 1, 3, sharex=ax1)
 ax3.scatter(xsecs, xsecs, yunits=hertz)
 ax3.yaxis.set_units(minutes)
 ax3.axis([0, 10, 0, 1])
 
-show()
+fig.tight_layout()
+plt.show()


### PR DESCRIPTION
Note: there are some instances where I `from matplotlib import pyplot`, since that's what I'm in the habit of doing now.

Obviously I prefer it that way, but if I need to switch from `import matplotlib.pyplot as plt`, just let me know. I understand the inertial forces at work there.