### PR TITLE
WIP: factorizing tight bbox calculation and application

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2158,59 +2158,9 @@ class FigureCanvasBase(object):
         if bbox_inches:
             # call adjust_bbox to save only the given area
             if bbox_inches == "tight":
-                # when bbox_inches == "tight", it saves the figure
-                # twice. The first save command is just to estimate
-                # the bounding box of the figure. A stringIO object is
-                # used as a temporary file object, but it causes a
-                # problem for some backends (ps backend with
-                # usetex=True) if they expect a filename, not a
-                # file-like object. As I think it is best to change
-                # the backend to support file-like object, i'm going
-                # to leave it as it is. However, a better solution
-                # than stringIO seems to be needed. -JJL
-                #result = getattr(self, method_name)
-                result = print_method(
-                    io.BytesIO(),
-                    dpi=dpi,
-                    facecolor=facecolor,
-                    edgecolor=edgecolor,
-                    orientation=orientation,
-                    dryrun=True,
-                    **kwargs)
-                renderer = self.figure._cachedRenderer
-                bbox_inches = self.figure.get_tightbbox(renderer)
-
-                bbox_artists = kwargs.pop("bbox_extra_artists", None)
-                if bbox_artists is None:
-                    bbox_artists = self.figure.get_default_bbox_extra_artists()
-
-                bbox_filtered = []
-                for a in bbox_artists:
-                    bbox = a.get_window_extent(renderer)
-                    if a.get_clip_on():
-                        clip_box = a.get_clip_box()
-                        if clip_box is not None:
-                            bbox = Bbox.intersection(bbox, clip_box)
-                        clip_path = a.get_clip_path()
-                        if clip_path is not None and bbox is not None:
-                            clip_path = clip_path.get_fully_transformed_path()
-                            bbox = Bbox.intersection(bbox,
-                                                     clip_path.get_extents())
-                    if bbox is not None and (bbox.width != 0 or
-                                             bbox.height != 0):
-                        bbox_filtered.append(bbox)
-
-                if bbox_filtered:
-                    _bbox = Bbox.union(bbox_filtered)
-                    trans = Affine2D().scale(1.0 / self.figure.dpi)
-                    bbox_extra = TransformedBbox(_bbox, trans)
-                    bbox_inches = Bbox.union([bbox_inches, bbox_extra])
-
-                pad = kwargs.pop("pad_inches", None)
-                if pad is None:
-                    pad = rcParams['savefig.pad_inches']
-
-                bbox_inches = bbox_inches.padded(pad)
+                bbox_inches = self.tight_bbox(
+                    canvas, dpi, facecolor, edgecolor, orientation,
+                    dryrun=True, **kwargs)
 
             restore_bbox = tight_bbox.adjust_bbox(self.figure, bbox_inches,
                                                   canvas.fixed_dpi)
@@ -2240,6 +2190,68 @@ class FigureCanvasBase(object):
             self._is_saving = False
             #self.figure.canvas.draw() ## seems superfluous
         return result
+
+    def tight_bbox(self, canvas, dpi, facecolor, edgecolor,
+                   orientation, dryrun=True, **kwargs):
+        """
+        when bbox_inches == "tight", it saves the figure
+        twice. The first save command is just to estimate
+        the bounding box of the figure. A stringIO object is
+        used as a temporary file object, but it causes a
+        problem for some backends (ps backend with
+        usetex=True) if they expect a filename, not a
+        file-like object. As I think it is best to change
+        the backend to support file-like object, i'm going
+        to leave it as it is. However, a better solution
+        than stringIO seems to be needed. -JJL
+        """
+        #result = getattr(self, method_name)
+        result = print_method(
+            io.BytesIO(),
+            dpi=dpi,
+            facecolor=facecolor,
+            edgecolor=edgecolor,
+            orientation=orientation,
+            dryrun=True,
+            **kwargs)
+        renderer = self.figure._cachedRenderer
+        bbox_inches = self.figure.get_tightbbox(renderer)
+
+        bbox_artists = kwargs.pop("bbox_extra_artists", None)
+        if bbox_artists is None:
+            bbox_artists = self.figure.get_default_bbox_extra_artists()
+
+        bbox_filtered = []
+        for a in bbox_artists:
+            bbox = a.get_window_extent(renderer)
+            if a.get_clip_on():
+                clip_box = a.get_clip_box()
+                if clip_box is not None:
+                    bbox = Bbox.intersection(bbox, clip_box)
+                clip_path = a.get_clip_path()
+                if clip_path is not None and bbox is not None:
+                    clip_path = clip_path.get_fully_transformed_path()
+                    bbox = Bbox.intersection(bbox,
+                                             clip_path.get_extents())
+            if bbox is not None and (bbox.width != 0 or
+                                     bbox.height != 0):
+                bbox_filtered.append(bbox)
+
+        if bbox_filtered:
+            _bbox = Bbox.union(bbox_filtered)
+            trans = Affine2D().scale(1.0 / self.figure.dpi)
+            bbox_extra = TransformedBbox(_bbox, trans)
+            bbox_inches = Bbox.union([bbox_inches, bbox_extra])
+
+        pad = kwargs.pop("pad_inches", None)
+        if pad is None:
+            pad = rcParams['savefig.pad_inches']
+        bbox_inches = bbox_inches.padded(pad)
+
+        if dryrun is not True:
+            tight_bbox.adjust_bbox(self.figure, bbox_inches, canvas.fixed_dpi)
+
+        return bbox_inches
 
     @classmethod
     def get_default_filetype(cls):

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -13,7 +13,7 @@
 # set this to True.  It will download and build a specific version of
 # FreeType, and then use that to build the ft2font extension.  This
 # ensures that test images are exactly reproducible.
-#local_freetype = False
+local_freetype = True
 
 [status]
 # To suppress display of the dependencies and their versions
@@ -25,7 +25,7 @@
 # optional.  They are all installed by default, but they may be turned
 # off here.
 #
-#tests = True
+tests = True
 #sample_data = True
 #toolkits = True
 # Tests for the toolkits are only automatically installed


### PR DESCRIPTION
See #7226 for some discussion. This creates a `tight_bbox` method so it can be called without necessarily needing to save the figure to disk.
