### PR TITLE
Rectangle patch angle attribute and patch __str__ improvements

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -656,8 +656,9 @@ class Rectangle(Patch):
     """
 
     def __str__(self):
-        return self.__class__.__name__ \
-            + "(%g,%g;%gx%g)" % (self._x, self._y, self._width, self._height)
+        pars = self._x, self._y, self._width, self._height, self.angle
+        fmt = "Rectangle(xy=(%g, %g), width=%g, height=%g, angle=%g)"
+        return fmt % pars
 
     @docstring.dedent_interpd
     def __init__(self, xy, width, height, angle=0.0, **kwargs):
@@ -1024,7 +1025,10 @@ class Wedge(Patch):
     Wedge shaped patch.
     """
     def __str__(self):
-        return "Wedge(%g,%g)" % (self.theta1, self.theta2)
+        pars = (self.center[0], self.center[1], self.r,
+                self.theta1, self.theta2, self.width)
+        fmt = "Wedge(center=(%g, %g), r=%g, theta1=%g, theta2=%g, width=%s)"
+        return fmt % pars
 
     @docstring.dedent_interpd
     def __init__(self, center, r, theta1, theta2, width=None, **kwargs):
@@ -1394,8 +1398,10 @@ class Ellipse(Patch):
     A scale-free ellipse.
     """
     def __str__(self):
-        return "Ellipse(%s,%s;%sx%s)" % (self.center[0], self.center[1],
-                                         self.width, self.height)
+        pars = (self.center[0], self.center[1],
+                self.width, self.height, self.angle)
+        fmt = "Ellipse(xy=(%s, %s), width=%s, height=%s, angle=%s)"
+        return fmt % pars
 
     @docstring.dedent_interpd
     def __init__(self, xy, width, height, angle=0.0, **kwargs):
@@ -1455,9 +1461,9 @@ class Circle(Ellipse):
     A circle patch.
     """
     def __str__(self):
-        return "Circle((%g,%g),r=%g)" % (self.center[0],
-                                         self.center[1],
-                                         self.radius)
+        pars = self.center[0], self.center[1], self.radius
+        fmt = "Circle(xy=(%g, %g), radius=%g)"
+        return fmt % pars
 
     @docstring.dedent_interpd
     def __init__(self, xy, radius=5, **kwargs):
@@ -1502,8 +1508,11 @@ class Arc(Ellipse):
     with high resolution.
     """
     def __str__(self):
-        return "Arc(%s,%s;%sx%s)" % (self.center[0], self.center[1],
-                                     self.width, self.height)
+        pars = (self.center[0], self.center[1], self.width,
+                self.height, self.angle, self.theta1, self.theta2)
+        fmt = ("Arc(xy=(%g, %g), width=%g, "
+               "height=%g, angle=%g, theta1=%g, theta2=%g)")
+        return fmt % pars
 
     @docstring.dedent_interpd
     def __init__(self, xy, width, height, angle=0.0,

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -652,7 +652,7 @@ class Shadow(Patch):
 class Rectangle(Patch):
     """
     Draw a rectangle with lower left at *xy* = (*x*, *y*) with
-    specified *width* and *height*.
+    specified *width*, *height* and rotation *angle*.
     """
 
     def __str__(self):
@@ -678,7 +678,7 @@ class Rectangle(Patch):
         self._y = float(xy[1])
         self._width = float(width)
         self._height = float(height)
-        self._angle = float(angle)
+        self.angle = float(angle)
         # Note: This cannot be calculated until this is added to an Axes
         self._rect_transform = transforms.IdentityTransform()
 
@@ -700,7 +700,7 @@ class Rectangle(Patch):
         height = self.convert_yunits(self._height)
         bbox = transforms.Bbox.from_bounds(x, y, width, height)
         rot_trans = transforms.Affine2D()
-        rot_trans.rotate_deg_around(x, y, self._angle)
+        rot_trans.rotate_deg_around(x, y, self.angle)
         self._rect_transform = transforms.BboxTransformTo(bbox)
         self._rect_transform += rot_trans
 

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -291,6 +291,30 @@ def test_wedge_range():
     ax.set_ylim([-2, 9])
 
 
+def test_patch_str():
+    """
+    Check that patches have nice and working `str` representation.
+
+    Note that the logic is that `__str__` is defined such that:
+    str(eval(str(p))) == str(p)
+    """
+    p = mpatches.Circle(xy=(1, 2), radius=3)
+    assert str(p) == 'Circle(xy=(1, 2), radius=3)'
+
+    p = mpatches.Ellipse(xy=(1, 2), width=3, height=4, angle=5)
+    assert str(p) == 'Ellipse(xy=(1, 2), width=3, height=4, angle=5)'
+
+    p = mpatches.Rectangle(xy=(1, 2), width=3, height=4, angle=5)
+    assert str(p) == 'Rectangle(xy=(1, 2), width=3, height=4, angle=5)'
+
+    p = mpatches.Wedge(center=(1, 2), r=3, theta1=4, theta2=5, width=6)
+    assert str(p) == 'Wedge(center=(1, 2), r=3, theta1=4, theta2=5, width=6)'
+
+    p = mpatches.Arc(xy=(1, 2), width=3, height=4, angle=5, theta1=6, theta2=7)
+    expected = 'Arc(xy=(1, 2), width=3, height=4, angle=5, theta1=6, theta2=7)'
+    assert str(p) == expected
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
We're in the process of writing an [astropy.regions](http://astropy-regions.readthedocs.io/en/latest/) package for astronomers, and we're adding an `as_patch` method to convert regions to matplotlib patch objects for plotting.

While writing a test for the rectangle region / patch, I noticed that `matplotlib.patches.Rectangle._angle` that was added in #1405 isn't exposed as a public attribute?

If that's the case, would it be possible to expose it via an `angle` attribute or `get_angle()` method?

I noticed that other parameters are exposed as a wild mix of attributes and `get_` methods:
```python
    def test_as_patch(self):
        patch = self.reg.as_patch()
        assert_allclose(patch.xy, (3, 4))
        assert_allclose(patch.get_width(), 4)
        assert_allclose(patch.get_height(), 3)
        assert_allclose(patch._angle, 5)
```

Presumably there are backward-compat constraints or name collisions, that make exposing patch data members in a uniform way difficult. Is there something that can be improved in general, or for `Rectangle.angle` specifically?

