### PR TITLE
[MRG+1] DOC: Fix for #7283 by adding a trailing underscore to misrendered URLs

### DIFF
--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -160,9 +160,9 @@ upstream changes, and resolving conflicts.
 In git, rebasing is a mild form of re-writing history: it effectively forwards
 all your commits to the updated upstream commit. For a much more detailed
 explanation (with pictures!) see `this nice write up
-<https://git-scm.com/book/en/Git-Branching-Rebasing>`.  The NumPy team has also
+<https://git-scm.com/book/en/Git-Branching-Rebasing>`_.  The NumPy team has also
 `documented how to do this
-<http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#rebasing-on-master>`
+<http://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#rebasing-on-master>`_.
 In general, re-writing history, particularly published history, is considered
 bad practice, but in this case it is very useful.
 


### PR DESCRIPTION
According to @QuLogic's suggestion (and some random doc about reST syntax found on the Internet, like [http://docutils.sourceforge.net/docs/user/rst/quickref.html#external-hyperlink-targets](http://docutils.sourceforge.net/docs/user/rst/quickref.html#external-hyperlink-targets)),  this PR should fix issue #7283 by adding trailing underscore characters. 

_Disclaimer: I did not build the whole documentation to test it_ (it is becoming late here).