### PR TITLE
CI: pin to qt4

### DIFF
--- a/ci/conda_recipe/meta.yaml
+++ b/ci/conda_recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - pytz
     - pyparsing
 #    - py2cairo  # [linux and py2k]
+    - qt 4*
     - libpng >=1.6.21,<1.7
     - pyqt  # [not osx]
     - tk 8.5*  # [linux and win]


### PR DESCRIPTION
This un-breaks 2 builds on appveyor.

Someone please merge this as soon as 4 of the 5 appveyor builds pass.