### PR TITLE
DOC: ensure we only pass ints into np slicing

### DIFF
--- a/examples/pylab_examples/data_helper.py
+++ b/examples/pylab_examples/data_helper.py
@@ -17,10 +17,10 @@ def get_two_stock_data():
     file2 = cbook.get_sample_data('AAPL.dat.gz')
     M1 = fromstring(file1.read(), '<d')
 
-    M1 = resize(M1, (M1.shape[0]/2, 2))
+    M1 = resize(M1, (M1.shape[0]//2, 2))
 
     M2 = fromstring(file2.read(), '<d')
-    M2 = resize(M2, (M2.shape[0]/2, 2))
+    M2 = resize(M2, (M2.shape[0]//2, 2))
 
     d1, p1 = M1[:, 0], M1[:, 1]
     d2, p2 = M2[:, 0], M2[:, 1]

--- a/examples/pylab_examples/image_slices_viewer.py
+++ b/examples/pylab_examples/image_slices_viewer.py
@@ -10,7 +10,7 @@ class IndexTracker(object):
 
         self.X = X
         rows, cols, self.slices = X.shape
-        self.ind = self.slices/2
+        self.ind = self.slices//2
 
         self.im = ax.imshow(self.X[:, :, self.ind])
         self.update()

--- a/examples/pylab_examples/quiver_demo.py
+++ b/examples/pylab_examples/quiver_demo.py
@@ -75,8 +75,8 @@ plt.title("triangular head; scale with x view; black edges")
 # 6
 plt.figure()
 M = np.zeros(U.shape, dtype='bool')
-M[U.shape[0]/3:2*U.shape[0]/3,
-  U.shape[1]/3:2*U.shape[1]/3] = True
+M[U.shape[0]//3:2*U.shape[0]//3,
+  U.shape[1]//3:2*U.shape[1]//3] = True
 U = ma.masked_array(U, mask=M)
 V = ma.masked_array(V, mask=M)
 Q = plt.quiver(U, V)


### PR DESCRIPTION
Fix 3 examples that fail under numpy '1.12.0.dev0+cb7f407'