### PR TITLE
BLD: look for an ghoauth token when using ghtools

### DIFF
--- a/tools/gh_api.py
+++ b/tools/gh_api.py
@@ -43,6 +43,13 @@ def get_auth_token():
     if token is not None:
         return token
 
+    try:
+        with open(os.path.join(os.path.expanduser('~'), '.ghoauth')) as f:
+            token, = f
+            return token
+    except:
+        pass
+
     import keyring
     token = keyring.get_password('github', fake_username)
     if token is not None:


### PR DESCRIPTION
Without this, you get rate-banned from the gh api pretty quickly if you try to update our PR/Issue summary pages.

I have been popping this off my stash/just rewriting everytime I need to do this.

These files are (I think) vendored from the IPython/Jupyter tools, might want to consider refreshing from it's upstream (or relying on the project @Carreau is working on to unify these across the scipy stack).

Nice to have this next time the docs get refreshed.