### PR TITLE
Add `style` to api doc; fix capitalization.

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -44,6 +44,7 @@
    patheffects_api.rst
    pyplot_api.rst
    sankey_api.rst
+   scale_api.rst
    spines_api.rst
    style_api.rst
    text_api.rst

--- a/doc/api/legend_api.rst
+++ b/doc/api/legend_api.rst
@@ -1,6 +1,6 @@
-******
-Legend
-******
+*************************
+legend and legend_handler
+*************************
 
 
 :mod:`matplotlib.legend`

--- a/doc/api/markers_api.rst
+++ b/doc/api/markers_api.rst
@@ -1,5 +1,5 @@
 *******
-Markers
+markers
 *******
 
 

--- a/doc/api/scale_api.rst
+++ b/doc/api/scale_api.rst
@@ -1,0 +1,12 @@
+*****
+scale
+*****
+
+
+:mod:`matplotlib.scale`
+=======================
+
+.. automodule:: matplotlib.scale
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
All other sections use a lowercase title.  Also mention `legend_handler`
in the title for the `legend` api doc as they are in the same file.