### PR TITLE
Add appropriate error on color size mismatch in `scatter`

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3952,6 +3952,7 @@ or tuple of floats
 
         # np.ma.ravel yields an ndarray, not a masked array,
         # unless its argument is a masked array.
+        xy_shape = (np.shape(x), np.shape(y))
         x = np.ma.ravel(x)
         y = np.ma.ravel(y)
         if x.size != y.size:
@@ -3974,18 +3975,22 @@ or tuple of floats
         else:
             try:
                 c_array = np.asanyarray(c, dtype=float)
+                if c_array.shape in xy_shape:
+                    c = np.ma.ravel(c_array)
+                else:
+                    # Wrong size; it must not be intended for mapping.
+                    c_array = None
             except ValueError:
                 # Failed to make a floating-point array; c must be color specs.
                 c_array = None
-            else:
-                if c_array.size == x.size:
-                    c = np.ma.ravel(c_array)
-                elif c_array.size not in (3, 4):
-                    # Wrong size. Not a rgb/rgba and not same size as x
-                    raise ValueError("x and c must be the same size")
 
         if c_array is None:
             colors = c     # must be acceptable as PathCollection facecolors
+            try:
+                mcolors.to_rgba_array(colors)
+            except ValueError:
+                # c not acceptable as PathCollection facecolor
+                raise ValueError("c not acceptable as color sequence")
         else:
             colors = None  # use cmap, norm after collection is created
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3974,14 +3974,15 @@ or tuple of floats
         else:
             try:
                 c_array = np.asanyarray(c, dtype=float)
-                if c_array.size == x.size:
-                    c = np.ma.ravel(c_array)
-                else:
-                    # Wrong size; it must not be intended for mapping.
-                    c_array = None
             except ValueError:
                 # Failed to make a floating-point array; c must be color specs.
                 c_array = None
+            else:
+                if c_array.size == x.size:
+                    c = np.ma.ravel(c_array)
+                elif c_array.size not in (3, 4):
+                    # Wrong size. Not a rgb/rgba and not same size as x
+                    raise ValueError("x and c must be the same size")
 
         if c_array is None:
             colors = c     # must be acceptable as PathCollection facecolors

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3990,7 +3990,9 @@ or tuple of floats
                 mcolors.to_rgba_array(colors)
             except ValueError:
                 # c not acceptable as PathCollection facecolor
-                raise ValueError("c not acceptable as color sequence")
+                msg = ("c of shape {0} not acceptable as a color sequence "
+                       "for x with shape {1}, y with shape {2}")
+                raise ValueError(msg.format(c.shape, x.shape, y.shape))
         else:
             colors = None  # use cmap, norm after collection is created
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3985,14 +3985,14 @@ or tuple of floats
                 c_array = None
 
         if c_array is None:
-            colors = c     # must be acceptable as PathCollection facecolors
             try:
-                mcolors.to_rgba_array(colors)
+                # must be acceptable as PathCollection facecolors
+                colors = mcolors.to_rgba_array(c)
             except ValueError:
                 # c not acceptable as PathCollection facecolor
                 msg = ("c of shape {0} not acceptable as a color sequence "
-                       "for x with shape {1}, y with shape {2}")
-                raise ValueError(msg.format(c.shape, x.shape, y.shape))
+                       "for x with size {1}, y with size {2}")
+                raise ValueError(msg.format(c.shape, x.size, y.size))
         else:
             colors = None  # use cmap, norm after collection is created
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4800,15 +4800,10 @@ def test_fillbetween_cycle():
 
 
 @cleanup
-def test_log_margins():
-    plt.rcParams['axes.autolimit_mode'] = 'data'
+def test_color_length_mismatch():
+    N = 500
+    x, y = np.random.rand(N), np.random.rand(N)
+    colors = np.random.rand(N+1)
     fig, ax = plt.subplots()
-    margin = 0.05
-    ax.set_xmargin(margin)
-    ax.semilogx([1, 10], [1, 10])
-    xlim0, xlim1 = ax.get_xlim()
-    transform = ax.xaxis.get_transform()
-    xlim0t, xlim1t = transform.transform([xlim0, xlim1])
-    x0t, x1t = transform.transform([1, 10])
-    delta = (x1t - x0t) * margin
-    assert_allclose([xlim0t + delta, xlim1t - delta], [x0t, x1t])
+    with pytest.raises(ValueError):
+        ax.scatter(x, y, c=colors)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4801,9 +4801,12 @@ def test_fillbetween_cycle():
 
 @cleanup
 def test_color_length_mismatch():
-    N = 500
-    x, y = np.random.rand(N), np.random.rand(N)
-    colors = np.random.rand(N+1)
+    N = 5
+    x, y = np.arange(N), np.arange(N)
+    colors = np.arange(N+1)
     fig, ax = plt.subplots()
     with pytest.raises(ValueError):
         ax.scatter(x, y, c=colors)
+    c_rgb = (0.5, 0.5, 0.5)
+    ax.scatter(x, y, c=c_rgb)
+    ax.scatter(x, y, c=[c_rgb] * N)


### PR DESCRIPTION
Addresses #7314.

I imagine that the call to `ravel` is a necessary evil, but if not, it might be more prudent to compare `shape` of `x` and `c_array`
