### PR TITLE
[MRG+1] Improve barbs() error message

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -392,6 +392,12 @@ def _parse_args(*args):
     return X, Y, U, V, C
 
 
+def _check_consistent_shapes(*arrays):
+    all_shapes = set(a.shape for a in arrays)
+    if len(all_shapes) != 1:
+        raise ValueError('The shapes of the passed in arrays do not match.')
+
+
 class Quiver(mcollections.PolyCollection):
     """
     Specialized PolyCollection for arrows.
@@ -1124,9 +1130,11 @@ class Barbs(mcollections.PolyCollection):
             x, y, u, v, c = delete_masked_points(self.x.ravel(),
                                                  self.y.ravel(),
                                                  self.u, self.v, c)
+            _check_consistent_shapes(x, y, u, v, c)
         else:
             x, y, u, v = delete_masked_points(self.x.ravel(), self.y.ravel(),
                                               self.u, self.v)
+            _check_consistent_shapes(x, y, u, v)
 
         magnitude = np.hypot(u, v)
         flags, barbs, halves, empty = self._find_tails(magnitude,
@@ -1161,6 +1169,7 @@ class Barbs(mcollections.PolyCollection):
         self.y = xy[:, 1]
         x, y, u, v = delete_masked_points(self.x.ravel(), self.y.ravel(),
                                           self.u, self.v)
+        _check_consistent_shapes(x, y, u, v)
         xy = np.hstack((x[:, np.newaxis], y[:, np.newaxis]))
         mcollections.PolyCollection.set_offsets(self, xy)
         self.stale = True

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -1159,9 +1159,9 @@ class Barbs(mcollections.PolyCollection):
 
     def set_offsets(self, xy):
         """
-        Set the offsets for the barb polygons.  This saves the offets passed in
-        and actually sets version masked as appropriate for the existing U/V
-        data. *offsets* should be a sequence.
+        Set the offsets for the barb polygons.  This saves the offsets passed
+        in and actually sets version masked as appropriate for the existing
+        U/V data. *offsets* should be a sequence.
 
         ACCEPTS: sequence of pairs of floats
         """

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import warnings
 import numpy as np
+from nose.tools import raises
 import sys
 from matplotlib import pyplot as plt
 from matplotlib.testing.decorators import cleanup
@@ -131,6 +132,20 @@ def test_barbs():
     ax.barbs(X, Y, U, V, np.sqrt(U*U + V*V), fill_empty=True, rounding=False,
              sizes=dict(emptybarb=0.25, spacing=0.2, height=0.3),
              cmap='viridis')
+
+
+@cleanup
+@raises(ValueError)
+def test_bad_masked_sizes():
+    'Test error handling when given differing sized masked arrays'
+    x = np.arange(3)
+    y = np.arange(3)
+    u = np.ma.array(15. * np.ones((4,)))
+    v = np.ma.array(15. * np.ones_like(u))
+    u[1] = np.ma.masked
+    v[1] = np.ma.masked
+    fig, ax = plt.subplots()
+    ax.barbs(x, y, u, v)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
So for the following code with badly sized (x,y with 3, u,v with 4) arrays:
```python
x = np.arange(3)
y = np.arange(3)
u = np.ma.array(15. * np.ones((4,)), mask=[False, True, False, False])
v = np.ma.array(15. * np.ones_like(u), mask=[False, True, False, False])
plt.barbs(x, y, u, v)
```
The error would end up with something inscrutable (I lost over an hour figuring out what was wrong):
```pytb
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)

<SNIP>

/Users/rmay/repos/matplotlib/lib/matplotlib/quiver.py in __init__(self, ax, *args, **kw)
    942         self.set_transform(transforms.IdentityTransform())
    943 
--> 944         self.set_UVC(u, v, c)
    945 
    946     def _find_tails(self, mag, rounding=True, half=5, full=10, flag=50):

/Users/rmay/repos/matplotlib/lib/matplotlib/quiver.py in set_UVC(self, U, V, C)
   1138         plot_barbs = self._make_barbs(u, v, flags, barbs, halves, empty,
   1139                                       self._length, self._pivot, self.sizes,
-> 1140                                       self.fill_empty, self.flip)
   1141         self.set_verts(plot_barbs)
   1142 

/Users/rmay/repos/matplotlib/lib/matplotlib/quiver.py in _make_barbs(self, u, v, nflags, nbarbs, half_barb, empty_flag, length, pivot, sizes, fill_empty, flip)
   1071 
   1072             # Add vertices for each flag
-> 1073             for i in range(nflags[index]):
   1074                 # The spacing that works for the barbs is a little to much for
   1075                 # the flags, but this only occurs when we have more than 1

TypeError: only integer arrays with one element can be converted to an index
```

It also only happens when masked arrays are involved--otherwise it silently succeeds, which seems poor as well. With this change now the error is easy to identify:
```pytb
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)

<SNIP>

/Users/rmay/repos/matplotlib/lib/matplotlib/quiver.py in __init__(self, ax, *args, **kw)
    948         self.set_transform(transforms.IdentityTransform())
    949 
--> 950         self.set_UVC(u, v, c)
    951 
    952     def _find_tails(self, mag, rounding=True, half=5, full=10, flag=50):

/Users/rmay/repos/matplotlib/lib/matplotlib/quiver.py in set_UVC(self, U, V, C)
   1135             x, y, u, v = delete_masked_points(self.x.ravel(), self.y.ravel(),
   1136                                               self.u, self.v)
-> 1137             check_array_shapes(x, y, u, v)
   1138 
   1139         magnitude = np.hypot(u, v)

/Users/rmay/repos/matplotlib/lib/matplotlib/quiver.py in check_array_shapes(*arrays)
    396     all_shapes = set(a.shape for a in arrays)
    397     if len(all_shapes) != 1:
--> 398         raise ValueError('The shapes of the passed in arrays do not match.')
    399 
    400 

ValueError: The shapes of the passed in arrays do not match.
```