### PR TITLE
[MRG+1] ENH ticks sublabel display is now an option

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -310,8 +310,8 @@ class ColorbarBase(cm.ScalarMappable):
         else:
             self.locator = ticks    # Handle default in _ticker()
         if format is None:
-            if isinstance(self.norm, colors.LogNorm):
-                self.formatter = ticker.LogFormatterMathtext()
+            if isinstance(self.norm, (colors.LogNorm, colors.SymLogNorm)):
+                self.formatter = ticker.LogFormatterSciNotation()
             else:
                 self.formatter = ticker.ScalarFormatter()
         elif cbook.is_string_like(format):
@@ -574,7 +574,12 @@ class ColorbarBase(cm.ScalarMappable):
                     b = self.norm.boundaries
                     locator = ticker.FixedLocator(b, nbins=10)
                 elif isinstance(self.norm, colors.LogNorm):
-                    locator = ticker.LogLocator()
+                    locator = ticker.LogLocator(subs='all')
+                # FIXME: we should be able to use the SymmetricalLogLocator
+                # but we need to give it a transform, or modify the
+                # locator to get what it needs from the Norm.
+                # elif isinstance(self.norm, colors.SymLogNorm):
+                #     locator = ticker.SymmetricalLogLocator(...)
                 else:
                     if mpl.rcParams['_internal.classic_mode']:
                         locator = ticker.MaxNLocator()

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -310,8 +310,11 @@ class ColorbarBase(cm.ScalarMappable):
         else:
             self.locator = ticks    # Handle default in _ticker()
         if format is None:
-            if isinstance(self.norm, (colors.LogNorm, colors.SymLogNorm)):
+            if isinstance(self.norm, colors.LogNorm):
                 self.formatter = ticker.LogFormatterSciNotation()
+            elif isinstance(self.norm, colors.SymLogNorm):
+                self.formatter = ticker.LogFormatterSciNotation(
+                                        linthresh=self.norm.linthresh)
             else:
                 self.formatter = ticker.ScalarFormatter()
         elif cbook.is_string_like(format):
@@ -575,11 +578,13 @@ class ColorbarBase(cm.ScalarMappable):
                     locator = ticker.FixedLocator(b, nbins=10)
                 elif isinstance(self.norm, colors.LogNorm):
                     locator = ticker.LogLocator(subs='all')
-                # FIXME: we should be able to use the SymmetricalLogLocator
-                # but we need to give it a transform, or modify the
-                # locator to get what it needs from the Norm.
-                # elif isinstance(self.norm, colors.SymLogNorm):
-                #     locator = ticker.SymmetricalLogLocator(...)
+                elif isinstance(self.norm, colors.SymLogNorm):
+                    # The subs setting here should be replaced
+                    # by logic in the locator.
+                    locator = ticker.SymmetricalLogLocator(
+                                      subs=np.arange(1, 10),
+                                      linthresh=self.norm.linthresh,
+                                      base=10)
                 else:
                     if mpl.rcParams['_internal.classic_mode']:
                         locator = ticker.MaxNLocator()

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -251,8 +251,7 @@ class LogScale(ScaleBase):
         axis.set_minor_locator(LogLocator(self.base, self.subs))
         axis.set_minor_formatter(
             LogFormatterSciNotation(self.base,
-                                    labelOnlyBase=self.subs,
-                                    label_pruning=True))
+                                    labelOnlyBase=self.subs))
 
     def get_transform(self):
         """

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -252,7 +252,7 @@ class LogScale(ScaleBase):
         axis.set_minor_formatter(
             LogFormatterSciNotation(self.base,
                                     labelOnlyBase=self.subs,
-                                    sublabel_filtering=True))
+                                    label_pruning=True))
 
     def get_transform(self):
         """

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -249,7 +249,10 @@ class LogScale(ScaleBase):
         axis.set_major_locator(LogLocator(self.base))
         axis.set_major_formatter(LogFormatterSciNotation(self.base))
         axis.set_minor_locator(LogLocator(self.base, self.subs))
