### PR TITLE
[MRG+1] Silence deprecation warning when importing finance in pylab

### DIFF
--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -225,7 +225,9 @@ from matplotlib.cbook import (
 import matplotlib as mpl
 # make mpl.finance module available for backwards compatability, in case folks
 # using pylab interface depended on not having to import it
-import matplotlib.finance
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")  # deprecation: moved to a toolkit
+    import matplotlib.finance
 
 from matplotlib.dates import (
     date2num, num2date, datestr2num, strpdate2num, drange, epoch2num,


### PR DESCRIPTION
The discussion is in #7295.

There is still a problem, though: the deprecation message says to switch to the toolkit. How is the user supposed to know how to do that? It's not in the mpl_toolkits part of the distribution.