### PR TITLE
[MRG+2] Fix Text layout cache lookup.

### DIFF
--- a/lib/matplotlib/tests/baseline_images/test_axes/hist_stacked_bar.svg
+++ b/lib/matplotlib/tests/baseline_images/test_axes/hist_stacked_bar.svg
@@ -27,7 +27,7 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="patch_3">
-    <path clip-path="url(#p7ed8b39af5)" d="M 79.2261 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 79.2261 388.8 
 L 114.7149 388.8 
 L 114.7149 365.76 
 L 79.2261 365.76 
@@ -35,7 +35,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_4">
-    <path clip-path="url(#p7ed8b39af5)" d="M 123.5871 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 123.5871 388.8 
 L 159.0759 388.8 
 L 159.0759 342.72 
 L 123.5871 342.72 
@@ -43,7 +43,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_5">
-    <path clip-path="url(#p7ed8b39af5)" d="M 167.9481 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 167.9481 388.8 
 L 203.4369 388.8 
 L 203.4369 377.28 
 L 167.9481 377.28 
@@ -51,7 +51,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_6">
-    <path clip-path="url(#p7ed8b39af5)" d="M 212.3091 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 212.3091 388.8 
 L 247.7979 388.8 
 L 247.7979 365.76 
 L 212.3091 365.76 
@@ -59,7 +59,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_7">
-    <path clip-path="url(#p7ed8b39af5)" d="M 256.6701 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 256.6701 388.8 
 L 292.1589 388.8 
 L 292.1589 388.8 
 L 256.6701 388.8 
@@ -67,7 +67,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_8">
-    <path clip-path="url(#p7ed8b39af5)" d="M 301.0311 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 301.0311 388.8 
 L 336.5199 388.8 
 L 336.5199 377.28 
 L 301.0311 377.28 
@@ -75,7 +75,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_9">
-    <path clip-path="url(#p7ed8b39af5)" d="M 345.3921 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 345.3921 388.8 
 L 380.8809 388.8 
 L 380.8809 388.8 
 L 345.3921 388.8 
@@ -83,7 +83,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_10">
-    <path clip-path="url(#p7ed8b39af5)" d="M 389.7531 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 389.7531 388.8 
 L 425.2419 388.8 
 L 425.2419 377.28 
 L 389.7531 377.28 
@@ -91,7 +91,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_11">
-    <path clip-path="url(#p7ed8b39af5)" d="M 434.1141 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 434.1141 388.8 
 L 469.6029 388.8 
 L 469.6029 388.8 
 L 434.1141 388.8 
@@ -99,7 +99,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_12">
-    <path clip-path="url(#p7ed8b39af5)" d="M 478.4751 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 478.4751 388.8 
 L 513.9639 388.8 
 L 513.9639 377.28 
 L 478.4751 377.28 
@@ -107,7 +107,7 @@ z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_13">
-    <path clip-path="url(#p7ed8b39af5)" d="M 79.2261 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 79.2261 365.76 
 L 114.7149 365.76 
 L 114.7149 319.68 
 L 79.2261 319.68 
@@ -115,7 +115,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_14">
-    <path clip-path="url(#p7ed8b39af5)" d="M 123.5871 342.72 
+    <path clip-path="url(#pca0d595b95)" d="M 123.5871 342.72 
 L 159.0759 342.72 
 L 159.0759 331.2 
 L 123.5871 331.2 
@@ -123,7 +123,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_15">
-    <path clip-path="url(#p7ed8b39af5)" d="M 167.9481 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 167.9481 377.28 
 L 203.4369 377.28 
 L 203.4369 377.28 
 L 167.9481 377.28 
@@ -131,7 +131,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_16">
-    <path clip-path="url(#p7ed8b39af5)" d="M 212.3091 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 212.3091 365.76 
 L 247.7979 365.76 
 L 247.7979 365.76 
 L 212.3091 365.76 
@@ -139,7 +139,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_17">
-    <path clip-path="url(#p7ed8b39af5)" d="M 256.6701 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 256.6701 388.8 
 L 292.1589 388.8 
 L 292.1589 388.8 
 L 256.6701 388.8 
@@ -147,7 +147,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_18">
-    <path clip-path="url(#p7ed8b39af5)" d="M 301.0311 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 301.0311 377.28 
 L 336.5199 377.28 
 L 336.5199 365.76 
 L 301.0311 365.76 
@@ -155,7 +155,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_19">
-    <path clip-path="url(#p7ed8b39af5)" d="M 345.3921 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 345.3921 388.8 
 L 380.8809 388.8 
 L 380.8809 388.8 
 L 345.3921 388.8 
@@ -163,7 +163,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_20">
-    <path clip-path="url(#p7ed8b39af5)" d="M 389.7531 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 389.7531 377.28 
 L 425.2419 377.28 
 L 425.2419 377.28 
 L 389.7531 377.28 
@@ -171,7 +171,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_21">
-    <path clip-path="url(#p7ed8b39af5)" d="M 434.1141 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 434.1141 388.8 
 L 469.6029 388.8 
 L 469.6029 388.8 
 L 434.1141 388.8 
@@ -179,7 +179,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_22">
-    <path clip-path="url(#p7ed8b39af5)" d="M 478.4751 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 478.4751 377.28 
 L 513.9639 377.28 
 L 513.9639 377.28 
 L 478.4751 377.28 
@@ -187,7 +187,7 @@ z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_23">
-    <path clip-path="url(#p7ed8b39af5)" d="M 79.2261 319.68 
+    <path clip-path="url(#pca0d595b95)" d="M 79.2261 319.68 
 L 114.7149 319.68 
 L 114.7149 319.68 
 L 79.2261 319.68 
@@ -195,7 +195,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_24">
-    <path clip-path="url(#p7ed8b39af5)" d="M 123.5871 331.2 
+    <path clip-path="url(#pca0d595b95)" d="M 123.5871 331.2 
 L 159.0759 331.2 
 L 159.0759 262.08 
 L 123.5871 262.08 
@@ -203,7 +203,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_25">
-    <path clip-path="url(#p7ed8b39af5)" d="M 167.9481 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 167.9481 377.28 
 L 203.4369 377.28 
 L 203.4369 365.76 
 L 167.9481 365.76 
@@ -211,7 +211,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_26">
-    <path clip-path="url(#p7ed8b39af5)" d="M 212.3091 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 212.3091 365.76 
 L 247.7979 365.76 
 L 247.7979 365.76 
 L 212.3091 365.76 
@@ -219,7 +219,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_27">
-    <path clip-path="url(#p7ed8b39af5)" d="M 256.6701 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 256.6701 388.8 
 L 292.1589 388.8 
 L 292.1589 388.8 
 L 256.6701 388.8 
@@ -227,7 +227,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_28">
-    <path clip-path="url(#p7ed8b39af5)" d="M 301.0311 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 301.0311 365.76 
 L 336.5199 365.76 
 L 336.5199 365.76 
 L 301.0311 365.76 
@@ -235,7 +235,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_29">
-    <path clip-path="url(#p7ed8b39af5)" d="M 345.3921 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 345.3921 388.8 
 L 380.8809 388.8 
 L 380.8809 388.8 
 L 345.3921 388.8 
@@ -243,7 +243,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_30">
-    <path clip-path="url(#p7ed8b39af5)" d="M 389.7531 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 389.7531 377.28 
 L 425.2419 377.28 
 L 425.2419 377.28 
 L 389.7531 377.28 
@@ -251,7 +251,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_31">
-    <path clip-path="url(#p7ed8b39af5)" d="M 434.1141 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 434.1141 388.8 
 L 469.6029 388.8 
 L 469.6029 388.8 
 L 434.1141 388.8 
@@ -259,7 +259,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_32">
-    <path clip-path="url(#p7ed8b39af5)" d="M 478.4751 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 478.4751 377.28 
 L 513.9639 377.28 
 L 513.9639 377.28 
 L 478.4751 377.28 
@@ -267,7 +267,7 @@ z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_33">
-    <path clip-path="url(#p7ed8b39af5)" d="M 79.2261 319.68 
+    <path clip-path="url(#pca0d595b95)" d="M 79.2261 319.68 
 L 114.7149 319.68 
 L 114.7149 216 
 L 79.2261 216 
@@ -275,7 +275,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_34">
-    <path clip-path="url(#p7ed8b39af5)" d="M 123.5871 262.08 
+    <path clip-path="url(#pca0d595b95)" d="M 123.5871 262.08 
 L 159.0759 262.08 
 L 159.0759 262.08 
 L 123.5871 262.08 
@@ -283,7 +283,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_35">
-    <path clip-path="url(#p7ed8b39af5)" d="M 167.9481 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 167.9481 365.76 
 L 203.4369 365.76 
 L 203.4369 365.76 
 L 167.9481 365.76 
@@ -291,7 +291,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_36">
-    <path clip-path="url(#p7ed8b39af5)" d="M 212.3091 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 212.3091 365.76 
 L 247.7979 365.76 
 L 247.7979 331.2 
 L 212.3091 331.2 
@@ -299,7 +299,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_37">
-    <path clip-path="url(#p7ed8b39af5)" d="M 256.6701 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 256.6701 388.8 
 L 292.1589 388.8 
 L 292.1589 388.8 
 L 256.6701 388.8 
@@ -307,7 +307,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_38">
-    <path clip-path="url(#p7ed8b39af5)" d="M 301.0311 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 301.0311 365.76 
 L 336.5199 365.76 
 L 336.5199 365.76 
 L 301.0311 365.76 
@@ -315,7 +315,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_39">
-    <path clip-path="url(#p7ed8b39af5)" d="M 345.3921 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 345.3921 388.8 
 L 380.8809 388.8 
 L 380.8809 388.8 
 L 345.3921 388.8 
@@ -323,7 +323,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_40">
-    <path clip-path="url(#p7ed8b39af5)" d="M 389.7531 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 389.7531 377.28 
 L 425.2419 377.28 
 L 425.2419 377.28 
 L 389.7531 377.28 
@@ -331,7 +331,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_41">
-    <path clip-path="url(#p7ed8b39af5)" d="M 434.1141 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 434.1141 388.8 
 L 469.6029 388.8 
 L 469.6029 388.8 
 L 434.1141 388.8 
@@ -339,7 +339,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_42">
-    <path clip-path="url(#p7ed8b39af5)" d="M 478.4751 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 478.4751 377.28 
 L 513.9639 377.28 
 L 513.9639 377.28 
 L 478.4751 377.28 
@@ -347,7 +347,7 @@ z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_43">
-    <path clip-path="url(#p7ed8b39af5)" d="M 79.2261 216 
+    <path clip-path="url(#pca0d595b95)" d="M 79.2261 216 
 L 114.7149 216 
 L 114.7149 135.36 
 L 79.2261 135.36 
@@ -355,7 +355,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_44">
-    <path clip-path="url(#p7ed8b39af5)" d="M 123.5871 262.08 
+    <path clip-path="url(#pca0d595b95)" d="M 123.5871 262.08 
 L 159.0759 262.08 
 L 159.0759 216 
 L 123.5871 216 
@@ -363,7 +363,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_45">
-    <path clip-path="url(#p7ed8b39af5)" d="M 167.9481 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 167.9481 365.76 
 L 203.4369 365.76 
 L 203.4369 365.76 
 L 167.9481 365.76 
@@ -371,7 +371,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_46">
-    <path clip-path="url(#p7ed8b39af5)" d="M 212.3091 331.2 
+    <path clip-path="url(#pca0d595b95)" d="M 212.3091 331.2 
 L 247.7979 331.2 
 L 247.7979 331.2 
 L 212.3091 331.2 
@@ -379,7 +379,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_47">
-    <path clip-path="url(#p7ed8b39af5)" d="M 256.6701 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 256.6701 388.8 
 L 292.1589 388.8 
 L 292.1589 388.8 
 L 256.6701 388.8 
@@ -387,7 +387,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_48">
-    <path clip-path="url(#p7ed8b39af5)" d="M 301.0311 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 301.0311 365.76 
 L 336.5199 365.76 
 L 336.5199 365.76 
 L 301.0311 365.76 
@@ -395,7 +395,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_49">
-    <path clip-path="url(#p7ed8b39af5)" d="M 345.3921 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 345.3921 388.8 
 L 380.8809 388.8 
 L 380.8809 354.24 
 L 345.3921 354.24 
@@ -403,7 +403,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_50">
-    <path clip-path="url(#p7ed8b39af5)" d="M 389.7531 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 389.7531 377.28 
 L 425.2419 377.28 
 L 425.2419 377.28 
 L 389.7531 377.28 
@@ -411,7 +411,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_51">
-    <path clip-path="url(#p7ed8b39af5)" d="M 434.1141 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 434.1141 388.8 
 L 469.6029 388.8 
 L 469.6029 388.8 
 L 434.1141 388.8 
@@ -419,7 +419,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_52">
-    <path clip-path="url(#p7ed8b39af5)" d="M 478.4751 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 478.4751 377.28 
 L 513.9639 377.28 
 L 513.9639 377.28 
 L 478.4751 377.28 
@@ -427,7 +427,7 @@ z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_53">
-    <path clip-path="url(#p7ed8b39af5)" d="M 79.2261 135.36 
+    <path clip-path="url(#pca0d595b95)" d="M 79.2261 135.36 
 L 114.7149 135.36 
 L 114.7149 89.28 
 L 79.2261 89.28 
@@ -435,7 +435,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_54">
-    <path clip-path="url(#p7ed8b39af5)" d="M 123.5871 216 
+    <path clip-path="url(#pca0d595b95)" d="M 123.5871 216 
 L 159.0759 216 
 L 159.0759 216 
 L 123.5871 216 
@@ -443,7 +443,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_55">
-    <path clip-path="url(#p7ed8b39af5)" d="M 167.9481 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 167.9481 365.76 
 L 203.4369 365.76 
 L 203.4369 365.76 
 L 167.9481 365.76 
@@ -451,7 +451,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_56">
-    <path clip-path="url(#p7ed8b39af5)" d="M 212.3091 331.2 
+    <path clip-path="url(#pca0d595b95)" d="M 212.3091 331.2 
 L 247.7979 331.2 
 L 247.7979 331.2 
 L 212.3091 331.2 
@@ -459,7 +459,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_57">
-    <path clip-path="url(#p7ed8b39af5)" d="M 256.6701 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 256.6701 388.8 
 L 292.1589 388.8 
 L 292.1589 296.64 
 L 256.6701 296.64 
@@ -467,7 +467,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_58">
-    <path clip-path="url(#p7ed8b39af5)" d="M 301.0311 365.76 
+    <path clip-path="url(#pca0d595b95)" d="M 301.0311 365.76 
 L 336.5199 365.76 
 L 336.5199 365.76 
 L 301.0311 365.76 
@@ -475,7 +475,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_59">
-    <path clip-path="url(#p7ed8b39af5)" d="M 345.3921 354.24 
+    <path clip-path="url(#pca0d595b95)" d="M 345.3921 354.24 
 L 380.8809 354.24 
 L 380.8809 354.24 
 L 345.3921 354.24 
@@ -483,7 +483,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_60">
-    <path clip-path="url(#p7ed8b39af5)" d="M 389.7531 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 389.7531 377.28 
 L 425.2419 377.28 
 L 425.2419 377.28 
 L 389.7531 377.28 
@@ -491,7 +491,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_61">
-    <path clip-path="url(#p7ed8b39af5)" d="M 434.1141 388.8 
+    <path clip-path="url(#pca0d595b95)" d="M 434.1141 388.8 
 L 469.6029 388.8 
 L 469.6029 388.8 
 L 434.1141 388.8 
@@ -499,7 +499,7 @@ z
 " style="fill:#af00ff;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_62">
-    <path clip-path="url(#p7ed8b39af5)" d="M 478.4751 377.28 
+    <path clip-path="url(#pca0d595b95)" d="M 478.4751 377.28 
 L 513.9639 377.28 
 L 513.9639 377.28 
 L 478.4751 377.28 
@@ -532,20 +532,20 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="mafe98fc5ca" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m99b6481df7" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_2">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m6be8621e0a" style="stroke:#000000;stroke-width:0.5;"/>
+" id="me7b1eb2014" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_1">
@@ -579,12 +579,12 @@ Q 19.53125 74.21875 31.78125 74.21875
     <g id="xtick_2">
      <g id="line2d_3">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_2">
@@ -614,12 +614,12 @@ z
     <g id="xtick_3">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_3">
@@ -659,12 +659,12 @@ Q 31.109375 20.453125 19.1875 8.296875
     <g id="xtick_4">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_4">
@@ -712,12 +712,12 @@ Q 46.96875 40.921875 40.578125 39.3125
     <g id="xtick_5">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_5">
@@ -751,12 +751,12 @@ z
     <g id="xtick_6">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_6">
@@ -797,12 +797,12 @@ z
     <g id="xtick_7">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_7">
@@ -847,12 +847,12 @@ Q 48.484375 72.75 52.59375 71.296875
     <g id="xtick_8">
      <g id="line2d_15">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_8">
@@ -878,12 +878,12 @@ z
     <g id="xtick_9">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mafe98fc5ca" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m99b6481df7" y="388.8"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m6be8621e0a" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me7b1eb2014" y="43.2"/>
       </g>
      </g>
      <g id="text_9">
@@ -940,20 +940,20 @@ Q 18.3125 60.0625 18.3125 54.390625
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="ma13e55b877" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m555172aa0a" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma13e55b877" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m555172aa0a" y="388.8"/>
       </g>
      </g>
      <g id="line2d_20">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="m514c559581" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mdcfcaba4c2" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m514c559581" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mdcfcaba4c2" y="388.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -966,12 +966,12 @@ L -4 0
     <g id="ytick_2">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma13e55b877" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m555172aa0a" y="331.2"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m514c559581" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mdcfcaba4c2" y="331.2"/>
       </g>
      </g>
      <g id="text_11">
@@ -984,12 +984,12 @@ L -4 0
     <g id="ytick_3">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma13e55b877" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m555172aa0a" y="273.6"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m514c559581" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mdcfcaba4c2" y="273.6"/>
       </g>
      </g>
      <g id="text_12">
@@ -1003,12 +1003,12 @@ L -4 0
     <g id="ytick_4">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma13e55b877" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m555172aa0a" y="216"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m514c559581" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mdcfcaba4c2" y="216"/>
       </g>
      </g>
      <g id="text_13">
@@ -1022,12 +1022,12 @@ L -4 0
     <g id="ytick_5">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma13e55b877" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m555172aa0a" y="158.4"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m514c559581" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mdcfcaba4c2" y="158.4"/>
       </g>
      </g>
      <g id="text_14">
@@ -1041,12 +1041,12 @@ L -4 0
     <g id="ytick_6">
      <g id="line2d_29">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma13e55b877" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m555172aa0a" y="100.8"/>
       </g>
      </g>
      <g id="line2d_30">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m514c559581" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mdcfcaba4c2" y="100.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1060,12 +1060,12 @@ L -4 0
     <g id="ytick_7">
      <g id="line2d_31">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma13e55b877" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m555172aa0a" y="43.2"/>
       </g>
      </g>
      <g id="line2d_32">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m514c559581" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mdcfcaba4c2" y="43.2"/>
       </g>
      </g>
      <g id="text_16">
@@ -1079,18 +1079,18 @@ L -4 0
    </g>
    <g id="legend_1">
     <g id="patch_67">
-     <path d="M 395.01625 160.314 
-L 511.2 160.314 
+     <path d="M 394.911 160.4025 
+L 511.2 160.4025 
 L 511.2 50.4 
-L 395.01625 50.4 
+L 394.911 50.4 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="patch_68">
-     <path d="M 400.77625 67.10175 
-L 429.57625 67.10175 
-L 429.57625 57.02175 
-L 400.77625 57.02175 
+     <path d="M 400.671 67.10175 
+L 429.471 67.10175 
+L 429.471 57.02175 
+L 400.671 57.02175 
 z
 " style="fill:#93ff00;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -1187,7 +1187,7 @@ Q 45.21875 56 50.046875 50.171875
 Q 54.890625 44.34375 54.890625 33.015625 
 " id="DejaVuSans-6e"/>
      </defs>
-     <g transform="translate(441.09625 67.10175)scale(0.144 -0.144)">
+     <g transform="translate(440.991 67.10175)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-67"/>
       <use x="63.476562" xlink:href="#DejaVuSans-72"/>
       <use x="104.558594" xlink:href="#DejaVuSans-65"/>
@@ -1196,10 +1196,10 @@ Q 54.890625 44.34375 54.890625 33.015625
      </g>
     </g>
     <g id="patch_69">
-     <path d="M 400.77625 88.23825 
-L 429.57625 88.23825 
-L 429.57625 78.15825 
-L 400.77625 78.15825 
+     <path d="M 400.671 88.23825 
+L 429.471 88.23825 
+L 429.471 78.15825 
+L 400.671 78.15825 
 z
 " style="fill:#00ff59;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -1257,7 +1257,7 @@ Q 40.484375 56 46.34375 49.84375
 Q 52.203125 43.703125 52.203125 31.203125 
 " id="DejaVuSans-61"/>
      </defs>
-     <g transform="translate(441.09625 88.23825)scale(0.144 -0.144)">
+     <g transform="translate(440.991 88.23825)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6f"/>
       <use x="61.181641" xlink:href="#DejaVuSans-72"/>
       <use x="102.294922" xlink:href="#DejaVuSans-61"/>
@@ -1267,10 +1267,10 @@ Q 52.203125 43.703125 52.203125 31.203125
      </g>
     </g>
     <g id="patch_70">
-     <path d="M 400.77625 109.37475 
-L 429.57625 109.37475 
-L 429.57625 99.29475 
-L 400.77625 99.29475 
+     <path d="M 400.671 109.37475 
+L 429.471 109.37475 
+L 429.471 99.29475 
+L 400.671 99.29475 
 z
 " style="fill:#00ffa7;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -1316,7 +1316,7 @@ L 18.5 0
 z
 " id="DejaVuSans-77"/>
      </defs>
-     <g transform="translate(441.09625 109.37475)scale(0.144 -0.144)">
+     <g transform="translate(440.991 109.37475)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-20"/>
       <use x="31.787109" xlink:href="#DejaVuSans-79"/>
       <use x="90.966797" xlink:href="#DejaVuSans-65"/>
@@ -1327,10 +1327,10 @@ z
      </g>
     </g>
     <g id="patch_71">
-     <path d="M 400.77625 130.51125 
-L 429.57625 130.51125 
-L 429.57625 120.43125 
-L 400.77625 120.43125 
+     <path d="M 400.671 130.51125 
+L 429.471 130.51125 
+L 429.471 120.43125 
+L 400.671 120.43125 
 z
 " style="fill:#00a8ff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -1387,7 +1387,7 @@ L 9.28125 70.21875
 z
 " id="DejaVuSans-74"/>
      </defs>
-     <g transform="translate(441.09625 130.51125)scale(0.144 -0.144)">
+     <g transform="translate(440.991 130.51125)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-61"/>
       <use x="158.691406" xlink:href="#DejaVuSans-67"/>
@@ -1398,10 +1398,10 @@ z
      </g>
     </g>
     <g id="patch_72">
-     <path d="M 400.77625 151.64775 
-L 429.57625 151.64775 
-L 429.57625 141.56775 
-L 400.77625 141.56775 
+     <path d="M 400.671 151.64775 
+L 429.471 151.64775 
+L 429.471 141.56775 
+L 400.671 141.56775 
 z
 " style="fill:#4800ff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -1466,7 +1466,7 @@ L 9.078125 0
 z
 " id="DejaVuSans-6b"/>
      </defs>
-     <g transform="translate(441.09625 151.64775)scale(0.144 -0.144)">
+     <g transform="translate(440.991 151.64775)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-62"/>
       <use x="63.476562" xlink:href="#DejaVuSans-6c"/>
       <use x="91.259766" xlink:href="#DejaVuSans-61"/>
@@ -1478,7 +1478,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p7ed8b39af5">
+  <clipPath id="pca0d595b95">
    <rect height="345.6" width="446.4" x="72" y="43.2"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_axes/markevery.svg
+++ b/lib/matplotlib/tests/baseline_images/test_axes/markevery.svg
@@ -38,109 +38,109 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="m19995b3cae" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m6a9fe3c038" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p2955ea2e08)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m19995b3cae" y="250.56"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.509091" xlink:href="#m19995b3cae" y="240.603932"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="81.018182" xlink:href="#m19995b3cae" y="230.554177"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.527273" xlink:href="#m19995b3cae" y="220.518979"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="90.036364" xlink:href="#m19995b3cae" y="210.608185"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.545455" xlink:href="#m19995b3cae" y="200.93202"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="99.054545" xlink:href="#m19995b3cae" y="191.599847"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.563636" xlink:href="#m19995b3cae" y="182.718924"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="108.072727" xlink:href="#m19995b3cae" y="174.393174"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.581818" xlink:href="#m19995b3cae" y="166.721974"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="117.090909" xlink:href="#m19995b3cae" y="159.798986"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.6" xlink:href="#m19995b3cae" y="153.711037"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="126.109091" xlink:href="#m19995b3cae" y="148.537067"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.618182" xlink:href="#m19995b3cae" y="144.347153"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="135.127273" xlink:href="#m19995b3cae" y="141.201614"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m19995b3cae" y="139.150231"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="144.145455" xlink:href="#m19995b3cae" y="138.231558"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="148.654545" xlink:href="#m19995b3cae" y="138.472367"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="153.163636" xlink:href="#m19995b3cae" y="139.887202"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="157.672727" xlink:href="#m19995b3cae" y="142.478076"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="162.181818" xlink:href="#m19995b3cae" y="146.234297"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="166.690909" xlink:href="#m19995b3cae" y="151.132435"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="171.2" xlink:href="#m19995b3cae" y="157.136427"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="175.709091" xlink:href="#m19995b3cae" y="164.19782"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="180.218182" xlink:href="#m19995b3cae" y="172.256161"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="184.727273" xlink:href="#m19995b3cae" y="181.239512"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="189.236364" xlink:href="#m19995b3cae" y="191.065101"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="193.745455" xlink:href="#m19995b3cae" y="201.640102"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="198.254545" xlink:href="#m19995b3cae" y="212.86252"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="202.763636" xlink:href="#m19995b3cae" y="224.622202"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m19995b3cae" y="236.80193"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="211.781818" xlink:href="#m19995b3cae" y="249.278616"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="216.290909" xlink:href="#m19995b3cae" y="261.924559"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="220.8" xlink:href="#m19995b3cae" y="274.608777"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="225.309091" xlink:href="#m19995b3cae" y="287.198376"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="229.818182" xlink:href="#m19995b3cae" y="299.559963"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="234.327273" xlink:href="#m19995b3cae" y="311.561068"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="238.836364" xlink:href="#m19995b3cae" y="323.071578"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="243.345455" xlink:href="#m19995b3cae" y="333.965155"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="247.854545" xlink:href="#m19995b3cae" y="344.120624"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="252.363636" xlink:href="#m19995b3cae" y="353.423324"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="256.872727" xlink:href="#m19995b3cae" y="361.766398"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="261.381818" xlink:href="#m19995b3cae" y="369.05201"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="265.890909" xlink:href="#m19995b3cae" y="375.192479"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="270.4" xlink:href="#m19995b3cae" y="380.11131"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m19995b3cae" y="383.744122"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="279.418182" xlink:href="#m19995b3cae" y="386.039443"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="283.927273" xlink:href="#m19995b3cae" y="386.959387"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="288.436364" xlink:href="#m19995b3cae" y="386.480179"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="292.945455" xlink:href="#m19995b3cae" y="384.592544"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="297.454545" xlink:href="#m19995b3cae" y="381.301936"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="301.963636" xlink:href="#m19995b3cae" y="376.628622"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="306.472727" xlink:href="#m19995b3cae" y="370.607598"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="310.981818" xlink:href="#m19995b3cae" y="363.288351"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m19995b3cae" y="354.734472"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="320" xlink:href="#m19995b3cae" y="345.023104"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="324.509091" xlink:href="#m19995b3cae" y="334.244247"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="329.018182" xlink:href="#m19995b3cae" y="322.499924"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="333.527273" xlink:href="#m19995b3cae" y="309.903207"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="338.036364" xlink:href="#m19995b3cae" y="296.577118"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="342.545455" xlink:href="#m19995b3cae" y="282.653419"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="347.054545" xlink:href="#m19995b3cae" y="268.271297"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="351.563636" xlink:href="#m19995b3cae" y="253.575962"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="356.072727" xlink:href="#m19995b3cae" y="238.717168"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="360.581818" xlink:href="#m19995b3cae" y="223.847675"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="365.090909" xlink:href="#m19995b3cae" y="209.121664"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="369.6" xlink:href="#m19995b3cae" y="194.693135"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="374.109091" xlink:href="#m19995b3cae" y="180.714281"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="378.618182" xlink:href="#m19995b3cae" y="167.333875"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#m19995b3cae" y="154.695687"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="387.636364" xlink:href="#m19995b3cae" y="142.936925"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="392.145455" xlink:href="#m19995b3cae" y="132.186756"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="396.654545" xlink:href="#m19995b3cae" y="122.564877"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="401.163636" xlink:href="#m19995b3cae" y="114.180196"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="405.672727" xlink:href="#m19995b3cae" y="107.129599"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="410.181818" xlink:href="#m19995b3cae" y="101.496852"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="414.690909" xlink:href="#m19995b3cae" y="97.351616"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="419.2" xlink:href="#m19995b3cae" y="94.748615"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="423.709091" xlink:href="#m19995b3cae" y="93.726951"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="428.218182" xlink:href="#m19995b3cae" y="94.309579"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="432.727273" xlink:href="#m19995b3cae" y="96.502943"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="437.236364" xlink:href="#m19995b3cae" y="100.296794"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="441.745455" xlink:href="#m19995b3cae" y="105.664168"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.254545" xlink:href="#m19995b3cae" y="112.56155"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#m19995b3cae" y="120.92921"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.272727" xlink:href="#m19995b3cae" y="130.691705"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="459.781818" xlink:href="#m19995b3cae" y="141.75856"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.290909" xlink:href="#m19995b3cae" y="154.025101"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="468.8" xlink:href="#m19995b3cae" y="167.373449"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.309091" xlink:href="#m19995b3cae" y="181.673656"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="477.818182" xlink:href="#m19995b3cae" y="196.784976"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.327273" xlink:href="#m19995b3cae" y="212.557255"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="486.836364" xlink:href="#m19995b3cae" y="228.832435"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.345455" xlink:href="#m19995b3cae" y="245.446139"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="495.854545" xlink:href="#m19995b3cae" y="262.229348"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.363636" xlink:href="#m19995b3cae" y="279.010121"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="504.872727" xlink:href="#m19995b3cae" y="295.61537"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.381818" xlink:href="#m19995b3cae" y="311.872651"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.890909" xlink:href="#m19995b3cae" y="327.611962"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m19995b3cae" y="342.667524"/>
+    <g clip-path="url(#p64c4d58d43)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m6a9fe3c038" y="250.56"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.509091" xlink:href="#m6a9fe3c038" y="240.603932"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="81.018182" xlink:href="#m6a9fe3c038" y="230.554177"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.527273" xlink:href="#m6a9fe3c038" y="220.518979"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="90.036364" xlink:href="#m6a9fe3c038" y="210.608185"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.545455" xlink:href="#m6a9fe3c038" y="200.93202"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="99.054545" xlink:href="#m6a9fe3c038" y="191.599847"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.563636" xlink:href="#m6a9fe3c038" y="182.718924"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="108.072727" xlink:href="#m6a9fe3c038" y="174.393174"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.581818" xlink:href="#m6a9fe3c038" y="166.721974"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="117.090909" xlink:href="#m6a9fe3c038" y="159.798986"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.6" xlink:href="#m6a9fe3c038" y="153.711037"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="126.109091" xlink:href="#m6a9fe3c038" y="148.537067"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.618182" xlink:href="#m6a9fe3c038" y="144.347153"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="135.127273" xlink:href="#m6a9fe3c038" y="141.201614"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m6a9fe3c038" y="139.150231"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="144.145455" xlink:href="#m6a9fe3c038" y="138.231558"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="148.654545" xlink:href="#m6a9fe3c038" y="138.472367"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="153.163636" xlink:href="#m6a9fe3c038" y="139.887202"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="157.672727" xlink:href="#m6a9fe3c038" y="142.478076"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="162.181818" xlink:href="#m6a9fe3c038" y="146.234297"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="166.690909" xlink:href="#m6a9fe3c038" y="151.132435"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="171.2" xlink:href="#m6a9fe3c038" y="157.136427"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="175.709091" xlink:href="#m6a9fe3c038" y="164.19782"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="180.218182" xlink:href="#m6a9fe3c038" y="172.256161"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="184.727273" xlink:href="#m6a9fe3c038" y="181.239512"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="189.236364" xlink:href="#m6a9fe3c038" y="191.065101"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="193.745455" xlink:href="#m6a9fe3c038" y="201.640102"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="198.254545" xlink:href="#m6a9fe3c038" y="212.86252"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="202.763636" xlink:href="#m6a9fe3c038" y="224.622202"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m6a9fe3c038" y="236.80193"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="211.781818" xlink:href="#m6a9fe3c038" y="249.278616"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="216.290909" xlink:href="#m6a9fe3c038" y="261.924559"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="220.8" xlink:href="#m6a9fe3c038" y="274.608777"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="225.309091" xlink:href="#m6a9fe3c038" y="287.198376"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="229.818182" xlink:href="#m6a9fe3c038" y="299.559963"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="234.327273" xlink:href="#m6a9fe3c038" y="311.561068"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="238.836364" xlink:href="#m6a9fe3c038" y="323.071578"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="243.345455" xlink:href="#m6a9fe3c038" y="333.965155"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="247.854545" xlink:href="#m6a9fe3c038" y="344.120624"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="252.363636" xlink:href="#m6a9fe3c038" y="353.423324"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="256.872727" xlink:href="#m6a9fe3c038" y="361.766398"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="261.381818" xlink:href="#m6a9fe3c038" y="369.05201"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="265.890909" xlink:href="#m6a9fe3c038" y="375.192479"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="270.4" xlink:href="#m6a9fe3c038" y="380.11131"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m6a9fe3c038" y="383.744122"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="279.418182" xlink:href="#m6a9fe3c038" y="386.039443"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="283.927273" xlink:href="#m6a9fe3c038" y="386.959387"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="288.436364" xlink:href="#m6a9fe3c038" y="386.480179"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="292.945455" xlink:href="#m6a9fe3c038" y="384.592544"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="297.454545" xlink:href="#m6a9fe3c038" y="381.301936"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="301.963636" xlink:href="#m6a9fe3c038" y="376.628622"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="306.472727" xlink:href="#m6a9fe3c038" y="370.607598"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="310.981818" xlink:href="#m6a9fe3c038" y="363.288351"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m6a9fe3c038" y="354.734472"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="320" xlink:href="#m6a9fe3c038" y="345.023104"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="324.509091" xlink:href="#m6a9fe3c038" y="334.244247"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="329.018182" xlink:href="#m6a9fe3c038" y="322.499924"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="333.527273" xlink:href="#m6a9fe3c038" y="309.903207"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="338.036364" xlink:href="#m6a9fe3c038" y="296.577118"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="342.545455" xlink:href="#m6a9fe3c038" y="282.653419"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="347.054545" xlink:href="#m6a9fe3c038" y="268.271297"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="351.563636" xlink:href="#m6a9fe3c038" y="253.575962"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="356.072727" xlink:href="#m6a9fe3c038" y="238.717168"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="360.581818" xlink:href="#m6a9fe3c038" y="223.847675"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="365.090909" xlink:href="#m6a9fe3c038" y="209.121664"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="369.6" xlink:href="#m6a9fe3c038" y="194.693135"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="374.109091" xlink:href="#m6a9fe3c038" y="180.714281"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="378.618182" xlink:href="#m6a9fe3c038" y="167.333875"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#m6a9fe3c038" y="154.695687"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="387.636364" xlink:href="#m6a9fe3c038" y="142.936925"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="392.145455" xlink:href="#m6a9fe3c038" y="132.186756"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="396.654545" xlink:href="#m6a9fe3c038" y="122.564877"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="401.163636" xlink:href="#m6a9fe3c038" y="114.180196"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="405.672727" xlink:href="#m6a9fe3c038" y="107.129599"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="410.181818" xlink:href="#m6a9fe3c038" y="101.496852"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="414.690909" xlink:href="#m6a9fe3c038" y="97.351616"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="419.2" xlink:href="#m6a9fe3c038" y="94.748615"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="423.709091" xlink:href="#m6a9fe3c038" y="93.726951"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="428.218182" xlink:href="#m6a9fe3c038" y="94.309579"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="432.727273" xlink:href="#m6a9fe3c038" y="96.502943"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="437.236364" xlink:href="#m6a9fe3c038" y="100.296794"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="441.745455" xlink:href="#m6a9fe3c038" y="105.664168"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.254545" xlink:href="#m6a9fe3c038" y="112.56155"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#m6a9fe3c038" y="120.92921"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.272727" xlink:href="#m6a9fe3c038" y="130.691705"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="459.781818" xlink:href="#m6a9fe3c038" y="141.75856"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.290909" xlink:href="#m6a9fe3c038" y="154.025101"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="468.8" xlink:href="#m6a9fe3c038" y="167.373449"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.309091" xlink:href="#m6a9fe3c038" y="181.673656"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="477.818182" xlink:href="#m6a9fe3c038" y="196.784976"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.327273" xlink:href="#m6a9fe3c038" y="212.557255"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="486.836364" xlink:href="#m6a9fe3c038" y="228.832435"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.345455" xlink:href="#m6a9fe3c038" y="245.446139"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="495.854545" xlink:href="#m6a9fe3c038" y="262.229348"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.363636" xlink:href="#m6a9fe3c038" y="279.010121"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="504.872727" xlink:href="#m6a9fe3c038" y="295.61537"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.381818" xlink:href="#m6a9fe3c038" y="311.872651"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.890909" xlink:href="#m6a9fe3c038" y="327.611962"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m6a9fe3c038" y="342.667524"/>
     </g>
    </g>
    <g id="line2d_2">
@@ -150,109 +150,109 @@ L 2.545584 0
 L 0 -4.242641 
 L -2.545584 -0 
 z
