### PR TITLE
[MRG+1] Enhance `annotation_demoX` examples

### DIFF
--- a/examples/pylab_examples/annotation_demo.py
+++ b/examples/pylab_examples/annotation_demo.py
@@ -39,104 +39,94 @@ from matplotlib.patches import Ellipse
 import numpy as np
 
 
-if 1:
-    # if only one location is given, the text and xypoint being
-    # annotated are assumed to be the same
-    fig = plt.figure()
-    ax = fig.add_subplot(111, autoscale_on=False, xlim=(-1, 5), ylim=(-3, 5))
+# If only one location is given, the text and xypoint being
+# annotated are assumed to be the same
+fig = plt.figure()
+ax = fig.add_subplot(111, autoscale_on=False, xlim=(-1, 5), ylim=(-3, 5))
 
-    t = np.arange(0.0, 5.0, 0.01)
-    s = np.cos(2*np.pi*t)
-    line, = ax.plot(t, s)
+t = np.arange(0.0, 5.0, 0.01)
+s = np.cos(2*np.pi*t)
+line, = ax.plot(t, s)
 
-    ax.annotate('figure pixels',
-                xy=(10, 10), xycoords='figure pixels')
+ax.annotate('figure pixels',
+            xy=(10, 10), xycoords='figure pixels')
 
-    ax.annotate('figure points', xy=(80, 80),
-                xycoords='figure points')
+ax.annotate('figure points',
+            xy=(80, 80), xycoords='figure points')
 
-    ax.annotate('point offset from data', xy=(2, 1),
-                xycoords='data',
-                xytext=(-15, 25), textcoords='offset points',
-                arrowprops=dict(facecolor='black', shrink=0.05),
-                horizontalalignment='right', verticalalignment='bottom',
-                )
+ax.annotate('point offset from data',
+            xy=(2, 1), xycoords='data',
+            xytext=(-15, 25), textcoords='offset points',
+            arrowprops=dict(facecolor='black', shrink=0.05),
+            horizontalalignment='right', verticalalignment='bottom')
 
-    ax.annotate('axes fraction', xy=(3, 1), xycoords='data',
-                xytext=(0.8, 0.95), textcoords='axes fraction',
-                arrowprops=dict(facecolor='black', shrink=0.05),
-                horizontalalignment='right', verticalalignment='top',
-                )
+ax.annotate('axes fraction',
+            xy=(3, 1), xycoords='data',
+            xytext=(0.8, 0.95), textcoords='axes fraction',
+            arrowprops=dict(facecolor='black', shrink=0.05),
+            horizontalalignment='right', verticalalignment='top')
 
-    ax.annotate('figure fraction', xy=(.025, .975),
-                xycoords='figure fraction',
-                horizontalalignment='left', verticalalignment='top',
-                fontsize=20)
+ax.annotate('figure fraction',
+            xy=(.025, .975), xycoords='figure fraction',
+            horizontalalignment='left', verticalalignment='top',
+            fontsize=20)
 
-    # use negative points or pixels to specify from right, top -10, 10
-    # is 10 points to the left of the right side of the axes and 10
-    # points above the bottom
-    ax.annotate('pixel offset from axes fraction', xy=(1, 0),
-                xycoords='axes fraction',
-                xytext=(-20, 20),
-                textcoords='offset pixels',
-                horizontalalignment='right',
-                verticalalignment='bottom')
+# use negative points or pixels to specify from right, top -10, 10
+# is 10 points to the left of the right side of the axes and 10
+# points above the bottom
+ax.annotate('pixel offset from axes fraction',
+            xy=(1, 0), xycoords='axes fraction',
+            xytext=(-20, 20), textcoords='offset pixels',
+            horizontalalignment='right',
+            verticalalignment='bottom')
 
 
-if 1:
-    # you can specify the xypoint and the xytext in different
-    # positions and coordinate systems, and optionally turn on a
-    # connecting line and mark the point with a marker.  Annotations
-    # work on polar axes too.  In the example below, the xy point is
-    # in native coordinates (xycoords defaults to 'data').  For a
-    # polar axes, this is in (theta, radius) space.  The text in this
-    # example is placed in the fractional figure coordinate system.
-    # Text keyword args like horizontal and vertical alignment are
-    # respected
-    fig = plt.figure()
-    ax = fig.add_subplot(111, projection='polar')
-    r = np.arange(0, 1, 0.001)
-    theta = 2*2*np.pi*r
-    line, = ax.plot(theta, r)
+# You can specify the xypoint and the xytext in different positions and
+# coordinate systems, and optionally turn on a connecting line and mark
+# the point with a marker.  Annotations work on polar axes too.
+# In the example below, the xy point is in native coordinates (xycoords
+# defaults to 'data').  For a polar axes, this is in (theta, radius) space.
+# The text in the example is placed in the fractional figure coordinate system.
+# Text keyword args like horizontal and vertical alignment are respected.
+fig = plt.figure()
+ax = fig.add_subplot(111, projection='polar')
+r = np.arange(0, 1, 0.001)
+theta = 2*2*np.pi*r
+line, = ax.plot(theta, r)
 