-        axis.set_minor_formatter(LogFormatterSciNotation(self.base, self.subs))
+        axis.set_minor_formatter(
+            LogFormatterSciNotation(self.base,
+                                    labelOnlyBase=self.subs,
+                                    sublabel_filtering=True))
 
     def get_transform(self):
         """

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -46,3 +46,8 @@ def test_log_scatter():
 
     buf = io.BytesIO()
     fig.savefig(buf, format='svg')
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -162,8 +162,7 @@ def test_SymmetricalLogLocator_set_params():
     See if change was successful.
     Should not exception.
     """
-    # since we only test for the params change. I will pass empty transform
-    sym = mticker.SymmetricalLogLocator(None)
+    sym = mticker.SymmetricalLogLocator(base=10, linthresh=1)
     sym.set_params(subs=[2.0], numticks=8)
     nose.tools.assert_equal(sym._subs, [2.0])
     nose.tools.assert_equal(sym.numticks, 8)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -241,9 +241,7 @@ def test_LogFormatter_sublabel():
     ax.xaxis.set_minor_locator(mticker.LogLocator(base=10,
                                                   subs=np.arange(2, 10)))
     ax.xaxis.set_major_formatter(mticker.LogFormatter(labelOnlyBase=True))
-    ax.xaxis.set_minor_formatter(mticker.LogFormatter(
-        labelOnlyBase=False,
-        label_pruning=True))
+    ax.xaxis.set_minor_formatter(mticker.LogFormatter(labelOnlyBase=False))
     # axis range above 3 decades, only bases are labeled
     ax.set_xlim(1, 1e4)
     fmt = ax.xaxis.get_major_formatter()
@@ -263,9 +261,13 @@ def test_LogFormatter_sublabel():
     ax.set_xlim(1, 80)
     _sub_labels(ax.xaxis, subs=[])
 
-    # axis range at 0 to 1 decades, label subs 2, 3, 6
+    # axis range at 0.4 to 1 decades, label subs 2, 3, 4, 6
     ax.set_xlim(1, 8)
-    _sub_labels(ax.xaxis, subs=[2, 3, 6])
+    _sub_labels(ax.xaxis, subs=[2, 3, 4, 6])
+
+    # axis range at 0 to 0.4 decades, label all
+    ax.set_xlim(0.5, 0.9)
+    _sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
 
 
 def _logfe_helper(formatter, base, locs, i, expected_result):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -240,8 +240,10 @@ def test_LogFormatter_sublabel():
     ax.xaxis.set_major_locator(mticker.LogLocator(base=10, subs=[]))
     ax.xaxis.set_minor_locator(mticker.LogLocator(base=10,
                                                   subs=np.arange(2, 10)))
-    ax.xaxis.set_major_formatter(mticker.LogFormatter())
-    ax.xaxis.set_minor_formatter(mticker.LogFormatter(labelOnlyBase=False))
+    ax.xaxis.set_major_formatter(mticker.LogFormatter(labelOnlyBase=True))
+    ax.xaxis.set_minor_formatter(mticker.LogFormatter(
+        labelOnlyBase=False,
+        sublabel_filtering=True))
     # axis range above 3 decades, only bases are labeled
     ax.set_xlim(1, 1e4)
     fmt = ax.xaxis.get_major_formatter()

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -243,7 +243,7 @@ def test_LogFormatter_sublabel():
     ax.xaxis.set_major_formatter(mticker.LogFormatter(labelOnlyBase=True))
     ax.xaxis.set_minor_formatter(mticker.LogFormatter(
         labelOnlyBase=False,
-        sublabel_filtering=True))
+        label_pruning=True))
     # axis range above 3 decades, only bases are labeled
     ax.set_xlim(1, 1e4)
     fmt = ax.xaxis.get_major_formatter()

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -801,25 +801,25 @@ class LogFormatter(Formatter):
     Format values for log axis.
     """
     def __init__(self, base=10.0, labelOnlyBase=False,
-                 sublabel_filtering=False):
+                 label_pruning=False):
         """
         `base` is used to locate the decade tick, which will be the only
         one to be labeled if `labelOnlyBase` is ``True``.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         base : float, optional, default: 10.
             base of the logarithm.
 
         labelOnlyBase : bool, optional, default: False