-" id="m5310570bd3" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
+" id="m82f7853944" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p2955ea2e08)">
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#m5310570bd3" y="250.56"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="76.509091" xlink:href="#m5310570bd3" y="240.603932"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="81.018182" xlink:href="#m5310570bd3" y="230.554177"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="85.527273" xlink:href="#m5310570bd3" y="220.518979"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="90.036364" xlink:href="#m5310570bd3" y="210.608185"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="94.545455" xlink:href="#m5310570bd3" y="200.93202"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="99.054545" xlink:href="#m5310570bd3" y="191.599847"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="103.563636" xlink:href="#m5310570bd3" y="182.718924"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="108.072727" xlink:href="#m5310570bd3" y="174.393174"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="112.581818" xlink:href="#m5310570bd3" y="166.721974"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#m5310570bd3" y="159.798986"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="121.6" xlink:href="#m5310570bd3" y="153.711037"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="126.109091" xlink:href="#m5310570bd3" y="148.537067"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="130.618182" xlink:href="#m5310570bd3" y="144.347153"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="135.127273" xlink:href="#m5310570bd3" y="141.201614"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="139.636364" xlink:href="#m5310570bd3" y="139.150231"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="144.145455" xlink:href="#m5310570bd3" y="138.231558"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="148.654545" xlink:href="#m5310570bd3" y="138.472367"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="153.163636" xlink:href="#m5310570bd3" y="139.887202"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="157.672727" xlink:href="#m5310570bd3" y="142.478076"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#m5310570bd3" y="146.234297"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="166.690909" xlink:href="#m5310570bd3" y="151.132435"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="171.2" xlink:href="#m5310570bd3" y="157.136427"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="175.709091" xlink:href="#m5310570bd3" y="164.19782"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="180.218182" xlink:href="#m5310570bd3" y="172.256161"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="184.727273" xlink:href="#m5310570bd3" y="181.239512"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="189.236364" xlink:href="#m5310570bd3" y="191.065101"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="193.745455" xlink:href="#m5310570bd3" y="201.640102"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="198.254545" xlink:href="#m5310570bd3" y="212.86252"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="202.763636" xlink:href="#m5310570bd3" y="224.622202"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#m5310570bd3" y="236.80193"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="211.781818" xlink:href="#m5310570bd3" y="249.278616"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="216.290909" xlink:href="#m5310570bd3" y="261.924559"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="220.8" xlink:href="#m5310570bd3" y="274.608777"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="225.309091" xlink:href="#m5310570bd3" y="287.198376"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="229.818182" xlink:href="#m5310570bd3" y="299.559963"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="234.327273" xlink:href="#m5310570bd3" y="311.561068"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="238.836364" xlink:href="#m5310570bd3" y="323.071578"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="243.345455" xlink:href="#m5310570bd3" y="333.965155"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="247.854545" xlink:href="#m5310570bd3" y="344.120624"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#m5310570bd3" y="353.423324"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="256.872727" xlink:href="#m5310570bd3" y="361.766398"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="261.381818" xlink:href="#m5310570bd3" y="369.05201"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="265.890909" xlink:href="#m5310570bd3" y="375.192479"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="270.4" xlink:href="#m5310570bd3" y="380.11131"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="274.909091" xlink:href="#m5310570bd3" y="383.744122"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="279.418182" xlink:href="#m5310570bd3" y="386.039443"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="283.927273" xlink:href="#m5310570bd3" y="386.959387"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="288.436364" xlink:href="#m5310570bd3" y="386.480179"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="292.945455" xlink:href="#m5310570bd3" y="384.592544"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#m5310570bd3" y="381.301936"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="301.963636" xlink:href="#m5310570bd3" y="376.628622"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="306.472727" xlink:href="#m5310570bd3" y="370.607598"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="310.981818" xlink:href="#m5310570bd3" y="363.288351"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="315.490909" xlink:href="#m5310570bd3" y="354.734472"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="320" xlink:href="#m5310570bd3" y="345.023104"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="324.509091" xlink:href="#m5310570bd3" y="334.244247"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="329.018182" xlink:href="#m5310570bd3" y="322.499924"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="333.527273" xlink:href="#m5310570bd3" y="309.903207"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="338.036364" xlink:href="#m5310570bd3" y="296.577118"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#m5310570bd3" y="282.653419"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="347.054545" xlink:href="#m5310570bd3" y="268.271297"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="351.563636" xlink:href="#m5310570bd3" y="253.575962"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="356.072727" xlink:href="#m5310570bd3" y="238.717168"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="360.581818" xlink:href="#m5310570bd3" y="223.847675"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="365.090909" xlink:href="#m5310570bd3" y="209.121664"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="369.6" xlink:href="#m5310570bd3" y="194.693135"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="374.109091" xlink:href="#m5310570bd3" y="180.714281"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="378.618182" xlink:href="#m5310570bd3" y="167.333875"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="383.127273" xlink:href="#m5310570bd3" y="154.695687"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#m5310570bd3" y="142.936925"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="392.145455" xlink:href="#m5310570bd3" y="132.186756"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="396.654545" xlink:href="#m5310570bd3" y="122.564877"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="401.163636" xlink:href="#m5310570bd3" y="114.180196"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="405.672727" xlink:href="#m5310570bd3" y="107.129599"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="410.181818" xlink:href="#m5310570bd3" y="101.496852"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="414.690909" xlink:href="#m5310570bd3" y="97.351616"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="419.2" xlink:href="#m5310570bd3" y="94.748615"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="423.709091" xlink:href="#m5310570bd3" y="93.726951"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="428.218182" xlink:href="#m5310570bd3" y="94.309579"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#m5310570bd3" y="96.502943"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="437.236364" xlink:href="#m5310570bd3" y="100.296794"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="441.745455" xlink:href="#m5310570bd3" y="105.664168"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="446.254545" xlink:href="#m5310570bd3" y="112.56155"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="450.763636" xlink:href="#m5310570bd3" y="120.92921"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="455.272727" xlink:href="#m5310570bd3" y="130.691705"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="459.781818" xlink:href="#m5310570bd3" y="141.75856"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="464.290909" xlink:href="#m5310570bd3" y="154.025101"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="468.8" xlink:href="#m5310570bd3" y="167.373449"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="473.309091" xlink:href="#m5310570bd3" y="181.673656"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#m5310570bd3" y="196.784976"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="482.327273" xlink:href="#m5310570bd3" y="212.557255"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="486.836364" xlink:href="#m5310570bd3" y="228.832435"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="491.345455" xlink:href="#m5310570bd3" y="245.446139"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="495.854545" xlink:href="#m5310570bd3" y="262.229348"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="500.363636" xlink:href="#m5310570bd3" y="279.010121"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="504.872727" xlink:href="#m5310570bd3" y="295.61537"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="509.381818" xlink:href="#m5310570bd3" y="311.872651"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="513.890909" xlink:href="#m5310570bd3" y="327.611962"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="518.4" xlink:href="#m5310570bd3" y="342.667524"/>
+    <g clip-path="url(#p64c4d58d43)">
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#m82f7853944" y="250.56"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="76.509091" xlink:href="#m82f7853944" y="240.603932"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="81.018182" xlink:href="#m82f7853944" y="230.554177"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="85.527273" xlink:href="#m82f7853944" y="220.518979"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="90.036364" xlink:href="#m82f7853944" y="210.608185"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="94.545455" xlink:href="#m82f7853944" y="200.93202"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="99.054545" xlink:href="#m82f7853944" y="191.599847"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="103.563636" xlink:href="#m82f7853944" y="182.718924"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="108.072727" xlink:href="#m82f7853944" y="174.393174"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="112.581818" xlink:href="#m82f7853944" y="166.721974"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#m82f7853944" y="159.798986"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="121.6" xlink:href="#m82f7853944" y="153.711037"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="126.109091" xlink:href="#m82f7853944" y="148.537067"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="130.618182" xlink:href="#m82f7853944" y="144.347153"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="135.127273" xlink:href="#m82f7853944" y="141.201614"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="139.636364" xlink:href="#m82f7853944" y="139.150231"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="144.145455" xlink:href="#m82f7853944" y="138.231558"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="148.654545" xlink:href="#m82f7853944" y="138.472367"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="153.163636" xlink:href="#m82f7853944" y="139.887202"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="157.672727" xlink:href="#m82f7853944" y="142.478076"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#m82f7853944" y="146.234297"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="166.690909" xlink:href="#m82f7853944" y="151.132435"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="171.2" xlink:href="#m82f7853944" y="157.136427"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="175.709091" xlink:href="#m82f7853944" y="164.19782"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="180.218182" xlink:href="#m82f7853944" y="172.256161"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="184.727273" xlink:href="#m82f7853944" y="181.239512"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="189.236364" xlink:href="#m82f7853944" y="191.065101"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="193.745455" xlink:href="#m82f7853944" y="201.640102"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="198.254545" xlink:href="#m82f7853944" y="212.86252"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="202.763636" xlink:href="#m82f7853944" y="224.622202"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#m82f7853944" y="236.80193"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="211.781818" xlink:href="#m82f7853944" y="249.278616"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="216.290909" xlink:href="#m82f7853944" y="261.924559"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="220.8" xlink:href="#m82f7853944" y="274.608777"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="225.309091" xlink:href="#m82f7853944" y="287.198376"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="229.818182" xlink:href="#m82f7853944" y="299.559963"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="234.327273" xlink:href="#m82f7853944" y="311.561068"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="238.836364" xlink:href="#m82f7853944" y="323.071578"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="243.345455" xlink:href="#m82f7853944" y="333.965155"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="247.854545" xlink:href="#m82f7853944" y="344.120624"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#m82f7853944" y="353.423324"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="256.872727" xlink:href="#m82f7853944" y="361.766398"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="261.381818" xlink:href="#m82f7853944" y="369.05201"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="265.890909" xlink:href="#m82f7853944" y="375.192479"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="270.4" xlink:href="#m82f7853944" y="380.11131"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="274.909091" xlink:href="#m82f7853944" y="383.744122"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="279.418182" xlink:href="#m82f7853944" y="386.039443"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="283.927273" xlink:href="#m82f7853944" y="386.959387"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="288.436364" xlink:href="#m82f7853944" y="386.480179"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="292.945455" xlink:href="#m82f7853944" y="384.592544"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#m82f7853944" y="381.301936"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="301.963636" xlink:href="#m82f7853944" y="376.628622"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="306.472727" xlink:href="#m82f7853944" y="370.607598"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="310.981818" xlink:href="#m82f7853944" y="363.288351"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="315.490909" xlink:href="#m82f7853944" y="354.734472"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="320" xlink:href="#m82f7853944" y="345.023104"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="324.509091" xlink:href="#m82f7853944" y="334.244247"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="329.018182" xlink:href="#m82f7853944" y="322.499924"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="333.527273" xlink:href="#m82f7853944" y="309.903207"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="338.036364" xlink:href="#m82f7853944" y="296.577118"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#m82f7853944" y="282.653419"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="347.054545" xlink:href="#m82f7853944" y="268.271297"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="351.563636" xlink:href="#m82f7853944" y="253.575962"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="356.072727" xlink:href="#m82f7853944" y="238.717168"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="360.581818" xlink:href="#m82f7853944" y="223.847675"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="365.090909" xlink:href="#m82f7853944" y="209.121664"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="369.6" xlink:href="#m82f7853944" y="194.693135"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="374.109091" xlink:href="#m82f7853944" y="180.714281"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="378.618182" xlink:href="#m82f7853944" y="167.333875"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="383.127273" xlink:href="#m82f7853944" y="154.695687"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#m82f7853944" y="142.936925"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="392.145455" xlink:href="#m82f7853944" y="132.186756"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="396.654545" xlink:href="#m82f7853944" y="122.564877"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="401.163636" xlink:href="#m82f7853944" y="114.180196"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="405.672727" xlink:href="#m82f7853944" y="107.129599"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="410.181818" xlink:href="#m82f7853944" y="101.496852"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="414.690909" xlink:href="#m82f7853944" y="97.351616"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="419.2" xlink:href="#m82f7853944" y="94.748615"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="423.709091" xlink:href="#m82f7853944" y="93.726951"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="428.218182" xlink:href="#m82f7853944" y="94.309579"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#m82f7853944" y="96.502943"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="437.236364" xlink:href="#m82f7853944" y="100.296794"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="441.745455" xlink:href="#m82f7853944" y="105.664168"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="446.254545" xlink:href="#m82f7853944" y="112.56155"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="450.763636" xlink:href="#m82f7853944" y="120.92921"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="455.272727" xlink:href="#m82f7853944" y="130.691705"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="459.781818" xlink:href="#m82f7853944" y="141.75856"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="464.290909" xlink:href="#m82f7853944" y="154.025101"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="468.8" xlink:href="#m82f7853944" y="167.373449"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="473.309091" xlink:href="#m82f7853944" y="181.673656"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#m82f7853944" y="196.784976"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="482.327273" xlink:href="#m82f7853944" y="212.557255"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="486.836364" xlink:href="#m82f7853944" y="228.832435"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="491.345455" xlink:href="#m82f7853944" y="245.446139"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="495.854545" xlink:href="#m82f7853944" y="262.229348"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="500.363636" xlink:href="#m82f7853944" y="279.010121"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="504.872727" xlink:href="#m82f7853944" y="295.61537"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="509.381818" xlink:href="#m82f7853944" y="311.872651"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="513.890909" xlink:href="#m82f7853944" y="327.611962"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="518.4" xlink:href="#m82f7853944" y="342.667524"/>
     </g>
    </g>
    <g id="line2d_3">
@@ -262,19 +262,19 @@ L 3 3
 L 3 -3 
 L -3 -3 
 z
-" id="m10b9748a1a" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
+" id="m82e88449c5" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p2955ea2e08)">
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#m10b9748a1a" y="250.56"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#m10b9748a1a" y="159.798986"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#m10b9748a1a" y="146.234297"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#m10b9748a1a" y="236.80193"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#m10b9748a1a" y="353.423324"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#m10b9748a1a" y="381.301936"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#m10b9748a1a" y="282.653419"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#m10b9748a1a" y="142.936925"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#m10b9748a1a" y="96.502943"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#m10b9748a1a" y="196.784976"/>
+    <g clip-path="url(#p64c4d58d43)">
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#m82e88449c5" y="250.56"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#m82e88449c5" y="159.798986"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#m82e88449c5" y="146.234297"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#m82e88449c5" y="236.80193"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#m82e88449c5" y="353.423324"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#m82e88449c5" y="381.301936"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#m82e88449c5" y="282.653419"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#m82e88449c5" y="142.936925"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#m82e88449c5" y="96.502943"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#m82e88449c5" y="196.784976"/>
     </g>
    </g>
    <g id="line2d_4">
@@ -283,14 +283,14 @@ z
 L 3 0 
 M 0 3 
 L 0 -3 
-" id="m41da80ca8e" style="stroke:#00bfbf;stroke-width:0.5;"/>
+" id="mfc7e25f046" style="stroke:#00bfbf;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p2955ea2e08)">
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="94.545455" xlink:href="#m41da80ca8e" y="200.93202"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="184.727273" xlink:href="#m41da80ca8e" y="181.239512"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="274.909091" xlink:href="#m41da80ca8e" y="383.744122"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="365.090909" xlink:href="#m41da80ca8e" y="209.121664"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="455.272727" xlink:href="#m41da80ca8e" y="130.691705"/>
+    <g clip-path="url(#p64c4d58d43)">
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="94.545455" xlink:href="#mfc7e25f046" y="200.93202"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="184.727273" xlink:href="#mfc7e25f046" y="181.239512"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="274.909091" xlink:href="#mfc7e25f046" y="383.744122"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="365.090909" xlink:href="#mfc7e25f046" y="209.121664"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="455.272727" xlink:href="#mfc7e25f046" y="130.691705"/>
     </g>
    </g>
    <g id="patch_3">
@@ -319,80 +319,80 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="ma0952b939b" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m5217868098" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma0952b939b" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m5217868098" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="mde7172798e" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m032bb84592" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mde7172798e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m032bb84592" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#ma0952b939b" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m5217868098" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mde7172798e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m032bb84592" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#ma0952b939b" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m5217868098" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mde7172798e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m032bb84592" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#ma0952b939b" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m5217868098" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mde7172798e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m032bb84592" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#ma0952b939b" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m5217868098" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mde7172798e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m032bb84592" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_15">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#ma0952b939b" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m5217868098" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde7172798e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m032bb84592" y="43.2"/>
       </g>
      </g>
     </g>
@@ -403,98 +403,98 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="mbe1077638f" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mf4ab786c76" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe1077638f" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf4ab786c76" y="388.8"/>
       </g>
      </g>
      <g id="line2d_18">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="m33e20e690d" style="stroke:#000000;stroke-width:0.5;"/>
+" id="me4c004bbf7" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m33e20e690d" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me4c004bbf7" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe1077638f" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf4ab786c76" y="319.68"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m33e20e690d" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me4c004bbf7" y="319.68"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe1077638f" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf4ab786c76" y="250.56"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m33e20e690d" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me4c004bbf7" y="250.56"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe1077638f" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf4ab786c76" y="181.44"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m33e20e690d" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me4c004bbf7" y="181.44"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe1077638f" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf4ab786c76" y="112.32"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m33e20e690d" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me4c004bbf7" y="112.32"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe1077638f" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf4ab786c76" y="43.2"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m33e20e690d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me4c004bbf7" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 261.20375 139.1775 
-L 511.2 139.1775 
+     <path d="M 260.92125 139.266 
+L 511.2 139.266 
 L 511.2 50.4 
-L 261.20375 50.4 
+L 260.92125 50.4 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_29"/>
     <g id="line2d_30">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="271.28375" xlink:href="#m19995b3cae" y="62.06175"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="291.44375" xlink:href="#m19995b3cae" y="62.06175"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="271.00125" xlink:href="#m6a9fe3c038" y="62.06175"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="291.16125" xlink:href="#m6a9fe3c038" y="62.06175"/>
      </g>
     </g>
     <g id="text_1">
@@ -645,7 +645,7 @@ L 9.28125 70.21875
 z
 " id="DejaVuSans-74"/>
      </defs>
-     <g transform="translate(307.28375 67.10175)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 67.10175)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-64"/>
       <use x="63.476562" xlink:href="#DejaVuSans-65"/>
       <use x="125" xlink:href="#DejaVuSans-66"/>
@@ -658,8 +658,8 @@ z
     <g id="line2d_31"/>
     <g id="line2d_32">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.28375" xlink:href="#m5310570bd3" y="83.19825"/>
-      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.44375" xlink:href="#m5310570bd3" y="83.19825"/>
+      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.00125" xlink:href="#m82f7853944" y="83.19825"/>
+      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.16125" xlink:href="#m82f7853944" y="83.19825"/>
      </g>
     </g>
     <g id="text_2">
@@ -725,7 +725,7 @@ z
 " id="DejaVuSans-6b"/>
       <path id="DejaVuSans-20"/>
      </defs>
-     <g transform="translate(307.28375 88.23825)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 88.23825)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-61"/>
       <use x="158.691406" xlink:href="#DejaVuSans-72"/>
@@ -739,8 +739,8 @@ z
     <g id="line2d_33"/>
     <g id="line2d_34">
      <g>
-      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.28375" xlink:href="#m10b9748a1a" y="104.33475"/>
-      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.44375" xlink:href="#m10b9748a1a" y="104.33475"/>
+      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.00125" xlink:href="#m82e88449c5" y="104.33475"/>
+      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.16125" xlink:href="#m82e88449c5" y="104.33475"/>
      </g>
     </g>
     <g id="text_3">
@@ -804,7 +804,7 @@ Q 6.59375 54.828125 13.0625 64.515625
 Q 19.53125 74.21875 31.78125 74.21875 
 " id="DejaVuSans-30"/>
      </defs>
-     <g transform="translate(307.28375 109.37475)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 109.37475)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-61"/>
       <use x="158.691406" xlink:href="#DejaVuSans-72"/>
@@ -823,8 +823,8 @@ Q 19.53125 74.21875 31.78125 74.21875
     <g id="line2d_35"/>
     <g id="line2d_36">
      <g>
-      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="271.28375" xlink:href="#m41da80ca8e" y="125.47125"/>
-      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="291.44375" xlink:href="#m41da80ca8e" y="125.47125"/>
+      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="271.00125" xlink:href="#mfc7e25f046" y="125.47125"/>
+      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="291.16125" xlink:href="#mfc7e25f046" y="125.47125"/>
      </g>
     </g>
     <g id="text_4">
@@ -946,7 +946,7 @@ L 54.390625 54.6875
 z
 " id="DejaVuSans-67"/>
      </defs>
-     <g transform="translate(307.28375 130.51125)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 130.51125)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-61"/>
       <use x="158.691406" xlink:href="#DejaVuSans-72"/>
@@ -980,7 +980,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p2955ea2e08">
+  <clipPath id="p64c4d58d43">
    <rect height="345.6" width="446.4" x="72" y="43.2"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_axes/markevery_line.svg
+++ b/lib/matplotlib/tests/baseline_images/test_axes/markevery_line.svg
@@ -27,7 +27,7 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="line2d_1">
-    <path clip-path="url(#p0eedb6d240)" d="M 72 250.56 
+    <path clip-path="url(#pd7f52cb7d8)" d="M 72 250.56 
 L 76.509091 240.603932 
 L 81.018182 230.554177 
 L 85.527273 220.518979 
@@ -139,113 +139,113 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="m2fc0b09e3a" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m2824b38e85" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p0eedb6d240)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m2fc0b09e3a" y="250.56"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.509091" xlink:href="#m2fc0b09e3a" y="240.603932"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="81.018182" xlink:href="#m2fc0b09e3a" y="230.554177"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.527273" xlink:href="#m2fc0b09e3a" y="220.518979"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="90.036364" xlink:href="#m2fc0b09e3a" y="210.608185"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.545455" xlink:href="#m2fc0b09e3a" y="200.93202"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="99.054545" xlink:href="#m2fc0b09e3a" y="191.599847"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.563636" xlink:href="#m2fc0b09e3a" y="182.718924"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="108.072727" xlink:href="#m2fc0b09e3a" y="174.393174"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.581818" xlink:href="#m2fc0b09e3a" y="166.721974"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="117.090909" xlink:href="#m2fc0b09e3a" y="159.798986"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.6" xlink:href="#m2fc0b09e3a" y="153.711037"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="126.109091" xlink:href="#m2fc0b09e3a" y="148.537067"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.618182" xlink:href="#m2fc0b09e3a" y="144.347153"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="135.127273" xlink:href="#m2fc0b09e3a" y="141.201614"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m2fc0b09e3a" y="139.150231"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="144.145455" xlink:href="#m2fc0b09e3a" y="138.231558"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="148.654545" xlink:href="#m2fc0b09e3a" y="138.472367"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="153.163636" xlink:href="#m2fc0b09e3a" y="139.887202"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="157.672727" xlink:href="#m2fc0b09e3a" y="142.478076"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="162.181818" xlink:href="#m2fc0b09e3a" y="146.234297"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="166.690909" xlink:href="#m2fc0b09e3a" y="151.132435"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="171.2" xlink:href="#m2fc0b09e3a" y="157.136427"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="175.709091" xlink:href="#m2fc0b09e3a" y="164.19782"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="180.218182" xlink:href="#m2fc0b09e3a" y="172.256161"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="184.727273" xlink:href="#m2fc0b09e3a" y="181.239512"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="189.236364" xlink:href="#m2fc0b09e3a" y="191.065101"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="193.745455" xlink:href="#m2fc0b09e3a" y="201.640102"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="198.254545" xlink:href="#m2fc0b09e3a" y="212.86252"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="202.763636" xlink:href="#m2fc0b09e3a" y="224.622202"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m2fc0b09e3a" y="236.80193"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="211.781818" xlink:href="#m2fc0b09e3a" y="249.278616"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="216.290909" xlink:href="#m2fc0b09e3a" y="261.924559"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="220.8" xlink:href="#m2fc0b09e3a" y="274.608777"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="225.309091" xlink:href="#m2fc0b09e3a" y="287.198376"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="229.818182" xlink:href="#m2fc0b09e3a" y="299.559963"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="234.327273" xlink:href="#m2fc0b09e3a" y="311.561068"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="238.836364" xlink:href="#m2fc0b09e3a" y="323.071578"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="243.345455" xlink:href="#m2fc0b09e3a" y="333.965155"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="247.854545" xlink:href="#m2fc0b09e3a" y="344.120624"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="252.363636" xlink:href="#m2fc0b09e3a" y="353.423324"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="256.872727" xlink:href="#m2fc0b09e3a" y="361.766398"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="261.381818" xlink:href="#m2fc0b09e3a" y="369.05201"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="265.890909" xlink:href="#m2fc0b09e3a" y="375.192479"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="270.4" xlink:href="#m2fc0b09e3a" y="380.11131"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m2fc0b09e3a" y="383.744122"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="279.418182" xlink:href="#m2fc0b09e3a" y="386.039443"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="283.927273" xlink:href="#m2fc0b09e3a" y="386.959387"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="288.436364" xlink:href="#m2fc0b09e3a" y="386.480179"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="292.945455" xlink:href="#m2fc0b09e3a" y="384.592544"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="297.454545" xlink:href="#m2fc0b09e3a" y="381.301936"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="301.963636" xlink:href="#m2fc0b09e3a" y="376.628622"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="306.472727" xlink:href="#m2fc0b09e3a" y="370.607598"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="310.981818" xlink:href="#m2fc0b09e3a" y="363.288351"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m2fc0b09e3a" y="354.734472"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="320" xlink:href="#m2fc0b09e3a" y="345.023104"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="324.509091" xlink:href="#m2fc0b09e3a" y="334.244247"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="329.018182" xlink:href="#m2fc0b09e3a" y="322.499924"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="333.527273" xlink:href="#m2fc0b09e3a" y="309.903207"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="338.036364" xlink:href="#m2fc0b09e3a" y="296.577118"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="342.545455" xlink:href="#m2fc0b09e3a" y="282.653419"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="347.054545" xlink:href="#m2fc0b09e3a" y="268.271297"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="351.563636" xlink:href="#m2fc0b09e3a" y="253.575962"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="356.072727" xlink:href="#m2fc0b09e3a" y="238.717168"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="360.581818" xlink:href="#m2fc0b09e3a" y="223.847675"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="365.090909" xlink:href="#m2fc0b09e3a" y="209.121664"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="369.6" xlink:href="#m2fc0b09e3a" y="194.693135"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="374.109091" xlink:href="#m2fc0b09e3a" y="180.714281"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="378.618182" xlink:href="#m2fc0b09e3a" y="167.333875"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#m2fc0b09e3a" y="154.695687"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="387.636364" xlink:href="#m2fc0b09e3a" y="142.936925"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="392.145455" xlink:href="#m2fc0b09e3a" y="132.186756"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="396.654545" xlink:href="#m2fc0b09e3a" y="122.564877"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="401.163636" xlink:href="#m2fc0b09e3a" y="114.180196"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="405.672727" xlink:href="#m2fc0b09e3a" y="107.129599"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="410.181818" xlink:href="#m2fc0b09e3a" y="101.496852"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="414.690909" xlink:href="#m2fc0b09e3a" y="97.351616"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="419.2" xlink:href="#m2fc0b09e3a" y="94.748615"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="423.709091" xlink:href="#m2fc0b09e3a" y="93.726951"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="428.218182" xlink:href="#m2fc0b09e3a" y="94.309579"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="432.727273" xlink:href="#m2fc0b09e3a" y="96.502943"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="437.236364" xlink:href="#m2fc0b09e3a" y="100.296794"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="441.745455" xlink:href="#m2fc0b09e3a" y="105.664168"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.254545" xlink:href="#m2fc0b09e3a" y="112.56155"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#m2fc0b09e3a" y="120.92921"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.272727" xlink:href="#m2fc0b09e3a" y="130.691705"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="459.781818" xlink:href="#m2fc0b09e3a" y="141.75856"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.290909" xlink:href="#m2fc0b09e3a" y="154.025101"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="468.8" xlink:href="#m2fc0b09e3a" y="167.373449"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.309091" xlink:href="#m2fc0b09e3a" y="181.673656"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="477.818182" xlink:href="#m2fc0b09e3a" y="196.784976"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.327273" xlink:href="#m2fc0b09e3a" y="212.557255"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="486.836364" xlink:href="#m2fc0b09e3a" y="228.832435"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.345455" xlink:href="#m2fc0b09e3a" y="245.446139"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="495.854545" xlink:href="#m2fc0b09e3a" y="262.229348"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.363636" xlink:href="#m2fc0b09e3a" y="279.010121"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="504.872727" xlink:href="#m2fc0b09e3a" y="295.61537"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.381818" xlink:href="#m2fc0b09e3a" y="311.872651"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.890909" xlink:href="#m2fc0b09e3a" y="327.611962"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2fc0b09e3a" y="342.667524"/>
+    <g clip-path="url(#pd7f52cb7d8)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m2824b38e85" y="250.56"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.509091" xlink:href="#m2824b38e85" y="240.603932"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="81.018182" xlink:href="#m2824b38e85" y="230.554177"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.527273" xlink:href="#m2824b38e85" y="220.518979"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="90.036364" xlink:href="#m2824b38e85" y="210.608185"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.545455" xlink:href="#m2824b38e85" y="200.93202"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="99.054545" xlink:href="#m2824b38e85" y="191.599847"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.563636" xlink:href="#m2824b38e85" y="182.718924"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="108.072727" xlink:href="#m2824b38e85" y="174.393174"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.581818" xlink:href="#m2824b38e85" y="166.721974"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="117.090909" xlink:href="#m2824b38e85" y="159.798986"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.6" xlink:href="#m2824b38e85" y="153.711037"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="126.109091" xlink:href="#m2824b38e85" y="148.537067"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.618182" xlink:href="#m2824b38e85" y="144.347153"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="135.127273" xlink:href="#m2824b38e85" y="141.201614"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m2824b38e85" y="139.150231"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="144.145455" xlink:href="#m2824b38e85" y="138.231558"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="148.654545" xlink:href="#m2824b38e85" y="138.472367"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="153.163636" xlink:href="#m2824b38e85" y="139.887202"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="157.672727" xlink:href="#m2824b38e85" y="142.478076"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="162.181818" xlink:href="#m2824b38e85" y="146.234297"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="166.690909" xlink:href="#m2824b38e85" y="151.132435"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="171.2" xlink:href="#m2824b38e85" y="157.136427"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="175.709091" xlink:href="#m2824b38e85" y="164.19782"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="180.218182" xlink:href="#m2824b38e85" y="172.256161"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="184.727273" xlink:href="#m2824b38e85" y="181.239512"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="189.236364" xlink:href="#m2824b38e85" y="191.065101"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="193.745455" xlink:href="#m2824b38e85" y="201.640102"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="198.254545" xlink:href="#m2824b38e85" y="212.86252"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="202.763636" xlink:href="#m2824b38e85" y="224.622202"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m2824b38e85" y="236.80193"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="211.781818" xlink:href="#m2824b38e85" y="249.278616"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="216.290909" xlink:href="#m2824b38e85" y="261.924559"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="220.8" xlink:href="#m2824b38e85" y="274.608777"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="225.309091" xlink:href="#m2824b38e85" y="287.198376"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="229.818182" xlink:href="#m2824b38e85" y="299.559963"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="234.327273" xlink:href="#m2824b38e85" y="311.561068"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="238.836364" xlink:href="#m2824b38e85" y="323.071578"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="243.345455" xlink:href="#m2824b38e85" y="333.965155"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="247.854545" xlink:href="#m2824b38e85" y="344.120624"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="252.363636" xlink:href="#m2824b38e85" y="353.423324"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="256.872727" xlink:href="#m2824b38e85" y="361.766398"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="261.381818" xlink:href="#m2824b38e85" y="369.05201"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="265.890909" xlink:href="#m2824b38e85" y="375.192479"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="270.4" xlink:href="#m2824b38e85" y="380.11131"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m2824b38e85" y="383.744122"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="279.418182" xlink:href="#m2824b38e85" y="386.039443"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="283.927273" xlink:href="#m2824b38e85" y="386.959387"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="288.436364" xlink:href="#m2824b38e85" y="386.480179"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="292.945455" xlink:href="#m2824b38e85" y="384.592544"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="297.454545" xlink:href="#m2824b38e85" y="381.301936"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="301.963636" xlink:href="#m2824b38e85" y="376.628622"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="306.472727" xlink:href="#m2824b38e85" y="370.607598"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="310.981818" xlink:href="#m2824b38e85" y="363.288351"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m2824b38e85" y="354.734472"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="320" xlink:href="#m2824b38e85" y="345.023104"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="324.509091" xlink:href="#m2824b38e85" y="334.244247"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="329.018182" xlink:href="#m2824b38e85" y="322.499924"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="333.527273" xlink:href="#m2824b38e85" y="309.903207"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="338.036364" xlink:href="#m2824b38e85" y="296.577118"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="342.545455" xlink:href="#m2824b38e85" y="282.653419"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="347.054545" xlink:href="#m2824b38e85" y="268.271297"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="351.563636" xlink:href="#m2824b38e85" y="253.575962"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="356.072727" xlink:href="#m2824b38e85" y="238.717168"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="360.581818" xlink:href="#m2824b38e85" y="223.847675"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="365.090909" xlink:href="#m2824b38e85" y="209.121664"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="369.6" xlink:href="#m2824b38e85" y="194.693135"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="374.109091" xlink:href="#m2824b38e85" y="180.714281"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="378.618182" xlink:href="#m2824b38e85" y="167.333875"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#m2824b38e85" y="154.695687"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="387.636364" xlink:href="#m2824b38e85" y="142.936925"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="392.145455" xlink:href="#m2824b38e85" y="132.186756"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="396.654545" xlink:href="#m2824b38e85" y="122.564877"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="401.163636" xlink:href="#m2824b38e85" y="114.180196"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="405.672727" xlink:href="#m2824b38e85" y="107.129599"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="410.181818" xlink:href="#m2824b38e85" y="101.496852"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="414.690909" xlink:href="#m2824b38e85" y="97.351616"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="419.2" xlink:href="#m2824b38e85" y="94.748615"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="423.709091" xlink:href="#m2824b38e85" y="93.726951"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="428.218182" xlink:href="#m2824b38e85" y="94.309579"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="432.727273" xlink:href="#m2824b38e85" y="96.502943"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="437.236364" xlink:href="#m2824b38e85" y="100.296794"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="441.745455" xlink:href="#m2824b38e85" y="105.664168"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.254545" xlink:href="#m2824b38e85" y="112.56155"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#m2824b38e85" y="120.92921"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.272727" xlink:href="#m2824b38e85" y="130.691705"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="459.781818" xlink:href="#m2824b38e85" y="141.75856"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.290909" xlink:href="#m2824b38e85" y="154.025101"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="468.8" xlink:href="#m2824b38e85" y="167.373449"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.309091" xlink:href="#m2824b38e85" y="181.673656"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="477.818182" xlink:href="#m2824b38e85" y="196.784976"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.327273" xlink:href="#m2824b38e85" y="212.557255"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="486.836364" xlink:href="#m2824b38e85" y="228.832435"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.345455" xlink:href="#m2824b38e85" y="245.446139"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="495.854545" xlink:href="#m2824b38e85" y="262.229348"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.363636" xlink:href="#m2824b38e85" y="279.010121"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="504.872727" xlink:href="#m2824b38e85" y="295.61537"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.381818" xlink:href="#m2824b38e85" y="311.872651"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.890909" xlink:href="#m2824b38e85" y="327.611962"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2824b38e85" y="342.667524"/>
     </g>
    </g>
    <g id="line2d_2">
-    <path clip-path="url(#p0eedb6d240)" d="M 72 250.56 
+    <path clip-path="url(#pd7f52cb7d8)" d="M 72 250.56 
 L 76.509091 240.603932 
 L 81.018182 230.554177 
 L 85.527273 220.518979 
@@ -352,113 +352,113 @@ L 2.545584 0
 L 0 -4.242641 
 L -2.545584 -0 
 z
