### PR TITLE
[MRG] Improve the the marker table in markers_api documentation

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -42,11 +42,15 @@ CARETDOWN                      caretdown (centered at tip)
 CARETLEFTBASE                  caretleft (centered at base)
 CARETRIGHTBASE                 caretright (centered at base)
 CARETUPBASE                    caretup (centered at base)
-`"None"`, None, `" "`, or `""` nothing
+`" "`, or `""`                 nothing
 ``'$...$'``                    render the string using mathtext.
 `verts`                        a list of (x, y) pairs used for Path vertices.
                                The center of the marker is located at (0,0) and
-                               the size is normalized.
+                               the size is normalized. For backward
+                               compatibility, the form (`verts`, 0) is also
+                               accepted, but it  is equivalent to just `verts`
+                               for giving a raw set of vertices that define the
+                               shape.
 path                           a `~matplotlib.path.Path` instance.
 (`numsides`, `style`, `angle`) The marker can also be a tuple (`numsides`,
                                `style`, `angle`), which will create a custom,
@@ -71,9 +75,9 @@ path                           a `~matplotlib.path.Path` instance.
                                    the angle of rotation of the symbol
 ============================== ===============================================
 
-For backward compatibility, the form (`verts`, 0) is also accepted,
-but it is equivalent to just `verts` for giving a raw set of vertices
-that define the shape.
+`None` is the default which often means 'nothing', however this table is
+referred to from other docs for the valid inputs from marker inputs and in
+those cases `None` still means 'default'.
 """
 
 from __future__ import (absolute_import, division, print_function,

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -8,31 +8,29 @@ All possible markers are defined here:
 ============================== ===============================================
 marker                         description
 ============================== ===============================================
-"."                            point
-","                            pixel
-"o"                            circle
-"v"                            triangle_down
-"^"                            triangle_up
-"<"                            triangle_left
-">"                            triangle_right
-"1"                            tri_down
-"2"                            tri_up
-"3"                            tri_left
-"4"                            tri_right
-"8"                            octagon
-"s"                            square
-"p"                            pentagon
-"*"                            star
-"h"                            hexagon1
-"H"                            hexagon2
-"+"                            plus
-"x"                            x
-"D"                            diamond
-"d"                            thin_diamond
-"|"                            vline
-"_"                            hline
-"P"                            plus (filled)
-"X"                            x (filled)
+`"."`                          point
+`","`                          pixel
+`"o"`                          circle
+`"v"`                          triangle_down
+`"^"`                          triangle_up
+`"<"`                          triangle_left
+`">"`                          triangle_right
+`"1"`                          tri_down
+`"2"`                          tri_up
+`"3"`                          tri_left
+`"4"`                          tri_right
+`"8"`                          octagon
+`"s"`                          square
+`"p"`                          pentagon
+`"*"`                          star
+`"h"`                          hexagon1
+`"H"`                          hexagon2
+`"+"`                          plus (filled)
+`"x"`                          x (filled)
+`"D"`                          diamond
+`"d"`                          thin_diamond
+`"|"`                          vline
+`"_"`                          hline
 TICKLEFT                       tickleft
 TICKRIGHT                      tickright
 TICKUP                         tickup
@@ -44,43 +42,40 @@ CARETDOWN                      caretdown (centered at tip)
 CARETLEFTBASE                  caretleft (centered at base)
 CARETRIGHTBASE                 caretright (centered at base)
 CARETUPBASE                    caretup (centered at base)
-"None"                         nothing
-None                           nothing
-" "                            nothing
-""                             nothing
+`"None"`, None, `" "`, or `""` nothing
 ``'$...$'``                    render the string using mathtext.
 `verts`                        a list of (x, y) pairs used for Path vertices.
                                The center of the marker is located at (0,0) and
                                the size is normalized.
 path                           a `~matplotlib.path.Path` instance.
-(`numsides`, `style`, `angle`) see below
+(`numsides`, `style`, `angle`) The marker can also be a tuple (`numsides`,
+                               `style`, `angle`), which will create a custom,
+                               regular symbol.
+
+                               `numsides`:
+                                   the number of sides
+
+                               `style`:
+                                   the style of the regular symbol:
+                                   """"""
+                                   =====   ===================================
+                                   Value   Description
+                                   0       a regular polygon
+                                   1       a star-like symbol
+                                   2       an asterisk
+                                   3       a circle (`numsides` and `angle` is
+                                           ignored)
+                                   =====   ===================================
+                                   """"""
+                               `angle`:
+                                   the angle of rotation of the symbol
 ============================== ===============================================
-
-The marker can also be a tuple (`numsides`, `style`, `angle`), which
-will create a custom, regular symbol.
-
-    `numsides`:
-      the number of sides
-
-    `style`:
-      the style of the regular symbol:
-
-      =====   =============================================
-      Value   Description
-      =====   =============================================
-      0       a regular polygon
-      1       a star-like symbol
-      2       an asterisk
-      3       a circle (`numsides` and `angle` is ignored)
-      =====   =============================================
-
-    `angle`:
-      the angle of rotation of the symbol, in degrees
 
 For backward compatibility, the form (`verts`, 0) is also accepted,
 but it is equivalent to just `verts` for giving a raw set of vertices
 that define the shape.
 """
