### PR TITLE
[MRG+1] DOC: switch pylab example `mri_with_eeg.py` to OO interface + cosmetick fixes

### DIFF
--- a/examples/pylab_examples/mri_demo.py
+++ b/examples/pylab_examples/mri_demo.py
@@ -2,7 +2,10 @@
 
 import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
+import matplotlib.cm as cm
 import numpy as np
+
+fig, ax = plt.subplots(num="MRI_demo")
 
 # Data are 256x256 16 bit integers
 dfile = cbook.get_sample_data('s1045.ima.gz')
@@ -10,7 +13,7 @@ im = np.fromstring(dfile.read(), np.uint16).astype(float)
 im.shape = (256, 256)
 dfile.close()
 
-plt.imshow(im, cmap=plt.cm.gray)
-plt.axis('off')
+ax.imshow(im, cmap=cm.gray)
+ax.axis('off')
 
 plt.show()

--- a/examples/pylab_examples/mri_demo.py
+++ b/examples/pylab_examples/mri_demo.py
@@ -1,11 +1,14 @@
-from __future__ import print_function
+"""Displays an MRI image."""
+
 import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
 import numpy as np
-# data are 256x256 16 bit integers
+
+# Data are 256x256 16 bit integers
 dfile = cbook.get_sample_data('s1045.ima.gz')
 im = np.fromstring(dfile.read(), np.uint16).astype(float)
-im.shape = 256, 256
+im.shape = (256, 256)
+dfile.close()
 
 plt.imshow(im, cmap=plt.cm.gray)
 plt.axis('off')

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -1,6 +1,7 @@
-"""
-This now uses the imshow command instead of pcolor which *is much
-faster*
+"""Displays a set of subplots with an MRI image, its density histogram and
+some EEG traces.
+
+NB: ones uses the imshow command instead of pcolor which *is much faster*.
 """
 
 from __future__ import division, print_function
@@ -11,38 +12,37 @@ import matplotlib.cbook as cbook
 import matplotlib.cm as cm
 
 from matplotlib.collections import LineCollection
-# I use if 1 to break up the different regions of code visually
 
+# NB: one uses "if 1:" to break up the different regions of code visually
 fig = plt.figure("MRI_with_EEG")
 
-if 1:   # load the data
-    # data are 256x256 16 bit integers
+if 1:   # Load the data
+    # Data are 256x256 16 bit integers
     dfile = cbook.get_sample_data('s1045.ima.gz')
     im = np.fromstring(dfile.read(), np.uint16).astype(float)
     im.shape = (256, 256)
 
-if 1:  # plot the MRI in pcolor
+if 1:  # Plot the MRI image
     ax0 = fig.add_subplot(2, 2, 1)
     ax0.imshow(im, cmap=cm.gray)
     ax0.axis('off')
 
-if 1:  # plot the histogram of MRI intensity
+if 1:  # Plot the histogram of MRI intensity
     ax1 = fig.add_subplot(2, 2, 2)
     im = np.ravel(im)
-    im = im[np.nonzero(im)]  # ignore the background
-    im = im / (2**15)  # normalize
+    im = im[np.nonzero(im)]  # Ignore the background
+    im = im / (2**15)  # Normalize
     ax1.hist(im, 100)
     ax1.set_xticks([-1, -0.5, 0, 0.5, 1])
     ax1.set_yticks([])
-    ax1.set_xlabel('intensity')
+    ax1.set_xlabel('Intensity')
     ax1.set_ylabel('MRI density')
 
-if 1:   # plot the EEG
-    # load the data
-
+if 1:   # Plot the EEG
+    # Load the data
     numSamples, numRows = 800, 4
     eegfile = cbook.get_sample_data('eeg.dat', asfileobj=False)
-    print('loading eeg %s' % eegfile)
+    print('Loading EEG %s' % eegfile)
     data = np.fromstring(open(eegfile, 'rb').read(), float)
     data.shape = (numSamples, numRows)
     t = 10.0 * np.arange(numSamples) / numSamples
@@ -68,10 +68,11 @@ if 1:   # plot the EEG
     lines = LineCollection(segs, offsets=offsets, transOffset=None)
     ax2.add_collection(lines)
 
-    # set the yticks to use axes coords on the y axis
+    # Set the yticks to use axes coords on the y axis
     ax2.set_yticks(ticklocs)
     ax2.set_yticklabels(['PG3', 'PG5', 'PG7', 'PG9'])
 
-    ax2.set_xlabel('time (s)')
+    ax2.set_xlabel('Time (s)')
 
+plt.tight_layout()
 plt.show()

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -1,4 +1,4 @@
-"""Displays a set of subplots with an MRI image, its density histogram and
+"""Displays a set of subplots with an MRI image, its intensity histogram and
 some EEG traces.
 
 NB: ones uses the imshow command instead of pcolor which *is much faster*.

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -29,11 +29,12 @@ ax0.axis('off')
 ax1 = fig.add_subplot(2, 2, 2)
 im = np.ravel(im)
 im = im[np.nonzero(im)]  # Ignore the background
-im = im / (2**15)  # Normalize
+im = im / (2**16 - 1)  # Normalize
 ax1.hist(im, bins=100)
-ax1.xaxis.set_major_locator(MultipleLocator(0.5))
+ax1.xaxis.set_major_locator(MultipleLocator(0.4))
+ax1.minorticks_on()
 ax1.set_yticks([])
-ax1.set_xlabel('Intensity')
+ax1.set_xlabel('Intensity (a.u.)')
 ax1.set_ylabel('MRI density')
 
 # Load the EEG data

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -1,7 +1,5 @@
 """Displays a set of subplots with an MRI image, its intensity histogram and
 some EEG traces.