-    ind = 800
-    thisr, thistheta = r[ind], theta[ind]
-    ax.plot([thistheta], [thisr], 'o')
-    ax.annotate('a polar annotation',
-                xy=(thistheta, thisr),  # theta, radius
-                xytext=(0.05, 0.05),    # fraction, fraction
-                textcoords='figure fraction',
-                arrowprops=dict(facecolor='black', shrink=0.05),
-                horizontalalignment='left',
-                verticalalignment='bottom',
-                )
+ind = 800
+thisr, thistheta = r[ind], theta[ind]
+ax.plot([thistheta], [thisr], 'o')
+ax.annotate('a polar annotation',
+            xy=(thistheta, thisr),  # theta, radius
+            xytext=(0.05, 0.05),    # fraction, fraction
+            textcoords='figure fraction',
+            arrowprops=dict(facecolor='black', shrink=0.05),
+            horizontalalignment='left',
+            verticalalignment='bottom')
 
 
-if 1:
-    # You can also use polar notation on a cartesian axes.  Here the
-    # native coordinate system ('data') is cartesian, so you need to
-    # specify the xycoords and textcoords as 'polar' if you want to
-    # use (theta, radius)
+# You can also use polar notation on a cartesian axes.  Here the native
+# coordinate system ('data') is cartesian, so you need to specify the
+# xycoords and textcoords as 'polar' if you want to use (theta, radius).
 
-    el = Ellipse((0, 0), 10, 20, facecolor='r', alpha=0.5)
+el = Ellipse((0, 0), 10, 20, facecolor='r', alpha=0.5)
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111, aspect='equal')
-    ax.add_artist(el)
-    el.set_clip_box(ax.bbox)
-    ax.annotate('the top',
-                xy=(np.pi/2., 10.),      # theta, radius
-                xytext=(np.pi/3, 20.),   # theta, radius
-                xycoords='polar',
-                textcoords='polar',
-                arrowprops=dict(facecolor='black', shrink=0.05),
-                horizontalalignment='left',
-                verticalalignment='bottom',
-                clip_on=True,  # clip to the axes bounding box
-                )
+fig = plt.figure()
+ax = fig.add_subplot(111, aspect='equal')
+ax.add_artist(el)
+el.set_clip_box(ax.bbox)
+ax.annotate('the top',
+            xy=(np.pi/2., 10.),      # theta, radius
+            xytext=(np.pi/3, 20.),   # theta, radius
+            xycoords='polar',
+            textcoords='polar',
+            arrowprops=dict(facecolor='black', shrink=0.05),
+            horizontalalignment='left',
+            verticalalignment='bottom',
+            clip_on=True)  # clip to the axes bounding box
 
-    ax.set_xlim(-20, 20)
-    ax.set_ylim(-20, 20)
+ax.set_xlim([-20, 20])
+ax.set_ylim([-20, 20])
 
 plt.show()

--- a/examples/pylab_examples/annotation_demo2.py
+++ b/examples/pylab_examples/annotation_demo2.py
@@ -1,153 +1,150 @@
-
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 import numpy as np
 
-if 1:
-    fig = plt.figure(1, figsize=(8, 5))
-    ax = fig.add_subplot(111, autoscale_on=False, xlim=(-1, 5), ylim=(-4, 3))
 
-    t = np.arange(0.0, 5.0, 0.01)
-    s = np.cos(2*np.pi*t)
-    line, = ax.plot(t, s, lw=3)
+fig = plt.figure(1, figsize=(8, 5))
+ax = fig.add_subplot(111, autoscale_on=False, xlim=(-1, 5), ylim=(-4, 3))
 
