### PR TITLE
[MRG+1] Fix Boxplot docs to conform to numpydoc (rebase #6240)

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3237,22 +3237,26 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        The following boolean options toggle the drawing of individual
-        components of the boxplots:
-            - showcaps: the caps on the ends of whiskers
-              (default is True)
-            - showbox: the central box (default is True)
-            - showfliers: the outliers beyond the caps (default is True)
-            - showmeans: the arithmetic means (default is False)
-
-        The remaining options can accept dictionaries that specify the
-        style of the individual artists:
-            - capprops
-            - boxprops
-            - whiskerprops
-            - flierprops
-            - medianprops
-            - meanprops
+        showcaps : bool, optional (True)
+            Show the caps on the ends of whiskers.
+        showbox : bool, optional (True)
+            Show the central box.
+        showfliers : bool, optional (True)
+            Show the outliers beyond the caps.
+        showmeans : bool, optional (False)
+            Show the arithmetic means.
+        capprops : dict, optional (None)
+            Specifies the style of the caps.
+        boxprops : dict, optional (None)
+            Specifies the style of the box.
+        whiskerprops : dict, optional (None)
+            Specifies the style of the whiskers.
+        flierprops : dict, optional (None)
+            Specifies the style of the fliers.
+        medianprops : dict, optional (None)
+            Specifies the style of the median.
+        meanprops : dict, optional (None)
+            Specifies the style of the mean.
 
         Returns
         -------


### PR DESCRIPTION
This is a rebase of #6240, which seems to have been left behind at some point. The original first commit was already made by @tacaswell at some other time, so there's only one here now.

cc @jenshnielsen