### PR TITLE
[MRG+2] ENH: _StringFuncParser to get numerical functions callables from strings

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2694,12 +2694,7 @@ class _FuncInfo(object):
         elif callable(check_params):
             self._check_params = check_params
         else:
-            raise ValueError("Check params must be a callable taking a list "
-                             "with function parameters and returning a "
-                             "boolean indicating whether that combination of "
-                             "parameters is valid. In case of validity for "
-                             "any combination of parameters it may be set "
-                             "to None.")
+            raise ValueError("Invalid 'check_params' argument.")
 
     def is_bounded_0_1(self, params=None):
         return self._bounded_0_1(params)

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2774,7 +2774,7 @@ class _StringFuncParser(object):
         """
 
         if not isinstance(str_func, six.string_types):
-            raise ValueError("'%s' is not a string." % str_func)
+            raise ValueError("'%s' must be a string." % str_func)
         self._str_func = six.text_type(str_func)
         self._key, self._params = self._get_key_params()
         self._func = self._parse_func()

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2665,22 +2665,38 @@ class Locked(object):
 
 class _FuncInfo(object):
     """
-    Class used to store a function
-
-    Each object has:
-    * The direct function (function)
-    * The inverse function (inverse)
-    * A boolean indicating whether the function
-      is bounded in the interval 0-1 (bounded_0_1), or
-      a method that returns the information depending
-      on this
-    * A callable (check_params) that takes a list of the parameters
-      and returns a boolean specifying if a certain combination of
-      parameters is valid. It is only required if the function has
-      parameters and some of them are restricted.
+    Class used to store a function.
 
     """
+
     def __init__(self, function, inverse, bounded_0_1=True, check_params=None):
+        """
+        Parameters
+        ----------
+
+        function : callable
+            A callable implementing the function receiving the variable as
+            first argument and any additional parameters in a list as second
+            argument.
+        inverse : callable
+            A callable implementing the inverse function receiving the variable
+            as first argument and any additional parameters in a list as
+            second argument. It must satisfy 'inverse(function(x, p), p) == x'.
+        bounded_0_1: bool or callable
+            A boolean indicating whether the function is bounded in the [0,1]
+            interval, or a callable taking a list of values for the additional
+            parameters, and returning a boolean indicating whether the function
+            is bounded in the [0,1] interval for that combination of
+            parameters. Default True.
+        check_params: callable or None
+            A callable taking a list of values for the additional parameters
+            and returning a boolean indicating whether that combination of
+            parameters is valid. It is only required if the function has
+            additional parameters and some of them are restricted.
+            Default None.
+
+        """
+
         self.function = function
         self.inverse = inverse
 
@@ -2697,9 +2713,47 @@ class _FuncInfo(object):
             raise ValueError("Invalid 'check_params' argument.")
 
     def is_bounded_0_1(self, params=None):
+        """
+        Returns a boolean indicating if the function is bounded in the [0,1]
+        interval for a particular set of additional parameters.
+
+        Parameters
+        ----------
+
+        params : list
+            The list of additional parameters. Default None.
+
+        Returns
+        -------
+
+        out : bool
+            True if the function is bounded in the [0,1] interval for
+            parameters 'params'. Otherwise False.
+
+        """
+
         return self._bounded_0_1(params)
 
     def check_params(self, params=None):
+        """
+        Returns a boolean indicating if the set of additional parameters is
+        valid.
+
+        Parameters
+        ----------
+
+        params : list
+            The list of additional parameters. Default None.
+
+        Returns
+        -------
+
+        out : bool
+            True if 'params' is a valid set of additional parameters for the
+            function. Otherwise False.
+
+        """
+
         return self._check_params(params)
 
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2851,7 +2851,7 @@ class _StringFuncParser(object):
 
         try:
             func = self._funcs[str_func]
-        except ValueError, KeyError:
+        except (ValueError, KeyError):
             raise ValueError("%s: invalid string. The only strings "
                              "recognized as functions are %s." %
                              (str_func, list(self._funcs)))

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2676,7 +2676,7 @@ class _FuncInfo(object):
       on this
     * A callable (check_params) that takes a list of the parameters
       and returns a boolean specifying if a certain combination of
-      parameters is valid. It is only required if the function as
+      parameters is valid. It is only required if the function has
       parameters and some of them are restricted.
 
     """

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2719,12 +2719,12 @@ class _StringFuncParser(object):
                                     np.sqrt,
                                     True)
     _funcs['cubic'] = _FuncInfo(lambda x: x**3,
-                                np.cbrt,
+                                lambda x: x**(1. / 3),
                                 True)
     _funcs['sqrt'] = _FuncInfo(np.sqrt,
                                np.square,
                                True)
