### PR TITLE
[mrg+1] Added notes on how to use matplotlib in pyenv

### DIFF
--- a/doc/faq/osx_framework.rst
+++ b/doc/faq/osx_framework.rst
@@ -44,6 +44,13 @@ instead of `virtualenv <https://virtualenv.pypa.io/en/latest/>`_::
 
 Otherwise you will need one of the workarounds below.
 
+Pyenv
+-----
+
+If you are using pyenv and virtualenv you can enable your python version to be installed as a framework:
+
+    PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install x.x.x
+
 Conda
 -----
 


### PR DESCRIPTION
When you install a python environment using pyenv, you can set `PYTHON_CONFIGURE_OPTS` to use `--enable-framework`.