-    ax.annotate('arrowstyle', xy=(0, 1), xycoords='data',
-                xytext=(-50, 30), textcoords='offset points',
-                arrowprops=dict(arrowstyle="->")
-                )
+t = np.arange(0.0, 5.0, 0.01)
+s = np.cos(2*np.pi*t)
+line, = ax.plot(t, s, lw=3)
 
-    ax.annotate('arc3', xy=(0.5, -1), xycoords='data',
-                xytext=(-30, -30), textcoords='offset points',
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle="arc3,rad=.2")
-                )
+ax.annotate('straight',
+            xy=(0, 1), xycoords='data',
+            xytext=(-50, 30), textcoords='offset points',
+            arrowprops=dict(arrowstyle="->"))
 
-    ax.annotate('arc', xy=(1., 1), xycoords='data',
-                xytext=(-40, 30), textcoords='offset points',
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle="arc,angleA=0,armA=30,rad=10"),
-                )
+ax.annotate('arc3,\nrad 0.2',
+            xy=(0.5, -1), xycoords='data',
+            xytext=(-80, -60), textcoords='offset points',
+            arrowprops=dict(arrowstyle="->",
+                            connectionstyle="arc3,rad=.2"))
 
-    ax.annotate('arc', xy=(1.5, -1), xycoords='data',
-                xytext=(-40, -30), textcoords='offset points',
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle="arc,angleA=0,armA=20,angleB=-90,armB=15,rad=7"),
-                )
+ax.annotate('arc,\nangle 50',
+            xy=(1., 1), xycoords='data',
+            xytext=(-90, 50), textcoords='offset points',
+            arrowprops=dict(arrowstyle="->",
+                            connectionstyle="arc,angleA=0,armA=50,rad=10"))
 
-    ax.annotate('angle', xy=(2., 1), xycoords='data',
-                xytext=(-50, 30), textcoords='offset points',
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle="angle,angleA=0,angleB=90,rad=10"),
-                )
+ax.annotate('arc,\narms',
+            xy=(1.5, -1), xycoords='data',
+            xytext=(-80, -60), textcoords='offset points',
+            arrowprops=dict(arrowstyle="->",
+                            connectionstyle="arc,angleA=0,armA=40,angleB=-90,armB=30,rad=7"))
 
-    ax.annotate('angle3', xy=(2.5, -1), xycoords='data',
-                xytext=(-50, -30), textcoords='offset points',
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle="angle3,angleA=0,angleB=-90"),
-                )
+ax.annotate('angle,\nangle 90',
+            xy=(2., 1), xycoords='data',
+            xytext=(-70, 30), textcoords='offset points',
+            arrowprops=dict(arrowstyle="->",
+                            connectionstyle="angle,angleA=0,angleB=90,rad=10"))
 
-    ax.annotate('angle', xy=(3., 1), xycoords='data',
-                xytext=(-50, 30), textcoords='offset points',
-                bbox=dict(boxstyle="round", fc="0.8"),
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle="angle,angleA=0,angleB=90,rad=10"),
-                )
+ax.annotate('angle3,\nangle -90',
+            xy=(2.5, -1), xycoords='data',
+            xytext=(-80, -60), textcoords='offset points',
+            arrowprops=dict(arrowstyle="->",
+                            connectionstyle="angle3,angleA=0,angleB=-90"))
 
-    ax.annotate('angle', xy=(3.5, -1), xycoords='data',
-                xytext=(-70, -60), textcoords='offset points',
-                size=20,
-                bbox=dict(boxstyle="round4,pad=.5", fc="0.8"),
-                arrowprops=dict(arrowstyle="->",
-                                connectionstyle="angle,angleA=0,angleB=-90,rad=10"),
-                )
+ax.annotate('angle,\nround',
+            xy=(3., 1), xycoords='data',
+            xytext=(-60, 30), textcoords='offset points',
+            bbox=dict(boxstyle="round", fc="0.8"),
+            arrowprops=dict(arrowstyle="->",
+                            connectionstyle="angle,angleA=0,angleB=90,rad=10"))
 
