### PR TITLE
[MRG+2] MAINT: TkAgg default backend depends on tkinter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,9 +193,9 @@ if __name__ == '__main__':
                     required_failed.append(package)
             else:
                 good_packages.append(package)
-                if (isinstance(package, setupext.OptionalBackendPackage)
-                        and package.runtime_check()
-                        and default_backend is None):
+                if (isinstance(package, setupext.OptionalBackendPackage) and
+                        package.runtime_check() and
+                        default_backend is None):
                     default_backend = package.name
     print_raw('')
 

--- a/setup.py
+++ b/setup.py
@@ -194,8 +194,8 @@ if __name__ == '__main__':
             else:
                 good_packages.append(package)
                 if (isinstance(package, setupext.OptionalBackendPackage)
-                    and package.runtime_check()
-                    and default_backend is None):
+                        and package.runtime_check()
+                        and default_backend is None):
                     default_backend = package.name
     print_raw('')
 

--- a/setup.py
+++ b/setup.py
@@ -193,9 +193,10 @@ if __name__ == '__main__':
                     required_failed.append(package)
             else:
                 good_packages.append(package)
-                if isinstance(package, setupext.OptionalBackendPackage):
-                    if default_backend is None:
-                        default_backend = package.name
+                if (isinstance(package, setupext.OptionalBackendPackage)
+                    and package.runtime_check()
+                    and default_backend is None):
+                    default_backend = package.name
     print_raw('')
 
     # Abort if any of the required packages can not be built.

--- a/setupext.py
+++ b/setupext.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import
 
+from importlib import import_module
+
 from distutils import sysconfig
 from distutils import version
 from distutils.core import Extension
@@ -1655,7 +1657,7 @@ class BackendTkAgg(OptionalBackendPackage):
         """
         pkg_name = 'tkinter' if PY3min else 'Tkinter'
         try:
-            __import__(pkg_name)
+            import_module(pkg_name)
         except ImportError:
             return False
         return True

--- a/setupext.py
+++ b/setupext.py
@@ -424,12 +424,19 @@ class SetupPackage(object):
 
     def check(self):
         """
-        Checks whether the dependencies are met.  Should raise a
-        `CheckFailed` exception if the dependency could not be met,
-        otherwise return a string indicating a version number or some
-        other message indicating what was found.
+        Checks whether the build dependencies are met.  Should raise a
+        `CheckFailed` exception if the dependency could not be met, otherwise
+        return a string indicating a version number or some other message
+        indicating what was found.
         """
         pass
+
+    def runtime_check(self):
+        """
+        True if the runtime dependencies of the backend are met.  Assumes that
+        the build-time dependencies are met.
+        """
+        return True
 
     def get_packages(self):
         """
@@ -1642,6 +1649,16 @@ class BackendTkAgg(OptionalBackendPackage):
 
     def check(self):
         return "installing; run-time loading from Python Tcl / Tk"
+
+    def runtime_check(self):
+        """ Checks whether TkAgg runtime dependencies are met
+        """
+        pkg_name = 'tkinter' if PY3min else 'Tkinter'
+        try:
+            __import__(pkg_name)
+        except ImportError:
+            return False
+        return True
 
     def get_extension(self):
         sources = [


### PR DESCRIPTION
We now always build the TkAgg backend, because it does not depend on the
Tk libraries being on the building system.

This had the unwanted effect of making the TkAgg backend be the default
even if Python tkinter libraries were not installed.

Make a `runtime_check` function for the optional packages, that gives
True if the package can be used at run time, and use that to reject
TkAgg as default backend when tkinter not available.