### PR TITLE
[MRG] MAINT Matplotlib -> matplotlib

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
 To help us understand and resolve your issue please check that you have provided
 the information below.
 
-- [ ] Matplotlib version, Python version and Platform (Windows, OSX, Linux ...)
-- [ ] How did you install Matplotlib and Python (pip, anaconda, from source ...)
+- [ ] matplotlib version, Python version and Platform (Windows, OSX, Linux ...)
+- [ ] How did you install matplotlib and Python (pip, anaconda, from source ...)
 - [ ] If possible please supply a [Short, Self Contained, Correct, Example](http://sscce.org/)
       that demonstrates the issue i.e a small piece of code which reproduces the issue
       and can be run with out any other (or as few as possible) external dependencies.
 - [ ] If this is an image generation bug attach a screenshot demonstrating the issue.
-- [ ] If this is a regression (Used to work in an earlier version of Matplotlib), please 
+- [ ] If this is a regression (Used to work in an earlier version of matplotlib), please 
       note where it used to work.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -244,7 +244,7 @@
            lie (TrapezoidMapTriFinder) to matplotlib.tri module. - IMT
 
 2012-12-05 Added MatplotlibDeprecationWarning class for signaling deprecation.
-           Matplotlib developers can use this class as follows:
+           matplotlib developers can use this class as follows:
 
            from matplotlib import MatplotlibDeprecationWarning as mplDeprecation
 
@@ -3635,7 +3635,7 @@
            (Thanks Paul McGuire) and minor fixes to scipy numerix and
            setuptools
 
-2005-12-12 Matplotlib data is now installed as package_data in
+2005-12-12 matplotlib data is now installed as package_data in
            the matplotlib module.  This gets rid of checking the
            many possibilities in matplotlib._get_data_path() - CM
 

--- a/INSTALL
+++ b/INSTALL
@@ -74,9 +74,9 @@ or
 `32 bit <http://www.microsoft.com/en-us/download/details.aspx?id=5555>`__
 for Python 3.4) redistributable packages need to be installed.
 
-Matplotlib depends on `Pillow <https://pypi.python.org/pypi/Pillow>`_
+matplotlib depends on `Pillow <https://pypi.python.org/pypi/Pillow>`_
 for reading and saving JPEG, BMP, and TIFF image files.
-Matplotlib requires `MiKTeX <http://miktex.org/>`_ and
+matplotlib requires `MiKTeX <http://miktex.org/>`_ and
 `GhostScript <http://www.ghostscript.com/download/>`_ for rendering text
 with LaTeX.
 `FFmpeg <https://www.ffmpeg.org/>`_, `avconv <https://libav.org/>`_,

