### PR TITLE
[MRG+1] FIX: search for tkinter first in builtins

### DIFF
--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -410,10 +410,19 @@ int load_tkinter_funcs(void)
     // Load tkinter global funcs from tkinter compiled module.
     // Return 0 for success, non-zero for failure.
     int ret = -1;
-    void *tkinter_lib;
+    void *main_program, *tkinter_lib;
     char *tkinter_libname;
     PyObject *pModule = NULL, *pSubmodule = NULL, *pString = NULL;
 
+    // Try loading from the main program namespace first
+    main_program = dlopen(NULL, RTLD_LAZY);
+    if (_func_loader(main_program) == 0) {
+        return 0;
+    }
+    // Clear exception triggered when we didn't find symbols above.
+    PyErr_Clear();
+
+    // Now try finding the tkinter compiled module
     pModule = PyImport_ImportModule(TKINTER_PKG);
     if (pModule == NULL) {
         goto exit;


### PR DESCRIPTION
Python compiled from Python.org source builds the tkinter module as a
built-in module, not an external module, as is the case for the packaged
builds of Debian etc:

    >>> Tkinter.tkinter
    <module '_tkinter' (built-in)>

This breaks the MPL algorithm for searching for tkinter symbols, which
loaded the external module .so file to get the symbols.

Try searching in the main program namespace for the tkinter symbols,
before looking for the extermal module .so file.

Thanks to github user ettaka for reporting : see
https://github.com/matplotlib/matplotlib/issues/7428