+
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -22,17 +22,17 @@ marker                         description
 `"8"`                          octagon
 `"s"`                          square
 `"p"`                          pentagon
+`"P"`                          plus (filled)
 `"*"`                          star
 `"h"`                          hexagon1
 `"H"`                          hexagon2
 `"+"`                          plus
 `"x"`                          x
+`"X"`                          x (filled)
 `"D"`                          diamond
 `"d"`                          thin_diamond
 `"|"`                          vline
 `"_"`                          hline
-`"P"`                          plus (filled)
-`"X"`                          x (filled)
 TICKLEFT                       tickleft
 TICKRIGHT                      tickright
 TICKUP                         tickup

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -25,12 +25,14 @@ marker                         description
 `"*"`                          star
 `"h"`                          hexagon1
 `"H"`                          hexagon2
-`"+"`                          plus (filled)
-`"x"`                          x (filled)
+`"+"`                          plus
+`"x"`                          x
 `"D"`                          diamond
 `"d"`                          thin_diamond
 `"|"`                          vline
 `"_"`                          hline
+`"P"`                          plus (filled)
+`"X"`                          x (filled)
 TICKLEFT                       tickleft
 TICKRIGHT                      tickright
 TICKUP                         tickup
@@ -42,15 +44,11 @@ CARETDOWN                      caretdown (centered at tip)
 CARETLEFTBASE                  caretleft (centered at base)
 CARETRIGHTBASE                 caretright (centered at base)
 CARETUPBASE                    caretup (centered at base)
-`" "`, or `""`                 nothing
+`"None"`, `" "` or `""`        nothing
 ``'$...$'``                    render the string using mathtext.
 `verts`                        a list of (x, y) pairs used for Path vertices.
                                The center of the marker is located at (0,0) and
-                               the size is normalized. For backward
-                               compatibility, the form (`verts`, 0) is also
-                               accepted, but it  is equivalent to just `verts`
-                               for giving a raw set of vertices that define the
-                               shape.
+                               the size is normalized.
 path                           a `~matplotlib.path.Path` instance.
 (`numsides`, `style`, `angle`) The marker can also be a tuple (`numsides`,
                                `style`, `angle`), which will create a custom,
@@ -75,7 +73,11 @@ path                           a `~matplotlib.path.Path` instance.
                                    the angle of rotation of the symbol
 ============================== ===============================================
 
-`None` is the default which often means 'nothing', however this table is
+For backward compatibility, the form (`verts`, 0) is also accepted,
+but it is equivalent to just `verts` for giving a raw set of vertices
+that define the shape.
+
+`None` is the default which means 'nothing', however this table is
 referred to from other docs for the valid inputs from marker inputs and in
 those cases `None` still means 'default'.
 """


### PR DESCRIPTION
Prefer to this issue: #7342 

Improve the current page: http://matplotlib.org/devdocs/api/markers_api.html. as below:

- Fixed the wrong directional curly quotes by adding backquotes.
- Grouped the marker implies "nothing" together.
- Fit the (numsides, style, angle) entry and its description inside the table.  
<br>

<img width="740" alt="markers matplotlib 2 0 0b4 2985 gc5a8b6b dirty documentation google chrome today at 11 25 01 am" src="https://cloud.githubusercontent.com/assets/11820627/20725410/977177a6-b626-11e6-8be2-c844223c4fec.png">

<br>

<img width="741" alt="markers matplotlib 2 0 0b4 2985 gc5a8b6b dirty documentation google chrome today at 11 25 16 am" src="https://cloud.githubusercontent.com/assets/11820627/20725420/a059021c-b626-11e6-81ab-c8dd95b6ba5c.png">
