### PR TITLE
Handle dvi font names as ASCII bytestrings

### DIFF
--- a/doc/api/api_changes/2017-02-12-JKS.rst
+++ b/doc/api/api_changes/2017-02-12-JKS.rst
@@ -1,0 +1,8 @@
+Changes to PDF backend methods
+``````````````````````````````
+
+The methods `embedTeXFont` and `tex_font_mapping` of
+`matplotlib.backend_pdf.PdfFile` have been removed.
+It is unlikely that external users would have called
+these methods, which are related to the font system
+internal to the PDF backend.

--- a/doc/api/dviread.rst
+++ b/doc/api/dviread.rst
@@ -8,4 +8,9 @@ dviread
 .. automodule:: matplotlib.dviread
    :members:
    :undoc-members:
+   :exclude-members: Dvi
+   :show-inheritance:
+
+.. autoclass:: matplotlib.dviread.Dvi
+   :members: __iter__,close
    :show-inheritance:

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -711,7 +711,7 @@ class PdfFile(object):
             Fx = info.pdfname
             matplotlib.verbose.report('Embedding Type-1 font %s from dvi'
                                       % dviname, 'debug')
-            fonts[Fx] = self.embedTeXFont(info)
+            fonts[Fx] = self._embedTeXFont(info)
         for filename in sorted(self.fontNames):
             Fx = self.fontNames[filename]
             matplotlib.verbose.report('Embedding font %s' % filename, 'debug')
@@ -740,7 +740,7 @@ class PdfFile(object):
         self.writeObject(fontdictObject, fontdict)
         return fontdictObject
 
-    def embedTeXFont(self, fontinfo):
+    def _embedTeXFont(self, fontinfo):
         msg = ('Embedding TeX font {0} - fontinfo={1}'
                .format(fontinfo.dvifont.texname, fontinfo.__dict__))
         matplotlib.verbose.report(msg, 'debug')

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -915,7 +915,7 @@ class PsfontsMap(object):
 
         # input must be bytestrings (the file format is ASCII)
         for word in words:
-            assert(isinstance(word, bytes))
+            assert isinstance(word, bytes)
 
         texname, psname = words[:2]
         effects, encoding, filename = b'', None, None

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -911,16 +911,23 @@ class PsfontsMap(object):
             effects, encoding, filename = b'', None, None
             words = word_re.finditer(line)
 
+            # The named groups are mutually exclusive and are
+            # referenced below at an estimated order of probability of
+            # occurrence based on looking at my copy of pdftex.map.
+            # The font names are probably unquoted:
             w = next(words)
             texname = w.group('eff2') or w.group('eff1')
             w = next(words)
             psname = w.group('eff2') or w.group('eff1')
 
             for w in words:
+                # Any effects are almost always quoted:
                 eff = w.group('eff1') or w.group('eff2')
                 if eff:
                     effects = eff
                     continue
+                # Encoding files usually have the .enc suffix
+                # and almost never need quoting:
                 enc = (w.group('enc4') or w.group('enc3') or
                        w.group('enc2') or w.group('enc1'))
                 if enc:
@@ -931,6 +938,7 @@ class PsfontsMap(object):
                             'debug')
                     encoding = enc
                     continue
+                # File names are probably unquoted:
                 filename = w.group('file2') or w.group('file1')
 
             effects_dict = {}

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -769,11 +769,11 @@ class PsfontsMap(object):
     Usage::
 
      >>> map = PsfontsMap(find_tex_file('pdftex.map'))
-     >>> entry = map['ptmbo8r']
+     >>> entry = map[b'ptmbo8r']
      >>> entry.texname
-     'ptmbo8r'
+     b'ptmbo8r'
      >>> entry.psname
-     'Times-Bold'
+     b'Times-Bold'
      >>> entry.encoding
      '/usr/local/texlive/2008/texmf-dist/fonts/enc/dvips/base/8r.enc'
      >>> entry.effects

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -901,10 +901,6 @@ class PsfontsMap(object):
         # http://tex.stackexchange.com/questions/10826/
         # http://article.gmane.org/gmane.comp.tex.pdftex/4914
 
-        # input must be bytestrings (the file format is ASCII)
-        for word in words:
-            assert isinstance(word, bytes)
-
         texname, psname = words[:2]
         words = words[2:]
         effects, encoding, filename = b'', None, None

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -31,6 +31,7 @@ import matplotlib.cbook as mpl_cbook
 from matplotlib.compat import subprocess
 from matplotlib import rcParams
 import numpy as np
+import re
 import struct
 import sys
 import textwrap
@@ -876,21 +877,8 @@ class PsfontsMap(object):
             line = line.strip()
             if line == b'' or line.startswith(b'%'):
                 continue