-" id="mcbc28bf52d" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
+" id="m5f7a0fab99" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p0eedb6d240)">
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#mcbc28bf52d" y="250.56"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="76.509091" xlink:href="#mcbc28bf52d" y="240.603932"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="81.018182" xlink:href="#mcbc28bf52d" y="230.554177"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="85.527273" xlink:href="#mcbc28bf52d" y="220.518979"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="90.036364" xlink:href="#mcbc28bf52d" y="210.608185"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="94.545455" xlink:href="#mcbc28bf52d" y="200.93202"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="99.054545" xlink:href="#mcbc28bf52d" y="191.599847"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="103.563636" xlink:href="#mcbc28bf52d" y="182.718924"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="108.072727" xlink:href="#mcbc28bf52d" y="174.393174"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="112.581818" xlink:href="#mcbc28bf52d" y="166.721974"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#mcbc28bf52d" y="159.798986"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="121.6" xlink:href="#mcbc28bf52d" y="153.711037"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="126.109091" xlink:href="#mcbc28bf52d" y="148.537067"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="130.618182" xlink:href="#mcbc28bf52d" y="144.347153"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="135.127273" xlink:href="#mcbc28bf52d" y="141.201614"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="139.636364" xlink:href="#mcbc28bf52d" y="139.150231"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="144.145455" xlink:href="#mcbc28bf52d" y="138.231558"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="148.654545" xlink:href="#mcbc28bf52d" y="138.472367"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="153.163636" xlink:href="#mcbc28bf52d" y="139.887202"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="157.672727" xlink:href="#mcbc28bf52d" y="142.478076"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#mcbc28bf52d" y="146.234297"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="166.690909" xlink:href="#mcbc28bf52d" y="151.132435"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="171.2" xlink:href="#mcbc28bf52d" y="157.136427"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="175.709091" xlink:href="#mcbc28bf52d" y="164.19782"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="180.218182" xlink:href="#mcbc28bf52d" y="172.256161"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="184.727273" xlink:href="#mcbc28bf52d" y="181.239512"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="189.236364" xlink:href="#mcbc28bf52d" y="191.065101"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="193.745455" xlink:href="#mcbc28bf52d" y="201.640102"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="198.254545" xlink:href="#mcbc28bf52d" y="212.86252"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="202.763636" xlink:href="#mcbc28bf52d" y="224.622202"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#mcbc28bf52d" y="236.80193"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="211.781818" xlink:href="#mcbc28bf52d" y="249.278616"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="216.290909" xlink:href="#mcbc28bf52d" y="261.924559"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="220.8" xlink:href="#mcbc28bf52d" y="274.608777"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="225.309091" xlink:href="#mcbc28bf52d" y="287.198376"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="229.818182" xlink:href="#mcbc28bf52d" y="299.559963"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="234.327273" xlink:href="#mcbc28bf52d" y="311.561068"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="238.836364" xlink:href="#mcbc28bf52d" y="323.071578"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="243.345455" xlink:href="#mcbc28bf52d" y="333.965155"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="247.854545" xlink:href="#mcbc28bf52d" y="344.120624"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#mcbc28bf52d" y="353.423324"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="256.872727" xlink:href="#mcbc28bf52d" y="361.766398"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="261.381818" xlink:href="#mcbc28bf52d" y="369.05201"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="265.890909" xlink:href="#mcbc28bf52d" y="375.192479"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="270.4" xlink:href="#mcbc28bf52d" y="380.11131"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="274.909091" xlink:href="#mcbc28bf52d" y="383.744122"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="279.418182" xlink:href="#mcbc28bf52d" y="386.039443"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="283.927273" xlink:href="#mcbc28bf52d" y="386.959387"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="288.436364" xlink:href="#mcbc28bf52d" y="386.480179"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="292.945455" xlink:href="#mcbc28bf52d" y="384.592544"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#mcbc28bf52d" y="381.301936"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="301.963636" xlink:href="#mcbc28bf52d" y="376.628622"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="306.472727" xlink:href="#mcbc28bf52d" y="370.607598"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="310.981818" xlink:href="#mcbc28bf52d" y="363.288351"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="315.490909" xlink:href="#mcbc28bf52d" y="354.734472"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="320" xlink:href="#mcbc28bf52d" y="345.023104"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="324.509091" xlink:href="#mcbc28bf52d" y="334.244247"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="329.018182" xlink:href="#mcbc28bf52d" y="322.499924"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="333.527273" xlink:href="#mcbc28bf52d" y="309.903207"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="338.036364" xlink:href="#mcbc28bf52d" y="296.577118"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#mcbc28bf52d" y="282.653419"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="347.054545" xlink:href="#mcbc28bf52d" y="268.271297"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="351.563636" xlink:href="#mcbc28bf52d" y="253.575962"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="356.072727" xlink:href="#mcbc28bf52d" y="238.717168"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="360.581818" xlink:href="#mcbc28bf52d" y="223.847675"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="365.090909" xlink:href="#mcbc28bf52d" y="209.121664"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="369.6" xlink:href="#mcbc28bf52d" y="194.693135"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="374.109091" xlink:href="#mcbc28bf52d" y="180.714281"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="378.618182" xlink:href="#mcbc28bf52d" y="167.333875"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="383.127273" xlink:href="#mcbc28bf52d" y="154.695687"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#mcbc28bf52d" y="142.936925"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="392.145455" xlink:href="#mcbc28bf52d" y="132.186756"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="396.654545" xlink:href="#mcbc28bf52d" y="122.564877"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="401.163636" xlink:href="#mcbc28bf52d" y="114.180196"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="405.672727" xlink:href="#mcbc28bf52d" y="107.129599"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="410.181818" xlink:href="#mcbc28bf52d" y="101.496852"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="414.690909" xlink:href="#mcbc28bf52d" y="97.351616"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="419.2" xlink:href="#mcbc28bf52d" y="94.748615"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="423.709091" xlink:href="#mcbc28bf52d" y="93.726951"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="428.218182" xlink:href="#mcbc28bf52d" y="94.309579"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#mcbc28bf52d" y="96.502943"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="437.236364" xlink:href="#mcbc28bf52d" y="100.296794"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="441.745455" xlink:href="#mcbc28bf52d" y="105.664168"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="446.254545" xlink:href="#mcbc28bf52d" y="112.56155"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="450.763636" xlink:href="#mcbc28bf52d" y="120.92921"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="455.272727" xlink:href="#mcbc28bf52d" y="130.691705"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="459.781818" xlink:href="#mcbc28bf52d" y="141.75856"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="464.290909" xlink:href="#mcbc28bf52d" y="154.025101"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="468.8" xlink:href="#mcbc28bf52d" y="167.373449"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="473.309091" xlink:href="#mcbc28bf52d" y="181.673656"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#mcbc28bf52d" y="196.784976"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="482.327273" xlink:href="#mcbc28bf52d" y="212.557255"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="486.836364" xlink:href="#mcbc28bf52d" y="228.832435"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="491.345455" xlink:href="#mcbc28bf52d" y="245.446139"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="495.854545" xlink:href="#mcbc28bf52d" y="262.229348"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="500.363636" xlink:href="#mcbc28bf52d" y="279.010121"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="504.872727" xlink:href="#mcbc28bf52d" y="295.61537"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="509.381818" xlink:href="#mcbc28bf52d" y="311.872651"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="513.890909" xlink:href="#mcbc28bf52d" y="327.611962"/>
-     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="518.4" xlink:href="#mcbc28bf52d" y="342.667524"/>
+    <g clip-path="url(#pd7f52cb7d8)">
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#m5f7a0fab99" y="250.56"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="76.509091" xlink:href="#m5f7a0fab99" y="240.603932"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="81.018182" xlink:href="#m5f7a0fab99" y="230.554177"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="85.527273" xlink:href="#m5f7a0fab99" y="220.518979"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="90.036364" xlink:href="#m5f7a0fab99" y="210.608185"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="94.545455" xlink:href="#m5f7a0fab99" y="200.93202"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="99.054545" xlink:href="#m5f7a0fab99" y="191.599847"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="103.563636" xlink:href="#m5f7a0fab99" y="182.718924"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="108.072727" xlink:href="#m5f7a0fab99" y="174.393174"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="112.581818" xlink:href="#m5f7a0fab99" y="166.721974"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#m5f7a0fab99" y="159.798986"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="121.6" xlink:href="#m5f7a0fab99" y="153.711037"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="126.109091" xlink:href="#m5f7a0fab99" y="148.537067"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="130.618182" xlink:href="#m5f7a0fab99" y="144.347153"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="135.127273" xlink:href="#m5f7a0fab99" y="141.201614"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="139.636364" xlink:href="#m5f7a0fab99" y="139.150231"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="144.145455" xlink:href="#m5f7a0fab99" y="138.231558"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="148.654545" xlink:href="#m5f7a0fab99" y="138.472367"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="153.163636" xlink:href="#m5f7a0fab99" y="139.887202"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="157.672727" xlink:href="#m5f7a0fab99" y="142.478076"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#m5f7a0fab99" y="146.234297"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="166.690909" xlink:href="#m5f7a0fab99" y="151.132435"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="171.2" xlink:href="#m5f7a0fab99" y="157.136427"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="175.709091" xlink:href="#m5f7a0fab99" y="164.19782"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="180.218182" xlink:href="#m5f7a0fab99" y="172.256161"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="184.727273" xlink:href="#m5f7a0fab99" y="181.239512"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="189.236364" xlink:href="#m5f7a0fab99" y="191.065101"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="193.745455" xlink:href="#m5f7a0fab99" y="201.640102"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="198.254545" xlink:href="#m5f7a0fab99" y="212.86252"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="202.763636" xlink:href="#m5f7a0fab99" y="224.622202"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#m5f7a0fab99" y="236.80193"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="211.781818" xlink:href="#m5f7a0fab99" y="249.278616"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="216.290909" xlink:href="#m5f7a0fab99" y="261.924559"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="220.8" xlink:href="#m5f7a0fab99" y="274.608777"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="225.309091" xlink:href="#m5f7a0fab99" y="287.198376"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="229.818182" xlink:href="#m5f7a0fab99" y="299.559963"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="234.327273" xlink:href="#m5f7a0fab99" y="311.561068"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="238.836364" xlink:href="#m5f7a0fab99" y="323.071578"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="243.345455" xlink:href="#m5f7a0fab99" y="333.965155"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="247.854545" xlink:href="#m5f7a0fab99" y="344.120624"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#m5f7a0fab99" y="353.423324"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="256.872727" xlink:href="#m5f7a0fab99" y="361.766398"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="261.381818" xlink:href="#m5f7a0fab99" y="369.05201"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="265.890909" xlink:href="#m5f7a0fab99" y="375.192479"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="270.4" xlink:href="#m5f7a0fab99" y="380.11131"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="274.909091" xlink:href="#m5f7a0fab99" y="383.744122"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="279.418182" xlink:href="#m5f7a0fab99" y="386.039443"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="283.927273" xlink:href="#m5f7a0fab99" y="386.959387"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="288.436364" xlink:href="#m5f7a0fab99" y="386.480179"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="292.945455" xlink:href="#m5f7a0fab99" y="384.592544"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#m5f7a0fab99" y="381.301936"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="301.963636" xlink:href="#m5f7a0fab99" y="376.628622"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="306.472727" xlink:href="#m5f7a0fab99" y="370.607598"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="310.981818" xlink:href="#m5f7a0fab99" y="363.288351"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="315.490909" xlink:href="#m5f7a0fab99" y="354.734472"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="320" xlink:href="#m5f7a0fab99" y="345.023104"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="324.509091" xlink:href="#m5f7a0fab99" y="334.244247"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="329.018182" xlink:href="#m5f7a0fab99" y="322.499924"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="333.527273" xlink:href="#m5f7a0fab99" y="309.903207"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="338.036364" xlink:href="#m5f7a0fab99" y="296.577118"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#m5f7a0fab99" y="282.653419"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="347.054545" xlink:href="#m5f7a0fab99" y="268.271297"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="351.563636" xlink:href="#m5f7a0fab99" y="253.575962"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="356.072727" xlink:href="#m5f7a0fab99" y="238.717168"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="360.581818" xlink:href="#m5f7a0fab99" y="223.847675"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="365.090909" xlink:href="#m5f7a0fab99" y="209.121664"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="369.6" xlink:href="#m5f7a0fab99" y="194.693135"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="374.109091" xlink:href="#m5f7a0fab99" y="180.714281"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="378.618182" xlink:href="#m5f7a0fab99" y="167.333875"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="383.127273" xlink:href="#m5f7a0fab99" y="154.695687"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#m5f7a0fab99" y="142.936925"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="392.145455" xlink:href="#m5f7a0fab99" y="132.186756"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="396.654545" xlink:href="#m5f7a0fab99" y="122.564877"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="401.163636" xlink:href="#m5f7a0fab99" y="114.180196"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="405.672727" xlink:href="#m5f7a0fab99" y="107.129599"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="410.181818" xlink:href="#m5f7a0fab99" y="101.496852"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="414.690909" xlink:href="#m5f7a0fab99" y="97.351616"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="419.2" xlink:href="#m5f7a0fab99" y="94.748615"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="423.709091" xlink:href="#m5f7a0fab99" y="93.726951"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="428.218182" xlink:href="#m5f7a0fab99" y="94.309579"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#m5f7a0fab99" y="96.502943"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="437.236364" xlink:href="#m5f7a0fab99" y="100.296794"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="441.745455" xlink:href="#m5f7a0fab99" y="105.664168"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="446.254545" xlink:href="#m5f7a0fab99" y="112.56155"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="450.763636" xlink:href="#m5f7a0fab99" y="120.92921"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="455.272727" xlink:href="#m5f7a0fab99" y="130.691705"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="459.781818" xlink:href="#m5f7a0fab99" y="141.75856"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="464.290909" xlink:href="#m5f7a0fab99" y="154.025101"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="468.8" xlink:href="#m5f7a0fab99" y="167.373449"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="473.309091" xlink:href="#m5f7a0fab99" y="181.673656"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#m5f7a0fab99" y="196.784976"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="482.327273" xlink:href="#m5f7a0fab99" y="212.557255"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="486.836364" xlink:href="#m5f7a0fab99" y="228.832435"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="491.345455" xlink:href="#m5f7a0fab99" y="245.446139"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="495.854545" xlink:href="#m5f7a0fab99" y="262.229348"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="500.363636" xlink:href="#m5f7a0fab99" y="279.010121"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="504.872727" xlink:href="#m5f7a0fab99" y="295.61537"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="509.381818" xlink:href="#m5f7a0fab99" y="311.872651"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="513.890909" xlink:href="#m5f7a0fab99" y="327.611962"/>
+     <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="518.4" xlink:href="#m5f7a0fab99" y="342.667524"/>
     </g>
    </g>
    <g id="line2d_3">
-    <path clip-path="url(#p0eedb6d240)" d="M 72 250.56 
+    <path clip-path="url(#pd7f52cb7d8)" d="M 72 250.56 
 L 76.509091 240.603932 
 L 81.018182 230.554177 
 L 85.527273 220.518979 
@@ -565,23 +565,23 @@ L 3 3
 L 3 -3 
 L -3 -3 
 z
-" id="m5a1be13dac" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
+" id="m88efd6ac17" style="stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p0eedb6d240)">
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#m5a1be13dac" y="250.56"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#m5a1be13dac" y="159.798986"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#m5a1be13dac" y="146.234297"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#m5a1be13dac" y="236.80193"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#m5a1be13dac" y="353.423324"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#m5a1be13dac" y="381.301936"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#m5a1be13dac" y="282.653419"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#m5a1be13dac" y="142.936925"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#m5a1be13dac" y="96.502943"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#m5a1be13dac" y="196.784976"/>
+    <g clip-path="url(#pd7f52cb7d8)">
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="72" xlink:href="#m88efd6ac17" y="250.56"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="117.090909" xlink:href="#m88efd6ac17" y="159.798986"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="162.181818" xlink:href="#m88efd6ac17" y="146.234297"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="207.272727" xlink:href="#m88efd6ac17" y="236.80193"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="252.363636" xlink:href="#m88efd6ac17" y="353.423324"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="297.454545" xlink:href="#m88efd6ac17" y="381.301936"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="342.545455" xlink:href="#m88efd6ac17" y="282.653419"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="387.636364" xlink:href="#m88efd6ac17" y="142.936925"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="432.727273" xlink:href="#m88efd6ac17" y="96.502943"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="477.818182" xlink:href="#m88efd6ac17" y="196.784976"/>
     </g>
    </g>
    <g id="line2d_4">
-    <path clip-path="url(#p0eedb6d240)" d="M 72 250.56 
+    <path clip-path="url(#pd7f52cb7d8)" d="M 72 250.56 
 L 76.509091 240.603932 
 L 81.018182 230.554177 
 L 85.527273 220.518979 
@@ -687,14 +687,14 @@ L 518.4 342.667524
 L 3 0 
 M 0 3 
 L 0 -3 
-" id="mab8d09bdce" style="stroke:#00bfbf;stroke-width:0.5;"/>
+" id="mb4ac259b61" style="stroke:#00bfbf;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p0eedb6d240)">
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="94.545455" xlink:href="#mab8d09bdce" y="200.93202"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="184.727273" xlink:href="#mab8d09bdce" y="181.239512"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="274.909091" xlink:href="#mab8d09bdce" y="383.744122"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="365.090909" xlink:href="#mab8d09bdce" y="209.121664"/>
-     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="455.272727" xlink:href="#mab8d09bdce" y="130.691705"/>
+    <g clip-path="url(#pd7f52cb7d8)">
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="94.545455" xlink:href="#mb4ac259b61" y="200.93202"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="184.727273" xlink:href="#mb4ac259b61" y="181.239512"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="274.909091" xlink:href="#mb4ac259b61" y="383.744122"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="365.090909" xlink:href="#mb4ac259b61" y="209.121664"/>
+     <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="455.272727" xlink:href="#mb4ac259b61" y="130.691705"/>
     </g>
    </g>
    <g id="patch_3">
@@ -723,80 +723,80 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m41ccaebf9c" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m116d6a5ea8" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m41ccaebf9c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m116d6a5ea8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="mf4608e5d0d" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m4c4a231df1" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf4608e5d0d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4c4a231df1" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m41ccaebf9c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m116d6a5ea8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mf4608e5d0d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m4c4a231df1" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m41ccaebf9c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m116d6a5ea8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mf4608e5d0d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m4c4a231df1" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m41ccaebf9c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m116d6a5ea8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mf4608e5d0d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m4c4a231df1" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m41ccaebf9c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m116d6a5ea8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mf4608e5d0d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m4c4a231df1" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_15">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m41ccaebf9c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m116d6a5ea8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf4608e5d0d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m4c4a231df1" y="43.2"/>
       </g>
      </g>
     </g>
@@ -807,102 +807,102 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m16eb309809" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mddc199f271" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m16eb309809" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mddc199f271" y="388.8"/>
       </g>
      </g>
      <g id="line2d_18">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="mb1f3e42fd9" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m45687904ac" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb1f3e42fd9" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m45687904ac" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m16eb309809" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mddc199f271" y="319.68"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb1f3e42fd9" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m45687904ac" y="319.68"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m16eb309809" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mddc199f271" y="250.56"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb1f3e42fd9" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m45687904ac" y="250.56"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m16eb309809" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mddc199f271" y="181.44"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb1f3e42fd9" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m45687904ac" y="181.44"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m16eb309809" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mddc199f271" y="112.32"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb1f3e42fd9" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m45687904ac" y="112.32"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m16eb309809" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mddc199f271" y="43.2"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb1f3e42fd9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m45687904ac" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 261.20375 139.1775 
-L 511.2 139.1775 
+     <path d="M 260.92125 139.266 
+L 511.2 139.266 
 L 511.2 50.4 
-L 261.20375 50.4 
+L 260.92125 50.4 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_29">
-     <path d="M 271.28375 62.06175 
-L 291.44375 62.06175 
+     <path d="M 271.00125 62.06175 
+L 291.16125 62.06175 
 " style="fill:none;stroke:#0000ff;stroke-linecap:square;"/>
     </g>
     <g id="line2d_30">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="271.28375" xlink:href="#m2fc0b09e3a" y="62.06175"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="291.44375" xlink:href="#m2fc0b09e3a" y="62.06175"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="271.00125" xlink:href="#m2824b38e85" y="62.06175"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="291.16125" xlink:href="#m2824b38e85" y="62.06175"/>
      </g>
     </g>
     <g id="text_1">
@@ -1053,7 +1053,7 @@ L 9.28125 70.21875
 z
 " id="DejaVuSans-74"/>
      </defs>
-     <g transform="translate(307.28375 67.10175)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 67.10175)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-64"/>
       <use x="63.476562" xlink:href="#DejaVuSans-65"/>
       <use x="125" xlink:href="#DejaVuSans-66"/>
@@ -1064,14 +1064,14 @@ z
      </g>
     </g>
     <g id="line2d_31">
-     <path d="M 271.28375 83.19825 
-L 291.44375 83.19825 
+     <path d="M 271.00125 83.19825 
+L 291.16125 83.19825 
 " style="fill:none;stroke:#008000;stroke-linecap:square;"/>
     </g>
     <g id="line2d_32">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.28375" xlink:href="#mcbc28bf52d" y="83.19825"/>
-      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.44375" xlink:href="#mcbc28bf52d" y="83.19825"/>
+      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.00125" xlink:href="#m5f7a0fab99" y="83.19825"/>
+      <use style="fill:#008000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.16125" xlink:href="#m5f7a0fab99" y="83.19825"/>
      </g>
     </g>
     <g id="text_2">
@@ -1137,7 +1137,7 @@ z
 " id="DejaVuSans-6b"/>
       <path id="DejaVuSans-20"/>
      </defs>
-     <g transform="translate(307.28375 88.23825)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 88.23825)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-61"/>
       <use x="158.691406" xlink:href="#DejaVuSans-72"/>
@@ -1149,14 +1149,14 @@ z
      </g>
     </g>
     <g id="line2d_33">
-     <path d="M 271.28375 104.33475 
-L 291.44375 104.33475 
+     <path d="M 271.00125 104.33475 
+L 291.16125 104.33475 
 " style="fill:none;stroke:#ff0000;stroke-linecap:square;"/>
     </g>
     <g id="line2d_34">
      <g>
-      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.28375" xlink:href="#m5a1be13dac" y="104.33475"/>
-      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.44375" xlink:href="#m5a1be13dac" y="104.33475"/>
+      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="271.00125" xlink:href="#m88efd6ac17" y="104.33475"/>
+      <use style="fill:#ff0000;stroke:#000000;stroke-linejoin:miter;stroke-width:0.5;" x="291.16125" xlink:href="#m88efd6ac17" y="104.33475"/>
      </g>
     </g>
     <g id="text_3">
@@ -1220,7 +1220,7 @@ Q 6.59375 54.828125 13.0625 64.515625
 Q 19.53125 74.21875 31.78125 74.21875 
 " id="DejaVuSans-30"/>
      </defs>
-     <g transform="translate(307.28375 109.37475)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 109.37475)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-61"/>
       <use x="158.691406" xlink:href="#DejaVuSans-72"/>
@@ -1237,14 +1237,14 @@ Q 19.53125 74.21875 31.78125 74.21875
      </g>
     </g>
     <g id="line2d_35">
-     <path d="M 271.28375 125.47125 
-L 291.44375 125.47125 
+     <path d="M 271.00125 125.47125 
+L 291.16125 125.47125 
 " style="fill:none;stroke:#00bfbf;stroke-linecap:square;"/>
     </g>
     <g id="line2d_36">
      <g>
-      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="271.28375" xlink:href="#mab8d09bdce" y="125.47125"/>
-      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="291.44375" xlink:href="#mab8d09bdce" y="125.47125"/>
+      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="271.00125" xlink:href="#mb4ac259b61" y="125.47125"/>
+      <use style="fill:#00bfbf;stroke:#00bfbf;stroke-width:0.5;" x="291.16125" xlink:href="#mb4ac259b61" y="125.47125"/>
      </g>
     </g>
     <g id="text_4">
@@ -1366,7 +1366,7 @@ L 54.390625 54.6875
 z
 " id="DejaVuSans-67"/>
      </defs>
-     <g transform="translate(307.28375 130.51125)scale(0.144 -0.144)">
+     <g transform="translate(307.00125 130.51125)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-61"/>
       <use x="158.691406" xlink:href="#DejaVuSans-72"/>
@@ -1400,7 +1400,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p0eedb6d240">
+  <clipPath id="pd7f52cb7d8">
    <rect height="345.6" width="446.4" x="72" y="43.2"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_legend/fancy.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/fancy.svg
@@ -38,87 +38,87 @@ C -2.000462 -1.161816 -2.236068 -0.593012 -2.236068 0
 C -2.236068 0.593012 -2.000462 1.161816 -1.581139 1.581139 
 C -1.161816 2.000462 -0.593012 2.236068 0 2.236068 
 z
-" id="m2ec9b9bc79" style="stroke:#000000;"/>
+" id="m27675ac663" style="stroke:#000000;"/>
     </defs>
-    <g clip-path="url(#p1a9c45eaec)">
-     <use style="fill:#0000ff;stroke:#000000;" x="105.818181818" xlink:href="#m2ec9b9bc79" y="92.5714285714"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="122.727272727" xlink:href="#m2ec9b9bc79" y="117.257142857"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="139.636363636" xlink:href="#m2ec9b9bc79" y="141.942857143"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="156.545454545" xlink:href="#m2ec9b9bc79" y="166.628571429"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="173.454545455" xlink:href="#m2ec9b9bc79" y="191.314285714"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="190.363636364" xlink:href="#m2ec9b9bc79" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="207.272727273" xlink:href="#m2ec9b9bc79" y="240.685714286"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="224.181818182" xlink:href="#m2ec9b9bc79" y="265.371428571"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="241.090909091" xlink:href="#m2ec9b9bc79" y="290.057142857"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="258.0" xlink:href="#m2ec9b9bc79" y="314.742857143"/>
+    <g clip-path="url(#p99d3117ecb)">
+     <use style="fill:#0000ff;stroke:#000000;" x="105.818182" xlink:href="#m27675ac663" y="92.571429"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="122.727273" xlink:href="#m27675ac663" y="117.257143"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="139.636364" xlink:href="#m27675ac663" y="141.942857"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="156.545455" xlink:href="#m27675ac663" y="166.628571"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="173.454545" xlink:href="#m27675ac663" y="191.314286"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="190.363636" xlink:href="#m27675ac663" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="207.272727" xlink:href="#m27675ac663" y="240.685714"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="224.181818" xlink:href="#m27675ac663" y="265.371429"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="241.090909" xlink:href="#m27675ac663" y="290.057143"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="258" xlink:href="#m27675ac663" y="314.742857"/>
     </g>
    </g>
    <g id="LineCollection_1">
-    <path clip-path="url(#p1a9c45eaec)" d="M 97.363636 339.428571 
+    <path clip-path="url(#p99d3117ecb)" d="M 97.363636 339.428571 
 L 114.272727 339.428571 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 114.272727 314.742857 
+    <path clip-path="url(#p99d3117ecb)" d="M 114.272727 314.742857 
 L 131.181818 314.742857 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 131.181818 290.057143 
+    <path clip-path="url(#p99d3117ecb)" d="M 131.181818 290.057143 
 L 148.090909 290.057143 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 148.090909 265.371429 
+    <path clip-path="url(#p99d3117ecb)" d="M 148.090909 265.371429 
 L 165 265.371429 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 165 240.685714 
+    <path clip-path="url(#p99d3117ecb)" d="M 165 240.685714 
 L 181.909091 240.685714 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 181.909091 216 
+    <path clip-path="url(#p99d3117ecb)" d="M 181.909091 216 
 L 198.818182 216 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 198.818182 191.314286 
+    <path clip-path="url(#p99d3117ecb)" d="M 198.818182 191.314286 
 L 215.727273 191.314286 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 215.727273 166.628571 
+    <path clip-path="url(#p99d3117ecb)" d="M 215.727273 166.628571 
 L 232.636364 166.628571 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 232.636364 141.942857 
+    <path clip-path="url(#p99d3117ecb)" d="M 232.636364 141.942857 
 L 249.545455 141.942857 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 249.545455 117.257143 
+    <path clip-path="url(#p99d3117ecb)" d="M 249.545455 117.257143 
 L 266.454545 117.257143 
 " style="fill:none;stroke:#008000;"/>
    </g>
    <g id="LineCollection_2">
-    <path clip-path="url(#p1a9c45eaec)" d="M 105.818182 351.771429 
+    <path clip-path="url(#p99d3117ecb)" d="M 105.818182 351.771429 
 L 105.818182 327.085714 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 122.727273 327.085714 
+    <path clip-path="url(#p99d3117ecb)" d="M 122.727273 327.085714 
 L 122.727273 302.4 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 139.636364 302.4 
+    <path clip-path="url(#p99d3117ecb)" d="M 139.636364 302.4 
 L 139.636364 277.714286 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 156.545455 277.714286 
+    <path clip-path="url(#p99d3117ecb)" d="M 156.545455 277.714286 
 L 156.545455 253.028571 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 173.454545 253.028571 
+    <path clip-path="url(#p99d3117ecb)" d="M 173.454545 253.028571 
 L 173.454545 228.342857 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 190.363636 228.342857 
+    <path clip-path="url(#p99d3117ecb)" d="M 190.363636 228.342857 
 L 190.363636 203.657143 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 207.272727 203.657143 
+    <path clip-path="url(#p99d3117ecb)" d="M 207.272727 203.657143 
 L 207.272727 178.971429 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 224.181818 178.971429 
+    <path clip-path="url(#p99d3117ecb)" d="M 224.181818 178.971429 
 L 224.181818 154.285714 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 241.090909 154.285714 
+    <path clip-path="url(#p99d3117ecb)" d="M 241.090909 154.285714 
 L 241.090909 129.6 
 " style="fill:none;stroke:#008000;"/>
-    <path clip-path="url(#p1a9c45eaec)" d="M 258 129.6 
+    <path clip-path="url(#p99d3117ecb)" d="M 258 129.6 
 L 258 104.914286 
 " style="fill:none;stroke:#008000;"/>
    </g>
    <g id="line2d_1">
-    <path clip-path="url(#p1a9c45eaec)" d="M 105.818182 216 
+    <path clip-path="url(#p99d3117ecb)" d="M 105.818182 216 
 L 122.727273 216 
 L 139.636364 216 
 L 156.545455 216 
@@ -128,7 +128,7 @@ L 207.272727 216
 L 224.181818 216 
 L 241.090909 216 
 L 258 216 
-" style="fill:none;stroke:#0000ff;stroke-dasharray:6.000000,6.000000;stroke-dashoffset:0.0;"/>
+" style="fill:none;stroke:#0000ff;stroke-dasharray:6,6;stroke-dashoffset:0;"/>
     <defs>
      <path d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
@@ -140,89 +140,89 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="m2c9e9e07fc" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m83e9afba35" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p1a9c45eaec)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="105.818181818" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="122.727272727" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="139.636363636" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="156.545454545" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="173.454545455" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="190.363636364" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="207.272727273" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="224.181818182" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="241.090909091" xlink:href="#m2c9e9e07fc" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="258.0" xlink:href="#m2c9e9e07fc" y="216.0"/>
+    <g clip-path="url(#p99d3117ecb)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="122.727273" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="156.545455" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="190.363636" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="224.181818" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m83e9afba35" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="258" xlink:href="#m83e9afba35" y="216"/>
     </g>
    </g>
    <g id="line2d_2">
     <defs>
      <path d="M 0 3 
 L 0 -3 
-" id="m0a9ea99b5c" style="stroke:#008000;stroke-width:0.500000;"/>
+" id="m632805ea67" style="stroke:#008000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p1a9c45eaec)">
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="97.3636363636" xlink:href="#m0a9ea99b5c" y="339.428571429"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="114.272727273" xlink:href="#m0a9ea99b5c" y="314.742857143"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="131.181818182" xlink:href="#m0a9ea99b5c" y="290.057142857"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="148.090909091" xlink:href="#m0a9ea99b5c" y="265.371428571"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="165.0" xlink:href="#m0a9ea99b5c" y="240.685714286"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="181.909090909" xlink:href="#m0a9ea99b5c" y="216.0"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="198.818181818" xlink:href="#m0a9ea99b5c" y="191.314285714"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="215.727272727" xlink:href="#m0a9ea99b5c" y="166.628571429"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="232.636363636" xlink:href="#m0a9ea99b5c" y="141.942857143"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="249.545454545" xlink:href="#m0a9ea99b5c" y="117.257142857"/>
+    <g clip-path="url(#p99d3117ecb)">
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="97.363636" xlink:href="#m632805ea67" y="339.428571"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="114.272727" xlink:href="#m632805ea67" y="314.742857"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="131.181818" xlink:href="#m632805ea67" y="290.057143"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="148.090909" xlink:href="#m632805ea67" y="265.371429"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="165" xlink:href="#m632805ea67" y="240.685714"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="181.909091" xlink:href="#m632805ea67" y="216"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="198.818182" xlink:href="#m632805ea67" y="191.314286"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="215.727273" xlink:href="#m632805ea67" y="166.628571"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="232.636364" xlink:href="#m632805ea67" y="141.942857"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="249.545455" xlink:href="#m632805ea67" y="117.257143"/>
     </g>
    </g>
    <g id="line2d_3">
-    <g clip-path="url(#p1a9c45eaec)">
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="114.272727273" xlink:href="#m0a9ea99b5c" y="339.428571429"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="131.181818182" xlink:href="#m0a9ea99b5c" y="314.742857143"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="148.090909091" xlink:href="#m0a9ea99b5c" y="290.057142857"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="165.0" xlink:href="#m0a9ea99b5c" y="265.371428571"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="181.909090909" xlink:href="#m0a9ea99b5c" y="240.685714286"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="198.818181818" xlink:href="#m0a9ea99b5c" y="216.0"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="215.727272727" xlink:href="#m0a9ea99b5c" y="191.314285714"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="232.636363636" xlink:href="#m0a9ea99b5c" y="166.628571429"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="249.545454545" xlink:href="#m0a9ea99b5c" y="141.942857143"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="266.454545455" xlink:href="#m0a9ea99b5c" y="117.257142857"/>
+    <g clip-path="url(#p99d3117ecb)">
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="114.272727" xlink:href="#m632805ea67" y="339.428571"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="131.181818" xlink:href="#m632805ea67" y="314.742857"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="148.090909" xlink:href="#m632805ea67" y="290.057143"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="165" xlink:href="#m632805ea67" y="265.371429"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="181.909091" xlink:href="#m632805ea67" y="240.685714"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="198.818182" xlink:href="#m632805ea67" y="216"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="215.727273" xlink:href="#m632805ea67" y="191.314286"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="232.636364" xlink:href="#m632805ea67" y="166.628571"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="249.545455" xlink:href="#m632805ea67" y="141.942857"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="266.454545" xlink:href="#m632805ea67" y="117.257143"/>
     </g>
    </g>
    <g id="line2d_4">
     <defs>
      <path d="M 3 0 
 L -3 -0 
-" id="m49d836aba8" style="stroke:#008000;stroke-width:0.500000;"/>
+" id="mf2f92b29a1" style="stroke:#008000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p1a9c45eaec)">
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="105.818181818" xlink:href="#m49d836aba8" y="351.771428571"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="122.727272727" xlink:href="#m49d836aba8" y="327.085714286"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="139.636363636" xlink:href="#m49d836aba8" y="302.4"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="156.545454545" xlink:href="#m49d836aba8" y="277.714285714"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="173.454545455" xlink:href="#m49d836aba8" y="253.028571429"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="190.363636364" xlink:href="#m49d836aba8" y="228.342857143"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="207.272727273" xlink:href="#m49d836aba8" y="203.657142857"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="224.181818182" xlink:href="#m49d836aba8" y="178.971428571"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="241.090909091" xlink:href="#m49d836aba8" y="154.285714286"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="258.0" xlink:href="#m49d836aba8" y="129.6"/>
+    <g clip-path="url(#p99d3117ecb)">
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="105.818182" xlink:href="#mf2f92b29a1" y="351.771429"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="122.727273" xlink:href="#mf2f92b29a1" y="327.085714"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="139.636364" xlink:href="#mf2f92b29a1" y="302.4"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="156.545455" xlink:href="#mf2f92b29a1" y="277.714286"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="173.454545" xlink:href="#mf2f92b29a1" y="253.028571"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="190.363636" xlink:href="#mf2f92b29a1" y="228.342857"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="207.272727" xlink:href="#mf2f92b29a1" y="203.657143"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="224.181818" xlink:href="#mf2f92b29a1" y="178.971429"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="241.090909" xlink:href="#mf2f92b29a1" y="154.285714"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="258" xlink:href="#mf2f92b29a1" y="129.6"/>
     </g>
    </g>
    <g id="line2d_5">
-    <g clip-path="url(#p1a9c45eaec)">
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="105.818181818" xlink:href="#m49d836aba8" y="327.085714286"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="122.727272727" xlink:href="#m49d836aba8" y="302.4"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="139.636363636" xlink:href="#m49d836aba8" y="277.714285714"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="156.545454545" xlink:href="#m49d836aba8" y="253.028571429"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="173.454545455" xlink:href="#m49d836aba8" y="228.342857143"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="190.363636364" xlink:href="#m49d836aba8" y="203.657142857"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="207.272727273" xlink:href="#m49d836aba8" y="178.971428571"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="224.181818182" xlink:href="#m49d836aba8" y="154.285714286"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="241.090909091" xlink:href="#m49d836aba8" y="129.6"/>
-     <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="258.0" xlink:href="#m49d836aba8" y="104.914285714"/>
+    <g clip-path="url(#p99d3117ecb)">
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="105.818182" xlink:href="#mf2f92b29a1" y="327.085714"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="122.727273" xlink:href="#mf2f92b29a1" y="302.4"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="139.636364" xlink:href="#mf2f92b29a1" y="277.714286"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="156.545455" xlink:href="#mf2f92b29a1" y="253.028571"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="173.454545" xlink:href="#mf2f92b29a1" y="228.342857"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="190.363636" xlink:href="#mf2f92b29a1" y="203.657143"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="207.272727" xlink:href="#mf2f92b29a1" y="178.971429"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="224.181818" xlink:href="#mf2f92b29a1" y="154.285714"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="241.090909" xlink:href="#mf2f92b29a1" y="129.6"/>
+     <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="258" xlink:href="#mf2f92b29a1" y="104.914286"/>
     </g>
    </g>
    <g id="line2d_6">
-    <path clip-path="url(#p1a9c45eaec)" d="M 105.818182 339.428571 
+    <path clip-path="url(#p99d3117ecb)" d="M 105.818182 339.428571 
 L 122.727273 314.742857 
 L 139.636364 290.057143 
 L 156.545455 265.371429 
@@ -260,92 +260,92 @@ L 274.909091 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="med7cff0d33" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m32de9dd134" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#med7cff0d33" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m32de9dd134" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m2af37955a9" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m8a9609bd6e" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m2af37955a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8a9609bd6e" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="105.818181818" xlink:href="#med7cff0d33" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m32de9dd134" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="105.818181818" xlink:href="#m2af37955a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m8a9609bd6e" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="139.636363636" xlink:href="#med7cff0d33" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m32de9dd134" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="139.636363636" xlink:href="#m2af37955a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m8a9609bd6e" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="173.454545455" xlink:href="#med7cff0d33" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m32de9dd134" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="173.454545455" xlink:href="#m2af37955a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m8a9609bd6e" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_15">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="207.272727273" xlink:href="#med7cff0d33" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m32de9dd134" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="207.272727273" xlink:href="#m2af37955a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m8a9609bd6e" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="241.090909091" xlink:href="#med7cff0d33" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m32de9dd134" y="388.8"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="241.090909091" xlink:href="#m2af37955a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m8a9609bd6e" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#med7cff0d33" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m32de9dd134" y="388.8"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m2af37955a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m8a9609bd6e" y="43.2"/>
       </g>
      </g>
     </g>
@@ -356,122 +356,122 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m82540cdf45" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m00cc0744e5" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="388.8"/>
       </g>
      </g>
      <g id="line2d_22">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="md3aea5b045" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m76ad6f44c1" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="339.428571429"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="339.428571"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="339.428571429"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="339.428571"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="290.057142857"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="290.057143"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="290.057142857"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="290.057143"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="240.685714286"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="240.685714"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="240.685714286"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="240.685714"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_29">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="191.314285714"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="191.314286"/>
       </g>
      </g>
      <g id="line2d_30">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="191.314285714"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="191.314286"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_31">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="141.942857143"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="141.942857"/>
       </g>
      </g>
      <g id="line2d_32">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="141.942857143"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="141.942857"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_33">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="92.5714285714"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="92.571429"/>
       </g>
      </g>
      <g id="line2d_34">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="92.5714285714"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="92.571429"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_35">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m82540cdf45" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m00cc0744e5" y="43.2"/>
       </g>
      </g>
      <g id="line2d_36">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md3aea5b045" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m76ad6f44c1" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 284.109091 258.351688 
