### PR TITLE
Delay the fc-list warning by 5 seconds

### DIFF
--- a/lib/matplotlib/compat/subprocess.py
+++ b/lib/matplotlib/compat/subprocess.py
@@ -26,7 +26,7 @@ if os.name == 'posix' and sys.version_info[0] < 3:
 else:
     import subprocess
 
-__all__ = ['Popen', 'PIPE', 'STDOUT', 'check_output', 'CalledProcessError']
+__all__ = ['Popen', 'PIPE', 'STDOUT', 'check_output', 'CalledProcessError', 'TimeoutExpired']
 
 
 if hasattr(subprocess, 'Popen'):
@@ -36,6 +36,7 @@ if hasattr(subprocess, 'Popen'):
     STDOUT = subprocess.STDOUT
     CalledProcessError = subprocess.CalledProcessError
     check_output = subprocess.check_output
+    TimeoutExpired = subprocess.TimeoutExpired
 else:
     # In restricted environments (such as Google App Engine), these are
     # non-existent. Replace them with dummy versions that always raise OSError.
@@ -49,3 +50,4 @@ else:
     # There is no need to catch CalledProcessError. These stubs cannot raise
     # it. None in an except clause will simply not match any exceptions.
     CalledProcessError = None
+    TimeoutExpired = None

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -278,12 +278,19 @@ def get_fontconfig_fonts(fontext='ttf'):
                                 stderr=subprocess.PIPE)
         # We emit a warning if the process has not completed after 5 seconds.
         # We avoid showing it before since if this takes < 5 seconds, the user
-        # probably won't notice.
-        try:
-            output = pipe.communicate(timeout=5)[0]
-        except subprocess.TimeoutExpired:
-            warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')
+        # probably won't notice. However, this only works on Python 3 because
+        # the timeout keyword argument for communicate is not implemented in 2.
+        if six.PY2:
+            warnings.warn('Matplotlib is building the font cache using fc-list. '
+                          'This may take a moment.')
             output = pipe.communicate()[0]
+        else:
+            try:
+                output = pipe.communicate(timeout=5)[0]
+            except subprocess.TimeoutExpired:
+                warnings.warn('Matplotlib is building the font cache using '
+                              'fc-list. This may take a moment.')
+                output = pipe.communicate()[0]
     except (OSError, IOError):
         # Calling fc-list did not work, so we'll just return nothing
         return fontfiles

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -280,16 +280,18 @@ def get_fontconfig_fonts(fontext='ttf'):
         # We avoid showing it before since if this takes < 5 seconds, the user
         # probably won't notice. However, this only works on Python 3 because
         # the timeout keyword argument for communicate is not implemented in 2.
+
+        message = ('Matplotlib is building the font cache using fc-list. '
+                   'This may take a moment.')
+
         if six.PY2:
-            warnings.warn('Matplotlib is building the font cache using fc-list. '
-                          'This may take a moment.')
+            warnings.warn(message)
             output = pipe.communicate()[0]
         else:
             try:
                 output = pipe.communicate(timeout=5)[0]
             except subprocess.TimeoutExpired:
-                warnings.warn('Matplotlib is building the font cache using '
-                              'fc-list. This may take a moment.')
+                warnings.warn(message)
                 output = pipe.communicate()[0]
     except (OSError, IOError):
         # Calling fc-list did not work, so we'll just return nothing

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -273,11 +273,17 @@ def get_fontconfig_fonts(fontext='ttf'):
 
     fontfiles = {}
     try:
-        warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')
         pipe = subprocess.Popen(['fc-list', '--format=%{file}\\n'],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
-        output = pipe.communicate()[0]
+        # We emit a warning if the process has not completed after 5 seconds.
+        # We avoid showing it before since if this takes < 5 seconds, the user
+        # probably won't notice.
+        try:
+            output = pipe.communicate(timeout=5)[0]
+        except subprocess.TimeoutExpired:
+            warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')
+            output = pipe.communicate()[0]
     except (OSError, IOError):
         # Calling fc-list did not work, so we'll just return nothing
         return fontfiles


### PR DESCRIPTION
In https://github.com/matplotlib/matplotlib/issues/5836#issuecomment-263591164, @tacaswell said:

*If there is a non-thread based way to get a 5s delay I am 👍 on that, but bringing threads in this seems like complexity overkill.*

The solution here doesn't use any extra threads/processes compared to what was being used before, and is a pretty simple/robust solution.

cc @tacaswell @efiring 