### PR TITLE
[MRG+1] Added `-j` shortcut for `--processes=`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
     - PANDAS=
     - NPROC=2
     - TEST_ARGS=--no-pep8
-    - NOSE_ARGS="--processes=$NPROC --process-timeout=300"
+    - NOSE_ARGS="-j $NPROC"
     - PYTEST_ARGS="-ra --timeout=300 --durations=25 --cov-report= --cov=lib" # -n $NPROC
     - PYTHON_ARGS=
     - DELETE_FONT_CACHE=

--- a/tests.py
+++ b/tests.py
@@ -28,6 +28,14 @@ if __name__ == '__main__':
         disable_internet.turn_off_internet()
         extra_args.extend(['-a', '!network'])
         sys.argv.remove('--no-network')
+    if '-j' in sys.argv:
+        nproc = sys.argv[sys.argv.index('-j') + 1]
+        extra_args.extend([
+            '--processes={}'.format(int(nproc)),
+            '--process-timeout=300'
+        ])
+        sys.argv.remove('-j')
+        sys.argv.remove(nproc)
 
     print('Python byte-compilation optimization level: %d' % sys.flags.optimize)
 

--- a/tests.py
+++ b/tests.py
@@ -16,8 +16,6 @@ import argparse
 if __name__ == '__main__':
     from matplotlib import default_test_modules, test
 
-    extra_args = []
-
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--no-pep8', action='store_true',
                         help='Run all tests except PEP8 testing')
@@ -27,7 +25,7 @@ if __name__ == '__main__':
                         help='Run tests without network connection')
     parser.add_argument('-j', type=int,
                         help='Shortcut for specifying number of test processes')
-    args = parser.parse_args()
+    args, extra_args = parser.parse_known_args()
 
     if args.no_pep8:
         default_test_modules.remove('matplotlib.tests.test_coding_standards')

--- a/tests.py
+++ b/tests.py
@@ -10,6 +10,7 @@
 # these options.
 
 import sys
+import argparse
 
 
 if __name__ == '__main__':
@@ -17,25 +18,31 @@ if __name__ == '__main__':
 
     extra_args = []
 
-    if '--no-pep8' in sys.argv:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--no-pep8', action="store_true")
+    parser.add_argument('--pep8', action="store_true")
+    parser.add_argument('--no-network', action="store_true")
+    parser.add_argument('-j', type=int)
+    args = parser.parse_args()
+
+    if args.no_pep8:
         default_test_modules.remove('matplotlib.tests.test_coding_standards')
         sys.argv.remove('--no-pep8')
-    elif '--pep8' in sys.argv:
+    elif args.pep8:
         default_test_modules[:] = ['matplotlib.tests.test_coding_standards']
         sys.argv.remove('--pep8')
-    if '--no-network' in sys.argv:
+    if args.no_network:
         from matplotlib.testing import disable_internet
         disable_internet.turn_off_internet()
         extra_args.extend(['-a', '!network'])
         sys.argv.remove('--no-network')
-    if '-j' in sys.argv:
-        nproc = sys.argv[sys.argv.index('-j') + 1]
+    if args.j:
         extra_args.extend([
-            '--processes={}'.format(int(nproc)),
+            '--processes={}'.format(args.j),
             '--process-timeout=300'
         ])
+        sys.argv.pop(sys.argv.index('-j') + 1)
         sys.argv.remove('-j')
-        sys.argv.remove(nproc)
 
     print('Python byte-compilation optimization level: %d' % sys.flags.optimize)
 

--- a/tests.py
+++ b/tests.py
@@ -19,10 +19,14 @@ if __name__ == '__main__':
     extra_args = []
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--no-pep8', action="store_true")
-    parser.add_argument('--pep8', action="store_true")
-    parser.add_argument('--no-network', action="store_true")
-    parser.add_argument('-j', type=int)
+    parser.add_argument('--no-pep8', action='store_true',
+                        help='Run all tests except PEP8 testing')
+    parser.add_argument('--pep8', action='store_true',
+                        help='Run only PEP8 testing')
+    parser.add_argument('--no-network', action='store_true',
+                        help='Run tests without network connection')
+    parser.add_argument('-j', type=int,
+                        help='Shortcut for specifying number of test processes')
     args = parser.parse_args()
 
     if args.no_pep8:

--- a/tests.py
+++ b/tests.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 
     extra_args = []
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--no-pep8', action='store_true',
                         help='Run all tests except PEP8 testing')
     parser.add_argument('--pep8', action='store_true',


### PR DESCRIPTION
Addresses #7361.

The argv parsing is a bit naive, but I'm not sure what matplotlib's opinion on `getopt` or `argparse` is.
