### PR TITLE
Add `clf` kwarg to plt.figure() 

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -429,6 +429,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
            facecolor=None,  # defaults to rc figure.facecolor
            edgecolor=None,  # defaults to rc figure.edgecolor
            frameon=True,
+           clf=False,
            FigureClass=Figure,
            **kwargs
            ):
@@ -460,6 +461,12 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
 
     edgecolor :
         the border color. If not provided, defaults to rc figure.edgecolor
+
+    frameon : bool, optional, default: True
+        If False, suppress drawing the figure frame
+
+    clf : bool, optinal, default: False
+        If True and figure already exists, then it is cleared.
 
     Returns
     -------
@@ -556,6 +563,9 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
 
         if _INSTALL_FIG_OBSERVER:
             fig.stale_callback = _auto_draw_if_interactive
+
+    if clf and len(figManager.canvas.figure.axes) > 0:
+        figManager.canvas.figure.clear()
 
     return figManager.canvas.figure
 


### PR DESCRIPTION
Adds the keyword `clf=False` to `plt.figure()`.  It clears the content of an already existing figure (being referenced by the `num` kwarg).  

The original motivation is stated in #6285. Another view would be: Instead of writing
`fg = plt.figure(num=10);  fg.clf()`, one can write `fg = plt.figure(num=10, clf=True)`. The `clf()` is needed when the script is called repeatedly (with different parameters) in an interactive interpreter. 

The discussion if this is api bloat or not can be continued here. From a user perspective, it changes
```
fg = plt.figure(num=10)
fg.clf()
fg, axx = plt.subplots(3, 3, num=10)
```
to 
``` 
fg, axx = plt.subplots(3, 3, num=10, clf=True)
```
which is imho much more readable.