-            words, pos = [], 0
-            while pos < len(line):
-                if line[pos:pos+1] == b'"':   # double quoted word
-                    pos += 1
-                    end = line.index(b'"', pos)
-                    words.append(line[pos:end])
-                    pos = end + 1
-                else:                  # ordinary word
-                    end = line.find(b' ', pos+1)
-                    if end == -1:
-                        end = len(line)
-                    words.append(line[pos:end])
-                    pos = end
-                while pos < len(line) and line[pos:pos+1] == b' ':
-                    pos += 1
+            words = [word.strip(b'"') for word in
+                     re.findall(b'("[^"]*"|[^ ]+)', line)]
             self._register(words)
 
     def _register(self, words):

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -839,7 +839,8 @@ class PsfontsMap(object):
         self._font = {}
         self._filename = filename
         if six.PY3 and isinstance(filename, bytes):
-            self._filename = filename.decode('ascii', errors='replace')
+            encoding = sys.getfilesystemencoding() or 'utf-8'
+            self._filename = filename.decode(encoding, errors='replace')
         with open(filename, 'rb') as file:
             self._parse(file)
 

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -869,8 +869,6 @@ class PsfontsMap(object):
         return result._replace(filename=fn, encoding=enc)
 
     def _parse(self, file):
-        """Parse each line into words and process them."""
-
         for line in file:
             line = six.b(line)
             line = line.strip()

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -546,7 +546,9 @@ class DviFont(object):
     __slots__ = ('texname', 'size', 'widths', '_scale', '_vf', '_tfm')
 
     def __init__(self, scale, tfm, texname, vf):
-        assert(isinstance(texname, bytes))
+        if not isinstance(texname, bytes):
+            raise ValueError("texname must be a bytestring, got %s"
+                             % type(texname))
         self._scale, self._tfm, self.texname, self._vf = \
             scale, tfm, texname, vf
         self.size = scale * (72.0 / (72.27 * 2**16))

--- a/lib/matplotlib/tests/baseline_images/dviread/test.map
+++ b/lib/matplotlib/tests/baseline_images/dviread/test.map
@@ -1,9 +1,9 @@
 % used by test_dviread.py