-             whether to only label decades ticks.
+            whether to only label decades ticks.
 
-        sublabel_filtering : bool, optional, default: False
-            When set to True, label on a subset of ticks.
+        label_pruning : bool, optional, default: False
+            when set to True, label on a subset of ticks.
         """
         self._base = base + 0.0
         self.labelOnlyBase = labelOnlyBase
-        self.sublabel_filtering = sublabel_filtering
+        self.label_pruning = label_pruning
         self._sublabels = [1, ]
 
     def base(self, base):
@@ -895,7 +895,7 @@ class LogFormatter(Formatter):
         exponent = np.round(fx) if isDecade else np.floor(fx)
         coeff = np.round(x / b ** exponent)
 
-        if self.sublabel_filtering and coeff not in self._sublabels:
+        if self.label_pruning and coeff not in self._sublabels:
             return ''
         if not isDecade and self.labelOnlyBase:
             return ''
@@ -976,10 +976,10 @@ class LogFormatterExponent(LogFormatter):
         fx = math.log(abs(x)) / math.log(b)
 
         isDecade = is_close_to_int(fx)
-        exponent = np.round(fx) if is_decade else np.floor(fx)
+        exponent = np.round(fx) if isDecade else np.floor(fx)
         coeff = np.round(abs(x) / b ** exponent)
 
-        if self.sublabel_filtering and coeff not in self._sublabels:
+        if self.label_pruning and coeff not in self._sublabels:
             return ''
         if not isDecade and self.labelOnlyBase:
             return ''
@@ -1039,7 +1039,7 @@ class LogFormatterMathtext(LogFormatter):
         else:
             base = '%s' % b
 
-        if self.sublabel_filtering and coeff not in self._sublabels:
+        if self.label_pruning and coeff not in self._sublabels:
             return ''
         if not is_decade and self.labelOnlyBase:
             return ''

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -876,8 +876,8 @@ class LogFormatter(Formatter):
 
         Parameters
         ----------
-        labelOnlyBase : bool, optional, default: True
-            If true, label ticks only at integer powers of base.
+        labelOnlyBase : bool
+            If True, label ticks only at integer powers of base.
 
         """
         self.labelOnlyBase = labelOnlyBase
@@ -1908,7 +1908,9 @@ class LogLocator(Locator):
         if subs is None:  # consistency with previous bad API
             self._subs = 'auto'
         elif cbook.is_string_like(subs):
-            # TODO: validation ('all', 'auto')
+            if subs not in ('all', 'auto'):
+                raise ValueError("A subs string must be 'all' or 'auto'; "
+                                 "found '%s'." % subs)
             self._subs = subs
         else:
             self._subs = np.asarray(subs, dtype=float)
@@ -2045,8 +2047,8 @@ class SymmetricalLogLocator(Locator):
             self._base = base
             self._linthresh = linthresh
         else:
-            raise ValueError("Either transform or linthresh "
-                             "and base must be provided.")
+            raise ValueError("Either transform, or both linthresh "
+                             "and base, must be provided.")
         if subs is None:
             self._subs = [1.0]
         else:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -836,7 +836,11 @@ class LogFormatter(Formatter):
         """
         Switch minor tick labeling on or off.
 
-        ``labelOnlyBase=True`` to turn off minor ticks.
+        Parameters
+        ----------
+        labelOnlyBase : bool, optional, default: True
+            If True, only label decades.
+
         """
         self.labelOnlyBase = labelOnlyBase
 
@@ -878,7 +882,7 @@ class LogFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         """
-        Return the format for tick val `x` at position `pos`.
+        Return the format for tick val `x`.
         """
         b = self._base
         if x == 0.0:
@@ -960,8 +964,6 @@ class LogFormatterExponent(LogFormatter):
     def __call__(self, x, pos=None):
         """
         Return the format for tick value `x`.
-
-        The position `pos` is ignored.
         """
         vmin, vmax = self.axis.get_view_interval()
         vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)
