### PR TITLE
Fix and clean up Skew-T example

### DIFF
--- a/examples/api/skewt.py
+++ b/examples/api/skewt.py
@@ -24,19 +24,30 @@ from matplotlib.projections import register_projection
 # The sole purpose of this class is to look at the upper, lower, or total
 # interval as appropriate and see what parts of the tick to draw, if any.
 class SkewXTick(maxis.XTick):
+    def update_position(self, loc):
+        # This ensures that the new value of the location is set before
+        # any other updates take place
+        self._loc = loc
+        super(SkewXTick, self).update_position(loc)
+
+    def _has_default_loc(self):
+        return self.get_loc() is None
+
     def _need_lower(self):
-        return transforms.interval_contains(self.axes.lower_xlim,
-                                            self.get_loc())
+        return (self._has_default_loc() or
+                transforms.interval_contains(self.axes.lower_xlim,
+                                             self.get_loc()))
 
     def _need_upper(self):
-        return transforms.interval_contains(self.axes.upper_xlim,
-                                            self.get_loc())
+        return (self._has_default_loc() or
+                transforms.interval_contains(self.axes.upper_xlim,
+                                             self.get_loc()))
 
     @property
     def gridOn(self):
-        return (self._gridOn and
+        return (self._gridOn and (self._has_default_loc() or
                 transforms.interval_contains(self.get_view_interval(),
-                                             self.get_loc()))
+                                             self.get_loc())))
 
     @gridOn.setter
     def gridOn(self, value):
@@ -82,7 +93,7 @@ class SkewXTick(maxis.XTick):
 # as well as create instances of the custom tick
 class SkewXAxis(maxis.XAxis):
     def _get_tick(self, major):
-        return SkewXTick(self.axes, 0, '', major=major)
+        return SkewXTick(self.axes, None, '', major=major)
 
     def get_view_interval(self):
         return self.axes.upper_xlim[0], self.axes.lower_xlim[1]

--- a/examples/api/skewt.py
+++ b/examples/api/skewt.py
@@ -146,7 +146,8 @@ register_projection(SkewXAxes)
 
 if __name__ == '__main__':
     # Now make a simple example using the custom projection.
-    from matplotlib.ticker import ScalarFormatter, MultipleLocator
+    from matplotlib.ticker import (MultipleLocator, NullFormatter,
+                                   ScalarFormatter)
     import matplotlib.pyplot as plt
     from six import StringIO
     import numpy as np
@@ -248,6 +249,7 @@ if __name__ == '__main__':
 
     # Disables the log-formatting that comes with semilogy
     ax.yaxis.set_major_formatter(ScalarFormatter())
+    ax.yaxis.set_minor_formatter(NullFormatter())
     ax.set_yticks(np.linspace(100, 1000, 10))
     ax.set_ylim(1050, 100)
 

--- a/examples/api/skewt.py
+++ b/examples/api/skewt.py
@@ -241,11 +241,11 @@ if __name__ == '__main__':
 
     # Plot the data using normal plotting functions, in this case using
     # log scaling in Y, as dictated by the typical meteorological plot
-    ax.semilogy(T, p)
-    ax.semilogy(Td, p)
+    ax.semilogy(T, p, color='C3')
+    ax.semilogy(Td, p, color='C2')
 
     # An example of a slanted line at constant X
-    l = ax.axvline(0)
+    l = ax.axvline(0, color='C0')
 
     # Disables the log-formatting that comes with semilogy
     ax.yaxis.set_major_formatter(ScalarFormatter())

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -344,6 +344,12 @@ class Tick(artist.Artist):
         'Set the location of tick in data coords with scalar *loc*'
         raise NotImplementedError('Derived must override')
 
