### PR TITLE
BUG: make MaxNLocator.tick_values() obey _symmetric value.

### DIFF
--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -10,6 +10,7 @@ from matplotlib import mlab
 from matplotlib.testing.decorators import cleanup, image_comparison
 from matplotlib import pyplot as plt
 from nose.tools import assert_equal, assert_raises
+from numpy.testing import assert_array_almost_equal
 import warnings
 
 import re
@@ -290,6 +291,15 @@ def test_contourf_decreasing_levels():
     with warnings.catch_warnings(record=True) as w:
         plt.contourf(z, [1.0, 0.0], corner_mask='legacy')
     assert_equal(len(w), 2)
+
+
+@cleanup
+def test_contourf_symmetric_locator():
+    # github issue 7271
+    z = np.arange(12).reshape((3, 4))
+    locator = plt.MaxNLocator(nbins=4, symmetric=True)
+    cs = plt.contourf(z, locator=locator)
+    assert_array_almost_equal(cs.levels, np.linspace(-12, 12, 5))
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1701,9 +1701,13 @@ class MaxNLocator(Locator):
         return self.tick_values(vmin, vmax)
 
     def tick_values(self, vmin, vmax):
+        if self._symmetric:
+            vmax = max(abs(vmin), abs(vmax))
+            vmin = -vmax
         vmin, vmax = mtransforms.nonsingular(
             vmin, vmax, expander=1e-13, tiny=1e-14)
         locs = self._raw_ticks(vmin, vmax)
+
         prune = self._prune
         if prune == 'lower':
             locs = locs[1:]
@@ -1715,9 +1719,8 @@ class MaxNLocator(Locator):
 
     def view_limits(self, dmin, dmax):
         if self._symmetric:
-            maxabs = max(abs(dmin), abs(dmax))
-            dmin = -maxabs
-            dmax = maxabs
+            dmax = max(abs(dmin), abs(dmax))
+            dmin = -dmax
 
         dmin, dmax = mtransforms.nonsingular(
             dmin, dmax, expander=1e-12, tiny=1e-13)


### PR DESCRIPTION
A likely use case is contouring fields such as a velocity
component, where one wants to use a diverging colormap
centered on zero.
Closes #7271.