-    _funcs['cbrt'] = _FuncInfo(np.cbrt,
+    _funcs['cbrt'] = _FuncInfo(lambda x: x**(1. / 3),
                                lambda x: x**3,
                                True)
     _funcs['log10'] = _FuncInfo(np.log10,

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2661,3 +2661,81 @@ class Locked(object):
                     os.rmdir(path)
                 except OSError:
                     pass
+
+
+class _StringFuncParser(object):
+    # Each element has:
+    #     -The direct function,
+    #     -The inverse function,
+    #     -A boolean indicating whether the function
+    #      is bounded in the interval 0-1
+
+    funcs = {'linear': (lambda x: x, lambda x: x, True),
+             'quadratic': (lambda x: x**2, lambda x: x**(1. / 2), True),
+             'cubic': (lambda x: x**3, lambda x: x**(1. / 3), True),
+             'sqrt': (lambda x: x**(1. / 2), lambda x: x**2, True),
+             'cbrt': (lambda x: x**(1. / 3), lambda x: x**3, True),
+             'log10': (lambda x: np.log10(x), lambda x: (10**(x)), False),
+             'log': (lambda x: np.log(x), lambda x: (np.exp(x)), False),
+             'power{a}': (lambda x, a: x**a,
+                          lambda x, a: x**(1. / a), True),
+             'root{a}': (lambda x, a: x**(1. / a),
+                         lambda x, a: x**a, True),
+             'log10(x+{a})': (lambda x, a: np.log10(x + a),
+                              lambda x, a: 10**x - a, True),
+             'log(x+{a})': (lambda x, a: np.log(x + a),
+                            lambda x, a: np.exp(x) - a, True)}
+
+    def __init__(self, str_func):
+        self.str_func = str_func
+
+    def is_string(self):
+        return not hasattr(self.str_func, '__call__')
+
+    def get_func(self):
+        return self._get_element(0)
+
+    def get_invfunc(self):
+        return self._get_element(1)
+
+    def is_bounded_0_1(self):
+        return self._get_element(2)
+
+    def _get_element(self, ind):
+        if not self.is_string():
+            raise ValueError("The argument passed is not a string.")
+
+        str_func = six.text_type(self.str_func)
+        # Checking if it comes with a parameter
+        param = None
+        regex = '\{(.*?)\}'
+        search = re.search(regex, str_func)
+        if search is not None:
+            parstring = search.group(1)
+
+            try:
+                param = float(parstring)
+            except:
+                raise ValueError("'a' in parametric function strings must be "
+                                 "replaced by a number that is not "
+                                 "zero, e.g. 'log10(x+{0.1})'.")
+            if param == 0:
+                raise ValueError("'a' in parametric function strings must be "
+                                 "replaced by a number that is not "
+                                 "zero.")
+            str_func = re.sub(regex, '{a}', str_func)
+
+        try:
+            output = self.funcs[str_func][ind]
+            if param is not None:
+                output = (lambda x, output=output: output(x, param))
+
+            return output
+        except KeyError:
+            raise ValueError("%s: invalid function. The only strings "
+                             "recognized as functions are %s." %
+                             (str_func, self.funcs.keys()))
+        except:
+            raise ValueError("Invalid function. The only strings recognized "
+                             "as functions are %s." %
+                             (self.funcs.keys()))

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -553,22 +553,22 @@ class TestFuncParser(object):
                              ids=validstrings)
     def test_values(self, string, func):
         func_parser = cbook._StringFuncParser(string)
-        f = func_parser.directfunc
+        f = func_parser.function
         assert_array_almost_equal(f(self.x_test), func(self.x_test))
 
     @pytest.mark.parametrize("string", validstrings, ids=validstrings)
     def test_inverse(self, string):
         func_parser = cbook._StringFuncParser(string)
-        f = func_parser.func
-        fdir = f.direct
+        f = func_parser.func_info
+        fdir = f.function
         finv = f.inverse
         assert_array_almost_equal(finv(fdir(self.x_test)), self.x_test)
 
     @pytest.mark.parametrize("string", validstrings, ids=validstrings)
-    def test_get_invfunc(self, string):
+    def test_get_inverse(self, string):
         func_parser = cbook._StringFuncParser(string)
-        finv1 = func_parser.invfunc
-        finv2 = func_parser.func.inverse
+        finv1 = func_parser.inverse
+        finv2 = func_parser.func_info.inverse
         assert_array_almost_equal(finv1(self.x_test), finv2(self.x_test))
 
     @pytest.mark.parametrize("string, bounded",

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -530,7 +530,7 @@ class TestFuncParser(object):
                np.square,
                (lambda x: x**3),
                np.sqrt,
-               np.cbrt,
+               (lambda x: x**(1. / 3)),
                np.log,
                np.log10,
                np.log2,

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -522,37 +522,44 @@ def test_flatiter():
 class TestFuncParser(object):
     x_test = np.linspace(0.01, 0.5, 3)
     validstrings = ['linear', 'quadratic', 'cubic', 'sqrt', 'cbrt',
-                    'log', 'log10', 'x**{1.5}', 'root{2.5}(x)',
-                    'log(x+{0.5})', 'log10(x+{0.1})', 'log{2}(x+{0.1})']
+                    'log', 'log10', 'log2', 'x**{1.5}', 'root{2.5}(x)',
+                    'log{2}(x)',
+                    'log(x+{0.5})', 'log10(x+{0.1})', 'log{2}(x+{0.1})',
+                    'log{2}(x+{0})']
     results = [(lambda x: x),
-               (lambda x: x**2),
+               np.square,
                (lambda x: x**3),
-               (lambda x: x**(1. / 2)),
-               (lambda x: x**(1. / 3)),
-               (lambda x: np.log(x)),
-               (lambda x: np.log10(x)),
+               np.sqrt,
+               np.cbrt,
+               np.log,
+               np.log10,
+               np.log2,
                (lambda x: x**1.5),
                (lambda x: x**(1 / 2.5)),
+               (lambda x: np.log2(x)),
                (lambda x: np.log(x + 0.5)),
                (lambda x: np.log10(x + 0.1)),
-               (lambda x: np.log2(x + 0.1))]
+               (lambda x: np.log2(x + 0.1)),
+               (lambda x: np.log2(x))]
 
     bounded_list = [True, True, True, True, True,
-                    False, False, True, True,
-                    True, True, True]
+                    False, False, False, True, True,
+                    False,
+                    True, True, True,
+                    False]
 
     @pytest.mark.parametrize("string, func",
                              zip(validstrings, results),
                              ids=validstrings)
     def test_values(self, string, func):
         func_parser = cbook._StringFuncParser(string)
