### PR TITLE
TST: fix skip for pytest

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -36,7 +36,7 @@ def skip(msg=""):
     __tracebackhide__ = True
     if is_called_from_pytest():
         import pytest
-        pytest.skip(msg)
+        pytest.mark.skip(msg)
     else:
         from nose import SkipTest
         raise SkipTest(msg)


### PR DESCRIPTION
Trying to fix this error on appveyor:

```

=================================== ERRORS ====================================
____________ ERROR collecting lib/matplotlib/tests/test_dviread.py ____________
Using @pytest.skip outside of a test (e.g. as a test function decorator) is not allowed. Use @pytest.mark.skip or @pytest.mark.skipif instead.

```

attn @Kojoley 