### PR TITLE
Add link to O'Reilly video course covering matplotlib

### DIFF
--- a/doc/resources/index.rst
+++ b/doc/resources/index.rst
@@ -50,6 +50,10 @@
 * `Anatomy of Matplotlib
   <https://conference.scipy.org/scipy2013/tutorial_detail.php?id=103>`_
   by Benjamin Root
+  
+* `Data Visualization Basics with Python (O'Reilly)
+  <http://shop.oreilly.com/product/0636920046592.do>`_
+  by Randal S. Olson
 
 ==========
  Tutorials


### PR DESCRIPTION
This PR adds a link to the video course on matplotlib that I put together for O'Reilly. I think it will be a useful video resource for novice matplotlib users.