### PR TITLE
[MRG] DOC refer to plot in the scatter plot doc

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3889,17 +3889,25 @@ class Axes(_AxesBase):
         ----------------
         kwargs : `~matplotlib.collections.Collection` properties
 
-        Notes
-        ------
-        Any or all of `x`, `y`, `s`, and `c` may be masked arrays, in
-        which case all masks will be combined and only unmasked points
-        will be plotted.
+        See Also
+        --------
+        plot : to plot scatter plots when markers are identical in size and
+            color
 
-        Fundamentally, scatter works with 1-D arrays; `x`, `y`, `s`,
-        and `c` may be input as 2-D arrays, but within scatter
-        they will be flattened. The exception is `c`, which
-        will be flattened only if its size matches the size of `x`
-        and `y`.
+        Notes
+        -----
+
+        * When attempting to plot a scatter plots where markers don't vary in
+          size and color, the `plot` function will be faster.
+
+        * Any or all of `x`, `y`, `s`, and `c` may be masked arrays, in which
+          case all masks will be combined and only unmasked points will be
+          plotted.
+
+          Fundamentally, scatter works with 1-D arrays; `x`, `y`, `s`, and `c`
+          may be input as 2-D arrays, but within scatter they will be
+          flattened. The exception is `c`, which will be flattened only if its
+          size matches the size of `x` and `y`.
 
         Examples
         --------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3897,8 +3897,8 @@ class Axes(_AxesBase):
         Notes
         -----
 
-        * When attempting to plot a scatter plots where markers don't vary in
-          size and color, the `plot` function will be faster.
+        * The `plot` function will be faster for scatterplots where markers
+          don't vary in size or color.
 
         * Any or all of `x`, `y`, `s`, and `c` may be masked arrays, in which
           case all masks will be combined and only unmasked points will be


### PR DESCRIPTION
Encourage users to use plot instead of scatter when all markers are identical in size and colour.

Closes #7083 

Here is a preview of the rendered docstring in Sphinx. Note that the "Notes" section is not rendered properly (see #7095 )

![scatter_doc](https://cloud.githubusercontent.com/assets/184798/18445880/86634924-78d4-11e6-9540-4ebbfe85823f.png)
