### PR TITLE
fix small error in poly_editor example

### DIFF
--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -141,6 +141,8 @@ class PolygonInteractor(object):
         x, y = event.xdata, event.ydata
 
         self.poly.xy[self._ind] = x, y
+        if self._ind == 0:
+            self.poly.xy[-1] = x, y
         self.line.set_data(zip(*self.poly.xy))
 
         self.canvas.restore_region(self.background)

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -143,6 +143,8 @@ class PolygonInteractor(object):
         self.poly.xy[self._ind] = x, y
         if self._ind == 0:
             self.poly.xy[-1] = x, y
+        elif self._ind == len(self.poly.xy) - 1:
+            self.poly.xy[0] = x, y
         self.line.set_data(zip(*self.poly.xy))
 
         self.canvas.restore_region(self.background)


### PR DESCRIPTION
* if vertex 0 is grabbed, the last point of the poly should be updated as well

If you grab the 0 vertex, the last vertex is left behind:

![screen shot 2016-10-26 at 9 40 34 am](https://cloud.githubusercontent.com/assets/9245329/19735794/ddc829d2-9b61-11e6-98ad-b095c7205f66.png)

if you grab it, it looks like like a separate line segment:

![screen shot 2016-10-26 at 9 40 46 am](https://cloud.githubusercontent.com/assets/9245329/19735811/ec3511e2-9b61-11e6-9d07-6f2f2d2211bd.png)

after the fix:

![screen shot 2016-10-26 at 9 39 57 am](https://cloud.githubusercontent.com/assets/9245329/19735826/f92f676c-9b61-11e6-9ba1-0a8038c401ca.png)

