### PR TITLE
FIX: sphinx 1.4.0 details

### DIFF
--- a/lib/matplotlib/sphinxext/only_directives.py
+++ b/lib/matplotlib/sphinxext/only_directives.py
@@ -64,10 +64,12 @@ def setup(app):
     def depart_ignore(self, node):
         node.children = []
 
-    app.add_node(html_only, html=(visit_perform, depart_perform))
-    app.add_node(html_only, latex=(visit_ignore, depart_ignore))
-    app.add_node(latex_only, latex=(visit_perform, depart_perform))
-    app.add_node(latex_only, html=(visit_ignore, depart_ignore))
+    app.add_node(html_only,
+                 html=(visit_perform, depart_perform),
+                 latex=(visit_ignore, depart_ignore))
+    app.add_node(latex_only,
+                 latex=(visit_perform, depart_perform),
+                 html=(visit_ignore, depart_ignore))
 
     metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
     return metadata


### PR DESCRIPTION
In 10bbf1c1747857b5946045574e65ce1ba977bb0e which merged parallel
building, the changes from 3a944a6c87e4452a215045a5281c352838898f25
(which accounted for sphinx 1.4.0 becoming stricter) were discarded.