-L 444.444091 258.351688 
-L 444.444091 177.648312 
-L 284.109091 177.648312 
+     <path d="M 284.109091 258.7658 
+L 444.525091 258.7658 
+L 444.525091 177.2342 
+L 284.109091 177.2342 
 z
-" style="fill:#4c4c4c;opacity:0.500000;stroke:#4c4c4c;stroke-linejoin:miter;"/>
+" style="fill:#4c4c4c;opacity:0.5;stroke:#4c4c4c;stroke-linejoin:miter;"/>
     </g>
     <g id="patch_8">
-     <path d="M 282.109091 256.351688 
-L 442.444091 256.351688 
-L 442.444091 175.648312 
-L 282.109091 175.648312 
+     <path d="M 282.109091 256.7658 
+L 442.525091 256.7658 
+L 442.525091 175.2342 
+L 282.109091 175.2342 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -614,26 +614,26 @@ Q 22.953125 48.484375 18.875 42.84375
 Q 14.796875 37.203125 14.796875 27.296875 
 " id="DejaVuSans-64"/>
      </defs>
-     <g transform="translate(331.151591 190.533312)scale(0.120000 -0.120000)">
+     <g transform="translate(331.210841 190.112325)scale(0.12 -0.12)">
       <use xlink:href="#DejaVuSans-4d"/>
-      <use x="86.279296875" xlink:href="#DejaVuSans-79"/>
-      <use x="145.458984375" xlink:href="#DejaVuSans-20"/>
-      <use x="177.24609375" xlink:href="#DejaVuSans-6c"/>
-      <use x="205.029296875" xlink:href="#DejaVuSans-65"/>
-      <use x="266.552734375" xlink:href="#DejaVuSans-67"/>
-      <use x="330.029296875" xlink:href="#DejaVuSans-65"/>
-      <use x="391.552734375" xlink:href="#DejaVuSans-6e"/>
-      <use x="454.931640625" xlink:href="#DejaVuSans-64"/>
+      <use x="86.279297" xlink:href="#DejaVuSans-79"/>
+      <use x="145.458984" xlink:href="#DejaVuSans-20"/>
+      <use x="177.246094" xlink:href="#DejaVuSans-6c"/>
+      <use x="205.029297" xlink:href="#DejaVuSans-65"/>
+      <use x="266.552734" xlink:href="#DejaVuSans-67"/>
+      <use x="330.029297" xlink:href="#DejaVuSans-65"/>
+      <use x="391.552734" xlink:href="#DejaVuSans-6e"/>
+      <use x="454.931641" xlink:href="#DejaVuSans-64"/>
      </g>
     </g>
     <g id="line2d_37">
-     <path d="M 287.869091 206.135063 
-L 316.669091 206.135063 
-" style="fill:none;stroke:#0000ff;stroke-dasharray:6.000000,6.000000;stroke-dashoffset:0.0;"/>
+     <path d="M 287.869091 205.7097 
+L 316.669091 205.7097 
+" style="fill:none;stroke:#0000ff;stroke-dasharray:6,6;stroke-dashoffset:0;"/>
     </g>
     <g id="line2d_38">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="302.269090909" xlink:href="#m2c9e9e07fc" y="206.1350625"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="302.269091" xlink:href="#m83e9afba35" y="205.7097"/>
      </g>
     </g>
     <g id="text_2">
@@ -654,107 +654,107 @@ L 29 38.921875
 z
 " id="DejaVuSans-58"/>
      </defs>
-     <g transform="translate(328.189091 211.175062)scale(0.144000 -0.144000)">
+     <g transform="translate(328.189091 210.7497)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-58"/>
-      <use x="68.505859375" xlink:href="#DejaVuSans-58"/>
+      <use x="68.505859" xlink:href="#DejaVuSans-58"/>
      </g>
     </g>
     <g id="PathCollection_2">
-     <path d="M 292.189091 239.907693 
-C 292.782103 239.907693 293.350907 239.672087 293.77023 239.252764 
-C 294.189553 238.833441 294.425159 238.264637 294.425159 237.671625 
-C 294.425159 237.078613 294.189553 236.509809 293.77023 236.090486 
-C 293.350907 235.671163 292.782103 235.435557 292.189091 235.435557 
-C 291.596079 235.435557 291.027275 235.671163 290.607952 236.090486 
-C 290.188629 236.509809 289.953023 237.078613 289.953023 237.671625 
-C 289.953023 238.264637 290.188629 238.833441 290.607952 239.252764 
-C 291.027275 239.672087 291.596079 239.907693 292.189091 239.907693 
+     <path d="M 292.189091 239.902068 
+C 292.782103 239.902068 293.350907 239.666462 293.77023 239.247139 
+C 294.189553 238.827816 294.425159 238.259012 294.425159 237.666 
+C 294.425159 237.072988 294.189553 236.504184 293.77023 236.084861 
+C 293.350907 235.665538 292.782103 235.429932 292.189091 235.429932 
+C 291.596079 235.429932 291.027275 235.665538 290.607952 236.084861 
+C 290.188629 236.504184 289.953023 237.072988 289.953023 237.666 
+C 289.953023 238.259012 290.188629 238.827816 290.607952 239.247139 
+C 291.027275 239.666462 291.596079 239.902068 292.189091 239.902068 
 z
 " style="fill:#0000ff;stroke:#000000;"/>
-     <path d="M 302.269091 238.647693 
-C 302.862103 238.647693 303.430907 238.412087 303.85023 237.992764 
-C 304.269553 237.573441 304.505159 237.004637 304.505159 236.411625 
-C 304.505159 235.818613 304.269553 235.249809 303.85023 234.830486 
-C 303.430907 234.411163 302.862103 234.175557 302.269091 234.175557 
-C 301.676079 234.175557 301.107275 234.411163 300.687952 234.830486 
-C 300.268629 235.249809 300.033023 235.818613 300.033023 236.411625 
-C 300.033023 237.004637 300.268629 237.573441 300.687952 237.992764 
-C 301.107275 238.412087 301.676079 238.647693 302.269091 238.647693 
+     <path d="M 302.269091 238.642068 
+C 302.862103 238.642068 303.430907 238.406462 303.85023 237.987139 
+C 304.269553 237.567816 304.505159 236.999012 304.505159 236.406 
+C 304.505159 235.812988 304.269553 235.244184 303.85023 234.824861 
+C 303.430907 234.405538 302.862103 234.169932 302.269091 234.169932 
+C 301.676079 234.169932 301.107275 234.405538 300.687952 234.824861 
+C 300.268629 235.244184 300.033023 235.812988 300.033023 236.406 
+C 300.033023 236.999012 300.268629 237.567816 300.687952 237.987139 
+C 301.107275 238.406462 301.676079 238.642068 302.269091 238.642068 
 z
 " style="fill:#0000ff;stroke:#000000;"/>
-     <path d="M 312.349091 240.537693 
-C 312.942103 240.537693 313.510907 240.302087 313.93023 239.882764 
-C 314.349553 239.463441 314.585159 238.894637 314.585159 238.301625 
-C 314.585159 237.708613 314.349553 237.139809 313.93023 236.720486 
-C 313.510907 236.301163 312.942103 236.065557 312.349091 236.065557 
-C 311.756079 236.065557 311.187275 236.301163 310.767952 236.720486 
-C 310.348629 237.139809 310.113023 237.708613 310.113023 238.301625 
-C 310.113023 238.894637 310.348629 239.463441 310.767952 239.882764 
-C 311.187275 240.302087 311.756079 240.537693 312.349091 240.537693 
+     <path d="M 312.349091 240.532068 
+C 312.942103 240.532068 313.510907 240.296462 313.93023 239.877139 
+C 314.349553 239.457816 314.585159 238.889012 314.585159 238.296 
+C 314.585159 237.702988 314.349553 237.134184 313.93023 236.714861 
+C 313.510907 236.295538 312.942103 236.059932 312.349091 236.059932 
+C 311.756079 236.059932 311.187275 236.295538 310.767952 236.714861 
+C 310.348629 237.134184 310.113023 237.702988 310.113023 238.296 
+C 310.113023 238.889012 310.348629 239.457816 310.767952 239.877139 
+C 311.187275 240.296462 311.756079 240.532068 312.349091 240.532068 
 z
 " style="fill:#0000ff;stroke:#000000;"/>
     </g>
     <g id="text_3">
      <!-- XX -->
-     <g transform="translate(328.189091 231.560587)scale(0.144000 -0.144000)">
+     <g transform="translate(328.189091 231.8862)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-58"/>
-      <use x="68.505859375" xlink:href="#DejaVuSans-58"/>
+      <use x="68.505859" xlink:href="#DejaVuSans-58"/>
      </g>
      <!-- XX -->
-     <g transform="translate(328.189091 247.685437)scale(0.144000 -0.144000)">
+     <g transform="translate(328.189091 248.01105)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-58"/>
-      <use x="68.505859375" xlink:href="#DejaVuSans-58"/>
+      <use x="68.505859" xlink:href="#DejaVuSans-58"/>
      </g>
     </g>
     <g id="LineCollection_3">
-     <path d="M 383.876591 206.135063 
-L 398.276591 206.135063 
+     <path d="M 383.917091 205.7097 
+L 398.317091 205.7097 
 " style="fill:none;stroke:#008000;"/>
     </g>
     <g id="LineCollection_4">
-     <path d="M 391.076591 213.335062 
-L 391.076591 198.935062 
+     <path d="M 391.117091 212.9097 
+L 391.117091 198.5097 
 " style="fill:none;stroke:#008000;"/>
     </g>
     <g id="line2d_39">
      <g>
-      <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="383.876590909" xlink:href="#m0a9ea99b5c" y="206.1350625"/>
+      <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="383.917091" xlink:href="#m632805ea67" y="205.7097"/>
      </g>
     </g>
     <g id="line2d_40">
      <g>
-      <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="398.276590909" xlink:href="#m0a9ea99b5c" y="206.1350625"/>
+      <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="398.317091" xlink:href="#m632805ea67" y="205.7097"/>
      </g>
     </g>
     <g id="line2d_41">
      <g>
-      <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="391.076590909" xlink:href="#m49d836aba8" y="213.3350625"/>
+      <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="391.117091" xlink:href="#mf2f92b29a1" y="212.9097"/>
      </g>
     </g>
     <g id="line2d_42">
      <g>
-      <use style="fill:#008000;stroke:#008000;stroke-width:0.500000;" x="391.076590909" xlink:href="#m49d836aba8" y="198.9350625"/>
+      <use style="fill:#008000;stroke:#008000;stroke-width:0.5;" x="391.117091" xlink:href="#mf2f92b29a1" y="198.5097"/>
      </g>
     </g>
     <g id="line2d_43">
-     <path d="M 376.676591 206.135063 
-L 405.476591 206.135063 
+     <path d="M 376.717091 205.7097 
+L 405.517091 205.7097 
 " style="fill:none;stroke:#008000;stroke-linecap:square;"/>
     </g>
     <g id="line2d_44"/>
     <g id="text_4">
      <!-- XX -->
-     <g transform="translate(416.996591 211.175062)scale(0.144000 -0.144000)">
+     <g transform="translate(417.037091 210.7497)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-58"/>
-      <use x="68.505859375" xlink:href="#DejaVuSans-58"/>
+      <use x="68.505859" xlink:href="#DejaVuSans-58"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1a9c45eaec">
-   <rect height="345.6" width="202.909090909" x="72.0" y="43.2"/>
+  <clipPath id="p99d3117ecb">
+   <rect height="345.6" width="202.909091" x="72" y="43.2"/>
   </clipPath>
  </defs>
 </svg>

--- a/lib/matplotlib/tests/baseline_images/test_legend/framealpha.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/framealpha.svg
@@ -27,7 +27,7 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="line2d_1">
-    <path clip-path="url(#p01e2f8305d)" d="M 76.464 385.344 
+    <path clip-path="url(#p93cfadde4b)" d="M 76.464 385.344 
 L 80.928 381.888 
 L 85.392 378.432 
 L 89.856 374.976 
@@ -155,80 +155,80 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m67c16d98ac" style="stroke:#000000;stroke-width:0.5;"/>
+" id="medc72a6524" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m67c16d98ac" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#medc72a6524" y="388.8"/>
       </g>
      </g>
      <g id="line2d_3">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m712beb4c17" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m0a07e70d89" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m712beb4c17" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m0a07e70d89" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m67c16d98ac" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#medc72a6524" y="388.8"/>
       </g>
      </g>
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m712beb4c17" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m0a07e70d89" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m67c16d98ac" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#medc72a6524" y="388.8"/>
       </g>
      </g>
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m712beb4c17" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m0a07e70d89" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m67c16d98ac" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#medc72a6524" y="388.8"/>
       </g>
      </g>
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m712beb4c17" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m0a07e70d89" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m67c16d98ac" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#medc72a6524" y="388.8"/>
       </g>
      </g>
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m712beb4c17" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m0a07e70d89" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m67c16d98ac" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#medc72a6524" y="388.8"/>
       </g>
      </g>
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m712beb4c17" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0a07e70d89" y="43.2"/>
       </g>
      </g>
     </g>
@@ -239,96 +239,96 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m44341230d4" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m0157d7a694" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m44341230d4" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m0157d7a694" y="388.8"/>
       </g>
      </g>
      <g id="line2d_15">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="mb3867c0b44" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m3785766d9c" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb3867c0b44" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m3785766d9c" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m44341230d4" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m0157d7a694" y="319.68"/>
       </g>
      </g>
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb3867c0b44" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m3785766d9c" y="319.68"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m44341230d4" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m0157d7a694" y="250.56"/>
       </g>
      </g>
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb3867c0b44" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m3785766d9c" y="250.56"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m44341230d4" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m0157d7a694" y="181.44"/>
       </g>
      </g>
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb3867c0b44" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m3785766d9c" y="181.44"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m44341230d4" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m0157d7a694" y="112.32"/>
       </g>
      </g>
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb3867c0b44" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m3785766d9c" y="112.32"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m44341230d4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m0157d7a694" y="43.2"/>
       </g>
      </g>
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mb3867c0b44" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m3785766d9c" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 402.063125 75.768 
-L 511.2 75.768 
+     <path d="M 401.98275 75.8565 
+L 511.2 75.8565 
 L 511.2 50.4 
-L 402.063125 50.4 
+L 401.98275 50.4 
 z
 " style="fill:#ffffff;opacity:0.5;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_26">
-     <path d="M 412.143125 62.06175 
-L 432.303125 62.06175 
+     <path d="M 412.06275 62.06175 
+L 432.22275 62.06175 
 " style="fill:none;stroke:#0000ff;stroke-linecap:square;stroke-width:10;"/>
     </g>
     <g id="line2d_27"/>
@@ -465,7 +465,7 @@ Q 15.875 39.890625 15.1875 32.171875
 z
 " id="DejaVuSans-65"/>
      </defs>
-     <g transform="translate(448.143125 67.10175)scale(0.144 -0.144)">
+     <g transform="translate(448.06275 67.10175)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use x="97.412109" xlink:href="#DejaVuSans-79"/>
       <use x="156.591797" xlink:href="#DejaVuSans-6c"/>
@@ -479,7 +479,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p01e2f8305d">
+  <clipPath id="p93cfadde4b">
    <rect height="345.6" width="446.4" x="72" y="43.2"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_legend/legend_auto1.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/legend_auto1.svg
@@ -38,109 +38,109 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="mee187e3765" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m7eacf8141d" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p2af9473b96)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mee187e3765" y="72"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#mee187e3765" y="74.88"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#mee187e3765" y="77.76"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#mee187e3765" y="80.64"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#mee187e3765" y="83.52"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#mee187e3765" y="86.4"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#mee187e3765" y="89.28"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#mee187e3765" y="92.16"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#mee187e3765" y="95.04"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#mee187e3765" y="97.92"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#mee187e3765" y="100.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#mee187e3765" y="103.68"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#mee187e3765" y="106.56"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#mee187e3765" y="109.44"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#mee187e3765" y="112.32"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#mee187e3765" y="115.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#mee187e3765" y="118.08"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#mee187e3765" y="120.96"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#mee187e3765" y="123.84"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#mee187e3765" y="126.72"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mee187e3765" y="129.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#mee187e3765" y="132.48"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#mee187e3765" y="135.36"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#mee187e3765" y="138.24"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#mee187e3765" y="141.12"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#mee187e3765" y="144"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#mee187e3765" y="146.88"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#mee187e3765" y="149.76"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#mee187e3765" y="152.64"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#mee187e3765" y="155.52"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#mee187e3765" y="158.4"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#mee187e3765" y="161.28"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#mee187e3765" y="164.16"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#mee187e3765" y="167.04"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#mee187e3765" y="169.92"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#mee187e3765" y="172.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#mee187e3765" y="175.68"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#mee187e3765" y="178.56"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#mee187e3765" y="181.44"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#mee187e3765" y="184.32"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mee187e3765" y="187.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#mee187e3765" y="190.08"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#mee187e3765" y="192.96"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#mee187e3765" y="195.84"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#mee187e3765" y="198.72"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#mee187e3765" y="201.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#mee187e3765" y="204.48"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#mee187e3765" y="207.36"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#mee187e3765" y="210.24"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#mee187e3765" y="213.12"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#mee187e3765" y="216"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#mee187e3765" y="218.88"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#mee187e3765" y="221.76"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#mee187e3765" y="224.64"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#mee187e3765" y="227.52"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#mee187e3765" y="230.4"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#mee187e3765" y="233.28"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#mee187e3765" y="236.16"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#mee187e3765" y="239.04"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#mee187e3765" y="241.92"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mee187e3765" y="244.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#mee187e3765" y="247.68"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#mee187e3765" y="250.56"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#mee187e3765" y="253.44"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#mee187e3765" y="256.32"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#mee187e3765" y="259.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#mee187e3765" y="262.08"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#mee187e3765" y="264.96"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#mee187e3765" y="267.84"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#mee187e3765" y="270.72"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#mee187e3765" y="273.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#mee187e3765" y="276.48"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#mee187e3765" y="279.36"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#mee187e3765" y="282.24"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#mee187e3765" y="285.12"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#mee187e3765" y="288"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#mee187e3765" y="290.88"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#mee187e3765" y="293.76"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#mee187e3765" y="296.64"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#mee187e3765" y="299.52"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mee187e3765" y="302.4"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#mee187e3765" y="305.28"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#mee187e3765" y="308.16"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#mee187e3765" y="311.04"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#mee187e3765" y="313.92"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#mee187e3765" y="316.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#mee187e3765" y="319.68"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#mee187e3765" y="322.56"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#mee187e3765" y="325.44"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#mee187e3765" y="328.32"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#mee187e3765" y="331.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#mee187e3765" y="334.08"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#mee187e3765" y="336.96"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#mee187e3765" y="339.84"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#mee187e3765" y="342.72"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#mee187e3765" y="345.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#mee187e3765" y="348.48"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#mee187e3765" y="351.36"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#mee187e3765" y="354.24"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#mee187e3765" y="357.12"/>
+    <g clip-path="url(#pea87398402)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m7eacf8141d" y="72"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m7eacf8141d" y="74.88"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m7eacf8141d" y="77.76"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m7eacf8141d" y="80.64"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m7eacf8141d" y="83.52"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m7eacf8141d" y="86.4"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m7eacf8141d" y="89.28"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m7eacf8141d" y="92.16"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m7eacf8141d" y="95.04"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m7eacf8141d" y="97.92"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m7eacf8141d" y="100.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m7eacf8141d" y="103.68"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m7eacf8141d" y="106.56"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m7eacf8141d" y="109.44"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m7eacf8141d" y="112.32"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m7eacf8141d" y="115.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m7eacf8141d" y="118.08"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m7eacf8141d" y="120.96"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m7eacf8141d" y="123.84"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m7eacf8141d" y="126.72"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m7eacf8141d" y="129.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m7eacf8141d" y="132.48"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m7eacf8141d" y="135.36"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m7eacf8141d" y="138.24"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m7eacf8141d" y="141.12"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m7eacf8141d" y="144"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m7eacf8141d" y="146.88"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m7eacf8141d" y="149.76"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m7eacf8141d" y="152.64"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m7eacf8141d" y="155.52"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m7eacf8141d" y="158.4"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m7eacf8141d" y="161.28"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m7eacf8141d" y="164.16"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m7eacf8141d" y="167.04"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m7eacf8141d" y="169.92"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m7eacf8141d" y="172.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m7eacf8141d" y="175.68"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m7eacf8141d" y="178.56"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m7eacf8141d" y="181.44"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m7eacf8141d" y="184.32"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m7eacf8141d" y="187.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m7eacf8141d" y="190.08"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m7eacf8141d" y="192.96"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m7eacf8141d" y="195.84"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m7eacf8141d" y="198.72"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m7eacf8141d" y="201.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m7eacf8141d" y="204.48"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m7eacf8141d" y="207.36"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m7eacf8141d" y="210.24"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m7eacf8141d" y="213.12"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m7eacf8141d" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m7eacf8141d" y="218.88"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m7eacf8141d" y="221.76"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m7eacf8141d" y="224.64"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m7eacf8141d" y="227.52"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m7eacf8141d" y="230.4"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m7eacf8141d" y="233.28"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m7eacf8141d" y="236.16"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m7eacf8141d" y="239.04"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m7eacf8141d" y="241.92"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m7eacf8141d" y="244.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m7eacf8141d" y="247.68"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m7eacf8141d" y="250.56"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m7eacf8141d" y="253.44"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m7eacf8141d" y="256.32"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m7eacf8141d" y="259.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m7eacf8141d" y="262.08"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m7eacf8141d" y="264.96"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m7eacf8141d" y="267.84"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m7eacf8141d" y="270.72"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m7eacf8141d" y="273.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m7eacf8141d" y="276.48"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m7eacf8141d" y="279.36"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m7eacf8141d" y="282.24"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m7eacf8141d" y="285.12"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m7eacf8141d" y="288"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m7eacf8141d" y="290.88"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m7eacf8141d" y="293.76"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m7eacf8141d" y="296.64"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m7eacf8141d" y="299.52"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m7eacf8141d" y="302.4"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m7eacf8141d" y="305.28"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m7eacf8141d" y="308.16"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m7eacf8141d" y="311.04"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m7eacf8141d" y="313.92"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m7eacf8141d" y="316.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m7eacf8141d" y="319.68"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m7eacf8141d" y="322.56"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m7eacf8141d" y="325.44"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m7eacf8141d" y="328.32"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m7eacf8141d" y="331.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m7eacf8141d" y="334.08"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m7eacf8141d" y="336.96"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m7eacf8141d" y="339.84"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m7eacf8141d" y="342.72"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m7eacf8141d" y="345.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m7eacf8141d" y="348.48"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m7eacf8141d" y="351.36"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m7eacf8141d" y="354.24"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m7eacf8141d" y="357.12"/>
     </g>
    </g>
    <g id="line2d_2">
@@ -155,109 +155,109 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="m88dc45b409" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mc3995d4ecd" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p2af9473b96)">
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m88dc45b409" y="360"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m88dc45b409" y="357.12"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m88dc45b409" y="354.24"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m88dc45b409" y="351.36"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m88dc45b409" y="348.48"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m88dc45b409" y="345.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m88dc45b409" y="342.72"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m88dc45b409" y="339.84"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m88dc45b409" y="336.96"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m88dc45b409" y="334.08"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m88dc45b409" y="331.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m88dc45b409" y="328.32"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m88dc45b409" y="325.44"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m88dc45b409" y="322.56"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m88dc45b409" y="319.68"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m88dc45b409" y="316.8"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m88dc45b409" y="313.92"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m88dc45b409" y="311.04"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m88dc45b409" y="308.16"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m88dc45b409" y="305.28"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m88dc45b409" y="302.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m88dc45b409" y="299.52"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m88dc45b409" y="296.64"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m88dc45b409" y="293.76"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m88dc45b409" y="290.88"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m88dc45b409" y="288"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m88dc45b409" y="285.12"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m88dc45b409" y="282.24"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m88dc45b409" y="279.36"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m88dc45b409" y="276.48"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m88dc45b409" y="273.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m88dc45b409" y="270.72"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m88dc45b409" y="267.84"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m88dc45b409" y="264.96"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m88dc45b409" y="262.08"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m88dc45b409" y="259.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m88dc45b409" y="256.32"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m88dc45b409" y="253.44"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m88dc45b409" y="250.56"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m88dc45b409" y="247.68"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m88dc45b409" y="244.8"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m88dc45b409" y="241.92"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m88dc45b409" y="239.04"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m88dc45b409" y="236.16"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m88dc45b409" y="233.28"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m88dc45b409" y="230.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m88dc45b409" y="227.52"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m88dc45b409" y="224.64"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m88dc45b409" y="221.76"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m88dc45b409" y="218.88"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m88dc45b409" y="216"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m88dc45b409" y="213.12"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m88dc45b409" y="210.24"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m88dc45b409" y="207.36"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m88dc45b409" y="204.48"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m88dc45b409" y="201.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m88dc45b409" y="198.72"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m88dc45b409" y="195.84"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m88dc45b409" y="192.96"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m88dc45b409" y="190.08"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m88dc45b409" y="187.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m88dc45b409" y="184.32"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m88dc45b409" y="181.44"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m88dc45b409" y="178.56"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m88dc45b409" y="175.68"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m88dc45b409" y="172.8"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m88dc45b409" y="169.92"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m88dc45b409" y="167.04"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m88dc45b409" y="164.16"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m88dc45b409" y="161.28"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m88dc45b409" y="158.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m88dc45b409" y="155.52"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m88dc45b409" y="152.64"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m88dc45b409" y="149.76"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m88dc45b409" y="146.88"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m88dc45b409" y="144"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m88dc45b409" y="141.12"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m88dc45b409" y="138.24"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m88dc45b409" y="135.36"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m88dc45b409" y="132.48"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m88dc45b409" y="129.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m88dc45b409" y="126.72"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m88dc45b409" y="123.84"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m88dc45b409" y="120.96"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m88dc45b409" y="118.08"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m88dc45b409" y="115.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m88dc45b409" y="112.32"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m88dc45b409" y="109.44"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m88dc45b409" y="106.56"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m88dc45b409" y="103.68"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m88dc45b409" y="100.8"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m88dc45b409" y="97.92"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m88dc45b409" y="95.04"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m88dc45b409" y="92.16"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m88dc45b409" y="89.28"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m88dc45b409" y="86.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m88dc45b409" y="83.52"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m88dc45b409" y="80.64"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m88dc45b409" y="77.76"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m88dc45b409" y="74.88"/>
+    <g clip-path="url(#pea87398402)">
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mc3995d4ecd" y="360"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#mc3995d4ecd" y="357.12"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#mc3995d4ecd" y="354.24"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#mc3995d4ecd" y="351.36"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#mc3995d4ecd" y="348.48"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#mc3995d4ecd" y="345.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#mc3995d4ecd" y="342.72"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#mc3995d4ecd" y="339.84"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#mc3995d4ecd" y="336.96"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#mc3995d4ecd" y="334.08"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#mc3995d4ecd" y="331.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#mc3995d4ecd" y="328.32"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#mc3995d4ecd" y="325.44"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#mc3995d4ecd" y="322.56"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#mc3995d4ecd" y="319.68"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#mc3995d4ecd" y="316.8"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#mc3995d4ecd" y="313.92"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#mc3995d4ecd" y="311.04"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#mc3995d4ecd" y="308.16"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#mc3995d4ecd" y="305.28"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mc3995d4ecd" y="302.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#mc3995d4ecd" y="299.52"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#mc3995d4ecd" y="296.64"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#mc3995d4ecd" y="293.76"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#mc3995d4ecd" y="290.88"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#mc3995d4ecd" y="288"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#mc3995d4ecd" y="285.12"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#mc3995d4ecd" y="282.24"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#mc3995d4ecd" y="279.36"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#mc3995d4ecd" y="276.48"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#mc3995d4ecd" y="273.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#mc3995d4ecd" y="270.72"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#mc3995d4ecd" y="267.84"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#mc3995d4ecd" y="264.96"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#mc3995d4ecd" y="262.08"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#mc3995d4ecd" y="259.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#mc3995d4ecd" y="256.32"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#mc3995d4ecd" y="253.44"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#mc3995d4ecd" y="250.56"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#mc3995d4ecd" y="247.68"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mc3995d4ecd" y="244.8"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#mc3995d4ecd" y="241.92"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#mc3995d4ecd" y="239.04"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#mc3995d4ecd" y="236.16"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#mc3995d4ecd" y="233.28"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#mc3995d4ecd" y="230.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#mc3995d4ecd" y="227.52"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#mc3995d4ecd" y="224.64"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#mc3995d4ecd" y="221.76"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#mc3995d4ecd" y="218.88"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#mc3995d4ecd" y="216"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#mc3995d4ecd" y="213.12"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#mc3995d4ecd" y="210.24"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#mc3995d4ecd" y="207.36"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#mc3995d4ecd" y="204.48"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#mc3995d4ecd" y="201.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#mc3995d4ecd" y="198.72"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#mc3995d4ecd" y="195.84"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#mc3995d4ecd" y="192.96"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#mc3995d4ecd" y="190.08"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mc3995d4ecd" y="187.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#mc3995d4ecd" y="184.32"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#mc3995d4ecd" y="181.44"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#mc3995d4ecd" y="178.56"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#mc3995d4ecd" y="175.68"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#mc3995d4ecd" y="172.8"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#mc3995d4ecd" y="169.92"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#mc3995d4ecd" y="167.04"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#mc3995d4ecd" y="164.16"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#mc3995d4ecd" y="161.28"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#mc3995d4ecd" y="158.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#mc3995d4ecd" y="155.52"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#mc3995d4ecd" y="152.64"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#mc3995d4ecd" y="149.76"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#mc3995d4ecd" y="146.88"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#mc3995d4ecd" y="144"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#mc3995d4ecd" y="141.12"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#mc3995d4ecd" y="138.24"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#mc3995d4ecd" y="135.36"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#mc3995d4ecd" y="132.48"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mc3995d4ecd" y="129.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#mc3995d4ecd" y="126.72"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#mc3995d4ecd" y="123.84"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#mc3995d4ecd" y="120.96"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#mc3995d4ecd" y="118.08"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#mc3995d4ecd" y="115.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#mc3995d4ecd" y="112.32"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#mc3995d4ecd" y="109.44"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#mc3995d4ecd" y="106.56"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#mc3995d4ecd" y="103.68"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#mc3995d4ecd" y="100.8"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#mc3995d4ecd" y="97.92"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#mc3995d4ecd" y="95.04"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#mc3995d4ecd" y="92.16"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#mc3995d4ecd" y="89.28"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#mc3995d4ecd" y="86.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#mc3995d4ecd" y="83.52"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#mc3995d4ecd" y="80.64"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#mc3995d4ecd" y="77.76"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#mc3995d4ecd" y="74.88"/>
     </g>
    </g>
    <g id="patch_3">
@@ -286,80 +286,80 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m2250c0ee28" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m8ddb832080" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m2250c0ee28" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8ddb832080" y="388.8"/>
       </g>
      </g>
      <g id="line2d_4">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m146e8ccc2e" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mc999b5ce47" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m146e8ccc2e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mc999b5ce47" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m2250c0ee28" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m8ddb832080" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m146e8ccc2e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mc999b5ce47" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m2250c0ee28" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m8ddb832080" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m146e8ccc2e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mc999b5ce47" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m2250c0ee28" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m8ddb832080" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m146e8ccc2e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mc999b5ce47" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m2250c0ee28" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m8ddb832080" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m146e8ccc2e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mc999b5ce47" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2250c0ee28" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m8ddb832080" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m146e8ccc2e" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc999b5ce47" y="43.2"/>
       </g>
      </g>
     </g>
@@ -370,110 +370,110 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="mbe5cfa7a37" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mef78f1d744" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe5cfa7a37" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mef78f1d744" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="mde48ce3dec" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m91e46507ef" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde48ce3dec" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m91e46507ef" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe5cfa7a37" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mef78f1d744" y="331.2"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde48ce3dec" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m91e46507ef" y="331.2"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe5cfa7a37" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mef78f1d744" y="273.6"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde48ce3dec" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m91e46507ef" y="273.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe5cfa7a37" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mef78f1d744" y="216"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde48ce3dec" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m91e46507ef" y="216"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe5cfa7a37" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mef78f1d744" y="158.4"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde48ce3dec" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m91e46507ef" y="158.4"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe5cfa7a37" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mef78f1d744" y="100.8"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde48ce3dec" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m91e46507ef" y="100.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbe5cfa7a37" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mef78f1d744" y="43.2"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mde48ce3dec" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m91e46507ef" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 424.469375 239.25225 
-L 511.2 239.25225 
-L 511.2 192.74775 
-L 424.469375 192.74775 
+     <path d="M 424.413 239.2965 
+L 511.2 239.2965 
+L 511.2 192.7035 
+L 424.413 192.7035 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_29"/>
     <g id="line2d_30">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="434.549375" xlink:href="#mee187e3765" y="204.4095"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="454.709375" xlink:href="#mee187e3765" y="204.4095"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="434.493" xlink:href="#m7eacf8141d" y="204.36525"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="454.653" xlink:href="#m7eacf8141d" y="204.36525"/>
      </g>
     </g>
     <g id="text_1">
@@ -520,7 +520,7 @@ L 12.40625 0
 z
 " id="DejaVuSans-31"/>
      </defs>
-     <g transform="translate(470.549375 209.4495)scale(0.144 -0.144)">
+     <g transform="translate(470.493 209.40525)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-31"/>
@@ -529,8 +529,8 @@ z
     <g id="line2d_31"/>
     <g id="line2d_32">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="434.549375" xlink:href="#m88dc45b409" y="225.546"/>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="454.709375" xlink:href="#m88dc45b409" y="225.546"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="434.493" xlink:href="#mc3995d4ecd" y="225.50175"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="454.653" xlink:href="#mc3995d4ecd" y="225.50175"/>
      </g>
     </g>
     <g id="text_2">
@@ -543,7 +543,7 @@ L 4.890625 23.390625
 z
 " id="DejaVuSans-2d"/>
      </defs>
-     <g transform="translate(470.549375 230.586)scale(0.144 -0.144)">
+     <g transform="translate(470.493 230.54175)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-2d"/>
@@ -554,7 +554,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p2af9473b96">
+  <clipPath id="pea87398402">
    <rect height="345.6" width="446.4" x="72" y="43.2"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_legend/legend_auto2.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/legend_auto2.svg
@@ -27,7 +27,7 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="patch_3">
-    <path clip-path="url(#p406e489705)" d="M 72 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 72 388.8 
 L 75.5712 388.8 
 L 75.5712 388.8 
 L 72 388.8 
@@ -35,7 +35,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_4">
-    <path clip-path="url(#p406e489705)" d="M 76.464 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 76.464 388.8 
 L 80.0352 388.8 
 L 80.0352 385.344 
 L 76.464 385.344 
@@ -43,7 +43,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_5">
-    <path clip-path="url(#p406e489705)" d="M 80.928 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 80.928 388.8 
 L 84.4992 388.8 
 L 84.4992 381.888 
 L 80.928 381.888 
@@ -51,7 +51,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_6">
-    <path clip-path="url(#p406e489705)" d="M 85.392 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 85.392 388.8 
 L 88.9632 388.8 
 L 88.9632 378.432 
 L 85.392 378.432 
@@ -59,7 +59,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_7">
-    <path clip-path="url(#p406e489705)" d="M 89.856 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 89.856 388.8 
 L 93.4272 388.8 
 L 93.4272 374.976 
 L 89.856 374.976 
@@ -67,7 +67,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_8">
-    <path clip-path="url(#p406e489705)" d="M 94.32 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 94.32 388.8 
 L 97.8912 388.8 
 L 97.8912 371.52 
 L 94.32 371.52 
@@ -75,7 +75,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_9">
-    <path clip-path="url(#p406e489705)" d="M 98.784 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 98.784 388.8 
 L 102.3552 388.8 
 L 102.3552 368.064 
 L 98.784 368.064 
@@ -83,7 +83,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_10">
-    <path clip-path="url(#p406e489705)" d="M 103.248 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 103.248 388.8 
 L 106.8192 388.8 
 L 106.8192 364.608 
 L 103.248 364.608 
@@ -91,7 +91,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_11">
-    <path clip-path="url(#p406e489705)" d="M 107.712 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 107.712 388.8 
 L 111.2832 388.8 
 L 111.2832 361.152 
 L 107.712 361.152 
@@ -99,7 +99,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_12">
-    <path clip-path="url(#p406e489705)" d="M 112.176 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 112.176 388.8 
 L 115.7472 388.8 
 L 115.7472 357.696 
 L 112.176 357.696 
@@ -107,7 +107,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_13">
-    <path clip-path="url(#p406e489705)" d="M 116.64 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 116.64 388.8 
 L 120.2112 388.8 
 L 120.2112 354.24 
 L 116.64 354.24 
@@ -115,7 +115,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_14">
-    <path clip-path="url(#p406e489705)" d="M 121.104 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 121.104 388.8 
 L 124.6752 388.8 
 L 124.6752 350.784 
 L 121.104 350.784 
@@ -123,7 +123,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_15">
-    <path clip-path="url(#p406e489705)" d="M 125.568 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 125.568 388.8 
 L 129.1392 388.8 
 L 129.1392 347.328 
 L 125.568 347.328 
@@ -131,7 +131,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_16">
-    <path clip-path="url(#p406e489705)" d="M 130.032 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 130.032 388.8 
 L 133.6032 388.8 
 L 133.6032 343.872 
 L 130.032 343.872 
@@ -139,7 +139,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_17">
-    <path clip-path="url(#p406e489705)" d="M 134.496 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 134.496 388.8 
 L 138.0672 388.8 
 L 138.0672 340.416 
 L 134.496 340.416 
@@ -147,7 +147,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_18">
-    <path clip-path="url(#p406e489705)" d="M 138.96 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 138.96 388.8 
 L 142.5312 388.8 
 L 142.5312 336.96 
 L 138.96 336.96 
@@ -155,7 +155,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_19">
-    <path clip-path="url(#p406e489705)" d="M 143.424 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 143.424 388.8 
 L 146.9952 388.8 
 L 146.9952 333.504 
 L 143.424 333.504 
@@ -163,7 +163,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_20">
-    <path clip-path="url(#p406e489705)" d="M 147.888 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 147.888 388.8 
 L 151.4592 388.8 
 L 151.4592 330.048 
 L 147.888 330.048 
