### PR TITLE
Don't blacklist test_usetex using pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,9 +14,7 @@ from matplotlib.testing.decorators import ImageComparisonTest
 
 
 IGNORED_TESTS = {
-    'matplotlib': [
-        'test_usetex',
-    ],
+    'matplotlib': [],
 }
 
 


### PR DESCRIPTION
The tests where fixed in #6918 but not enabled for pytest