### PR TITLE
[MRG+1] DOC Replaced documentation with numpydoc for semilogx

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1544,11 +1544,12 @@ class Axes(_AxesBase):
     def semilogx(self, *args, **kwargs):
         """
         Make a plot with log scaling on the *x* axis.
-        
+
         Parameters
         ----------
         basex : float, optional
-            Base of the *x* logarithm.
+            Base of the *x* logarithm. The scalar should be larger
+            than 1.
 
         subsx : array_like, optional
             The location of the minor xticks; *None* defaults to
@@ -1570,14 +1571,14 @@ class Axes(_AxesBase):
         :class:`~matplotlib.lines.Line2D` properties:
 
         %(Line2D)s
-	
+
         See Also
         --------
         loglog : For example code and figure.
 
         Notes
         -----
-        *This function supports all the keyword arguments of
+        This function supports all the keyword arguments of
         :func:`~matplotlib.pyplot.plot` and
         :meth:`matplotlib.axes.Axes.set_xscale`.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1544,39 +1544,43 @@ class Axes(_AxesBase):
     def semilogx(self, *args, **kwargs):
         """
         Make a plot with log scaling on the *x* axis.
+	
+	Parameters
+	----------
+	basex : float, optional
+	    Base of the *x* logarithm.
 
-        Call signature::
-
-          semilogx(*args, **kwargs)
-
-        :func:`semilogx` supports all the keyword arguments of
-        :func:`~matplotlib.pyplot.plot` and
-        :meth:`matplotlib.axes.Axes.set_xscale`.
-
-        Notable keyword arguments:
-
-          *basex*: scalar > 1
-            Base of the *x* logarithm
-
-          *subsx*: [ *None* | sequence ]
-            The location of the minor xticks; *None* defaults to
+	subsx : array_like, optional
+	    The location of the minor xticks; *None* defaults to
             autosubs, which depend on the number of decades in the
             plot; see :meth:`~matplotlib.axes.Axes.set_xscale` for
             details.
 
-          *nonposx*: [ 'mask' | 'clip' ]
-            Non-positive values in *x* can be masked as
-            invalid, or clipped to a very small positive number
+	nonposx : string, optional, {'mask', 'clip'}
+	    Non-positive values in *x* can be masked as
+            invalid, or clipped to a very small positive number.
 
-        The remaining valid kwargs are
+	Returns
+	-------
+	`~matplotlib.pyplot.plot`
+	    Log-scaled plot on the *x* axis.
+
+	Other Parameters
+        ----------------
         :class:`~matplotlib.lines.Line2D` properties:
 
         %(Line2D)s
+	
+	See Also
+	--------
+	loglog : For example code and figure.
 
-        .. seealso::
+	Notes
+	-----
+	*This function supports all the keyword arguments of
+        :func:`~matplotlib.pyplot.plot` and
+        :meth:`matplotlib.axes.Axes.set_xscale`.
 
-            :meth:`loglog`
-                For example code and figure
         """
         if not self._hold:
             self.cla()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1544,40 +1544,40 @@ class Axes(_AxesBase):
     def semilogx(self, *args, **kwargs):
         """
         Make a plot with log scaling on the *x* axis.
-	
-	Parameters
-	----------
-	basex : float, optional
-	    Base of the *x* logarithm.
+        
+        Parameters
+        ----------
+        basex : float, optional
+            Base of the *x* logarithm.
 
-	subsx : array_like, optional
-	    The location of the minor xticks; *None* defaults to
+        subsx : array_like, optional
+            The location of the minor xticks; *None* defaults to
             autosubs, which depend on the number of decades in the
             plot; see :meth:`~matplotlib.axes.Axes.set_xscale` for
             details.
 
-	nonposx : string, optional, {'mask', 'clip'}
-	    Non-positive values in *x* can be masked as
+        nonposx : string, optional, {'mask', 'clip'}
+            Non-positive values in *x* can be masked as
             invalid, or clipped to a very small positive number.
 
-	Returns
-	-------
-	`~matplotlib.pyplot.plot`
-	    Log-scaled plot on the *x* axis.
+        Returns
+        -------
+        `~matplotlib.pyplot.plot`
+            Log-scaled plot on the *x* axis.
 
-	Other Parameters
+        Other Parameters
         ----------------
         :class:`~matplotlib.lines.Line2D` properties:
 
         %(Line2D)s
 	
-	See Also
-	--------
-	loglog : For example code and figure.
+        See Also
+        --------
+        loglog : For example code and figure.
 
-	Notes
-	-----
-	*This function supports all the keyword arguments of
+        Notes
+        -----
+        *This function supports all the keyword arguments of
         :func:`~matplotlib.pyplot.plot` and
         :meth:`matplotlib.axes.Axes.set_xscale`.
 


### PR DESCRIPTION
Hello matplotlib!

We have updated the documentation for the semilogx function to numpydoc.

Pavel Soriano & Dorieke Grijseels

@NelleV