### PR TITLE
[MRG+1] DOC: Normalize symlink target

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -178,7 +178,7 @@ for link, target in required_symlinks:
                                " isn't".format(link))
     if not os.path.exists(link):
         try:
-            os.symlink(target, link)
+            os.symlink(os.path.normcase(target), link)
         except OSError:
             symlink_warnings.append('files copied to {0}'.format(link))
             shutil.copytree(os.path.join(link, '..', target), link)


### PR DESCRIPTION
Fixes `OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect` error on docs build.

It happens because symlinks are created with forward slashes, while Windows supports only backward slashes.