### PR TITLE
Add mplcursors to third-party packages.

### DIFF
--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -134,6 +134,15 @@ toolkit written by Joe Kington to provide interactive "data cursors"
 (clickable annotation boxes) for matplotlib.
 
 
+.. _toolkit_mplcursors:
+
+mplcursors
+==========
+
+`mplcursors <https://mplcursors.readthedocs.io>`_ provides interactive
+data cursors for matplotlib.
+
+
 .. _toolkit_natgrid:
 
 Natgrid

--- a/examples/pylab_examples/cursor_demo.py
+++ b/examples/pylab_examples/cursor_demo.py
@@ -8,8 +8,10 @@ requires redrawing the figure with every mouse move.
 Faster cursoring is possible using native GUI drawing, as in
 wxcursor_demo.py.
 
-Also, mpldatacursor can be used to achieve a similar effect. See webpage:
-https://github.com/joferkington/mpldatacursor
+The mpldatacursor and mplcursors third-party packages can be used to achieve a
+similar effect.  See
+    https://github.com/joferkington/mpldatacursor
+    https://github.com/anntzer/mplcursors
 """
 from __future__ import print_function
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Self-plug :-)

@joferkington I would like to add a paragraph comparing the approaches of mpldatacursor and mplcursors, but I'd like to make sure that you agree with it.  My feeling that mpldatacursor tries to provide as many customizations to the annotation as possible as kwargs in the call to `datacursor()`, whereas I tried to make `mplcursors` as minimal as possible, by letting instead the user hook into annotation-adding or removing events to customize the annotation as he sees fit.

If we can agree on a comparison, then perhaps the two sections can be merged together, too.