### PR TITLE
FIX symlog scale now shows negative labels.

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,8 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
-
 from numpy.testing import assert_almost_equal
 import numpy as np
 import pytest
@@ -305,6 +303,7 @@ def test_LogFormatterExponent_blank():
 def test_LogFormatterSciNotation():
     test_cases = {
         10: (
+             (-1, '${-10^{0}}$'),
              (1e-05, '${10^{-5}}$'),
              (1, '${10^{0}}$'),
              (100000, '${10^{5}}$'),

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -902,7 +902,7 @@ class LogFormatter(Formatter):
         fx = math.log(abs(x)) / math.log(b)
         isDecade = is_close_to_int(fx)
         exponent = np.round(fx) if isDecade else np.floor(fx)
-        coeff = np.round(x / b ** exponent)
+        coeff = np.round(abs(x) / b ** exponent)
         if coeff in self.sublabel:
             if not isDecade and self.labelOnlyBase:
                 s = ''
@@ -1032,7 +1032,7 @@ class LogFormatterMathtext(LogFormatter):
         fx = math.log(abs(x)) / math.log(b)
         is_decade = is_close_to_int(fx)
         exponent = np.round(fx) if is_decade else np.floor(fx)
-        coeff = np.round(x / b ** exponent)
+        coeff = np.round(abs(x) / b ** exponent)
 
         sign_string = '-' if x < 0 else ''
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -898,18 +898,19 @@ class LogFormatter(Formatter):
         if x == 0.0:
             return '0'
         sign = np.sign(x)
+        x = abs(x)
         # only label the decades
-        fx = math.log(abs(x)) / math.log(b)
+        fx = math.log(x) / math.log(b)
         isDecade = is_close_to_int(fx)
         exponent = np.round(fx) if isDecade else np.floor(fx)
-        coeff = np.round(abs(x) / b ** exponent)
+        coeff = np.round(x / b ** exponent)
         if coeff in self.sublabel:
             if not isDecade and self.labelOnlyBase:
                 return ''
             elif x > 10000:
-                s = '%1.0e' % abs(x)
+                s = '%1.0e' % x
             elif x < 1:
-                s = '%1.0e' % abs(x)
+                s = '%1.0e' % x
             else:
                 s = self.pprint_val(x, self.d)
             if sign == -1:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -905,11 +905,11 @@ class LogFormatter(Formatter):
         coeff = np.round(abs(x) / b ** exponent)
         if coeff in self.sublabel:
             if not isDecade and self.labelOnlyBase:
-                s = ''
+                return ''
             elif x > 10000:
-                s = '%1.0e' % x
+                s = '%1.0e' % abs(x)
             elif x < 1:
-                s = '%1.0e' % x
+                s = '%1.0e' % abs(x)
             else:
                 s = self.pprint_val(x, self.d)
             if sign == -1:


### PR DESCRIPTION
The formatter returned empty strings for negative value.

closes #7146