### PR TITLE
BUG: Fix Axes3D.plot_surface with no edgecolor (Fixes #7313)

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -621,7 +621,8 @@ class Poly3DCollection(PolyCollection):
         if len(cedge) != len(xyzlist):
             if len(cedge) == 0:
                 cedge = cface
-            cedge = cedge.repeat(len(xyzlist), axis=0)
+            else:
+                cedge = cedge.repeat(len(xyzlist), axis=0)
 
         # if required sort by depth (furthest drawn first)
         if self._zsort:


### PR DESCRIPTION
Empty edge color array was being improperly repeated after being set to
match the face colors.