### PR TITLE
[MRG+1] Avoid division by zero if headlength=0 for quiver

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -702,7 +702,7 @@ class Quiver(mcollections.PolyCollection):
         X0 = x0.take(ii)
         Y0 = y0.take(ii)
         Y0[3:-1] *= -1
-        shrink = length / minsh
+        shrink = length / minsh if minsh > 0. else 0.
         X0 = shrink * X0[np.newaxis, :]
         Y0 = shrink * Y0[np.newaxis, :]
         short = np.repeat(length < minsh, 8, axis=1)

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -702,7 +702,7 @@ class Quiver(mcollections.PolyCollection):
         X0 = x0.take(ii)
         Y0 = y0.take(ii)
         Y0[3:-1] *= -1
-        shrink = length / minsh if minsh > 0. else 0.
+        shrink = length / minsh if minsh != 0. else 0.
         X0 = shrink * X0[np.newaxis, :]
         Y0 = shrink * Y0[np.newaxis, :]
         short = np.repeat(length < minsh, 8, axis=1)

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -59,6 +59,19 @@ def test_no_warnings():
     assert len(w) == 0
 
 
+@cleanup
+def test_zero_headlength():
+    # Based on report by Doug McNeil:
+    # http://matplotlib.1069221.n5.nabble.com/quiver-warnings-td28107.html
+    fig, ax = plt.subplots()
+    X,Y = np.meshgrid(np.arange(10),np.arange(10))
+    U, V = np.cos(X), np.sin(Y)
+    with warnings.catch_warnings(record=True) as w:
+        ax.quiver(U, V, headlength=0, headaxislength=0)
+        fig.canvas.draw()
+    assert len(w) == 0
+
+
 @image_comparison(baseline_images=['quiver_animated_test_image'],
                   extensions=['png'])
 def test_quiver_animate():

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -64,7 +64,7 @@ def test_zero_headlength():
     # Based on report by Doug McNeil:
     # http://matplotlib.1069221.n5.nabble.com/quiver-warnings-td28107.html
     fig, ax = plt.subplots()
-    X,Y = np.meshgrid(np.arange(10),np.arange(10))
+    X, Y = np.meshgrid(np.arange(10), np.arange(10))
     U, V = np.cos(X), np.sin(Y)
     with warnings.catch_warnings(record=True) as w:
         ax.quiver(U, V, headlength=0, headaxislength=0)


### PR DESCRIPTION
I use quiver a lot with headless arrows to make whisker plots.  But the code always outputs a division by zero warning, which I need to suppress.  I don't think there is an open issue about this, but it was mentioned [on list](http://matplotlib.1069221.n5.nabble.com/quiver-warnings-td28107.html) over four years ago.  

Anyway, the fix is simple, so here it is.