### PR TITLE
[MRG+1] DOC: instructions on installing matplotlib for dev

### DIFF
--- a/doc/devel/gitwash/index.rst
+++ b/doc/devel/gitwash/index.rst
@@ -11,6 +11,6 @@ Contents:
    git_intro
    git_install
    following_latest
-   git_development
+   setting_up_for_development
    git_resources
    patching

--- a/doc/devel/gitwash/matplotlib_for_dev.rst
+++ b/doc/devel/gitwash/matplotlib_for_dev.rst
@@ -1,0 +1,20 @@
+.. _matplotlib-for-dev:
+
+=================================================
+Installing matplotlib from source for development
+=================================================
+
+After obtaining a local copy of the matpotlib source code (:ref:`set-up-fork`),
+navigate to the matplotlib directory and run the following in the shell:
+
+::
+    
+    python setup.py develop
+
+This installs matplotlib for development (i.e., builds everything and places the
+symbolic links back to the source code). Note that this command has to be
+called everytime a `c` file is changed.
+
+You may want to consider setting up a `virtual environment
+<http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_ or a `conda
+environment <http://conda.pydata.org/docs/using/envs.html>`_

--- a/doc/devel/gitwash/matplotlib_for_dev.rst
+++ b/doc/devel/gitwash/matplotlib_for_dev.rst
@@ -11,6 +11,10 @@ navigate to the matplotlib directory and run the following in the shell:
     
     python setup.py develop
 
+or::
+  
+   pip install -v -e .
+
 This installs matplotlib for development (i.e., builds everything and places the
 symbolic links back to the source code). Note that this command has to be
 called everytime a `c` file is changed.

--- a/doc/devel/gitwash/matplotlib_for_dev.rst
+++ b/doc/devel/gitwash/matplotlib_for_dev.rst
@@ -15,10 +15,13 @@ or::
   
    pip install -v -e .
 
-This installs matplotlib for development (i.e., builds everything and places the
-symbolic links back to the source code). Note that this command has to be
-called everytime a `c` file is changed.
+This installs matplotlib for development (i.e., builds everything and places
+the symbolic links back to the source code). This command has to be called
+everytime a `c` file is changed. Note that changing branches may change the
+`c`-code.
 
-You may want to consider setting up a `virtual environment
+When working on bleeding edge packages, setting up a
+`virtual environment
 <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_ or a `conda
-environment <http://conda.pydata.org/docs/using/envs.html>`_
+environment <http://conda.pydata.org/docs/using/envs.html>`_ is recommended.
+

--- a/doc/devel/gitwash/setting_up_for_development.rst
+++ b/doc/devel/gitwash/setting_up_for_development.rst
@@ -1,7 +1,7 @@
-.. _git-development:
+.. _setting_up_for_development:
 
 =====================
- Git for development
+ Setting up for development
 =====================
 
 Contents:
@@ -11,6 +11,7 @@ Contents:
 
    forking_hell
    set_up_fork
+   matplotlib_for_dev
    configure_git
    development_workflow
    dot2_dot3

--- a/doc/devel/gitwash/setting_up_for_development.rst
+++ b/doc/devel/gitwash/setting_up_for_development.rst
@@ -1,8 +1,8 @@
 .. _setting_up_for_development:
 
-=====================
- Setting up for development
-=====================
+==========================
+Setting up for development
+==========================
 
 Contents:
 

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -1,8 +1,8 @@
 .. _release-guide:
 
-**************************
-Doing a matplotlib release
-**************************
+*************
+Release Guide
+*************
 
 A guide for developers who are doing a matplotlib release.
 


### PR DESCRIPTION
This PR supersedes #3961 and fixes #3959 

It improves the documentation on installing matplotlib.

(Note that this is a documentation fix - we should probably consider at some point converting matplotlib's code organisation to a more standard python project organization to fix a number of issues contributors regularly run into)