### PR TITLE
FIX: be resilient to rcParams being mutated

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -995,7 +995,7 @@ class TempCache(object):
 
     def make_rcparams_key(self):
         return [id(fontManager)] + [
-            rcParams[param] for param in self.invalidating_rcparams]
+            tuple(rcParams[param]) for param in self.invalidating_rcparams]
 
     def get(self, prop):
         key = self.make_rcparams_key()
@@ -1420,7 +1420,6 @@ else:
         if _fmcache:
             with cbook.Locked(cachedir):
                 pickle_dump(fontManager, _fmcache)
-
 
         verbose.report("generated new fontManager")
 

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -9,6 +9,7 @@ import os.path
 from matplotlib.font_manager import (findfont, FontProperties, get_font,
                                      is_opentype_cff_font, fontManager as fm)
 from matplotlib import rc_context
+import matplotlib
 
 
 def test_font_priority():
@@ -36,3 +37,11 @@ def test_otf():
         with open(f, 'rb') as fd:
             res = fd.read(4) == b'OTTO'
         assert res == is_opentype_cff_font(f)
+
+
+def test_cache_invalidation():
+    f1 = findfont(FontProperties())
+    del matplotlib.rcParams['font.sans-serif'][0]
+    f2 = findfont(FontProperties())
+
+    assert f1 != f2

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -41,7 +41,7 @@ def test_otf():
 
 def test_cache_invalidation():
     f1 = findfont(FontProperties())
-    del matplotlib.rcParams['font.sans-serif'][0]
+    matplotlib.rcParams['font.sans-serif'] = matplotlib.rcParams['font.serif']
     f2 = findfont(FontProperties())
 
     assert f1 != f2


### PR DESCRIPTION
This avoids some subtle bugs where the rcParams are changed via
mutation and the cache is used to look up the font to use in error.

attn @mdboom 

I will write a test for this, just have to figure out what fonts are reliably on travis and appveyor.
