### PR TITLE
[MRG+1] Qt5Agg HiDPI support

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -243,6 +243,11 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         w, h = self.get_width_height()
         self.resize(w, h)
 
+    def get_width_height(self):
+        dpi_ratio = self.devicePixelRatio()
+        w, h = FigureCanvasBase.get_width_height(self)
+        return int(w / dpi_ratio), int(h / dpi_ratio)
+
     def enterEvent(self, event):
         FigureCanvasBase.enter_notify_event(self, guiEvent=event)
 
@@ -320,7 +325,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('key release', key)
 
     def resizeEvent(self, event):
-        dpi_ratio = getattr(self, '_dpi_ratio', 1)
+        dpi_ratio = self.devicePixelRatio()
         w = event.size().width() * dpi_ratio
         h = event.size().height() * dpi_ratio
         if DEBUG:

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -250,10 +250,14 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         QtWidgets.QApplication.restoreOverrideCursor()
         FigureCanvasBase.leave_notify_event(self, guiEvent=event)
 
+    def mouseEventCoords(self, pos):
+        x = pos.x() * self.devicePixelRatio()
+        # flip y so y=0 is bottom of canvas
+        y = self.figure.bbox.height - pos.y() * self.devicePixelRatio()
+        return x, y
+
     def mousePressEvent(self, event):
