### PR TITLE
Adjust face colors for 3D panes

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -66,9 +66,9 @@ class Axis(maxis.XAxis):
         'x': {'i': 0, 'tickdir': 1, 'juggled': (1, 0, 2),
             'color': (0.95, 0.95, 0.95, 0.5)},
         'y': {'i': 1, 'tickdir': 0, 'juggled': (0, 1, 2),
-            'color': (0.90, 0.90, 0.90, 0.5)},
+            'color': (0.95, 0.95, 0.95, 0.5)},
         'z': {'i': 2, 'tickdir': 0, 'juggled': (0, 2, 1),
-            'color': (0.925, 0.925, 0.925, 0.5)},
+            'color': (0.95, 0.95, 0.95, 0.5)},
     }
 
     def __init__(self, adir, v_intervalx, d_intervalx, axes, *args, **kwargs):


### PR DESCRIPTION
- Avoid using the same color as grid lines even if the alpha value is different. There are problems with formats lacking transparency.
- Make the face colors for all panes identical.
