### PR TITLE
Check for fontproperties in figure.suptitle.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -523,6 +523,11 @@ class Figure(Artist):
           *verticalalignment* : 'top'
             The vertical alignment of the text
 
+        If the `fontproperties` keyword argument is given then the
+        rcParams defaults for `fontsize` (`figure.titlesize`) and
+        `fontweight` (`figure.titleweight`) will be ignored in favour
+        of the `FontProperties` defaults.
+
         A :class:`matplotlib.text.Text` instance is returned.
 
         Example::
@@ -537,10 +542,11 @@ class Figure(Artist):
         if ('verticalalignment' not in kwargs) and ('va' not in kwargs):
             kwargs['verticalalignment'] = 'top'
 
-        if 'fontsize' not in kwargs and 'size' not in kwargs:
-            kwargs['size'] = rcParams['figure.titlesize']
-        if 'fontweight' not in kwargs and 'weight' not in kwargs:
-            kwargs['weight'] = rcParams['figure.titleweight']
+        if 'fontproperties' not in kwargs:
+            if 'fontsize' not in kwargs and 'size' not in kwargs:
+                kwargs['size'] = rcParams['figure.titlesize']
+            if 'fontweight' not in kwargs and 'weight' not in kwargs:
+                kwargs['weight'] = rcParams['figure.titleweight']
 
         sup = self.text(x, y, t, **kwargs)
         if self._suptitle is not None:

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -100,6 +100,17 @@ def test_suptitle():
     fig.suptitle('title', color='g', rotation='30')
 
 
+@cleanup
+def test_suptitle_fontproperties():
+    from matplotlib.font_manager import FontProperties
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    fps = FontProperties(size='large', weight='bold')
+    txt = fig.suptitle('fontprops title', fontproperties=fps)
+    assert_equal(txt.get_fontsize(), fps.get_size_in_points())
+    assert_equal(txt.get_weight(), fps.get_weight())
+
+
 @image_comparison(baseline_images=['alpha_background'],
                   # only test png and svg. The PDF output appears correct,
                   # but Ghostscript does not preserve the background color.


### PR DESCRIPTION
Fixes #6996 

Was previously applying defaults from rcParams when fontproperties was provided. This meant fontproperties got ignored.

Travis CI failed a seemingly unrelated test when I ran it on this change (https://travis-ci.org/dmkent/matplotlib/builds/156481606), will see what it thinks on the PR....