### PR TITLE
FIX: better handle margins on ax.bar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2080,6 +2080,55 @@ or tuple of floats
             raise ValueError("incompatible sizes: argument 'bottom' "
                              "must be length %d or scalar" % nbars)
 
+        margins = {}
+
+        if orientation == 'vertical':
+            # base case of 'simple' bar plot
+            use_bottom_margin = False
+            use_top_margin = True
+            print(use_bottom_margin, use_top_margin)
+            # if negative height bars, do not pin the bottom
+            if any(h < 0 for h in height):
+                use_bottom_margin = True
+                use_top_margin = True
+            print(use_bottom_margin, use_top_margin)
+
+            # if all bars are negative pin top, but not bottom
+            if all(h < 0 for h in height):
+                use_bottom_margin = True
+                use_top_margin = False
+
+            print(use_bottom_margin, use_top_margin)
+            # if non-trivial bottom, do not pin the bottom
+            if _bottom is not None:
+                use_bottom_margin = True
+                use_top_margin = True
+            print(use_bottom_margin, use_top_margin)
+            margins = {'bottom': use_bottom_margin,
+                       'top': use_top_margin}
+
+        elif orientation == 'horizontal':
+            # base case of 'simple' bar plot
+            use_left_margin = False
+            use_right_margin = True
+            # if negative height bars, do not pin the bottom
+            if any(w < 0 for w in width):
+                use_left_margin = True
+                use_right_margin = True
+
+            # if all bars are negative pin top, but not bottom
+            if all(w < 0 for w in width):
+                use_left_margin = True
+                use_right_margin = False
+
+            # if non-trivial left, do not pin the anything
+            if _left is not None:
+                use_left_margin = True
+                use_right_margin = True
+
+            margins = {'left': use_left_margin,
+                       'right': use_right_margin}
+
         patches = []
 
         # lets do some conversions now since some types cannot be
@@ -2095,13 +2144,6 @@ or tuple of floats
             height = self.convert_yunits(height)
             if yerr is not None:
                 yerr = self.convert_yunits(yerr)
-
-        margins = {}
-
-        if orientation == 'vertical':
-            margins = {'bottom': False}
-        elif orientation == 'horizontal':
-            margins = {'left': False}
 
         if align == 'center':
             if orientation == 'vertical':


### PR DESCRIPTION
Cancel margin on the proper sides depending on if the bar is positive,
negative, or mixed.

This mostly works, some pathological issues with multiple bar plots

```python
import matplotlib.pyplot as plt
plt.ion()

fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, tight_layout=True)

ax1.set_title('all positive')
ax1.bar([1, 2, 3], [1, 3, 5])

ax2.set_title('all negative')
ax2.bar([1, 2, 3], [-1, -3, -5])

ax3.set_title('mixed')
ax3.bar([1, 2, 3], [1, -3, 5])

ax4.set_title('bars with conflicting constraints')
ax4.bar([1, 2, 3], [1, 3, 5])
ax4.bar([1, 2, 3], [-1, -3, -5])
```

![so](https://cloud.githubusercontent.com/assets/199813/20367909/896036ea-ac1f-11e6-95d5-43cc30e1f4dc.png)
