### PR TITLE
[MRG] Bump minimum numpy version to 1.7.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: MOCK=mock NUMPY=numpy==1.6
+      env: MOCK=mock NUMPY=numpy==1.7.1
     - python: 3.4
     - python: 3.5
       env: PANDAS=pandas DELETE_FONT_CACHE=1

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -135,7 +135,7 @@ from ._version import get_versions
 __version__ = str(get_versions()['version'])
 del get_versions
 
-__version__numpy__ = str('1.6')  # minimum required numpy version
+__version__numpy__ = str('1.7.1')  # minimum required numpy version
 
 __bibtex__ = """@Article{Hunter:2007,
   Author    = {Hunter, J. D.},

--- a/setupext.py
+++ b/setupext.py
@@ -898,10 +898,10 @@ class Numpy(SetupPackage):
                                   'NPY_1_7_API_VERSION'))
 
     def get_setup_requires(self):
-        return ['numpy>=1.6']
+        return ['numpy>=1.7.1']
 
     def get_install_requires(self):
-        return ['numpy>=1.6']
+        return ['numpy>=1.7.1']
 
 
 class LibAgg(SetupPackage):


### PR DESCRIPTION
This matches the version required by SciPy 0.18.0, and provided
by RHEL 7.