### PR TITLE
API: remove unused attribute on Annotation

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -2149,8 +2149,6 @@ class Annotation(Text, _AnnotationBase):
 
         self.arrowprops = arrowprops
 
-        self.arrow = None
-
         if arrowprops is not None:
             if "arrowstyle" in arrowprops:
                 arrowprops = self.arrowprops.copy()
@@ -2170,9 +2168,6 @@ class Annotation(Text, _AnnotationBase):
 
     def contains(self, event):
         contains, tinfo = Text.contains(self, event)
-        if self.arrow is not None:
-            in_arrow, _ = self.arrow.contains(event)
-            contains = contains or in_arrow
         if self.arrow_patch is not None:
             in_patch, _ = self.arrow_patch.contains(event)
             contains = contains or in_patch
@@ -2197,8 +2192,6 @@ class Annotation(Text, _AnnotationBase):
 
     def set_figure(self, fig):
 
-        if self.arrow is not None:
-            self.arrow.set_figure(fig)
         if self.arrow_patch is not None:
             self.arrow_patch.set_figure(fig)
         Artist.set_figure(self, fig)
@@ -2366,8 +2359,6 @@ class Annotation(Text, _AnnotationBase):
         text_bbox = Text.get_window_extent(self, renderer=renderer)
         bboxes = [text_bbox]
 
-        if self.arrow is not None:
-            bboxes.append(arrow.get_window_extent(renderer=renderer))
         elif self.arrow_patch is not None:
             bboxes.append(arrow_patch.get_window_extent(renderer=renderer))
 


### PR DESCRIPTION
Pretty sure this is fall out from @efiring cleaning up the arrow handling in annotation to always use the fancy arrows.

Definitely needs docs,  might need deprecation cycle.

Posting this due to almost losing a whole pile of stashes today.