### PR TITLE
DOC: fix py2 compatibility issue

### DIFF
--- a/examples/showcase/mandelbrot.py
+++ b/examples/showcase/mandelbrot.py
@@ -47,7 +47,9 @@ if __name__ == '__main__':
     # This line will generate warnings for null values but it is faster to
     # process them afterwards using the nan_to_num
     with np.errstate(invalid='ignore'):
-        M = np.nan_to_num(N + 1 - np.log(np.log(abs(Z)))/np.log(2) + log_horizon)
+        M = np.nan_to_num(N + 1 -
+                          np.log(np.log(abs(Z)))/np.log(2) +
+                          log_horizon)
 
     dpi = 72
     width = 10
@@ -65,9 +67,9 @@ if __name__ == '__main__':
 
     # Some advertisement for matplotlib
     year = time.strftime("%Y")
-    major, minor, micro = matplotlib.__version__.split('.', maxsplit=2)
+    major, minor, micro = matplotlib.__version__.split('.', 2)
     text = ("The Mandelbrot fractal set\n"
-            "Rendered with matplotlib %s.%s, %s — http://matplotlib.org"
+            "Rendered with matplotlib %s.%s, %s - http://matplotlib.org"
             % (major, minor, year))
     ax.text(xmin+.025, ymin+.025, text, color="white", fontsize=12, alpha=0.5)
 


### PR DESCRIPTION
Turns out that maxsplit can only be used as a keyword arg in py3.3+