### PR TITLE
DOC: minor fix  in development_workflow.rst

### DIFF
--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -398,7 +398,7 @@ Deleting a branch on GitHub_
    git push origin :my-unwanted-branch
 
 Note the colon ``:`` before ``my-unwanted-branch``.  See also:
-https://help.github.com/articles/removing-a-remote/
+https://help.github.com/articles/pushing-to-a-remote/#deleting-a-remote-branch-or-tag
 
 Exploring your repository
 =========================


### PR DESCRIPTION
Related to #7131. Simply replacing the URL with the actual correct one that @QuLogic found.

PS: I did not break the URL to fit in a 79 charachter-wide column, because a few other lines were already longer than the limit and I think an URL looks nicer in raw mode that way. But if it is a problem, this URL could be broken.