### PR TITLE
[MRG+1] Remove hard-coded streamplot zorder kwarg

### DIFF
--- a/doc/users/whats_new/streamplot_zorder.rst
+++ b/doc/users/whats_new/streamplot_zorder.rst
@@ -1,0 +1,7 @@
+Streamplot Zorder Keyword Argument Changes
+------------------------------------------
+
+The ``zorder`` parameter for :func:`streamplot` now has default
+value of ``None`` instead of ``2``. If ``None`` is given as ``zorder``,
+:func:`streamplot` has a default ``zorder`` of 
+``matplotlib.lines.Line2D.zorder``.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4613,9 +4613,12 @@ or tuple of floats
                          label_namer=None)
     def streamplot(self, x, y, u, v, density=1, linewidth=None, color=None,
                    cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
-                   minlength=0.1, transform=None, zorder=2, start_points=None):
+                   minlength=0.1, transform=None, zorder=None,
+                   start_points=None):
         if not self._hold:
             self.cla()
+        if zorder is None:
+            zorder = mlines.Line2D.zorder
         stream_container = mstream.streamplot(self, x, y, u, v,
                                               density=density,
                                               linewidth=linewidth,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4617,8 +4617,6 @@ or tuple of floats
                    start_points=None):
         if not self._hold:
             self.cla()
-        if zorder is None:
-            zorder = mlines.Line2D.zorder
         stream_container = mstream.streamplot(self, x, y, u, v,
                                               density=density,
                                               linewidth=linewidth,

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -13,6 +13,7 @@ import matplotlib
 import matplotlib.cm as cm
 import matplotlib.colors as mcolors
 import matplotlib.collections as mcollections
+import matplotlib.lines as mlines
 import matplotlib.patches as patches
 
 
@@ -21,7 +22,7 @@ __all__ = ['streamplot']
 
 def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
                cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
-               minlength=0.1, transform=None, zorder=2, start_points=None):
+               minlength=0.1, transform=None, zorder=None, start_points=None):
     """Draws streamlines of a vector flow.
 
     *x*, *y* : 1d arrays
@@ -77,6 +78,9 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     grid = Grid(x, y)
     mask = StreamMask(density)
     dmap = DomainMap(grid, mask)
+
+    if zorder is None:
+        zorder = mlines.Line2D.zorder
 
     # default to data coordinates
     if transform is None:


### PR DESCRIPTION
`streamplot` still has a hard coded default `zorder` of `2`. The default kwarg value should be `None`, and use `Lines2D.zorder` as the default for the plot.

Addresses https://github.com/matplotlib/matplotlib/pull/7178#issuecomment-249654472