### PR TITLE
Deprecate update_datalim_numerix&update_from_data.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1940,6 +1940,7 @@ class _AxesBase(martist.Artist):
                                          updatex=updatex, updatey=updatey)
         self.ignore_existing_data_limits = False
 
+    @cbook.deprecated('2.0', alternative='update_datalim')
     def update_datalim_numerix(self, x, y):
         """
         Update the data lim bbox with seq of xy tups

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -42,6 +42,7 @@ from numpy.linalg import inv
 import weakref
 import warnings
 
+from . import cbook
 from .path import Path
 
 DEBUG = False
@@ -857,19 +858,19 @@ class Bbox(BboxBase):
     def ignore(self, value):
         """
         Set whether the existing bounds of the box should be ignored
-        by subsequent calls to :meth:`update_from_data` or
-        :meth:`update_from_data_xy`.
+        by subsequent calls to :meth:`update_from_data_xy`.
 
         *value*:
 
-           - When True, subsequent calls to :meth:`update_from_data`
+           - When True, subsequent calls to :meth:`update_from_data_xy`
              will ignore the existing bounds of the :class:`Bbox`.
 
-           - When False, subsequent calls to :meth:`update_from_data`
+           - When False, subsequent calls to :meth:`update_from_data_xy`
              will include the existing bounds of the :class:`Bbox`.
         """
         self._ignore = value
 
+    @cbook.deprecated('2.0', alternative='update_from_data_xy')
     def update_from_data(self, x, y, ignore=None):
         """
         Update the bounds of the :class:`Bbox` based on the passed in


### PR DESCRIPTION
There's been a warning on the latter since 2007 (and regarding the former I don't think anyone still uses numerix...).

(Making this a separate PR because I'd like to get the deprecation message in asap :-))