### PR TITLE
[MRG+1] Remove unused variable.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3555,14 +3555,6 @@ or tuple of floats
         # empty list of xticklabels
         datalabels = []
 
-        # translates between line2D and patch linestyles
-        linestyle_map = {
-            'solid': '-',
-            'dashed': '--',
-            'dashdot': '-.',
-            'dotted': ':'
-        }
-
         zorder = mlines.Line2D.zorder
         zdelta = 0.1
         # box properties


### PR DESCRIPTION
This was added during 2.0-dev cycle, all it uses were removed.
So it is not useful to keep around anymore, and is local anyway.

Closes #7162