### PR TITLE
ENH: Added share_tickers parameter to axes._AxesBase.twinx/y

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -604,6 +604,14 @@ class Ticker(object):
     locator = None
     formatter = None
 
+    def update_from(self, ticker):
+        """
+        Copies the formatter and locator of another ticker into this
+        one.
+        """
+        self.locator = ticker.locator
+        self.formatter = ticker.formatter
+
 
 class Axis(artist.Artist):
     """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -25,6 +25,7 @@ import matplotlib.pyplot as plt
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
 import matplotlib.colors as mcolors
+import matplotlib.ticker as mticker
 from numpy.testing import assert_allclose, assert_array_equal
 from matplotlib.cbook import IgnoredKeywordWarning
 import matplotlib.colors as mcolors
@@ -142,6 +143,58 @@ def test_twinx_cla():
     assert ax.xaxis.get_visible()
     assert ax.patch.get_visible()
     assert ax.yaxis.get_visible()
+
+@cleanup
+def test_twin_xy_sharing():
+    fig, ax = plt.subplots()
+
+    # Make some twinned axes to play with (with share_tickers=True)
+    ax2 = ax.twinx()
+    ax3 = ax2.twiny()
+    plt.draw()
+
+    assert ax.xaxis.major is ax2.xaxis.major
+    assert ax.xaxis.minor is ax2.xaxis.minor
+    assert ax2.yaxis.major is ax3.yaxis.major
+    assert ax2.yaxis.minor is ax3.yaxis.minor
+
+    # Verify that for share_tickers=True, the formatters and locators
+    # are identical no matter what
+    ax2.xaxis.set_major_formatter(mticker.PercentFormatter())
+    ax3.yaxis.set_major_locator(mticker.MaxNLocator())
+
+    assert ax.xaxis.get_major_formatter() is ax2.xaxis.get_major_formatter()
+    assert ax2.yaxis.get_major_locator() is ax3.yaxis.get_major_locator()
+
+    # Make some more twinned axes to play with (with share_tickers=False)
+    ax4 = ax.twinx(share_tickers=False)
+    ax5 = ax2.twiny(share_tickers=False)
+    plt.draw()
+
+    assert ax4 is not ax2
+    assert ax5 is not ax3
+
+    assert ax.xaxis.major is not ax4.xaxis.major
+    assert ax.xaxis.minor is not ax4.xaxis.minor
+    assert ax.xaxis.get_major_formatter() is ax4.xaxis.get_major_formatter()
+    assert ax.xaxis.get_minor_formatter() is ax4.xaxis.get_minor_formatter()
+    assert ax.xaxis.get_major_locator() is ax4.xaxis.get_major_locator()
+    assert ax.xaxis.get_minor_locator() is ax4.xaxis.get_minor_locator()
+
+    assert ax2.yaxis.major is not ax5.yaxis.major
+    assert ax2.yaxis.minor is not ax5.yaxis.minor
+    assert ax2.yaxis.get_major_formatter() is ax5.yaxis.get_major_formatter()
+    assert ax2.yaxis.get_minor_formatter() is ax5.yaxis.get_minor_formatter()
+    assert ax2.yaxis.get_major_locator() is ax5.yaxis.get_major_locator()
+    assert ax2.yaxis.get_minor_locator() is ax5.yaxis.get_minor_locator()
+
+    # Verify that for share_tickers=False, the formatters and locators
+    # can be changed independently
+    ax4.xaxis.set_minor_formatter(mticker.PercentFormatter())
+    ax5.yaxis.set_minor_locator(mticker.MaxNLocator())
+
+    assert ax.xaxis.get_minor_formatter() is not ax4.xaxis.get_minor_formatter()
+    assert ax2.yaxis.get_minor_locator() is not ax4.yaxis.get_minor_locator()
 
 
 @image_comparison(baseline_images=['twin_autoscale'], extensions=['png'])


### PR DESCRIPTION
Allow a copy of `Axis.minor` and `Axis.major` objects to be made when axes are twinned. This will allow two twinned axes to have different `Formatter` and `Locator` objects when they are both visible. The default of always sharing the same references (via a shared `matplotlib.axis.Ticker` container) has been preserved.

I made the keyword parameter `share_tickers` propagate all the way to `axes._AxesBase.__init__` rather than implementing the copy in `axes.AxesBase._make_twin_axes`. The reason is that I would like to be able to modify the meaning of `sharex` and `sharey` directly in the constructor.

Fixes #7376.

This PR includes tests.

A couple of places that I would ask reviewers to look at:

  - I made one functional change that I think is OK, but may need to be reverted. In axes/_base.py, around line 1004, where the formatter and locator get reset, the original code called `Axis.set_major/minor_formatter/locator`. This would set the `axis` attribute of the locators and formatters to the second axis, not the original one that `twinx/y` was called on in the first place. I have gone ahead and changed that behavior for both the `shared_ticker=True` case and the `False` case. For the `False` case this is pretty obvious, since we do not want to change the `axis` attribute of the original formatter and locator at all. It should not cause any problems in the `True` case either, but it is technically a minor change in the functionality that I would like to bring attention to.
  - Did I add documentation for the `share_tickers` parameter correctly in axes/_base.py:473?
  - Did I add the handling of the parameter correctly? Specifically, it will affect the axis key in `Figure._make_key`. I think that this is correct because the axes with and without `share_tickers` will serve different purposes visually, so it should be OK to treat them as different objects.
  - I did not add an explicit test for the new copy constructor of `axis.Ticker` because it is really trivial. However, the code does get complete coverage in the tests that I wrote for `twinx/y`.
