### PR TITLE
FIX: guard against numpy warnings

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -606,12 +606,13 @@ class Quiver(mcollections.PolyCollection):
 
     def _make_verts(self, U, V):
         uv = (U + V * 1j)
-        if self.angles == 'xy' and self.scale_units == 'xy':
+        str_angles = isinstance(self.angles, six.string_types)
+        if str_angles and (self.angles == 'xy' and self.scale_units == 'xy'):
             # Here eps is 1 so that if we get U, V by diffing
             # the X, Y arrays, the vectors will connect the
             # points, regardless of the axis scaling (including log).
             angles, lengths = self._angles_lengths(U, V, eps=1)
-        elif self.angles == 'xy' or self.scale_units == 'xy':
+        elif str_angles and (self.angles == 'xy' or self.scale_units == 'xy'):
             # Calculate eps based on the extents of the plot
             # so that we don't end up with roundoff error from
             # adding a small number to a large.
@@ -644,9 +645,9 @@ class Quiver(mcollections.PolyCollection):
                 self.scale = scale * widthu_per_lenu
         length = a * (widthu_per_lenu / (self.scale * self.width))
         X, Y = self._h_arrows(length)
-        if self.angles == 'xy':
+        if str_angles and (self.angles == 'xy'):
             theta = angles
-        elif self.angles == 'uv':
+        elif str_angles and (self.angles == 'uv'):
             theta = np.angle(uv)
         else:
             # Make a copy to avoid changing the input array.

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
-import os
-import tempfile
+import warnings
 import numpy as np
 import sys
 from matplotlib import pyplot as plt
@@ -43,6 +42,20 @@ def test_quiver_key_memory_leak():
     assert sys.getrefcount(qk) == 3
     qk.remove()
     assert sys.getrefcount(qk) == 2
+
+
+@cleanup
+def test_no_warnings():
+    fig, ax = plt.subplots()
+
+    X, Y = np.meshgrid(np.arange(15), np.arange(10))
+    U = V = np.ones_like(X)
+
+    phi = (np.random.rand(15, 10) - .5) * 150
+    with warnings.catch_warnings(record=True) as w:
+        ax.quiver(X, Y, U, V, angles=phi)
+        fig.canvas.draw()
+    assert len(w) == 0
 
 
 @image_comparison(baseline_images=['quiver_animated_test_image'],


### PR DESCRIPTION
Do not try to compare a string to an array.

closes #6970