### PR TITLE
Remove deprecated stuff schedule for removal.

### DIFF
--- a/doc/api/api_changes/code_removal.rst
+++ b/doc/api/api_changes/code_removal.rst
@@ -10,3 +10,18 @@ via ``matplotlib.tri``
 qt4_compat.py
 -------------
 Moved to ``qt_compat.py``.  Renamed because it now handles Qt5 as well.
+
+
+Deprecated methods
+------------------
+
+The ``GraphicsContextBase.set_graylevel``, ``FigureCanvasBase.onHilite`` and
+``mpl_toolkits.axes_grid1.mpl_axes.Axes.toggle_axisline`` methods have been
+removed.
+
+
+`Axes.set_aspect("normal")`
+---------------------------
+
+Support for setting an ``Axes``' aspect to ``"normal"`` has been removed, in
+favor of the synonym ``"auto"``.

--- a/examples/user_interfaces/embedding_in_qt4_wtoolbar.py
+++ b/examples/user_interfaces/embedding_in_qt4_wtoolbar.py
@@ -3,13 +3,15 @@ from __future__ import print_function
 import sys
 
 import numpy as np
+import matplotlib
+matplotlib.use("Qt4Agg")
 from matplotlib.figure import Figure
 from matplotlib.backend_bases import key_press_handler
 from matplotlib.backends.backend_qt4agg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar)
-from matplotlib.backends import qt4_compat
-use_pyside = qt4_compat.QT_API == qt4_compat.QT_API_PYSIDE
+from matplotlib.backends import qt_compat
+use_pyside = qt_compat.QT_API == qt_compat.QT_API_PYSIDE
 
 if use_pyside:
     from PySide.QtCore import *
@@ -69,6 +71,7 @@ def main():
     form = AppForm()
     form.show()
     app.exec_()
+
 
 if __name__ == "__main__":
     main()

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1227,7 +1227,6 @@ class _AxesBase(martist.Artist):
           value      description
           ========   ================================================
           'auto'     automatic; fill position rectangle with data
-          'normal'   same as 'auto'; deprecated
           'equal'    same scaling from data to plot units for x and y
            num       a circle will be stretched such that the height
                      is num times the width. aspect=1 is the same as
@@ -1259,16 +1258,8 @@ class _AxesBase(martist.Artist):
           'SE'    lower right corner
           etc.
           =====   =====================
-
-        .. deprecated:: 1.2
-            the option 'normal' for aspect is deprecated. Use 'auto' instead.
         """
-        if aspect == 'normal':
-            cbook.warn_deprecated(
-                '1.2', name='normal', alternative='auto', obj_type='aspect')
-            self._aspect = 'auto'
-
-        elif aspect in ('equal', 'auto'):
+        if aspect in ('equal', 'auto'):
             self._aspect = aspect
         else:
             self._aspect = float(aspect)  # raise ValueError if necessary

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1016,17 +1016,6 @@ class GraphicsContextBase(object):
         else:
             self._rgb = colors.to_rgba(fg)
 
-    def set_graylevel(self, frac):
-        """
-        Set the foreground color to be a gray level with *frac*
-        """
-        # When removing, remember to remove all overrides in subclasses.
-        msg = ("set_graylevel is deprecated for removal in 1.6; "
-                "you can achieve the same result by using "
-                "set_foreground((frac, frac, frac))")
-        warnings.warn(msg, mplDeprecation)
-        self._rgb = (frac, frac, frac, self._alpha)
-
     def set_joinstyle(self, js):
         """
         Set the join style to be one of ('miter', 'round', 'bevel')
@@ -1726,53 +1715,6 @@ class FigureCanvasBase(object):
                     parent = p
                     break
             h = parent
-
-    def onHilite(self, ev):
-        """
-        Mouse event processor which highlights the artists
-        under the cursor.  Connect this to the 'motion_notify_event'
-        using::
-
-            canvas.mpl_connect('motion_notify_event',canvas.onHilite)
-        """
-        msg = ("onHilite has been deprecated in 1.5 and will be removed "
-               "in 1.6.  This function has not been used internally by mpl "
-               "since 2007.")
-        warnings.warn(msg, mplDeprecation)
-        if not hasattr(self, '_active'):
-            self._active = dict()
-
-        under = self.figure.hitlist(ev)
-        enter = [a for a in under if a not in self._active]
-        leave = [a for a in self._active if a not in under]
-        # On leave restore the captured colour
-        for a in leave:
-            if hasattr(a, 'get_color'):
-                a.set_color(self._active[a])
-            elif hasattr(a, 'get_edgecolor'):
-                a.set_edgecolor(self._active[a][0])
-                a.set_facecolor(self._active[a][1])
-            del self._active[a]
-        # On enter, capture the color and repaint the artist
-        # with the highlight colour.  Capturing colour has to
-        # be done first in case the parent recolouring affects
-        # the child.
-        for a in enter:
-            if hasattr(a, 'get_color'):
-                self._active[a] = a.get_color()
-            elif hasattr(a, 'get_edgecolor'):
-                self._active[a] = (a.get_edgecolor(), a.get_facecolor())
-            else:
-                self._active[a] = None
-        for a in enter:
-            if hasattr(a, 'get_color'):
-                a.set_color('red')
-            elif hasattr(a, 'get_edgecolor'):
-                a.set_edgecolor('red')
-                a.set_facecolor('lightblue')
-            else:
-                self._active[a] = None
-        self.draw_idle()
 
     def pick(self, mouseevent):
         if not self.widgetlock.locked():

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -468,13 +468,6 @@ class GraphicsContextCairo(GraphicsContextBase):
         else:
             self.ctx.set_source_rgba(*self._rgb)
 
