### PR TITLE
DOC: improve engineering formatter example

### DIFF
--- a/examples/api/engineering_formatter.py
+++ b/examples/api/engineering_formatter.py
@@ -7,13 +7,15 @@ import numpy as np
 
 from matplotlib.ticker import EngFormatter
 
+prng = np.random.RandomState(123)
+
 fig, ax = plt.subplots()
 ax.set_xscale('log')
 formatter = EngFormatter(unit='Hz')
 ax.xaxis.set_major_formatter(formatter)
 
 xs = np.logspace(1, 9, 100)
-ys = (0.8 + 0.4*np.random.uniform(size=100))*np.log10(xs)**2
+ys = (0.8 + 0.4 * prng.uniform(size=100)) * np.log10(xs)**2
 ax.plot(xs, ys)
 
 plt.show()

--- a/examples/api/engineering_formatter.py
+++ b/examples/api/engineering_formatter.py
@@ -9,7 +9,7 @@ from matplotlib.ticker import EngFormatter
 
 fig, ax = plt.subplots()
 ax.set_xscale('log')
-formatter = EngFormatter(unit='Hz', places=1)
+formatter = EngFormatter(unit='Hz')
 ax.xaxis.set_major_formatter(formatter)
 
 xs = np.logspace(1, 9, 100)


### PR DESCRIPTION
@efiring  Here are a couple of adjustements to [http://matplotlib.org/devdocs/examples/api/engineering_formatter.html](http://matplotlib.org/devdocs/examples/api/engineering_formatter.html) that should make it less ugly:
![engineering_example_fix](https://cloud.githubusercontent.com/assets/17270724/18623433/50cb7e94-7e3d-11e6-932f-df5638e2db7b.png)
 

The x-ticklabel adjustement is somehow a backport from the on-going PR #6542 . The fix-seed PRNG is an addition to ensure reproducibility.