### PR TITLE
[MRG+1] Avoid temporaries when preparing step plots.

### DIFF
--- a/doc/api/api_changes/lines_removed_api.rst
+++ b/doc/api/api_changes/lines_removed_api.rst
@@ -1,0 +1,6 @@
+Functions removed from the `lines` module
+`````````````````````````````````````````
+
+The `matplotlib.lines` module no longer imports the `pts_to_prestep`,
+`pts_to_midstep` and `pts_to_poststep` functions from the `matplotlib.cbook`
+module.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -12,27 +12,24 @@ import six
 import warnings
 
 import numpy as np
-from numpy import ma
-from . import artist, colors as mcolors
-from .artist import Artist
-from .cbook import (iterable, is_string_like, is_numlike, ls_mapper_r,
-                    pts_to_prestep, pts_to_poststep, pts_to_midstep, ls_mapper,
-                    is_hashable, STEP_LOOKUP_MAP)
 
+from . import artist, colors as mcolors, docstring, rcParams
+from .artist import Artist, allow_rasterization
+from .cbook import (
+    iterable, is_string_like, is_numlike, ls_mapper, ls_mapper_r, is_hashable,
+    STEP_LOOKUP_MAP)
+from .markers import MarkerStyle
 from .path import Path
 from .transforms import Bbox, TransformedPath, IdentityTransform
 
-from matplotlib import rcParams
-from .artist import allow_rasterization
-from matplotlib import docstring
-from matplotlib.markers import MarkerStyle
 # Imported here for backward compatibility, even though they don't
 # really belong.
-from matplotlib.markers import TICKLEFT, TICKRIGHT, TICKUP, TICKDOWN
-from matplotlib.markers import (
+from numpy import ma
+from . import _path
+from .markers import (
     CARETLEFT, CARETRIGHT, CARETUP, CARETDOWN,
-    CARETLEFTBASE, CARETRIGHTBASE, CARETUPBASE, CARETDOWNBASE)
-from matplotlib import _path
+    CARETLEFTBASE, CARETRIGHTBASE, CARETUPBASE, CARETDOWNBASE,
+    TICKLEFT, TICKRIGHT, TICKUP, TICKDOWN)
 
 
 def _get_dash_pattern(style):

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -460,18 +460,14 @@ def test_to_midstep():
     assert_array_equal(y1_target, y1s)
 
 
-def test_step_fails():
+@pytest.mark.parametrize(
+    "args",
+    [(np.arange(12).reshape(3, 4), 'a'),
+     (np.arange(12), 'a'),
+     (np.arange(12), np.arange(3))])
+def test_step_fails(args):
     with pytest.raises(ValueError):
-        cbook._step_validation(np.arange(12).reshape(3, 4), 'a')
-
-    with pytest.raises(ValueError):
-        cbook._step_validation(np.arange(12), 'a')
-
-    with pytest.raises(ValueError):
-        cbook._step_validation(np.arange(12))
-
-    with pytest.raises(ValueError):
-        cbook._step_validation(np.arange(12), np.arange(3))
+        cbook.pts_to_prestep(*args)
 
 
 def test_grouper():


### PR DESCRIPTION
The previous implementation of `pts_to_{pre,mid,post}`step was fairly
unefficient: it allocated a large array during validation (`vstack`),
then a second array to build the return tuple, then converted the
columns to a tuple, then immediately converted the tuple back to a new
array at the call site (to construct a Path).  Instead, just create a
single array and work with it all along.

Also some minor related cleanups (moving imports in lines.py, in
particular suggesting to not expose the individual `pts_to_*step`
functions anymore (they are not directly used, only via the
`STEP_LOOKUP_MAP` mapping).