### PR TITLE
CI: exclude bad pyshp version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ install:
     # We have to install it after matplotlib to avoid pulling in MPL as
     # a dependency
     if [[ $BUILD_DOCS == true ]]; then
+      pip install pyshp!=1.2.8
       pip install https://github.com/matplotlib/basemap/tarball/master
     fi;
 


### PR DESCRIPTION
This is a dependency of basemap

Reported upstream as https://github.com/GeospatialPython/pyshp/issues/63 and https://github.com/GeospatialPython/pyshp/issues/65 

Fixed upstream in https://github.com/GeospatialPython/pyshp/issues/64 but not uploaded to pypi yet.

Plan to self-merge once travis passes as this is a CI only change.