### PR TITLE
Update seaborn link away from Stanford site.

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -158,7 +158,7 @@ including a choice of two projection and mapping toolkits <a href="http://matplo
 3d plotting with <a href="{{ pathto('mpl_toolkits/mplot3d/index') }}">mplot3d</a>,
 axes and axis helpers in <a href="{{ pathto('mpl_toolkits/axes_grid/index') }}">axes_grid</a>,
 several higher-level plotting interfaces
-    <a href="http://web.stanford.edu/~mwaskom/software/seaborn">seaborn</a>,
+    <a href="https://seaborn.github.io/">seaborn</a>,
     <a href="http://holoviews.org">holoviews</a>,
     <a href="http://ggplot.yhathq.com">ggplot</a>, and more.
  </p>

--- a/doc/mpl_toolkits/index.rst
+++ b/doc/mpl_toolkits/index.rst
@@ -176,10 +176,9 @@ seaborn
 =======
 (*Not distributed with matplotlib*)
 
-`seaborn <http://web.stanford.edu/~mwaskom/software/seaborn>`_ is a high
-level interface for drawing statistical graphics with matplotlib. It
-aims to make visualization a central part of exploring and
-understanding complex datasets.
+`seaborn <https://seaborn.github.io/>`_ is a high level interface for drawing
+statistical graphics with matplotlib. It aims to make visualization a central
+part of exploring and understanding complex datasets.
 
 .. image:: /_static/seaborn.png
     :height: 157px


### PR DESCRIPTION
As I understand mwaskom/seaborn#958, they might eventually go to pydata, but this should fix the now-broken links in our posted documentation in the meantime.