### PR TITLE
[MRG+2] DOC Numpydoc documentation for def fill()

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4668,25 +4668,28 @@ or tuple of floats
 
 	Parameters
 	----------
-        args : a variable length argument, allowing for multiple
+        args : a variable length argument
+            It allowing for multiple
             *x*, *y* pairs with an optional color format string; see
             :func:`~matplotlib.pyplot.plot` for details on the argument
-            parsing.  For example, to plot a polygon with vertices at *x*,
-            *y* in blue.::
-            ax.fill(x,y, 'b' )
+            parsing.  For example, each of the following is legal::
+
+                ax.fill(x, y)
+                ax.fill(x, y, "b")
+                ax.fill(x, y, "b", x, y, "r")
+
             An arbitrary number of *x*, *y*, *color* groups can be specified::
             ax.fill(x1, y1, 'g', x2, y2, 'r')
 
- 	kwargs : The *closed* kwarg will close the polygon when *True* (default).
-            kwargs control the :class:`~matplotlib.patches.Polygon` properties:
-            %(Polygon)s
+        Returns
+        -------
+	a list of :class:`~matplotlib.patches.Patch`
 
+        Other Parameters
+        ----------------
+        kwargs : :class:`~matplotlib.patches.Polygon` properties
 
-        Return 
-	------
-	Return value is a list of :class:`~matplotlib.patches.Patch`
-        instances that were added.
-
+        %(Polygons)
 
 	Notes
 	-----
@@ -4696,11 +4699,11 @@ or tuple of floats
         If you would like to fill below a curve, e.g., shade a region
         between 0 and *y* along *x*, use :meth:`fill_between`
 
-       
+
         Example
 	-------
-
         .. plot:: mpl_examples/lines_bars_and_markers/fill_demo.py
+
 
         """
         if not self._hold:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4689,8 +4689,6 @@ or tuple of floats
         ----------------
         kwargs : :class:`~matplotlib.patches.Polygon` properties
 
-        %(Polygon)s
-
         Notes
         -----
         The same color strings that :func:`~matplotlib.pyplot.plot`
@@ -4698,7 +4696,6 @@ or tuple of floats
 
         If you would like to fill below a curve, e.g., shade a region
         between 0 and *y* along *x*, use :meth:`fill_between`
-
 
         Examples
         --------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4715,8 +4715,6 @@ or tuple of floats
         self.autoscale_view()
         return patches
 
-
-
     @_preprocess_data(replace_names=["x", "y1", "y2", "where"],
                          label_namer=None)
     @docstring.dedent_interpd

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4664,41 +4664,41 @@ or tuple of floats
                         positional_parameter_names=["x", "y", "c"])
     @docstring.dedent_interpd
     def fill(self, *args, **kwargs):
-        """
-        Plot filled polygons.
+        """Plot filled polygons.
 
-        Call signature::
+	Parameters
+	----------
+        args : a variable length argument, allowing for multiple
+            *x*, *y* pairs with an optional color format string; see
+            :func:`~matplotlib.pyplot.plot` for details on the argument
+            parsing.  For example, to plot a polygon with vertices at *x*,
+            *y* in blue.::
+            ax.fill(x,y, 'b' )
+            An arbitrary number of *x*, *y*, *color* groups can be specified::
+            ax.fill(x1, y1, 'g', x2, y2, 'r')
 
-          fill(*args, **kwargs)
+ 	kwargs : The *closed* kwarg will close the polygon when *True* (default).
+            kwargs control the :class:`~matplotlib.patches.Polygon` properties:
+            %(Polygon)s
 
-        *args* is a variable length argument, allowing for multiple
-        *x*, *y* pairs with an optional color format string; see
-        :func:`~matplotlib.pyplot.plot` for details on the argument
-        parsing.  For example, to plot a polygon with vertices at *x*,
-        *y* in blue.::
 
-          ax.fill(x,y, 'b' )
-
-        An arbitrary number of *x*, *y*, *color* groups can be specified::
-
-          ax.fill(x1, y1, 'g', x2, y2, 'r')
-
-        Return value is a list of :class:`~matplotlib.patches.Patch`
+        Return 
+	------
+	Return value is a list of :class:`~matplotlib.patches.Patch`
         instances that were added.
 
+
+	Notes
+	-----
         The same color strings that :func:`~matplotlib.pyplot.plot`
         supports are supported by the fill format string.
 
         If you would like to fill below a curve, e.g., shade a region
         between 0 and *y* along *x*, use :meth:`fill_between`
 
-        The *closed* kwarg will close the polygon when *True* (default).
-
-        kwargs control the :class:`~matplotlib.patches.Polygon` properties:
-
-        %(Polygon)s
-
-        **Example:**
+       
+        Example
+	-------
 
         .. plot:: mpl_examples/lines_bars_and_markers/fill_demo.py
 
@@ -4714,6 +4714,8 @@ or tuple of floats
             patches.append(poly)
         self.autoscale_view()
         return patches
+
+
 
     @_preprocess_data(replace_names=["x", "y1", "y2", "where"],
                          label_namer=None)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4689,7 +4689,7 @@ or tuple of floats
         ----------------
         kwargs : :class:`~matplotlib.patches.Polygon` properties
 
-        %(Polygons)
+        %(Polygon)s
 
         Notes
         -----
@@ -4700,8 +4700,8 @@ or tuple of floats
         between 0 and *y* along *x*, use :meth:`fill_between`
 
 
-        Example
-        -------
+        Examples
+        --------
         .. plot:: mpl_examples/lines_bars_and_markers/fill_demo.py
 
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4666,8 +4666,8 @@ or tuple of floats
     def fill(self, *args, **kwargs):
         """Plot filled polygons.
 
-	Parameters
-	----------
+        Parameters
+        ----------
         args : a variable length argument
             It allowing for multiple
             *x*, *y* pairs with an optional color format string; see
@@ -4683,7 +4683,7 @@ or tuple of floats
 
         Returns
         -------
-	a list of :class:`~matplotlib.patches.Patch`
+        a list of :class:`~matplotlib.patches.Patch`
 
         Other Parameters
         ----------------
@@ -4691,8 +4691,8 @@ or tuple of floats
 
         %(Polygons)
 
-	Notes
-	-----
+        Notes
+        -----
         The same color strings that :func:`~matplotlib.pyplot.plot`
         supports are supported by the fill format string.
 
@@ -4701,7 +4701,7 @@ or tuple of floats
 
 
         Example
-	-------
+        -------
         .. plot:: mpl_examples/lines_bars_and_markers/fill_demo.py
 
 


### PR DESCRIPTION
This PR converts the fill documentation to numpy doc.

This supersedes #7034 (removes the polygon args which are referred to properly in the docstring already and add pep8 fixes).