### PR TITLE
FIX: default color handling in bar3D

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2443,9 +2443,9 @@ class Axes3D(Axes):
 
         facecolors = []
         if color is None:
-            # no color specified
-            facecolors = [None] * len(x)
-        elif len(color) == len(x):
+            color = [self._get_lines.get_next_color()]
+
+        if len(color) == len(x):
             # bar colors specified, need to expand to number of faces
             for c in color:
                 facecolors.extend([c] * 6)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -20,6 +20,19 @@ def test_bar3d():
         ax.bar(xs, ys, zs=z, zdir='y', color=cs, alpha=0.8)
 
 
+@cleanup
+def test_bar3d_dflt_smoke():
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    x = np.arange(4)
+    y = np.arange(5)
+    x2d, y2d = np.meshgrid(x, y)
+    x2d, y2d = x2d.ravel(), y2d.ravel()
+    z = x2d + y2d
+    ax.bar3d(x2d, y2d, x2d * 0, 1, 1, z)
+    fig.canvas.draw()
+
+
 @image_comparison(baseline_images=['contour3d'], remove_text=True)
 def test_contour3d():
     fig = plt.figure()


### PR DESCRIPTION
If color not specified (default to `None`), get the next color from the
axes color cycle.

closes #6989