### PR TITLE
[MRG+1] API: fill_between and fill_betweenx color cycle

### DIFF
--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -473,6 +473,37 @@ or by setting::
 in your :file:`matplotlibrc` file.
 
 
+``fill_between`` and ``fill_betweenx``
+--------------------------------------
+
+`~matplotlib.axes.Axes.fill_between` and
+`~matplotlib.axes.Axes.fill_betweenx` both follow the patch color
+cycle.
+
+.. plot::
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(6, 3))
+   th = np.linspace(0, 2*np.pi, 128)
+   N = 5
+
+   def demo(ax, extra_kwargs, title):
+       ax.set_title(title)
+       return [ax.fill_between(th, np.sin((j / N) * np.pi + th), alpha=.5, **extra_kwargs)
+               for j in range(N)]
+
+   demo(ax1, {}, '2.x')
+   demo(ax2, {'facecolor': 'C0'}, 'non-cycled')
+
+If the facecolor is set via the ``facecolors`` or ``color`` keyword argument,
+then the color is not cycled.
+
+To restore the previous behavior, explicitly pass the keyword argument
+``facecolors='C0'`` to the method call.
+
+
 Patch edges and color
 ---------------------
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4764,6 +4764,14 @@ or tuple of floats
                 for filling between two sets of x-values
 
         """
+        if not rcParams['_internal.classic_mode']:
+            color_aliases = mcoll._color_aliases
+            kwargs = cbook.normalize_kwargs(kwargs, color_aliases)
+
+            if not any(c in kwargs for c in ('color', 'facecolors')):
+                fc = self._get_patches_for_fill.get_next_color()
+                kwargs['facecolors'] = fc
+
         # Handle united data, such as dates
         self._process_unit_info(xdata=x, ydata=y1, kwargs=kwargs)
         self._process_unit_info(ydata=y2)
@@ -4914,6 +4922,13 @@ or tuple of floats
                 for filling between two sets of y-values
 
         """
+        if not rcParams['_internal.classic_mode']:
+            color_aliases = mcoll._color_aliases
+            kwargs = cbook.normalize_kwargs(kwargs, color_aliases)
+
+            if not any(c in kwargs for c in ('color', 'facecolors')):
+                fc = self._get_patches_for_fill.get_next_color()
+                kwargs['facecolors'] = fc
         # Handle united data, such as dates
         self._process_unit_info(ydata=y, xdata=x1, kwargs=kwargs)
         self._process_unit_info(xdata=x2)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -39,6 +39,10 @@ import matplotlib.lines as mlines
 CIRCLE_AREA_FACTOR = 1.0 / np.sqrt(np.pi)
 
 
+_color_aliases = {'facecolors': ['facecolor'],
+                  'edgecolors': ['edgecolor']}
+
+
 class Collection(artist.Artist, cm.ScalarMappable):
     """
     Base class for Collections.  Must be subclassed to be usable.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -27,6 +27,7 @@ from matplotlib.testing.noseclasses import KnownFailureTest
 import matplotlib.pyplot as plt
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
+import matplotlib.colors as mcolors
 from numpy.testing import assert_allclose, assert_array_equal
 from matplotlib.cbook import IgnoredKeywordWarning
 import matplotlib.colors as mcolors
@@ -4611,6 +4612,34 @@ def test_bar_color_cycle():
         brs = ax.bar(range(3), range(3))
         for br in brs:
             assert ccov(ln.get_color()) == ccov(br.get_facecolor())
+
+
+@cleanup(style='default')
+def test_fillbetween_cycle():
+    fig, ax = plt.subplots()
+
+    for j in range(3):
+        cc = ax.fill_between(range(3), range(3))
+        target = mcolors.to_rgba('C{}'.format(j))
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
+
+    for j in range(3, 6):
+        cc = ax.fill_betweenx(range(3), range(3))
+        target = mcolors.to_rgba('C{}'.format(j))
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
+
+    target = mcolors.to_rgba('k')
+
+    for al in ['facecolor', 'facecolors', 'color']:
+        cc = ax.fill_between(range(3), range(3), **{al: 'k'})
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
+
+    edge_target = mcolors.to_rgba('k')
+    for j, el in enumerate(['edgecolor', 'edgecolors'], start=6):
+        cc = ax.fill_between(range(3), range(3), **{el: 'k'})
+        face_target = mcolors.to_rgba('C{}'.format(j))
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(face_target)
+        assert tuple(cc.get_edgecolors().squeeze()) == tuple(edge_target)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
They follow the patch property cycle (but only use the color).

Closes #7157