-    ax.annotate('angle', xy=(4., 1), xycoords='data',
-                xytext=(-50, 30), textcoords='offset points',
-                bbox=dict(boxstyle="round", fc="0.8"),
-                arrowprops=dict(arrowstyle="->",
-                                shrinkA=0, shrinkB=10,
-                                connectionstyle="angle,angleA=0,angleB=90,rad=10"),
-                )
+ax.annotate('angle,\nround4',
+            xy=(3.5, -1), xycoords='data',
+            xytext=(-70, -80), textcoords='offset points',
+            size=20,
+            bbox=dict(boxstyle="round4,pad=.5", fc="0.8"),
+            arrowprops=dict(arrowstyle="->",
+                            connectionstyle="angle,angleA=0,angleB=-90,rad=10"))
 
-    ann = ax.annotate('', xy=(4., 1.), xycoords='data',
-                      xytext=(4.5, -1), textcoords='data',
-                      arrowprops=dict(arrowstyle="<->",
-                                      connectionstyle="bar",
-                                      ec="k",
-                                      shrinkA=5, shrinkB=5,
-                                      )
-                      )
+ax.annotate('angle,\nshrink',
+            xy=(4., 1), xycoords='data',
+            xytext=(-60, 30), textcoords='offset points',
+            bbox=dict(boxstyle="round", fc="0.8"),
+            arrowprops=dict(arrowstyle="->",
+                            shrinkA=0, shrinkB=10,
+                            connectionstyle="angle,angleA=0,angleB=90,rad=10"))
+
+# You can pass an empty string to get only annotation arrows rendered
+ann = ax.annotate('', xy=(4., 1.), xycoords='data',
+                  xytext=(4.5, -1), textcoords='data',
+                  arrowprops=dict(arrowstyle="<->",
+                                  connectionstyle="bar",
+                                  ec="k",
+                                  shrinkA=5, shrinkB=5))
 
 
-if 1:
-    fig = plt.figure(2)
-    fig.clf()
-    ax = fig.add_subplot(111, autoscale_on=False, xlim=(-1, 5), ylim=(-5, 3))
+fig = plt.figure(2)
+fig.clf()
+ax = fig.add_subplot(111, autoscale_on=False, xlim=(-1, 5), ylim=(-5, 3))
 
-    el = Ellipse((2, -1), 0.5, 0.5)
-    ax.add_patch(el)
+el = Ellipse((2, -1), 0.5, 0.5)
+ax.add_patch(el)
 
-    ax.annotate('$->$', xy=(2., -1), xycoords='data',
-                xytext=(-150, -140), textcoords='offset points',
-                bbox=dict(boxstyle="round", fc="0.8"),
-                arrowprops=dict(arrowstyle="->",
-                                patchB=el,
-                                connectionstyle="angle,angleA=90,angleB=0,rad=10"),
-                )
+ax.annotate('$->$',
+            xy=(2., -1), xycoords='data',
+            xytext=(-150, -140), textcoords='offset points',
+            bbox=dict(boxstyle="round", fc="0.8"),
+            arrowprops=dict(arrowstyle="->",
+                            patchB=el,
+                            connectionstyle="angle,angleA=90,angleB=0,rad=10"))
 
-    ax.annotate('fancy', xy=(2., -1), xycoords='data',
-                xytext=(-100, 60), textcoords='offset points',
-                size=20,
-                # bbox=dict(boxstyle="round", fc="0.8"),
-                arrowprops=dict(arrowstyle="fancy",
-                                fc="0.6", ec="none",
-                                patchB=el,
-                                connectionstyle="angle3,angleA=0,angleB=-90"),
-                )
+ax.annotate('arrow\nfancy',
+            xy=(2., -1), xycoords='data',
+            xytext=(-100, 60), textcoords='offset points',
+            size=20,
+            # bbox=dict(boxstyle="round", fc="0.8"),
+            arrowprops=dict(arrowstyle="fancy",
+                            fc="0.6", ec="none",
+                            patchB=el,
+                            connectionstyle="angle3,angleA=0,angleB=-90"))
 
