### PR TITLE
[MRG+1] Fix table.py bug

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -586,7 +586,7 @@ def table(ax,
         # assume just colours are needed
         rows = len(cellColours)
         cols = len(cellColours[0])
-        cellText = [[''] * rows] * cols
+        cellText = [[''] * cols] * rows
 
     rows = len(cellText)
     cols = len(cellText[0])

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -5,11 +5,18 @@ import six
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, cleanup
 
 from matplotlib.table import CustomCell
 from matplotlib.path import Path
 from nose.tools import assert_equal
+
+
+@cleanup
+def test_non_square():
+    # Check that creating a non-square table works
+    cellcolors = ['b', 'r']
+    plt.table(cellColours=cellcolors)
 
 
 @image_comparison(baseline_images=['table_zorder'],


### PR DESCRIPTION
Allows creation of non-square tables when cellText isn't given to plt.table(). Fixes #5350.