### PR TITLE
Adding the artist data on mouse move event message

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2881,7 +2881,7 @@ class NavigationToolbar2(object):
                 pass
             else:
                 artists = [a for a in event.inaxes.mouseover_set
-                           if a.contains(event)]
+                           if a.contains(event) and a.get_visible()]
 
                 if artists:
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2884,8 +2884,7 @@ class NavigationToolbar2(object):
                            if a.contains(event) and a.get_visible()]
 
                 if artists:
-
-                    a = max(enumerate(artists), key=lambda x: x[1].zorder)[1]
+                    a = max(artists, key=lambda x: x.zorder)
                     if a is not event.inaxes.patch:
                         data = a.get_cursor_data(event)
                         if data is not None:

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -339,7 +339,7 @@ class ToolCursorPosition(ToolBase):
                            if a.contains(event) and a.get_visible()]
 
                 if artists:
-                    a = max(enumerate(artists), key=lambda x: x[1].zorder)[1]
+                    a = max(artists, key=lambda x: x.zorder)
                     if a is not event.inaxes.patch:
                         data = a.get_cursor_data(event)
                         if data is not None:

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -335,6 +335,16 @@ class ToolCursorPosition(ToolBase):
             except (ValueError, OverflowError):
                 pass
             else:
+                artists = [a for a in event.inaxes.mouseover_set
+                           if a.contains(event) and a.get_visible()]
+
+                if artists:
+                    a = max(enumerate(artists), key=lambda x: x[1].zorder)[1]
+                    if a is not event.inaxes.patch:
+                        data = a.get_cursor_data(event)
+                        if data is not None:
+                            s += ' [%s]' % a.format_cursor_data(data)
+
                 message = s
         self.toolmanager.message_event(message, self)
 


### PR DESCRIPTION
In the tools we didn't add the artist data to the message on mouse move event.

Also added a small check, for `get_visible` artist list, this is because if the artist is not visible we shouldn't show its data