### PR TITLE
[MRG+2] fix ReST tag

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -414,7 +414,7 @@ class Figure(Artist):
 
     def get_tight_layout(self):
         """
-        Return the Boolean flag, True to use :meth`tight_layout` when drawing.
+        Return the Boolean flag, True to use :meth:`tight_layout` when drawing.
         """
         return self._tight
 


### PR DESCRIPTION
(This is rendering incorrectly in the HTML docs at http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure.get_tight_layout because of a missing colon)