@@ -171,7 +171,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_21">
-    <path clip-path="url(#p406e489705)" d="M 152.352 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 152.352 388.8 
 L 155.9232 388.8 
 L 155.9232 326.592 
 L 152.352 326.592 
@@ -179,7 +179,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_22">
-    <path clip-path="url(#p406e489705)" d="M 156.816 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 156.816 388.8 
 L 160.3872 388.8 
 L 160.3872 323.136 
 L 156.816 323.136 
@@ -187,7 +187,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_23">
-    <path clip-path="url(#p406e489705)" d="M 161.28 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 161.28 388.8 
 L 164.8512 388.8 
 L 164.8512 319.68 
 L 161.28 319.68 
@@ -195,7 +195,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_24">
-    <path clip-path="url(#p406e489705)" d="M 165.744 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 165.744 388.8 
 L 169.3152 388.8 
 L 169.3152 316.224 
 L 165.744 316.224 
@@ -203,7 +203,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_25">
-    <path clip-path="url(#p406e489705)" d="M 170.208 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 170.208 388.8 
 L 173.7792 388.8 
 L 173.7792 312.768 
 L 170.208 312.768 
@@ -211,7 +211,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_26">
-    <path clip-path="url(#p406e489705)" d="M 174.672 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 174.672 388.8 
 L 178.2432 388.8 
 L 178.2432 309.312 
 L 174.672 309.312 
@@ -219,7 +219,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_27">
-    <path clip-path="url(#p406e489705)" d="M 179.136 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 179.136 388.8 
 L 182.7072 388.8 
 L 182.7072 305.856 
 L 179.136 305.856 
@@ -227,7 +227,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_28">
-    <path clip-path="url(#p406e489705)" d="M 183.6 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 183.6 388.8 
 L 187.1712 388.8 
 L 187.1712 302.4 
 L 183.6 302.4 
@@ -235,7 +235,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_29">
-    <path clip-path="url(#p406e489705)" d="M 188.064 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 188.064 388.8 
 L 191.6352 388.8 
 L 191.6352 298.944 
 L 188.064 298.944 
@@ -243,7 +243,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_30">
-    <path clip-path="url(#p406e489705)" d="M 192.528 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 192.528 388.8 
 L 196.0992 388.8 
 L 196.0992 295.488 
 L 192.528 295.488 
@@ -251,7 +251,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_31">
-    <path clip-path="url(#p406e489705)" d="M 196.992 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 196.992 388.8 
 L 200.5632 388.8 
 L 200.5632 292.032 
 L 196.992 292.032 
@@ -259,7 +259,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_32">
-    <path clip-path="url(#p406e489705)" d="M 201.456 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 201.456 388.8 
 L 205.0272 388.8 
 L 205.0272 288.576 
 L 201.456 288.576 
@@ -267,7 +267,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_33">
-    <path clip-path="url(#p406e489705)" d="M 205.92 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 205.92 388.8 
 L 209.4912 388.8 
 L 209.4912 285.12 
 L 205.92 285.12 
@@ -275,7 +275,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_34">
-    <path clip-path="url(#p406e489705)" d="M 210.384 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 210.384 388.8 
 L 213.9552 388.8 
 L 213.9552 281.664 
 L 210.384 281.664 
@@ -283,7 +283,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_35">
-    <path clip-path="url(#p406e489705)" d="M 214.848 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 214.848 388.8 
 L 218.4192 388.8 
 L 218.4192 278.208 
 L 214.848 278.208 
@@ -291,7 +291,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_36">
-    <path clip-path="url(#p406e489705)" d="M 219.312 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 219.312 388.8 
 L 222.8832 388.8 
 L 222.8832 274.752 
 L 219.312 274.752 
@@ -299,7 +299,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_37">
-    <path clip-path="url(#p406e489705)" d="M 223.776 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 223.776 388.8 
 L 227.3472 388.8 
 L 227.3472 271.296 
 L 223.776 271.296 
@@ -307,7 +307,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_38">
-    <path clip-path="url(#p406e489705)" d="M 228.24 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 228.24 388.8 
 L 231.8112 388.8 
 L 231.8112 267.84 
 L 228.24 267.84 
@@ -315,7 +315,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_39">
-    <path clip-path="url(#p406e489705)" d="M 232.704 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 232.704 388.8 
 L 236.2752 388.8 
 L 236.2752 264.384 
 L 232.704 264.384 
@@ -323,7 +323,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_40">
-    <path clip-path="url(#p406e489705)" d="M 237.168 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 237.168 388.8 
 L 240.7392 388.8 
 L 240.7392 260.928 
 L 237.168 260.928 
@@ -331,7 +331,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_41">
-    <path clip-path="url(#p406e489705)" d="M 241.632 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 241.632 388.8 
 L 245.2032 388.8 
 L 245.2032 257.472 
 L 241.632 257.472 
@@ -339,7 +339,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_42">
-    <path clip-path="url(#p406e489705)" d="M 246.096 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 246.096 388.8 
 L 249.6672 388.8 
 L 249.6672 254.016 
 L 246.096 254.016 
@@ -347,7 +347,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_43">
-    <path clip-path="url(#p406e489705)" d="M 250.56 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 250.56 388.8 
 L 254.1312 388.8 
 L 254.1312 250.56 
 L 250.56 250.56 
@@ -355,7 +355,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_44">
-    <path clip-path="url(#p406e489705)" d="M 255.024 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 255.024 388.8 
 L 258.5952 388.8 
 L 258.5952 247.104 
 L 255.024 247.104 
@@ -363,7 +363,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_45">
-    <path clip-path="url(#p406e489705)" d="M 259.488 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 259.488 388.8 
 L 263.0592 388.8 
 L 263.0592 243.648 
 L 259.488 243.648 
@@ -371,7 +371,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_46">
-    <path clip-path="url(#p406e489705)" d="M 263.952 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 263.952 388.8 
 L 267.5232 388.8 
 L 267.5232 240.192 
 L 263.952 240.192 
@@ -379,7 +379,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_47">
-    <path clip-path="url(#p406e489705)" d="M 268.416 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 268.416 388.8 
 L 271.9872 388.8 
 L 271.9872 236.736 
 L 268.416 236.736 
@@ -387,7 +387,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_48">
-    <path clip-path="url(#p406e489705)" d="M 272.88 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 272.88 388.8 
 L 276.4512 388.8 
 L 276.4512 233.28 
 L 272.88 233.28 
@@ -395,7 +395,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_49">
-    <path clip-path="url(#p406e489705)" d="M 277.344 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 277.344 388.8 
 L 280.9152 388.8 
 L 280.9152 229.824 
 L 277.344 229.824 
@@ -403,7 +403,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_50">
-    <path clip-path="url(#p406e489705)" d="M 281.808 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 281.808 388.8 
 L 285.3792 388.8 
 L 285.3792 226.368 
 L 281.808 226.368 
@@ -411,7 +411,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_51">
-    <path clip-path="url(#p406e489705)" d="M 286.272 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 286.272 388.8 
 L 289.8432 388.8 
 L 289.8432 222.912 
 L 286.272 222.912 
@@ -419,7 +419,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_52">
-    <path clip-path="url(#p406e489705)" d="M 290.736 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 290.736 388.8 
 L 294.3072 388.8 
 L 294.3072 219.456 
 L 290.736 219.456 
@@ -427,7 +427,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_53">
-    <path clip-path="url(#p406e489705)" d="M 295.2 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 295.2 388.8 
 L 298.7712 388.8 
 L 298.7712 216 
 L 295.2 216 
@@ -435,7 +435,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_54">
-    <path clip-path="url(#p406e489705)" d="M 299.664 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 299.664 388.8 
 L 303.2352 388.8 
 L 303.2352 212.544 
 L 299.664 212.544 
@@ -443,7 +443,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_55">
-    <path clip-path="url(#p406e489705)" d="M 304.128 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 304.128 388.8 
 L 307.6992 388.8 
 L 307.6992 209.088 
 L 304.128 209.088 
@@ -451,7 +451,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_56">
-    <path clip-path="url(#p406e489705)" d="M 308.592 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 308.592 388.8 
 L 312.1632 388.8 
 L 312.1632 205.632 
 L 308.592 205.632 
@@ -459,7 +459,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_57">
-    <path clip-path="url(#p406e489705)" d="M 313.056 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 313.056 388.8 
 L 316.6272 388.8 
 L 316.6272 202.176 
 L 313.056 202.176 
@@ -467,7 +467,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_58">
-    <path clip-path="url(#p406e489705)" d="M 317.52 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 317.52 388.8 
 L 321.0912 388.8 
 L 321.0912 198.72 
 L 317.52 198.72 
@@ -475,7 +475,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_59">
-    <path clip-path="url(#p406e489705)" d="M 321.984 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 321.984 388.8 
 L 325.5552 388.8 
 L 325.5552 195.264 
 L 321.984 195.264 
@@ -483,7 +483,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_60">
-    <path clip-path="url(#p406e489705)" d="M 326.448 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 326.448 388.8 
 L 330.0192 388.8 
 L 330.0192 191.808 
 L 326.448 191.808 
@@ -491,7 +491,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_61">
-    <path clip-path="url(#p406e489705)" d="M 330.912 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 330.912 388.8 
 L 334.4832 388.8 
 L 334.4832 188.352 
 L 330.912 188.352 
@@ -499,7 +499,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_62">
-    <path clip-path="url(#p406e489705)" d="M 335.376 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 335.376 388.8 
 L 338.9472 388.8 
 L 338.9472 184.896 
 L 335.376 184.896 
@@ -507,7 +507,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_63">
-    <path clip-path="url(#p406e489705)" d="M 339.84 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 339.84 388.8 
 L 343.4112 388.8 
 L 343.4112 181.44 
 L 339.84 181.44 
@@ -515,7 +515,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_64">
-    <path clip-path="url(#p406e489705)" d="M 344.304 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 344.304 388.8 
 L 347.8752 388.8 
 L 347.8752 177.984 
 L 344.304 177.984 
@@ -523,7 +523,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_65">
-    <path clip-path="url(#p406e489705)" d="M 348.768 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 348.768 388.8 
 L 352.3392 388.8 
 L 352.3392 174.528 
 L 348.768 174.528 
@@ -531,7 +531,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_66">
-    <path clip-path="url(#p406e489705)" d="M 353.232 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 353.232 388.8 
 L 356.8032 388.8 
 L 356.8032 171.072 
 L 353.232 171.072 
@@ -539,7 +539,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_67">
-    <path clip-path="url(#p406e489705)" d="M 357.696 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 357.696 388.8 
 L 361.2672 388.8 
 L 361.2672 167.616 
 L 357.696 167.616 
@@ -547,7 +547,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_68">
-    <path clip-path="url(#p406e489705)" d="M 362.16 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 362.16 388.8 
 L 365.7312 388.8 
 L 365.7312 164.16 
 L 362.16 164.16 
@@ -555,7 +555,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_69">
-    <path clip-path="url(#p406e489705)" d="M 366.624 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 366.624 388.8 
 L 370.1952 388.8 
 L 370.1952 160.704 
 L 366.624 160.704 
@@ -563,7 +563,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_70">
-    <path clip-path="url(#p406e489705)" d="M 371.088 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 371.088 388.8 
 L 374.6592 388.8 
 L 374.6592 157.248 
 L 371.088 157.248 
@@ -571,7 +571,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_71">
-    <path clip-path="url(#p406e489705)" d="M 375.552 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 375.552 388.8 
 L 379.1232 388.8 
 L 379.1232 153.792 
 L 375.552 153.792 
@@ -579,7 +579,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_72">
-    <path clip-path="url(#p406e489705)" d="M 380.016 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 380.016 388.8 
 L 383.5872 388.8 
 L 383.5872 150.336 
 L 380.016 150.336 
@@ -587,7 +587,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_73">
-    <path clip-path="url(#p406e489705)" d="M 384.48 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 384.48 388.8 
 L 388.0512 388.8 
 L 388.0512 146.88 
 L 384.48 146.88 
@@ -595,7 +595,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_74">
-    <path clip-path="url(#p406e489705)" d="M 388.944 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 388.944 388.8 
 L 392.5152 388.8 
 L 392.5152 143.424 
 L 388.944 143.424 
@@ -603,7 +603,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_75">
-    <path clip-path="url(#p406e489705)" d="M 393.408 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 393.408 388.8 
 L 396.9792 388.8 
 L 396.9792 139.968 
 L 393.408 139.968 
@@ -611,7 +611,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_76">
-    <path clip-path="url(#p406e489705)" d="M 397.872 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 397.872 388.8 
 L 401.4432 388.8 
 L 401.4432 136.512 
 L 397.872 136.512 
@@ -619,7 +619,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_77">
-    <path clip-path="url(#p406e489705)" d="M 402.336 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 402.336 388.8 
 L 405.9072 388.8 
 L 405.9072 133.056 
 L 402.336 133.056 
@@ -627,7 +627,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_78">
-    <path clip-path="url(#p406e489705)" d="M 406.8 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 406.8 388.8 
 L 410.3712 388.8 
 L 410.3712 129.6 
 L 406.8 129.6 
@@ -635,7 +635,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_79">
-    <path clip-path="url(#p406e489705)" d="M 411.264 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 411.264 388.8 
 L 414.8352 388.8 
 L 414.8352 126.144 
 L 411.264 126.144 
@@ -643,7 +643,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_80">
-    <path clip-path="url(#p406e489705)" d="M 415.728 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 415.728 388.8 
 L 419.2992 388.8 
 L 419.2992 122.688 
 L 415.728 122.688 
@@ -651,7 +651,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_81">
-    <path clip-path="url(#p406e489705)" d="M 420.192 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 420.192 388.8 
 L 423.7632 388.8 
 L 423.7632 119.232 
 L 420.192 119.232 
@@ -659,7 +659,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_82">
-    <path clip-path="url(#p406e489705)" d="M 424.656 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 424.656 388.8 
 L 428.2272 388.8 
 L 428.2272 115.776 
 L 424.656 115.776 
@@ -667,7 +667,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_83">
-    <path clip-path="url(#p406e489705)" d="M 429.12 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 429.12 388.8 
 L 432.6912 388.8 
 L 432.6912 112.32 
 L 429.12 112.32 
@@ -675,7 +675,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_84">
-    <path clip-path="url(#p406e489705)" d="M 433.584 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 433.584 388.8 
 L 437.1552 388.8 
 L 437.1552 108.864 
 L 433.584 108.864 
@@ -683,7 +683,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_85">
-    <path clip-path="url(#p406e489705)" d="M 438.048 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 438.048 388.8 
 L 441.6192 388.8 
 L 441.6192 105.408 
 L 438.048 105.408 
@@ -691,7 +691,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_86">
-    <path clip-path="url(#p406e489705)" d="M 442.512 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 442.512 388.8 
 L 446.0832 388.8 
 L 446.0832 101.952 
 L 442.512 101.952 
@@ -699,7 +699,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_87">
-    <path clip-path="url(#p406e489705)" d="M 446.976 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 446.976 388.8 
 L 450.5472 388.8 
 L 450.5472 98.496 
 L 446.976 98.496 
@@ -707,7 +707,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_88">
-    <path clip-path="url(#p406e489705)" d="M 451.44 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 451.44 388.8 
 L 455.0112 388.8 
 L 455.0112 95.04 
 L 451.44 95.04 
@@ -715,7 +715,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_89">
-    <path clip-path="url(#p406e489705)" d="M 455.904 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 455.904 388.8 
 L 459.4752 388.8 
 L 459.4752 91.584 
 L 455.904 91.584 
@@ -723,7 +723,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_90">
-    <path clip-path="url(#p406e489705)" d="M 460.368 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 460.368 388.8 
 L 463.9392 388.8 
 L 463.9392 88.128 
 L 460.368 88.128 
@@ -731,7 +731,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_91">
-    <path clip-path="url(#p406e489705)" d="M 464.832 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 464.832 388.8 
 L 468.4032 388.8 
 L 468.4032 84.672 
 L 464.832 84.672 
@@ -739,7 +739,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_92">
-    <path clip-path="url(#p406e489705)" d="M 469.296 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 469.296 388.8 
 L 472.8672 388.8 
 L 472.8672 81.216 
 L 469.296 81.216 
@@ -747,7 +747,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_93">
-    <path clip-path="url(#p406e489705)" d="M 473.76 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 473.76 388.8 
 L 477.3312 388.8 
 L 477.3312 77.76 
 L 473.76 77.76 
@@ -755,7 +755,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_94">
-    <path clip-path="url(#p406e489705)" d="M 478.224 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 478.224 388.8 
 L 481.7952 388.8 
 L 481.7952 74.304 
 L 478.224 74.304 
@@ -763,7 +763,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_95">
-    <path clip-path="url(#p406e489705)" d="M 482.688 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 482.688 388.8 
 L 486.2592 388.8 
 L 486.2592 70.848 
 L 482.688 70.848 
@@ -771,7 +771,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_96">
-    <path clip-path="url(#p406e489705)" d="M 487.152 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 487.152 388.8 
 L 490.7232 388.8 
 L 490.7232 67.392 
 L 487.152 67.392 
@@ -779,7 +779,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_97">
-    <path clip-path="url(#p406e489705)" d="M 491.616 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 491.616 388.8 
 L 495.1872 388.8 
 L 495.1872 63.936 
 L 491.616 63.936 
@@ -787,7 +787,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_98">
-    <path clip-path="url(#p406e489705)" d="M 496.08 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 496.08 388.8 
 L 499.6512 388.8 
 L 499.6512 60.48 
 L 496.08 60.48 
@@ -795,7 +795,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_99">
-    <path clip-path="url(#p406e489705)" d="M 500.544 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 500.544 388.8 
 L 504.1152 388.8 
 L 504.1152 57.024 
 L 500.544 57.024 
@@ -803,7 +803,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_100">
-    <path clip-path="url(#p406e489705)" d="M 505.008 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 505.008 388.8 
 L 508.5792 388.8 
 L 508.5792 53.568 
 L 505.008 53.568 
@@ -811,7 +811,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_101">
-    <path clip-path="url(#p406e489705)" d="M 509.472 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 509.472 388.8 
 L 513.0432 388.8 
 L 513.0432 50.112 
 L 509.472 50.112 
@@ -819,7 +819,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_102">
-    <path clip-path="url(#p406e489705)" d="M 513.936 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 513.936 388.8 
 L 517.5072 388.8 
 L 517.5072 46.656 
 L 513.936 46.656 
@@ -827,7 +827,7 @@ z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_103">
-    <path clip-path="url(#p406e489705)" d="M 72 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 72 388.8 
 L 75.5712 388.8 
 L 75.5712 46.656 
 L 72 46.656 
@@ -835,7 +835,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_104">
-    <path clip-path="url(#p406e489705)" d="M 76.464 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 76.464 388.8 
 L 80.0352 388.8 
 L 80.0352 50.112 
 L 76.464 50.112 
@@ -843,7 +843,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_105">
-    <path clip-path="url(#p406e489705)" d="M 80.928 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 80.928 388.8 
 L 84.4992 388.8 
 L 84.4992 53.568 
 L 80.928 53.568 
@@ -851,7 +851,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_106">
-    <path clip-path="url(#p406e489705)" d="M 85.392 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 85.392 388.8 
 L 88.9632 388.8 
 L 88.9632 57.024 
 L 85.392 57.024 
@@ -859,7 +859,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_107">
-    <path clip-path="url(#p406e489705)" d="M 89.856 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 89.856 388.8 
 L 93.4272 388.8 
 L 93.4272 60.48 
 L 89.856 60.48 
@@ -867,7 +867,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_108">
-    <path clip-path="url(#p406e489705)" d="M 94.32 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 94.32 388.8 
 L 97.8912 388.8 
 L 97.8912 63.936 
 L 94.32 63.936 
@@ -875,7 +875,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_109">
-    <path clip-path="url(#p406e489705)" d="M 98.784 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 98.784 388.8 
 L 102.3552 388.8 
 L 102.3552 67.392 
 L 98.784 67.392 
@@ -883,7 +883,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_110">
-    <path clip-path="url(#p406e489705)" d="M 103.248 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 103.248 388.8 
 L 106.8192 388.8 
 L 106.8192 70.848 
 L 103.248 70.848 
@@ -891,7 +891,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_111">
-    <path clip-path="url(#p406e489705)" d="M 107.712 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 107.712 388.8 
 L 111.2832 388.8 
 L 111.2832 74.304 
 L 107.712 74.304 
@@ -899,7 +899,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_112">
-    <path clip-path="url(#p406e489705)" d="M 112.176 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 112.176 388.8 
 L 115.7472 388.8 
 L 115.7472 77.76 
 L 112.176 77.76 
@@ -907,7 +907,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_113">
-    <path clip-path="url(#p406e489705)" d="M 116.64 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 116.64 388.8 
 L 120.2112 388.8 
 L 120.2112 81.216 
 L 116.64 81.216 
@@ -915,7 +915,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_114">
-    <path clip-path="url(#p406e489705)" d="M 121.104 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 121.104 388.8 
 L 124.6752 388.8 
 L 124.6752 84.672 
 L 121.104 84.672 
@@ -923,7 +923,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_115">
-    <path clip-path="url(#p406e489705)" d="M 125.568 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 125.568 388.8 
 L 129.1392 388.8 
 L 129.1392 88.128 
 L 125.568 88.128 
@@ -931,7 +931,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_116">
-    <path clip-path="url(#p406e489705)" d="M 130.032 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 130.032 388.8 
 L 133.6032 388.8 
 L 133.6032 91.584 
 L 130.032 91.584 
@@ -939,7 +939,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_117">
-    <path clip-path="url(#p406e489705)" d="M 134.496 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 134.496 388.8 
 L 138.0672 388.8 
 L 138.0672 95.04 
 L 134.496 95.04 
@@ -947,7 +947,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_118">
-    <path clip-path="url(#p406e489705)" d="M 138.96 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 138.96 388.8 
 L 142.5312 388.8 
 L 142.5312 98.496 
 L 138.96 98.496 
@@ -955,7 +955,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_119">
-    <path clip-path="url(#p406e489705)" d="M 143.424 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 143.424 388.8 
 L 146.9952 388.8 
 L 146.9952 101.952 
 L 143.424 101.952 
@@ -963,7 +963,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_120">
-    <path clip-path="url(#p406e489705)" d="M 147.888 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 147.888 388.8 
 L 151.4592 388.8 
 L 151.4592 105.408 
 L 147.888 105.408 
@@ -971,7 +971,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_121">
-    <path clip-path="url(#p406e489705)" d="M 152.352 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 152.352 388.8 
 L 155.9232 388.8 
 L 155.9232 108.864 
 L 152.352 108.864 
@@ -979,7 +979,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_122">
-    <path clip-path="url(#p406e489705)" d="M 156.816 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 156.816 388.8 
 L 160.3872 388.8 
 L 160.3872 112.32 
 L 156.816 112.32 
@@ -987,7 +987,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_123">
-    <path clip-path="url(#p406e489705)" d="M 161.28 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 161.28 388.8 
 L 164.8512 388.8 
 L 164.8512 115.776 
 L 161.28 115.776 
@@ -995,7 +995,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_124">
-    <path clip-path="url(#p406e489705)" d="M 165.744 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 165.744 388.8 
 L 169.3152 388.8 
 L 169.3152 119.232 
 L 165.744 119.232 
@@ -1003,7 +1003,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_125">
-    <path clip-path="url(#p406e489705)" d="M 170.208 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 170.208 388.8 
 L 173.7792 388.8 
 L 173.7792 122.688 
 L 170.208 122.688 
@@ -1011,7 +1011,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_126">
-    <path clip-path="url(#p406e489705)" d="M 174.672 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 174.672 388.8 
 L 178.2432 388.8 
 L 178.2432 126.144 
 L 174.672 126.144 
@@ -1019,7 +1019,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_127">
-    <path clip-path="url(#p406e489705)" d="M 179.136 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 179.136 388.8 
 L 182.7072 388.8 
 L 182.7072 129.6 
 L 179.136 129.6 
@@ -1027,7 +1027,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_128">
-    <path clip-path="url(#p406e489705)" d="M 183.6 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 183.6 388.8 
 L 187.1712 388.8 
 L 187.1712 133.056 
 L 183.6 133.056 
@@ -1035,7 +1035,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_129">
-    <path clip-path="url(#p406e489705)" d="M 188.064 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 188.064 388.8 
 L 191.6352 388.8 
 L 191.6352 136.512 
 L 188.064 136.512 
@@ -1043,7 +1043,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_130">
-    <path clip-path="url(#p406e489705)" d="M 192.528 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 192.528 388.8 
 L 196.0992 388.8 
 L 196.0992 139.968 
 L 192.528 139.968 
@@ -1051,7 +1051,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_131">
-    <path clip-path="url(#p406e489705)" d="M 196.992 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 196.992 388.8 
 L 200.5632 388.8 
 L 200.5632 143.424 
 L 196.992 143.424 
@@ -1059,7 +1059,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_132">
-    <path clip-path="url(#p406e489705)" d="M 201.456 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 201.456 388.8 
 L 205.0272 388.8 
 L 205.0272 146.88 
 L 201.456 146.88 
@@ -1067,7 +1067,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_133">
-    <path clip-path="url(#p406e489705)" d="M 205.92 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 205.92 388.8 
 L 209.4912 388.8 
 L 209.4912 150.336 
 L 205.92 150.336 
@@ -1075,7 +1075,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_134">
-    <path clip-path="url(#p406e489705)" d="M 210.384 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 210.384 388.8 
 L 213.9552 388.8 
 L 213.9552 153.792 
 L 210.384 153.792 
@@ -1083,7 +1083,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_135">
-    <path clip-path="url(#p406e489705)" d="M 214.848 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 214.848 388.8 
 L 218.4192 388.8 
 L 218.4192 157.248 
 L 214.848 157.248 
@@ -1091,7 +1091,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_136">
-    <path clip-path="url(#p406e489705)" d="M 219.312 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 219.312 388.8 
 L 222.8832 388.8 
 L 222.8832 160.704 
 L 219.312 160.704 
@@ -1099,7 +1099,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_137">
-    <path clip-path="url(#p406e489705)" d="M 223.776 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 223.776 388.8 
 L 227.3472 388.8 
 L 227.3472 164.16 
 L 223.776 164.16 
@@ -1107,7 +1107,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_138">
-    <path clip-path="url(#p406e489705)" d="M 228.24 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 228.24 388.8 
 L 231.8112 388.8 
 L 231.8112 167.616 
 L 228.24 167.616 
@@ -1115,7 +1115,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_139">
-    <path clip-path="url(#p406e489705)" d="M 232.704 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 232.704 388.8 
 L 236.2752 388.8 
 L 236.2752 171.072 
 L 232.704 171.072 
@@ -1123,7 +1123,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_140">
-    <path clip-path="url(#p406e489705)" d="M 237.168 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 237.168 388.8 
 L 240.7392 388.8 
 L 240.7392 174.528 
 L 237.168 174.528 
@@ -1131,7 +1131,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_141">
-    <path clip-path="url(#p406e489705)" d="M 241.632 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 241.632 388.8 
 L 245.2032 388.8 
 L 245.2032 177.984 
 L 241.632 177.984 
@@ -1139,7 +1139,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_142">
-    <path clip-path="url(#p406e489705)" d="M 246.096 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 246.096 388.8 
 L 249.6672 388.8 
 L 249.6672 181.44 
 L 246.096 181.44 
@@ -1147,7 +1147,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_143">
-    <path clip-path="url(#p406e489705)" d="M 250.56 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 250.56 388.8 
 L 254.1312 388.8 
 L 254.1312 184.896 
 L 250.56 184.896 
@@ -1155,7 +1155,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_144">
-    <path clip-path="url(#p406e489705)" d="M 255.024 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 255.024 388.8 
 L 258.5952 388.8 
 L 258.5952 188.352 
 L 255.024 188.352 
@@ -1163,7 +1163,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_145">
-    <path clip-path="url(#p406e489705)" d="M 259.488 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 259.488 388.8 
 L 263.0592 388.8 
 L 263.0592 191.808 
 L 259.488 191.808 
@@ -1171,7 +1171,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_146">
-    <path clip-path="url(#p406e489705)" d="M 263.952 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 263.952 388.8 
 L 267.5232 388.8 
 L 267.5232 195.264 
 L 263.952 195.264 
@@ -1179,7 +1179,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_147">
-    <path clip-path="url(#p406e489705)" d="M 268.416 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 268.416 388.8 
 L 271.9872 388.8 
 L 271.9872 198.72 
 L 268.416 198.72 
@@ -1187,7 +1187,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_148">
-    <path clip-path="url(#p406e489705)" d="M 272.88 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 272.88 388.8 
 L 276.4512 388.8 
 L 276.4512 202.176 
 L 272.88 202.176 
@@ -1195,7 +1195,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_149">
-    <path clip-path="url(#p406e489705)" d="M 277.344 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 277.344 388.8 
 L 280.9152 388.8 
 L 280.9152 205.632 
 L 277.344 205.632 
@@ -1203,7 +1203,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_150">
-    <path clip-path="url(#p406e489705)" d="M 281.808 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 281.808 388.8 
 L 285.3792 388.8 
 L 285.3792 209.088 
 L 281.808 209.088 
@@ -1211,7 +1211,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_151">
-    <path clip-path="url(#p406e489705)" d="M 286.272 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 286.272 388.8 
 L 289.8432 388.8 
 L 289.8432 212.544 
 L 286.272 212.544 
@@ -1219,7 +1219,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_152">
-    <path clip-path="url(#p406e489705)" d="M 290.736 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 290.736 388.8 
 L 294.3072 388.8 
 L 294.3072 216 
 L 290.736 216 
@@ -1227,7 +1227,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_153">
-    <path clip-path="url(#p406e489705)" d="M 295.2 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 295.2 388.8 
 L 298.7712 388.8 
 L 298.7712 219.456 
 L 295.2 219.456 
@@ -1235,7 +1235,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_154">
-    <path clip-path="url(#p406e489705)" d="M 299.664 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 299.664 388.8 
 L 303.2352 388.8 
 L 303.2352 222.912 
 L 299.664 222.912 
@@ -1243,7 +1243,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_155">
-    <path clip-path="url(#p406e489705)" d="M 304.128 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 304.128 388.8 
 L 307.6992 388.8 
 L 307.6992 226.368 
 L 304.128 226.368 
@@ -1251,7 +1251,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_156">
-    <path clip-path="url(#p406e489705)" d="M 308.592 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 308.592 388.8 
 L 312.1632 388.8 
 L 312.1632 229.824 
 L 308.592 229.824 
@@ -1259,7 +1259,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_157">
-    <path clip-path="url(#p406e489705)" d="M 313.056 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 313.056 388.8 
 L 316.6272 388.8 
 L 316.6272 233.28 
 L 313.056 233.28 
@@ -1267,7 +1267,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_158">
-    <path clip-path="url(#p406e489705)" d="M 317.52 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 317.52 388.8 
 L 321.0912 388.8 
 L 321.0912 236.736 
 L 317.52 236.736 
@@ -1275,7 +1275,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_159">
-    <path clip-path="url(#p406e489705)" d="M 321.984 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 321.984 388.8 
 L 325.5552 388.8 
 L 325.5552 240.192 
 L 321.984 240.192 
@@ -1283,7 +1283,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_160">
-    <path clip-path="url(#p406e489705)" d="M 326.448 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 326.448 388.8 
 L 330.0192 388.8 
 L 330.0192 243.648 
 L 326.448 243.648 
@@ -1291,7 +1291,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_161">
-    <path clip-path="url(#p406e489705)" d="M 330.912 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 330.912 388.8 
 L 334.4832 388.8 
 L 334.4832 247.104 
 L 330.912 247.104 
@@ -1299,7 +1299,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_162">
-    <path clip-path="url(#p406e489705)" d="M 335.376 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 335.376 388.8 
 L 338.9472 388.8 
 L 338.9472 250.56 
 L 335.376 250.56 
@@ -1307,7 +1307,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_163">
-    <path clip-path="url(#p406e489705)" d="M 339.84 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 339.84 388.8 
 L 343.4112 388.8 
 L 343.4112 254.016 
 L 339.84 254.016 
@@ -1315,7 +1315,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_164">
-    <path clip-path="url(#p406e489705)" d="M 344.304 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 344.304 388.8 
 L 347.8752 388.8 
 L 347.8752 257.472 
 L 344.304 257.472 
@@ -1323,7 +1323,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_165">
-    <path clip-path="url(#p406e489705)" d="M 348.768 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 348.768 388.8 
 L 352.3392 388.8 
 L 352.3392 260.928 
 L 348.768 260.928 
@@ -1331,7 +1331,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_166">
-    <path clip-path="url(#p406e489705)" d="M 353.232 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 353.232 388.8 
 L 356.8032 388.8 
 L 356.8032 264.384 
 L 353.232 264.384 
@@ -1339,7 +1339,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_167">
-    <path clip-path="url(#p406e489705)" d="M 357.696 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 357.696 388.8 
 L 361.2672 388.8 
 L 361.2672 267.84 
 L 357.696 267.84 
@@ -1347,7 +1347,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_168">
-    <path clip-path="url(#p406e489705)" d="M 362.16 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 362.16 388.8 
 L 365.7312 388.8 
 L 365.7312 271.296 
 L 362.16 271.296 
@@ -1355,7 +1355,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_169">
-    <path clip-path="url(#p406e489705)" d="M 366.624 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 366.624 388.8 
 L 370.1952 388.8 
 L 370.1952 274.752 
 L 366.624 274.752 
@@ -1363,7 +1363,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_170">
-    <path clip-path="url(#p406e489705)" d="M 371.088 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 371.088 388.8 
 L 374.6592 388.8 
 L 374.6592 278.208 
 L 371.088 278.208 
@@ -1371,7 +1371,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_171">
-    <path clip-path="url(#p406e489705)" d="M 375.552 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 375.552 388.8 
 L 379.1232 388.8 
 L 379.1232 281.664 
 L 375.552 281.664 
@@ -1379,7 +1379,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_172">
-    <path clip-path="url(#p406e489705)" d="M 380.016 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 380.016 388.8 
 L 383.5872 388.8 
 L 383.5872 285.12 
 L 380.016 285.12 
@@ -1387,7 +1387,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_173">
-    <path clip-path="url(#p406e489705)" d="M 384.48 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 384.48 388.8 
 L 388.0512 388.8 
 L 388.0512 288.576 
 L 384.48 288.576 
@@ -1395,7 +1395,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_174">
-    <path clip-path="url(#p406e489705)" d="M 388.944 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 388.944 388.8 
 L 392.5152 388.8 
 L 392.5152 292.032 
 L 388.944 292.032 
@@ -1403,7 +1403,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_175">
-    <path clip-path="url(#p406e489705)" d="M 393.408 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 393.408 388.8 
 L 396.9792 388.8 
 L 396.9792 295.488 
 L 393.408 295.488 
@@ -1411,7 +1411,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_176">
-    <path clip-path="url(#p406e489705)" d="M 397.872 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 397.872 388.8 
 L 401.4432 388.8 
 L 401.4432 298.944 
 L 397.872 298.944 
@@ -1419,7 +1419,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_177">
-    <path clip-path="url(#p406e489705)" d="M 402.336 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 402.336 388.8 
 L 405.9072 388.8 
 L 405.9072 302.4 
 L 402.336 302.4 
@@ -1427,7 +1427,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_178">
-    <path clip-path="url(#p406e489705)" d="M 406.8 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 406.8 388.8 
 L 410.3712 388.8 
 L 410.3712 305.856 
 L 406.8 305.856 
@@ -1435,7 +1435,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_179">
-    <path clip-path="url(#p406e489705)" d="M 411.264 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 411.264 388.8 
 L 414.8352 388.8 
 L 414.8352 309.312 
 L 411.264 309.312 
@@ -1443,7 +1443,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_180">
-    <path clip-path="url(#p406e489705)" d="M 415.728 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 415.728 388.8 
 L 419.2992 388.8 
 L 419.2992 312.768 
 L 415.728 312.768 
@@ -1451,7 +1451,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_181">
-    <path clip-path="url(#p406e489705)" d="M 420.192 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 420.192 388.8 
 L 423.7632 388.8 
 L 423.7632 316.224 
 L 420.192 316.224 
@@ -1459,7 +1459,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_182">
-    <path clip-path="url(#p406e489705)" d="M 424.656 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 424.656 388.8 
 L 428.2272 388.8 
 L 428.2272 319.68 
 L 424.656 319.68 
@@ -1467,7 +1467,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_183">
-    <path clip-path="url(#p406e489705)" d="M 429.12 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 429.12 388.8 
 L 432.6912 388.8 
 L 432.6912 323.136 
 L 429.12 323.136 
@@ -1475,7 +1475,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_184">
-    <path clip-path="url(#p406e489705)" d="M 433.584 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 433.584 388.8 
 L 437.1552 388.8 
 L 437.1552 326.592 
 L 433.584 326.592 
@@ -1483,7 +1483,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_185">
-    <path clip-path="url(#p406e489705)" d="M 438.048 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 438.048 388.8 
 L 441.6192 388.8 
 L 441.6192 330.048 
 L 438.048 330.048 
@@ -1491,7 +1491,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_186">
-    <path clip-path="url(#p406e489705)" d="M 442.512 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 442.512 388.8 
 L 446.0832 388.8 
 L 446.0832 333.504 
 L 442.512 333.504 
@@ -1499,7 +1499,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_187">
-    <path clip-path="url(#p406e489705)" d="M 446.976 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 446.976 388.8 
 L 450.5472 388.8 
 L 450.5472 336.96 
 L 446.976 336.96 
@@ -1507,7 +1507,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_188">
-    <path clip-path="url(#p406e489705)" d="M 451.44 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 451.44 388.8 
 L 455.0112 388.8 
 L 455.0112 340.416 
 L 451.44 340.416 
@@ -1515,7 +1515,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_189">
-    <path clip-path="url(#p406e489705)" d="M 455.904 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 455.904 388.8 
 L 459.4752 388.8 
 L 459.4752 343.872 
 L 455.904 343.872 
@@ -1523,7 +1523,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_190">
-    <path clip-path="url(#p406e489705)" d="M 460.368 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 460.368 388.8 
 L 463.9392 388.8 
 L 463.9392 347.328 
 L 460.368 347.328 
@@ -1531,7 +1531,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_191">
-    <path clip-path="url(#p406e489705)" d="M 464.832 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 464.832 388.8 
 L 468.4032 388.8 
 L 468.4032 350.784 
 L 464.832 350.784 
