### PR TITLE
[MRG+1] Catch IO errors when building font cache

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -591,6 +591,9 @@ def createFontList(fontfiles, fontext='ttf'):
                 verbose.report("Cannot handle unicode filenames")
                 # print >> sys.stderr, 'Bad file is', fpath
                 continue
+            except IOError:
+                verbose.report("IO error - cannot open font file %s" % fpath)
+                continue
             try:
                 prop = ttfFontProperty(font)
             except (KeyError, RuntimeError, ValueError):


### PR DESCRIPTION
Problem seen on Windows machines where permission was denied when trying to load specific fonts (DINpro Light).