### PR TITLE
[MRG+1] Adding names to the color in the new Vega10 color cycle

### DIFF
--- a/doc/users/colors.rst
+++ b/doc/users/colors.rst
@@ -17,9 +17,9 @@ it can be provided as:
 * a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__
   prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``)
 * one of ``{'C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9'}``
-* one of ``{'vega10:blue', 'vega10:orange', 'vega10:green', 'vega10:red',
-            'vega10:purple', 'vega10:brown', 'vega10:pink', 'vega10:gray',
-            'vega10:olive', 'vega10:cyan'}``
+* one of ``{'vega10:blue', 'vega10:orange', 'vega10:green',
+  'vega10:red', 'vega10:purple', 'vega10:brown', 'vega10:pink',
+  'vega10:gray', 'vega10:olive', 'vega10:cyan'}``
 
 All string specifications of color are case-insensitive.
 

--- a/doc/users/colors.rst
+++ b/doc/users/colors.rst
@@ -17,7 +17,7 @@ it can be provided as:
 * a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__
   prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``)
 * one of ``{'C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9'}``
-* one of ``{'blue', 'orange', 'green', 'red', 'purple', 'brown', 'pink', 'gray', 'olive', 'cyan'}``
+* one of ``{'vega10:blue', 'vega10:orange', 'vega10:green', 'vega10:red', 'vega10:purple', 'vega10:brown', 'vega10:pink', 'vega10:gray', 'vega10:olive', 'vega10:cyan'}``
 
 All string specifications of color are case-insensitive.
 

--- a/doc/users/colors.rst
+++ b/doc/users/colors.rst
@@ -17,7 +17,9 @@ it can be provided as:
 * a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__
   prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``)
 * one of ``{'C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9'}``
-* one of ``{'vega10:blue', 'vega10:orange', 'vega10:green', 'vega10:red', 'vega10:purple', 'vega10:brown', 'vega10:pink', 'vega10:gray', 'vega10:olive', 'vega10:cyan'}``
+* one of ``{'vega10:blue', 'vega10:orange', 'vega10:green', 'vega10:red',
+            'vega10:purple', 'vega10:brown', 'vega10:pink', 'vega10:gray',
+            'vega10:olive', 'vega10:cyan'}``
 
 All string specifications of color are case-insensitive.
 

--- a/doc/users/colors.rst
+++ b/doc/users/colors.rst
@@ -17,9 +17,9 @@ it can be provided as:
 * a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__
   prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``)
 * one of ``{'C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9'}``
-* one of ``{'vega10:blue', 'vega10:orange', 'vega10:green',
-  'vega10:red', 'vega10:purple', 'vega10:brown', 'vega10:pink',
-  'vega10:gray', 'vega10:olive', 'vega10:cyan'}``
+* one of ``{'vega:blue', 'vega:orange', 'vega:green',
+  'vega:red', 'vega:purple', 'vega:brown', 'vega:pink',
+  'vega:gray', 'vega:olive', 'vega:cyan'}``
 
 All string specifications of color are case-insensitive.
 

--- a/doc/users/colors.rst
+++ b/doc/users/colors.rst
@@ -17,6 +17,7 @@ it can be provided as:
 * a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__
   prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``)
 * one of ``{'C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9'}``
+* one of ``{'blue', 'orange', 'green', 'red', 'purple', 'brown', 'pink', 'gray', 'olive', 'cyan'}``
 
 All string specifications of color are case-insensitive.
 

--- a/lib/matplotlib/_color_data.py
+++ b/lib/matplotlib/_color_data.py
@@ -15,7 +15,7 @@ BASE_COLORS = {
     'w': (1, 1, 1)}
 
 