-        f = func_parser.get_directfunc()
+        f = func_parser.directfunc
         assert_array_almost_equal(f(self.x_test), func(self.x_test))
 
     @pytest.mark.parametrize("string", validstrings, ids=validstrings)
     def test_inverse(self, string):
         func_parser = cbook._StringFuncParser(string)
-        f = func_parser.get_func()
+        f = func_parser.func
         fdir = f.direct
         finv = f.inverse
         assert_array_almost_equal(finv(fdir(self.x_test)), self.x_test)
@@ -560,8 +567,8 @@ class TestFuncParser(object):
     @pytest.mark.parametrize("string", validstrings, ids=validstrings)
     def test_get_invfunc(self, string):
         func_parser = cbook._StringFuncParser(string)
-        finv1 = func_parser.get_invfunc()
-        finv2 = func_parser.get_func().inverse
+        finv1 = func_parser.invfunc
+        finv2 = func_parser.func.inverse
         assert_array_almost_equal(finv1(self.x_test), finv2(self.x_test))
 
     @pytest.mark.parametrize("string, bounded",
@@ -569,5 +576,5 @@ class TestFuncParser(object):
                              ids=validstrings)
     def test_bounded(self, string, bounded):
         func_parser = cbook._StringFuncParser(string)
-        b = func_parser.is_bounded_0_1()
+        b = func_parser.is_bounded_0_1
         assert_array_equal(b, bounded)

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -522,8 +522,8 @@ def test_flatiter():
 class TestFuncParser(object):
     x_test = np.linspace(0.01, 0.5, 3)
     validstrings = ['linear', 'quadratic', 'cubic', 'sqrt', 'cbrt',
-                    'log', 'log10', 'power{1.5}', 'root{2.5}',
-                    'log(x+{0.5})', 'log10(x+{0.1})']
+                    'log', 'log10', 'x**{1.5}', 'root{2.5}(x)',
+                    'log(x+{0.5})', 'log10(x+{0.1})', 'log{2}(x+{0.1})']
     results = [(lambda x: x),
                (lambda x: x**2),
                (lambda x: x**3),
@@ -534,19 +534,40 @@ class TestFuncParser(object):
                (lambda x: x**1.5),
                (lambda x: x**(1 / 2.5)),
                (lambda x: np.log(x + 0.5)),
-               (lambda x: np.log10(x + 0.1))]
+               (lambda x: np.log10(x + 0.1)),
+               (lambda x: np.log2(x + 0.1))]
 
