### PR TITLE
[MRG] MAINT docstring appending doesn't mess with rendering anymore.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1602,14 +1602,12 @@ def _replacer(data, key):
 
 _DATA_DOC_APPENDIX = """
 
-Notes
------
+.. note::
+    In addition to the above described arguments, this function can take a
+    **data** keyword argument. If such a **data** argument is given, the
+    following arguments are replaced by **data[<arg>]**:
 
-In addition to the above described arguments, this function can take a
-**data** keyword argument. If such a **data** argument is given, the
-following arguments are replaced by **data[<arg>]**:
-
-{replaced}
+    {replaced}
 """
 
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4676,7 +4676,8 @@ or tuple of floats
                         positional_parameter_names=["x", "y", "c"])
     @docstring.dedent_interpd
     def fill(self, *args, **kwargs):
-        """Plot filled polygons.
+        """
+        Plot filled polygons.
 
         Parameters
         ----------


### PR DESCRIPTION
- numpydoc did not accept two Notes section. Replaced a Note section with a
  sphinx .. note:: one
- fill's docstring title was messing up indentation.

closes #7095

fill's doc now look like:

![fill](https://cloud.githubusercontent.com/assets/184798/19458467/154a0494-9481-11e6-97d4-51483a2c4288.png)


(Notice the two different notes!)
