### PR TITLE
DOC - SpanSelector widget documentation

### DIFF
--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -191,7 +191,6 @@ def test_pep8_conformance_installed_files():
                           'texmanager.py',
                           'transforms.py',
                           'type1font.py',
-                          'widgets.py',
                           'testing/decorators.py',
                           'testing/jpl_units/Duration.py',
                           'testing/jpl_units/Epoch.py',

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1679,61 +1679,67 @@ class _SelectorWidget(AxesWidget):
 
 class SpanSelector(_SelectorWidget):
     """
-    Select a min/max range of the x or y axes for a matplotlib Axes.
+    Visually select a min/max range on a single axis and call a function with
+    those values.
 
-    For the selector to remain responsive you must keep a reference to
+    To guarantee that the selector remains responsive, keep a reference to
     it.
 
-    Example usage::
+    In order to turn off the SpanSelector, set `span_selector.active=False`. To
+    turn it back on, set `span_selector.active=True`.
 
-        ax = subplot(111)
-        ax.plot(x,y)
+    Parameters
+    ----------
+    ax :  :class:`matplotlib.axes.Axes` object
 
-        def onselect(vmin, vmax):
+    onselect : func(min, max), min/max are floats
+
+    direction : "horizontal" or "vertical"
+      The axis along which to draw the span selector
+
+    minspan : float, default is None
+     If selection is less than *minspan*, do not call *onselect*
+
+    useblit : bool, default is False
+      If True, use the backend-dependent blitting features for faster
+      canvas updates. Only available for GTKAgg right now.
+
+    rectprops : dict, default is None
+      Dictionary of :class:`matplotlib.patches.Patch` properties
+
+    onmove_callback : func(min, max), min/max are floats, default is None
+      Called on mouse move while the span is being selected
+
+    span_stays : bool, default is False
+      If True, the span stays visible after the mouse is released
+
+    button : int or list of ints
+      Determines which mouse buttons activate the span selector
+        1 = left mouse button\n
+        2 = center mouse button (scroll wheel)\n
+        3 = right mouse button\n
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import matplotlib.widgets as mwidgets
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot([1, 2, 3], [10, 50, 100])
+    >>> def onselect(vmin, vmax):
             print(vmin, vmax)
-        span = SpanSelector(ax, onselect, 'horizontal')
+    >>> rectprops = dict(facecolor='blue', alpha=0.5)
+    >>> span = mwidgets.SpanSelector(ax, onselect, 'horizontal',
+                                     rectprops=rectprops)
+    >>> fig.show()
 
-    *onmove_callback* is an optional callback that is called on mouse
-    move within the span range
+    See also: :ref:`widgets-span_selector`
 
     """
 
     def __init__(self, ax, onselect, direction, minspan=None, useblit=False,
                  rectprops=None, onmove_callback=None, span_stays=False,
                  button=None):
-        """
-        Create a span selector in *ax*.  When a selection is made, clear
-        the span and call *onselect* with::
 
-            onselect(vmin, vmax)
-
-        and clear the span.
-
-        *direction* must be 'horizontal' or 'vertical'
-
-        If *minspan* is not *None*, ignore events smaller than *minspan*
-
-        The span rectangle is drawn with *rectprops*; default::
-
-          rectprops = dict(facecolor='red', alpha=0.5)
-
-        Set the visible attribute to *False* if you want to turn off
-        the functionality of the span selector
-
-        If *span_stays* is True, the span stays visble after making
-        a valid selection.
-
-        *button* is a list of integers indicating which mouse buttons should
-        be used for selection.  You can also specify a single
-        integer if only a single button is desired.  Default is *None*,
-        which does not limit which button can be used.
-
-        Note, typically:
-         1 = left mouse button
-         2 = center mouse button (scroll wheel)
-         3 = right mouse button
-
-        """
         _SelectorWidget.__init__(self, ax, onselect, useblit=useblit,
                                  button=button)
 
@@ -1763,6 +1769,7 @@ class SpanSelector(_SelectorWidget):
         self.new_axes(ax)
 
     def new_axes(self, ax):
+        """Set SpanSelector to operate on a new Axes"""
         self.ax = ax
         if self.canvas is not ax.figure.canvas:
             if self.canvas is not None:
@@ -2479,7 +2486,8 @@ class LassoSelector(_SelectorWidget):
 
     def __init__(self, ax, onselect=None, useblit=True, lineprops=None,
             button=None):
-        _SelectorWidget.__init__(self, ax, onselect, useblit=useblit, button=button)
+        _SelectorWidget.__init__(self, ax, onselect, useblit=useblit,
+            button=button)
 
         self.verts = None
 


### PR DESCRIPTION
Initial focus was to add a reference to AxesWidget.active in the documentation. I went ahead and made it numpy standard while I was in there.

Removed: I made the `ignore` method into `_ignore` so that it would not be build into the docs, as a user will have zero reason to call it. 

Resolves #7009