-    def set_graylevel(self, frac):
-        GraphicsContextBase.set_graylevel(self, frac)
-        if len(self._rgb) == 3:
-            self.ctx.set_source_rgb(*self._rgb)
-        else:
-            self.ctx.set_source_rgba(*self._rgb)
-
     def get_rgb(self):
         return self.ctx.get_source().get_rgba()[:3]
 

--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -394,11 +394,6 @@ class GraphicsContextGDK(GraphicsContextBase):
         self.gdkGC.foreground = self.rgb_to_gdk_color(self.get_rgb())
 
 
-    def set_graylevel(self, frac):
-        GraphicsContextBase.set_graylevel(self, frac)
-        self.gdkGC.foreground = self.rgb_to_gdk_color(self.get_rgb())
-
-
     def set_joinstyle(self, js):
         GraphicsContextBase.set_joinstyle(self, js)
         self.gdkGC.join_style = self._joind[self._joinstyle]

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -467,19 +467,6 @@ class GraphicsContextWx(GraphicsContextBase):
         self.gfx_ctx.SetPen(self._pen)
         self.unselect()
 
-    def set_graylevel(self, frac):
-        """
-        Set the foreground color.  fg can be a matlab format string, a
-        html hex color string, an rgb unit tuple, or a float between 0
-        and 1.  In the latter case, grayscale is used.
-        """
-        DEBUG_MSG("set_graylevel()", 1, self)
-        self.select()
-        GraphicsContextBase.set_graylevel(self, frac)
-        self._pen.SetColour(self.get_wxcolour(self.get_rgb()))
-        self.gfx_ctx.SetPen(self._pen)
-        self.unselect()
-
     def set_linewidth(self, w):
         """
         Set the line width.

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -3,19 +3,16 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-import matplotlib.cbook as cbook
-
-import matplotlib.axes as maxes
-#import matplotlib.colorbar as mcolorbar
-from . import colorbar as mcolorbar
 import matplotlib as mpl
-import matplotlib.patches as mpatches
+import matplotlib.axes as maxes
+import matplotlib.cbook as cbook
 import matplotlib.lines as mlines
+import matplotlib.patches as mpatches
 import matplotlib.ticker as ticker
-
 from matplotlib.gridspec import SubplotSpec
 
 from .axes_divider import Size, SubplotDivider, LocatableAxes, Divider
+from .colorbar import Colorbar
 
 
 def _extend_axes_pad(value):
@@ -35,43 +32,6 @@ def _tick_only(ax, bottom_on, left_on):
     # ax.yaxis.label.set_visible(left_off)
     ax.axis["bottom"].toggle(ticklabels=bottom_off, label=bottom_off)
     ax.axis["left"].toggle(ticklabels=left_off, label=left_off)
-
-
-class Colorbar(mcolorbar.Colorbar):
-    def _config_axes_deprecated(self, X, Y):
-        '''
-        Make an axes patch and outline.
-        '''
-        ax = self.ax
-        ax.set_frame_on(False)
-        ax.set_navigate(False)
-        xy = self._outline(X, Y)
-        ax.update_datalim(xy)
-        ax.set_xlim(*ax.dataLim.intervalx)
-        ax.set_ylim(*ax.dataLim.intervaly)
-        self.outline = mlines.Line2D(xy[:, 0], xy[:, 1],
-                                     color=mpl.rcParams['axes.edgecolor'],
-                                     linewidth=mpl.rcParams['axes.linewidth'])
-        ax.add_artist(self.outline)
-        self.outline.set_clip_box(None)
-        self.outline.set_clip_path(None)
-        c = mpl.rcParams['axes.facecolor']
-        self.patch = mpatches.Polygon(xy, edgecolor=c,
-                                      facecolor=c,
-                                      linewidth=0.01,
-                                      zorder=-1)
-        ax.add_artist(self.patch)
-        ticks, ticklabels, offset_string = self._ticker()
-
-        if self.orientation == 'vertical':
-            ax.set_yticks(ticks)
-            ax.set_yticklabels(ticklabels)
-            ax.yaxis.get_major_formatter().set_offset_string(offset_string)
-
-        else:
-            ax.set_xticks(ticks)
-            ax.set_xticklabels(ticklabels)
-            ax.xaxis.get_major_formatter().set_offset_string(offset_string)
 
 
 class CbarAxesBase(object):

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -23,8 +23,6 @@ class SimpleChainedObjects(object):
 
 
 class Axes(maxes.Axes):
-    def toggle_axisline(self, b):
-        warnings.warn("toggle_axisline is not necessary and deprecated in axes_grid1")
 
     class AxisDict(dict):
         def __init__(self, axes):


### PR DESCRIPTION
Everything removed here had either a deprecation warning indicating
removal scheduled in 1.6, or deprecation since at least two minor
releases.

(The exception, `axes_grid1.axes_grid.Colorbar`, is completely
equivalent to the standard Colorbar -- it only adds a private, unused
method.)

Also adjusted an example that used a deprecated module.