-TeXfont1 PSfont1 <font1.pfb <font1.enc
-TeXfont2 PSfont2 <font2.enc <font2.pfa
-TeXfont3 PSfont3 "1.23 UnknownEffect" <[enc3.foo <font3.pfa
+TeXfont1 PSfont1 <font1.pfb "<font1.enc"
+TeXfont2 PSfont2 <font2.enc "<font2.pfa"
+"TeXfont3" PSfont3 "1.23 UnknownEffect" <[enc3.foo <font3.pfa
 TeXfont4 PSfont4 "-0.1 SlantFont 2.2 ExtendFont" <font4.enc <font4.pfa
-TeXfont5 PSfont5 <encoding1.enc <encoding2.enc <font5.pfb
+TeXfont5 "PSfont5" <encoding1.enc <encoding2.enc <font5.pfb
 TeXfont6 PSfont6
 TeXfont7 PSfont7 <font7.enc
 TeXfont8 PSfont8 <font8.pfb

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -52,7 +52,7 @@ def test_PsfontsMap(monkeypatch):
     # Missing font
     with pytest.raises(KeyError) as exc:
         fontmap[b'no-such-font']
-    assert b'no-such-font' in bytes(exc.value)
+    assert 'no-such-font' in str(exc.value)
 
 
 @skip_if_command_unavailable(["kpsewhich", "-version"])

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -19,7 +19,7 @@ def test_PsfontsMap(monkeypatch):
     fontmap = dr.PsfontsMap(filename)
     # Check all properties of a few fonts
     for n in [1, 2, 3, 4, 5]:
-        key = b'TeXfont%d' % n
+        key = ('TeXfont%d' % n).encode('ascii')
         entry = fontmap[key]
         assert entry.texname == key
         assert entry.psname == b'PSfont%d' % n

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -61,7 +61,7 @@ def test_dviread():
     with open(os.path.join(dir, 'test.json')) as f:
         correct = json.load(f)
         for entry in correct:
-            entry['text'] = [[a, b, c, six.b(d), e]
+            entry['text'] = [[a, b, c, d.encode('ascii'), e]
                              for [a, b, c, d, e] in entry['text']]
     with dr.Dvi(os.path.join(dir, 'test.dvi'), None) as dvi:
         data = [{'text': [[t.x, t.y,

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -18,36 +18,36 @@ def test_PsfontsMap(monkeypatch):
     fontmap = dr.PsfontsMap(filename)
     # Check all properties of a few fonts
     for n in [1, 2, 3, 4, 5]:
-        key = 'TeXfont%d' % n
+        key = b'TeXfont%d' % n
         entry = fontmap[key]
         assert entry.texname == key
-        assert entry.psname == 'PSfont%d' % n
+        assert entry.psname == b'PSfont%d' % n
         if n not in [3, 5]:
-            assert entry.encoding == 'font%d.enc' % n
+            assert entry.encoding == b'font%d.enc' % n
         elif n == 3:
-            assert entry.encoding == 'enc3.foo'
+            assert entry.encoding == b'enc3.foo'
         # We don't care about the encoding of TeXfont5, which specifies
         # multiple encodings.
         if n not in [1, 5]:
-            assert entry.filename == 'font%d.pfa' % n
+            assert entry.filename == b'font%d.pfa' % n
         else:
-            assert entry.filename == 'font%d.pfb' % n
+            assert entry.filename == b'font%d.pfb' % n
         if n == 4:
             assert entry.effects == {'slant': -0.1, 'extend': 2.2}
         else:
             assert entry.effects == {}
     # Some special cases
-    entry = fontmap['TeXfont6']
+    entry = fontmap[b'TeXfont6']
     assert entry.filename is None
     assert entry.encoding is None
-    entry = fontmap['TeXfont7']
+    entry = fontmap[b'TeXfont7']
     assert entry.filename is None
-    assert entry.encoding == 'font7.enc'
-    entry = fontmap['TeXfont8']
-    assert entry.filename == 'font8.pfb'
+    assert entry.encoding == b'font7.enc'
+    entry = fontmap[b'TeXfont8']
+    assert entry.filename == b'font8.pfb'
     assert entry.encoding is None
-    entry = fontmap['TeXfont9']
-    assert entry.filename == '/absolute/font9.pfb'
+    entry = fontmap[b'TeXfont9']
+    assert entry.filename == b'/absolute/font9.pfb'
 
 
 @skip_if_command_unavailable(["kpsewhich", "-version"])
@@ -55,10 +55,13 @@ def test_dviread():
     dir = os.path.join(os.path.dirname(__file__), 'baseline_images', 'dviread')
     with open(os.path.join(dir, 'test.json')) as f:
         correct = json.load(f)
+        for entry in correct:
+            entry['text'] = [[a, b, c, six.b(d), e]
+                             for [a, b, c, d, e] in entry['text']]
     with dr.Dvi(os.path.join(dir, 'test.dvi'), None) as dvi:
         data = [{'text': [[t.x, t.y,
                            six.unichr(t.glyph),
-                           six.text_type(t.font.texname),
+                           t.font.texname,
                            round(t.font.size, 2)]
                           for t in page.text],
                  'boxes': [[b.x, b.y, b.height, b.width] for b in page.boxes]}

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -22,17 +22,17 @@ def test_PsfontsMap(monkeypatch):
         key = ('TeXfont%d' % n).encode('ascii')
         entry = fontmap[key]
         assert entry.texname == key
-        assert entry.psname == b'PSfont%d' % n
+        assert entry.psname == ('PSfont%d' % n).encode('ascii')
         if n not in [3, 5]:
-            assert entry.encoding == b'font%d.enc' % n
+            assert entry.encoding == ('font%d.enc' % n).encode('ascii')
         elif n == 3:
             assert entry.encoding == b'enc3.foo'
         # We don't care about the encoding of TeXfont5, which specifies
         # multiple encodings.
         if n not in [1, 5]:
-            assert entry.filename == b'font%d.pfa' % n
+            assert entry.filename == ('font%d.pfa' % n).encode('ascii')
         else:
-            assert entry.filename == b'font%d.pfb' % n
+            assert entry.filename == ('font%d.pfb' % n).encode('ascii')
         if n == 4:
             assert entry.effects == {'slant': -0.1, 'extend': 2.2}
         else:

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -7,6 +7,7 @@ from matplotlib.testing.decorators import skip_if_command_unavailable
 import matplotlib.dviread as dr
 import os.path
 import json
+import pytest
 
 
 def test_PsfontsMap(monkeypatch):
@@ -48,6 +49,10 @@ def test_PsfontsMap(monkeypatch):
     assert entry.encoding is None
     entry = fontmap[b'TeXfont9']
     assert entry.filename == b'/absolute/font9.pfb'
+    # Missing font
+    with pytest.raises(KeyError) as exc:
+        fontmap[b'no-such-font']
+    assert b'no-such-font' in bytes(exc.value)
 
 
 @skip_if_command_unavailable(["kpsewhich", "-version"])


### PR DESCRIPTION
Dvi is a binary format that includes some ASCII strings such as
TeX names of some fonts. The associated files such as psfonts.map
need to be ASCII too. This patch changes their handling to keep
them as binary strings all the time.

This avoids the ugly workaround

```
    try:
        result = some_mapping[texname]
    except KeyError:
        result = some_mapping[texname.decode('ascii')]
```

which is essentially saying that texname is sometimes a string,
sometimes a bytestring. The workaround masks real KeyErrors,
leading to incomprehensible error messages such as in #6516.