-    @pytest.mark.parametrize("string", validstrings, ids=validstrings)
-    def test_inverse(self, string):
-        func_parser = cbook._StringFuncParser(string)
-        f = func_parser.get_func()
-        finv = func_parser.get_invfunc()
-        assert_array_almost_equal(finv(f(self.x_test)), self.x_test)
+    bounded_list = [True, True, True, True, True,
+                    False, False, True, True,
+                    True, True, True]
 
     @pytest.mark.parametrize("string, func",
                              zip(validstrings, results),
                              ids=validstrings)
     def test_values(self, string, func):
         func_parser = cbook._StringFuncParser(string)
-        f = func_parser.get_func()
+        f = func_parser.get_directfunc()
         assert_array_almost_equal(f(self.x_test), func(self.x_test))
+
+    @pytest.mark.parametrize("string", validstrings, ids=validstrings)
+    def test_inverse(self, string):
+        func_parser = cbook._StringFuncParser(string)
+        f = func_parser.get_func()
+        fdir = f.direct
+        finv = f.inverse
+        assert_array_almost_equal(finv(fdir(self.x_test)), self.x_test)
+
+    @pytest.mark.parametrize("string", validstrings, ids=validstrings)
+    def test_get_invfunc(self, string):
+        func_parser = cbook._StringFuncParser(string)
+        finv1 = func_parser.get_invfunc()
+        finv2 = func_parser.get_func().inverse
+        assert_array_almost_equal(finv1(self.x_test), finv2(self.x_test))
+
+    @pytest.mark.parametrize("string, bounded",
+                             zip(validstrings, bounded_list),
+                             ids=validstrings)
+    def test_bounded(self, string, bounded):
+        func_parser = cbook._StringFuncParser(string)
+        b = func_parser.is_bounded_0_1()
+        assert_array_equal(b, bounded)

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -517,3 +517,36 @@ def test_flatiter():
 
     assert 0 == next(it)
     assert 1 == next(it)
+
+
+class TestFuncParser(object):
+    x_test = np.linspace(0.01, 0.5, 3)
+    validstrings = ['linear', 'quadratic', 'cubic', 'sqrt', 'cbrt',
+                    'log', 'log10', 'power{1.5}', 'root{2.5}',
+                    'log(x+{0.5})', 'log10(x+{0.1})']
+    results = [(lambda x: x),
+               (lambda x: x**2),
+               (lambda x: x**3),
+               (lambda x: x**(1. / 2)),
+               (lambda x: x**(1. / 3)),
+               (lambda x: np.log(x)),
+               (lambda x: np.log10(x)),
+               (lambda x: x**1.5),
+               (lambda x: x**(1 / 2.5)),
+               (lambda x: np.log(x + 0.5)),
+               (lambda x: np.log10(x + 0.1))]
+
+    @pytest.mark.parametrize("string", validstrings, ids=validstrings)
+    def test_inverse(self, string):
+        func_parser = cbook._StringFuncParser(string)
+        f = func_parser.get_func()
+        finv = func_parser.get_invfunc()
+        assert_array_almost_equal(finv(f(self.x_test)), self.x_test)
+
+    @pytest.mark.parametrize("string, func",
+                             zip(validstrings, results),
+                             ids=validstrings)
+    def test_values(self, string, func):
+        func_parser = cbook._StringFuncParser(string)
+        f = func_parser.get_func()
+        assert_array_almost_equal(f(self.x_test), func(self.x_test))


### PR DESCRIPTION
This PR is part of a [larger PR](https://github.com/matplotlib/matplotlib/pull/7294/commits) originally proposed to include FuncNorm and PiecewiseNorm. It was decided to split it into several PRs for easier review starting from the simpler classes.

The new functionality is inside a class _StringFuncParser in cbook, specialized on returning a _FuncInfo object with callables and other information about some predefined functions by just feeding it with a string. 

A typical example of use is:

```python
   func_info=_StringFuncParser('sqrt')
   func_info.direct #Is a callable implementing the square root
   func_info.inverse #Is a callable implementing the inverse of square root: the square
```

It also allows parametrical functions such as:

```
    _StringFuncParser('root{3}(x)')  # Receives a parameter (3) to define the degree of the root
```
```
    _StringFuncParser('log{7}(x+{4})')  # Receives a parameter (7) to define the base 
                                        # of the root, and a constant (4)
```

The immediate use of this will be mainly related to FuncNorm and PiecewiseNorm, but in general it may come in handy for any other function taking callables. The advantage over just passing the callable, is that we have access to more information such as the inverse function, or any other property that we may want to store, without having to ask the user directly for all of those.

For now the classes are defined as hidden, so we do not have to guarantee back compatibility in case it is decided to change the way it is designed in the future. However, this still allows other matplotlib functions/classes to use it.