### PR TITLE
ENH: Added a new Formatter to mpl.ticker and some example recipes

### DIFF
--- a/doc/users/whats_new/new_formatters.rst
+++ b/doc/users/whats_new/new_formatters.rst
@@ -1,0 +1,29 @@
+Two new Formatters added to `matplotlib.ticker`
+-----------------------------------------------
+
+Two new formatters have been added for displaying some specialized
+tick labels:
+
+  - :class:`matplotlib.ticker.PercentFormatter`
+  - :class:`matplotlib.ticker.TransformFormatter`
+
+
+:class:`matplotlib.ticker.PercentFormatter`
+```````````````````````````````````````````
+
+This new formatter has some nice features like being able to convert
+from arbitrary data scales to percents, a customizable percent symbol
+and either automatic or manual control over the decimal points.
+
+
+:class:`matplotlib.ticker.TransformFormatter`
+```````````````````````````````````````````````
+
+A more generic version of :class:`matplotlib.ticker.FuncFormatter` that
+allows the tick values to be transformed before being passed to an
+underlying formatter. The transformation can yield results of arbitrary
+type, so for example, using `int` as the transformation will allow
+:class:`matplotlib.ticker.StrMethodFormatter` to use integer format
+strings. If the underlying formatter is an instance of
+:class:`matplotlib.ticker.Formatter`, it will be configured correctly
+through this class.

--- a/doc/users/whats_new/percent_formatter.rst
+++ b/doc/users/whats_new/percent_formatter.rst
@@ -1,6 +1,0 @@
-Added `matplotlib.ticker.PercentFormatter`
-------------------------------------------
-
-The new formatter has some nice features like being able to convert from
-arbitrary data scales to percents, a customizable percent symbol and
-either automatic or manual control over the decimal points.

--- a/examples/ticks_and_spines/tick-formatters.py
+++ b/examples/ticks_and_spines/tick-formatters.py
@@ -19,16 +19,16 @@ def setup(ax):
     ax.set_xlim(0, 5)
     ax.set_ylim(0, 1)
     ax.patch.set_alpha(0.0)
+    ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
+    ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 
 
 plt.figure(figsize=(8, 6))
-n = 7
+n = 8
 
 # Null formatter
 ax = plt.subplot(n, 1, 1)
 setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 ax.xaxis.set_major_formatter(ticker.NullFormatter())
 ax.xaxis.set_minor_formatter(ticker.NullFormatter())
 ax.text(0.0, 0.1, "NullFormatter()", fontsize=16, transform=ax.transAxes)
