### PR TITLE
[MRG+1] ENH: restore default ability to label some minor log ticks.

### DIFF
--- a/examples/pylab_examples/log_demo.py
+++ b/examples/pylab_examples/log_demo.py
@@ -21,7 +21,7 @@ plt.grid(True)
 plt.subplot(223)
 plt.loglog(t, 20*np.exp(-t/10.0), basex=2)
 plt.grid(True)
-plt.title('loglog base 4 on x')
+plt.title('loglog base 2 on x')
 
 # with errorbars: clip non-positive values
 ax = plt.subplot(224)

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -306,7 +306,7 @@ class LogScale(ScaleBase):
         axis.set_major_locator(LogLocator(self.base))
         axis.set_major_formatter(LogFormatterSciNotation(self.base))
         axis.set_minor_locator(LogLocator(self.base, self.subs))
-        axis.set_minor_formatter(NullFormatter())
+        axis.set_minor_formatter(LogFormatterSciNotation(self.base, self.subs))
 
     def get_transform(self):
         """

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -250,13 +250,16 @@ def test_LogFormatter_sublabel():
     assert np.all(show_major_labels)
     _sub_labels(ax.xaxis, subs=[])
 
-    # axis range at 2 to 3 decades, label sub 3
+    # For the next two, if the numdec threshold in LogFormatter.set_locs
+    # were 3, then the label sub would be 3 for 2-3 decades and (2,5)
+    # for 1-2 decades.  With a threshold of 1, subs are not labeled.
+    # axis range at 2 to 3 decades
     ax.set_xlim(1, 800)
-    _sub_labels(ax.xaxis, subs=[3])
+    _sub_labels(ax.xaxis, subs=[])
 
-    # axis range at 1 to 2 decades, label subs 2 and 5
+    # axis range at 1 to 2 decades
     ax.set_xlim(1, 80)
-    _sub_labels(ax.xaxis, subs=[2, 5])
+    _sub_labels(ax.xaxis, subs=[])
 
     # axis range at 0 to 1 decades, label subs 2, 3, 6
     ax.set_xlim(1, 8)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -853,7 +853,7 @@ class LogFormatter(Formatter):
             vmax = math.log(vmax) / math.log(b)
             numdec = abs(vmax - vmin)
 
-        if numdec > 3:
+        if numdec > 1:
             # Label only bases
             self.sublabel = set((1,))
         else:
@@ -1857,10 +1857,10 @@ class LogLocator(Locator):
 
         numdec = math.floor(vmax) - math.ceil(vmin)
 
-        if self._subs is None:  # autosub
-            if numdec > 10:
-                subs = np.array([1.0])
-            elif numdec > 6:
+        if self._subs is None:  # autosub for minor ticks
+            if numdec > 10 or b < 3:
+                return np.array([])  # no minor ticks
+            elif numdec > 5 and b >= 6:
                 subs = np.arange(2.0, b, 2.0)
             else:
                 subs = np.arange(2.0, b)


### PR DESCRIPTION
This partly restores the functionality that was added in
PR #5161 and partly removed in #7000.  The "partly" is because
now the labeling of minor log ticks is turned on only when
numdecs (the axis range in powers of the log base) is less
than or equal to one, rather than 3.

This also fixes a bug that was causing double labeling with a
base of 2; minor ticks were coinciding with major ticks, and
both were being labeled.