### PR TITLE
Remove deprecations from C extensions

### DIFF
--- a/src/_backend_gdk.c
+++ b/src/_backend_gdk.c
@@ -7,11 +7,6 @@
 
 #include <pygtk/pygtk.h>
 
-// support numpy 1.6 - this macro was renamed and deprecated at once in 1.7
-#ifndef NPY_ARRAY_WRITEABLE
-#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
-#endif
-
 static PyTypeObject *_PyGdkPixbuf_Type;
 #define PyGdkPixbuf_Type (*_PyGdkPixbuf_Type)
 
@@ -52,15 +47,11 @@ static PyObject *pixbuf_get_pixels_array(PyObject *self, PyObject *args)
 
     /* the array holds a ref to the pixbuf pixels through this wrapper*/
     Py_INCREF(py_pixbuf);
-#if NPY_API_VERSION >= 0x00000007
     if (PyArray_SetBaseObject(array, (PyObject *)py_pixbuf) == -1) {
         Py_DECREF(py_pixbuf);
         Py_DECREF(array);
         return NULL;
     }
-#else
-    PyArray_BASE(array) = (PyObject *) py_pixbuf;
-#endif
     return PyArray_Return(array);
 }
 

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -11,17 +11,6 @@
 #define PY3K 0
 #endif
 
-#if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >=3)
-#define PY33 1
-#else
-#define PY33 0
-#endif
-
-/* Must define Py_TYPE for Python 2.5 or older */
-#ifndef Py_TYPE
-# define Py_TYPE(o) ((o)->ob_type)
-#endif
-
 /* Proper way to check for the OS X version we are compiling for, from
    http://developer.apple.com/documentation/DeveloperTools/Conceptual/cross_development */
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
@@ -1896,7 +1885,7 @@ choose_save_file(PyObject* unused, PyObject* args)
         unsigned int n = [filename length];
         unichar* buffer = malloc(n*sizeof(unichar));
         [filename getCharacters: buffer];
-#if PY33
+#if PY3K
         PyObject* string =  PyUnicode_FromKindAndData(PyUnicode_2BYTE_KIND, buffer, n);
 #else
         PyObject* string =  PyUnicode_FromUnicode(buffer, n);


### PR DESCRIPTION
Some backwards compatibility code for NumPy 1.6, Python 2.5, and Python 3.3, all of which are no longer supported.