+    def _get_text1_transform(self):
+        raise NotImplementedError('Derived must override')
+
+    def _get_text2_transform(self):
+        raise NotImplementedError('Derived must override')
+
 
 class XTick(Tick):
     """

--- a/lib/matplotlib/tests/test_skew.py
+++ b/lib/matplotlib/tests/test_skew.py
@@ -20,31 +20,58 @@ from matplotlib.projections import register_projection
 # The sole purpose of this class is to look at the upper, lower, or total
 # interval as appropriate and see what parts of the tick to draw, if any.
 class SkewXTick(maxis.XTick):
-    def draw(self, renderer):
-        if not self.get_visible():
-            return
-        renderer.open_group(self.__name__)
+    def _need_lower(self):
+        return transforms.interval_contains(self.axes.lower_xlim,
+                                            self.get_loc())
 
-        lower_interval = self.axes.xaxis.lower_interval
-        upper_interval = self.axes.xaxis.upper_interval
+    def _need_upper(self):
+        return transforms.interval_contains(self.axes.upper_xlim,
+                                            self.get_loc())
 
-        if self.gridOn and transforms.interval_contains(
-                self.axes.xaxis.get_view_interval(), self.get_loc()):
-            self.gridline.draw(renderer)
+    @property
+    def gridOn(self):
+        return (self._gridOn and
+                transforms.interval_contains(self.get_view_interval(),
+                                             self.get_loc()))
 
-        if transforms.interval_contains(lower_interval, self.get_loc()):
-            if self.tick1On:
-                self.tick1line.draw(renderer)
-            if self.label1On:
-                self.label1.draw(renderer)
+    @gridOn.setter
+    def gridOn(self, value):
+        self._gridOn = value
 
-        if transforms.interval_contains(upper_interval, self.get_loc()):
-            if self.tick2On:
-                self.tick2line.draw(renderer)
-            if self.label2On:
-                self.label2.draw(renderer)
+    @property
+    def tick1On(self):
+        return self._tick1On and self._need_lower()
 
-        renderer.close_group(self.__name__)
+    @tick1On.setter
+    def tick1On(self, value):
+        self._tick1On = value
+
+    @property
+    def label1On(self):
+        return self._label1On and self._need_lower()
+
+    @label1On.setter
+    def label1On(self, value):
+        self._label1On = value
+
+    @property
+    def tick2On(self):
+        return self._tick2On and self._need_upper()
+
+    @tick2On.setter
+    def tick2On(self, value):
+        self._tick2On = value
+
+    @property
+    def label2On(self):
+        return self._label2On and self._need_upper()
+
+    @label2On.setter
+    def label2On(self, value):
+        self._label2On = value
+
+    def get_view_interval(self):
+        return self.axes.xaxis.get_view_interval()
 
 
 # This class exists to provide two separate sets of intervals to the tick,
@@ -53,16 +80,8 @@ class SkewXAxis(maxis.XAxis):
     def _get_tick(self, major):
         return SkewXTick(self.axes, 0, '', major=major)
 
-    @property
-    def lower_interval(self):
-        return self.axes.viewLim.intervalx
-
-    @property
-    def upper_interval(self):
-        return self.axes.upper_xlim
-
     def get_view_interval(self):
-        return self.upper_interval[0], self.lower_interval[1]
+        return self.axes.upper_xlim[0], self.axes.lower_xlim[1]
 
 
 # This class exists to calculate the separate data range of the
@@ -72,9 +91,9 @@ class SkewSpine(mspines.Spine):
     def _adjust_location(self):
         pts = self._path.vertices
         if self.spine_type == 'top':
-            pts[:, 0] = self.axis.upper_interval
+            pts[:, 0] = self.axes.upper_xlim
         else:
-            pts[:, 0] = self.axis.lower_interval
+            pts[:, 0] = self.axes.lower_xlim
 
 
 # This class handles registration of the skew-xaxes as a projection as well
@@ -130,6 +149,10 @@ class SkewXAxes(Axes):
             self.transScale + self.transLimits,
             transforms.IdentityTransform()) +
             transforms.Affine2D().skew_deg(rot, 0)) + self.transAxes
+
+    @property
+    def lower_xlim(self):
+        return self.axes.viewLim.intervalx
 
     @property
     def upper_xlim(self):


### PR DESCRIPTION
The main purpose is to address the gridline initial draw issue in #6873--which is achieved by refactoring and not doing some horrible things with mutable state. (Setting state directly was faster, but who cares about a 250x slowdown when the attribute access time is measured in microseconds either way?)

While I'm at it, I've updated for 2.x: improved the colors and addressed potential problems with minor log ticks showing up. I also updated the skew test to match the example's new design.