### PR TITLE
[MRG+1] Fix image watermark example where image was hidden by axes (#7265)

### DIFF
--- a/examples/api/watermark_image.py
+++ b/examples/api/watermark_image.py
@@ -16,6 +16,6 @@ fig, ax = plt.subplots()
 
 ax.plot(np.random.rand(20), '-o', ms=20, lw=2, alpha=0.7, mfc='orange')
 ax.grid()
-fig.figimage(im, 10, 10)
+fig.figimage(im, 10, 10, zorder=3)
 
 plt.show()

--- a/examples/api/watermark_image.py
+++ b/examples/api/watermark_image.py
@@ -1,4 +1,6 @@
 """
+Watermark image example
+
 Use a PNG file as a watermark
 """
 from __future__ import print_function


### PR DESCRIPTION
Hi!

I'm new to matplotlib and would be happy to contribute if I can.
Did as @anntzer  suggested in the issue (only with `zorder=3` like in the Text class) and of course it worked:
![ex](https://cloud.githubusercontent.com/assets/9948531/19411538/4c1f3938-930c-11e6-95da-fe4a18d14006.png)

I was also wondering why FigureImage has `zorder=0` by default, doesn't that mean images drawn on figures will always be hidden by the axes (unless the `zorder` argument is explicitly set)?

Another thing that could be a bit confusing is that the example passes the `zorder` keyword argument to `figimage` even though it's only intercepted by the constructor of Artist class (and thus doesn't appear in `figimage`'s docs)... Then again maybe it's only confusing for new people :)

Thanks!