### PR TITLE
CI: test on 3.6-dev branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
 before_install:
   - source tools/travis_tools.sh
   # Install into our own pristine virtualenv
+  - pip install --upgrade virtualenv
   - virtualenv --python=python venv
   - source venv/bin/activate
   - export PATH=/usr/lib/ccache:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ matrix:
       env: TEST_ARGS=--pep8
     - python: 2.7
       env: BUILD_DOCS=true MOCK=mock
+    - python: "3.6-dev"
+      env: PRE=--pre
     - python: "nightly"
       env: PRE=--pre
   allow_failures:


### PR DESCRIPTION
~~nightly currently points at 3.7-dev which is broken during Travis's
portion of setting up the test.~~

Require the 3.6 build to pass (as it will be out soon).

travis docs: https://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against