@@ -1068,11 +1070,11 @@ class LogFormatterSciNotation(LogFormatterMathtext):
         if is_close_to_int(coeff):
             coeff = nearest_long(coeff)
         if usetex:
-            return (r'$%g\times%s^{%d}$') % \
-                                        (coeff, base, exponent)
+            return (r'$%s%g\times%s^{%d}$') % \
+                                        (sign_string, coeff, base, exponent)
         else:
-            return ('$%s$' % _mathdefault(r'%g\times%s^{%d}' %
-                                        (coeff, base, exponent)))
+            return ('$%s$' % _mathdefault(r'%s%g\times%s^{%d}' %
+                                        (sign_string, coeff, base, exponent)))
 
 
 class LogitFormatter(Formatter):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -906,7 +906,7 @@ class LogFormatter(Formatter):
             except AttributeError:
                 pass
 
-        if linthresh is not None: # symlog
+        if linthresh is not None:  # symlog
             # Only compute the number of decades in the logarithmic part of the
             # axis
             numdec = 0
@@ -931,7 +931,7 @@ class LogFormatter(Formatter):
             c = np.logspace(0, 1, b//2 + 1, base=b)
             self._sublabels = set(np.round(c))
         else:
-            self._sublabels = set(np.linspace(1, b, b-2))
+            self._sublabels = set(np.linspace(1, b, b))
 
     def __call__(self, x, pos=None):
         """
@@ -947,7 +947,6 @@ class LogFormatter(Formatter):
         is_x_decade = is_close_to_int(fx)
         exponent = np.round(fx) if is_x_decade else np.floor(fx)
         coeff = np.round(x / b ** exponent)
-
         if self.labelOnlyBase and not is_x_decade:
             return ''
         if self._sublabels is not None and coeff not in self._sublabels:
@@ -2172,7 +2171,7 @@ class SymmetricalLogLocator(Locator):
 
     def view_limits(self, vmin, vmax):
         'Try to choose the view limits intelligently'
-        b = self._transform.base
+        b = self._base
         if vmax < vmin:
             vmin, vmax = vmax, vmin
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -808,7 +808,7 @@ class LogFormatter(Formatter):
 
         Parameter
         ---------
-        base : float, optional, default: 10.
+        base : float, optional, default: 10.
             base of the logarithm.
 
         labelOnlyBase : bool, optional, default: False

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1048,7 +1048,7 @@ class LogFormatterMathtext(LogFormatter):
         else:
             base = '%s' % b
 
-        if self.labelOnlyBase and not isDecade:
+        if self.labelOnlyBase and not is_decade:
             return ''
         if self._sublabels is not None and coeff not in self._sublabels:
             return ''

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1050,7 +1050,7 @@ class LogFormatterMathtext(LogFormatter):
             if usetex:
                 return (r'$%s%s^{%d}$') % (sign_string,
                                            base,
-                                            nearest_long(fx))
+                                           nearest_long(fx))
             else:
                 return ('$%s$' % _mathdefault(
                     '%s%s^{%d}' %

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -877,7 +877,7 @@ class LogFormatter(Formatter):
         Parameters
         ----------
         labelOnlyBase : bool, optional, default: True
-            If True, only label decades.
+            If true, label ticks only at integer powers of base.
 
         """
         self.labelOnlyBase = labelOnlyBase

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -899,11 +899,11 @@ class LogFormatter(Formatter):
         x = abs(x)
         # only label the decades
         fx = math.log(x) / math.log(b)
-        isDecade = is_close_to_int(fx)
-        exponent = np.round(fx) if isDecade else np.floor(fx)
+        is_x_decade = is_close_to_int(fx)
+        exponent = np.round(fx) if is_x_decade else np.floor(fx)
         coeff = np.round(x / b ** exponent)
 
-        if self.labelOnlyBase and not isDecade:
+        if self.labelOnlyBase and not is_x_decade:
             return ''
         if self._sublabels is not None and coeff not in self._sublabels:
             return ''
@@ -984,11 +984,11 @@ class LogFormatterExponent(LogFormatter):
         # only label the decades
         fx = math.log(x) / math.log(b)
 
-        isDecade = is_close_to_int(fx)
-        exponent = np.round(fx) if isDecade else np.floor(fx)
+        is_x_decade = is_close_to_int(fx)
+        exponent = np.round(fx) if is_x_decade else np.floor(fx)
         coeff = np.round(x / b ** exponent)
 
-        if self.labelOnlyBase and not isDecade:
+        if self.labelOnlyBase and not is_x_decade:
             return ''
         if self._sublabels is not None and coeff not in self._sublabels:
             return ''
@@ -1036,8 +1036,8 @@ class LogFormatterMathtext(LogFormatter):
                 return '$%s$' % _mathdefault('0')
 
         fx = math.log(abs(x)) / math.log(b)
-        is_decade = is_close_to_int(fx)
-        exponent = np.round(fx) if is_decade else np.floor(fx)
+        is_x_decade = is_close_to_int(fx)
+        exponent = np.round(fx) if is_x_decade else np.floor(fx)
         coeff = np.round(abs(x) / b ** exponent)
 
         sign_string = '-' if x < 0 else ''
@@ -1048,12 +1048,12 @@ class LogFormatterMathtext(LogFormatter):
         else:
             base = '%s' % b
 
-        if self.labelOnlyBase and not is_decade:
+        if self.labelOnlyBase and not is_x_decade:
             return ''
         if self._sublabels is not None and coeff not in self._sublabels:
             return ''
 
-        if not is_decade:
+        if not is_x_decade:
             return self._non_decade_format(sign_string, base, fx, usetex)
         else:
             if usetex:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -824,7 +824,7 @@ class LogFormatter(Formatter):
         avoid crowding. If ``numdec > subset`` then no minor ticks will
         be labeled.
 
-    linthresh: None or float, optional, default: None
+    linthresh : None or float, optional, default: None
         If a symmetric log scale is in use, its ``linthresh``
         parameter must be supplied here.
 


### PR DESCRIPTION
This is work in progress.

fixes #7202 and supersedes #7211 

Here how the defaults behave:

![symlog](https://cloud.githubusercontent.com/assets/184798/20190843/f08209c6-a737-11e6-910f-44f5f378dae5.png)

Using the formatter's directly yields the expected behaviour, even on colorbar:
![log_colorbar_default](https://cloud.githubusercontent.com/assets/184798/20191290/af6f11de-a739-11e6-8391-f4fd63a94bd0.png)

Here is the code to reproduce those plots:

```python
import numpy as np
import matplotlib.pyplot as plt

X_1 = np.random.randint(12000, 90000, size=(1000,))
X_1.sort()
X_2 = np.random.randint(1e5, 1e12, size=(1000,))
X_2.sort()
X_3 = np.random.randint(1e5, 1e16, size=(1000,))
X_3.sort()

X = [X_1, X_2, X_3]

fig, ax = plt.subplots(ncols=len(X), figsize=(12, 6))
for i, x in enumerate(X):
    ax[i].plot(x)
    ax[i].set_yscale("log")
 ```

```python
import numpy as np

import matplotlib.pyplot as plt
from matplotlib import ticker, colors

X_1 = -np.random.randint(10000, 90000, size=(100, 100))
X_2 = np.random.randint(10000, 1000000, size=(100, 100))

formatter = ticker.LogFormatter(
    10)
sciformatter = ticker.LogFormatterSciNotation(
    10)

X = [X_1, X_2]

fig, axes = plt.subplots(ncols=2, nrows=2, figsize=(10, 10))
for i, x in enumerate(X):
    ax = axes[0, i]
    m = ax.imshow(x, norm=colors.SymLogNorm(1))
    ax.set_title("Log Formatter")

    cb = fig.colorbar(m, format=formatter, ax=ax, shrink=0.9, )
    ax = axes[1, i]
    m = ax.imshow(x, norm=colors.SymLogNorm(1))
    ax.set_title("Log Formatter Sci")
    cb = fig.colorbar(m, format=sciformatter, ax=ax, shrink=0.9, )
```



