### PR TITLE
[MRG+1] FIX: MPL should not use new tool manager unless explicited asked for.  Closes #7404

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -495,7 +495,7 @@ class FigureManagerGTK3(FigureManagerBase):
 
     def _get_toolmanager(self):
         # must be initialised after toolbar has been setted
-        if rcParams['toolbar'] != 'toolbar2':
+        if rcParams['toolbar'] == 'toolmanager':
             toolmanager = ToolManager(self.canvas.figure)
         else:
             toolmanager = None

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -569,7 +569,7 @@ class FigureManagerTkAgg(FigureManagerBase):
         return toolbar
 
     def _get_toolmanager(self):
-        if rcParams['toolbar'] != 'toolbar2':
+        if rcParams['toolbar'] == 'toolmanager':
             toolmanager = ToolManager(self.canvas.figure)
         else:
             toolmanager = None


### PR DESCRIPTION
~A quick fix to close the bug, but we probably need to come up with a better PR strategy for this.~

@fariza Any other ideas/alternatives to this patch?  IIRC we compromised on this before saying that ``toolbar == None`` should not prevent the tools from working with shortcut keys, just that the toolbar would not get displayed.

Of course the main MEP27 PR fixes this straight away as we decided the new toolmanager should only work with the new figuremanager code, so this got taken care over there yonks ago.