--- a/doc/_templates/citing.html
+++ b/doc/_templates/citing.html
@@ -11,7 +11,7 @@ BibTeX entry:
 <pre>
 @Article{Hunter:2007,
   Author    = {Hunter, J. D.},
-  Title     = {matplotlib: A 2D graphics environment},
+  Title     = {Matplotlib: A 2D graphics environment},
   Journal   = {Computing In Science \& Engineering},
   Volume    = {9},
   Number    = {3},

--- a/doc/_templates/citing.html
+++ b/doc/_templates/citing.html
@@ -11,12 +11,12 @@ BibTeX entry:
 <pre>
 @Article{Hunter:2007,
   Author    = {Hunter, J. D.},
-  Title     = {Matplotlib: A 2D graphics environment},
+  Title     = {matplotlib: A 2D graphics environment},
   Journal   = {Computing In Science \& Engineering},
   Volume    = {9},
   Number    = {3},
   Pages     = {90--95},
-  abstract  = {Matplotlib is a 2D graphics package used for Python
+  abstract  = {matplotlib is a 2D graphics package used for Python
   for application development, interactive scripting, and
   publication-quality image generation across user
   interfaces and operating systems.},

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -170,7 +170,7 @@ changes</a> file.</p>
 
 <h1>Toolkits</h1>
 
-<p>Matplotlib ships with several add-on <a href="{{ pathto('mpl_toolkits/index') }}">toolkits</a>,
+<p>matplotlib ships with several add-on <a href="{{ pathto('mpl_toolkits/index') }}">toolkits</a>,
     Including 3d plotting with <a href="{{ pathto('mpl_toolkits/mplot3d/index') }}">mplot3d</a>,
     axes helpers in <a href="{{ pathto('mpl_toolkits/axes_grid1/index') }}">axes_grid1</a> and
     axis helpers in <a href="{{ pathto('mpl_toolkits/axisartist/index') }}">axisartist</a>.
@@ -179,7 +179,7 @@ changes</a> file.</p>
 <h1>Third party packages</h1>
 
 <p>A large number of <a href="{{ pathto('thirdpartypackages/index') }}">third party packages</a>
-    extend and build on Matplotlib functionality, including several higher-level plotting interfaces
+    extend and build on matplotlib functionality, including several higher-level plotting interfaces
     <a href="https://seaborn.github.io/">seaborn</a>,
     <a href="http://holoviews.org">holoviews</a>,
     <a href="http://ggplot.yhathq.com">ggplot</a>, and
@@ -221,7 +221,7 @@ who have made significant <a href="{{ pathto('users/credits') }}">contributions<
 </p>
 
 <p>
-Matplotlib is hosted on <a href="https://github.com/matplotlib/matplotlib">Github</a>.
+matplotlib is hosted on <a href="https://github.com/matplotlib/matplotlib">Github</a>.
 <a href="https://github.com/matplotlib/matplotlib/issues">Issues</a> and
 <a href="https://github.com/matplotlib/matplotlib/pulls">Pull requests</a>
 are tracked at Github too.

--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -130,7 +130,7 @@ to the axis length relative to the ticklabel font size.
 New defaults for 3D quiver function in mpl_toolkits.mplot3d.axes3d.py
 ---------------------------------------------------------------------
 
-Matplotlib has both a 2D and a 3D ``quiver`` function. These changes
+matplotlib has both a 2D and a 3D ``quiver`` function. These changes
 affect only the 3D function and make the default behavior of the 3D
 function match the 2D version. There are two changes:
 
@@ -2076,7 +2076,7 @@ Changes for 0.86
 
 ::
 
-     Matplotlib data is installed into the matplotlib module.
+     matplotlib data is installed into the matplotlib module.
      This is similar to package_data.  This should get rid of
      having to check for many possibilities in _get_data_path().
      The MATPLOTLIBDATA env key is still checked first to allow

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -1,7 +1,7 @@
 .. _api-index:
 
 ####################
-  The Matplotlib API
+  The matplotlib API
 ####################
 
 .. htmlonly::

--- a/doc/devel/MEP/MEP12.rst
+++ b/doc/devel/MEP/MEP12.rst
@@ -176,7 +176,7 @@ Additional suggestions
 Backward compatibility
 ======================
 
-The website for each Matplotlib version is readily accessible, so
+The website for each matplotlib version is readily accessible, so
 users who want to refer to old examples can still do so.
 
 
@@ -196,6 +196,6 @@ navigate the gallery. Thus, tags are complementary to this reorganization.
 
 .. [1] http://github.com/matplotlib/matplotlib/pull/714
 .. [2] http://github.com/matplotlib/matplotlib/issues/524
-.. [3] http://matplotlib.1069221.n5.nabble.com/Matplotlib-gallery-td762.html#a33379091
+.. [3] http://matplotlib.1069221.n5.nabble.com/matplotlib-gallery-td762.html#a33379091
 .. [4] http://www.loria.fr/~rougier/teaching/matplotlib/
 .. [5] http://www.loria.fr/~rougier/coding/gallery/

--- a/doc/devel/MEP/MEP25.rst
+++ b/doc/devel/MEP/MEP25.rst
@@ -31,7 +31,7 @@ interpretations.
 Detailed description
 --------------------
 
-Matplotlib is a core plotting engine with an API that many users
+matplotlib is a core plotting engine with an API that many users
 already understand. It's difficult/impossible for other graphing
 libraries to (1) get a complete figure description, (2) output raw
 data from the figure object as the user has provided it, (3)

--- a/doc/devel/MEP/MEP26.rst
+++ b/doc/devel/MEP/MEP26.rst
@@ -220,7 +220,7 @@ MEP25, which may assist in this development
 Appendix
 ========
 
-Matplotlib primitives
+matplotlib primitives
 ---------------------
 
 This will form the initial selectors which stylesheets can use.

--- a/doc/devel/MEP/MEP28.rst
+++ b/doc/devel/MEP/MEP28.rst
@@ -60,7 +60,7 @@ needs to be drawn. At the moment, that logic contains 9 separate if/else
 statements nested up to 5 levels deep with a for loop, and may raise up to 2 errors.
 These parameters were added prior to the creation of the ``Axes.bxp`` method,
 which draws boxplots from a list of dictionaries containing the relevant
-statistics. Matplotlib also provides a function that computes these
+statistics. matplotlib also provides a function that computes these
 statistics via ``cbook.boxplot_stats``. Note that advanced users can now
 either a) write their own function to compute the stats required by
 ``Axes.bxp``, or b) modify the output returned by ``cbook.boxplots_stats``

--- a/doc/devel/MEP/index.rst
+++ b/doc/devel/MEP/index.rst
@@ -1,7 +1,7 @@
 .. _MEP-index:
 
 ################################
-Matplotlib Enhancement Proposals
+matplotlib Enhancement Proposals
 ################################
 
 .. htmlonly::

--- a/doc/devel/add_new_projection.rst
+++ b/doc/devel/add_new_projection.rst
@@ -6,7 +6,7 @@ Developer's guide for creating scales and transformations
 
 .. ::author Michael Droettboom
 
-Matplotlib supports the addition of custom procedures that transform
+matplotlib supports the addition of custom procedures that transform
 the data before it is displayed.
 
 There is an important distinction between two kinds of

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -286,7 +286,7 @@ C/C++ extensions
 Keyword argument processing
 ---------------------------
 
-Matplotlib makes extensive use of ``**kwargs`` for pass-through
+matplotlib makes extensive use of ``**kwargs`` for pass-through
 customizations from one function to another.  A typical example is in
 :func:`matplotlib.pyplot.text`.  The definition of the pylab text
 function is a simple pass-through to

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -36,7 +36,7 @@ The actual ReStructured Text files are kept in :file:`doc/users`,
 :file:`doc/index.rst`, which pulls in the :file:`index.rst` file for the users
 guide, developers guide, api reference, and faqs. The documentation suite is
 built as a single document in order to make the most effective use of cross
-referencing, we want to make navigating the Matplotlib documentation as easy as
+referencing, we want to make navigating the matplotlib documentation as easy as
 possible.
 
 Additional files can be added to the various guides by including their base
@@ -55,7 +55,7 @@ For the most part, these are standard Python docstrings, but
 matplotlib also includes some features to better support documenting
 getters and setters.
 
-Matplotlib uses artist introspection of docstrings to support
+matplotlib uses artist introspection of docstrings to support
 properties.  All properties that you want to support through ``setp``
 and ``getp`` should have a ``set_property`` and ``get_property``
 method in the :class:`~matplotlib.artist.Artist` class.  Yes, this is
@@ -76,7 +76,7 @@ Since matplotlib uses a lot of pass-through ``kwargs``, e.g., in every
 function that creates a line (:func:`~matplotlib.pyplot.plot`,
 :func:`~matplotlib.pyplot.semilogx`,
 :func:`~matplotlib.pyplot.semilogy`, etc...), it can be difficult for
-the new user to know which ``kwargs`` are supported.  Matplotlib uses
+the new user to know which ``kwargs`` are supported.  matplotlib uses
 a docstring interpolation scheme to support documentation of every
 function that takes a ``**kwargs``.  The requirements are:
 
@@ -135,7 +135,7 @@ The Sphinx website contains plenty of documentation_ concerning ReST markup and
 working with Sphinx in general. Here are a few additional things to keep in mind:
 
 * Please familiarize yourself with the Sphinx directives for `inline
-  markup`_. Matplotlib's documentation makes heavy use of cross-referencing and
+  markup`_. matplotlib's documentation makes heavy use of cross-referencing and
   other semantic markup. For example, when referring to external files, use the
   ``:file:`` directive.
 

--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -1,7 +1,7 @@
 .. _developers-guide-index:
 
 ################################
-The Matplotlib Developers' Guide
+The matplotlib Developers' Guide
 ################################
 
 .. htmlonly::

--- a/doc/devel/license.rst
+++ b/doc/devel/license.rst
@@ -3,7 +3,7 @@
 Licenses
 ========
 
-Matplotlib only uses BSD compatible code.  If you bring in code from
+matplotlib only uses BSD compatible code.  If you bring in code from
 another project make sure it has a PSF, BSD, MIT or compatible license
 (see the Open Source Initiative `licenses page
 <http://www.opensource.org/licenses>`_ for details on individual

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -152,7 +152,7 @@ Then copy the build products into your local checkout of the
 `~/matplotlib.github.com`::
 
   cp -r build/html/* ~/matplotlib.github.com
-  cp build/latex/matplotlib.pdf ~/matplotlib.github.com
+  cp build/latex/Matplotlib.pdf ~/matplotlib.github.com
 
 Then, from the `matplotlib.github.com` directory, commit and push the
 changes upstream::

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -152,7 +152,7 @@ Then copy the build products into your local checkout of the
 `~/matplotlib.github.com`::
 
   cp -r build/html/* ~/matplotlib.github.com
-  cp build/latex/Matplotlib.pdf ~/matplotlib.github.com
+  cp build/latex/matplotlib.pdf ~/matplotlib.github.com
 
 Then, from the `matplotlib.github.com` directory, commit and push the
 changes upstream::

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -4,7 +4,7 @@
 Developer's tips for testing
 ============================
 
-Matplotlib has a testing infrastructure based on nose_, making it easy
+matplotlib has a testing infrastructure based on nose_, making it easy
 to write new tests. The tests are in :mod:`matplotlib.tests`, and
 customizations to the nose testing infrastructure are in
 :mod:`matplotlib.testing`. (There is other old testing cruft around,
@@ -109,7 +109,7 @@ matplotlib library function :func:`matplotlib.test`::
 Writing a simple test
 ---------------------
 
-Many elements of Matplotlib can be tested using standard tests. For
+Many elements of matplotlib can be tested using standard tests. For
 example, here is a test from :mod:`matplotlib.tests.test_basic`::
 
   from nose.tools import assert_equal

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -723,7 +723,7 @@ Cite matplotlib
 ===============
 
 If you want to refer to matplotlib in a publication, you can use
-"matplotlib: A 2D Graphics Environment" by J. D. Hunter In Computing
+"Matplotlib: A 2D Graphics Environment" by J. D. Hunter In Computing
 in Science & Engineering, Vol. 9, No. 3. (2007), pp. 90-95 (see `this
 reference page <http://dx.doi.org/10.1109/MCSE.2007.55>`_)::
 

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -614,7 +614,7 @@ or look at the open issues on github.
 
 .. _howto-webapp:
 
-Matplotlib in a web application server
+matplotlib in a web application server
 ======================================
 
 Many users report initial problems trying to use maptlotlib in web
@@ -719,11 +719,11 @@ ellipse, :ref:`search` for ``codex ellipse``.
 
 .. _how-to-cite-mpl:
 
-Cite Matplotlib
+Cite matplotlib
 ===============
 
 If you want to refer to matplotlib in a publication, you can use
-"Matplotlib: A 2D Graphics Environment" by J. D. Hunter In Computing
+"matplotlib: A 2D Graphics Environment" by J. D. Hunter In Computing
 in Science & Engineering, Vol. 9, No. 3. (2007), pp. 90-95 (see `this
 reference page <http://dx.doi.org/10.1109/MCSE.2007.55>`_)::
 
@@ -740,11 +740,11 @@ reference page <http://dx.doi.org/10.1109/MCSE.2007.55>`_)::
 	  Pages = {90--95},
 	  Publisher = {IEEE COMPUTER SOC},
 	  Times-Cited = {21},
-	  Title = {Matplotlib: A 2D graphics environment},
+	  Title = {matplotlib: A 2D graphics environment},
 	  Type = {Editorial Material},
 	  Volume = {9},
 	  Year = {2007},
-	  Abstract = {Matplotlib is a 2D graphics package used for Python for application
+	  Abstract = {matplotlib is a 2D graphics package used for Python for application
                       development, interactive scripting, and publication-quality image
                       generation across user interfaces and operating systems.},
 	  Bdsk-Url-1 = {http://gateway.isiknowledge.com/gateway/Gateway.cgi?GWVersion=2&SrcAuth=Alerting&SrcApp=Alerting&DestApp=WOS&DestLinkType=FullRecord;KeyUT=000245668100019}}

--- a/doc/faq/index.rst
+++ b/doc/faq/index.rst
@@ -1,7 +1,7 @@
 .. _faq-index:
 
 ##################
-The Matplotlib FAQ
+The matplotlib FAQ
 ##################
 
 .. htmlonly::

--- a/doc/faq/osx_framework.rst
+++ b/doc/faq/osx_framework.rst
@@ -1,7 +1,7 @@
 .. _osxframework-faq:
 
 ******************************
-Working with Matplotlib on OSX
+Working with matplotlib on OSX
 ******************************
 
 .. contents::
@@ -20,7 +20,7 @@ At the time of writing the ``macosx`` and ``WXAgg`` backends require a
 framework build to function correctly. This can result in issues for
 a python installation not build as a framework and may also happen in 
 virtual envs and when using (Ana)Conda.
-From Matplotlib 1.5 onwards the ``macosx`` backend
+From matplotlib 1.5 onwards the ``macosx`` backend
 checks that a framework build is available and fails if a non framework
 build is found. WX has a similar check build in.
 

--- a/doc/faq/usage_faq.rst
+++ b/doc/faq/usage_faq.rst
@@ -138,10 +138,10 @@ and to covert a `np.matrix` ::
 
 .. _pylab:
 
-Matplotlib, pyplot and pylab: how are they related?
+matplotlib, pyplot and pylab: how are they related?
 ====================================================
 
-Matplotlib is the whole package; :mod:`matplotlib.pyplot`
+matplotlib is the whole package; :mod:`matplotlib.pyplot`
 is a module in matplotlib; and :mod:`pylab` is a module
 that gets installed alongside :mod:`matplotlib`.
 
@@ -461,7 +461,7 @@ WX backends
 At present the release version of `wxPython` (also known as wxPython classic)
 does not support python3. A work in progress redesigned version known as
 wxPython-Phoenix_ does support python3.
-Matplotlib should work with both versions.
+matplotlib should work with both versions.
 
 .. _wxPython-Phoenix: http://wxpython.org/Phoenix/docs/html/main.html
 
@@ -469,7 +469,7 @@ GTK and Cairo
 =============
 
 Both `GTK2` and `GTK3` have implicit dependencies on PyCairo regardless of the
-specific Matplotlib backend used. Unfortunatly the latest release of PyCairo
+specific matplotlib backend used. Unfortunatly the latest release of PyCairo
 for Python3 does not implement the Python wrappers needed for the `GTK3Agg`
 backend. `Cairocffi` can be used as a replacement which implements the correct
 wrapper.

--- a/doc/faq/virtualenv_faq.rst
+++ b/doc/faq/virtualenv_faq.rst
@@ -1,7 +1,7 @@
 .. _virtualenv-faq:
 
 ***********************************************
-Working with Matplotlib in Virtual environments
+Working with matplotlib in Virtual environments
 ***********************************************
 
 .. contents::
@@ -18,20 +18,20 @@ When running :mod:`matplotlib` in a
 a few issues. :mod:`matplotlib` itself has no issue with virtual environments.
 However, the GUI frameworks that :mod:`matplotlib` uses for interactive
 figures have some issues with virtual environments. Everything below assumes
-some familiarity with the Matplotlib backends as found in :ref:`What is a
+some familiarity with the matplotlib backends as found in :ref:`What is a
 backend? <what-is-a-backend>`.
 
 If you only use the ``IPython/Jupyter Notebook``'s ``inline`` and ``notebook``
 backends and non interactive backends you should not have any issues and can
 ignore everything below.
 
-If you are using Matplotlib on OSX you may also want to consider the
+If you are using matplotlib on OSX you may also want to consider the
 :ref:`OSX framework FAQ <osxframework-faq>`.
 
 GUI Frameworks
 ==============
 
-Interactive Matplotlib relies heavily on the interaction with external GUI
+Interactive matplotlib relies heavily on the interaction with external GUI
 frameworks.
 
 Most GUI frameworks are not pip installable. This makes it tricky to install

--- a/doc/mpl_toolkits/axes_grid1/api/index.rst
+++ b/doc/mpl_toolkits/axes_grid1/api/index.rst
@@ -1,7 +1,7 @@
 .. _axes_grid1-api-index:
 
 #######################################
-  The Matplotlib axes_grid1 Toolkit API
+  The matplotlib axes_grid1 Toolkit API
 #######################################
 
 :Release: |version|

--- a/doc/mpl_toolkits/axes_grid1/index.rst
+++ b/doc/mpl_toolkits/axes_grid1/index.rst
@@ -1,7 +1,7 @@
 
 .. _toolkit_axesgrid1-index:
 
-Matplotlib axes_grid1 Toolkit
+matplotlib axes_grid1 Toolkit
 =============================
 
 The matplotlib :class:`mpl_toolkits.axes_grid1` toolkit is a collection of

--- a/doc/mpl_toolkits/axes_grid1/users/index.rst
+++ b/doc/mpl_toolkits/axes_grid1/users/index.rst
@@ -1,7 +1,7 @@
 .. _axes_grid1_users-guide-index:
 
 #################################################
-  The Matplotlib axes_grid1 Toolkit User's Guide
+  The matplotlib axes_grid1 Toolkit User's Guide
 #################################################
 
 :Release: |version|

--- a/doc/mpl_toolkits/axisartist/api/index.rst
+++ b/doc/mpl_toolkits/axisartist/api/index.rst
@@ -1,7 +1,7 @@
 .. _axisartist-api-index:
 
 #######################################
-  The Matplotlib axisartist Toolkit API
+  The matplotlib axisartist Toolkit API
 #######################################
 
 :Release: |version|

--- a/doc/mpl_toolkits/axisartist/index.rst
+++ b/doc/mpl_toolkits/axisartist/index.rst
@@ -1,6 +1,6 @@
 .. _toolkit_axisartist-index:
 
-Matplotlib axisartist Toolkit
+matplotlib axisartist Toolkit
 =============================
 
 .. toctree::

--- a/doc/mpl_toolkits/axisartist/users/index.rst
+++ b/doc/mpl_toolkits/axisartist/users/index.rst
@@ -1,7 +1,7 @@
 .. _axisartist_users-guide-index:
 
 ################################################
-  The Matplotlib axisartist Toolkit User's Guide
+  The matplotlib axisartist Toolkit User's Guide
 ################################################
 
 :Release: |version|

--- a/doc/mpl_toolkits/mplot3d/index.rst
+++ b/doc/mpl_toolkits/mplot3d/index.rst
@@ -5,7 +5,7 @@
 mplot3d
 *******
 
-Matplotlib mplot3d toolkit
+matplotlib mplot3d toolkit
 ==========================
 The mplot3d toolkit adds simple 3D plotting capabilities to matplotlib by
 supplying an axes object that can create a 2D projection of a 3D scene.

--- a/doc/resources/index.rst
+++ b/doc/resources/index.rst
@@ -13,19 +13,19 @@
   <https://www.packtpub.com/big-data-and-business-intelligence/mastering-matplotlib>`_
   by Duncan M. McGreggor
 
-* `Interactive Applications Using Matplotlib
+* `Interactive Applications Using matplotlib
   <https://www.packtpub.com/application-development/interactive-applications-using-matplotlib>`_
   by Benjamin Root
 
-* `Matplotlib for Python Developers
+* `matplotlib for Python Developers
   <http://www.packtpub.com/matplotlib-python-development/book?mid/171109cna1h>`_
   by Sandro Tosi
 
-* `Matplotlib chapter <http://www.aosabook.org/en/matplotlib.html>`_
+* `matplotlib chapter <http://www.aosabook.org/en/matplotlib.html>`_
   by John Hunter and Michael Droettboom in The Architecture of Open Source
   Applications
 
-* `Graphics with Matplotlib
+* `Graphics with matplotlib
   <http://physics.nmt.edu/~raymond/software/python_notes/paper004.html>`_
   by David J. Raymond
 
@@ -37,17 +37,17 @@
  Videos
 =======
 
-* `Getting started with Matplotlib
+* `Getting started with matplotlib
   <http://showmedo.com/videotutorials/video?name=7200090&fromSeriesID=720>`_
   by `unpingco <http://showmedo.com/videotutorials/?author=6237>`_
 
 * `Plotting with matplotlib <http://www.youtube.com/watch?v=P7SVi0YTIuE>`_
   by Mike Müller
 
-* `Introduction to NumPy and Matplotlib
+* `Introduction to NumPy and matplotlib
   <http://www.youtube.com/watch?v=3Fp1zn5ao2M&feature=plcp>`_ by Eric Jones
 
-* `Anatomy of Matplotlib
+* `Anatomy of matplotlib
   <https://conference.scipy.org/scipy2013/tutorial_detail.php?id=103>`_
   by Benjamin Root
   
@@ -59,9 +59,9 @@
  Tutorials
 ==========
 
-* `Matplotlib tutorial <http://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_
+* `matplotlib tutorial <http://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_
   by Nicolas P. Rougier
 
-* `Anatomy of Matplotlib - IPython Notebooks
-  <https://github.com/WeatherGod/AnatomyOfMatplotlib>`_
+* `Anatomy of matplotlib - IPython Notebooks
+  <https://github.com/WeatherGod/AnatomyOfmatplotlib>`_
   by Benjamin Root

--- a/doc/resources/index.rst
+++ b/doc/resources/index.rst
@@ -13,7 +13,7 @@
   <https://www.packtpub.com/big-data-and-business-intelligence/mastering-matplotlib>`_
   by Duncan M. McGreggor
 
-* `Interactive Applications Using matplotlib
+* `Interactive Applications Using Matplotlib
   <https://www.packtpub.com/application-development/interactive-applications-using-matplotlib>`_
   by Benjamin Root
 

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -4,14 +4,14 @@
  Third party packages
 *********************
 
-Several external packages that extend or build on Matplotlib functionality
+Several external packages that extend or build on matplotlib functionality
 exist. Below we list a number of these. Note that they are each
-maintained and distributed separately from Matplotlib, and will need
+maintained and distributed separately from matplotlib, and will need
 to be installed individually.
 
 Please submit an issue or pull request
 on Github if you have created a package that you would like to have included.
-We are also happy to host third party packages within the `Matplotlib Github
+We are also happy to host third party packages within the `matplotlib Github
 Organization <https://github.com/matplotlib>`_.
 
 .. _hl_plotting:
@@ -154,15 +154,15 @@ irregularly spaced data.  This requires a separate installation of the
 
 .. _toolkit_matplotlibvenn:
 
-Matplotlib-Venn
+matplotlib-Venn
 ===============
 
-`Matplotlib-Venn <https://github.com/konstantint/matplotlib-venn>`_ provides a set of functions for plotting 2- and 3-set area-weighted (or unweighted) Venn diagrams.
+`matplotlib-Venn <https://github.com/konstantint/matplotlib-venn>`_ provides a set of functions for plotting 2- and 3-set area-weighted (or unweighted) Venn diagrams.
 
 mplstereonet
 ===============
 
-`mplstereonet <https://github.com/joferkington/mplstereonet>`_ provides stereonets for plotting and analyzing orientation data in Matplotlib.
+`mplstereonet <https://github.com/joferkington/mplstereonet>`_ provides stereonets for plotting and analyzing orientation data in matplotlib.
 
 pyupset
 ===============
@@ -170,4 +170,4 @@ pyupset
 
 Windrose
 ===============
-`Windrose <https://github.com/scls19fr/windrose>`_ is a Python Matplotlib, Numpy library to manage wind data, draw windrose (also known as a polar rose plot), draw probability density function and fit Weibull distribution
+`Windrose <https://github.com/scls19fr/windrose>`_ is a Python matplotlib, Numpy library to manage wind data, draw windrose (also known as a polar rose plot), draw probability density function and fit Weibull distribution

--- a/doc/users/colormapnorms.rst
+++ b/doc/users/colormapnorms.rst
@@ -12,7 +12,7 @@ will map the data in *Z* linearly from -1 to +1, so *Z=0* will
 give a color at the center of the colormap *RdBu_r* (white in this
 case).
 
-Matplotlib does this mapping in two steps, with a normalization from
+matplotlib does this mapping in two steps, with a normalization from
 [0,1] occurring first, and then mapping onto the indices in the
 colormap.  Normalizations are classes defined in the
 :func:`matplotlib.colors` module.  The default, linear normalization is

--- a/doc/users/customizing.rst
+++ b/doc/users/customizing.rst
@@ -108,7 +108,7 @@ the matplotlib package. rcParams can be modified directly, for example::
     mpl.rcParams['lines.linewidth'] = 2
     mpl.rcParams['lines.color'] = 'r'
 
-Matplotlib also provides a couple of convenience functions for modifying rc
+matplotlib also provides a couple of convenience functions for modifying rc
 settings. The :func:`matplotlib.rc` command can be used to modify multiple
 settings in a single group at once, using keyword arguments::
 

--- a/doc/users/event_handling.rst
+++ b/doc/users/event_handling.rst
@@ -240,13 +240,13 @@ Here is the solution::
 
 **Extra credit**: use the animation blit techniques discussed in the
 `animations recipe
-<http://www.scipy.org/Cookbook/Matplotlib/Animations>`_ to make the
+<http://www.scipy.org/Cookbook/matplotlib/Animations>`_ to make the
 animated drawing faster and smoother.
 
 Extra credit solution::
 
     # draggable rectangle with the animation blit techniques; see
-    # http://www.scipy.org/Cookbook/Matplotlib/Animations
+    # http://www.scipy.org/Cookbook/matplotlib/Animations
     import numpy as np
     import matplotlib.pyplot as plt
 

--- a/doc/users/github_stats.rst
+++ b/doc/users/github_stats.rst
@@ -720,17 +720,17 @@ Issues (605):
 * :ghissue:`6970`: quiver problems when angles is an array of values rather than 'uv' or 'xy'
 * :ghissue:`6966`: No Windows wheel available on PyPI for new version of matplotlib (1.5.2)
 * :ghissue:`6721`: Font cache building of matplotlib blocks requests made to HTTPd
-* :ghissue:`6844`: scatter edgecolor is broken in Matplotlib 2.0.0b3
+* :ghissue:`6844`: scatter edgecolor is broken in matplotlib 2.0.0b3
 * :ghissue:`6849`: BUG: endless loop with MaxNLocator integer kwarg and short axis
 * :ghissue:`6935`: matplotlib.dates.DayLocator cannot handle invalid input
-* :ghissue:`6951`: Ring over A in \AA is too high in Matplotlib 1.5.1
+* :ghissue:`6951`: Ring over A in \AA is too high in matplotlib 1.5.1
 * :ghissue:`6960`: axvline is sometimes not shown
-* :ghissue:`6473`: Matplotlib manylinux wheel - ready to ship?
+* :ghissue:`6473`: matplotlib manylinux wheel - ready to ship?
 * :ghissue:`5013`: Add Hershey Fonts a la IDL
 * :ghissue:`6953`: ax.vlines adds unwanted padding, changes ticks
 * :ghissue:`6946`: No Coveralls reports on GitHub
 * :ghissue:`6933`: Misleading error message for matplotlib.pyplot.errorbar()
-* :ghissue:`6945`: Matplotlib 2.0.0b3 wheel can't load libpng in OS X 10.6
+* :ghissue:`6945`: matplotlib 2.0.0b3 wheel can't load libpng in OS X 10.6
 * :ghissue:`3865`: Improvement suggestions for matplotlib.Animation.save('video.mp4')
 * :ghissue:`6932`: Investigate issue with pyparsing 2.1.6
 * :ghissue:`6941`: Interfering with yahoo_finance
@@ -739,7 +739,7 @@ Issues (605):
 * :ghissue:`6510`: 2.0 beta: Boxplot patches zorder differs from lines
 * :ghissue:`6911`: freetype build won't become local
 * :ghissue:`6866`: examples/misc/longshort.py is outdated
-* :ghissue:`6912`: Matplotlib fail to compile matplotlib._png
+* :ghissue:`6912`: matplotlib fail to compile matplotlib._png
 * :ghissue:`1711`: Autoscale to automatically include a tiny margin with ``Axes.errorbar()``
 * :ghissue:`6903`: RuntimeError('Invalid DISPLAY variable') - With docker and django
 * :ghissue:`6888`: Can not maintain zoom level when left key is pressed
@@ -914,7 +914,7 @@ Issues (605):
 * :ghissue:`5219`: Notebook backend: possible to remove javascript/html when figure is closed?
 * :ghissue:`5111`: nbagg backend captures exceptions raised by callbacks
 * :ghissue:`4940`: NBAgg figure management issues
-* :ghissue:`4582`: Matplotlib IPython Widget
+* :ghissue:`4582`: matplotlib IPython Widget
 * :ghissue:`6142`: matplotlib.ticker.LinearLocator view_limits algorithm improvement?
 * :ghissue:`6326`: Unicode invisible after image saved
 * :ghissue:`5980`: Gridlines on top of plot by default in 2.0?
@@ -1008,10 +1008,10 @@ Issues (605):
 * :ghissue:`5331`: Boxplot with zero IQR sets whiskers to max and min and leaves no outliers
 * :ghissue:`5575`: plot_date() ignores timezone
 * :ghissue:`6143`: drawstyle accepts anything as default rather than raising
-* :ghissue:`6151`: Matplotlib 1.5.1 ignores annotation_clip parameter
+* :ghissue:`6151`: matplotlib 1.5.1 ignores annotation_clip parameter
 * :ghissue:`6147`: colormaps issue
 * :ghissue:`5916`: Headless get_window_extent or equivalent
-* :ghissue:`6141`: Matplotlib subplots and datetime x-axis functionality not working as intended?
+* :ghissue:`6141`: matplotlib subplots and datetime x-axis functionality not working as intended?
 * :ghissue:`6138`: No figure shows, no error
 * :ghissue:`6134`: Cannot plot a line of width=1 without antialiased
 * :ghissue:`6120`: v2.x failures on travis
@@ -1031,14 +1031,14 @@ Issues (605):
 * :ghissue:`6063`: Axes.relim() seems not to work when copying Line2D objects
 * :ghissue:`6065`: Proposal to change color -- 'indianred'
 * :ghissue:`6056`: quiver plot in polar projection - how to make the quiver density latitude-dependent ?
-* :ghissue:`6051`: Matplotlib v1.5.1 apparently not compatible with python-dateutil 2.4.2
+* :ghissue:`6051`: matplotlib v1.5.1 apparently not compatible with python-dateutil 2.4.2
 * :ghissue:`5513`: Call get_backend in pylab_setup
 * :ghissue:`5983`: Option to Compress Graphs for pgf-backend
 * :ghissue:`5895`: Polar Projection PDF Issue
 * :ghissue:`5948`: tilted line visible in generated pdf file
 * :ghissue:`5737`: matplotlib 1.5 compatibility with wxPython
 * :ghissue:`5645`: Missing line in a self-sufficient example in navigation_toolbar.rst :: a minor bug in docs
-* :ghissue:`6037`: Matplotlib xtick appends .%f after %H:%M%:%S on chart
+* :ghissue:`6037`: matplotlib xtick appends .%f after %H:%M%:%S on chart
 * :ghissue:`6025`: Exception in Tkinter/to_rgb with new colormaps
 * :ghissue:`6034`: colormap name is broken for ListedColormap?
 * :ghissue:`5982`: Styles need update after default style changes
@@ -1144,7 +1144,7 @@ Issues (605):
 * :ghissue:`5747`: Figure.suptitle does not respect ``size`` argument
 * :ghissue:`5641`: plt.errorbar error with empty list
 * :ghissue:`5476`: annotate doesn't trigger redraw
-* :ghissue:`5572`: Matplotlib 1.5  broken_barh fails on empty data.
+* :ghissue:`5572`: matplotlib 1.5  broken_barh fails on empty data.
 * :ghissue:`5089`: axes.properties calls get_axes internally
 * :ghissue:`5745`: Using internal qhull despite the presence of pyqhull installed in the system
 * :ghissue:`5744`: cycler is required, is missing, yet build succeeds.
@@ -1255,7 +1255,7 @@ Issues (605):
 * :ghissue:`5444`: \overline and subscripts/superscripts in mathtext
 * :ghissue:`4859`: Call ``tight_layout()`` by default
 * :ghissue:`5429`: Segfault in matplotlib.tests.test_image:test_get_window_extent_for_AxisImage on python3.5
-* :ghissue:`5431`: Matplotlib 1.4.3 broken on Windows
+* :ghissue:`5431`: matplotlib 1.4.3 broken on Windows
 * :ghissue:`5409`: Match zdata cursor display scalling with colorbar ?
 * :ghissue:`5128`: ENH: Better default font
 * :ghissue:`5420`: [Mac OS X 10.10.5] Macports install error :unknown locale: UTF-8

--- a/doc/users/image_tutorial.rst
+++ b/doc/users/image_tutorial.rst
@@ -12,7 +12,7 @@ Startup commands
 
 First, let's start IPython.  It is a most excellent enhancement to the
 standard Python prompt, and it ties in especially well with
-Matplotlib.  Start IPython either at a shell, or the IPython Notebook now.
+matplotlib.  Start IPython either at a shell, or the IPython Notebook now.
 
 With IPython started, we now need to connect to a GUI event loop.  This
 tells IPython where (and how) to display plots.  To connect to a GUI
@@ -99,10 +99,10 @@ And here we go...
             [ 0.44705883,  0.44705883,  0.44705883],
             [ 0.44313726,  0.44313726,  0.44313726]]], dtype=float32)
 
-Note the dtype there - float32.  Matplotlib has rescaled the 8 bit
+Note the dtype there - float32.  matplotlib has rescaled the 8 bit
 data from each channel to floating point data between 0.0 and 1.0.  As
 a side note, the only datatype that Pillow can work with is uint8.
-Matplotlib plotting can handle float32 and uint8, but image
+matplotlib plotting can handle float32 and uint8, but image
 reading/writing for any format other than PNG is limited to uint8
 data.  Why 8 bits? Most displays can only render 8 bits per channel
 worth of color gradation.  Why can they only render 8 bits/channel?
@@ -125,7 +125,7 @@ Plotting numpy arrays as images
 ===================================
 
 So, you have your data in a numpy array (either by importing it, or by
-generating it).  Let's render it.  In Matplotlib, this is performed
+generating it).  Let's render it.  In matplotlib, this is performed
 using the :func:`~matplotlib.pyplot.imshow` function.  Here we'll grab
 the plot object.  This object gives you an easy way to manipulate the
 plot from the prompt.

--- a/doc/users/license.rst
+++ b/doc/users/license.rst
@@ -5,7 +5,7 @@ License
 ***********************************************
 
 
-Matplotlib only uses BSD compatible code, and its license is based on
+matplotlib only uses BSD compatible code, and its license is based on
 the `PSF <http://www.python.org/psf/license>`_ license.  See the Open
 Source Initiative `licenses page
 <http://www.opensource.org/licenses>`_ for details on individual
@@ -36,14 +36,14 @@ changes/contributions they have specific copyright on, they should
 indicate their copyright in the commit message of the change, when
 they commit the change to one of the matplotlib repositories.
 
-The Matplotlib Development Team is the set of all contributors to the
+The matplotlib Development Team is the set of all contributors to the
 matplotlib project.  A full list can be obtained from the git version
 control logs.
 
 License agreement for matplotlib |version|
 ==============================================
 
-1. This LICENSE AGREEMENT is between the Matplotlib Development Team
+1. This LICENSE AGREEMENT is between the matplotlib Development Team
 ("MDT"), and the Individual or Organization ("Licensee") accessing and
 otherwise using matplotlib software in source or binary form and its
 associated documentation.
@@ -54,7 +54,7 @@ to reproduce, analyze, test, perform and/or display publicly, prepare
 derivative works, distribute, and otherwise use matplotlib |version|
 alone or in any derivative version, provided, however, that MDT's
 License Agreement and MDT's notice of copyright, i.e., "Copyright (c)
-2012-2013 Matplotlib Development Team; All Rights Reserved" are retained in
+2012-2013 matplotlib Development Team; All Rights Reserved" are retained in
 matplotlib |version| alone or in any derivative version prepared by
 Licensee.
 

--- a/doc/users/patheffects_guide.rst
+++ b/doc/users/patheffects_guide.rst
@@ -7,7 +7,7 @@ Path effects guide
 .. py:module:: matplotlib.patheffects
 
 
-Matplotlib's :mod:`~matplotlib.patheffects` module provides functionality to
+matplotlib's :mod:`~matplotlib.patheffects` module provides functionality to
 apply a multiple draw stage to any Artist which can be rendered via a
 :class:`~matplotlib.path.Path`.
 

--- a/doc/users/pgf.rst
+++ b/doc/users/pgf.rst
@@ -27,7 +27,7 @@ or registering it for handling pdf output
 The second method allows you to keep using regular interactive backends and to
 save xelatex, lualatex or pdflatex compiled PDF files from the graphical user interface.
 
-Matplotlib's pgf support requires a recent LaTeX_ installation that includes
+matplotlib's pgf support requires a recent LaTeX_ installation that includes
 the TikZ/PGF packages (such as TeXLive_), preferably with XeLaTeX or LuaLaTeX
 installed. If either pdftocairo or ghostscript is present on your system,
 figures can optionally be saved to PNG images as well. The executables

--- a/doc/users/prev_whats_new/whats_new_1.2.rst
+++ b/doc/users/prev_whats_new/whats_new_1.2.rst
@@ -14,7 +14,7 @@ New in matplotlib 1.2
 Python 3.x support
 ------------------
 
-Matplotlib 1.2 is the first version to support Python 3.x,
+matplotlib 1.2 is the first version to support Python 3.x,
 specifically Python 3.1 and 3.2.  To make this happen in a reasonable
 way, we also had to drop support for Python versions earlier than 2.6.
 

--- a/doc/users/prev_whats_new/whats_new_1.4.rst
+++ b/doc/users/prev_whats_new/whats_new_1.4.rst
@@ -294,7 +294,7 @@ background. ``nbagg.transparent`` is ``True`` by default.
 
 XDG compliance
 ``````````````
-Matplotlib now looks for configuration files (both rcparams and style) in XDG
+matplotlib now looks for configuration files (both rcparams and style) in XDG
 compliant locations.
 
 ``style`` package added
@@ -416,4 +416,4 @@ rectangle stay on the axes after you release the mouse.
 
 GAE integration
 ---------------
-Matplotlib will now run on google app engine.
+matplotlib will now run on google app engine.

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -690,8 +690,8 @@ Previously, the last two prints returned false.
 New ``close-figs`` argument for plot directive
 ----------------------------------------------
 
-Matplotlib has a sphinx extension ``plot_directive`` that creates plots for
-inclusion in sphinx documents.  Matplotlib 1.5 adds a new option to the plot
+matplotlib has a sphinx extension ``plot_directive`` that creates plots for
+inclusion in sphinx documents.  matplotlib 1.5 adds a new option to the plot
 directive - ``close-figs`` - that closes any previous figure windows before
 creating the plots.  This can help avoid some surprising duplicates of plots
 when using ``plot_directive``.

--- a/doc/users/screenshots.rst
+++ b/doc/users/screenshots.rst
@@ -150,7 +150,7 @@ alpha attribute is used to make semitransparent circle markers.
 Slider demo
 ===========
 
-Matplotlib has basic GUI widgets that are independent of the graphical
+matplotlib has basic GUI widgets that are independent of the graphical
 user interface you are using, allowing you to write cross GUI figures
 and widgets.  See :mod:`matplotlib.widgets` and the
 `widget examples <../examples/widgets/index.html>`_.
@@ -234,7 +234,7 @@ fonts.  See the :mod:`matplotlib.mathtext` module for additional details.
 
 .. plot:: mpl_examples/pylab_examples/mathtext_examples.py
 
-Matplotlib's mathtext infrastructure is an independent implementation and
+matplotlib's mathtext infrastructure is an independent implementation and
 does not require TeX or any external packages installed on your computer. See
 the tutorial at :ref:`mathtext-tutorial`.
 
@@ -245,7 +245,7 @@ Native TeX rendering
 ====================
 
 Although matplotlib's internal math rendering engine is quite
-powerful, sometimes you need TeX. Matplotlib supports external TeX
+powerful, sometimes you need TeX. matplotlib supports external TeX
 rendering of strings with the *usetex* option.
 
 .. plot:: pyplots/tex_demo.py

--- a/doc/users/tight_layout_guide.rst
+++ b/doc/users/tight_layout_guide.rst
@@ -37,7 +37,7 @@ clipped.
 
 To prevent this, the location of axes needs to be adjusted. For
 subplots, this can be done by adjusting the subplot params
-(:ref:`howto-subplots-adjust`). Matplotlib v1.1 introduces a new
+(:ref:`howto-subplots-adjust`). matplotlib v1.1 introduces a new
 command :func:`~matplotlib.pyplot.tight_layout` that does this
 automatically for you.
 
@@ -286,7 +286,7 @@ Colorbar
 
 If you create a colorbar with the :func:`~matplotlib.pyplot.colorbar`
 command, the created colorbar is an instance of Axes, *not* Subplot, so
-tight_layout does not work. With Matplotlib v1.1, you may create a
+tight_layout does not work. With matplotlib v1.1, you may create a
 colorbar as a subplot using the gridspec.
 
 .. plot::

--- a/doc/users/usetex.rst
+++ b/doc/users/usetex.rst
@@ -4,7 +4,7 @@
 Text rendering With LaTeX
 *************************
 
-Matplotlib has the option to use LaTeX to manage all text layout.  This
+matplotlib has the option to use LaTeX to manage all text layout.  This
 option is available with the following backends:
 
 * Agg
@@ -19,7 +19,7 @@ packages (font packages, math packages, etc.)  can be used. The
 results can be striking, especially when you take care to use the same
 fonts in your figures as in the main document.
 
-Matplotlib's LaTeX support requires a working LaTeX_ installation, dvipng_
+matplotlib's LaTeX support requires a working LaTeX_ installation, dvipng_
 (which may be included with your LaTeX installation), and Ghostscript_
 (GPL Ghostscript 8.60 or later is recommended). The executables for these
 external dependencies must all be located on your :envvar:`PATH`.


### PR DESCRIPTION
For consistency, renaming all instances **in the documentation** of Matplotlib into matplotlib.
Somehow, I did not feel comfortable sedding the code…

attn @anntzer 