### PR TITLE
FIX: testings.nose was not installed

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -703,6 +703,7 @@ class Matplotlib(SetupPackage):
             'matplotlib.sphinxext',
             'matplotlib.style',
             'matplotlib.testing',
+            'matplotlib.testing.nose',
             'matplotlib.testing.jpl_units',
             'matplotlib.tri',
             ]


### PR DESCRIPTION
I am not sure how the tests work on any platform right now… testing.nose was not installed, so the tests could not run.