@@ -1539,7 +1539,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_192">
-    <path clip-path="url(#p406e489705)" d="M 469.296 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 469.296 388.8 
 L 472.8672 388.8 
 L 472.8672 354.24 
 L 469.296 354.24 
@@ -1547,7 +1547,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_193">
-    <path clip-path="url(#p406e489705)" d="M 473.76 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 473.76 388.8 
 L 477.3312 388.8 
 L 477.3312 357.696 
 L 473.76 357.696 
@@ -1555,7 +1555,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_194">
-    <path clip-path="url(#p406e489705)" d="M 478.224 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 478.224 388.8 
 L 481.7952 388.8 
 L 481.7952 361.152 
 L 478.224 361.152 
@@ -1563,7 +1563,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_195">
-    <path clip-path="url(#p406e489705)" d="M 482.688 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 482.688 388.8 
 L 486.2592 388.8 
 L 486.2592 364.608 
 L 482.688 364.608 
@@ -1571,7 +1571,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_196">
-    <path clip-path="url(#p406e489705)" d="M 487.152 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 487.152 388.8 
 L 490.7232 388.8 
 L 490.7232 368.064 
 L 487.152 368.064 
@@ -1579,7 +1579,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_197">
-    <path clip-path="url(#p406e489705)" d="M 491.616 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 491.616 388.8 
 L 495.1872 388.8 
 L 495.1872 371.52 
 L 491.616 371.52 
@@ -1587,7 +1587,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_198">
-    <path clip-path="url(#p406e489705)" d="M 496.08 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 496.08 388.8 
 L 499.6512 388.8 
 L 499.6512 374.976 
 L 496.08 374.976 
@@ -1595,7 +1595,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_199">
-    <path clip-path="url(#p406e489705)" d="M 500.544 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 500.544 388.8 
 L 504.1152 388.8 
 L 504.1152 378.432 
 L 500.544 378.432 
@@ -1603,7 +1603,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_200">
-    <path clip-path="url(#p406e489705)" d="M 505.008 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 505.008 388.8 
 L 508.5792 388.8 
 L 508.5792 381.888 
 L 505.008 381.888 
@@ -1611,7 +1611,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_201">
-    <path clip-path="url(#p406e489705)" d="M 509.472 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 509.472 388.8 
 L 513.0432 388.8 
 L 513.0432 385.344 
 L 509.472 385.344 
@@ -1619,7 +1619,7 @@ z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_202">
-    <path clip-path="url(#p406e489705)" d="M 513.936 388.8 
+    <path clip-path="url(#p7c8a22ed72)" d="M 513.936 388.8 
 L 517.5072 388.8 
 L 517.5072 388.8 
 L 513.936 388.8 
@@ -1652,80 +1652,80 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m4ef07a9fdb" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m2f4acd5ff8" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m4ef07a9fdb" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m2f4acd5ff8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_2">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="mc99d1f7c82" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m90d8af5bf8" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#mc99d1f7c82" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m90d8af5bf8" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="161.28" xlink:href="#m4ef07a9fdb" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m2f4acd5ff8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="161.28" xlink:href="#mc99d1f7c82" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m90d8af5bf8" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="250.56" xlink:href="#m4ef07a9fdb" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m2f4acd5ff8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="250.56" xlink:href="#mc99d1f7c82" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m90d8af5bf8" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="339.84" xlink:href="#m4ef07a9fdb" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m2f4acd5ff8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="339.84" xlink:href="#mc99d1f7c82" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m90d8af5bf8" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="429.12" xlink:href="#m4ef07a9fdb" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m2f4acd5ff8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="429.12" xlink:href="#mc99d1f7c82" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m90d8af5bf8" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#m4ef07a9fdb" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2f4acd5ff8" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#mc99d1f7c82" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m90d8af5bf8" y="43.2"/>
       </g>
      </g>
     </g>
@@ -1736,98 +1736,98 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="maebeb2a73c" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m9b961d60fc" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#maebeb2a73c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9b961d60fc" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="m94153b032c" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m2db8527770" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#m94153b032c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2db8527770" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_15">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#maebeb2a73c" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9b961d60fc" y="319.68"/>
       </g>
      </g>
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#m94153b032c" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2db8527770" y="319.68"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#maebeb2a73c" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9b961d60fc" y="250.56"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#m94153b032c" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2db8527770" y="250.56"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#maebeb2a73c" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9b961d60fc" y="181.44"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#m94153b032c" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2db8527770" y="181.44"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#maebeb2a73c" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9b961d60fc" y="112.32"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#m94153b032c" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2db8527770" y="112.32"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#maebeb2a73c" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9b961d60fc" y="43.2"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="518.4" xlink:href="#m94153b032c" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m2db8527770" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_207">
-     <path d="M 249.881563 96.9045 
-L 340.518438 96.9045 
-L 340.518438 50.4 
-L 249.881563 50.4 
+     <path d="M 249.852375 96.993 
+L 340.547625 96.993 
+L 340.547625 50.4 
+L 249.852375 50.4 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="patch_208">
-     <path d="M 255.641563 67.10175 
-L 284.441563 67.10175 
-L 284.441563 57.02175 
-L 255.641563 57.02175 
+     <path d="M 255.612375 67.10175 
+L 284.412375 67.10175 
+L 284.412375 57.02175 
+L 255.612375 57.02175 
 z
 " style="fill:#bf00bf;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -1879,16 +1879,16 @@ Q 40.53125 6.109375 44.609375 11.75
 Q 48.6875 17.390625 48.6875 27.296875 
 " id="DejaVuSans-70"/>
      </defs>
-     <g transform="translate(295.961563 67.101750)scale(0.144000 -0.144000)">
+     <g transform="translate(295.932375 67.10175)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-75"/>
-      <use x="63.37890625" xlink:href="#DejaVuSans-70"/>
+      <use x="63.378906" xlink:href="#DejaVuSans-70"/>
      </g>
     </g>
     <g id="patch_209">
-     <path d="M 255.641563 88.23825 
-L 284.441563 88.23825 
-L 284.441563 78.15825 
-L 255.641563 78.15825 
+     <path d="M 255.612375 88.23825 
+L 284.412375 88.23825 
+L 284.412375 78.15825 
+L 255.612375 78.15825 
 z
 " style="fill:#008000;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -1972,19 +1972,19 @@ Q 45.21875 56 50.046875 50.171875
 Q 54.890625 44.34375 54.890625 33.015625 
 " id="DejaVuSans-6e"/>
      </defs>
-     <g transform="translate(295.961563 88.238250)scale(0.144000 -0.144000)">
+     <g transform="translate(295.932375 88.23825)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-64"/>
-      <use x="63.4765625" xlink:href="#DejaVuSans-6f"/>
-      <use x="124.658203125" xlink:href="#DejaVuSans-77"/>
-      <use x="206.4453125" xlink:href="#DejaVuSans-6e"/>
+      <use x="63.476562" xlink:href="#DejaVuSans-6f"/>
+      <use x="124.658203" xlink:href="#DejaVuSans-77"/>
+      <use x="206.445312" xlink:href="#DejaVuSans-6e"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p406e489705">
-   <rect height="345.6" width="446.4" x="72.0" y="43.2"/>
+  <clipPath id="p7c8a22ed72">
+   <rect height="345.6" width="446.4" x="72" y="43.2"/>
   </clipPath>
  </defs>
 </svg>

--- a/lib/matplotlib/tests/baseline_images/test_legend/legend_auto3.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/legend_auto3.svg
@@ -27,7 +27,7 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="line2d_1">
-    <path clip-path="url(#p5858f70f46)" d="M 473.76 60.48 
+    <path clip-path="url(#p9ed4042574)" d="M 473.76 60.48 
 L 116.64 60.48 
 L 116.64 371.52 
 L 473.76 371.52 
@@ -45,15 +45,15 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="ma76a8ae5af" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m8b3506c23b" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p5858f70f46)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#ma76a8ae5af" y="60.48"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#ma76a8ae5af" y="60.48"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#ma76a8ae5af" y="371.52"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#ma76a8ae5af" y="371.52"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#ma76a8ae5af" y="216"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#ma76a8ae5af" y="216"/>
+    <g clip-path="url(#p9ed4042574)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m8b3506c23b" y="60.48"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m8b3506c23b" y="60.48"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m8b3506c23b" y="371.52"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m8b3506c23b" y="371.52"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m8b3506c23b" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m8b3506c23b" y="216"/>
     </g>
    </g>
    <g id="patch_3">
@@ -82,20 +82,20 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="mf173b4e4d8" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m4441fa3ef9" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mf173b4e4d8" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4441fa3ef9" y="388.8"/>
       </g>
      </g>
      <g id="line2d_3">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m10aa586f28" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m637bc81bd0" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m10aa586f28" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m637bc81bd0" y="43.2"/>
       </g>
      </g>
      <g id="text_1">
@@ -137,12 +137,12 @@ z
     <g id="xtick_2">
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mf173b4e4d8" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m4441fa3ef9" y="388.8"/>
       </g>
      </g>
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m10aa586f28" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m637bc81bd0" y="43.2"/>
       </g>
      </g>
      <g id="text_2">
@@ -182,12 +182,12 @@ Q 31.109375 20.453125 19.1875 8.296875
     <g id="xtick_3">
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mf173b4e4d8" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m4441fa3ef9" y="388.8"/>
       </g>
      </g>
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m10aa586f28" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m637bc81bd0" y="43.2"/>
       </g>
      </g>
      <g id="text_3">
@@ -221,12 +221,12 @@ z
     <g id="xtick_4">
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mf173b4e4d8" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m4441fa3ef9" y="388.8"/>
       </g>
      </g>
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m10aa586f28" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m637bc81bd0" y="43.2"/>
       </g>
      </g>
      <g id="text_4">
@@ -271,12 +271,12 @@ Q 48.484375 72.75 52.59375 71.296875
     <g id="xtick_5">
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mf173b4e4d8" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m4441fa3ef9" y="388.8"/>
       </g>
      </g>
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m10aa586f28" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m637bc81bd0" y="43.2"/>
       </g>
      </g>
      <g id="text_5">
@@ -329,12 +329,12 @@ Q 18.3125 60.0625 18.3125 54.390625
     <g id="xtick_6">
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf173b4e4d8" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m4441fa3ef9" y="388.8"/>
       </g>
      </g>
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m10aa586f28" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m637bc81bd0" y="43.2"/>
       </g>
      </g>
      <g id="text_6">
@@ -368,20 +368,20 @@ z
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m3e763eb8ec" style="stroke:#000000;stroke-width:0.5;"/>
+" id="maf9ad61188" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3e763eb8ec" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#maf9ad61188" y="388.8"/>
       </g>
      </g>
      <g id="line2d_15">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="mfc9d70d7f3" style="stroke:#000000;stroke-width:0.5;"/>
+" id="md7511c2572" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mfc9d70d7f3" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#md7511c2572" y="388.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -396,12 +396,12 @@ L -4 0
     <g id="ytick_2">
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3e763eb8ec" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#maf9ad61188" y="319.68"/>
       </g>
      </g>
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mfc9d70d7f3" y="319.68"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#md7511c2572" y="319.68"/>
       </g>
      </g>
      <g id="text_8">
@@ -416,12 +416,12 @@ L -4 0
     <g id="ytick_3">
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3e763eb8ec" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#maf9ad61188" y="250.56"/>
       </g>
      </g>
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mfc9d70d7f3" y="250.56"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#md7511c2572" y="250.56"/>
       </g>
      </g>
      <g id="text_9">
@@ -436,12 +436,12 @@ L -4 0
     <g id="ytick_4">
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3e763eb8ec" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#maf9ad61188" y="181.44"/>
       </g>
      </g>
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mfc9d70d7f3" y="181.44"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#md7511c2572" y="181.44"/>
       </g>
      </g>
      <g id="text_10">
@@ -456,12 +456,12 @@ L -4 0
     <g id="ytick_5">
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3e763eb8ec" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#maf9ad61188" y="112.32"/>
       </g>
      </g>
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mfc9d70d7f3" y="112.32"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#md7511c2572" y="112.32"/>
       </g>
      </g>
      <g id="text_11">
@@ -476,12 +476,12 @@ L -4 0
     <g id="ytick_6">
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3e763eb8ec" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#maf9ad61188" y="43.2"/>
       </g>
      </g>
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mfc9d70d7f3" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#md7511c2572" y="43.2"/>
       </g>
      </g>
      <g id="text_12">
@@ -496,22 +496,22 @@ L -4 0
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 79.2 228.684 
-L 156.993125 228.684 
-L 156.993125 203.316 
-L 79.2 203.316 
+     <path d="M 79.2 228.72825 
+L 157.0275 228.72825 
+L 157.0275 203.27175 
+L 79.2 203.27175 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_26">
-     <path d="M 89.28 214.97775 
-L 109.44 214.97775 
+     <path d="M 89.28 214.9335 
+L 109.44 214.9335 
 " style="fill:none;stroke:#0000ff;stroke-linecap:square;"/>
     </g>
     <g id="line2d_27">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#ma76a8ae5af" y="214.97775"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#ma76a8ae5af" y="214.97775"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m8b3506c23b" y="214.9335"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m8b3506c23b" y="214.9335"/>
      </g>
     </g>
     <g id="text_13">
@@ -576,7 +576,7 @@ Q 15.875 39.890625 15.1875 32.171875
 z
 " id="DejaVuSans-65"/>
      </defs>
-     <g transform="translate(125.28 220.01775)scale(0.144 -0.144)">
+     <g transform="translate(125.28 219.9735)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6c"/>
       <use x="27.783203" xlink:href="#DejaVuSans-69"/>
       <use x="55.566406" xlink:href="#DejaVuSans-6e"/>
@@ -587,7 +587,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5858f70f46">
+  <clipPath id="p9ed4042574">
    <rect height="345.6" width="446.4" x="72" y="43.2"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_legend/legend_expand.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/legend_expand.svg
@@ -38,109 +38,109 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="m9073693cf8" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m7e6ac844bc" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p1b19e773f7)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9073693cf8" y="56.290909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m9073693cf8" y="57.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m9073693cf8" y="58.909091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m9073693cf8" y="60.218182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m9073693cf8" y="61.527273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m9073693cf8" y="62.836364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m9073693cf8" y="64.145455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m9073693cf8" y="65.454545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m9073693cf8" y="66.763636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m9073693cf8" y="68.072727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m9073693cf8" y="69.381818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m9073693cf8" y="70.690909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m9073693cf8" y="72"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m9073693cf8" y="73.309091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m9073693cf8" y="74.618182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m9073693cf8" y="75.927273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m9073693cf8" y="77.236364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m9073693cf8" y="78.545455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m9073693cf8" y="79.854545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m9073693cf8" y="81.163636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m9073693cf8" y="82.472727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m9073693cf8" y="83.781818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m9073693cf8" y="85.090909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m9073693cf8" y="86.4"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m9073693cf8" y="87.709091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m9073693cf8" y="89.018182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m9073693cf8" y="90.327273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m9073693cf8" y="91.636364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m9073693cf8" y="92.945455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m9073693cf8" y="94.254545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m9073693cf8" y="95.563636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m9073693cf8" y="96.872727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m9073693cf8" y="98.181818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m9073693cf8" y="99.490909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m9073693cf8" y="100.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m9073693cf8" y="102.109091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m9073693cf8" y="103.418182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m9073693cf8" y="104.727273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m9073693cf8" y="106.036364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m9073693cf8" y="107.345455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m9073693cf8" y="108.654545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m9073693cf8" y="109.963636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m9073693cf8" y="111.272727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m9073693cf8" y="112.581818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m9073693cf8" y="113.890909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m9073693cf8" y="115.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m9073693cf8" y="116.509091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m9073693cf8" y="117.818182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m9073693cf8" y="119.127273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m9073693cf8" y="120.436364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m9073693cf8" y="121.745455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m9073693cf8" y="123.054545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m9073693cf8" y="124.363636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m9073693cf8" y="125.672727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m9073693cf8" y="126.981818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m9073693cf8" y="128.290909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m9073693cf8" y="129.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m9073693cf8" y="130.909091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m9073693cf8" y="132.218182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m9073693cf8" y="133.527273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m9073693cf8" y="134.836364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m9073693cf8" y="136.145455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m9073693cf8" y="137.454545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m9073693cf8" y="138.763636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m9073693cf8" y="140.072727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m9073693cf8" y="141.381818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m9073693cf8" y="142.690909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m9073693cf8" y="144"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m9073693cf8" y="145.309091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m9073693cf8" y="146.618182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m9073693cf8" y="147.927273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m9073693cf8" y="149.236364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m9073693cf8" y="150.545455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m9073693cf8" y="151.854545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m9073693cf8" y="153.163636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m9073693cf8" y="154.472727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m9073693cf8" y="155.781818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m9073693cf8" y="157.090909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m9073693cf8" y="158.4"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m9073693cf8" y="159.709091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m9073693cf8" y="161.018182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m9073693cf8" y="162.327273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m9073693cf8" y="163.636364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m9073693cf8" y="164.945455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m9073693cf8" y="166.254545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m9073693cf8" y="167.563636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m9073693cf8" y="168.872727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m9073693cf8" y="170.181818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m9073693cf8" y="171.490909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m9073693cf8" y="172.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m9073693cf8" y="174.109091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m9073693cf8" y="175.418182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m9073693cf8" y="176.727273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m9073693cf8" y="178.036364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m9073693cf8" y="179.345455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m9073693cf8" y="180.654545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m9073693cf8" y="181.963636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m9073693cf8" y="183.272727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m9073693cf8" y="184.581818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m9073693cf8" y="185.890909"/>
+    <g clip-path="url(#p044f8b735d)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m7e6ac844bc" y="56.290909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m7e6ac844bc" y="57.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m7e6ac844bc" y="58.909091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m7e6ac844bc" y="60.218182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m7e6ac844bc" y="61.527273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m7e6ac844bc" y="62.836364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m7e6ac844bc" y="64.145455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m7e6ac844bc" y="65.454545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m7e6ac844bc" y="66.763636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m7e6ac844bc" y="68.072727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m7e6ac844bc" y="69.381818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m7e6ac844bc" y="70.690909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m7e6ac844bc" y="72"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m7e6ac844bc" y="73.309091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m7e6ac844bc" y="74.618182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m7e6ac844bc" y="75.927273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m7e6ac844bc" y="77.236364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m7e6ac844bc" y="78.545455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m7e6ac844bc" y="79.854545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m7e6ac844bc" y="81.163636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m7e6ac844bc" y="82.472727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m7e6ac844bc" y="83.781818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m7e6ac844bc" y="85.090909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m7e6ac844bc" y="86.4"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m7e6ac844bc" y="87.709091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m7e6ac844bc" y="89.018182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m7e6ac844bc" y="90.327273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m7e6ac844bc" y="91.636364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m7e6ac844bc" y="92.945455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m7e6ac844bc" y="94.254545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m7e6ac844bc" y="95.563636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m7e6ac844bc" y="96.872727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m7e6ac844bc" y="98.181818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m7e6ac844bc" y="99.490909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m7e6ac844bc" y="100.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m7e6ac844bc" y="102.109091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m7e6ac844bc" y="103.418182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m7e6ac844bc" y="104.727273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m7e6ac844bc" y="106.036364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m7e6ac844bc" y="107.345455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m7e6ac844bc" y="108.654545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m7e6ac844bc" y="109.963636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m7e6ac844bc" y="111.272727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m7e6ac844bc" y="112.581818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m7e6ac844bc" y="113.890909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m7e6ac844bc" y="115.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m7e6ac844bc" y="116.509091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m7e6ac844bc" y="117.818182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m7e6ac844bc" y="119.127273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m7e6ac844bc" y="120.436364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m7e6ac844bc" y="121.745455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m7e6ac844bc" y="123.054545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m7e6ac844bc" y="124.363636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m7e6ac844bc" y="125.672727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m7e6ac844bc" y="126.981818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m7e6ac844bc" y="128.290909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m7e6ac844bc" y="129.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m7e6ac844bc" y="130.909091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m7e6ac844bc" y="132.218182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m7e6ac844bc" y="133.527273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m7e6ac844bc" y="134.836364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m7e6ac844bc" y="136.145455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m7e6ac844bc" y="137.454545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m7e6ac844bc" y="138.763636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m7e6ac844bc" y="140.072727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m7e6ac844bc" y="141.381818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m7e6ac844bc" y="142.690909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m7e6ac844bc" y="144"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m7e6ac844bc" y="145.309091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m7e6ac844bc" y="146.618182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m7e6ac844bc" y="147.927273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m7e6ac844bc" y="149.236364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m7e6ac844bc" y="150.545455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m7e6ac844bc" y="151.854545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m7e6ac844bc" y="153.163636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m7e6ac844bc" y="154.472727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m7e6ac844bc" y="155.781818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m7e6ac844bc" y="157.090909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m7e6ac844bc" y="158.4"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m7e6ac844bc" y="159.709091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m7e6ac844bc" y="161.018182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m7e6ac844bc" y="162.327273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m7e6ac844bc" y="163.636364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m7e6ac844bc" y="164.945455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m7e6ac844bc" y="166.254545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m7e6ac844bc" y="167.563636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m7e6ac844bc" y="168.872727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m7e6ac844bc" y="170.181818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m7e6ac844bc" y="171.490909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m7e6ac844bc" y="172.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m7e6ac844bc" y="174.109091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m7e6ac844bc" y="175.418182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m7e6ac844bc" y="176.727273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m7e6ac844bc" y="178.036364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m7e6ac844bc" y="179.345455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m7e6ac844bc" y="180.654545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m7e6ac844bc" y="181.963636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m7e6ac844bc" y="183.272727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m7e6ac844bc" y="184.581818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m7e6ac844bc" y="185.890909"/>
     </g>
    </g>
    <g id="line2d_2">
@@ -155,109 +155,109 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="ma473e560d5" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m19a60f92bb" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p1b19e773f7)">
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma473e560d5" y="187.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#ma473e560d5" y="185.890909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#ma473e560d5" y="184.581818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#ma473e560d5" y="183.272727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#ma473e560d5" y="181.963636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#ma473e560d5" y="180.654545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#ma473e560d5" y="179.345455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#ma473e560d5" y="178.036364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#ma473e560d5" y="176.727273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#ma473e560d5" y="175.418182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#ma473e560d5" y="174.109091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#ma473e560d5" y="172.8"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#ma473e560d5" y="171.490909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#ma473e560d5" y="170.181818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#ma473e560d5" y="168.872727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#ma473e560d5" y="167.563636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#ma473e560d5" y="166.254545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#ma473e560d5" y="164.945455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#ma473e560d5" y="163.636364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#ma473e560d5" y="162.327273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#ma473e560d5" y="161.018182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#ma473e560d5" y="159.709091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#ma473e560d5" y="158.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#ma473e560d5" y="157.090909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#ma473e560d5" y="155.781818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#ma473e560d5" y="154.472727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#ma473e560d5" y="153.163636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#ma473e560d5" y="151.854545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#ma473e560d5" y="150.545455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#ma473e560d5" y="149.236364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#ma473e560d5" y="147.927273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#ma473e560d5" y="146.618182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#ma473e560d5" y="145.309091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#ma473e560d5" y="144"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#ma473e560d5" y="142.690909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#ma473e560d5" y="141.381818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#ma473e560d5" y="140.072727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#ma473e560d5" y="138.763636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#ma473e560d5" y="137.454545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#ma473e560d5" y="136.145455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#ma473e560d5" y="134.836364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#ma473e560d5" y="133.527273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#ma473e560d5" y="132.218182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#ma473e560d5" y="130.909091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#ma473e560d5" y="129.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#ma473e560d5" y="128.290909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#ma473e560d5" y="126.981818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#ma473e560d5" y="125.672727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#ma473e560d5" y="124.363636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#ma473e560d5" y="123.054545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#ma473e560d5" y="121.745455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#ma473e560d5" y="120.436364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#ma473e560d5" y="119.127273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#ma473e560d5" y="117.818182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#ma473e560d5" y="116.509091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#ma473e560d5" y="115.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#ma473e560d5" y="113.890909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#ma473e560d5" y="112.581818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#ma473e560d5" y="111.272727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#ma473e560d5" y="109.963636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#ma473e560d5" y="108.654545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#ma473e560d5" y="107.345455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#ma473e560d5" y="106.036364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#ma473e560d5" y="104.727273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#ma473e560d5" y="103.418182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#ma473e560d5" y="102.109091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#ma473e560d5" y="100.8"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#ma473e560d5" y="99.490909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#ma473e560d5" y="98.181818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#ma473e560d5" y="96.872727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#ma473e560d5" y="95.563636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#ma473e560d5" y="94.254545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#ma473e560d5" y="92.945455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#ma473e560d5" y="91.636364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#ma473e560d5" y="90.327273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#ma473e560d5" y="89.018182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#ma473e560d5" y="87.709091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#ma473e560d5" y="86.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#ma473e560d5" y="85.090909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#ma473e560d5" y="83.781818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#ma473e560d5" y="82.472727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#ma473e560d5" y="81.163636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#ma473e560d5" y="79.854545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#ma473e560d5" y="78.545455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#ma473e560d5" y="77.236364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#ma473e560d5" y="75.927273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#ma473e560d5" y="74.618182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#ma473e560d5" y="73.309091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#ma473e560d5" y="72"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#ma473e560d5" y="70.690909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#ma473e560d5" y="69.381818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#ma473e560d5" y="68.072727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#ma473e560d5" y="66.763636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#ma473e560d5" y="65.454545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#ma473e560d5" y="64.145455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#ma473e560d5" y="62.836364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#ma473e560d5" y="61.527273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#ma473e560d5" y="60.218182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#ma473e560d5" y="58.909091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#ma473e560d5" y="57.6"/>
+    <g clip-path="url(#p044f8b735d)">
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m19a60f92bb" y="187.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m19a60f92bb" y="185.890909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m19a60f92bb" y="184.581818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m19a60f92bb" y="183.272727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m19a60f92bb" y="181.963636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m19a60f92bb" y="180.654545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m19a60f92bb" y="179.345455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m19a60f92bb" y="178.036364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m19a60f92bb" y="176.727273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m19a60f92bb" y="175.418182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m19a60f92bb" y="174.109091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m19a60f92bb" y="172.8"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m19a60f92bb" y="171.490909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m19a60f92bb" y="170.181818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m19a60f92bb" y="168.872727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m19a60f92bb" y="167.563636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m19a60f92bb" y="166.254545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m19a60f92bb" y="164.945455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m19a60f92bb" y="163.636364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m19a60f92bb" y="162.327273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m19a60f92bb" y="161.018182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m19a60f92bb" y="159.709091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m19a60f92bb" y="158.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m19a60f92bb" y="157.090909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m19a60f92bb" y="155.781818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m19a60f92bb" y="154.472727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m19a60f92bb" y="153.163636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m19a60f92bb" y="151.854545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m19a60f92bb" y="150.545455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m19a60f92bb" y="149.236364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m19a60f92bb" y="147.927273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m19a60f92bb" y="146.618182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m19a60f92bb" y="145.309091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m19a60f92bb" y="144"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m19a60f92bb" y="142.690909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m19a60f92bb" y="141.381818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m19a60f92bb" y="140.072727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m19a60f92bb" y="138.763636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m19a60f92bb" y="137.454545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m19a60f92bb" y="136.145455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m19a60f92bb" y="134.836364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m19a60f92bb" y="133.527273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m19a60f92bb" y="132.218182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m19a60f92bb" y="130.909091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m19a60f92bb" y="129.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m19a60f92bb" y="128.290909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m19a60f92bb" y="126.981818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m19a60f92bb" y="125.672727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m19a60f92bb" y="124.363636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m19a60f92bb" y="123.054545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m19a60f92bb" y="121.745455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m19a60f92bb" y="120.436364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m19a60f92bb" y="119.127273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m19a60f92bb" y="117.818182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m19a60f92bb" y="116.509091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m19a60f92bb" y="115.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m19a60f92bb" y="113.890909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m19a60f92bb" y="112.581818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m19a60f92bb" y="111.272727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m19a60f92bb" y="109.963636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m19a60f92bb" y="108.654545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m19a60f92bb" y="107.345455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m19a60f92bb" y="106.036364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m19a60f92bb" y="104.727273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m19a60f92bb" y="103.418182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m19a60f92bb" y="102.109091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m19a60f92bb" y="100.8"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m19a60f92bb" y="99.490909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m19a60f92bb" y="98.181818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m19a60f92bb" y="96.872727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m19a60f92bb" y="95.563636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m19a60f92bb" y="94.254545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m19a60f92bb" y="92.945455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m19a60f92bb" y="91.636364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m19a60f92bb" y="90.327273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m19a60f92bb" y="89.018182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m19a60f92bb" y="87.709091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m19a60f92bb" y="86.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m19a60f92bb" y="85.090909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m19a60f92bb" y="83.781818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m19a60f92bb" y="82.472727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m19a60f92bb" y="81.163636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m19a60f92bb" y="79.854545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m19a60f92bb" y="78.545455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m19a60f92bb" y="77.236364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m19a60f92bb" y="75.927273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m19a60f92bb" y="74.618182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m19a60f92bb" y="73.309091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m19a60f92bb" y="72"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m19a60f92bb" y="70.690909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m19a60f92bb" y="69.381818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m19a60f92bb" y="68.072727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m19a60f92bb" y="66.763636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m19a60f92bb" y="65.454545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m19a60f92bb" y="64.145455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m19a60f92bb" y="62.836364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m19a60f92bb" y="61.527273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m19a60f92bb" y="60.218182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m19a60f92bb" y="58.909091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m19a60f92bb" y="57.6"/>
     </g>
    </g>
    <g id="patch_3">
@@ -286,80 +286,80 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m9ebc78685f" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m28c5f88269" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9ebc78685f" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m28c5f88269" y="200.290909"/>
       </g>
      </g>
      <g id="line2d_4">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="mbf9dd32f7b" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m343928b920" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbf9dd32f7b" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m343928b920" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m9ebc78685f" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m28c5f88269" y="200.290909"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mbf9dd32f7b" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m343928b920" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m9ebc78685f" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m28c5f88269" y="200.290909"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mbf9dd32f7b" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m343928b920" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m9ebc78685f" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m28c5f88269" y="200.290909"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mbf9dd32f7b" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m343928b920" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m9ebc78685f" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m28c5f88269" y="200.290909"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mbf9dd32f7b" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m343928b920" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m9ebc78685f" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m28c5f88269" y="200.290909"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mbf9dd32f7b" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m343928b920" y="43.2"/>
       </g>
      </g>
     </g>
@@ -370,101 +370,101 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m63e81bcd77" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m8235ff0f9c" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="200.290909"/>
       </g>
      </g>
      <g id="line2d_16">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="mf05d6e34b6" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m176a0e503c" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="200.290909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="200.290909"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="174.109091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="174.109091"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="174.109091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="174.109091"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="147.927273"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="147.927273"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="147.927273"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="147.927273"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="121.745455"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="121.745455"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="121.745455"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="121.745455"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="95.563636"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="95.563636"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="95.563636"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="95.563636"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="69.381818"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="69.381818"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="69.381818"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="69.381818"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="43.2"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 79.2 75.768 
-L 160.743125 75.768 
-L 160.743125 50.4 
+     <path d="M 79.2 75.8565 
+L 160.79175 75.8565 
+L 160.79175 50.4 
 L 79.2 50.4 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
@@ -472,8 +472,8 @@ z
     <g id="line2d_29"/>
     <g id="line2d_30">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m9073693cf8" y="62.06175"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m9073693cf8" y="62.06175"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m7e6ac844bc" y="62.06175"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m7e6ac844bc" y="62.06175"/>
      </g>
     </g>
     <g id="text_1">
@@ -529,23 +529,23 @@ z
    </g>
    <g id="legend_2">
     <g id="patch_8">
-     <path d="M 424.469375 144.997705 
-L 511.2 144.997705 
-L 511.2 98.493205 
-L 424.469375 98.493205 
+     <path d="M 424.413 145.041955 
+L 511.2 145.041955 
+L 511.2 98.448955 
+L 424.413 98.448955 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_31"/>
     <g id="line2d_32">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="434.549375" xlink:href="#m9073693cf8" y="110.154955"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="454.709375" xlink:href="#m9073693cf8" y="110.154955"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="434.493" xlink:href="#m7e6ac844bc" y="110.110705"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="454.653" xlink:href="#m7e6ac844bc" y="110.110705"/>
      </g>
     </g>
     <g id="text_2">
      <!-- y=1 -->
-     <g transform="translate(470.549375 115.194955)scale(0.144 -0.144)">
+     <g transform="translate(470.493 115.150705)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-31"/>
@@ -554,8 +554,8 @@ z
     <g id="line2d_33"/>
     <g id="line2d_34">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="434.549375" xlink:href="#ma473e560d5" y="131.291455"/>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="454.709375" xlink:href="#ma473e560d5" y="131.291455"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="434.493" xlink:href="#m19a60f92bb" y="131.247205"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="454.653" xlink:href="#m19a60f92bb" y="131.247205"/>
      </g>
     </g>
     <g id="text_3">
@@ -568,7 +568,7 @@ L 4.890625 23.390625
 z
 " id="DejaVuSans-2d"/>
      </defs>
-     <g transform="translate(470.549375 136.331455)scale(0.144 -0.144)">
+     <g transform="translate(470.493 136.287205)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-2d"/>
@@ -579,22 +579,22 @@ z
    <g id="legend_3">
     <g id="patch_9">
      <path d="M 79.2 193.090909 
-L 264.75375 193.090909 
-L 264.75375 167.722909 
-L 79.2 167.722909 
+L 264.85875 193.090909 
+L 264.85875 167.634409 
+L 79.2 167.634409 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_35"/>
     <g id="line2d_36">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m9073693cf8" y="179.384659"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m9073693cf8" y="179.384659"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m7e6ac844bc" y="179.296159"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m7e6ac844bc" y="179.296159"/>
      </g>
     </g>
     <g id="text_4">
      <!-- y=1 -->
-     <g transform="translate(125.28 184.424659)scale(0.144 -0.144)">
+     <g transform="translate(125.28 184.336159)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-31"/>
@@ -603,13 +603,13 @@ z
     <g id="line2d_37"/>
     <g id="line2d_38">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.103125" xlink:href="#ma473e560d5" y="179.384659"/>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="208.263125" xlink:href="#ma473e560d5" y="179.384659"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.15175" xlink:href="#m19a60f92bb" y="179.296159"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="208.31175" xlink:href="#m19a60f92bb" y="179.296159"/>
      </g>
     </g>
     <g id="text_5">
      <!-- y=-1 -->
