### PR TITLE
Cleanups: np.clip and np.ptp are awesome

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3397,10 +3397,11 @@ or tuple of floats
           Sets the positions of the boxes. The ticks and limits
           are automatically set to match the positions.
 
-        widths : array-like, default = 0.5
+        widths : array-like, default = None
           Either a scalar or a vector and sets the width of each
-          box. The default is 0.5, or ``0.15*(distance between extreme
-          positions)`` if that is smaller.
+          box. The default is ``0.15*(distance between extreme
+          positions)``, clipped to no less than 0.15 and no more than
+          0.5.
 
         vert : bool, default = False
           If `True` (default), makes the boxes vertical.  If `False`,
@@ -3637,8 +3638,7 @@ or tuple of floats
 
         # width
         if widths is None:
-            distance = max(positions) - min(positions)
-            widths = [min(0.15 * max(distance, 1.0), 0.5)] * N
+            widths = [np.clip(0.15 * np.ptp(positions), 0.15, 0.5)] * N
         elif np.isscalar(widths):
             widths = [widths] * N
         elif len(widths) != N:

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2780,7 +2780,10 @@ class NavigationToolbar2(object):
         self.canvas.draw_idle()
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
-        """Draw a rectangle rubberband to indicate zoom limits."""
+        """Draw a rectangle rubberband to indicate zoom limits.
+
+        Note that it is not guaranteed that ``x0 <= x1`` and ``y0 <= y1``.
+        """
 
     def remove_rubberband(self):
         """Remove the rubberband."""
@@ -3029,20 +3032,13 @@ class NavigationToolbar2(object):
         if self._xypress:
             x, y = event.x, event.y
             lastx, lasty, a, ind, view = self._xypress[0]
-
-            # adjust x, last, y, last
-            x1, y1, x2, y2 = a.bbox.extents
-            x, lastx = max(min(x, lastx), x1), min(max(x, lastx), x2)
-            y, lasty = max(min(y, lasty), y1), min(max(y, lasty), y2)
-
+            (x1, y1), (x2, y2) = np.clip(
+                [[lastx, lasty], [x, y]], a.bbox.min, a.bbox.max)
             if self._zoom_mode == "x":
-                x1, y1, x2, y2 = a.bbox.extents
-                y, lasty = y1, y2
+                y1, y2 = a.bbox.intervaly
             elif self._zoom_mode == "y":
-                x1, y1, x2, y2 = a.bbox.extents
-                x, lastx = x1, x2
-
-            self.draw_rubberband(event, x, y, lastx, lasty)
+                x1, x2 = a.bbox.intervalx
+            self.draw_rubberband(event, x1, y1, x2, y2)
 
     def release_zoom(self, event):
         """Callback for mouse button release in zoom to rect mode."""

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -895,23 +895,15 @@ class ToolZoom(ZoomPanBase):
 
         if self._xypress:
             x, y = event.x, event.y
-            lastx, lasty, a, _ind, _view = self._xypress[0]
-
-            # adjust x, last, y, last
-            x1, y1, x2, y2 = a.bbox.extents
-            x, lastx = max(min(x, lastx), x1), min(max(x, lastx), x2)
-            y, lasty = max(min(y, lasty), y1), min(max(y, lasty), y2)
-
+            lastx, lasty, a, ind, view = self._xypress[0]
+            (x1, y1), (x2, y2) = np.clip(
+                [[lastx, lasty], [x, y]], a.bbox.min, a.bbox.max)
             if self._zoom_mode == "x":
-                x1, y1, x2, y2 = a.bbox.extents
-                y, lasty = y1, y2
+                y1, y2 = a.bbox.intervaly
             elif self._zoom_mode == "y":
-                x1, y1, x2, y2 = a.bbox.extents
-                x, lastx = x1, x2
-
-            self.toolmanager.trigger_tool('rubberband',
-                                          self,
-                                          data=(x, y, lastx, lasty))
+                x1, x2 = a.bbox.intervalx
+            self.toolmanager.trigger_tool(
+                'rubberband', self, data=(x1, y1, x2, y2))
 
     def _release(self, event):
         """the release mouse button callback in zoom to rect mode"""

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -684,11 +684,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         height = self.canvas.figure.bbox.height
         y1 = height - y1
         y0 = height - y0
