### PR TITLE
FIX added matplotlib.testing.nose.plugins to setupext.py

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -704,6 +704,7 @@ class Matplotlib(SetupPackage):
             'matplotlib.style',
             'matplotlib.testing',
             'matplotlib.testing.nose',
+            'matplotlib.testing.nose.plugins',
             'matplotlib.testing.jpl_units',
             'matplotlib.tri',
             ]


### PR DESCRIPTION
Tests can now run on the installed version of matplotlib.
Before, the plugins submodule was missing.

Thanks,
N