### PR TITLE
FIX: slow plots of pandas objects (Second try)

### DIFF
--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -44,7 +44,7 @@ datetime objects::
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from matplotlib.cbook import iterable, is_numlike
+from matplotlib.cbook import iterable, is_numlike, safe_first_element
 import numpy as np
 
 
@@ -155,14 +155,11 @@ class Registry(dict):
                     converter = self.get_converter(next_item)
                 return converter
 
-        if converter is None and iterable(x):
-            for thisx in x:
-                # Make sure that recursing might actually lead to a solution,
-                # if we are just going to re-examine another item of the same
-                # kind, then do not look at it.
-                if classx and classx != getattr(thisx, '__class__', None):
-                    converter = self.get_converter(thisx)
-                    return converter
+        if converter is None and iterable(x) and (len(x) > 0):
+            thisx = safe_first_element(x)
+            if classx and classx != getattr(thisx, '__class__', None):
+                converter = self.get_converter(thisx)
+                return converter
 
         # DISABLED self._cached[idx] = converter
         return converter


### PR DESCRIPTION
Second attempt: Removes loop to iterate through all elements in order to find a convertor. closes #6804.