### PR TITLE
Uncaught exns are fatal for PyQt5, so catch them.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -6,8 +6,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-import sys
 import ctypes
+import sys
+import traceback
 
 from matplotlib.figure import Figure
 
@@ -181,6 +182,9 @@ class FigureCanvasQTAggBase(object):
         try:
             FigureCanvasAgg.draw(self)
             self.update()
+        except Exception:
+            # Uncaught exceptions are fatal for PyQt5, so catch them instead.
+            traceback.print_exc()
         finally:
             self._agg_draw_pending = False
 


### PR DESCRIPTION
See discussion starting at https://github.com/matplotlib/matplotlib/issues/6816#issuecomment-244838928.

Minimal example:
```
from matplotlib import pyplot as plt
plt.gcf().canvas.mpl_connect("draw_event", lambda event: 1/0)
plt.show()
```