-    ax.annotate('simple', xy=(2., -1), xycoords='data',
-                xytext=(100, 60), textcoords='offset points',
-                size=20,
-                # bbox=dict(boxstyle="round", fc="0.8"),
-                arrowprops=dict(arrowstyle="simple",
-                                fc="0.6", ec="none",
-                                patchB=el,
-                                connectionstyle="arc3,rad=0.3"),
-                )
+ax.annotate('arrow\nsimple',
+            xy=(2., -1), xycoords='data',
+            xytext=(100, 60), textcoords='offset points',
+            size=20,
+            # bbox=dict(boxstyle="round", fc="0.8"),
+            arrowprops=dict(arrowstyle="simple",
+                            fc="0.6", ec="none",
+                            patchB=el,
+                            connectionstyle="arc3,rad=0.3"))
 
-    ax.annotate('wedge', xy=(2., -1), xycoords='data',
-                xytext=(-100, -100), textcoords='offset points',
-                size=20,
-                # bbox=dict(boxstyle="round", fc="0.8"),
-                arrowprops=dict(arrowstyle="wedge,tail_width=0.7",
-                                fc="0.6", ec="none",
-                                patchB=el,
-                                connectionstyle="arc3,rad=-0.3"),
-                )
+ax.annotate('wedge',
+            xy=(2., -1), xycoords='data',
+            xytext=(-100, -100), textcoords='offset points',
+            size=20,
+            # bbox=dict(boxstyle="round", fc="0.8"),
+            arrowprops=dict(arrowstyle="wedge,tail_width=0.7",
+                            fc="0.6", ec="none",
+                            patchB=el,
+                            connectionstyle="arc3,rad=-0.3"))
 
-    ann = ax.annotate('wedge', xy=(2., -1), xycoords='data',
-                      xytext=(0, -45), textcoords='offset points',
-                      size=20,
-                      bbox=dict(boxstyle="round", fc=(1.0, 0.7, 0.7), ec=(1., .5, .5)),
-                      arrowprops=dict(arrowstyle="wedge,tail_width=1.",
-                                      fc=(1.0, 0.7, 0.7), ec=(1., .5, .5),
-                                      patchA=None,
-                                      patchB=el,
-                                      relpos=(0.2, 0.8),
-                                      connectionstyle="arc3,rad=-0.1"),
-                      )
+ann = ax.annotate('bubble,\ncontours',
+                  xy=(2., -1), xycoords='data',
+                  xytext=(0, -70), textcoords='offset points',
+                  size=20,
+                  bbox=dict(boxstyle="round",
+                            fc=(1.0, 0.7, 0.7),
+                            ec=(1., .5, .5)),
+                  arrowprops=dict(arrowstyle="wedge,tail_width=1.",
+                                  fc=(1.0, 0.7, 0.7), ec=(1., .5, .5),
+                                  patchA=None,
+                                  patchB=el,
+                                  relpos=(0.2, 0.8),
+                                  connectionstyle="arc3,rad=-0.1"))
 
-    ann = ax.annotate('wedge', xy=(2., -1), xycoords='data',
-                      xytext=(35, 0), textcoords='offset points',
-                      size=20, va="center",
-                      bbox=dict(boxstyle="round", fc=(1.0, 0.7, 0.7), ec="none"),
-                      arrowprops=dict(arrowstyle="wedge,tail_width=1.",
-                                      fc=(1.0, 0.7, 0.7), ec="none",
-                                      patchA=None,
-                                      patchB=el,
-                                      relpos=(0.2, 0.5),
-                                      )
-                      )
-
+ann = ax.annotate('bubble',
+                  xy=(2., -1), xycoords='data',
+                  xytext=(55, 0), textcoords='offset points',
+                  size=20, va="center",
+                  bbox=dict(boxstyle="round", fc=(1.0, 0.7, 0.7), ec="none"),
+                  arrowprops=dict(arrowstyle="wedge,tail_width=1.",
+                                  fc=(1.0, 0.7, 0.7), ec="none",
+                                  patchA=None,
+                                  patchB=el,
+                                  relpos=(0.2, 0.5)))
 
 plt.show()

--- a/examples/pylab_examples/annotation_demo3.py
+++ b/examples/pylab_examples/annotation_demo3.py
@@ -1,4 +1,6 @@
 import matplotlib.pyplot as plt
+from matplotlib.text import OffsetFrom
+
 
 fig, (ax1, ax2) = plt.subplots(1, 2)
 