@@ -36,8 +36,6 @@ ax.text(0.0, 0.1, "NullFormatter()", fontsize=16, transform=ax.transAxes)
 # Fixed formatter
 ax = plt.subplot(n, 1, 2)
 setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.0))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 majors = ["", "0", "1", "2", "3", "4", "5"]
 ax.xaxis.set_major_formatter(ticker.FixedFormatter(majors))
 minors = [""] + ["%.2f" % (x-int(x)) if (x-int(x))
@@ -54,8 +52,6 @@ def major_formatter(x, pos):
 
 ax = plt.subplot(n, 1, 3)
 setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 ax.xaxis.set_major_formatter(ticker.FuncFormatter(major_formatter))
 ax.text(0.0, 0.1, 'FuncFormatter(lambda x, pos: "[%.2f]" % x)',
         fontsize=15, transform=ax.transAxes)
@@ -64,8 +60,6 @@ ax.text(0.0, 0.1, 'FuncFormatter(lambda x, pos: "[%.2f]" % x)',
 # FormatStr formatter
 ax = plt.subplot(n, 1, 4)
 setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 ax.xaxis.set_major_formatter(ticker.FormatStrFormatter(">%d<"))
 ax.text(0.0, 0.1, "FormatStrFormatter('>%d<')",
         fontsize=15, transform=ax.transAxes)
@@ -73,16 +67,12 @@ ax.text(0.0, 0.1, "FormatStrFormatter('>%d<')",
 # Scalar formatter
 ax = plt.subplot(n, 1, 5)
 setup(ax)
-ax.xaxis.set_major_locator(ticker.AutoLocator())
-ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())
 ax.xaxis.set_major_formatter(ticker.ScalarFormatter(useMathText=True))
 ax.text(0.0, 0.1, "ScalarFormatter()", fontsize=15, transform=ax.transAxes)
 
 # StrMethod formatter
 ax = plt.subplot(n, 1, 6)
 setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 ax.xaxis.set_major_formatter(ticker.StrMethodFormatter("{x}"))
 ax.text(0.0, 0.1, "StrMethodFormatter('{x}')",
         fontsize=15, transform=ax.transAxes)
@@ -90,14 +80,19 @@ ax.text(0.0, 0.1, "StrMethodFormatter('{x}')",
 # Percent formatter
 ax = plt.subplot(n, 1, 7)
 setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 ax.xaxis.set_major_formatter(ticker.PercentFormatter(xmax=5))
 ax.text(0.0, 0.1, "PercentFormatter(xmax=5)",
         fontsize=15, transform=ax.transAxes)
 
-# Push the top of the top axes outside the figure because we only show the
-# bottom spine.
+# TransformFormatter
+ax = plt.subplot(n, 1, 8)
+setup(ax)
+ax.xaxis.set_major_formatter(ticker.TransformFormatter(lambda x: 7 - 2 * x))
+ax.text(0.0, 0.1, "TransformFormatter(lambda x: 7 - 2 * x)",
+        fontsize=15, transform=ax.transAxes)
+
+# Push the top of the top axes outside the figure because we only show
+# the bottom spine.
 plt.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=1.05)
 
 plt.show()

--- a/examples/ticks_and_spines/tick_transform_formatter.py
+++ b/examples/ticks_and_spines/tick_transform_formatter.py
@@ -37,38 +37,22 @@ class LinearTransform:
     def __init__(self, in_start=0.0, in_end=None, out_start=0.0, out_end=None):
         """
         Sets up the transformation such that `in_start` gets mapped to
-        `out_start` and `in_end` gets mapped to `out_end`. The following
-        shortcuts apply when only some of the inputs are specified:
+        `out_start` and `in_end` gets mapped to `out_end`.
 
-          - none: no-op
-          - in_start: translation to zero
-          - out_start: translation from zero
-          - in_end: scaling to one (divide input by in_end)
-          - out_end: scaling from one (multiply input by in_end)
-          - in_start, out_start: translation
-          - in_end, out_end: scaling (in_start and out_start zero)
-          - in_start, out_end: in_end=out_end, out_start=0
-          - in_end, out_start: in_start=0, out_end=in_end
+        Configuration arguments set up the mapping and do not impose
+        any restriction on the subsequent arguments to `__call__`. None
+        of the configuration arguments are required.
 
-        Based on the following rules:
+        A missing `in_start` or `out_start` defaults to zero. A missing
+        `in_end` and `out_end` default to `in_start + 1.0` and
+        `out_start + 1.0`, respectively.
 
-          - start missing: set start to zero
-          - both ends are missing: set ranges to 1.0
-          - one end is missing: set it to the other end
+        A simple scaling transformation can be created by only
+        supplying the end arguments. A translation can be obtained by
+        only supplying the start arguments.
         """
-        if in_end is not None:
-            in_scale = in_end - in_start
-        elif out_end is not None:
-            in_scale = out_end - in_start
-        else:
-            in_scale = 1.0
-
-        if out_end is not None:
-            out_scale = out_end - out_start
-        elif in_end is not None:
-            out_scale = in_end - out_start
-        else:
-            out_scale = 1.0
+        in_scale = 1.0 if in_end is None else in_end - in_start
+        out_scale = 1.0 if out_end is None else out_end - out_start
 
         self._scale = out_scale / in_scale
         self._offset = out_start - self._scale * in_start
@@ -114,9 +98,9 @@ ax1.yaxis.set_major_locator(MaxNLocator(integer=True))
 ax1.yaxis.set_major_formatter(
         TransformFormatter(int, StrMethodFormatter('{x:02X}')))
 
-ax1.set_xlabel('Temperature (\u00B0C)')
+ax1.set_xlabel('Temperature (\N{DEGREE SIGN}C)')
 ax1.set_ylabel('Samples (Hex)')
-ax2.set_xlabel('Temperature (\u00B0R)')
+ax2.set_xlabel('Temperature (\N{DEGREE SIGN}R)')
 
 ax1.xaxis.tick_top()
 ax1.xaxis.set_label_position('top')

--- a/examples/ticks_and_spines/tick_transform_formatter.py
+++ b/examples/ticks_and_spines/tick_transform_formatter.py
@@ -1,0 +1,124 @@
+"""
+Demo of the `matplotlib.ticker.TransformFormatter` class.
+
+This code demonstrates two features:
+
+  1. A linear transformation of the input values. A callable class for
+     doing the transformation is presented as a recipe here. The data
+     type of the inputs does not change.
+  2. A transformation of the input type. The example here allows
+     `matplotlib.ticker.StrMethodFormatter` to handle integer formats
+     ('b', 'o', 'd', 'n', 'x', 'X'), which will normally raise an error
+     if used directly. This transformation is associated with a
+     `matplotlib.ticker.MaxNLocator` which has `integer` set to True to
+     ensure that the inputs are indeed integers.
+
+The same histogram is plotted in two sub-plots with a shared x-axis.
+Each axis shows a different temperature scale: one in degrees Celsius,
+one in degrees Rankine (the Fahrenheit analogue of Kelvins). This is one
+of the few examples of recognized scientific units that have both a
+scale and an offset relative to each other.
+"""
+
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.axis import Ticker
+from matplotlib.ticker import (
+    TransformFormatter, StrMethodFormatter, MaxNLocator
+)
+
+
+class LinearTransform:
+    """
+    A callable class that transforms input values to output according to
+    a linear transformation.
+    """
+
+    def __init__(self, in_start=0.0, in_end=None, out_start=0.0, out_end=None):
+        """
+        Sets up the transformation such that `in_start` gets mapped to
+        `out_start` and `in_end` gets mapped to `out_end`. The following
+        shortcuts apply when only some of the inputs are specified:
+
+          - none: no-op
+          - in_start: translation to zero
+          - out_start: translation from zero
+          - in_end: scaling to one (divide input by in_end)
+          - out_end: scaling from one (multiply input by in_end)
+          - in_start, out_start: translation
+          - in_end, out_end: scaling (in_start and out_start zero)
+          - in_start, out_end: in_end=out_end, out_start=0
+          - in_end, out_start: in_start=0, out_end=in_end
+
+        Based on the following rules:
+
+          - start missing: set start to zero
+          - both ends are missing: set ranges to 1.0
+          - one end is missing: set it to the other end
+        """
+        if in_end is not None:
+            in_scale = in_end - in_start
+        elif out_end is not None:
+            in_scale = out_end - in_start
+        else:
+            in_scale = 1.0
+
+        if out_end is not None:
+            out_scale = out_end - out_start
+        elif in_end is not None:
+            out_scale = in_end - out_start
+        else:
+            out_scale = 1.0
+
+        self._scale = out_scale / in_scale
+        self._offset = out_start - self._scale * in_start
+
+    def __call__(self, x):
+        """
+        Transforms the input value `x` according to the rule set up in
+        `__init__`.
+        """
+        return x * self._scale + self._offset
+
+# X-data
+temp_C = np.arange(-5.0, 5.1, 0.25)
+# Y-data
+counts = 15.0 * np.exp(-temp_C**2 / 25)
+# Add some noise
+counts += np.random.normal(scale=4.0, size=counts.shape)
+if counts.min() < 0:
+    counts += counts.min()
+
+fig, ax1 = plt.subplots()
+ax2 = fig.add_subplot(111, sharex=ax1, sharey=ax1, frameon=False)
+
+ax1.plot(temp_C, counts, drawstyle='steps-mid')
+
+ax1.xaxis.set_major_formatter(StrMethodFormatter('{x:0.2f}'))
+
+# This step is necessary to allow the shared x-axes to have different
+# Formatter and Locator objects.
+ax2.xaxis.major = Ticker()
+# 0C -> 491.67R (definition), -273.15C (0K)->0R (-491.67F)(definition)
+ax2.xaxis.set_major_locator(ax1.xaxis.get_major_locator())
+ax2.xaxis.set_major_formatter(
+        TransformFormatter(LinearTransform(in_start=-273.15, in_end=0,
+                                           out_end=491.67),
+                           StrMethodFormatter('{x:0.2f}')))
+
+# The y-axes share their locators and formatters, so only one needs to
+# be set
+ax1.yaxis.set_major_locator(MaxNLocator(integer=True))
+# Setting the transfrom to `int` will only alter the type, not the
+# actual value of the ticks
+ax1.yaxis.set_major_formatter(
+        TransformFormatter(int, StrMethodFormatter('{x:02X}')))
+
+ax1.set_xlabel('Temperature (\u00B0C)')
+ax1.set_ylabel('Samples (Hex)')
+ax2.set_xlabel('Temperature (\u00B0R)')
+
+ax1.xaxis.tick_top()
+ax1.xaxis.set_label_position('top')
+
+plt.show()

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -622,25 +622,23 @@ class TestTransformFormatter(object):
     def transform2(self, x):
         return 2 * x
 
-    @pytest.fixture()
+    @pytest.fixture
     def empty_fmt(self):
         return mticker.TransformFormatter(self.transform1)
 
-    @pytest.fixture()
-    def fmt(self):
-        fmt = self.empty_fmt()
-        fmt.create_dummy_axis()
-        return fmt
+    @pytest.fixture
+    def fmt(self, empty_fmt):
+        empty_fmt.create_dummy_axis()
+        return empty_fmt
 
-    @pytest.fixture()
-    def loc_fmt(self):
-        fmt = self.fmt()
+    @pytest.fixture
+    def loc_fmt(self, fmt):
         fmt.set_locs([1, 2, 3])
         return fmt
 
     def test_attributes(self, empty_fmt):
         # Using == is the right way to compare bound methods:
-        # http://stackoverflow.com/q/41900639/2988730
+        # https://stackoverflow.com/q/41900639/2988730
         assert empty_fmt.transform == self.transform1
         assert isinstance(empty_fmt.formatter, mticker.ScalarFormatter)
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1518,7 +1518,7 @@ class TransformFormatter(Formatter):
         transformed values.
 
         The input may be an instance of
-        :class:`matplotlib.ticker.Formatter` or an other callable with
+        :class:`matplotlib.ticker.Formatter` or another callable with
         the same signature.
 
         .. note::


### PR DESCRIPTION
- BinaryIntFormatter: Formats ticks as binary integers. Intended for use with `MaxNLocator(integer=True)`.
- HexIntFormatter: Formats ticks as hexadecimal integers. Intended for use with `MaxNLocator(integer=True)`.
- LinearScaleFormatter: Wraps any other formatter and transforms the input to it on a linear scale. The wrapped formatter can be any callable that accepts `x` and `pos` as arguments, but actual `Formatter` instances will get special treatment.

Also, changed the annotation in PercentFormatter tests slightly (non-functional change).