### PR TITLE
[WIP] Add Axes method for drawing infinite lines.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -794,6 +794,69 @@ or tuple of floats
         return l
 
     @docstring.dedent_interpd
+    def axline(self, slope=1, intercept=0, **kwargs):
+        """
+        Add an infinite line across the axes.
+
+        Parameters
+        ----------
+        slope : scalar, optional, default: 1
+            Slope of the line.
+
+        intercept : scalar, optional, default: 0
+            Intercept of the line with the y-axis.
+
+        Returns
+        -------
+        :class:`~matplotlib.lines.Line2D`
+
+        Other Parameters
+        ----------------
+        Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
+        with the exception of 'transform':
+
+        %(Line2D)s
+
+        Examples
+        --------
+        * draw a thick red line with slope 1 and y-intercept 0::
+
+            >>> axline(linewidth=4, color='r')
+
+        * draw a default line with slope 1 and y-intercept 1::
+
+            >>> axline(intercept=1)
+
+        * draw a default line with slope 5 and y-intercept 0::
+
+            >>> axline(slope=5)
+
+        See Also
+        --------
+        axhline : for strictly horizontal lines
+        axvline : for strictly vertical lines
+
+        """
+
+        if "transform" in kwargs:
+            raise ValueError("'transform' is not allowed as a kwarg; "
+                             "axline generates its own transform.")
+
+        xtrans = mtransforms.BboxTransformTo(self.viewLim)
+        viewLimT = mtransforms.TransformedBbox(
+            self.viewLim,
+            mtransforms.Affine2D().rotate_deg(90).scale(-1, 1))
+        ytrans = (mtransforms.BboxTransformTo(viewLimT) +
+                  mtransforms.Affine2D().scale(slope).translate(0, intercept))
+        trans = mtransforms.blended_transform_factory(xtrans, ytrans)
+
+        l = mlines.Line2D([0, 1], [0, 1],
+                          transform=trans + self.transData,
+                          **kwargs)
+        self.add_line(l)
+        return l
+
+    @docstring.dedent_interpd
     def axhspan(self, ymin, ymax, xmin=0, xmax=1, **kwargs):
         """
         Add a horizontal span (rectangle) across the axis.


### PR DESCRIPTION
This is an implementation of an infinite line artist following the transforms I outlined in #5253. However, I did need to change from `ax.dataLim` to `ax.viewLim` because the former is infinite when nothing else is on the plot. I'm not sure if that will cause problems (maybe in log-scaled plots?), though it seems to work:
```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
ax.axline(linewidth=4, color='r')
ax.axline(intercept=1)
ax.axline(slope=5)
ax.grid(True)
ax.set_xlim(0, 10)
ax.set_ylim(0, 10)
plt.show()
```
![figure_1](https://cloud.githubusercontent.com/assets/302469/20583892/c43a4980-b1bb-11e6-84d8-e5160398dae9.png) https://youtu.be/DJjbFMoAw68

Unlike `axhline` and `axvline`, there is no `[xy]{min,max}` or autoscaling based on these artists because I don't think it makes sense for infinite lines.

I've only implemented `slope`/`intercept` and not any of the alternates in #5253; not sure which ones we want to support. Also needs some tests, wrapper in `pyplot`, etc., so it's still WIP.