-
-NB: ones uses the imshow command instead of pcolor which *is much faster*.
 """
 
 from __future__ import division, print_function

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -12,6 +12,7 @@ import matplotlib.cbook as cbook
 import matplotlib.cm as cm
 
 from matplotlib.collections import LineCollection
+from matplotlib.ticker import MultipleLocator
 
 # NB: one uses "if 1:" to break up the different regions of code visually
 fig = plt.figure("MRI_with_EEG")
@@ -33,7 +34,7 @@ if 1:  # Plot the histogram of MRI intensity
     im = im[np.nonzero(im)]  # Ignore the background
     im = im / (2**15)  # Normalize
     ax1.hist(im, 100)
-    ax1.set_xticks([-1, -0.5, 0, 0.5, 1])
+    ax1.xaxis.set_major_locator(MultipleLocator(0.5))
     ax1.set_yticks([])
     ax1.set_xlabel('Intensity')
     ax1.set_ylabel('MRI density')

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -6,33 +6,36 @@ faster*
 from __future__ import division, print_function
 
 import numpy as np
-
-from matplotlib.pyplot import *
-from matplotlib.collections import LineCollection
+import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
+import matplotlib.cm as cm
+
+from matplotlib.collections import LineCollection
 # I use if 1 to break up the different regions of code visually
+
+fig = plt.figure("MRI_with_EEG")
 
 if 1:   # load the data
     # data are 256x256 16 bit integers
     dfile = cbook.get_sample_data('s1045.ima.gz')
     im = np.fromstring(dfile.read(), np.uint16).astype(float)
-    im.shape = 256, 256
+    im.shape = (256, 256)
 
 if 1:  # plot the MRI in pcolor
-    subplot(221)
-    imshow(im, cmap=cm.gray)
-    axis('off')
+    ax0 = fig.add_subplot(2, 2, 1)
+    ax0.imshow(im, cmap=cm.gray)
+    ax0.axis('off')
 
 if 1:  # plot the histogram of MRI intensity
-    subplot(222)
+    ax1 = fig.add_subplot(2, 2, 2)
     im = np.ravel(im)
     im = im[np.nonzero(im)]  # ignore the background
-    im = im/(2.0**15)  # normalize
-    hist(im, 100)
-    xticks([-1, -.5, 0, .5, 1])
-    yticks([])
-    xlabel('intensity')
-    ylabel('MRI density')
+    im = im / (2**15)  # normalize
+    ax1.hist(im, 100)
+    ax1.set_xticks([-1, -0.5, 0, 0.5, 1])
+    ax1.set_yticks([])
+    ax1.set_xlabel('intensity')
+    ax1.set_ylabel('MRI density')
 
 if 1:   # plot the EEG
     # load the data
@@ -41,37 +44,34 @@ if 1:   # plot the EEG
     eegfile = cbook.get_sample_data('eeg.dat', asfileobj=False)
     print('loading eeg %s' % eegfile)
     data = np.fromstring(open(eegfile, 'rb').read(), float)
-    data.shape = numSamples, numRows
-    t = 10.0 * np.arange(numSamples, dtype=float)/numSamples
+    data.shape = (numSamples, numRows)
+    t = 10.0 * np.arange(numSamples) / numSamples
     ticklocs = []
-    ax = subplot(212)
-    xlim(0, 10)
-    xticks(np.arange(10))
+    ax2 = fig.add_subplot(2, 1, 2)
+    ax2.set_xlim(0, 10)
+    ax2.set_xticks(np.arange(10))
     dmin = data.min()
     dmax = data.max()
-    dr = (dmax - dmin)*0.7  # Crowd them a bit.
+    dr = (dmax - dmin) * 0.7  # Crowd them a bit.
     y0 = dmin
     y1 = (numRows - 1) * dr + dmax
-    ylim(y0, y1)
+    ax2.set_ylim(y0, y1)
 
     segs = []
     for i in range(numRows):
         segs.append(np.hstack((t[:, np.newaxis], data[:, i, np.newaxis])))
-        ticklocs.append(i*dr)
+        ticklocs.append(i * dr)
 
     offsets = np.zeros((numRows, 2), dtype=float)
     offsets[:, 1] = ticklocs
 
-    lines = LineCollection(segs, offsets=offsets,
-                           transOffset=None,
-                           )
-
-    ax.add_collection(lines)
+    lines = LineCollection(segs, offsets=offsets, transOffset=None)
+    ax2.add_collection(lines)
 
     # set the yticks to use axes coords on the y axis
-    ax.set_yticks(ticklocs)
-    ax.set_yticklabels(['PG3', 'PG5', 'PG7', 'PG9'])
+    ax2.set_yticks(ticklocs)
+    ax2.set_yticklabels(['PG3', 'PG5', 'PG7', 'PG9'])
 
-    xlabel('time (s)')
+    ax2.set_xlabel('time (s)')
 
-show()
+plt.show()

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -20,6 +20,7 @@ fig = plt.figure("MRI_with_EEG")
 dfile = cbook.get_sample_data('s1045.ima.gz')
 im = np.fromstring(dfile.read(), np.uint16).astype(float)
 im.shape = (256, 256)
+dfile.close()
 
 # Plot the MRI image
 ax0 = fig.add_subplot(2, 2, 1)
@@ -41,7 +42,7 @@ ax1.set_ylabel('MRI density')
 numSamples, numRows = 800, 4
 eegfile = cbook.get_sample_data('eeg.dat', asfileobj=False)
 print('Loading EEG %s' % eegfile)
-data = np.fromstring(open(eegfile, 'rb').read(), float)
+data = np.fromfile(eegfile, dtype=float)
 data.shape = (numSamples, numRows)
 t = 10.0 * np.arange(numSamples) / numSamples
 

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -16,38 +16,28 @@ from matplotlib.ticker import MultipleLocator
 
 fig = plt.figure("MRI_with_EEG")
 
-"""
-Load the data
-"""
-# Data are 256x256 16 bit integers
+# Load the MRI data (256x256 16 bit integers)
 dfile = cbook.get_sample_data('s1045.ima.gz')
 im = np.fromstring(dfile.read(), np.uint16).astype(float)
 im.shape = (256, 256)
 
-"""
-Plot the MRI image
-"""
+# Plot the MRI image
 ax0 = fig.add_subplot(2, 2, 1)
 ax0.imshow(im, cmap=cm.gray)
 ax0.axis('off')
 
-"""
-Plot the histogram of MRI intensity
-"""
+# Plot the histogram of MRI intensity
 ax1 = fig.add_subplot(2, 2, 2)
 im = np.ravel(im)
 im = im[np.nonzero(im)]  # Ignore the background
 im = im / (2**15)  # Normalize
-ax1.hist(im, 100)
+ax1.hist(im, bins=100)
 ax1.xaxis.set_major_locator(MultipleLocator(0.5))
 ax1.set_yticks([])
 ax1.set_xlabel('Intensity')
 ax1.set_ylabel('MRI density')
 
-"""
-Plot the EEG
-"""
-# Load the data
+# Load the EEG data
 numSamples, numRows = 800, 4
 eegfile = cbook.get_sample_data('eeg.dat', asfileobj=False)
 print('Loading EEG %s' % eegfile)
@@ -55,6 +45,7 @@ data = np.fromstring(open(eegfile, 'rb').read(), float)
 data.shape = (numSamples, numRows)
 t = 10.0 * np.arange(numSamples) / numSamples
 
+# Plot the EEG
 ticklocs = []
 ax2 = fig.add_subplot(2, 1, 2)
 ax2.set_xlim(0, 10)
@@ -77,7 +68,7 @@ offsets[:, 1] = ticklocs
 lines = LineCollection(segs, offsets=offsets, transOffset=None)
 ax2.add_collection(lines)
 
-# Set the yticks to use axes coords on the y axis
+# Set the yticks to use axes coordinates on the y axis
 ax2.set_yticks(ticklocs)
 ax2.set_yticklabels(['PG3', 'PG5', 'PG7', 'PG9'])
 

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -14,66 +14,75 @@ import matplotlib.cm as cm
 from matplotlib.collections import LineCollection
 from matplotlib.ticker import MultipleLocator
 
-# NB: one uses "if 1:" to break up the different regions of code visually
 fig = plt.figure("MRI_with_EEG")
 
-if 1:   # Load the data
-    # Data are 256x256 16 bit integers
-    dfile = cbook.get_sample_data('s1045.ima.gz')
-    im = np.fromstring(dfile.read(), np.uint16).astype(float)
-    im.shape = (256, 256)
+"""
+Load the data
+"""
+# Data are 256x256 16 bit integers
+dfile = cbook.get_sample_data('s1045.ima.gz')
+im = np.fromstring(dfile.read(), np.uint16).astype(float)
+im.shape = (256, 256)
 
-if 1:  # Plot the MRI image
-    ax0 = fig.add_subplot(2, 2, 1)
-    ax0.imshow(im, cmap=cm.gray)
-    ax0.axis('off')
+"""
+Plot the MRI image
+"""
+ax0 = fig.add_subplot(2, 2, 1)
+ax0.imshow(im, cmap=cm.gray)
+ax0.axis('off')
 
-if 1:  # Plot the histogram of MRI intensity
-    ax1 = fig.add_subplot(2, 2, 2)
-    im = np.ravel(im)
-    im = im[np.nonzero(im)]  # Ignore the background
-    im = im / (2**15)  # Normalize
-    ax1.hist(im, 100)
-    ax1.xaxis.set_major_locator(MultipleLocator(0.5))
-    ax1.set_yticks([])
-    ax1.set_xlabel('Intensity')
-    ax1.set_ylabel('MRI density')
+"""
+Plot the histogram of MRI intensity
+"""
+ax1 = fig.add_subplot(2, 2, 2)
+im = np.ravel(im)
+im = im[np.nonzero(im)]  # Ignore the background
+im = im / (2**15)  # Normalize
+ax1.hist(im, 100)
+ax1.xaxis.set_major_locator(MultipleLocator(0.5))
+ax1.set_yticks([])
+ax1.set_xlabel('Intensity')
+ax1.set_ylabel('MRI density')
 
-if 1:   # Plot the EEG
-    # Load the data
-    numSamples, numRows = 800, 4
-    eegfile = cbook.get_sample_data('eeg.dat', asfileobj=False)
-    print('Loading EEG %s' % eegfile)
-    data = np.fromstring(open(eegfile, 'rb').read(), float)
-    data.shape = (numSamples, numRows)
-    t = 10.0 * np.arange(numSamples) / numSamples
-    ticklocs = []
-    ax2 = fig.add_subplot(2, 1, 2)
-    ax2.set_xlim(0, 10)
-    ax2.set_xticks(np.arange(10))
-    dmin = data.min()
-    dmax = data.max()
-    dr = (dmax - dmin) * 0.7  # Crowd them a bit.
-    y0 = dmin
-    y1 = (numRows - 1) * dr + dmax
-    ax2.set_ylim(y0, y1)
+"""
+Plot the EEG
+"""
+# Load the data
+numSamples, numRows = 800, 4
+eegfile = cbook.get_sample_data('eeg.dat', asfileobj=False)
+print('Loading EEG %s' % eegfile)
+data = np.fromstring(open(eegfile, 'rb').read(), float)
+data.shape = (numSamples, numRows)
+t = 10.0 * np.arange(numSamples) / numSamples
 
-    segs = []
-    for i in range(numRows):
-        segs.append(np.hstack((t[:, np.newaxis], data[:, i, np.newaxis])))
-        ticklocs.append(i * dr)
+ticklocs = []
+ax2 = fig.add_subplot(2, 1, 2)
+ax2.set_xlim(0, 10)
+ax2.set_xticks(np.arange(10))
+dmin = data.min()
+dmax = data.max()
+dr = (dmax - dmin) * 0.7  # Crowd them a bit.
+y0 = dmin
+y1 = (numRows - 1) * dr + dmax
+ax2.set_ylim(y0, y1)
 
-    offsets = np.zeros((numRows, 2), dtype=float)
-    offsets[:, 1] = ticklocs
+segs = []
+for i in range(numRows):
+    segs.append(np.hstack((t[:, np.newaxis], data[:, i, np.newaxis])))
+    ticklocs.append(i * dr)
 
-    lines = LineCollection(segs, offsets=offsets, transOffset=None)
-    ax2.add_collection(lines)
+offsets = np.zeros((numRows, 2), dtype=float)
+offsets[:, 1] = ticklocs
 
-    # Set the yticks to use axes coords on the y axis
-    ax2.set_yticks(ticklocs)
-    ax2.set_yticklabels(['PG3', 'PG5', 'PG7', 'PG9'])
+lines = LineCollection(segs, offsets=offsets, transOffset=None)
+ax2.add_collection(lines)
 
-    ax2.set_xlabel('Time (s)')
+# Set the yticks to use axes coords on the y axis
+ax2.set_yticks(ticklocs)
+ax2.set_yticklabels(['PG3', 'PG5', 'PG7', 'PG9'])
+
+ax2.set_xlabel('Time (s)')
+
 
 plt.tight_layout()
 plt.show()


### PR DESCRIPTION
The first commit switch the script to pyplot OO interface. The next ones perform some minor cosmetick adjustements, either in the plot layout or the doctsrings and the comments.

If the added MultipleLocator is too much, then I think that at least one should not force negative xticks as former l. 32 did: they are no negative values in the MRI data.

Additional remark: I am not a big fan of the 
```python
if 1:  # <Description>
```
blocks. I wonder if simple
```python
"""
<Description>
"""
```
would not be as well OK visually and more semantically correct.