@@ -9,29 +11,25 @@ ax1.annotate('figure fraction : 0, 0', xy=(0, 0), xycoords='figure fraction',
              xytext=(20, 20), textcoords='offset points',
              ha="left", va="bottom",
              bbox=bbox_args,
-             arrowprops=arrow_args
-             )
+             arrowprops=arrow_args)
 
 ax1.annotate('figure fraction : 1, 1', xy=(1, 1), xycoords='figure fraction',
              xytext=(-20, -20), textcoords='offset points',
              ha="right", va="top",
              bbox=bbox_args,
-             arrowprops=arrow_args
-             )
+             arrowprops=arrow_args)
 
 ax1.annotate('axes fraction : 0, 0', xy=(0, 0), xycoords='axes fraction',
              xytext=(20, 20), textcoords='offset points',
              ha="left", va="bottom",
              bbox=bbox_args,
-             arrowprops=arrow_args
-             )
+             arrowprops=arrow_args)
 
 ax1.annotate('axes fraction : 1, 1', xy=(1, 1), xycoords='axes fraction',
              xytext=(-20, -20), textcoords='offset points',
              ha="right", va="top",
              bbox=bbox_args,
-             arrowprops=arrow_args
-             )
+             arrowprops=arrow_args)
 
 
 an1 = ax1.annotate('Drag me 1', xy=(.5, .7), xycoords='data',
@@ -47,8 +45,7 @@ an2 = ax1.annotate('Drag me 2', xy=(.5, .5), xycoords=an1,
                    bbox=bbox_args,
                    arrowprops=dict(patchB=an1.get_bbox_patch(),
                                    connectionstyle="arc3,rad=0.2",
-                                   **arrow_args)
-                   )
+                                   **arrow_args))
 
 an3 = ax1.annotate('', xy=(.5, .5), xycoords=an2,
                    xytext=(.5, .5), textcoords=an1,
@@ -57,8 +54,7 @@ an3 = ax1.annotate('', xy=(.5, .5), xycoords=an2,
                    arrowprops=dict(patchA=an1.get_bbox_patch(),
                                    patchB=an2.get_bbox_patch(),
                                    connectionstyle="arc3,rad=0.2",
-                                   **arrow_args)
-                   )
+                                   **arrow_args))
 
 
 t = ax2.annotate('xy=(0, 1)\nxycoords=("data", "axes fraction")',
@@ -66,29 +62,25 @@ t = ax2.annotate('xy=(0, 1)\nxycoords=("data", "axes fraction")',
                  xytext=(0, -20), textcoords='offset points',
                  ha="center", va="top",
                  bbox=bbox_args,
-                 arrowprops=arrow_args
-                 )
-
-from matplotlib.text import OffsetFrom
+                 arrowprops=arrow_args)
 
 ax2.annotate('xy=(0.5, 0)\nxycoords=artist',
              xy=(0.5, 0.), xycoords=t,
              xytext=(0, -20), textcoords='offset points',
              ha="center", va="top",
              bbox=bbox_args,
-             arrowprops=arrow_args
-             )
+             arrowprops=arrow_args)
 
 ax2.annotate('xy=(0.8, 0.5)\nxycoords=ax1.transData',
              xy=(0.8, 0.5), xycoords=ax1.transData,
-             xytext=(10, 10), textcoords=OffsetFrom(ax2.bbox, (0, 0), "points"),
+             xytext=(10, 10),
+             textcoords=OffsetFrom(ax2.bbox, (0, 0), "points"),
              ha="left", va="bottom",
              bbox=bbox_args,
-             arrowprops=arrow_args
-             )
+             arrowprops=arrow_args)
 
-ax2.set_xlim(-2, 2)
-ax2.set_ylim(-2, 2)
+ax2.set_xlim([-2, 2])
+ax2.set_ylim([-2, 2])
 
 an1.draggable()
 an2.draggable()


### PR DESCRIPTION
Closes https://github.com/matplotlib/matplotlib/issues/7440:

![figure_1](https://cloud.githubusercontent.com/assets/1315589/20229717/0b909192-a869-11e6-91d3-d478b1788cef.png)
![figure_2](https://cloud.githubusercontent.com/assets/1315589/20229719/0d7cb1ca-a869-11e6-80c8-5253c22c6f09.png)

See http://matplotlib.org/devdocs/examples/pylab_examples/annotation_demo2.html for the current versions.

Includes also cosmetic changes for `..._demo.py` and `..._demo3.py`.