### PR TITLE
Drop code that supports numpy pre-1.6.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -254,22 +254,11 @@ def calculate_rms(expectedImage, actualImage):
         raise ImageComparisonFailure(
             "image sizes do not match expected size: {0} "
             "actual size {1}".format(expectedImage.shape, actualImage.shape))
-
     num_values = np.prod(expectedImage.shape)
     abs_diff_image = abs(expectedImage - actualImage)
-
-    # On Numpy 1.6, we can use bincount with minlength, which is much
-    # faster than using histogram
-    expected_version = version.LooseVersion("1.6")
-    found_version = version.LooseVersion(np.__version__)
-    if found_version >= expected_version:
-        histogram = np.bincount(abs_diff_image.ravel(), minlength=256)
-    else:
-        histogram = np.histogram(abs_diff_image, bins=np.arange(257))[0]
-
+    histogram = np.bincount(abs_diff_image.ravel(), minlength=256)
     sum_of_squares = np.sum(histogram * np.arange(len(histogram)) ** 2)
     rms = np.sqrt(float(sum_of_squares) / num_values)
-
     return rms
 
 


### PR DESCRIPTION
(all's in the title -- numpy 1.6 is currently the minimum supported version.)