### PR TITLE
TST: Fixed `skip_if_command_unavailable` decorator problem

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -448,6 +448,6 @@ def skip_if_command_unavailable(cmd):
     try:
         check_output(cmd)
     except:
-        skip('missing command: %s' % cmd[0])
+        return skipif(True, reason='missing command: %s' % cmd[0])
 
     return lambda f: f


### PR DESCRIPTION
This should fix appveyor pytest build fail

attn @tacaswell