### PR TITLE
Drop old Python checks

### DIFF
--- a/lib/matplotlib/compat/subprocess.py
+++ b/lib/matplotlib/compat/subprocess.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import    # Required to import subprocess
 from __future__ import print_function
 import os
 import sys
-if os.name == 'posix' and sys.version_info[:2] < (3, 2):
+if os.name == 'posix' and sys.version_info[0] < 3:
     # work around for https://github.com/matplotlib/matplotlib/issues/5314
     try:
         import subprocess32 as subprocess

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-import sys
 import io
 import os
 
@@ -573,10 +572,6 @@ def test_minimized_rasterized():
     # in Postscript, the best way to detect it is to generate SVG
     # and then parse the output to make sure the two colorbar images
     # are the same size.
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("xml.etree.ElementTree.Element.iter "
-                            "added in py 2.7")
-
     from xml.etree import ElementTree
 
     np.random.seed(0)

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -17,8 +17,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup, image_comparison
 
-import sys
-
 
 @cleanup
 def test_invisible_Line_rendering():
@@ -112,10 +110,6 @@ def test_linestyle_variants():
 
 @cleanup
 def test_valid_linestyles():
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("assert_raises as context manager "
-                            "not supported with Python < 2.7")
-
     line = mlines.Line2D([], [])
     with assert_raises(ValueError):
         line.set_linestyle('aardvark')
@@ -135,10 +129,6 @@ def test_drawstyle_variants():
 
 @cleanup
 def test_valid_drawstyles():
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("assert_raises as context manager "
-                            "not supported with Python < 2.7")
-
     line = mlines.Line2D([], [])
     with assert_raises(ValueError):
         line.set_drawstyle('foobar')

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -5,8 +5,8 @@ import six
 
 import io
 import os
-import sys
 import warnings
+from collections import OrderedDict
 
 from cycler import cycler, Cycler
 
@@ -16,7 +16,6 @@ from matplotlib.tests import assert_str_equal
 from matplotlib.testing.decorators import cleanup, knownfailureif
 import matplotlib.colors as mcolors
 from nose.tools import assert_true, assert_raises, assert_equal
-from nose.plugins.skip import SkipTest
 import nose
 from itertools import chain
 import numpy as np
