### PR TITLE
Colorbar with SymmetricalLogLocator now handles negative values (Pull request issue for #7202)

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -600,12 +600,17 @@ class ColorbarBase(cm.ScalarMappable):
         formatter.set_data_interval(*intv)
 
         b = np.array(locator())
-        if isinstance(locator, ticker.LogLocator):
+        if isinstance(locator, ticker.LogLocator) or isinstance(locator, ticker.SymmetricalLogLocator):
             eps = 1e-10
             b = b[(b <= intv[1] * (1 + eps)) & (b >= intv[0] * (1 - eps))]
         else:
             eps = (intv[1] - intv[0]) * 1e-10
             b = b[(b <= intv[1] + eps) & (b >= intv[0] - eps)]
+
+        #failsafe in case less than 2 decades found    
+        if len(b)<2:
+            b = np.array(locator())
+
         self._tick_data_values = b
         ticks = self._locate(b)
         formatter.set_locs(b)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2126,6 +2126,8 @@ class SymmetricalLogLocator(Locator):
                 a_range = get_log_range(t, -vmin + 1)
             else:
                 a_range = get_log_range(-vmax, -vmin + 1)
+                if vmin<0 and vmax<0:
+                    a_range = ( a_range[0], a_range[1]+1 )
         else:
             a_range = (0, 0)
 


### PR DESCRIPTION
Pull request issue for issue #7202.
The attached patch allows to draw ticks/ticklabels in case no decade (or only one) was selected based on vmin/vmax detected values. There is however still an issue in the colorbar height.