### PR TITLE
[MRG+1] STY: in ScalarFormatter, use offset to save at least 4 digits, not 2

### DIFF
--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -1065,6 +1065,17 @@ Z-order
 
 
 
+``ScalarFormatter`` tick label formatting with offsets
+======================================================
+
+With the default of ``rcParams['axes.formatter.useoffset'] = True``,
+an offset will be used when it will save 4 or more digits.  This can
+be controlled with the new rcParam, ``axes.formatter.offset_threshold``.
+To restore the previous behavior of using an offset to save 2 or more
+digits, use ``rcParams['axes.formatter.offset_threshold'] = 2``.
+
+
+
 ``AutoDateFormatter`` format strings
 ====================================
 

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -82,13 +82,16 @@ New rcparams added
 |`ytick.minor.right`,             |                                                  |
 |`ytick.major.right`              |                                                  |
 +---------------------------------+--------------------------------------------------+
-|`hist.bins`                      | the default number of bins to use in             |
+|`hist.bins`                      | The default number of bins to use in             |
 |                                 | `~matplotlib.axes.Axes.hist`.  This can be an    |
 |                                 | `int`, a list of floats, or ``'auto'`` if numpy  |
 |                                 | >= 1.11 is installed.                            |
 +---------------------------------+--------------------------------------------------+
-|`lines.scale_dashes`             | If the line dash patterns should scale with      |
-|                                 | linewidth                                        |
+|`lines.scale_dashes`             | Whether the line dash patterns should scale with |
+|                                 | linewidth.                                       |
++---------------------------------+--------------------------------------------------+
+|`axes.formatter.offset_threshold`| Minimum number of digits saved in tick labels    |
+|                                 | that triggers using an offset.                   |
 +---------------------------------+--------------------------------------------------+
 
 

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -204,6 +204,10 @@ axes.formatter.useoffset      : True    # If True, the tick label formatter
                                         # to an offset when the data range is very
                                         # small compared to the minimum absolute
                                         # value of the data.
+axes.formatter.offset_threshold : 2      # When useoffset is True, the offset
+                                         # will be used when it can remove
+                                         # at least this number of significant
+                                         # digits from tick labels.
 
 axes.unicode_minus  : True    # use unicode for the minus symbol
                               # rather than hyphen.  See

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1085,6 +1085,7 @@ defaultParams = {
                                # Use the current locale to format ticks
     'axes.formatter.use_mathtext': [False, validate_bool],
     'axes.formatter.useoffset': [True, validate_bool],
+    'axes.formatter.offset_threshold': [4, validate_int],
     'axes.unicode_minus': [True, validate_bool],
     'axes.color_cycle': [
         ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728',

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -169,7 +169,7 @@ def test_SymmetricalLogLocator_set_params():
     nose.tools.assert_equal(sym.numticks, 8)
 
 
-@cleanup
+@cleanup(style='classic')
 def test_ScalarFormatter_offset_value():
     fig, ax = plt.subplots()
     formatter = ax.get_xaxis().get_major_formatter()

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -689,9 +689,9 @@ class ScalarFormatter(Formatter):
             # are no more than 1 apart at that precision?
             oom = 1 + next(oom for oom in itertools.count(oom_max, -1)
                            if abs_max // 10 ** oom - abs_min // 10 ** oom > 1)
-        # Only use offset if it saves at least two significant digits.
+        # Only use offset if it saves at least 4 significant digits.
         self.offset = (sign * (abs_max // 10 ** oom) * 10 ** oom
-                       if abs_max // 10 ** oom >= 10
+                       if abs_max // 10 ** oom >= 10**3  # 10**(4-1)
                        else 0)
 
     def _set_orderOfMagnitude(self, range):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -505,6 +505,7 @@ class ScalarFormatter(Formatter):
 
         if useOffset is None:
             useOffset = rcParams['axes.formatter.useoffset']
+        self._offset_threshold = rcParams['axes.formatter.offset_threshold']
         self.set_useOffset(useOffset)
         self._usetex = rcParams['text.usetex']
         if useMathText is None:
@@ -689,9 +690,10 @@ class ScalarFormatter(Formatter):
             # are no more than 1 apart at that precision?
             oom = 1 + next(oom for oom in itertools.count(oom_max, -1)
                            if abs_max // 10 ** oom - abs_min // 10 ** oom > 1)
-        # Only use offset if it saves at least 4 significant digits.
+        # Only use offset if it saves at least _offset_threshold digits.
+        n = self._offset_threshold - 1
         self.offset = (sign * (abs_max // 10 ** oom) * 10 ** oom
-                       if abs_max // 10 ** oom >= 10**3  # 10**(4-1)
+                       if abs_max // 10 ** oom >= 10**n
                        else 0)
 
     def _set_orderOfMagnitude(self, range):

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -317,10 +317,13 @@ backend      : $TEMPLATE_BACKEND
                                      # notation.
 #axes.formatter.useoffset      : True    # If True, the tick label formatter
                                          # will default to labeling ticks relative
-                                         # to an offset when the data range is very
+                                         # to an offset when the data range is
                                          # small compared to the minimum absolute
                                          # value of the data.
-
+#axes.formatter.offset_threshold : 4     # When useoffset is True, the offset
+                                         # will be used when it can remove
+                                         # at least this number of significant
+                                         # digits from tick labels.
 
 #axes.unicode_minus  : True    # use unicode for the minus symbol
                                # rather than hyphen.  See


### PR DESCRIPTION
Closes #7104.
