### PR TITLE
[MRG] DOC replaced dead links with active ones

### DIFF
--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -266,7 +266,8 @@ example <https://travis-ci.org/msabramo/matplotlib>`_.
 Using tox
 ---------
 
-`Tox <http://tox.testrun.org/>`_ is a tool for running tests against
+`Tox <https://tox.readthedocs.io/en/latest/>`_ is a tool for running
+tests against
 multiple Python environments, including multiple versions of Python
 (e.g., 2.7, 3.4, 3.5) and even different Python implementations
 altogether (e.g., CPython, PyPy, Jython, etc.)

--- a/doc/resources/index.rst
+++ b/doc/resources/index.rst
@@ -37,10 +37,6 @@
  Videos
 =======
 
-* `Getting started with Matplotlib
-  <http://showmedo.com/videotutorials/video?name=7200090&fromSeriesID=720>`_
-  by `unpingco <http://showmedo.com/videotutorials/?author=6237>`_
-
 * `Plotting with matplotlib <http://www.youtube.com/watch?v=P7SVi0YTIuE>`_
   by Mike Müller
 

--- a/doc/users/colormaps.rst
+++ b/doc/users/colormaps.rst
@@ -186,6 +186,6 @@ References
 .. [mycarta-lablinear] http://mycarta.wordpress.com/2012/12/06/the-rainbow-is-deadlong-live-the-rainbow-part-5-cie-lab-linear-l-rainbow/
 .. [mycarta-cubelaw] http://mycarta.wordpress.com/2013/02/21/perceptual-rainbow-palette-the-method/
 .. [bw] http://www.tannerhelland.com/3643/grayscale-image-algorithm-vb6/
-.. [colorblindness] http://aspnetresources.com/tools/colorBlindness
+.. [colorblindness] http://www.color-blindness.com/
 .. [asp] http://aspnetresources.com/tools/colorBlindness
 .. [IBM] http://www.research.ibm.com/people/l/lloydt/color/color.HTM

--- a/doc/users/prev_whats_new/whats_new_1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_1.0.rst
@@ -69,7 +69,7 @@ figures since the last call.  Eric has done a lot of testing on the
 user interface toolkits and versions and platforms he has access to,
 but it is not possible to test them all, so please report problems to
 the `mailing list
-<http://mail.python.org/mailman/listinfo/matplotlib-users>`__
+<https://mail.python.org/mailman/listinfo/matplotlib-users>`__
 and `bug tracker
 <http://github.com/matplotlib/matplotlib/issues>`__.
 

--- a/doc/users/prev_whats_new/whats_new_1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_1.0.rst
@@ -69,7 +69,7 @@ figures since the last call.  Eric has done a lot of testing on the
 user interface toolkits and versions and platforms he has access to,
 but it is not possible to test them all, so please report problems to
 the `mailing list
-<http://mail.python.org/mailman/listinfo/matplotlib users>`__
+<http://mail.python.org/mailman/listinfo/matplotlib-users>`__
 and `bug tracker
 <http://github.com/matplotlib/matplotlib/issues>`__.
 


### PR DESCRIPTION
closes #6678

Replaces dead links with new one. There is a deadline in gitwash, that would be fixed by updating the automatically generated content of gitwash - I did not do anything about this one.

linkchecker also complains about the ssl certificat of the scipy website.