### PR TITLE
BUG: 'saving' context manager now passes all args, kw to setup.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -169,7 +169,7 @@ class MovieWriter(object):
         width_inches, height_inches = self.fig.get_size_inches()
         return width_inches * self.dpi, height_inches * self.dpi
 
-    def setup(self, fig, outfile, dpi, *args):
+    def setup(self, fig, outfile, dpi):
         '''
         Perform setup for writing the movie file.
 
@@ -190,14 +190,14 @@ class MovieWriter(object):
         self._run()
 
     @contextlib.contextmanager
-    def saving(self, *args):
+    def saving(self, *args, **kw):
         '''
         Context manager to facilitate writing the movie file.
 
-        ``*args`` are any parameters that should be passed to `setup`.
+        ``*args, **kw`` are any parameters that should be passed to `setup`.
         '''
         # This particular sequence is what contextlib.contextmanager wants
-        self.setup(*args)
+        self.setup(*args, **kw)
         yield
         self.finish()
 


### PR DESCRIPTION
This is the functionality added to master in 6bac790 (#6304).
Directly cherry-picking that is not possible because of the intervening
introduction of abstract base classes.