-     <g transform="translate(224.103125 184.424659)scale(0.144 -0.144)">
+     <g transform="translate(224.15175 184.336159)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-2d"/>
@@ -628,211 +628,211 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="line2d_39">
-    <g clip-path="url(#padfca0a31b)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9073693cf8" y="244.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m9073693cf8" y="246.109091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m9073693cf8" y="247.418182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m9073693cf8" y="248.727273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m9073693cf8" y="250.036364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m9073693cf8" y="251.345455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m9073693cf8" y="252.654545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m9073693cf8" y="253.963636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m9073693cf8" y="255.272727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m9073693cf8" y="256.581818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m9073693cf8" y="257.890909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m9073693cf8" y="259.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m9073693cf8" y="260.509091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m9073693cf8" y="261.818182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m9073693cf8" y="263.127273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m9073693cf8" y="264.436364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m9073693cf8" y="265.745455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m9073693cf8" y="267.054545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m9073693cf8" y="268.363636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m9073693cf8" y="269.672727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m9073693cf8" y="270.981818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m9073693cf8" y="272.290909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m9073693cf8" y="273.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m9073693cf8" y="274.909091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m9073693cf8" y="276.218182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m9073693cf8" y="277.527273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m9073693cf8" y="278.836364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m9073693cf8" y="280.145455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m9073693cf8" y="281.454545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m9073693cf8" y="282.763636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m9073693cf8" y="284.072727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m9073693cf8" y="285.381818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m9073693cf8" y="286.690909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m9073693cf8" y="288"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m9073693cf8" y="289.309091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m9073693cf8" y="290.618182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m9073693cf8" y="291.927273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m9073693cf8" y="293.236364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m9073693cf8" y="294.545455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m9073693cf8" y="295.854545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m9073693cf8" y="297.163636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m9073693cf8" y="298.472727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m9073693cf8" y="299.781818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m9073693cf8" y="301.090909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m9073693cf8" y="302.4"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m9073693cf8" y="303.709091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m9073693cf8" y="305.018182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m9073693cf8" y="306.327273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m9073693cf8" y="307.636364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m9073693cf8" y="308.945455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m9073693cf8" y="310.254545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m9073693cf8" y="311.563636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m9073693cf8" y="312.872727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m9073693cf8" y="314.181818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m9073693cf8" y="315.490909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m9073693cf8" y="316.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m9073693cf8" y="318.109091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m9073693cf8" y="319.418182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m9073693cf8" y="320.727273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m9073693cf8" y="322.036364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m9073693cf8" y="323.345455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m9073693cf8" y="324.654545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m9073693cf8" y="325.963636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m9073693cf8" y="327.272727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m9073693cf8" y="328.581818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m9073693cf8" y="329.890909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m9073693cf8" y="331.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m9073693cf8" y="332.509091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m9073693cf8" y="333.818182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m9073693cf8" y="335.127273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m9073693cf8" y="336.436364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m9073693cf8" y="337.745455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m9073693cf8" y="339.054545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m9073693cf8" y="340.363636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m9073693cf8" y="341.672727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m9073693cf8" y="342.981818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m9073693cf8" y="344.290909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m9073693cf8" y="345.6"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m9073693cf8" y="346.909091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m9073693cf8" y="348.218182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m9073693cf8" y="349.527273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m9073693cf8" y="350.836364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m9073693cf8" y="352.145455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m9073693cf8" y="353.454545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m9073693cf8" y="354.763636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m9073693cf8" y="356.072727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m9073693cf8" y="357.381818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m9073693cf8" y="358.690909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m9073693cf8" y="360"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m9073693cf8" y="361.309091"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m9073693cf8" y="362.618182"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m9073693cf8" y="363.927273"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m9073693cf8" y="365.236364"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m9073693cf8" y="366.545455"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m9073693cf8" y="367.854545"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m9073693cf8" y="369.163636"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m9073693cf8" y="370.472727"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m9073693cf8" y="371.781818"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m9073693cf8" y="373.090909"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m9073693cf8" y="374.4"/>
+    <g clip-path="url(#pce68e6d5cd)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m7e6ac844bc" y="244.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m7e6ac844bc" y="246.109091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m7e6ac844bc" y="247.418182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m7e6ac844bc" y="248.727273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m7e6ac844bc" y="250.036364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m7e6ac844bc" y="251.345455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m7e6ac844bc" y="252.654545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m7e6ac844bc" y="253.963636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m7e6ac844bc" y="255.272727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m7e6ac844bc" y="256.581818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m7e6ac844bc" y="257.890909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m7e6ac844bc" y="259.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m7e6ac844bc" y="260.509091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m7e6ac844bc" y="261.818182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m7e6ac844bc" y="263.127273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m7e6ac844bc" y="264.436364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m7e6ac844bc" y="265.745455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m7e6ac844bc" y="267.054545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m7e6ac844bc" y="268.363636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m7e6ac844bc" y="269.672727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m7e6ac844bc" y="270.981818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m7e6ac844bc" y="272.290909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m7e6ac844bc" y="273.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m7e6ac844bc" y="274.909091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m7e6ac844bc" y="276.218182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m7e6ac844bc" y="277.527273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m7e6ac844bc" y="278.836364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m7e6ac844bc" y="280.145455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m7e6ac844bc" y="281.454545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m7e6ac844bc" y="282.763636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m7e6ac844bc" y="284.072727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m7e6ac844bc" y="285.381818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m7e6ac844bc" y="286.690909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m7e6ac844bc" y="288"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m7e6ac844bc" y="289.309091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m7e6ac844bc" y="290.618182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m7e6ac844bc" y="291.927273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m7e6ac844bc" y="293.236364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m7e6ac844bc" y="294.545455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m7e6ac844bc" y="295.854545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m7e6ac844bc" y="297.163636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m7e6ac844bc" y="298.472727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m7e6ac844bc" y="299.781818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m7e6ac844bc" y="301.090909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m7e6ac844bc" y="302.4"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m7e6ac844bc" y="303.709091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m7e6ac844bc" y="305.018182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m7e6ac844bc" y="306.327273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m7e6ac844bc" y="307.636364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m7e6ac844bc" y="308.945455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m7e6ac844bc" y="310.254545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m7e6ac844bc" y="311.563636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m7e6ac844bc" y="312.872727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m7e6ac844bc" y="314.181818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m7e6ac844bc" y="315.490909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m7e6ac844bc" y="316.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m7e6ac844bc" y="318.109091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m7e6ac844bc" y="319.418182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m7e6ac844bc" y="320.727273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m7e6ac844bc" y="322.036364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m7e6ac844bc" y="323.345455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m7e6ac844bc" y="324.654545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m7e6ac844bc" y="325.963636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m7e6ac844bc" y="327.272727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m7e6ac844bc" y="328.581818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m7e6ac844bc" y="329.890909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m7e6ac844bc" y="331.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m7e6ac844bc" y="332.509091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m7e6ac844bc" y="333.818182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m7e6ac844bc" y="335.127273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m7e6ac844bc" y="336.436364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m7e6ac844bc" y="337.745455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m7e6ac844bc" y="339.054545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m7e6ac844bc" y="340.363636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m7e6ac844bc" y="341.672727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m7e6ac844bc" y="342.981818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m7e6ac844bc" y="344.290909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m7e6ac844bc" y="345.6"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m7e6ac844bc" y="346.909091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m7e6ac844bc" y="348.218182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m7e6ac844bc" y="349.527273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m7e6ac844bc" y="350.836364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m7e6ac844bc" y="352.145455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m7e6ac844bc" y="353.454545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m7e6ac844bc" y="354.763636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m7e6ac844bc" y="356.072727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m7e6ac844bc" y="357.381818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m7e6ac844bc" y="358.690909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m7e6ac844bc" y="360"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m7e6ac844bc" y="361.309091"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m7e6ac844bc" y="362.618182"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m7e6ac844bc" y="363.927273"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m7e6ac844bc" y="365.236364"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m7e6ac844bc" y="366.545455"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m7e6ac844bc" y="367.854545"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m7e6ac844bc" y="369.163636"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m7e6ac844bc" y="370.472727"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m7e6ac844bc" y="371.781818"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m7e6ac844bc" y="373.090909"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m7e6ac844bc" y="374.4"/>
     </g>
    </g>
    <g id="line2d_40">
-    <g clip-path="url(#padfca0a31b)">
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#ma473e560d5" y="375.709091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#ma473e560d5" y="374.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#ma473e560d5" y="373.090909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#ma473e560d5" y="371.781818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#ma473e560d5" y="370.472727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#ma473e560d5" y="369.163636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#ma473e560d5" y="367.854545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#ma473e560d5" y="366.545455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#ma473e560d5" y="365.236364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#ma473e560d5" y="363.927273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#ma473e560d5" y="362.618182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#ma473e560d5" y="361.309091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#ma473e560d5" y="360"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#ma473e560d5" y="358.690909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#ma473e560d5" y="357.381818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#ma473e560d5" y="356.072727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#ma473e560d5" y="354.763636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#ma473e560d5" y="353.454545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#ma473e560d5" y="352.145455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#ma473e560d5" y="350.836364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#ma473e560d5" y="349.527273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#ma473e560d5" y="348.218182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#ma473e560d5" y="346.909091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#ma473e560d5" y="345.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#ma473e560d5" y="344.290909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#ma473e560d5" y="342.981818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#ma473e560d5" y="341.672727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#ma473e560d5" y="340.363636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#ma473e560d5" y="339.054545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#ma473e560d5" y="337.745455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#ma473e560d5" y="336.436364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#ma473e560d5" y="335.127273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#ma473e560d5" y="333.818182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#ma473e560d5" y="332.509091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#ma473e560d5" y="331.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#ma473e560d5" y="329.890909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#ma473e560d5" y="328.581818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#ma473e560d5" y="327.272727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#ma473e560d5" y="325.963636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#ma473e560d5" y="324.654545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#ma473e560d5" y="323.345455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#ma473e560d5" y="322.036364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#ma473e560d5" y="320.727273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#ma473e560d5" y="319.418182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#ma473e560d5" y="318.109091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#ma473e560d5" y="316.8"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#ma473e560d5" y="315.490909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#ma473e560d5" y="314.181818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#ma473e560d5" y="312.872727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#ma473e560d5" y="311.563636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#ma473e560d5" y="310.254545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#ma473e560d5" y="308.945455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#ma473e560d5" y="307.636364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#ma473e560d5" y="306.327273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#ma473e560d5" y="305.018182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#ma473e560d5" y="303.709091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#ma473e560d5" y="302.4"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#ma473e560d5" y="301.090909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#ma473e560d5" y="299.781818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#ma473e560d5" y="298.472727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#ma473e560d5" y="297.163636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#ma473e560d5" y="295.854545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#ma473e560d5" y="294.545455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#ma473e560d5" y="293.236364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#ma473e560d5" y="291.927273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#ma473e560d5" y="290.618182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#ma473e560d5" y="289.309091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#ma473e560d5" y="288"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#ma473e560d5" y="286.690909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#ma473e560d5" y="285.381818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#ma473e560d5" y="284.072727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#ma473e560d5" y="282.763636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#ma473e560d5" y="281.454545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#ma473e560d5" y="280.145455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#ma473e560d5" y="278.836364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#ma473e560d5" y="277.527273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#ma473e560d5" y="276.218182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#ma473e560d5" y="274.909091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#ma473e560d5" y="273.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#ma473e560d5" y="272.290909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#ma473e560d5" y="270.981818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#ma473e560d5" y="269.672727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#ma473e560d5" y="268.363636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#ma473e560d5" y="267.054545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#ma473e560d5" y="265.745455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#ma473e560d5" y="264.436364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#ma473e560d5" y="263.127273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#ma473e560d5" y="261.818182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#ma473e560d5" y="260.509091"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#ma473e560d5" y="259.2"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#ma473e560d5" y="257.890909"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#ma473e560d5" y="256.581818"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#ma473e560d5" y="255.272727"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#ma473e560d5" y="253.963636"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#ma473e560d5" y="252.654545"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#ma473e560d5" y="251.345455"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#ma473e560d5" y="250.036364"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#ma473e560d5" y="248.727273"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#ma473e560d5" y="247.418182"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#ma473e560d5" y="246.109091"/>
+    <g clip-path="url(#pce68e6d5cd)">
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m19a60f92bb" y="375.709091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="76.464" xlink:href="#m19a60f92bb" y="374.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="80.928" xlink:href="#m19a60f92bb" y="373.090909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="85.392" xlink:href="#m19a60f92bb" y="371.781818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.856" xlink:href="#m19a60f92bb" y="370.472727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="94.32" xlink:href="#m19a60f92bb" y="369.163636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="98.784" xlink:href="#m19a60f92bb" y="367.854545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="103.248" xlink:href="#m19a60f92bb" y="366.545455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="107.712" xlink:href="#m19a60f92bb" y="365.236364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="112.176" xlink:href="#m19a60f92bb" y="363.927273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m19a60f92bb" y="362.618182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="121.104" xlink:href="#m19a60f92bb" y="361.309091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="125.568" xlink:href="#m19a60f92bb" y="360"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="130.032" xlink:href="#m19a60f92bb" y="358.690909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="134.496" xlink:href="#m19a60f92bb" y="357.381818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="138.96" xlink:href="#m19a60f92bb" y="356.072727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="143.424" xlink:href="#m19a60f92bb" y="354.763636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="147.888" xlink:href="#m19a60f92bb" y="353.454545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="152.352" xlink:href="#m19a60f92bb" y="352.145455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="156.816" xlink:href="#m19a60f92bb" y="350.836364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m19a60f92bb" y="349.527273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="165.744" xlink:href="#m19a60f92bb" y="348.218182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="170.208" xlink:href="#m19a60f92bb" y="346.909091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="174.672" xlink:href="#m19a60f92bb" y="345.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="179.136" xlink:href="#m19a60f92bb" y="344.290909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m19a60f92bb" y="342.981818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="188.064" xlink:href="#m19a60f92bb" y="341.672727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="192.528" xlink:href="#m19a60f92bb" y="340.363636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="196.992" xlink:href="#m19a60f92bb" y="339.054545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="201.456" xlink:href="#m19a60f92bb" y="337.745455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m19a60f92bb" y="336.436364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="210.384" xlink:href="#m19a60f92bb" y="335.127273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="214.848" xlink:href="#m19a60f92bb" y="333.818182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="219.312" xlink:href="#m19a60f92bb" y="332.509091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="223.776" xlink:href="#m19a60f92bb" y="331.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="228.24" xlink:href="#m19a60f92bb" y="329.890909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="232.704" xlink:href="#m19a60f92bb" y="328.581818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="237.168" xlink:href="#m19a60f92bb" y="327.272727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="241.632" xlink:href="#m19a60f92bb" y="325.963636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="246.096" xlink:href="#m19a60f92bb" y="324.654545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m19a60f92bb" y="323.345455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="255.024" xlink:href="#m19a60f92bb" y="322.036364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="259.488" xlink:href="#m19a60f92bb" y="320.727273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="263.952" xlink:href="#m19a60f92bb" y="319.418182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="268.416" xlink:href="#m19a60f92bb" y="318.109091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="272.88" xlink:href="#m19a60f92bb" y="316.8"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="277.344" xlink:href="#m19a60f92bb" y="315.490909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="281.808" xlink:href="#m19a60f92bb" y="314.181818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="286.272" xlink:href="#m19a60f92bb" y="312.872727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="290.736" xlink:href="#m19a60f92bb" y="311.563636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m19a60f92bb" y="310.254545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="299.664" xlink:href="#m19a60f92bb" y="308.945455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="304.128" xlink:href="#m19a60f92bb" y="307.636364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="308.592" xlink:href="#m19a60f92bb" y="306.327273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="313.056" xlink:href="#m19a60f92bb" y="305.018182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="317.52" xlink:href="#m19a60f92bb" y="303.709091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="321.984" xlink:href="#m19a60f92bb" y="302.4"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="326.448" xlink:href="#m19a60f92bb" y="301.090909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="330.912" xlink:href="#m19a60f92bb" y="299.781818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="335.376" xlink:href="#m19a60f92bb" y="298.472727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m19a60f92bb" y="297.163636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="344.304" xlink:href="#m19a60f92bb" y="295.854545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="348.768" xlink:href="#m19a60f92bb" y="294.545455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="353.232" xlink:href="#m19a60f92bb" y="293.236364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="357.696" xlink:href="#m19a60f92bb" y="291.927273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="362.16" xlink:href="#m19a60f92bb" y="290.618182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="366.624" xlink:href="#m19a60f92bb" y="289.309091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="371.088" xlink:href="#m19a60f92bb" y="288"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="375.552" xlink:href="#m19a60f92bb" y="286.690909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="380.016" xlink:href="#m19a60f92bb" y="285.381818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="384.48" xlink:href="#m19a60f92bb" y="284.072727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="388.944" xlink:href="#m19a60f92bb" y="282.763636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="393.408" xlink:href="#m19a60f92bb" y="281.454545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="397.872" xlink:href="#m19a60f92bb" y="280.145455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="402.336" xlink:href="#m19a60f92bb" y="278.836364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m19a60f92bb" y="277.527273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="411.264" xlink:href="#m19a60f92bb" y="276.218182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="415.728" xlink:href="#m19a60f92bb" y="274.909091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="420.192" xlink:href="#m19a60f92bb" y="273.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="424.656" xlink:href="#m19a60f92bb" y="272.290909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m19a60f92bb" y="270.981818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="433.584" xlink:href="#m19a60f92bb" y="269.672727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="438.048" xlink:href="#m19a60f92bb" y="268.363636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="442.512" xlink:href="#m19a60f92bb" y="267.054545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="446.976" xlink:href="#m19a60f92bb" y="265.745455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="451.44" xlink:href="#m19a60f92bb" y="264.436364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="455.904" xlink:href="#m19a60f92bb" y="263.127273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="460.368" xlink:href="#m19a60f92bb" y="261.818182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="464.832" xlink:href="#m19a60f92bb" y="260.509091"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="469.296" xlink:href="#m19a60f92bb" y="259.2"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="473.76" xlink:href="#m19a60f92bb" y="257.890909"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="478.224" xlink:href="#m19a60f92bb" y="256.581818"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="482.688" xlink:href="#m19a60f92bb" y="255.272727"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="487.152" xlink:href="#m19a60f92bb" y="253.963636"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="491.616" xlink:href="#m19a60f92bb" y="252.654545"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="496.08" xlink:href="#m19a60f92bb" y="251.345455"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="500.544" xlink:href="#m19a60f92bb" y="250.036364"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="505.008" xlink:href="#m19a60f92bb" y="248.727273"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="509.472" xlink:href="#m19a60f92bb" y="247.418182"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="513.936" xlink:href="#m19a60f92bb" y="246.109091"/>
     </g>
    </g>
    <g id="patch_11">
@@ -859,72 +859,72 @@ L 518.4 231.709091
     <g id="xtick_7">
      <g id="line2d_41">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9ebc78685f" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m28c5f88269" y="388.8"/>
       </g>
      </g>
      <g id="line2d_42">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbf9dd32f7b" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m343928b920" y="231.709091"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_43">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m9ebc78685f" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m28c5f88269" y="388.8"/>
       </g>
      </g>
      <g id="line2d_44">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#mbf9dd32f7b" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m343928b920" y="231.709091"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_45">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m9ebc78685f" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m28c5f88269" y="388.8"/>
       </g>
      </g>
      <g id="line2d_46">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#mbf9dd32f7b" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m343928b920" y="231.709091"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_47">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m9ebc78685f" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m28c5f88269" y="388.8"/>
       </g>
      </g>
      <g id="line2d_48">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#mbf9dd32f7b" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="339.84" xlink:href="#m343928b920" y="231.709091"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_49">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m9ebc78685f" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m28c5f88269" y="388.8"/>
       </g>
      </g>
      <g id="line2d_50">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#mbf9dd32f7b" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="429.12" xlink:href="#m343928b920" y="231.709091"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_51">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m9ebc78685f" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m28c5f88269" y="388.8"/>
       </g>
      </g>
      <g id="line2d_52">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mbf9dd32f7b" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m343928b920" y="231.709091"/>
       </g>
      </g>
     </g>
@@ -933,92 +933,92 @@ L 518.4 231.709091
     <g id="ytick_8">
      <g id="line2d_53">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="388.8"/>
       </g>
      </g>
      <g id="line2d_54">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_55">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="362.618182"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="362.618182"/>
       </g>
      </g>
      <g id="line2d_56">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="362.618182"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="362.618182"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_57">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="336.436364"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="336.436364"/>
       </g>
      </g>
      <g id="line2d_58">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="336.436364"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="336.436364"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_59">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="310.254545"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="310.254545"/>
       </g>
      </g>
      <g id="line2d_60">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="310.254545"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="310.254545"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_61">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="284.072727"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="284.072727"/>
       </g>
      </g>
      <g id="line2d_62">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="284.072727"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="284.072727"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_63">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="257.890909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="257.890909"/>
       </g>
      </g>
      <g id="line2d_64">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="257.890909"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="257.890909"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_65">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m63e81bcd77" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m8235ff0f9c" y="231.709091"/>
       </g>
      </g>
      <g id="line2d_66">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mf05d6e34b6" y="231.709091"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m176a0e503c" y="231.709091"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_4">
     <g id="patch_15">
-     <path d="M 79.2 264.277091 
-L 511.2 264.277091 
+     <path d="M 79.2 264.365591 
+L 511.2 264.365591 
 L 511.2 238.909091 
 L 79.2 238.909091 
 z
@@ -1027,8 +1027,8 @@ z
     <g id="line2d_67"/>
     <g id="line2d_68">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m9073693cf8" y="250.570841"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m9073693cf8" y="250.570841"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m7e6ac844bc" y="250.570841"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m7e6ac844bc" y="250.570841"/>
      </g>
     </g>
     <g id="text_6">
@@ -1042,23 +1042,23 @@ z
    </g>
    <g id="legend_5">
     <g id="patch_16">
-     <path d="M 79.2 333.506795 
-L 511.2 333.506795 
-L 511.2 287.002295 
-L 79.2 287.002295 
+     <path d="M 79.2 333.551045 
+L 511.2 333.551045 
+L 511.2 286.958045 
+L 79.2 286.958045 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_69"/>
     <g id="line2d_70">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m9073693cf8" y="298.664045"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m9073693cf8" y="298.664045"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m7e6ac844bc" y="298.619795"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m7e6ac844bc" y="298.619795"/>
      </g>
     </g>
     <g id="text_7">
      <!-- y=1 -->
-     <g transform="translate(125.28 303.704045)scale(0.144 -0.144)">
+     <g transform="translate(125.28 303.659795)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-31"/>
@@ -1067,13 +1067,13 @@ z
     <g id="line2d_71"/>
     <g id="line2d_72">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#ma473e560d5" y="319.800545"/>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#ma473e560d5" y="319.800545"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m19a60f92bb" y="319.756295"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m19a60f92bb" y="319.756295"/>
      </g>
     </g>
     <g id="text_8">
      <!-- y=-1 -->
-     <g transform="translate(125.28 324.840545)scale(0.144 -0.144)">
+     <g transform="translate(125.28 324.796295)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-2d"/>
@@ -1085,21 +1085,21 @@ z
     <g id="patch_17">
      <path d="M 79.2 381.6 
 L 511.2 381.6 
-L 511.2 356.232 
-L 79.2 356.232 
+L 511.2 356.1435 
+L 79.2 356.1435 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_73"/>
     <g id="line2d_74">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m9073693cf8" y="367.89375"/>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m9073693cf8" y="367.89375"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="89.28" xlink:href="#m7e6ac844bc" y="367.80525"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="109.44" xlink:href="#m7e6ac844bc" y="367.80525"/>
      </g>
     </g>
     <g id="text_9">
      <!-- y=1 -->
-     <g transform="translate(125.28 372.93375)scale(0.144 -0.144)">
+     <g transform="translate(125.28 372.84525)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-31"/>
@@ -1108,13 +1108,13 @@ z
     <g id="line2d_75"/>
     <g id="line2d_76">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="434.549375" xlink:href="#ma473e560d5" y="367.89375"/>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="454.709375" xlink:href="#ma473e560d5" y="367.89375"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="434.493" xlink:href="#m19a60f92bb" y="367.80525"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="454.653" xlink:href="#m19a60f92bb" y="367.80525"/>
      </g>
     </g>
     <g id="text_10">
      <!-- y=-1 -->
-     <g transform="translate(470.549375 372.93375)scale(0.144 -0.144)">
+     <g transform="translate(470.493 372.84525)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-79"/>
       <use x="59.179688" xlink:href="#DejaVuSans-3d"/>
       <use x="142.96875" xlink:href="#DejaVuSans-2d"/>
@@ -1125,10 +1125,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p1b19e773f7">
+  <clipPath id="p044f8b735d">
    <rect height="157.090909" width="446.4" x="72" y="43.2"/>
   </clipPath>
-  <clipPath id="padfca0a31b">
+  <clipPath id="pce68e6d5cd">
    <rect height="157.090909" width="446.4" x="72" y="231.709091"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_legend/legend_various_labels.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/legend_various_labels.svg
@@ -38,13 +38,13 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="ma650ed4e71" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="mc3dd6596f1" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p701db9c174)">
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#ma650ed4e71" y="388.8"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="76.0581818182" xlink:href="#ma650ed4e71" y="312.0"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="80.1163636364" xlink:href="#ma650ed4e71" y="235.2"/>
-     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="84.1745454545" xlink:href="#ma650ed4e71" y="158.4"/>
+    <g clip-path="url(#p70587c40fd)">
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mc3dd6596f1" y="388.8"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="76.058182" xlink:href="#mc3dd6596f1" y="312"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="80.116364" xlink:href="#mc3dd6596f1" y="235.2"/>
+     <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="84.174545" xlink:href="#mc3dd6596f1" y="158.4"/>
     </g>
    </g>
    <g id="line2d_2">
@@ -59,59 +59,59 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="maa3ac86c13" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m7568b22d77" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p701db9c174)">
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#maa3ac86c13" y="81.6"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="76.0581818182" xlink:href="#maa3ac86c13" y="81.4432653061"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="80.1163636364" xlink:href="#maa3ac86c13" y="81.2865306122"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="84.1745454545" xlink:href="#maa3ac86c13" y="81.1297959184"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="88.2327272727" xlink:href="#maa3ac86c13" y="80.9730612245"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="92.2909090909" xlink:href="#maa3ac86c13" y="80.8163265306"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="96.3490909091" xlink:href="#maa3ac86c13" y="80.6595918367"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="100.407272727" xlink:href="#maa3ac86c13" y="80.5028571429"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="104.465454545" xlink:href="#maa3ac86c13" y="80.346122449"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="108.523636364" xlink:href="#maa3ac86c13" y="80.1893877551"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="112.581818182" xlink:href="#maa3ac86c13" y="80.0326530612"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="116.64" xlink:href="#maa3ac86c13" y="79.8759183673"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="120.698181818" xlink:href="#maa3ac86c13" y="79.7191836735"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="124.756363636" xlink:href="#maa3ac86c13" y="79.5624489796"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="128.814545455" xlink:href="#maa3ac86c13" y="79.4057142857"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="132.872727273" xlink:href="#maa3ac86c13" y="79.2489795918"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="136.930909091" xlink:href="#maa3ac86c13" y="79.092244898"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="140.989090909" xlink:href="#maa3ac86c13" y="78.9355102041"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="145.047272727" xlink:href="#maa3ac86c13" y="78.7787755102"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="149.105454545" xlink:href="#maa3ac86c13" y="78.6220408163"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="153.163636364" xlink:href="#maa3ac86c13" y="78.4653061224"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="157.221818182" xlink:href="#maa3ac86c13" y="78.3085714286"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="161.28" xlink:href="#maa3ac86c13" y="78.1518367347"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="165.338181818" xlink:href="#maa3ac86c13" y="77.9951020408"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="169.396363636" xlink:href="#maa3ac86c13" y="77.8383673469"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="173.454545455" xlink:href="#maa3ac86c13" y="77.6816326531"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="177.512727273" xlink:href="#maa3ac86c13" y="77.5248979592"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="181.570909091" xlink:href="#maa3ac86c13" y="77.3681632653"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="185.629090909" xlink:href="#maa3ac86c13" y="77.2114285714"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="189.687272727" xlink:href="#maa3ac86c13" y="77.0546938776"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="193.745454545" xlink:href="#maa3ac86c13" y="76.8979591837"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="197.803636364" xlink:href="#maa3ac86c13" y="76.7412244898"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="201.861818182" xlink:href="#maa3ac86c13" y="76.5844897959"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="205.92" xlink:href="#maa3ac86c13" y="76.427755102"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="209.978181818" xlink:href="#maa3ac86c13" y="76.2710204082"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="214.036363636" xlink:href="#maa3ac86c13" y="76.1142857143"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="218.094545455" xlink:href="#maa3ac86c13" y="75.9575510204"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="222.152727273" xlink:href="#maa3ac86c13" y="75.8008163265"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="226.210909091" xlink:href="#maa3ac86c13" y="75.6440816327"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="230.269090909" xlink:href="#maa3ac86c13" y="75.4873469388"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="234.327272727" xlink:href="#maa3ac86c13" y="75.3306122449"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="238.385454545" xlink:href="#maa3ac86c13" y="75.173877551"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="242.443636364" xlink:href="#maa3ac86c13" y="75.0171428571"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="246.501818182" xlink:href="#maa3ac86c13" y="74.8604081633"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="250.56" xlink:href="#maa3ac86c13" y="74.7036734694"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="254.618181818" xlink:href="#maa3ac86c13" y="74.5469387755"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="258.676363636" xlink:href="#maa3ac86c13" y="74.3902040816"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="262.734545455" xlink:href="#maa3ac86c13" y="74.2334693878"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="266.792727273" xlink:href="#maa3ac86c13" y="74.0767346939"/>
-     <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="270.850909091" xlink:href="#maa3ac86c13" y="73.92"/>
+    <g clip-path="url(#p70587c40fd)">
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m7568b22d77" y="81.6"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="76.058182" xlink:href="#m7568b22d77" y="81.443265"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="80.116364" xlink:href="#m7568b22d77" y="81.286531"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="84.174545" xlink:href="#m7568b22d77" y="81.129796"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="88.232727" xlink:href="#m7568b22d77" y="80.973061"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="92.290909" xlink:href="#m7568b22d77" y="80.816327"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="96.349091" xlink:href="#m7568b22d77" y="80.659592"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="100.407273" xlink:href="#m7568b22d77" y="80.502857"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="104.465455" xlink:href="#m7568b22d77" y="80.346122"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="108.523636" xlink:href="#m7568b22d77" y="80.189388"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="112.581818" xlink:href="#m7568b22d77" y="80.032653"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="116.64" xlink:href="#m7568b22d77" y="79.875918"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="120.698182" xlink:href="#m7568b22d77" y="79.719184"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="124.756364" xlink:href="#m7568b22d77" y="79.562449"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="128.814545" xlink:href="#m7568b22d77" y="79.405714"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="132.872727" xlink:href="#m7568b22d77" y="79.24898"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="136.930909" xlink:href="#m7568b22d77" y="79.092245"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="140.989091" xlink:href="#m7568b22d77" y="78.93551"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="145.047273" xlink:href="#m7568b22d77" y="78.778776"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="149.105455" xlink:href="#m7568b22d77" y="78.622041"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="153.163636" xlink:href="#m7568b22d77" y="78.465306"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="157.221818" xlink:href="#m7568b22d77" y="78.308571"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="161.28" xlink:href="#m7568b22d77" y="78.151837"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="165.338182" xlink:href="#m7568b22d77" y="77.995102"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="169.396364" xlink:href="#m7568b22d77" y="77.838367"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m7568b22d77" y="77.681633"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="177.512727" xlink:href="#m7568b22d77" y="77.524898"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="181.570909" xlink:href="#m7568b22d77" y="77.368163"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="185.629091" xlink:href="#m7568b22d77" y="77.211429"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="189.687273" xlink:href="#m7568b22d77" y="77.054694"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="193.745455" xlink:href="#m7568b22d77" y="76.897959"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="197.803636" xlink:href="#m7568b22d77" y="76.741224"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="201.861818" xlink:href="#m7568b22d77" y="76.58449"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="205.92" xlink:href="#m7568b22d77" y="76.427755"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="209.978182" xlink:href="#m7568b22d77" y="76.27102"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="214.036364" xlink:href="#m7568b22d77" y="76.114286"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="218.094545" xlink:href="#m7568b22d77" y="75.957551"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="222.152727" xlink:href="#m7568b22d77" y="75.800816"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="226.210909" xlink:href="#m7568b22d77" y="75.644082"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="230.269091" xlink:href="#m7568b22d77" y="75.487347"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="234.327273" xlink:href="#m7568b22d77" y="75.330612"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="238.385455" xlink:href="#m7568b22d77" y="75.173878"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="242.443636" xlink:href="#m7568b22d77" y="75.017143"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="246.501818" xlink:href="#m7568b22d77" y="74.860408"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="250.56" xlink:href="#m7568b22d77" y="74.703673"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="254.618182" xlink:href="#m7568b22d77" y="74.546939"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="258.676364" xlink:href="#m7568b22d77" y="74.390204"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="262.734545" xlink:href="#m7568b22d77" y="74.233469"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="266.792727" xlink:href="#m7568b22d77" y="74.076735"/>
+     <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="270.850909" xlink:href="#m7568b22d77" y="73.92"/>
     </g>
    </g>
    <g id="line2d_3">
@@ -126,12 +126,12 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
 C -1.55874 2.683901 -0.795609 3 0 3 
 z
-" id="mf313ae95ab" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="mbfad75ac03" style="stroke:#000000;stroke-width:0.5;"/>
     </defs>
-    <g clip-path="url(#p701db9c174)">
-     <use style="fill:#ff0000;stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#mf313ae95ab" y="81.6"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-width:0.500000;" x="76.0581818182" xlink:href="#mf313ae95ab" y="158.4"/>
-     <use style="fill:#ff0000;stroke:#000000;stroke-width:0.500000;" x="80.1163636364" xlink:href="#mf313ae95ab" y="235.2"/>
+    <g clip-path="url(#p70587c40fd)">
+     <use style="fill:#ff0000;stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mbfad75ac03" y="81.6"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-width:0.5;" x="76.058182" xlink:href="#mbfad75ac03" y="158.4"/>
+     <use style="fill:#ff0000;stroke:#000000;stroke-width:0.5;" x="80.116364" xlink:href="#mbfad75ac03" y="235.2"/>
     </g>
    </g>
    <g id="patch_3">
@@ -160,80 +160,80 @@ L 274.909091 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="md231fc4c00" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="mdba24f6042" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#md231fc4c00" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mdba24f6042" y="388.8"/>
       </g>
      </g>
      <g id="line2d_5">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="med83a0aafb" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m62fed728f4" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#med83a0aafb" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m62fed728f4" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="112.581818182" xlink:href="#md231fc4c00" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="112.581818" xlink:href="#mdba24f6042" y="388.8"/>
       </g>
      </g>
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="112.581818182" xlink:href="#med83a0aafb" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="112.581818" xlink:href="#m62fed728f4" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="153.163636364" xlink:href="#md231fc4c00" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="153.163636" xlink:href="#mdba24f6042" y="388.8"/>
       </g>
      </g>
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="153.163636364" xlink:href="#med83a0aafb" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="153.163636" xlink:href="#m62fed728f4" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="193.745454545" xlink:href="#md231fc4c00" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="193.745455" xlink:href="#mdba24f6042" y="388.8"/>
       </g>
      </g>
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="193.745454545" xlink:href="#med83a0aafb" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="193.745455" xlink:href="#m62fed728f4" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="234.327272727" xlink:href="#md231fc4c00" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="234.327273" xlink:href="#mdba24f6042" y="388.8"/>
       </g>
      </g>
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="234.327272727" xlink:href="#med83a0aafb" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="234.327273" xlink:href="#m62fed728f4" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#md231fc4c00" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mdba24f6042" y="388.8"/>
       </g>
      </g>
      <g id="line2d_15">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#med83a0aafb" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m62fed728f4" y="43.2"/>
       </g>
      </g>
     </g>
@@ -244,128 +244,128 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m0d3f5246ff" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m81b21c6288" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="388.8"/>
       </g>
      </g>
      <g id="line2d_17">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="ma1634d93c5" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m9c4dd6064b" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="350.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="350.4"/>
       </g>
      </g>
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="350.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="350.4"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="312.0"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="312"/>
       </g>
      </g>
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="312.0"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="312"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="273.6"/>
       </g>
      </g>
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="273.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="235.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="235.2"/>
       </g>
      </g>
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="235.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="235.2"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="196.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="196.8"/>
       </g>
      </g>
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="196.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="196.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="158.4"/>
       </g>
      </g>
      <g id="line2d_29">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="158.4"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_30">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="120.0"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="120"/>
       </g>
      </g>
      <g id="line2d_31">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="120.0"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="120"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_32">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="81.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="81.6"/>
       </g>
      </g>
      <g id="line2d_33">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="81.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="81.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_34">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m0d3f5246ff" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m81b21c6288" y="43.2"/>
       </g>
      </g>
      <g id="line2d_35">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#ma1634d93c5" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m9c4dd6064b" y="43.2"/>
       </g>
      </g>
     </g>
@@ -373,16 +373,16 @@ L -4 0
    <g id="legend_1">
     <g id="patch_7">
      <path d="M 79.2 381.6 
-L 215.680625 381.6 
-L 215.680625 334.834125 
-L 79.2 334.834125 
+L 215.829 381.6 
+L 215.829 334.431 
+L 79.2 334.431 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
     <g id="line2d_36"/>
     <g id="line2d_37">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.500000;" x="99.36" xlink:href="#ma650ed4e71" y="346.495875"/>
+      <use style="fill:#0000ff;stroke:#000000;stroke-width:0.5;" x="99.36" xlink:href="#mc3dd6596f1" y="346.09275"/>
      </g>
     </g>
     <g id="text_1">
@@ -402,14 +402,14 @@ L 12.40625 0
 z
 " id="DejaVuSans-31"/>
      </defs>
-     <g transform="translate(125.280000 351.535875)scale(0.144000 -0.144000)">
+     <g transform="translate(125.28 351.13275)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-31"/>
      </g>
     </g>
     <g id="line2d_38"/>
     <g id="line2d_39">
      <g>
-      <use style="fill:#008000;stroke:#000000;stroke-width:0.500000;" x="99.36" xlink:href="#maa3ac86c13" y="367.89375"/>
+      <use style="fill:#008000;stroke:#000000;stroke-width:0.5;" x="99.36" xlink:href="#m7568b22d77" y="367.80525"/>
      </g>
     </g>
     <g id="text_2">
@@ -572,25 +572,25 @@ Q 31.78125 56 36.171875 55.265625
 Q 40.578125 54.546875 44.28125 53.078125 
 " id="DejaVuSans-73"/>
      </defs>
-     <g transform="translate(125.280000 372.933750)scale(0.144000 -0.144000)">
+     <g transform="translate(125.28 372.84525)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-44"/>
-      <use x="77.001953125" xlink:href="#DejaVuSans-e9"/>
-      <use x="138.525390625" xlink:href="#DejaVuSans-76"/>
-      <use x="197.705078125" xlink:href="#DejaVuSans-65"/>
-      <use x="259.228515625" xlink:href="#DejaVuSans-6c"/>
-      <use x="287.01171875" xlink:href="#DejaVuSans-6f"/>
-      <use x="348.193359375" xlink:href="#DejaVuSans-70"/>
-      <use x="411.669921875" xlink:href="#DejaVuSans-70"/>
-      <use x="475.146484375" xlink:href="#DejaVuSans-e9"/>
-      <use x="536.669921875" xlink:href="#DejaVuSans-73"/>
+      <use x="77.001953" xlink:href="#DejaVuSans-e9"/>
+      <use x="138.525391" xlink:href="#DejaVuSans-76"/>
+      <use x="197.705078" xlink:href="#DejaVuSans-65"/>
+      <use x="259.228516" xlink:href="#DejaVuSans-6c"/>
+      <use x="287.011719" xlink:href="#DejaVuSans-6f"/>
+      <use x="348.193359" xlink:href="#DejaVuSans-70"/>
+      <use x="411.669922" xlink:href="#DejaVuSans-70"/>
+      <use x="475.146484" xlink:href="#DejaVuSans-e9"/>
+      <use x="536.669922" xlink:href="#DejaVuSans-73"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p701db9c174">
-   <rect height="345.6" width="202.909090909" x="72.0" y="43.2"/>
+  <clipPath id="p70587c40fd">
+   <rect height="345.6" width="202.909091" x="72" y="43.2"/>
   </clipPath>
  </defs>
 </svg>

--- a/lib/matplotlib/tests/baseline_images/test_legend/scatter_rc1.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/scatter_rc1.svg
@@ -38,19 +38,19 @@ C -2.000462 -1.161816 -2.236068 -0.593012 -2.236068 0
 C -2.236068 0.593012 -2.000462 1.161816 -1.581139 1.581139 
 C -1.161816 2.000462 -0.593012 2.236068 0 2.236068 
 z
-" id="m366d4cce12" style="stroke:#000000;"/>
+" id="m12f212a9d2" style="stroke:#000000;"/>
     </defs>
-    <g clip-path="url(#pd81b0505cf)">
-     <use style="fill:#0000ff;stroke:#000000;" x="105.818182" xlink:href="#m366d4cce12" y="100.8"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="122.727273" xlink:href="#m366d4cce12" y="129.6"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="139.636364" xlink:href="#m366d4cce12" y="158.4"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="156.545455" xlink:href="#m366d4cce12" y="187.2"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="173.454545" xlink:href="#m366d4cce12" y="216"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="190.363636" xlink:href="#m366d4cce12" y="244.8"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="207.272727" xlink:href="#m366d4cce12" y="273.6"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="224.181818" xlink:href="#m366d4cce12" y="302.4"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="241.090909" xlink:href="#m366d4cce12" y="331.2"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="258" xlink:href="#m366d4cce12" y="360"/>
+    <g clip-path="url(#p9287ad6a3e)">
+     <use style="fill:#0000ff;stroke:#000000;" x="105.818182" xlink:href="#m12f212a9d2" y="100.8"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="122.727273" xlink:href="#m12f212a9d2" y="129.6"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="139.636364" xlink:href="#m12f212a9d2" y="158.4"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="156.545455" xlink:href="#m12f212a9d2" y="187.2"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="173.454545" xlink:href="#m12f212a9d2" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="190.363636" xlink:href="#m12f212a9d2" y="244.8"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="207.272727" xlink:href="#m12f212a9d2" y="273.6"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="224.181818" xlink:href="#m12f212a9d2" y="302.4"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="241.090909" xlink:href="#m12f212a9d2" y="331.2"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="258" xlink:href="#m12f212a9d2" y="360"/>
     </g>
    </g>
    <g id="patch_3">