-
-        w = abs(x1 - x0)
-        h = abs(y1 - y0)
-
-        rect = [int(val) for val in (min(x0, x1), min(y0, y1), w, h)]
+        rect = [int(val) for val in (x0, y0, x1 - x0, y1 - y0)]
         self.canvas.drawRectangle(rect)
 
     def remove_rubberband(self):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1271,8 +1271,6 @@ class FancyArrow(Polygon):
 
 docstring.interpd.update({"FancyArrow": FancyArrow.__init__.__doc__})
 
-docstring.interpd.update({"FancyArrow": FancyArrow.__init__.__doc__})
-
 
 class YAArrow(Patch):
     """

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -523,7 +523,7 @@ class Quiver(mcollections.PolyCollection):
                                             (ax.bbox.width, ax.bbox.height))
             self.span = sx
             if self.width is None:
-                sn = max(8, min(25, math.sqrt(self.N)))
+                sn = np.clip(math.sqrt(self.N), 8, 25)
                 self.width = 0.06 * self.span / sn
 
             # _make_verts sets self.scale if not already specified

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1875,8 +1875,8 @@ class MaxNLocator(Locator):
     def _raw_ticks(self, vmin, vmax):
         if self._nbins == 'auto':
             if self.axis is not None:
-                nbins = max(min(self.axis.get_tick_space(), 9),
-                            max(1, self._min_n_ticks - 1))
+                nbins = np.clip(self.axis.get_tick_space(),
+                                max(1, self._min_n_ticks - 1), 9)
             else:
                 nbins = 9
         else:
@@ -2074,7 +2074,7 @@ class LogLocator(Locator):
     def tick_values(self, vmin, vmax):
         if self.numticks == 'auto':
             if self.axis is not None:
-                numticks = max(min(self.axis.get_tick_space(), 9), 2)
+                numticks = np.clip(self.axis.get_tick_space(), 2, 9)
             else:
                 numticks = 9
         else:

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -417,10 +417,10 @@ class CubicTriInterpolator(TriInterpolator):
         self._z = self._z[~node_mask]
 
         # Computing scale factors
-        self._unit_x = np.max(compressed_x) - np.min(compressed_x)
-        self._unit_y = np.max(compressed_y) - np.min(compressed_y)
-        self._pts = np.vstack((compressed_x/float(self._unit_x),
-                               compressed_y/float(self._unit_y))).T
+        self._unit_x = np.ptp(compressed_x)
+        self._unit_y = np.ptp(compressed_y)
+        self._pts = np.column_stack([compressed_x / self._unit_x,
+                                     compressed_y / self._unit_y])
         # Computing triangle points
         self._tris_pts = self._pts[self._triangles]
         # Computing eccentricities

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -50,11 +50,8 @@ class TriAnalyzer(object):
         compressed_triangles = self._triangulation.get_masked_triangles()
         node_used = (np.bincount(np.ravel(compressed_triangles),
                                  minlength=self._triangulation.x.size) != 0)
-        x = self._triangulation.x[node_used]
-        y = self._triangulation.y[node_used]
-        ux = np.max(x)-np.min(x)
-        uy = np.max(y)-np.min(y)
-        return (1./float(ux), 1./float(uy))
+        return (1 / np.ptp(self._triangulation.x[node_used]),
+                1 / np.ptp(self._triangulation.y[node_used]))
 
     def circle_ratios(self, rescale=True):
         """


### PR DESCRIPTION
All's in the title.

Also clarified that `draw_rubberband` does not require its arguments to be ordered... tested on all backends except on gtk, which seems broken as of master for me, and macos, which I cannot test and for which I would appreciate a confirmation (see https://gitter.im/matplotlib/matplotlib?at=5831157a238757566ccb3580).