### PR TITLE
Fix branch name in "Deleting a branch on GitHub_" section

### DIFF
--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -398,8 +398,7 @@ Deleting a branch on GitHub_
    git push origin :my-unwanted-branch
 
 Note the colon ``:`` before ``my-unwanted-branch``.  See also:
-http://github.com/guides/remove-a-remote-branch
-
+https://help.github.com/articles/removing-a-remote/
 
 Exploring your repository
 =========================

--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -397,7 +397,7 @@ Deleting a branch on GitHub_
    # delete branch on GitHub
    git push origin :my-unwanted-branch
 
-(Note the colon ``:`` before ``test-branch``.  See also:
+(Note the colon ``:`` before ``my-unwanted-branch``.  See also:
 http://github.com/guides/remove-a-remote-branch
 
 

--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -397,7 +397,7 @@ Deleting a branch on GitHub_
    # delete branch on GitHub
    git push origin :my-unwanted-branch
 
-(Note the colon ``:`` before ``my-unwanted-branch``.  See also:
+Note the colon ``:`` before ``my-unwanted-branch``.  See also:
 http://github.com/guides/remove-a-remote-branch
 
 


### PR DESCRIPTION
@tacaswell  : I could not find any "test_branch" in the example code in the "Deleting a branch on GitHub_" section, so I guess it was simply an old name forgotten after a change.