### PR TITLE
Catch invalid interactive switch to log scale.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2578,7 +2578,11 @@ def key_press_handler(event, canvas, toolbar=None):
             ax.set_yscale('linear')
             ax.figure.canvas.draw_idle()
         elif scale == 'linear':
-            ax.set_yscale('log')
+            try:
+                ax.set_yscale('log')
+            except ValueError as exc:
+                warnings.warn(str(exc))
+                ax.set_yscale('linear')
             ax.figure.canvas.draw_idle()
     # toggle scaling of x-axes between 'log and 'linear' (default key 'k')
     elif event.key in toggle_xscale_keys:
@@ -2587,7 +2591,11 @@ def key_press_handler(event, canvas, toolbar=None):
             ax.set_xscale('linear')
             ax.figure.canvas.draw_idle()
         elif scalex == 'linear':
-            ax.set_xscale('log')
+            try:
+                ax.set_xscale('log')
+            except ValueError:
+                warnings.warn(str(exc))
+                ax.set_xscale('linear')
             ax.figure.canvas.draw_idle()
 
     elif (event.key.isdigit() and event.key != '0') or event.key in all_keys:


### PR DESCRIPTION
`plt.plot([1, 2], [-1, -2])` and press `l` (switch y to log-scale).
Before, this would crash the Qt5 backend and cause an invalid internal
state in others, due to the complete lack of positive values.  Now a
warning is printed and the command is cancelled.

See #6852.