-        x = event.pos().x()
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.pos().y()
+        x, y = self.mouseEventCoords(event.pos())
         button = self.buttond.get(event.button())
         if button is not None:
             FigureCanvasBase.button_press_event(self, x, y, button,
@@ -262,9 +266,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('button pressed:', event.button())
 
     def mouseDoubleClickEvent(self, event):
-        x = event.pos().x()
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.pos().y()
+        x, y = self.mouseEventCoords(event.pos())
         button = self.buttond.get(event.button())
         if button is not None:
             FigureCanvasBase.button_press_event(self, x, y,
@@ -274,16 +276,12 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('button doubleclicked:', event.button())
 
     def mouseMoveEvent(self, event):
-        x = event.x()
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y()
+        x, y = self.mouseEventCoords(event)
         FigureCanvasBase.motion_notify_event(self, x, y, guiEvent=event)
         # if DEBUG: print('mouse move')
 
     def mouseReleaseEvent(self, event):
-        x = event.x()
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y()
+        x, y = self.mouseEventCoords(event)
         button = self.buttond.get(event.button())
         if button is not None:
             FigureCanvasBase.button_release_event(self, x, y, button,
@@ -292,9 +290,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('button released')
 
     def wheelEvent(self, event):
-        x = event.x()
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y()
+        x, y = self.mouseEventCoords(event)
         # from QWheelEvent::delta doc
         if event.pixelDelta().x() == 0 and event.pixelDelta().y() == 0:
             steps = event.angleDelta().y() / 120
@@ -324,8 +320,9 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('key release', key)
 
     def resizeEvent(self, event):
-        w = event.size().width()
-        h = event.size().height()
+        dpi_ratio = getattr(self, '_dpi_ratio', 1)
+        w = event.size().width() * dpi_ratio
+        h = event.size().height() * dpi_ratio
         if DEBUG:
             print('resize (%d x %d)' % (w, h))
             print("FigureCanvasQt.resizeEvent(%d, %d)" % (w, h))

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -243,10 +243,17 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         w, h = self.get_width_height()
         self.resize(w, h)
 
+    @property
+    def _dpi_ratio(self):
+        # Not available on Qt4 or some older Qt5.
+        try:
+            return self.devicePixelRatio()
+        except AttributeError:
+            return 1
+
     def get_width_height(self):
-        dpi_ratio = self.devicePixelRatio()
         w, h = FigureCanvasBase.get_width_height(self)
-        return int(w / dpi_ratio), int(h / dpi_ratio)
+        return int(w / self._dpi_ratio), int(h / self._dpi_ratio)
 
     def enterEvent(self, event):
         FigureCanvasBase.enter_notify_event(self, guiEvent=event)
@@ -256,9 +263,9 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         FigureCanvasBase.leave_notify_event(self, guiEvent=event)
 
     def mouseEventCoords(self, pos):
-        x = pos.x() * self.devicePixelRatio()
+        x = pos.x() * self._dpi_ratio
         # flip y so y=0 is bottom of canvas
-        y = self.figure.bbox.height - pos.y() * self.devicePixelRatio()
+        y = self.figure.bbox.height - pos.y() * self._dpi_ratio
         return x, y
 
     def mousePressEvent(self, event):
@@ -325,9 +332,8 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             print('key release', key)
 
     def resizeEvent(self, event):
-        dpi_ratio = self.devicePixelRatio()
-        w = event.size().width() * dpi_ratio
-        h = event.size().height() * dpi_ratio
+        w = event.size().width() * self._dpi_ratio
+        h = event.size().height() * self._dpi_ratio
         if DEBUG:
             print('resize (%d x %d)' % (w, h))
             print("FigureCanvasQt.resizeEvent(%d, %d)" % (w, h))

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -149,8 +149,9 @@ class FigureCanvasQTAggBase(object):
                 if QT_API == 'PySide' and six.PY3:
                     ctypes.c_long.from_address(id(stringBuffer)).value = 1
 
+                origin = QtCore.QPoint(l, self.renderer.height - t)
                 pixmap = QtGui.QPixmap.fromImage(qImage)
-                p.drawPixmap(QtCore.QPoint(l, self.renderer.height-t), pixmap)
+                p.drawPixmap(origin / self._dpi_ratio, pixmap)
 
             # draw the zoom rectangle to the QPainter
             if self._drawRect is not None:
@@ -207,9 +208,11 @@ class FigureCanvasQTAggBase(object):
             bbox = self.figure.bbox
 
         self.blitbox.append(bbox)
-        l, b, w, h = bbox.bounds
+
+        # repaint uses logical pixels, not physical pixels like the renderer.
+        l, b, w, h = [pt / self._dpi_ratio for pt in bbox.bounds]
         t = b + h
-        self.repaint(l, self.renderer.height-t, w, h)
+        self.repaint(l, self.renderer.height / self._dpi_ratio - t, w, h)
 
     def print_figure(self, *args, **kwargs):
         FigureCanvasAgg.print_figure(self, *args, **kwargs)

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -101,6 +101,7 @@ class FigureCanvasQTAggBase(object):
             qImage = QtGui.QImage(stringBuffer, self.renderer.width,
                                   self.renderer.height,
                                   QtGui.QImage.Format_ARGB32)
+            qImage.setDevicePixelRatio(self._dpi_ratio)
             # get the rectangle for the image
             rect = qImage.rect()
             p = QtGui.QPainter(self)
@@ -136,6 +137,7 @@ class FigureCanvasQTAggBase(object):
                 stringBuffer = reg.to_string_argb()
                 qImage = QtGui.QImage(stringBuffer, w, h,
                                       QtGui.QImage.Format_ARGB32)
+                qImage.setDevicePixelRatio(self._dpi_ratio)
                 # Adjust the stringBuffer reference count to work
                 # around a memory leak bug in QImage() under PySide on
                 # Python 3.x
@@ -226,6 +228,7 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         super(FigureCanvasQTAgg, self).__init__(figure=figure)
         self._drawRect = None
         self.blitbox = []
+        self._dpi_ratio = self.devicePixelRatio()
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
 
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -104,7 +104,9 @@ class FigureCanvasQTAggBase(object):
             qImage = QtGui.QImage(stringBuffer, self.renderer.width,
                                   self.renderer.height,
                                   QtGui.QImage.Format_ARGB32)
-            qImage.setDevicePixelRatio(self._dpi_ratio)
+            if hasattr(qImage, 'setDevicePixelRatio'):
+                # Not available on Qt4 or some older Qt5.
+                qImage.setDevicePixelRatio(self._dpi_ratio)
             # get the rectangle for the image
             rect = qImage.rect()
             p = QtGui.QPainter(self)
@@ -142,7 +144,9 @@ class FigureCanvasQTAggBase(object):
                 stringBuffer = reg.to_string_argb()
                 qImage = QtGui.QImage(stringBuffer, w, h,
                                       QtGui.QImage.Format_ARGB32)
-                qImage.setDevicePixelRatio(self._dpi_ratio)
+                if hasattr(qImage, 'setDevicePixelRatio'):
+                    # Not available on Qt4 or some older Qt5.
+                    qImage.setDevicePixelRatio(self._dpi_ratio)
                 # Adjust the stringBuffer reference count to work
                 # around a memory leak bug in QImage() under PySide on
                 # Python 3.x
@@ -238,7 +242,6 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         super(FigureCanvasQTAgg, self).__init__(figure=figure)
         self._drawRect = None
         self.blitbox = []
-        self._dpi_ratio = self.devicePixelRatio()
         # We don't want to scale up the figure DPI more than once.
         # Note, we don't handle a signal for changing DPI yet.
         if not hasattr(self.figure, '_original_dpi'):

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -67,7 +67,10 @@ class FigureCanvasQTAggBase(object):
         self._agg_draw_pending = False
 
     def drawRectangle(self, rect):
-        self._drawRect = rect
+        if rect is not None:
+            self._drawRect = [pt / self._dpi_ratio for pt in rect]
+        else:
+            self._drawRect = None
         self.update()
 
     def paintEvent(self, e):
@@ -112,7 +115,9 @@ class FigureCanvasQTAggBase(object):
 
             # draw the zoom rectangle to the QPainter
             if self._drawRect is not None:
-                p.setPen(QtGui.QPen(QtCore.Qt.black, 1, QtCore.Qt.DotLine))
+                pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio,
+                                 QtCore.Qt.DotLine)
+                p.setPen(pen)
                 x, y, w, h = self._drawRect
                 p.drawRect(x, y, w, h)
             p.end()
@@ -149,7 +154,9 @@ class FigureCanvasQTAggBase(object):
 
             # draw the zoom rectangle to the QPainter
             if self._drawRect is not None:
-                p.setPen(QtGui.QPen(QtCore.Qt.black, 1, QtCore.Qt.DotLine))
+                pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio,
+                                 QtCore.Qt.DotLine)
+                p.setPen(pen)
                 x, y, w, h = self._drawRect
                 p.drawRect(x, y, w, h)
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -229,6 +229,11 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         self._drawRect = None
         self.blitbox = []
         self._dpi_ratio = self.devicePixelRatio()
+        # We don't want to scale up the figure DPI more than once.
+        # Note, we don't handle a signal for changing DPI yet.
+        if not hasattr(self.figure, '_original_dpi'):
+            self.figure._original_dpi = self.figure.dpi
+        self.figure.dpi = self._dpi_ratio * self.figure._original_dpi
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
 
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -713,7 +713,8 @@ class Figure(Artist):
         self.bbox_inches.p1 = w, h
 
         if forward:
-            dpival = self.dpi
+            ratio = getattr(self.canvas, '_dpi_ratio', 1)
+            dpival = self.dpi / ratio
             canvasw = w * dpival
             canvash = h * dpival
             manager = getattr(self.canvas, 'manager', None)


### PR DESCRIPTION
This completes the work by @piannucci in #6389. Scaling is necessary on the figure DPI, and inverse scaling on rubberband and blitting locations.

I don't have a HiDPI display, but I tested by setting `QT_SCALE_FACTOR=2`. There is one bug with resizing if I use the grip in the status bar because it produces the wrong size. I'm not sure where that is created, so I haven't fixed it yet. Resizing using the OS's size works fine.

Ping @tacaswell, @astrofrog, @adrn, and @jenshnielsen who appear to have HiDPI screens based on other issues.