### PR TITLE
DOC: Fix entries in api section

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -42,6 +42,7 @@
    patches_api.rst
    path_api.rst
    patheffects_api.rst
+   projections_api.rst
    pyplot_api.rst
    sankey_api.rst
    scale_api.rst

--- a/doc/api/projections_api.rst
+++ b/doc/api/projections_api.rst
@@ -1,0 +1,19 @@
+***********
+projections
+***********
+
+
+:mod:`matplotlib.projections`
+=============================
+
+.. automodule:: matplotlib.projections
+   :members:
+   :show-inheritance:
+
+
+:mod:`matplotlib.projections.polar`
+===================================
+
+.. automodule:: matplotlib.projections.polar
+   :members:
+   :show-inheritance:

--- a/doc/devel/add_new_projection.rst
+++ b/doc/devel/add_new_projection.rst
@@ -130,12 +130,7 @@ interest.
 API documentation
 =================
 
-matplotlib.scale
-----------------
-
-.. automodule:: matplotlib.scale
-   :members:
-   :show-inheritance:
+* :mod:`matplotlib.scale`
 
 matplotlib.projections
 ----------------------

--- a/doc/devel/add_new_projection.rst
+++ b/doc/devel/add_new_projection.rst
@@ -131,17 +131,5 @@ API documentation
 =================
 
 * :mod:`matplotlib.scale`
-
-matplotlib.projections
-----------------------
-
-.. automodule:: matplotlib.projections
-   :members:
-   :show-inheritance:
-
-matplotlib.projections.polar
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: matplotlib.projections.polar
-   :members:
-   :show-inheritance:
+* :mod:`matplotlib.projections`
+* :mod:`matplotlib.projections.polar`


### PR DESCRIPTION
Documentation was broken by the backport of #7145. I'm not really sure why there wasn't any problem on `master`, though. Fix that and also move the projections API into the `api` section as well.