@@ -115,9 +114,6 @@ font.weight: normal""".lstrip()
 
 
 def test_rcparams_update():
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("assert_raises as context manager "
-                            "not supported with Python < 2.7")
     rc = mpl.RcParams({'figure.figsize': (3.5, 42)})
     bad_dict = {'figure.figsize': (3.5, 42, 1)}
     # make sure validation happens on input
@@ -131,9 +127,6 @@ def test_rcparams_update():
 
 
 def test_rcparams_init():
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("assert_raises as context manager "
-                            "not supported with Python < 2.7")
     with assert_raises(ValueError):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
@@ -172,14 +165,6 @@ def test_Bug_2543():
             mpl.rcParams['svg.embed_char_paths'] = False
             assert_true(mpl.rcParams['svg.fonttype'] == "none")
 
-
-@cleanup
-def test_Bug_2543_newer_python():
-    # only split from above because of the usage of assert_raises
-    # as a context manager, which only works in 2.7 and above
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("assert_raises as context manager not supported with Python < 2.7")
-    from matplotlib.rcsetup import validate_bool_maybe_none, validate_bool
     with assert_raises(ValueError):
         validate_bool_maybe_none("blah")
     with assert_raises(ValueError):
@@ -249,9 +234,6 @@ def _validation_test_helper(validator, arg, target):
 
 
 def _validation_fail_helper(validator, arg, exception_type):
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("assert_raises as context manager not "
-                            "supported with Python < 2.7")
     with assert_raises(exception_type):
         validator(arg)
 
@@ -394,11 +376,6 @@ def test_rcparams_reset_after_fail():
     # There was previously a bug that meant that if rc_context failed and
     # raised an exception due to issues in the supplied rc parameters, the
     # global rc parameters were left in a modified state.
-
-    if sys.version_info[:2] >= (2, 7):
-        from collections import OrderedDict
-    else:
-        raise SkipTest("Test can only be run in Python >= 2.7 as it requires OrderedDict")
 
     with mpl.rc_context(rc={'text.usetex': False}):
 

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -2,12 +2,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
-import sys
 import shutil
 import tempfile
+from collections import OrderedDict
 from contextlib import contextmanager
 
-from nose import SkipTest
 from nose.tools import assert_raises
 from nose.plugins.attrib import attr
 
@@ -121,12 +120,6 @@ def test_context_with_union_of_dict_and_namedstyle():
 
 
 def test_context_with_badparam():
-    if sys.version_info[:2] >= (2, 7):
-        from collections import OrderedDict
-    else:
-        m = "Test can only be run in Python >= 2.7 as it requires OrderedDict"
-        raise SkipTest(m)
-
     original_value = 'gray'
     other_value = 'blue'
     d = OrderedDict([(PARAM, original_value), ('badparam', None)])

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -7,7 +7,6 @@ import warnings
 import numpy as np
 from numpy.testing import assert_almost_equal
 from nose.tools import eq_, assert_raises
-from nose.plugins.skip import SkipTest
 
 from matplotlib.transforms import Bbox
 import matplotlib
@@ -287,10 +286,6 @@ def test_get_rotation_int():
 
 def test_get_rotation_raises():
     from matplotlib import text
-    import sys
-    if sys.version_info[:2] < (2, 7):
-        raise SkipTest("assert_raises as context manager "
-                       "not supported with Python < 2.7")
     with assert_raises(ValueError):
         text.get_rotation('hozirontal')
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1,5 +1,3 @@
-import sys
-import nose
 from nose.tools import assert_raises
 from mpl_toolkits.mplot3d import Axes3D, axes3d
 from matplotlib import cm
@@ -218,9 +216,6 @@ def test_wireframe3dzerorstride():
 
 @cleanup
 def test_wireframe3dzerostrideraises():
-    if sys.version_info[:2] < (2, 7):
-        raise nose.SkipTest("assert_raises as context manager "
-                            "not supported with Python < 2.7")
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)

--- a/setupext.py
+++ b/setupext.py
@@ -17,7 +17,6 @@ import versioneer
 
 
 PY3min = (sys.version_info[0] >= 3)
-PY32min = (PY3min and sys.version_info[1] >= 2 or sys.version_info[0] > 3)
 
 
 def _get_home():
@@ -90,7 +89,7 @@ options = {
 
 setup_cfg = os.environ.get('MPLSETUPCFG', 'setup.cfg')
 if os.path.exists(setup_cfg):
-    if PY32min:
+    if PY3min:
         config = configparser.ConfigParser()
     else:
         config = configparser.SafeConfigParser()
@@ -724,7 +723,7 @@ class Tests(OptionalPackage):
         except ImportError:
             msgs += [bad_nose]
 
-        if sys.version_info >= (3, 3):
+        if PY3min:
             msgs += ['using unittest.mock']
         else:
             try:
@@ -849,7 +848,7 @@ class Numpy(SetupPackage):
 
     @staticmethod
     def include_dirs_hook():
-        if sys.version_info[0] >= 3:
+        if PY3min:
             import builtins
             if hasattr(builtins, '__NUMPY_SETUP__'):
                 del builtins.__NUMPY_SETUP__
@@ -1047,11 +1046,11 @@ class FreeType(SetupPackage):
                         pass
 
             if not os.path.isfile(tarball_path):
-
-                if sys.version_info[0] == 2:
-                    from urllib import urlretrieve
-                else:
+                if PY3min:
                     from urllib.request import urlretrieve
+                else:
+                    from urllib import urlretrieve
+
                 if not os.path.exists('build'):
                     os.makedirs('build')
 
@@ -1370,14 +1369,6 @@ class Dateutil(SetupPackage):
         try:
             import dateutil
         except ImportError:
-            # dateutil 2.1 has a file encoding bug that breaks installation on
-            # python 3.3
-            # https://github.com/matplotlib/matplotlib/issues/2373
-            # hack around the problem by installing the (working) v2.0
-            major, minor1, _, _, _ = sys.version_info
-            if self.version is None and (major, minor1) == (3, 3):
-                self.version = '!=2.1'
-
             return (
                 "dateutil was not found. It is required for date axis "
                 "support. pip/easy_install may attempt to install it "
@@ -1396,7 +1387,7 @@ class FuncTools32(SetupPackage):
     name = "functools32"
 
     def check(self):
-        if sys.version_info[:2] < (3, 2):
+        if not PY3min:
             try:
                 import functools32
             except ImportError:
@@ -1409,7 +1400,7 @@ class FuncTools32(SetupPackage):
             return "Not required"
 
     def get_install_requires(self):
-        if sys.version_info[:2] < (3, 2):
+        if not PY3min:
             return ['functools32']
         else:
             return []
@@ -1419,7 +1410,7 @@ class Subprocess32(SetupPackage):
     name = "subprocess32"
 
     def check(self):
-        if sys.version_info[:2] < (3, 2):
+        if not PY3min:
             try:
                 import subprocess32
             except ImportError:
@@ -1433,7 +1424,7 @@ class Subprocess32(SetupPackage):
             return "Not required"
 
     def get_install_requires(self):
-        if sys.version_info[:2] < (3, 2) and os.name == 'posix':
+        if not PY3min and os.name == 'posix':
             return ['subprocess32']
         else:
             return []


### PR DESCRIPTION
#5373 raised minimum Python to 2.7 or 3.4+. A lot of `try`/`except` stuff was removed, but explicit checks of `sys.version_info` were not.