@@ -79,92 +79,92 @@ L 274.909091 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m992aa56356" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m1bcd58660f" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m992aa56356" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m1bcd58660f" y="388.8"/>
       </g>
      </g>
      <g id="line2d_2">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m5df397da19" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m17b078cda5" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m5df397da19" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m17b078cda5" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m992aa56356" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m1bcd58660f" y="388.8"/>
       </g>
      </g>
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m5df397da19" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m17b078cda5" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m992aa56356" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m1bcd58660f" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m5df397da19" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m17b078cda5" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m992aa56356" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m1bcd58660f" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m5df397da19" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m17b078cda5" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m992aa56356" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m1bcd58660f" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m5df397da19" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m17b078cda5" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m992aa56356" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m1bcd58660f" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m5df397da19" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m17b078cda5" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m992aa56356" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m1bcd58660f" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m5df397da19" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m17b078cda5" y="43.2"/>
       </g>
      </g>
     </g>
@@ -175,102 +175,102 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m3a4eda9d3c" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m9f2d582f58" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3a4eda9d3c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9f2d582f58" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="m53cb58d85d" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mf7da5caec5" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m53cb58d85d" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mf7da5caec5" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3a4eda9d3c" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9f2d582f58" y="331.2"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m53cb58d85d" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mf7da5caec5" y="331.2"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3a4eda9d3c" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9f2d582f58" y="273.6"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m53cb58d85d" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mf7da5caec5" y="273.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3a4eda9d3c" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9f2d582f58" y="216"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m53cb58d85d" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mf7da5caec5" y="216"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3a4eda9d3c" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9f2d582f58" y="158.4"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m53cb58d85d" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mf7da5caec5" y="158.4"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3a4eda9d3c" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9f2d582f58" y="100.8"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m53cb58d85d" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mf7da5caec5" y="100.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3a4eda9d3c" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m9f2d582f58" y="43.2"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m53cb58d85d" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mf7da5caec5" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 282.109091 238.0965 
-L 360.699091 238.0965 
-L 360.699091 193.9035 
-L 282.109091 193.9035 
+     <path d="M 282.109091 238.135125 
+L 360.746591 238.135125 
+L 360.746591 193.864875 
+L 282.109091 193.864875 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -413,7 +413,7 @@ Q 22.953125 48.484375 18.875 42.84375
 Q 14.796875 37.203125 14.796875 27.296875 
 " id="DejaVuSans-64"/>
      </defs>
-     <g transform="translate(290.279091 208.7885)scale(0.12 -0.12)">
+     <g transform="translate(290.321591 208.743)scale(0.12 -0.12)">
       <use xlink:href="#DejaVuSans-4d"/>
       <use x="86.279297" xlink:href="#DejaVuSans-79"/>
       <use x="145.458984" xlink:href="#DejaVuSans-20"/>
@@ -427,7 +427,7 @@ Q 14.796875 37.203125 14.796875 27.296875
     </g>
     <g id="PathCollection_2">
      <g>
-      <use style="fill:#0000ff;stroke:#000000;" x="302.269091" xlink:href="#m366d4cce12" y="225.65025"/>
+      <use style="fill:#0000ff;stroke:#000000;" x="302.269091" xlink:href="#m12f212a9d2" y="225.600375"/>
      </g>
     </g>
     <g id="text_2">
@@ -453,7 +453,7 @@ Q 5.515625 40.765625 12.171875 48.375
 Q 18.84375 56 30.609375 56 
 " id="DejaVuSans-6f"/>
      </defs>
-     <g transform="translate(328.189091 229.43025)scale(0.144 -0.144)">
+     <g transform="translate(328.189091 229.380375)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-6f"/>
       <use x="61.181641" xlink:href="#DejaVuSans-6e"/>
       <use x="124.560547" xlink:href="#DejaVuSans-65"/>
@@ -463,7 +463,7 @@ Q 18.84375 56 30.609375 56
   </g>
  </g>
  <defs>
-  <clipPath id="pd81b0505cf">
+  <clipPath id="p9287ad6a3e">
    <rect height="345.6" width="202.909091" x="72" y="43.2"/>
   </clipPath>
  </defs>

--- a/lib/matplotlib/tests/baseline_images/test_legend/scatter_rc3.svg
+++ b/lib/matplotlib/tests/baseline_images/test_legend/scatter_rc3.svg
@@ -38,19 +38,19 @@ C -2.000462 -1.161816 -2.236068 -0.593012 -2.236068 0
 C -2.236068 0.593012 -2.000462 1.161816 -1.581139 1.581139 
 C -1.161816 2.000462 -0.593012 2.236068 0 2.236068 
 z
-" id="m48c19c8559" style="stroke:#000000;"/>
+" id="mcf9aeaf088" style="stroke:#000000;"/>
     </defs>
-    <g clip-path="url(#p63fce7746a)">
-     <use style="fill:#0000ff;stroke:#000000;" x="105.818181818" xlink:href="#m48c19c8559" y="100.8"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="122.727272727" xlink:href="#m48c19c8559" y="129.6"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="139.636363636" xlink:href="#m48c19c8559" y="158.4"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="156.545454545" xlink:href="#m48c19c8559" y="187.2"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="173.454545455" xlink:href="#m48c19c8559" y="216.0"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="190.363636364" xlink:href="#m48c19c8559" y="244.8"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="207.272727273" xlink:href="#m48c19c8559" y="273.6"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="224.181818182" xlink:href="#m48c19c8559" y="302.4"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="241.090909091" xlink:href="#m48c19c8559" y="331.2"/>
-     <use style="fill:#0000ff;stroke:#000000;" x="258.0" xlink:href="#m48c19c8559" y="360.0"/>
+    <g clip-path="url(#p89274aeaf5)">
+     <use style="fill:#0000ff;stroke:#000000;" x="105.818182" xlink:href="#mcf9aeaf088" y="100.8"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="122.727273" xlink:href="#mcf9aeaf088" y="129.6"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="139.636364" xlink:href="#mcf9aeaf088" y="158.4"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="156.545455" xlink:href="#mcf9aeaf088" y="187.2"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="173.454545" xlink:href="#mcf9aeaf088" y="216"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="190.363636" xlink:href="#mcf9aeaf088" y="244.8"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="207.272727" xlink:href="#mcf9aeaf088" y="273.6"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="224.181818" xlink:href="#mcf9aeaf088" y="302.4"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="241.090909" xlink:href="#mcf9aeaf088" y="331.2"/>
+     <use style="fill:#0000ff;stroke:#000000;" x="258" xlink:href="#mcf9aeaf088" y="360"/>
     </g>
    </g>
    <g id="patch_3">
@@ -79,92 +79,92 @@ L 274.909091 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m8a33f25af5" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m5e0c2cbe87" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m8a33f25af5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m5e0c2cbe87" y="388.8"/>
       </g>
      </g>
      <g id="line2d_2">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="mba387dcad4" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m6eb12c5c59" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#mba387dcad4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m6eb12c5c59" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="105.818181818" xlink:href="#m8a33f25af5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m5e0c2cbe87" y="388.8"/>
       </g>
      </g>
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="105.818181818" xlink:href="#mba387dcad4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m6eb12c5c59" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="139.636363636" xlink:href="#m8a33f25af5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m5e0c2cbe87" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="139.636363636" xlink:href="#mba387dcad4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m6eb12c5c59" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="173.454545455" xlink:href="#m8a33f25af5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m5e0c2cbe87" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="173.454545455" xlink:href="#mba387dcad4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m6eb12c5c59" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="207.272727273" xlink:href="#m8a33f25af5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m5e0c2cbe87" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="207.272727273" xlink:href="#mba387dcad4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m6eb12c5c59" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="241.090909091" xlink:href="#m8a33f25af5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m5e0c2cbe87" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="241.090909091" xlink:href="#mba387dcad4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m6eb12c5c59" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m8a33f25af5" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m5e0c2cbe87" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#mba387dcad4" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m6eb12c5c59" y="43.2"/>
       </g>
      </g>
     </g>
@@ -175,102 +175,102 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m7459eec92c" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="mcddd9bfd3e" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m7459eec92c" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mcddd9bfd3e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="m24ee422304" style="stroke:#000000;stroke-width:0.500000;"/>
+" id="m729bb16df5" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m24ee422304" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m729bb16df5" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m7459eec92c" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mcddd9bfd3e" y="331.2"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m24ee422304" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m729bb16df5" y="331.2"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m7459eec92c" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mcddd9bfd3e" y="273.6"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m24ee422304" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m729bb16df5" y="273.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m7459eec92c" y="216.0"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mcddd9bfd3e" y="216"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m24ee422304" y="216.0"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m729bb16df5" y="216"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m7459eec92c" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mcddd9bfd3e" y="158.4"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m24ee422304" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m729bb16df5" y="158.4"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m7459eec92c" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mcddd9bfd3e" y="100.8"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m24ee422304" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m729bb16df5" y="100.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="72.0" xlink:href="#m7459eec92c" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mcddd9bfd3e" y="43.2"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.500000;" x="274.909090909" xlink:href="#m24ee422304" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m729bb16df5" y="43.2"/>
       </g>
      </g>
     </g>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 282.109091 238.0965 
-L 372.292841 238.0965 
-L 372.292841 193.9035 
-L 282.109091 193.9035 
+     <path d="M 282.109091 238.135125 
+L 372.356591 238.135125 
+L 372.356591 193.864875 
+L 282.109091 193.864875 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
     </g>
@@ -413,50 +413,50 @@ Q 22.953125 48.484375 18.875 42.84375
 Q 14.796875 37.203125 14.796875 27.296875 
 " id="DejaVuSans-64"/>
      </defs>
-     <g transform="translate(296.075966 208.788500)scale(0.120000 -0.120000)">
+     <g transform="translate(296.126591 208.743)scale(0.12 -0.12)">
       <use xlink:href="#DejaVuSans-4d"/>
-      <use x="86.279296875" xlink:href="#DejaVuSans-79"/>
-      <use x="145.458984375" xlink:href="#DejaVuSans-20"/>
-      <use x="177.24609375" xlink:href="#DejaVuSans-6c"/>
-      <use x="205.029296875" xlink:href="#DejaVuSans-65"/>
-      <use x="266.552734375" xlink:href="#DejaVuSans-67"/>
-      <use x="330.029296875" xlink:href="#DejaVuSans-65"/>
-      <use x="391.552734375" xlink:href="#DejaVuSans-6e"/>
-      <use x="454.931640625" xlink:href="#DejaVuSans-64"/>
+      <use x="86.279297" xlink:href="#DejaVuSans-79"/>
+      <use x="145.458984" xlink:href="#DejaVuSans-20"/>
+      <use x="177.246094" xlink:href="#DejaVuSans-6c"/>
+      <use x="205.029297" xlink:href="#DejaVuSans-65"/>
+      <use x="266.552734" xlink:href="#DejaVuSans-67"/>
+      <use x="330.029297" xlink:href="#DejaVuSans-65"/>
+      <use x="391.552734" xlink:href="#DejaVuSans-6e"/>
+      <use x="454.931641" xlink:href="#DejaVuSans-64"/>
      </g>
     </g>
     <g id="PathCollection_2">
-     <path d="M 292.189091 227.886318 
-C 292.782103 227.886318 293.350907 227.650712 293.77023 227.231389 
-C 294.189553 226.812066 294.425159 226.243262 294.425159 225.65025 
-C 294.425159 225.057238 294.189553 224.488434 293.77023 224.069111 
-C 293.350907 223.649788 292.782103 223.414182 292.189091 223.414182 
-C 291.596079 223.414182 291.027275 223.649788 290.607952 224.069111 
-C 290.188629 224.488434 289.953023 225.057238 289.953023 225.65025 
-C 289.953023 226.243262 290.188629 226.812066 290.607952 227.231389 
-C 291.027275 227.650712 291.596079 227.886318 292.189091 227.886318 
+     <path d="M 292.189091 227.836443 
+C 292.782103 227.836443 293.350907 227.600837 293.77023 227.181514 
+C 294.189553 226.762191 294.425159 226.193387 294.425159 225.600375 
+C 294.425159 225.007363 294.189553 224.438559 293.77023 224.019236 
+C 293.350907 223.599913 292.782103 223.364307 292.189091 223.364307 
+C 291.596079 223.364307 291.027275 223.599913 290.607952 224.019236 
+C 290.188629 224.438559 289.953023 225.007363 289.953023 225.600375 
+C 289.953023 226.193387 290.188629 226.762191 290.607952 227.181514 
+C 291.027275 227.600837 291.596079 227.836443 292.189091 227.836443 
 z
 " style="fill:#0000ff;stroke:#000000;"/>
-     <path d="M 302.269091 226.626318 
-C 302.862103 226.626318 303.430907 226.390712 303.85023 225.971389 
-C 304.269553 225.552066 304.505159 224.983262 304.505159 224.39025 
-C 304.505159 223.797238 304.269553 223.228434 303.85023 222.809111 
-C 303.430907 222.389788 302.862103 222.154182 302.269091 222.154182 
-C 301.676079 222.154182 301.107275 222.389788 300.687952 222.809111 
-C 300.268629 223.228434 300.033023 223.797238 300.033023 224.39025 
-C 300.033023 224.983262 300.268629 225.552066 300.687952 225.971389 
-C 301.107275 226.390712 301.676079 226.626318 302.269091 226.626318 
+     <path d="M 302.269091 226.576443 
+C 302.862103 226.576443 303.430907 226.340837 303.85023 225.921514 
+C 304.269553 225.502191 304.505159 224.933387 304.505159 224.340375 
+C 304.505159 223.747363 304.269553 223.178559 303.85023 222.759236 
+C 303.430907 222.339913 302.862103 222.104307 302.269091 222.104307 
+C 301.676079 222.104307 301.107275 222.339913 300.687952 222.759236 
+C 300.268629 223.178559 300.033023 223.747363 300.033023 224.340375 
+C 300.033023 224.933387 300.268629 225.502191 300.687952 225.921514 
+C 301.107275 226.340837 301.676079 226.576443 302.269091 226.576443 
 z
 " style="fill:#0000ff;stroke:#000000;"/>
-     <path d="M 312.349091 228.516318 
-C 312.942103 228.516318 313.510907 228.280712 313.93023 227.861389 
-C 314.349553 227.442066 314.585159 226.873262 314.585159 226.28025 
-C 314.585159 225.687238 314.349553 225.118434 313.93023 224.699111 
-C 313.510907 224.279788 312.942103 224.044182 312.349091 224.044182 
-C 311.756079 224.044182 311.187275 224.279788 310.767952 224.699111 
-C 310.348629 225.118434 310.113023 225.687238 310.113023 226.28025 
-C 310.113023 226.873262 310.348629 227.442066 310.767952 227.861389 
-C 311.187275 228.280712 311.756079 228.516318 312.349091 228.516318 
+     <path d="M 312.349091 228.466443 
+C 312.942103 228.466443 313.510907 228.230837 313.93023 227.811514 
+C 314.349553 227.392191 314.585159 226.823387 314.585159 226.230375 
+C 314.585159 225.637363 314.349553 225.068559 313.93023 224.649236 
+C 313.510907 224.229913 312.942103 223.994307 312.349091 223.994307 
+C 311.756079 223.994307 311.187275 224.229913 310.767952 224.649236 
+C 310.348629 225.068559 310.113023 225.637363 310.113023 226.230375 
+C 310.113023 226.823387 310.348629 227.392191 310.767952 227.811514 
+C 311.187275 228.230837 311.756079 228.466443 312.349091 228.466443 
 z
 " style="fill:#0000ff;stroke:#000000;"/>
     </g>
@@ -518,20 +518,20 @@ Q 39.703125 55.765625 41.0625 55.515625
 z
 " id="DejaVuSans-72"/>
      </defs>
-     <g transform="translate(328.189091 229.430250)scale(0.144000 -0.144000)">
+     <g transform="translate(328.189091 229.380375)scale(0.144 -0.144)">
       <use xlink:href="#DejaVuSans-74"/>
-      <use x="39.208984375" xlink:href="#DejaVuSans-68"/>
-      <use x="102.587890625" xlink:href="#DejaVuSans-72"/>
-      <use x="143.669921875" xlink:href="#DejaVuSans-65"/>
-      <use x="205.193359375" xlink:href="#DejaVuSans-65"/>
+      <use x="39.208984" xlink:href="#DejaVuSans-68"/>
+      <use x="102.587891" xlink:href="#DejaVuSans-72"/>
+      <use x="143.669922" xlink:href="#DejaVuSans-65"/>
+      <use x="205.193359" xlink:href="#DejaVuSans-65"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p63fce7746a">
-   <rect height="345.6" width="202.909090909" x="72.0" y="43.2"/>
+  <clipPath id="p89274aeaf5">
+   <rect height="345.6" width="202.909091" x="72" y="43.2"/>
   </clipPath>
  </defs>
 </svg>

--- a/lib/matplotlib/tests/baseline_images/test_patheffects/patheffect3.svg
+++ b/lib/matplotlib/tests/baseline_images/test_patheffects/patheffect3.svg
@@ -26,19 +26,19 @@ L 72 43.2
 z
 " style="fill:#ffffff;"/>
    </g>
-   <path clip-path="url(#p354b95cc47)" d="M 74 390.8 
+   <path clip-path="url(#p8cf5e323f9)" d="M 74 390.8 
 L 185.6 218 
 L 297.2 45.2 
 L 408.8 131.6 
 L 520.4 218 
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-linecap:square;stroke-width:4;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 72 388.8 
+   <path clip-path="url(#p8cf5e323f9)" d="M 72 388.8 
 L 183.6 216 
 L 295.2 43.2 
 L 406.8 129.6 
 L 518.4 216 
 " style="fill:none;stroke:#0000ff;stroke-linecap:square;stroke-width:4;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 74 393.8 
+   <path clip-path="url(#p8cf5e323f9)" d="M 74 393.8 
 C 74.795609 393.8 75.55874 393.483901 76.12132 392.92132 
 C 76.683901 392.35874 77 391.595609 77 390.8 
 C 77 390.004391 76.683901 389.24126 76.12132 388.67868 
@@ -49,7 +49,7 @@ C 71 391.595609 71.316099 392.35874 71.87868 392.92132
 C 72.44126 393.483901 73.204391 393.8 74 393.8 
 z
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 185.6 221 
+   <path clip-path="url(#p8cf5e323f9)" d="M 185.6 221 
 C 186.395609 221 187.15874 220.683901 187.72132 220.12132 
 C 188.283901 219.55874 188.6 218.795609 188.6 218 
 C 188.6 217.204391 188.283901 216.44126 187.72132 215.87868 
@@ -60,7 +60,7 @@ C 182.6 218.795609 182.916099 219.55874 183.47868 220.12132
 C 184.04126 220.683901 184.804391 221 185.6 221 
 z
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 297.2 48.2 
+   <path clip-path="url(#p8cf5e323f9)" d="M 297.2 48.2 
 C 297.995609 48.2 298.75874 47.883901 299.32132 47.32132 
 C 299.883901 46.75874 300.2 45.995609 300.2 45.2 
 C 300.2 44.404391 299.883901 43.64126 299.32132 43.07868 
@@ -71,7 +71,7 @@ C 294.2 45.995609 294.516099 46.75874 295.07868 47.32132
 C 295.64126 47.883901 296.404391 48.2 297.2 48.2 
 z
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 408.8 134.6 
+   <path clip-path="url(#p8cf5e323f9)" d="M 408.8 134.6 
 C 409.595609 134.6 410.35874 134.283901 410.92132 133.72132 
 C 411.483901 133.15874 411.8 132.395609 411.8 131.6 
 C 411.8 130.804391 411.483901 130.04126 410.92132 129.47868 
@@ -82,7 +82,7 @@ C 405.8 132.395609 406.116099 133.15874 406.67868 133.72132
 C 407.24126 134.283901 408.004391 134.6 408.8 134.6 
 z
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 520.4 221 
+   <path clip-path="url(#p8cf5e323f9)" d="M 520.4 221 
 C 521.195609 221 521.95874 220.683901 522.52132 220.12132 
 C 523.083901 219.55874 523.4 218.795609 523.4 218 
 C 523.4 217.204391 523.083901 216.44126 522.52132 215.87868 
@@ -93,7 +93,7 @@ C 517.4 218.795609 517.716099 219.55874 518.27868 220.12132
 C 518.84126 220.683901 519.604391 221 520.4 221 
 z
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 72 391.8 
+   <path clip-path="url(#p8cf5e323f9)" d="M 72 391.8 
 C 72.795609 391.8 73.55874 391.483901 74.12132 390.92132 
 C 74.683901 390.35874 75 389.595609 75 388.8 
 C 75 388.004391 74.683901 387.24126 74.12132 386.67868 
@@ -104,7 +104,7 @@ C 69 389.595609 69.316099 390.35874 69.87868 390.92132
 C 70.44126 391.483901 71.204391 391.8 72 391.8 
 z
 " style="fill:#0000ff;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 183.6 219 
+   <path clip-path="url(#p8cf5e323f9)" d="M 183.6 219 
 C 184.395609 219 185.15874 218.683901 185.72132 218.12132 
 C 186.283901 217.55874 186.6 216.795609 186.6 216 
 C 186.6 215.204391 186.283901 214.44126 185.72132 213.87868 
@@ -115,7 +115,7 @@ C 180.6 216.795609 180.916099 217.55874 181.47868 218.12132
 C 182.04126 218.683901 182.804391 219 183.6 219 
 z
 " style="fill:#0000ff;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 295.2 46.2 
+   <path clip-path="url(#p8cf5e323f9)" d="M 295.2 46.2 
 C 295.995609 46.2 296.75874 45.883901 297.32132 45.32132 
 C 297.883901 44.75874 298.2 43.995609 298.2 43.2 
 C 298.2 42.404391 297.883901 41.64126 297.32132 41.07868 
@@ -126,7 +126,7 @@ C 292.2 43.995609 292.516099 44.75874 293.07868 45.32132
 C 293.64126 45.883901 294.404391 46.2 295.2 46.2 
 z
 " style="fill:#0000ff;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 406.8 132.6 
+   <path clip-path="url(#p8cf5e323f9)" d="M 406.8 132.6 
 C 407.595609 132.6 408.35874 132.283901 408.92132 131.72132 
 C 409.483901 131.15874 409.8 130.395609 409.8 129.6 
 C 409.8 128.804391 409.483901 128.04126 408.92132 127.47868 
@@ -137,7 +137,7 @@ C 403.8 130.395609 404.116099 131.15874 404.67868 131.72132
 C 405.24126 132.283901 406.004391 132.6 406.8 132.6 
 z
 " style="fill:#0000ff;stroke:#000000;stroke-width:0.5;"/>
-   <path clip-path="url(#p354b95cc47)" d="M 518.4 219 
+   <path clip-path="url(#p8cf5e323f9)" d="M 518.4 219 
 C 519.195609 219 519.95874 218.683901 520.52132 218.12132 
 C 521.083901 217.55874 521.4 216.795609 521.4 216 
 C 521.4 215.204391 521.083901 214.44126 520.52132 213.87868 
@@ -174,20 +174,20 @@ L 518.4 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m7db43fc4c2" style="stroke:#000000;stroke-width:0.5;"/>
+" id="me149d1514e" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_2">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m916bd2f6a9" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mc09ce5b844" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_1">
@@ -229,12 +229,12 @@ z
     <g id="xtick_2">
      <g id="line2d_3">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="127.8" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_2">
@@ -275,12 +275,12 @@ z
     <g id="xtick_3">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="183.6" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_3">
@@ -310,12 +310,12 @@ z
     <g id="xtick_4">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="239.4" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_4">
@@ -330,12 +330,12 @@ z
     <g id="xtick_5">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_5">
@@ -375,12 +375,12 @@ Q 31.109375 20.453125 19.1875 8.296875
     <g id="xtick_6">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="351" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_6">
@@ -395,12 +395,12 @@ Q 31.109375 20.453125 19.1875 8.296875
     <g id="xtick_7">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="406.8" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_7">
@@ -448,12 +448,12 @@ Q 46.96875 40.921875 40.578125 39.3125
     <g id="xtick_8">
      <g id="line2d_15">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="462.6" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_8">
@@ -468,12 +468,12 @@ Q 46.96875 40.921875 40.578125 39.3125
     <g id="xtick_9">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m7db43fc4c2" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#me149d1514e" y="388.8"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m916bd2f6a9" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc09ce5b844" y="43.2"/>
       </g>
      </g>
      <g id="text_9">
@@ -511,20 +511,20 @@ z
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="me2cea9c67b" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m3d2fc7613c" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="388.8"/>
       </g>
      </g>
      <g id="line2d_20">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="m0352d24642" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m0e6e0d799d" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="388.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -539,12 +539,12 @@ L -4 0
     <g id="ytick_2">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="345.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="345.6"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="345.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="345.6"/>
       </g>
      </g>
      <g id="text_11">
@@ -559,12 +559,12 @@ L -4 0
     <g id="ytick_3">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="302.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="302.4"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="302.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="302.4"/>
       </g>
      </g>
      <g id="text_12">
@@ -579,12 +579,12 @@ L -4 0
     <g id="ytick_4">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="259.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="259.2"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="259.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="259.2"/>
       </g>
      </g>
      <g id="text_13">
@@ -599,12 +599,12 @@ L -4 0
     <g id="ytick_5">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="216"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="216"/>
       </g>
      </g>
      <g id="text_14">
@@ -619,12 +619,12 @@ L -4 0
     <g id="ytick_6">
      <g id="line2d_29">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="172.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="172.8"/>
       </g>
      </g>
      <g id="line2d_30">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="172.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="172.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -639,12 +639,12 @@ L -4 0
     <g id="ytick_7">
      <g id="line2d_31">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="129.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="129.6"/>
       </g>
      </g>
      <g id="line2d_32">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="129.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="129.6"/>
       </g>
      </g>
      <g id="text_16">
@@ -659,12 +659,12 @@ L -4 0
     <g id="ytick_8">
      <g id="line2d_33">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="86.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="86.4"/>
       </g>
      </g>
      <g id="line2d_34">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="86.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="86.4"/>
       </g>
      </g>
      <g id="text_17">
@@ -679,12 +679,12 @@ L -4 0
     <g id="ytick_9">
      <g id="line2d_35">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#me2cea9c67b" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d2fc7613c" y="43.2"/>
       </g>
      </g>
      <g id="line2d_36">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0352d24642" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m0e6e0d799d" y="43.2"/>
       </g>
      </g>
      <g id="text_18">
@@ -1737,76 +1737,76 @@ z
     </g>
     <g id="legend_1">
      <g id="patch_8">
-      <path d="M 84.08 77.92 
-L 181.16 77.92 
-Q 184.04 77.92 184.04 75.04 
-L 184.04 55.28 
-Q 184.04 52.4 181.16 52.4 
+      <path d="M 84.08 77.8565 
+L 180.56 77.8565 
+Q 183.44 77.8565 183.44 74.9765 
+L 183.44 55.28 
+Q 183.44 52.4 180.56 52.4 
 L 84.08 52.4 
 Q 81.2 52.4 81.2 55.28 
-L 81.2 75.04 
-Q 81.2 77.92 84.08 77.92 
+L 81.2 74.9765 
+Q 81.2 77.8565 84.08 77.8565 
 z
 " style="fill:#4c4c4c;opacity:0.3;"/>
-      <path d="M 82.08 75.92 
-L 179.16 75.92 
-Q 182.04 75.92 182.04 73.04 
-L 182.04 53.28 
-Q 182.04 50.4 179.16 50.4 
+      <path d="M 82.08 75.8565 
+L 178.56 75.8565 
+Q 181.44 75.8565 181.44 72.9765 
+L 181.44 53.28 
+Q 181.44 50.4 178.56 50.4 
 L 82.08 50.4 
 Q 79.2 50.4 79.2 53.28 
-L 79.2 73.04 
-Q 79.2 75.92 82.08 75.92 
+L 79.2 72.9765 
+Q 79.2 75.8565 82.08 75.8565 
 z
 " style="fill:#ffffff;stroke:#000000;stroke-linejoin:miter;"/>
-      <path d="M 91.28 64.21375 
-L 111.44 64.21375 
+      <path d="M 91.28 64.06175 
+L 111.44 64.06175 
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-linecap:square;stroke-width:4;"/>
-      <path d="M 89.28 62.21375 
-L 109.44 62.21375 
+      <path d="M 89.28 62.06175 
+L 109.44 62.06175 
 " style="fill:none;stroke:#0000ff;stroke-linecap:square;stroke-width:4;"/>
-      <path d="M 91.28 67.21375 
-C 92.075609 67.21375 92.83874 66.897651 93.40132 66.33507 
-C 93.963901 65.77249 94.28 65.009359 94.28 64.21375 
-C 94.28 63.418141 93.963901 62.65501 93.40132 62.09243 
-C 92.83874 61.529849 92.075609 61.21375 91.28 61.21375 
-C 90.484391 61.21375 89.72126 61.529849 89.15868 62.09243 
-C 88.596099 62.65501 88.28 63.418141 88.28 64.21375 
-C 88.28 65.009359 88.596099 65.77249 89.15868 66.33507 
-C 89.72126 66.897651 90.484391 67.21375 91.28 67.21375 
+      <path d="M 91.28 67.06175 
+C 92.075609 67.06175 92.83874 66.745651 93.40132 66.18307 
+C 93.963901 65.62049 94.28 64.857359 94.28 64.06175 
+C 94.28 63.266141 93.963901 62.50301 93.40132 61.94043 
+C 92.83874 61.377849 92.075609 61.06175 91.28 61.06175 
+C 90.484391 61.06175 89.72126 61.377849 89.15868 61.94043 
+C 88.596099 62.50301 88.28 63.266141 88.28 64.06175 
+C 88.28 64.857359 88.596099 65.62049 89.15868 66.18307 
+C 89.72126 66.745651 90.484391 67.06175 91.28 67.06175 
 z
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-width:0.5;"/>
-      <path d="M 111.44 67.21375 
-C 112.235609 67.21375 112.99874 66.897651 113.56132 66.33507 
-C 114.123901 65.77249 114.44 65.009359 114.44 64.21375 
-C 114.44 63.418141 114.123901 62.65501 113.56132 62.09243 
-C 112.99874 61.529849 112.235609 61.21375 111.44 61.21375 
-C 110.644391 61.21375 109.88126 61.529849 109.31868 62.09243 
-C 108.756099 62.65501 108.44 63.418141 108.44 64.21375 
-C 108.44 65.009359 108.756099 65.77249 109.31868 66.33507 
-C 109.88126 66.897651 110.644391 67.21375 111.44 67.21375 
+      <path d="M 111.44 67.06175 
+C 112.235609 67.06175 112.99874 66.745651 113.56132 66.18307 
+C 114.123901 65.62049 114.44 64.857359 114.44 64.06175 
+C 114.44 63.266141 114.123901 62.50301 113.56132 61.94043 
+C 112.99874 61.377849 112.235609 61.06175 111.44 61.06175 
+C 110.644391 61.06175 109.88126 61.377849 109.31868 61.94043 
+C 108.756099 62.50301 108.44 63.266141 108.44 64.06175 
+C 108.44 64.857359 108.756099 65.62049 109.31868 66.18307 
+C 109.88126 66.745651 110.644391 67.06175 111.44 67.06175 
 z
 " style="fill:none;opacity:0.3;stroke:#000000;stroke-width:0.5;"/>
-      <path d="M 89.28 65.21375 
-C 90.075609 65.21375 90.83874 64.897651 91.40132 64.33507 
-C 91.963901 63.77249 92.28 63.009359 92.28 62.21375 
-C 92.28 61.418141 91.963901 60.65501 91.40132 60.09243 
-C 90.83874 59.529849 90.075609 59.21375 89.28 59.21375 
-C 88.484391 59.21375 87.72126 59.529849 87.15868 60.09243 
-C 86.596099 60.65501 86.28 61.418141 86.28 62.21375 
-C 86.28 63.009359 86.596099 63.77249 87.15868 64.33507 
-C 87.72126 64.897651 88.484391 65.21375 89.28 65.21375 
+      <path d="M 89.28 65.06175 
+C 90.075609 65.06175 90.83874 64.745651 91.40132 64.18307 
+C 91.963901 63.62049 92.28 62.857359 92.28 62.06175 
+C 92.28 61.266141 91.963901 60.50301 91.40132 59.94043 
+C 90.83874 59.377849 90.075609 59.06175 89.28 59.06175 
+C 88.484391 59.06175 87.72126 59.377849 87.15868 59.94043 
+C 86.596099 60.50301 86.28 61.266141 86.28 62.06175 
+C 86.28 62.857359 86.596099 63.62049 87.15868 64.18307 
+C 87.72126 64.745651 88.484391 65.06175 89.28 65.06175 
 z
 " style="fill:#0000ff;stroke:#000000;stroke-width:0.5;"/>
-      <path d="M 109.44 65.21375 
-C 110.235609 65.21375 110.99874 64.897651 111.56132 64.33507 
-C 112.123901 63.77249 112.44 63.009359 112.44 62.21375 
-C 112.44 61.418141 112.123901 60.65501 111.56132 60.09243 
-C 110.99874 59.529849 110.235609 59.21375 109.44 59.21375 
-C 108.644391 59.21375 107.88126 59.529849 107.31868 60.09243 
-C 106.756099 60.65501 106.44 61.418141 106.44 62.21375 
-C 106.44 63.009359 106.756099 63.77249 107.31868 64.33507 
-C 107.88126 64.897651 108.644391 65.21375 109.44 65.21375 
+      <path d="M 109.44 65.06175 
+C 110.235609 65.06175 110.99874 64.745651 111.56132 64.18307 
+C 112.123901 63.62049 112.44 62.857359 112.44 62.06175 
+C 112.44 61.266141 112.123901 60.50301 111.56132 59.94043 
+C 110.99874 59.377849 110.235609 59.06175 109.44 59.06175 
+C 108.644391 59.06175 107.88126 59.377849 107.31868 59.94043 
+C 106.756099 60.50301 106.44 61.266141 106.44 62.06175 
+C 106.44 62.857359 106.756099 63.62049 107.31868 64.18307 
+C 107.88126 64.745651 108.644391 65.06175 109.44 65.06175 
 z
 " style="fill:#0000ff;stroke:#000000;stroke-width:0.5;"/>
       <g id="text_21">
@@ -1914,7 +1914,7 @@ L 42.09375 0
 z
 " id="Cmr10-32"/>
        </defs>
-       <g transform="translate(125.28 67.25375)scale(0.144 -0.144)">
+       <g transform="translate(125.28 67.10175)scale(0.144 -0.144)">
         <use transform="translate(0 0.109375)" xlink:href="#DejaVuSans-4c"/>
         <use transform="translate(55.712891 0.109375)" xlink:href="#DejaVuSans-69"/>
         <use transform="translate(83.496094 0.109375)" xlink:href="#DejaVuSans-6e"/>
@@ -2163,7 +2163,7 @@ L 577.211406 385.3
 L 570.3325 413.495313 
 L 556.012187 413.495313 
 z
-" style="fill:url(#h6c4b1eddc0);stroke:#000000;stroke-linejoin:miter;"/>
+" style="fill:url(#hab4508ec66);stroke:#000000;stroke-linejoin:miter;"/>
      </g>
      <g id="patch_10">
       <path d="M 18.410625 354.815625 
@@ -2406,12 +2406,12 @@ z
     </g>
    </g>
    <defs>
-    <clipPath id="p354b95cc47">
+    <clipPath id="p8cf5e323f9">
      <rect height="345.6" width="446.4" x="72" y="43.2"/>
     </clipPath>
    </defs>
    <defs>
-    <pattern height="72" id="h6c4b1eddc0" patternUnits="userSpaceOnUse" width="72" x="0" y="0">
+    <pattern height="72" id="hab4508ec66" patternUnits="userSpaceOnUse" width="72" x="0" y="0">
      <rect fill="#808080" height="73" width="73" x="0" y="0"/>
      <path d="M -36 36 
 L 36 -36 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -332,7 +332,7 @@ class Text(Artist):
         multiple-alignment information. Note that it returns an extent
         of a rotated text when necessary.
         """
-        key = self.get_prop_tup()
+        key = self.get_prop_tup(renderer=renderer)
         if key in self._cached:
             return self._cached[key]
 
@@ -897,7 +897,7 @@ class Text(Artist):
         # specified with 'set_x' and 'set_y'.
         return self._x, self._y
 
-    def get_prop_tup(self):
+    def get_prop_tup(self, renderer=None):
         """
         Return a hashable tuple of properties.
 
@@ -910,7 +910,7 @@ class Text(Artist):
                 self._verticalalignment, self._horizontalalignment,
                 hash(self._fontproperties),
                 self._rotation, self._rotation_mode,
-                self.figure.dpi, id(self._renderer),
+                self.figure.dpi, id(renderer or self._renderer),
                 )
 
     def get_text(self):
@@ -1393,7 +1393,7 @@ class TextWithDash(Text):
         # specified with set_x and set_y
         return self._dashx, self._dashy
 
-    def get_prop_tup(self):
+    def get_prop_tup(self, renderer=None):
         """
         Return a hashable tuple of properties.
 
@@ -1401,7 +1401,7 @@ class TextWithDash(Text):
         want to cache derived information about text (e.g., layouts) and
         need to know if the text has changed.
         """
-        props = [p for p in Text.get_prop_tup(self)]
+        props = [p for p in Text.get_prop_tup(self, renderer=renderer)]
         props.extend([self._x, self._y, self._dashlength,
                       self._dashdirection, self._dashrotation, self._dashpad,
                       self._dashpush])


### PR DESCRIPTION
Even though `Text._get_layout` takes a `renderer` parameter, the cache is looked up by the `self._renderer` attribute. If an alternate renderer is provided without changing any other properties, the cached layout from the previous renderer is returned.

An alternate renderer is passed by `offsetbox.TextArea`, which, through its use in legends, causes the legend to shift slightly if figures are saved in different formats.

Fixes #6899.