-VEGA10_COLORS = {
+VEGA_COLORS = {
     'blue': '#1f77b4',
     'orange': '#ff7f0e',
     'green': '#2ca02c',
@@ -29,8 +29,7 @@ VEGA10_COLORS = {
 
 
 # Normalize name to "vega10:<name>" to avoid name collisions.
-VEGA10_COLORS = {'vega10:' + name: value for name,
-                 value in VEGA10_COLORS.items()}
+VEGA_COLORS = {'vega:' + name: value for name, value in VEGA_COLORS.items()}
 
 
 # This mapping of color names -> hex values is taken from

--- a/lib/matplotlib/_color_data.py
+++ b/lib/matplotlib/_color_data.py
@@ -28,8 +28,8 @@ VEGA10_COLORS = {
     'cyan': '#17becf'}
 
 
-# Normalize name to "vega:<name>" to avoid name collisions.
-VEGA10_COLORS = {'vega:' + name: value for name,
+# Normalize name to "vega10:<name>" to avoid name collisions.
+VEGA10_COLORS = {'vega10:' + name: value for name,
                  value in VEGA10_COLORS.items()}
 
 

--- a/lib/matplotlib/_color_data.py
+++ b/lib/matplotlib/_color_data.py
@@ -29,7 +29,8 @@ VEGA10_COLORS = {
 
 
 # Normalize name to "vega:<name>" to avoid name collisions.
-VEGA10_COLORS = {'vega:' + name: value for name, value in VEGA10_COLORS.items()}
+VEGA10_COLORS = {'vega:' + name: value for name,
+                 value in VEGA10_COLORS.items()}
 
 
 # This mapping of color names -> hex values is taken from

--- a/lib/matplotlib/_color_data.py
+++ b/lib/matplotlib/_color_data.py
@@ -15,6 +15,23 @@ BASE_COLORS = {
     'w': (1, 1, 1)}
 
 
+VEGA10_COLORS = {
+    'blue': '#1f77b4',
+    'orange': '#ff7f0e',
+    'green': '#2ca02c',
+    'red': '#d62728',
+    'purple': '#9467bd',
+    'brown': '#8c564b',
+    'pink': '#e377c2',
+    'gray': '#7f7f7f',
+    'olive': '#bcbd22',
+    'cyan': '#17becf'}
+
+
+# Normalize name to "vega:<name>" to avoid name collisions.
+VEGA10_COLORS = {'vega:' + name: value for name, value in VEGA10_COLORS.items()}
+
+
 # This mapping of color names -> hex values is taken from
 # a survey run by Randel Monroe see:
 # http://blog.xkcd.com/2010/05/03/color-survey-results/

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -65,7 +65,7 @@ import warnings
 
 import numpy as np
 import matplotlib.cbook as cbook
-from ._color_data import BASE_COLORS, VEGA10_COLORS, CSS4_COLORS, XKCD_COLORS
+from ._color_data import BASE_COLORS, VEGA_COLORS, CSS4_COLORS, XKCD_COLORS
 
 
 class _ColorMapping(dict):
@@ -86,7 +86,7 @@ _colors_full_map = {}
 # Set by reverse priority order.
 _colors_full_map.update(XKCD_COLORS)
 _colors_full_map.update(CSS4_COLORS)
-_colors_full_map.update(VEGA10_COLORS)
+_colors_full_map.update(VEGA_COLORS)
 _colors_full_map.update(BASE_COLORS)
 _colors_full_map = _ColorMapping(_colors_full_map)
 
@@ -251,8 +251,7 @@ def to_hex(c, keep_alpha=False):
 ### Backwards-compatible color-conversion API
 
 cnames = CSS4_COLORS
-COLOR_NAMES = {'xkcd': XKCD_COLORS, 'css4': CSS4_COLORS,
-               'vega10': VEGA10_COLORS}
+COLOR_NAMES = {'xkcd': XKCD_COLORS, 'css4': CSS4_COLORS, 'vega': VEGA_COLORS}
 hexColorPattern = re.compile("\A#[a-fA-F0-9]{6}\Z")
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -65,7 +65,7 @@ import warnings
 
 import numpy as np
 import matplotlib.cbook as cbook
-from ._color_data import BASE_COLORS, CSS4_COLORS, XKCD_COLORS
+from ._color_data import BASE_COLORS, VEGA10_COLORS, CSS4_COLORS, XKCD_COLORS
 
 
 class _ColorMapping(dict):
@@ -86,6 +86,7 @@ _colors_full_map = {}
 # Set by reverse priority order.
 _colors_full_map.update(XKCD_COLORS)
 _colors_full_map.update(CSS4_COLORS)
+_colors_full_map.update(VEGA10_COLORS)
 _colors_full_map.update(BASE_COLORS)
 _colors_full_map = _ColorMapping(_colors_full_map)
 
@@ -250,7 +251,7 @@ def to_hex(c, keep_alpha=False):
 ### Backwards-compatible color-conversion API
 
 cnames = CSS4_COLORS
-COLOR_NAMES = {'xkcd': XKCD_COLORS, 'css4': CSS4_COLORS}
+COLOR_NAMES = {'xkcd': XKCD_COLORS, 'css4': CSS4_COLORS, 'vega': VEGA10_COLORS}
 hexColorPattern = re.compile("\A#[a-fA-F0-9]{6}\Z")
 
 
@@ -401,7 +402,7 @@ class Colormap(object):
 
     """
     def __init__(self, name, N=256):
-        r"""
+        """
         Parameters
         ----------
         name : str

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -251,7 +251,8 @@ def to_hex(c, keep_alpha=False):
 ### Backwards-compatible color-conversion API
 
 cnames = CSS4_COLORS
-COLOR_NAMES = {'xkcd': XKCD_COLORS, 'css4': CSS4_COLORS, 'vega': VEGA10_COLORS}
+COLOR_NAMES = {'xkcd': XKCD_COLORS, 'css4': CSS4_COLORS,
+               'vega10': VEGA10_COLORS}
 hexColorPattern = re.compile("\A#[a-fA-F0-9]{6}\Z")
 
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -572,9 +572,10 @@ def test_light_source_planar_hillshading():
             assert_array_almost_equal(h, np.cos(np.radians(angle)))
 
 
-def test_xkcd():
+def test_color_names():
     assert mcolors.to_hex("blue") == "#0000ff"
     assert mcolors.to_hex("xkcd:blue") == "#0343df"
+    assert mcolors.to_hex("vega10:blue") == "#1f77b4"
 
 
 def _sph2cart(theta, phi):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -575,7 +575,7 @@ def test_light_source_planar_hillshading():
 def test_color_names():
     assert mcolors.to_hex("blue") == "#0000ff"
     assert mcolors.to_hex("xkcd:blue") == "#0343df"
-    assert mcolors.to_hex("vega10:blue") == "#1f77b4"
+    assert mcolors.to_hex("vega:blue") == "#1f77b4"
 
 
 def _sph2cart(theta, phi):


### PR DESCRIPTION
Prefer to this ticket: #7248 "Adding names to the color in the new (Vega) default color cycle"
- Implement VEGA10_COLORS dictionary package in _color_data.py, 
- Use name colors, prefix vega10:__ (where __ is blue, orange, green, red, purple, brown, pink, gray, olive, cyan), respectively equivalent to C0, C1,..., C9
- In colors.py, import VEGA10_COLORS, and add this new dictionary into _colors_full_map
