### PR TITLE
Additional cleanups

### DIFF
--- a/boilerplate.py
+++ b/boilerplate.py
@@ -317,7 +317,7 @@ def boilerplate_gen():
             # A gensym-like facility in case some function takes an
             # argument named washold, ax, or ret
             washold, ret, ax = 'washold', 'ret', 'ax'
-            bad = set(args) | set((varargs, varkw))
+            bad = set(args) | {varargs, varkw}
             while washold in bad or ret in bad or ax in bad:
                 washold = 'washold' + str(random.randrange(10 ** 12))
                 ret = 'ret' + str(random.randrange(10 ** 12))

--- a/doc/sphinxext/gen_gallery.py
+++ b/doc/sphinxext/gen_gallery.py
@@ -76,12 +76,10 @@ def gen_gallery(app, doctree):
     # images we want to skip for the gallery because they are an unusual
     # size that doesn't layout well in a table, or because they may be
     # redundant with other images or uninteresting
-    skips = set([
-        'mathtext_examples',
-        'matshow_02',
-        'matshow_03',
-        'matplotlib_icon',
-        ])
+    skips = {'mathtext_examples',
+             'matshow_02',
+             'matshow_03',
+             'matplotlib_icon'}
 
     thumbnails = {}
     rows = []

--- a/doc/utils/pylab_names.py
+++ b/doc/utils/pylab_names.py
@@ -46,16 +46,13 @@ for mod in mods:
 
     print()
     funcs, docs = zip(*modd[mod])
-    maxfunc = max([len(f) for f in funcs])
-    maxdoc = max(40, max([len(d) for d in docs]) )
-    border = ' '.join(['='*maxfunc, '='*maxdoc])
+    maxfunc = max(len(f) for f in funcs)
+    maxdoc = max(40, max(len(d) for d in docs))
+    border = '=' * maxfunc + ' ' + '=' * maxdoc
     print(border)
-    print(' '.join(['symbol'.ljust(maxfunc), 'description'.ljust(maxdoc)]))
+    print('{:<{}} {:<{}}'.format('symbol', maxfunc, 'description', maxdoc))
     print(border)
     for func, doc in modd[mod]:
-        row = ' '.join([func.ljust(maxfunc), doc.ljust(maxfunc)])
-        print(row)
-
+        print('{:<{}} {:<{}}'.format(func, maxfunc, doc, maxdoc))
     print(border)
     print()
-    #break

--- a/examples/api/collections_demo.py
+++ b/examples/api/collections_demo.py
@@ -89,9 +89,8 @@ ax2.set_title('PolyCollection using offsets')
 
 # 7-sided regular polygons
 
-col = collections.RegularPolyCollection(7,
-                                        sizes=np.fabs(xx) * 10.0, offsets=xyo,
-                                        transOffset=ax3.transData)
+col = collections.RegularPolyCollection(
+    7, sizes=np.abs(xx) * 10.0, offsets=xyo, transOffset=ax3.transData)
 trans = transforms.Affine2D().scale(fig.dpi / 72.0)
 col.set_transform(trans)  # the points to pixels transform
 ax3.add_collection(col, autolim=True)
@@ -109,7 +108,7 @@ ncurves = 20
 offs = (0.1, 0.0)
 
 yy = np.linspace(0, 2*np.pi, nverts)
-ym = np.amax(yy)
+ym = np.max(yy)
 xx = (0.2 + (ym - yy)/ym)**2 * np.cos(yy - 0.4)*0.5
 segs = []
 for i in range(ncurves):

--- a/examples/api/sankey_demo_old.py
+++ b/examples/api/sankey_demo_old.py
@@ -37,11 +37,11 @@ def sankey(ax,
     import matplotlib.patches as mpatches
     from matplotlib.path import Path
 
-    outs = np.absolute(outputs)
+    outs = np.abs(outputs)
     outsigns = np.sign(outputs)
     outsigns[-1] = 0  # Last output
 
-    ins = np.absolute(inputs)
+    ins = np.abs(inputs)
     insigns = np.sign(inputs)
     insigns[0] = 0  # First input
 

--- a/examples/axes_grid1/scatter_hist.py
+++ b/examples/axes_grid1/scatter_hist.py
@@ -30,7 +30,7 @@ plt.setp(axHistx.get_xticklabels() + axHisty.get_yticklabels(),
 
 # now determine nice limits by hand:
 binwidth = 0.25
-xymax = np.max([np.max(np.fabs(x)), np.max(np.fabs(y))])
+xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))
 lim = (int(xymax/binwidth) + 1)*binwidth
 
 bins = np.arange(-lim, lim + binwidth, binwidth)

--- a/examples/axes_grid1/simple_axesgrid.py
+++ b/examples/axes_grid1/simple_axesgrid.py
@@ -2,8 +2,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import ImageGrid
 import numpy as np
 
-im = np.arange(100)
-im.shape = 10, 10
+im = np.arange(100).reshape((10, 10))
 
 fig = plt.figure(1, (4., 4.))
 grid = ImageGrid(fig, 111,  # similar to subplot(111)

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -70,8 +70,8 @@ class PolygonInteractor(object):
         xy = np.asarray(self.poly.xy)
         xyt = self.poly.get_transform().transform(xy)
         xt, yt = xyt[:, 0], xyt[:, 1]
-        d = np.sqrt((xt - event.x)**2 + (yt - event.y)**2)
-        indseq = np.nonzero(np.equal(d, np.amin(d)))[0]
+        d = np.hypot(xt - event.x, yt - event.y)
+        indseq, = np.nonzero(d == d.min())
         ind = indseq[0]
 
         if d[ind] >= self.epsilon:

--- a/examples/pylab_examples/agg_buffer.py
+++ b/examples/pylab_examples/agg_buffer.py
@@ -26,8 +26,7 @@ s = agg.tostring_rgb()
 l, b, w, h = agg.figure.bbox.bounds
 w, h = int(w), int(h)
 
-X = np.fromstring(s, np.uint8)
-X.shape = h, w, 3
+X = np.fromstring(s, np.uint8).reshape((h, w, 3))
 
 try:
     im = Image.fromstring("RGB", (w, h), s)

--- a/examples/pylab_examples/anscombe.py
+++ b/examples/pylab_examples/anscombe.py
@@ -22,7 +22,7 @@ def fit(x):
     return 3 + 0.5*x
 
 
-xfit = np.array([np.amin(x), np.amax(x)])
+xfit = np.array([np.min(x), np.max(x)])
 
 plt.subplot(221)
 plt.plot(x, y1, 'ks', xfit, fit(xfit), 'r-', lw=2)
@@ -43,8 +43,7 @@ plt.text(3, 12, 'III', fontsize=20)
 plt.setp(plt.gca(), yticks=(4, 8, 12), xticks=(0, 10, 20))
 
 plt.subplot(224)
-
-xfit = np.array([np.amin(x4), np.amax(x4)])
+xfit = np.array([np.min(x4), np.max(x4)])
 plt.plot(x4, y4, 'ks', xfit, fit(xfit), 'r-', lw=2)
 plt.axis([2, 20, 2, 14])
 plt.setp(plt.gca(), yticklabels=[], yticks=(4, 8, 12), xticks=(0, 10, 20))

--- a/examples/pylab_examples/arrow_demo.py
+++ b/examples/pylab_examples/arrow_demo.py
@@ -14,8 +14,8 @@ import numpy as np
 rates_to_bases = {'r1': 'AT', 'r2': 'TA', 'r3': 'GA', 'r4': 'AG', 'r5': 'CA',
                   'r6': 'AC', 'r7': 'GT', 'r8': 'TG', 'r9': 'CT', 'r10': 'TC',
                   'r11': 'GC', 'r12': 'CG'}
-numbered_bases_to_rates = dict([(v, k) for k, v in rates_to_bases.items()])
-lettered_bases_to_rates = dict([(v, 'r' + v) for k, v in rates_to_bases.items()])
+numbered_bases_to_rates = {v: k for k, v in rates_to_bases.items()}
+lettered_bases_to_rates = {v: 'r' + v for k, v in rates_to_bases.items()}
 
 
 def add_dicts(d1, d2):

--- a/examples/pylab_examples/axes_demo.py
+++ b/examples/pylab_examples/axes_demo.py
@@ -14,7 +14,7 @@ s = np.convolve(x, r)[:len(x)]*dt  # colored noise
 
 # the main axes is subplot(111) by default
 plt.plot(t, s)
-plt.axis([0, 1, 1.1*np.amin(s), 2*np.amax(s)])
+plt.axis([0, 1, 1.1 * np.min(s), 2 * np.max(s)])
 plt.xlabel('time (s)')
 plt.ylabel('current (nA)')
 plt.title('Gaussian colored noise')

--- a/examples/pylab_examples/barcode_demo.py
+++ b/examples/pylab_examples/barcode_demo.py
@@ -14,15 +14,12 @@ barprops = dict(aspect='auto', cmap=plt.cm.binary, interpolation='nearest')
 fig = plt.figure()
 
 # a vertical barcode -- this is broken at present
-x.shape = len(x), 1
 ax = fig.add_axes([0.1, 0.3, 0.1, 0.6], **axprops)
-ax.imshow(x, **barprops)
+ax.imshow(x.reshape((-1, 1)), **barprops)
 
-x = x.copy()
 # a horizontal barcode
-x.shape = 1, len(x)
 ax = fig.add_axes([0.3, 0.1, 0.6, 0.1], **axprops)
-ax.imshow(x, **barprops)
+ax.imshow(x.reshape((1, -1)), **barprops)
 
 
 plt.show()

--- a/examples/pylab_examples/figimage_demo.py
+++ b/examples/pylab_examples/figimage_demo.py
@@ -9,11 +9,10 @@ import matplotlib.pyplot as plt
 
 
 fig = plt.figure()
-Z = np.arange(10000.0)
-Z.shape = 100, 100
-Z[:, 50:] = 1.
+Z = np.arange(10000).reshape(100, 100)
+Z[:, 50:] = 1
 
-im1 = plt.figimage(Z, xo=50, yo=0, origin='lower')
-im2 = plt.figimage(Z, xo=100, yo=100, alpha=.8, origin='lower')
+im1 = fig.figimage(Z, xo=50, yo=0, origin='lower')
+im2 = fig.figimage(Z, xo=100, yo=100, alpha=.8, origin='lower')
 
 plt.show()

--- a/examples/pylab_examples/figimage_demo.py
+++ b/examples/pylab_examples/figimage_demo.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 
 
 fig = plt.figure()
-Z = np.arange(10000).reshape(100, 100)
+Z = np.arange(10000).reshape((100, 100))
 Z[:, 50:] = 1
 
 im1 = fig.figimage(Z, xo=50, yo=0, origin='lower')

--- a/examples/pylab_examples/image_demo2.py
+++ b/examples/pylab_examples/image_demo2.py
@@ -7,9 +7,8 @@ w, h = 512, 512
 
 datafile = cbook.get_sample_data('ct.raw.gz', asfileobj=True)
 s = datafile.read()
-A = np.fromstring(s, np.uint16).astype(float)
-A *= 1.0 / max(A)
-A.shape = w, h
+A = np.fromstring(s, np.uint16).astype(float).reshape((w, h))
+A /= A.max()
 
 extent = (0, 25, 0, 25)
 im = plt.imshow(A, cmap=plt.cm.hot, origin='upper', extent=extent)

--- a/examples/pylab_examples/image_origin.py
+++ b/examples/pylab_examples/image_origin.py
@@ -7,8 +7,7 @@ matplotlibrc file; see http://matplotlib.org/matplotlibrc
 import matplotlib.pyplot as plt
 import numpy as np
 
-x = np.arange(120)
-x.shape = (10, 12)
+x = np.arange(120).reshape((10, 12))
 
 interp = 'bilinear'
 fig, axs = plt.subplots(nrows=2, sharex=True, figsize=(3, 5))

--- a/examples/pylab_examples/layer_images.py
+++ b/examples/pylab_examples/layer_images.py
@@ -28,8 +28,7 @@ xmin, xmax, ymin, ymax = np.amin(x), np.amax(x), np.amin(y), np.amax(y)
 extent = xmin, xmax, ymin, ymax
 fig = plt.figure(frameon=False)
 
-Z1 = np.array(([0, 1]*4 + [1, 0]*4)*4)
-Z1.shape = (8, 8)  # chessboard
+Z1 = np.add.outer(range(8), range(8)) % 2  # chessboard
 im1 = plt.imshow(Z1, cmap=plt.cm.gray, interpolation='nearest',
                  extent=extent)
 

--- a/examples/pylab_examples/layer_images.py
+++ b/examples/pylab_examples/layer_images.py
@@ -23,9 +23,7 @@ X, Y = np.meshgrid(x, y)
 # for the images their apparent extent could be different due to
 # interpolation edge effects
 
-
-xmin, xmax, ymin, ymax = np.amin(x), np.amax(x), np.amin(y), np.amax(y)
-extent = xmin, xmax, ymin, ymax
+extent = np.min(x), np.max(x), np.min(y), np.max(y)
 fig = plt.figure(frameon=False)
 
 Z1 = np.add.outer(range(8), range(8)) % 2  # chessboard

--- a/examples/pylab_examples/line_collection2.py
+++ b/examples/pylab_examples/line_collection2.py
@@ -13,8 +13,8 @@ ys = [x + i for i in x]
 
 # We need to set the plot limits, they will not autoscale
 ax = plt.axes()
-ax.set_xlim((np.amin(x), np.amax(x)))
-ax.set_ylim((np.amin(np.amin(ys)), np.amax(np.amax(ys))))
+ax.set_xlim(np.min(x), np.max(x))
+ax.set_ylim(np.min(ys), np.max(ys))
 
 # colors is sequence of rgba tuples
 # linestyle is a string or dash tuple. Legal string values are

--- a/examples/pylab_examples/mri_demo.py
+++ b/examples/pylab_examples/mri_demo.py
@@ -9,8 +9,7 @@ fig, ax = plt.subplots(num="MRI_demo")
 
 # Data are 256x256 16 bit integers
 dfile = cbook.get_sample_data('s1045.ima.gz')
-im = np.fromstring(dfile.read(), np.uint16).astype(float)
-im.shape = (256, 256)
+im = np.fromstring(dfile.read(), np.uint16).reshape((256, 256))
 dfile.close()
 
 ax.imshow(im, cmap=cm.gray)

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -16,7 +16,7 @@ fig = plt.figure("MRI_with_EEG")
 
 # Load the MRI data (256x256 16 bit integers)
 dfile = cbook.get_sample_data('s1045.ima.gz')
-im = np.fromstring(dfile.read(), np.uint16).astype(float).reshape((256, 256))
+im = np.fromstring(dfile.read(), np.uint16).reshape((256, 256))
 dfile.close()
 
 # Plot the MRI image

--- a/examples/pylab_examples/mri_with_eeg.py
+++ b/examples/pylab_examples/mri_with_eeg.py
@@ -16,8 +16,7 @@ fig = plt.figure("MRI_with_EEG")
 
 # Load the MRI data (256x256 16 bit integers)
 dfile = cbook.get_sample_data('s1045.ima.gz')
-im = np.fromstring(dfile.read(), np.uint16).astype(float)
-im.shape = (256, 256)
+im = np.fromstring(dfile.read(), np.uint16).astype(float).reshape((256, 256))
 dfile.close()
 
 # Plot the MRI image

--- a/examples/pylab_examples/multi_image.py
+++ b/examples/pylab_examples/multi_image.py
@@ -7,8 +7,7 @@ It also illustrates colorbar tick labelling with a multiplier.
 from matplotlib.pyplot import figure, show, axes, sci
 from matplotlib import cm, colors
 from matplotlib.font_manager import FontProperties
-from numpy import amin, amax, ravel
-from numpy.random import rand
+import numpy as np
 
 Nr = 3
 Nc = 2
@@ -37,12 +36,12 @@ for i in range(Nr):
             a.set_xticklabels([])
         # Make some fake data with a range that varies
         # somewhat from one plot to the next.
-        data = ((1 + i + j)/10.0)*rand(10, 20)*1e-6
-        dd = ravel(data)
+        data = ((1 + i + j) / 10) * np.random.rand(10, 20) * 1e-6
+        dd = data.ravel()
         # Manually find the min and max of all colors for
         # use in setting the color scale.
-        vmin = min(vmin, amin(dd))
-        vmax = max(vmax, amax(dd))
+        vmin = min(vmin, np.min(dd))
+        vmax = max(vmax, np.max(dd))
         images.append(a.imshow(data, cmap=cmap))
 
         ax.append(a)

--- a/examples/pylab_examples/quadmesh_demo.py
+++ b/examples/pylab_examples/quadmesh_demo.py
@@ -21,8 +21,7 @@ Z = np.sqrt(X**2 + Y**2)/5
 Z = (Z - Z.min()) / (Z.max() - Z.min())
 
 # The color array can include masked values:
-Zm = ma.masked_where(np.fabs(Qz) < 0.5*np.amax(Qz), Z)
-
+Zm = ma.masked_where(np.abs(Qz) < 0.5 * np.max(Qz), Z)
 
 fig = figure()
 ax = fig.add_subplot(121)

--- a/examples/pylab_examples/scatter_hist.py
+++ b/examples/pylab_examples/scatter_hist.py
@@ -37,7 +37,7 @@ axScatter.scatter(x, y)
 
 # now determine nice limits by hand:
 binwidth = 0.25
-xymax = np.max([np.max(np.fabs(x)), np.max(np.fabs(y))])
+xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))
 lim = (int(xymax/binwidth) + 1) * binwidth
 
 axScatter.set_xlim((-lim, lim))

--- a/examples/pylab_examples/vline_hline_demo.py
+++ b/examples/pylab_examples/vline_hline_demo.py
@@ -10,7 +10,7 @@ import numpy.random as rnd
 def f(t):
     s1 = np.sin(2 * np.pi * t)
     e1 = np.exp(-t)
-    return np.absolute((s1 * e1)) + .05
+    return np.abs(s1 * e1) + .05
 
 t = np.arange(0.0, 5.0, 0.1)
 s = f(t)

--- a/examples/tests/backend_driver.py
+++ b/examples/tests/backend_driver.py
@@ -321,14 +321,13 @@ def report_missing(dir, flist):
     globstr = os.path.join(dir, '*.py')
     fnames = glob.glob(globstr)
 
-    pyfiles = set([os.path.split(fullpath)[-1] for fullpath in set(fnames)])
+    pyfiles = {os.path.split(fullpath)[-1] for fullpath in set(fnames)}
 
     exclude = set(excluded.get(dir, []))
     flist = set(flist)
     missing = list(pyfiles - flist - exclude)
-    missing.sort()
     if missing:
-        print('%s files not tested: %s' % (dir, ', '.join(missing)))
+        print('%s files not tested: %s' % (dir, ', '.join(sorted(missing))))
 
 
 def report_all_missing(directories):

--- a/examples/user_interfaces/embedding_in_wx3.py
+++ b/examples/user_interfaces/embedding_in_wx3.py
@@ -74,7 +74,7 @@ class PlotPanel(wx.Panel):
         z = np.sin(self.x) + np.cos(self.y)
         self.im = a.imshow(z, cmap=cm.RdBu)  # , interpolation='nearest')
 
-        zmax = np.amax(z) - ERR_TOL
+        zmax = np.max(z) - ERR_TOL
         ymax_i, xmax_i = np.nonzero(z >= zmax)
         if self.im.origin == 'upper':
             ymax_i = z.shape[0] - ymax_i
@@ -93,7 +93,7 @@ class PlotPanel(wx.Panel):
         z = np.sin(self.x) + np.cos(self.y)
         self.im.set_array(z)
 
-        zmax = np.amax(z) - ERR_TOL
+        zmax = np.max(z) - ERR_TOL
         ymax_i, xmax_i = np.nonzero(z >= zmax)
         if self.im.origin == 'upper':
             ymax_i = z.shape[0] - ymax_i

--- a/examples/user_interfaces/histogram_demo_canvasagg.py
+++ b/examples/user_interfaces/histogram_demo_canvasagg.py
@@ -48,8 +48,7 @@ w, h = int(w), int(h)
 
 if 0:
     # convert to a numpy array
-    X = numpy.fromstring(s, numpy.uint8)
-    X.shape = h, w, 3
+    X = numpy.fromstring(s, numpy.uint8).reshape((h, w, 3))
 
 if 0:
     # pass off to PIL

--- a/examples/widgets/menu.py
+++ b/examples/widgets/menu.py
@@ -126,8 +126,8 @@ class Menu(object):
         self.menuitems = menuitems
         self.numitems = len(menuitems)
 
-        maxw = max([item.labelwidth for item in menuitems])
-        maxh = max([item.labelheight for item in menuitems])
+        maxw = max(item.labelwidth for item in menuitems)
+        maxh = max(item.labelheight for item in menuitems)
 
         totalh = self.numitems*maxh + (self.numitems + 1)*2*MenuItem.pady
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -263,7 +263,7 @@ class Verbose(object):
     instance to handle the output.  Default is sys.stdout
     """
     levels = ('silent', 'helpful', 'debug', 'debug-annoying')
-    vald = dict([(level, i) for i, level in enumerate(levels)])
+    vald = {level: i for i, level in enumerate(levels)}
 
     # parse the verbosity from the command line; flags look like
     # --verbose-silent or --verbose-helpful
@@ -860,10 +860,10 @@ _deprecated_map = {
 _deprecated_ignore_map = {
     }
 
-_obsolete_set = set(['tk.pythoninspect', 'legend.isaxes'])
+_obsolete_set = {'tk.pythoninspect', 'legend.isaxes'}
 
 # The following may use a value of None to suppress the warning.
-_deprecated_set = set(['axes.hold'])  # do NOT include in _all_deprecated
+_deprecated_set = {'axes.hold'}  # do NOT include in _all_deprecated
 
 _all_deprecated = set(chain(_deprecated_ignore_map,
                             _deprecated_map,

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1278,12 +1278,11 @@ class ArtistInspector(object):
 
         ########
         names = [self.aliased_name_rest(prop, target)
-                 for prop, target
-                 in attrs]
+                 for prop, target in attrs]
         accepts = [self.get_valid_values(prop) for prop, target in attrs]
 
-        col0_len = max([len(n) for n in names])
-        col1_len = max([len(a) for a in accepts])
+        col0_len = max(len(n) for n in names)
+        col1_len = max(len(a) for a in accepts)
         table_formatstr = pad + '=' * col0_len + '   ' + '=' * col1_len
 
         lines.append('')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4264,35 +4264,23 @@ or tuple of floats
         d2 = (x - ix2 - 0.5) ** 2 + 3.0 * (y - iy2 - 0.5) ** 2
         bdist = (d1 < d2)
         if C is None:
-            accum = np.zeros(n)
-            # Create appropriate views into "accum" array.
-            lattice1 = accum[:nx1 * ny1]
-            lattice2 = accum[nx1 * ny1:]
-            lattice1.shape = (nx1, ny1)
-            lattice2.shape = (nx2, ny2)
+            lattice1 = np.zeros((nx1, ny1))
+            lattice2 = np.zeros((nx2, ny2))
 
             for i in xrange(len(x)):
                 if bdist[i]:
-                    if ((ix1[i] >= 0) and (ix1[i] < nx1) and
-                        (iy1[i] >= 0) and (iy1[i] < ny1)):
+                    if 0 <= ix1[i] < nx1 and 0 <= iy1[i] < ny1:
                         lattice1[ix1[i], iy1[i]] += 1
                 else:
-                    if ((ix2[i] >= 0) and (ix2[i] < nx2) and
-                        (iy2[i] >= 0) and (iy2[i] < ny2)):
+                    if 0 <= ix2[i] < nx2 and 0 <= iy2[i] < ny2:
                         lattice2[ix2[i], iy2[i]] += 1
 
             # threshold
             if mincnt is not None:
-                for i in xrange(nx1):
-                    for j in xrange(ny1):
-                        if lattice1[i, j] < mincnt:
-                            lattice1[i, j] = np.nan
-                for i in xrange(nx2):
-                    for j in xrange(ny2):
-                        if lattice2[i, j] < mincnt:
-                            lattice2[i, j] = np.nan
-            accum = np.hstack((lattice1.astype(float).ravel(),
-                               lattice2.astype(float).ravel()))
+                lattice1[lattice1 < mincnt] = np.nan
+                lattice2[lattice2 < mincnt] = np.nan
+            accum = np.hstack((lattice1.ravel(),
+                               lattice2.ravel()))
             good_idxs = ~np.isnan(accum)
 
         else:
@@ -4311,12 +4299,10 @@ or tuple of floats
 
             for i in xrange(len(x)):
                 if bdist[i]:
-                    if ((ix1[i] >= 0) and (ix1[i] < nx1) and
-                        (iy1[i] >= 0) and (iy1[i] < ny1)):
+                    if 0 <= ix1[i] < nx1 and 0 <= iy1[i] < ny1:
                         lattice1[ix1[i], iy1[i]].append(C[i])
                 else:
-                    if ((ix2[i] >= 0) and (ix2[i] < nx2) and
-                        (iy2[i] >= 0) and (iy2[i] < ny2)):
+                    if 0 <= ix2[i] < nx2 and 0 <= iy2[i] < ny2:
                         lattice2[ix2[i], iy2[i]].append(C[i])
 
             for i in xrange(nx1):
@@ -6612,7 +6598,6 @@ or tuple of floats
         pxx, freqs = mlab.psd(x=x, NFFT=NFFT, Fs=Fs, detrend=detrend,
                               window=window, noverlap=noverlap, pad_to=pad_to,
                               sides=sides, scale_by_freq=scale_by_freq)
-        pxx.shape = len(freqs),
         freqs += Fc
 
         if scale_by_freq in (None, True):
@@ -6736,7 +6721,6 @@ or tuple of floats
         pxy, freqs = mlab.csd(x=x, y=y, NFFT=NFFT, Fs=Fs, detrend=detrend,
                               window=window, noverlap=noverlap, pad_to=pad_to,
                               sides=sides, scale_by_freq=scale_by_freq)
-        pxy.shape = len(freqs),
         # pxy is complex
         freqs += Fc
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2460,7 +2460,7 @@ or tuple of floats
                            marker=linemarker, label="_nolegend_")
             stemlines.append(l)
 
-        baseline, = self.plot([np.amin(x), np.amax(x)], [bottom, bottom],
+        baseline, = self.plot([np.min(x), np.max(x)], [bottom, bottom],
                               color=basecolor, linestyle=basestyle,
                               marker=basemarker, label="_nolegend_")
 
@@ -4228,8 +4228,8 @@ or tuple of floats
         if extent is not None:
             xmin, xmax, ymin, ymax = extent
         else:
-            xmin, xmax = (np.amin(x), np.amax(x)) if len(x) else (0, 1)
-            ymin, ymax = (np.amin(y), np.amax(y)) if len(y) else (0, 1)
+            xmin, xmax = (np.min(x), np.max(x)) if len(x) else (0, 1)
+            ymin, ymax = (np.min(y), np.max(y)) if len(y) else (0, 1)
 
             # to avoid issues with singular data, expand the min/max pairs
             xmin, xmax = mtrans.nonsingular(xmin, xmax, expander=0.1)
@@ -5470,10 +5470,10 @@ or tuple of floats
 
         self.add_collection(collection, autolim=False)
 
-        minx = np.amin(x)
-        maxx = np.amax(x)
-        miny = np.amin(y)
-        maxy = np.amax(y)
+        minx = np.min(x)
+        maxx = np.max(x)
+        miny = np.min(y)
+        maxy = np.max(y)
         collection.sticky_edges.x[:] = [minx, maxx]
         collection.sticky_edges.y[:] = [miny, maxy]
         corners = (minx, miny), (maxx, maxy)
@@ -5622,10 +5622,10 @@ or tuple of floats
 
         self.add_collection(collection, autolim=False)
 
-        minx = np.amin(X)
-        maxx = np.amax(X)
-        miny = np.amin(Y)
-        maxy = np.amax(Y)
+        minx = np.min(X)
+        maxx = np.max(X)
+        miny = np.min(Y)
+        maxy = np.max(Y)
         collection.sticky_edges.x[:] = [minx, maxx]
         collection.sticky_edges.y[:] = [miny, maxy]
         corners = (minx, miny), (maxx, maxy)
@@ -6386,7 +6386,7 @@ or tuple of floats
         else:
             labels = [six.text_type(lab) for lab in label]
 
-        for (patch, lbl) in zip_longest(patches, labels, fillvalue=None):
+        for patch, lbl in zip_longest(patches, labels, fillvalue=None):
             if patch:
                 p = patch[0]
                 p.update(kwargs)
@@ -6724,7 +6724,7 @@ or tuple of floats
         # pxy is complex
         freqs += Fc
 
-        line = self.plot(freqs, 10 * np.log10(np.absolute(pxy)), **kwargs)
+        line = self.plot(freqs, 10 * np.log10(np.abs(pxy)), **kwargs)
         self.set_xlabel('Frequency')
         self.set_ylabel('Cross Spectrum Magnitude (dB)')
         self.grid(True)
@@ -7227,7 +7227,7 @@ or tuple of floats
         Z = np.flipud(Z)
 
         if xextent is None:
-            xextent = 0, np.amax(t)
+            xextent = 0, np.max(t)
         xmin, xmax = xextent
         freqs += Fc
         extent = xmin, xmax, freqs[0], freqs[-1]
@@ -7300,7 +7300,7 @@ or tuple of floats
             marker = 's'
         if marker is None and markersize is None:
             Z = np.asarray(Z)
-            mask = np.absolute(Z) > precision
+            mask = np.abs(Z) > precision
 
             if 'cmap' not in kwargs:
                 kwargs['cmap'] = mcolors.ListedColormap(['w', 'k'],
@@ -7316,12 +7316,12 @@ or tuple of floats
                     y = c.row
                     x = c.col
                 else:
-                    nonzero = np.absolute(c.data) > precision
+                    nonzero = np.abs(c.data) > precision
                     y = c.row[nonzero]
                     x = c.col[nonzero]
             else:
                 Z = np.asarray(Z)
-                nonzero = np.absolute(Z) > precision
+                nonzero = np.abs(Z) > precision
                 y, x = np.nonzero(nonzero)
             if marker is None:
                 marker = 's'

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2162,17 +2162,17 @@ or tuple of floats
 
         if adjust_xlim:
             xmin, xmax = self.dataLim.intervalx
-            xmin = np.amin([w for w in width if w > 0])
+            xmin = np.min(w for w in width if w > 0)
             if xerr is not None:
-                xmin = xmin - np.amax(xerr)
+                xmin = xmin - np.max(xerr)
             xmin = max(xmin * 0.9, 1e-100)
             self.dataLim.intervalx = (xmin, xmax)
 
         if adjust_ylim:
             ymin, ymax = self.dataLim.intervaly
-            ymin = np.amin([h for h in height if h > 0])
+            ymin = np.min(h for h in height if h > 0)
             if yerr is not None:
-                ymin = ymin - np.amax(yerr)
+                ymin = ymin - np.max(yerr)
             ymin = max(ymin * 0.9, 1e-100)
             self.dataLim.intervaly = (ymin, ymax)
         self.autoscale_view()

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1346,8 +1346,8 @@ class _AxesBase(martist.Artist):
         xmin, xmax = self.get_xbound()
         ymin, ymax = self.get_ybound()
 
-        xsize = max(math.fabs(xmax - xmin), 1e-30)
-        ysize = max(math.fabs(ymax - ymin), 1e-30)
+        xsize = max(abs(xmax - xmin), 1e-30)
+        ysize = max(abs(ymax - ymin), 1e-30)
 
         return ysize / xsize
 
@@ -1359,8 +1359,8 @@ class _AxesBase(martist.Artist):
         xmin, xmax = self.get_xbound()
         ymin, ymax = self.get_ybound()
 
-        xsize = max(math.fabs(math.log10(xmax) - math.log10(xmin)), 1e-30)
-        ysize = max(math.fabs(math.log10(ymax) - math.log10(ymin)), 1e-30)
+        xsize = max(abs(math.log10(xmax) - math.log10(xmin)), 1e-30)
+        ysize = max(abs(math.log10(ymax) - math.log10(ymin)), 1e-30)
 
         return ysize / xsize
 
@@ -1432,8 +1432,8 @@ class _AxesBase(martist.Artist):
             xmin, xmax = math.log10(xmin), math.log10(xmax)
             ymin, ymax = math.log10(ymin), math.log10(ymax)
 
-        xsize = max(math.fabs(xmax - xmin), 1e-30)
-        ysize = max(math.fabs(ymax - ymin), 1e-30)
+        xsize = max(abs(xmax - xmin), 1e-30)
+        ysize = max(abs(ymax - ymin), 1e-30)
 
         l, b, w, h = position.bounds
         box_aspect = fig_aspect * (h / w)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -263,7 +263,7 @@ class _process_plot_var_args(object):
         """
         prop_keys = self._prop_keys
         if ignore is None:
-            ignore = set([])
+            ignore = set()
         prop_keys = prop_keys - ignore
 
         if any(all(kw.get(k, None) is None for kw in kwargs)
@@ -309,8 +309,8 @@ class _process_plot_var_args(object):
         # *user* explicitly specifies a marker which should be an error.
         # We also want to prevent advancing the cycler if there are no
         # defaults needed after ignoring the given properties.
-        ignores = set(['marker', 'markersize', 'markeredgecolor',
-                       'markerfacecolor', 'markeredgewidth'])
+        ignores = {'marker', 'markersize', 'markeredgecolor',
+                   'markerfacecolor', 'markeredgewidth'}
         # Also ignore anything provided by *kwargs*.
         for k, v in six.iteritems(kwargs):
             if v is not None:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -324,8 +324,8 @@ class Tick(artist.Artist):
             self.label1.set_transform(trans)
             trans = self._get_text2_transform()[0]
             self.label2.set_transform(trans)
-        tick_kw = dict([kv for kv in six.iteritems(kw)
-                        if kv[0] in ['color', 'zorder']])
+        tick_kw = {k: v for k, v in six.iteritems(kw)
+                   if k in ['color', 'zorder']}
         if tick_kw:
             self.tick1line.set(**tick_kw)
             self.tick2line.set(**tick_kw)
@@ -334,7 +334,7 @@ class Tick(artist.Artist):
         label_list = [k for k in six.iteritems(kw)
                       if k[0] in ['labelsize', 'labelcolor', 'labelrotation']]
         if label_list:
-            label_kw = dict([(k[5:], v) for (k, v) in label_list])
+            label_kw = {k[5:]: v for k, v in label_list}
             self.label1.set(**label_kw)
             self.label2.set(**label_kw)
             for k, v in six.iteritems(label_kw):

--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -134,7 +134,6 @@ class RendererGDK(RendererBase):
                                   int(x), int(y), cols, rows,
                                   gdk.RGB_DITHER_NONE, 0, 0)
 
-
     def draw_text(self, gc, x, y, s, prop, angle, ismath=False, mtext=None):
         x, y = int(x), int(y)
 
@@ -158,31 +157,17 @@ class RendererGDK(RendererBase):
 
             self.gdkDrawable.draw_layout(gc.gdkGC, x, y-h-b, layout)
 
-
     def _draw_mathtext(self, gc, x, y, s, prop, angle):
         ox, oy, width, height, descent, font_image, used_characters = \
             self.mathtext_parser.parse(s, self.dpi, prop)
 
-        if angle==90:
+        if angle == 90:
             width, height = height, width
             x -= width
         y -= height
 
         imw = font_image.get_width()
         imh = font_image.get_height()
-        N = imw * imh
-
-        # a numpixels by num fonts array
-        Xall = np.zeros((N,1), np.uint8)
-
-        image_str = font_image.as_str()
-        Xall[:,0] = np.fromstring(image_str, np.uint8)
-
-        # get the max alpha at each pixel
-        Xs = np.amax(Xall,axis=1)
-
-        # convert it to it's proper shape
-        Xs.shape = imh, imw
 
         pixbuf = gtk.gdk.Pixbuf(gtk.gdk.COLORSPACE_RGB, has_alpha=True,
                                 bits_per_sample=8, width=imw, height=imh)
@@ -190,22 +175,16 @@ class RendererGDK(RendererBase):
         array = pixbuf_get_pixels_array(pixbuf)
 
         rgb = gc.get_rgb()
-        array[:,:,0]=int(rgb[0]*255)
-        array[:,:,1]=int(rgb[1]*255)
-        array[:,:,2]=int(rgb[2]*255)
-        array[:,:,3]=Xs
+        array[:,:,0] = int(rgb[0]*255)
+        array[:,:,1] = int(rgb[1]*255)
+        array[:,:,2] = int(rgb[2]*255)
+        array[:,:,3] = (
+            np.fromstring(font_image.as_str(), np.uint8).reshape((imh, imw)))
 
-        try: # new in 2.2
-            # can use None instead of gc.gdkGC, if don't need clipping
-            self.gdkDrawable.draw_pixbuf (gc.gdkGC, pixbuf, 0, 0,
-                                          int(x), int(y), imw, imh,
-                                          gdk.RGB_DITHER_NONE, 0, 0)
-        except AttributeError:
-            # deprecated in 2.2
-            pixbuf.render_to_drawable(self.gdkDrawable, gc.gdkGC, 0, 0,
-                                  int(x), int(y), imw, imh,
-                                  gdk.RGB_DITHER_NONE, 0, 0)
-
+        # can use None instead of gc.gdkGC, if don't need clipping
+        self.gdkDrawable.draw_pixbuf(gc.gdkGC, pixbuf, 0, 0,
+                                     int(x), int(y), imw, imh,
+                                     gdk.RGB_DITHER_NONE, 0, 0)
 
     def _draw_rotated_text(self, gc, x, y, s, prop, angle):
         """
@@ -259,7 +238,6 @@ class RendererGDK(RendererBase):
         gdrawable.draw_image(ggc, imageVert, 0, 0, x, y, h, w)
         self.rotated[key] = imageVert
 
-
     def _get_pango_layout(self, s, prop):
         """
         Create a pango layout instance for Text 's' with properties 'prop'.
@@ -293,7 +271,6 @@ class RendererGDK(RendererBase):
         self.layoutd[key] = layout, inkRect, logicalRect
         return layout, inkRect, logicalRect
 
-
     def flipy(self):
         return True
 
@@ -314,7 +291,6 @@ class RendererGDK(RendererBase):
 
     def new_gc(self):
         return GraphicsContextGDK(renderer=self)
-
 
     def points_to_pixels(self, points):
         return points/72.0 * self.dpi

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -905,12 +905,11 @@ class DialogLineprops(object):
         )
 
     linestyles = [ls for ls in lines.Line2D.lineStyles if ls.strip()]
-    linestyled = dict([ (s,i) for i,s in enumerate(linestyles)])
+    linestyled = {s: i for i, s in enumerate(linestyles)}
 
-
-    markers =  [m for m in markers.MarkerStyle.markers if cbook.is_string_like(m)]
-
-    markerd = dict([(s,i) for i,s in enumerate(markers)])
+    markers =  [m for m in markers.MarkerStyle.markers
+                if cbook.is_string_like(m)]
+    markerd = {s: i for i, s in enumerate(markers)}
 
     def __init__(self, lines):
         import gtk.glade
@@ -918,12 +917,14 @@ class DialogLineprops(object):
         datadir = matplotlib.get_data_path()
         gladefile = os.path.join(datadir, 'lineprops.glade')
         if not os.path.exists(gladefile):
-            raise IOError('Could not find gladefile lineprops.glade in %s'%datadir)
+            raise IOError(
+                'Could not find gladefile lineprops.glade in %s' % datadir)
 
         self._inited = False
         self._updateson = True # suppress updates when setting widgets manually
         self.wtree = gtk.glade.XML(gladefile, 'dialog_lineprops')
-        self.wtree.signal_autoconnect(dict([(s, getattr(self, s)) for s in self.signals]))
+        self.wtree.signal_autoconnect(
+            {s: getattr(self, s) for s in self.signals})
 
         self.dlg = self.wtree.get_widget('dialog_lineprops')
 
@@ -947,7 +948,6 @@ class DialogLineprops(object):
         self._lastcnt = 0
         self._inited = True
 
-
     def show(self):
         'populate the combo box'
         self._updateson = False
@@ -970,7 +970,6 @@ class DialogLineprops(object):
         ind = self.cbox_lineprops.get_active()
         line = self.lines[ind]
         return line
-
 
     def get_active_linestyle(self):
         'get the active lineinestyle'
@@ -1004,8 +1003,6 @@ class DialogLineprops(object):
         line.set_markerfacecolor((r,g,b))
 
         line.figure.canvas.draw()
-
-
 
     def on_combobox_lineprops_changed(self, item):
         'update the widgets from the active line'

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -560,7 +560,8 @@ class PdfFile(object):
             {val[0]: val[1] for val in six.itervalues(self.alphaStates)})
         self.writeHatches()
         self.writeGouraudTriangles()
-        xobjects = dict(x[1:] for x in six.itervalues(self._images))
+        xobjects = {
+            name: ob for image, name, ob in six.itervalues(self._images)}
         for tup in six.itervalues(self.markers):
             xobjects[tup[0]] = tup[1]
         for name, value in six.iteritems(self.multi_byte_charprocs):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -318,8 +318,7 @@ _pdfops = dict(
     grestore=b'Q', textpos=b'Td', selectfont=b'Tf', textmatrix=b'Tm',
     show=b'Tj', showkern=b'TJ', setlinewidth=b'w', clip=b'W', shading=b'sh')
 
-Op = Bunch(**dict([(name, Operator(value))
-                   for name, value in six.iteritems(_pdfops)]))
+Op = Bunch(**{name: Operator(value) for name, value in six.iteritems(_pdfops)})
 
 
 def _paint_path(fill, stroke):
@@ -556,9 +555,9 @@ class PdfFile(object):
         self.endStream()
         # Write out the various deferred objects
         self.writeFonts()
-        self.writeObject(self.alphaStateObject,
-                         dict([(val[0], val[1])
-                               for val in six.itervalues(self.alphaStates)]))
+        self.writeObject(
+            self.alphaStateObject,
+            {val[0]: val[1] for val in six.itervalues(self.alphaStates)})
         self.writeHatches()
         self.writeGouraudTriangles()
         xobjects = dict(x[1:] for x in six.itervalues(self._images))

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -207,8 +207,8 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             # The buffer is created as type uint32 so that entire
             # pixels can be compared in one numpy call, rather than
             # needing to compare each plane separately.
-            buff = np.frombuffer(renderer.buffer_rgba(), dtype=np.uint32)
-            buff.shape = (renderer.height, renderer.width)
+            buff = (np.frombuffer(renderer.buffer_rgba(), dtype=np.uint32)
+                    .reshape((renderer.height, renderer.width)))
 
             # If any pixels have transparency, we need to force a full
             # draw as we cannot overlay new on top of old.
@@ -219,10 +219,9 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 output = buff
             else:
                 self.set_image_mode('diff')
-                last_buffer = np.frombuffer(self._last_renderer.buffer_rgba(),
-                                            dtype=np.uint32)
-                last_buffer.shape = (renderer.height, renderer.width)
-
+                last_buffer = (np.frombuffer(self._last_renderer.buffer_rgba(),
+                                             dtype=np.uint32)
+                               .reshape((renderer.height, renderer.width)))
                 diff = buff != last_buffer
                 output = np.where(diff, buff, 0)
 

--- a/lib/matplotlib/backends/qt_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/formlayout.py
@@ -56,7 +56,7 @@ from matplotlib import colors as mcolors
 from matplotlib.backends.qt_compat import QtGui, QtWidgets, QtCore
 
 
-BLACKLIST = set(["title", "label"])
+BLACKLIST = {"title", "label"}
 
 
 class ColorButton(QtWidgets.QPushButton):

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -658,7 +658,7 @@ class Bunch(object):
 
 def unique(x):
     """Return a list of unique elements of *x*"""
-    return list(six.iterkeys(dict([(val, 1) for val in x])))
+    return list(set(x))
 
 
 def iterable(obj):
@@ -1407,7 +1407,7 @@ def finddir(o, match, case=False):
 
 def reverse_dict(d):
     """reverse the dictionary -- may lose data if values are not unique!"""
-    return dict([(v, k) for k, v in six.iteritems(d)])
+    return {v: k for k, v in six.iteritems(d)}
 
 
 def restrict_dict(d, keys):
@@ -1415,7 +1415,7 @@ def restrict_dict(d, keys):
     Return a dictionary that contains those keys that appear in both
     d and keys, with values from d.
     """
-    return dict([(k, v) for (k, v) in six.iteritems(d) if k in keys])
+    return {k: v for k, v in six.iteritems(d) if k in keys}
 
 
 def report_memory(i=0):  # argument may go away
@@ -2077,7 +2077,7 @@ ls_mapper = dict(_linestyles)
 # The ls_mapper maps short codes for line style to their full name used
 # by backends
 # The reverse mapper is for mapping full names to short ones
-ls_mapper_r = dict([(ls[1], ls[0]) for ls in _linestyles])
+ls_mapper_r = reverse_dict(ls_mapper)
 
 
 def align_iterators(func, *iterables):

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2067,16 +2067,10 @@ def unmasked_index_ranges(mask, compressed=True):
     ic1 = breakpoints
     return np.concatenate((ic0[:, np.newaxis], ic1[:, np.newaxis]), axis=1)
 
-# a dict to cross-map linestyle arguments
-_linestyles = [('-', 'solid'),
-               ('--', 'dashed'),
-               ('-.', 'dashdot'),
-               (':', 'dotted')]
 
-ls_mapper = dict(_linestyles)
-# The ls_mapper maps short codes for line style to their full name used
-# by backends
-# The reverse mapper is for mapping full names to short ones
+# The ls_mapper maps short codes for line style to their full name used by
+# backends; the reverse mapper is for mapping full names to short ones.
+ls_mapper = {'-': 'solid', '--': 'dashed', '-.': 'dashdot', ':': 'dotted'}
 ls_mapper_r = reverse_dict(ls_mapper)
 
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -83,9 +83,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
     (i.e., a call to set_array has been made), at draw time a call to
     scalar mappable will be made to set the face colors.
     """
-    _offsets = np.array([], float)
-    # _offsets must be a Nx2 array!
-    _offsets.shape = (0, 2)
+    _offsets = np.zeros((0, 2))
     _transOffset = transforms.IdentityTransform()
     #: Either a list of 3x3 arrays or an Nx3x3 array of transforms, suitable
     #: for the `all_transforms` argument to
@@ -147,8 +145,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._uniform_offsets = None
         self._offsets = np.array([[0, 0]], float)
         if offsets is not None:
-            offsets = np.asanyarray(offsets)
-            offsets.shape = (-1, 2)             # Make it Nx2
+            offsets = np.asanyarray(offsets).reshape((-1, 2))
             if transOffset is not None:
                 self._offsets = offsets
                 self._transOffset = transOffset
@@ -213,11 +210,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
             offsets = transOffset.transform_non_affine(offsets)
             transOffset = transOffset.get_affine()
 
-        offsets = np.asanyarray(offsets, float)
+        offsets = np.asanyarray(offsets, float).reshape((-1, 2))
         if isinstance(offsets, np.ma.MaskedArray):
             offsets = offsets.filled(np.nan)
             # get_path_collection_extents handles nan but not masked arrays
-        offsets.shape = (-1, 2)                     # Make it Nx2
 
         if len(paths) and len(offsets):
             result = mpath.get_path_collection_extents(
@@ -255,8 +251,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 ys = self.convert_yunits(offsets[:, 1])
                 offsets = list(zip(xs, ys))
 
-        offsets = np.asanyarray(offsets, float)
-        offsets.shape = (-1, 2)             # Make it Nx2
+        offsets = np.asanyarray(offsets, float).reshape((-1, 2))
 
         if not transform.is_affine:
             paths = [transform.transform_path_non_affine(path)
@@ -436,8 +431,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         ACCEPTS: float or sequence of floats
         """
-        offsets = np.asanyarray(offsets, float)
-        offsets.shape = (-1, 2)             # Make it Nx2
+        offsets = np.asanyarray(offsets, float).reshape((-1, 2))
         #This decision is based on how they are initialized above
         if self._uniform_offsets is None:
             self._offsets = offsets
@@ -1889,8 +1883,7 @@ class QuadMesh(Collection):
                 ys = self.convert_yunits(self._offsets[:, 1])
                 offsets = list(zip(xs, ys))
 
-        offsets = np.asarray(offsets, float)
-        offsets.shape = (-1, 2)                 # Make it Nx2
+        offsets = np.asarray(offsets, float).reshape((-1, 2))
 
         self.update_scalarmappable()
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1330,15 +1330,14 @@ def rgb_to_hsv(arr):
     # check length of the last dimension, should be _some_ sort of rgb
     if arr.shape[-1] != 3:
         raise ValueError("Last dimension of input array must be 3; "
-                         "shape {shp} was found.".format(shp=arr.shape))
+                         "shape {} was found.".format(arr.shape))
 
     in_ndim = arr.ndim
     if arr.ndim == 1:
         arr = np.array(arr, ndmin=2)
 
     # make sure we don't have an int image
-    if arr.dtype.kind in ('iu'):
-        arr = arr.astype(np.float32)
+    arr = arr.astype(np.promote_types(arr.dtype, np.float32))
 
     out = np.zeros_like(arr)
     arr_max = arr.max(-1)
@@ -1396,8 +1395,7 @@ def hsv_to_rgb(hsv):
         hsv = np.array(hsv, ndmin=2)
 
     # make sure we don't have an int image
-    if hsv.dtype.kind in ('iu'):
-        hsv = hsv.astype(np.float32)
+    hsv = hsv.astype(np.promote_types(hsv.dtype, np.float32))
 
     h = hsv[..., 0]
     s = hsv[..., 1]
@@ -1448,13 +1446,11 @@ def hsv_to_rgb(hsv):
     g[idx] = v[idx]
     b[idx] = v[idx]
 
-    rgb = np.empty_like(hsv)
-    rgb[..., 0] = r
-    rgb[..., 1] = g
-    rgb[..., 2] = b
+    # `np.stack([r, g, b], axis=-1)` (numpy 1.10).
+    rgb = np.concatenate([r[..., None], g[..., None], b[..., None]], -1)
 
     if in_ndim == 1:
-        rgb.shape = (3, )
+        rgb.shape = (3,)
 
     return rgb
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -226,20 +226,8 @@ class ContourLabeler(object):
 
     def print_label(self, linecontour, labelwidth):
         "Return *False* if contours are too short for a label."
-        lcsize = len(linecontour)
-        if lcsize > 10 * labelwidth:
-            return True
-
-        xmax = np.amax(linecontour[:, 0])
-        xmin = np.amin(linecontour[:, 0])
-        ymax = np.amax(linecontour[:, 1])
-        ymin = np.amin(linecontour[:, 1])
-
-        lw = labelwidth
-        if (xmax - xmin) > 1.2 * lw or (ymax - ymin) > 1.2 * lw:
-            return True
-        else:
-            return False
+        return (len(linecontour) > 10 * labelwidth
+                or (np.ptp(linecontour, axis=0) > 1.2 * labelwidth).any())
 
     def too_close(self, x, y, lw):
         "Return *True* if a label is already near this location."
@@ -1056,8 +1044,8 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         self.levels = args[0]
         self.allsegs = args[1]
         self.allkinds = len(args) > 2 and args[2] or None
-        self.zmax = np.amax(self.levels)
-        self.zmin = np.amin(self.levels)
+        self.zmax = np.max(self.levels)
+        self.zmin = np.min(self.levels)
         self._auto = False
 
         # Check lengths of levels and allsegs.
@@ -1180,7 +1168,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         if self.filled and len(self.levels) < 2:
             raise ValueError("Filled contours require at least 2 levels.")
 
-        if len(self.levels) > 1 and np.amin(np.diff(self.levels)) <= 0.0:
+        if len(self.levels) > 1 and np.min(np.diff(self.levels)) <= 0.0:
             if hasattr(self, '_corner_mask') and self._corner_mask == 'legacy':
                 warnings.warn("Contour levels are not increasing")
             else:
@@ -1210,8 +1198,8 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         with line contours.
         """
         # following are deprecated and will be removed in 2.2
-        self._vmin = np.amin(self.levels)
-        self._vmax = np.amax(self.levels)
+        self._vmin = np.min(self.levels)
+        self._vmax = np.max(self.levels)
 
         # Make a private _levels to include extended regions; we
         # want to leave the original levels attribute unchanged.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -95,7 +95,7 @@ class AxesStack(Stack):
         return item[1]
 
     def _entry_from_axes(self, e):
-        ind, k = dict([(a, (ind, k)) for (k, (ind, a)) in self._elements])[e]
+        ind, k = {a: (ind, k) for k, (ind, a) in self._elements}[e]
         return (k, (ind, e))
 
     def remove(self, a):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -108,14 +108,14 @@ weight_dict = {
     'extra bold' : 800,
     'black'      : 900}
 
-font_family_aliases = set([
-        'serif',
-        'sans-serif',
-        'sans serif',
-        'cursive',
-        'fantasy',
-        'monospace',
-        'sans'])
+font_family_aliases = {
+    'serif',
+    'sans-serif',
+    'sans serif',
+    'cursive',
+    'fantasy',
+    'monospace',
+    'sans'}
 
 #  OS Font paths
 MSFolders = \

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -255,8 +255,6 @@ class GridSpec(GridSpecBase):
                         ax.update_params()
                         ax.set_position(ax.figbox)
 
-
-
     def get_subplot_params(self, fig=None):
         """
         return a dictionary of subplot layout parameters. The default
@@ -265,13 +263,12 @@ class GridSpec(GridSpecBase):
         from matplotlib.figure import SubplotParams
         import copy
         if fig is None:
-            kw = dict([(k, rcParams["figure.subplot."+k]) \
-                       for k in self._AllowedKeys])
+            kw = {k: rcParams["figure.subplot."+k] for k in self._AllowedKeys}
             subplotpars = SubplotParams(**kw)
         else:
             subplotpars = copy.copy(fig.subplotpars)
 
-        update_kw = dict([(k, getattr(self, k)) for k in self._AllowedKeys])
+        update_kw = {k: getattr(self, k) for k in self._AllowedKeys}
         subplotpars.update(**update_kw)
 
         return subplotpars
@@ -427,7 +424,6 @@ class SubplotSpec(object):
 
         figBottoms, figTops, figLefts, figRights = \
                     gridspec.get_grid_positions(fig)
-
 
         rowNum, colNum =  divmod(self.num1, ncols)
         figBottom = figBottoms[rowNum]

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -186,7 +186,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
     # backward compatibility just in case.
     _interpd = _interpd_
     # reverse interp dict
-    _interpdr = dict([(v, k) for k, v in six.iteritems(_interpd_)])
+    _interpdr = {v: k for k, v in six.iteritems(_interpd_)}
     iterpnames = interpolations_names
     # <end unused keys>
 

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -551,7 +551,7 @@ class HandlerStem(HandlerNpointsYoffsets):
         for lm, m in zip(leg_stemlines, stemlines):
             self.update_prop(lm, m, legend)
 
-        leg_baseline = Line2D([np.amin(xdata), np.amax(xdata)],
+        leg_baseline = Line2D([np.min(xdata), np.max(xdata)],
                               [bottom, bottom])
 
         self.update_prop(leg_baseline, baseline, legend)

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -3183,8 +3183,8 @@ class Parser(object):
     def _auto_sized_delimiter(self, front, middle, back):
         state = self.get_state()
         if len(middle):
-            height = max([x.height for x in middle])
-            depth = max([x.depth for x in middle])
+            height = max(x.height for x in middle)
+            depth = max(x.depth for x in middle)
             factor = None
         else:
             height = 0

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -2410,7 +2410,7 @@ class Parser(object):
         p.ambi_delim    <<= oneOf(list(self._ambi_delim))
         p.left_delim    <<= oneOf(list(self._left_delim))
         p.right_delim   <<= oneOf(list(self._right_delim))
-        p.right_delim_safe <<= oneOf(list(self._right_delim - set(['}'])) + [r'\}'])
+        p.right_delim_safe <<= oneOf(list(self._right_delim - {'}'}) + [r'\}'])
 
         p.genfrac       <<= Group(
                              Suppress(Literal(r"\genfrac"))

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -723,11 +723,11 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
         resultY = apply_window(resultY, window, axis=0)
         resultY = detrend(resultY, detrend_func, axis=0)
         resultY = np.fft.fft(resultY, n=pad_to, axis=0)[:numFreqs, :]
-        result = np.conjugate(result) * resultY
+        result = np.conj(result) * resultY
     elif mode == 'psd':
-        result = np.conjugate(result) * result
+        result = np.conj(result) * result
     elif mode == 'magnitude':
-        result = np.absolute(result)
+        result = np.abs(result)
     elif mode == 'angle' or mode == 'phase':
         # we unwrap the phase later to handle the onesided vs. twosided case
         result = np.angle(result)
@@ -1470,7 +1470,7 @@ def cohere_pairs(X, ij, NFFT=256, Fs=2, detrend=detrend_none,
 
         FFTSlices[iCol] = Slices
         if preferSpeedOverMemory:
-            FFTConjSlices[iCol] = np.conjugate(Slices)
+            FFTConjSlices[iCol] = np.conj(Slices)
         Pxx[iCol] = np.divide(np.mean(abs(Slices)**2, axis=0), normVal)
     del Slices, ind, windowVals
 
@@ -1488,7 +1488,7 @@ def cohere_pairs(X, ij, NFFT=256, Fs=2, detrend=detrend_none,
         if preferSpeedOverMemory:
             Pxy = FFTSlices[i] * FFTConjSlices[j]
         else:
-            Pxy = FFTSlices[i] * np.conjugate(FFTSlices[j])
+            Pxy = FFTSlices[i] * np.conj(FFTSlices[j])
         if numSlices > 1:
             Pxy = np.mean(Pxy, axis=0)
 #       Pxy = np.divide(Pxy, normVal)
@@ -2080,7 +2080,7 @@ def rms_flat(a):
     """
     Return the root mean square of all the elements of *a*, flattened out.
     """
-    return np.sqrt(np.mean(np.absolute(a)**2))
+    return np.sqrt(np.mean(np.abs(a) ** 2))
 
 
 def l1norm(a):
@@ -2089,7 +2089,7 @@ def l1norm(a):
 
     Implemented as a separate function (not a call to :func:`norm` for speed).
     """
-    return np.sum(np.absolute(a))
+    return np.sum(np.abs(a))
 
 
 def l2norm(a):
@@ -2098,7 +2098,7 @@ def l2norm(a):
 
     Implemented as a separate function (not a call to :func:`norm` for speed).
     """
-    return np.sqrt(np.sum(np.absolute(a)**2))
+    return np.sqrt(np.sum(np.abs(a) ** 2))
 
 
 def norm_flat(a, p=2):
@@ -2113,9 +2113,9 @@ def norm_flat(a, p=2):
     # This function was being masked by a more general norm later in
     # the file.  We may want to simply delete it.
     if p == 'Infinity':
-        return np.amax(np.absolute(a))
+        return np.max(np.abs(a))
     else:
-        return (np.sum(np.absolute(a)**p))**(1.0/p)
+        return np.sum(np.abs(a) ** p) ** (1 / p)
 
 
 def frange(xini, xfin=None, delta=None, **kw):

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2495,8 +2495,8 @@ def rec_join(key, r1, r2, jointype='inner', defaults=None, r1postfix='1',
     def makekey(row):
         return tuple([row[name] for name in key])
 
-    r1d = dict([(makekey(row), i) for i, row in enumerate(r1)])
-    r2d = dict([(makekey(row), i) for i, row in enumerate(r2)])
+    r1d = {makekey(row): i for i, row in enumerate(r1)}
+    r2d = {makekey(row): i for i, row in enumerate(r2)}
 
     r1keys = set(r1d.keys())
     r2keys = set(r2d.keys())

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1339,9 +1339,7 @@ def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
                  scale_by_freq)
     Pxy, f = csd(x, y, NFFT, Fs, detrend, window, noverlap, pad_to, sides,
                  scale_by_freq)
-
-    Cxy = np.divide(np.absolute(Pxy)**2, Pxx*Pyy)
-    Cxy.shape = (len(f),)
+    Cxy = np.abs(Pxy) ** 2 / (Pxx * Pxy)
     return Cxy, f
 
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -119,11 +119,11 @@ def _get_aligned_offsets(hd_list, height, align="baseline"):
     """
 
     if height is None:
-        height = max([h for h, d in hd_list])
+        height = max(h for h, d in hd_list)
 
     if align == "baseline":
-        height_descent = max([h - d for h, d in hd_list])
-        descent = max([d for h, d in hd_list])
+        height_descent = max(h - d for h, d in hd_list)
+        descent = max(d for h, d in hd_list)
         height = height_descent + descent
         offsets = [0. for h, d in hd_list]
     elif align in ["left", "top"]:
@@ -465,8 +465,8 @@ class HPacker(PackerBase):
             return 2 * pad, 2 * pad, pad, pad, []
 
         if self.height is None:
-            height_descent = max([h - yd for w, h, xd, yd in whd_list])
-            ydescent = max([yd for w, h, xd, yd in whd_list])
+            height_descent = max(h - yd for w, h, xd, yd in whd_list)
+            ydescent = max(yd for w, h, xd, yd in whd_list)
             height = height_descent + ydescent
         else:
             height = self.height - 2 * pad  # width w/o pad

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1867,7 +1867,7 @@ class _Style(object):
 
         try:
             _args_pair = [cs.split("=") for cs in _list[1:]]
-            _args = dict([(k, float(v)) for k, v in _args_pair])
+            _args = {k: float(v) for k, v in _args_pair}
         except ValueError:
             raise ValueError("Incorrect style argument : %s" % stylename)
         _args.update(kw)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1773,7 +1773,7 @@ def _pprint_table(_table, leadingspace=2):
         for column, cell in zip(columns, row):
             column.append(cell)
 
-    col_len = [max([len(cell) for cell in column]) for column in columns]
+    col_len = [max(len(cell) for cell in column) for column in columns]
 
     lines = []
     table_formatstr = pad + '   '.join([('=' * cl) for cl in col_len])
@@ -2050,8 +2050,8 @@ class BoxStyle(_Style):
 
             # boundary of the padded box
             x0, y0 = x0 - pad, y0 - pad,
-            return Path.circle((x0 + width/2., y0 + height/2.),
-                               (max([width, height]) / 2.))
+            return Path.circle((x0 + width / 2, y0 + height / 2),
+                               max(width, height) / 2)
 
     _style_list["circle"] = Circle
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1797,9 +1797,9 @@ def get_plot_commands():
 
     import inspect
 
-    exclude = set(['colormaps', 'colors', 'connect', 'disconnect',
-                   'get_plot_commands', 'get_current_fig_manager',
-                   'ginput', 'plotting', 'waitforbuttonpress'])
+    exclude = {'colormaps', 'colors', 'connect', 'disconnect',
+               'get_plot_commands', 'get_current_fig_manager', 'ginput',
+               'plotting', 'waitforbuttonpress'}
     exclude |= set(colormaps())
     this_module = inspect.getmodule(get_plot_commands)
 

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -656,11 +656,8 @@ class Quiver(mcollections.PolyCollection):
         elif str_angles and (self.angles == 'uv'):
             theta = np.angle(uv)
         else:
-            # Make a copy to avoid changing the input array.
-            theta = ma.masked_invalid(self.angles, copy=True).filled(0)
-            theta = theta.ravel()
-            theta *= (np.pi / 180.0)
-        theta.shape = (theta.shape[0], 1)  # for broadcasting
+            theta = ma.masked_invalid(np.deg2rad(self.angles)).filled(0)
+            theta = theta.reshape((-1, 1))  # for broadcasting
         xy = (X + Y * 1j) * np.exp(1j * theta) * self.width
         xy = xy[:, :, np.newaxis]
         XY = np.concatenate((xy.real, xy.imag), axis=2)

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -607,7 +607,7 @@ class Quiver(mcollections.PolyCollection):
         xyp = self.ax.transData.transform(self.XY + eps * uv)
         dxy = xyp - xy
         angles = np.arctan2(dxy[:, 1], dxy[:, 0])
-        lengths = np.absolute(dxy[:, 0] + dxy[:, 1] * 1j) / eps
+        lengths = np.hypot(*dxy.T) / eps
         return angles, lengths
 
     def _make_verts(self, U, V):
@@ -627,7 +627,7 @@ class Quiver(mcollections.PolyCollection):
         if self.scale_units == 'xy':
             a = lengths
         else:
-            a = np.absolute(uv)
+            a = np.abs(uv)
         if self.scale is None:
             sn = max(10, math.sqrt(self.N))
             if self.Umask is not ma.nomask:

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -657,7 +657,7 @@ class Quiver(mcollections.PolyCollection):
             theta = np.angle(uv)
         else:
             theta = ma.masked_invalid(np.deg2rad(self.angles)).filled(0)
-            theta = theta.reshape((-1, 1))  # for broadcasting
+        theta = theta.reshape((-1, 1))  # for broadcasting
         xy = (X + Y * 1j) * np.exp(1j * theta) * self.width
         xy = xy[:, :, np.newaxis]
         XY = np.concatenate((xy.real, xy.imag), axis=2)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -62,7 +62,7 @@ class ValidateInStrings(object):
                 return s.lower()
             else:
                 return s
-        self.valid = dict([(func(k), k) for k in valid])
+        self.valid = {func(k): k for k in valid}
 
     def __call__(self, s):
         if self.ignorecase:
@@ -683,9 +683,7 @@ def validate_hatch(s):
     """
     if not isinstance(s, six.string_types):
         raise ValueError("Hatch pattern must be a string")
-    unique_chars = set(s)
-    unknown = (unique_chars -
-                set(['\\', '/', '|', '-', '+', '*', '.', 'x', 'o', 'O']))
+    unknown = set(s) - {'\\', '/', '|', '-', '+', '*', '.', 'x', 'o', 'O'}
     if unknown:
         raise ValueError("Unknown hatch symbol(s): %s" % list(unknown))
     return s

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -494,7 +494,7 @@ class Sankey(object):
             raise ValueError(
             "trunklength is negative.\nThis isn't allowed, because it would "
             "cause poor layout.")
-        if np.absolute(np.sum(flows)) > self.tolerance:
+        if np.abs(np.sum(flows)) > self.tolerance:
             verbose.report(
                 "The sum of the flows is nonzero (%f).\nIs the "
                 "system not at steady state?" % np.sum(flows), 'helpful')

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -36,11 +36,11 @@ STYLE_FILE_PATTERN = re.compile('([\S]+).%s$' % STYLE_EXTENSION)
 
 
 # A list of rcParams that should not be applied from styles
-STYLE_BLACKLIST = set([
+STYLE_BLACKLIST = {
     'interactive', 'backend', 'backend.qt4', 'webagg.port',
     'webagg.port_retries', 'webagg.open_in_browser', 'backend_fallback',
     'toolbar', 'timezone', 'datapath', 'figure.max_open_warning',
-    'savefig.directory', 'tk.window_focus', 'docstring.hardcopy'])
+    'savefig.directory', 'tk.window_focus', 'docstring.hardcopy'}
 
 
 def _remove_blacklisted_style_params(d, warn=True):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -386,11 +386,8 @@ def test_shaped_data():
                       [0.01383268,  0.34060930,  0.76084285,  0.70800694,  0.87634056,
                        0.08213693,  0.54655021,  0.98123181,  0.44080053,  0.86815815]])
 
-    y1 = np.arange(10)
-    y1.shape = 1, 10
-
-    y2 = np.arange(10)
-    y2.shape = 10, 1
+    y1 = np.arange(10).reshape((1, -1))
+    y2 = np.arange(10).reshape((-1, 1))
 
     fig = plt.figure()
     plt.subplot(411)
@@ -551,8 +548,7 @@ def test_hexbin_extent():
     fig = plt.figure()
 
     ax = fig.add_subplot(111)
-    data = np.arange(2000.)/2000.
-    data.shape = 2, 1000
+    data = (np.arange(2000) / 2000).reshape((2, 1000))
     x, y = data
 
     ax.hexbin(x, y, extent=[.1, .3, .6, .7])
@@ -583,8 +579,7 @@ def test_hexbin_pickable():
     fig = plt.figure()
 
     ax = fig.add_subplot(111)
-    data = np.arange(200.)/200.
-    data.shape = 2, 100
+    data = (np.arange(200) / 200).reshape((2, 100))
     x, y = data
     hb = ax.hexbin(x, y, extent=[.1, .3, .6, .7], picker=-1)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -805,11 +805,11 @@ def test_pcolormesh():
     Qx = np.cos(Y) - np.cos(X)
     Qz = np.sin(Y) + np.sin(X)
     Qx = (Qx + 1.1)
-    Z = np.sqrt(X**2 + Y**2)/5
-    Z = (Z - Z.min()) / (Z.max() - Z.min())
+    Z = np.hypot(X, Y) / 5
+    Z = (Z - Z.min()) / Z.ptp()
 
     # The color array can include masked values:
-    Zm = ma.masked_where(np.fabs(Qz) < 0.5*np.amax(Qz), Z)
+    Zm = ma.masked_where(np.abs(Qz) < 0.5 * np.max(Qz), Z)
 
     fig = plt.figure()
     ax = fig.add_subplot(131)

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -63,7 +63,7 @@ def test_restrict_dict():
     assert d3 == {'foo': 'bar'}
     d4 = cbook.restrict_dict(d, {})
     assert d4 == {}
-    d5 = cbook.restrict_dict(d, set(['foo', 2]))
+    d5 = cbook.restrict_dict(d, {'foo', 2})
     assert d5 == {'foo': 'bar'}
     # check that d was not modified
     assert d == {'foo': 'bar', 1: 2}

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -21,10 +21,8 @@ from matplotlib.cbook import delete_masked_points as dmp
 def test_is_string_like():
     y = np.arange(10)
     assert not cbook.is_string_like(y)
-    y.shape = 10, 1
-    assert not cbook.is_string_like(y)
-    y.shape = 1, 10
-    assert not cbook.is_string_like(y)
+    assert not cbook.is_string_like(y.reshape((-1, 1)))
+    assert not cbook.is_string_like(y.reshape((1, -1)))
 
     assert cbook.is_string_like("hello world")
     assert not cbook.is_string_like(10)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -340,7 +340,7 @@ def test_LogFormatterSciNotation():
 
     for base in test_cases.keys():
         formatter = mticker.LogFormatterSciNotation(base=base)
-        formatter.sublabel = set([1, 2, 5, 1.2])
+        formatter.sublabel = {1, 2, 5, 1.2}
         for value, expected in test_cases[base]:
             with matplotlib.rc_context({'text.usetex': False}):
                 assert formatter(value) == expected

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -234,7 +234,7 @@ Could not rename old TeX cache dir "%s": a suitable configuration
     def get_font_config(self):
         """Reinitializes self if relevant rcParams on have changed."""
         if self._rc_cache is None:
-            self._rc_cache = dict([(k, None) for k in self._rc_cache_keys])
+            self._rc_cache = dict.fromkeys(self._rc_cache_keys)
         changed = [par for par in self._rc_cache_keys
                    if rcParams[par] != self._rc_cache[par]]
         if changed:

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -49,7 +49,7 @@ class TextToPath(object):
     def _get_adobe_standard_encoding(self):
         enc_name = dviread.find_tex_file('8a.enc')
         enc = dviread.Encoding(enc_name)
-        return dict([(c, i) for i, c in enumerate(enc.encoding)])
+        return {c: i for i, c in enumerate(enc.encoding)}
 
     def _get_font(self, prop):
         """
@@ -354,10 +354,10 @@ class TextToPath(object):
 
                 if charmap_name == "ADOBE_STANDARD" and font_bunch.encoding:
                     enc0 = dviread.Encoding(font_bunch.encoding)
-                    enc = dict([(i, self._adobe_standard_encoding.get(c, None))
-                                for i, c in enumerate(enc0.encoding)])
+                    enc = {i: self._adobe_standard_encoding.get(c, None)
+                           for i, c in enumerate(enc0.encoding)}
                 else:
-                    enc = dict()
+                    enc = {}
                 self._ps_fontd[dvifont.texname] = font, enc
 
             else:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1623,11 +1623,9 @@ class LinearLocator(Locator):
             vmax += 1
 
         if rcParams['axes.autolimit_mode'] == 'round_numbers':
-            exponent, remainder = _divmod(math.log10(vmax - vmin),
-                                         math.log10(max([self.numticks-1, 1])))
-            if remainder < 0.5:
-                exponent -= 1
-            scale = max([self.numticks-1, 1]) ** (-exponent)
+            exponent = round(math.log10(vmax - vmin)
+                             / math.log10(max(self.numticks - 1, 1))) - 1
+            scale = max(self.numticks - 1, 1) ** (-exponent)
             vmin = math.floor(scale * vmin) / scale
             vmax = math.ceil(scale * vmax) / scale
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -732,7 +732,7 @@ class ScalarFormatter(Formatter):
         if not self._scientific:
             self.orderOfMagnitude = 0
             return
-        locs = np.absolute(self.locs)
+        locs = np.abs(self.locs)
         if self.offset:
             oom = math.floor(math.log10(range))
         else:
@@ -788,7 +788,7 @@ class ScalarFormatter(Formatter):
 
     def pprint_val(self, x):
         xp = (x - self.offset) / (10. ** self.orderOfMagnitude)
-        if np.absolute(xp) < 1e-8:
+        if np.abs(xp) < 1e-8:
             xp = 0
         if self._useLocale:
             return locale.format_string(self.format, (xp,))
@@ -1535,7 +1535,7 @@ class FixedLocator(Locator):
         ticks = self.locs[::step]
         for i in range(1, step):
             ticks1 = self.locs[i::step]
-            if np.absolute(ticks1).min() < np.absolute(ticks).min():
+            if np.abs(ticks1).min() < np.abs(ticks).min():
                 ticks = ticks1
         return self.raise_if_exceeds(ticks)
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1623,8 +1623,9 @@ class LinearLocator(Locator):
             vmax += 1
 
         if rcParams['axes.autolimit_mode'] == 'round_numbers':
-            exponent = round(math.log10(vmax - vmin)
-                             / math.log10(max(self.numticks - 1, 1))) - 1
+            exponent, remainder = _divmod(
+                math.log10(vmax - vmin), math.log10(max(self.numticks - 1, 1)))
+            exponent -= (remainder < .5)
             scale = max(self.numticks - 1, 1) ** (-exponent)
             vmin = math.floor(scale * vmin) / scale
             vmax = math.ceil(scale * vmax) / scale

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -952,7 +952,7 @@ class LogFormatter(Formatter):
 
         if numdec > self.minor_thresholds[0]:
             # Label only bases
-            self._sublabels = set((1,))
+            self._sublabels = {1}
         elif numdec > self.minor_thresholds[1]:
             # Add labels between bases at log-spaced coefficients;
             # include base powers in case the locations include

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -188,22 +188,18 @@ def auto_adjust_subplotpars(fig, renderer,
                   top=1 - margin_top)
 
     if cols > 1:
-        hspace = max([sum(s)
-                      for i in range(rows)
-                      for s
-                      in hspaces[i * (cols + 1) + 1:(i + 1) * (cols + 1) - 1]])
-        hspace += hpad_inches / fig_width_inch
-        h_axes = ((1 - margin_right - margin_left) -
-                  hspace * (cols - 1)) / cols
-
+        hspace = (
+            max(sum(s)
+                for i in range(rows)
+                for s in hspaces[i * (cols + 1) + 1:(i + 1) * (cols + 1) - 1])
+            + hpad_inches / fig_width_inch)
+        h_axes = (1 - margin_right - margin_left - hspace * (cols - 1)) / cols
         kwargs["wspace"] = hspace / h_axes
 
     if rows > 1:
-        vspace = max([sum(s) for s in vspaces[cols:-cols]])
-        vspace += vpad_inches / fig_height_inch
-        v_axes = ((1 - margin_top - margin_bottom) -
-                  vspace * (rows - 1)) / rows
-
+        vspace = (max(sum(s) for s in vspaces[cols:-cols])
+                  + vpad_inches / fig_height_inch)
+        v_axes = (1 - margin_top - margin_bottom - vspace * (rows - 1)) / rows
         kwargs["hspace"] = vspace / v_axes
 
     return kwargs

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -761,10 +761,10 @@ class BboxBase(TransformNode):
                           bbox2.ymax < bbox1.ymin)
 
         if intersects:
-            x0 = max([bbox1.xmin, bbox2.xmin])
-            x1 = min([bbox1.xmax, bbox2.xmax])
-            y0 = max([bbox1.ymin, bbox2.ymin])
-            y1 = min([bbox1.ymax, bbox2.ymax])
+            x0 = max(bbox1.xmin, bbox2.xmin)
+            x1 = min(bbox1.xmax, bbox2.xmax)
+            y0 = max(bbox1.ymin, bbox2.ymin)
+            y1 = min(bbox1.ymax, bbox2.ymax)
             return Bbox.from_extents(x0, y0, x1, y1)
 
         return None
@@ -2115,7 +2115,7 @@ class BlendedGenericTransform(Transform):
 
     @property
     def depth(self):
-        return max([self._x.depth, self._y.depth])
+        return max(self._x.depth, self._y.depth)
 
     def contains_branch(self, other):
         # a blended transform cannot possibly contain a branch from two different transforms.

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1826,13 +1826,6 @@ class Affine2D(Affine2DBase):
     def __repr__(self):
         return "Affine2D(%s)" % repr(self._mtx)
 
-#    def __cmp__(self, other):
-#        # XXX redundant. this only tells us eq.
-#        if (isinstance(other, Affine2D) and
-#            (self.get_matrix() == other.get_matrix()).all()):
-#            return 0
-#        return -1
-
     @staticmethod
     def from_values(a, b, c, d, e, f):
         """

--- a/lib/matplotlib/tri/trifinder.py
+++ b/lib/matplotlib/tri/trifinder.py
@@ -61,8 +61,8 @@ class TrapezoidMapTriFinder(TriFinder):
             raise ValueError("x and y must be array-like with the same shape")
 
         # C++ does the heavy lifting, and expects 1D arrays.
-        indices = self._cpp_trifinder.find_many(x.ravel(), y.ravel())
-        indices.shape = x.shape
+        indices = (self._cpp_trifinder.find_many(x.ravel(), y.ravel())
+                   .reshape(x.shape))
         return indices
 
     def _get_tree_stats(self):

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -26,8 +26,8 @@ is_string_like = cbook.is_string_like
 class ParasiteAxesBase(object):
 
     def get_images_artists(self):
-        artists = set([a for a in self.get_children() if a.get_visible()])
-        images = set([a for a in self.images if a.get_visible()])
+        artists = {a for a in self.get_children() if a.get_visible()}
+        images = {a for a in self.images if a.get_visible()}
 
         return list(images), list(artists - images)
 

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -714,37 +714,37 @@ class TickLabels(AxisLabel, AttributeCopier): # mtext.Text
         va, ha = self.get_va(), self.get_ha()
 
         if label_direction == "left":
-            pad = max([w for (w, h, d) in whd_list])
+            pad = max(w for w, h, d in whd_list)
             if ha == "left":
                 r = pad
             elif ha == "center":
                 r = .5 * pad
         elif label_direction == "right":
-            pad = max([w for (w, h, d) in whd_list])
+            pad = max(w for w, h, d in whd_list)
             if ha == "right":
                 r = pad
             elif ha == "center":
                 r = .5 * pad
         elif label_direction == "bottom":
-            pad = max([h for (w, h, d) in whd_list])
+            pad = max(h for w, h, d in whd_list)
             if va == "bottom":
                 r = pad
             elif va == "center":
                 r =.5 * pad
             elif va == "baseline":
-                max_ascent = max([(h-d) for (w, h, d) in whd_list])
-                max_descent = max([d for (w, h, d) in whd_list])
+                max_ascent = max(h - d for w, h, d in whd_list)
+                max_descent = max(d for w, h, d in whd_list)
                 r  = max_ascent
                 pad = max_ascent + max_descent
         elif label_direction == "top":
-            pad = max([h for (w, h, d) in whd_list])
+            pad = max(h for w, h, d in whd_list)
             if va == "top":
                 r = pad
             elif va == "center":
                 r =.5 * pad
             elif va == "baseline":
-                max_ascent = max([(h-d) for (w, h, d) in whd_list])
-                max_descent = max([d for (w, h, d) in whd_list])
+                max_ascent = max(h - d for w, h, d in whd_list)
+                max_descent = max(d for w, h, d in whd_list)
                 r  = max_descent
                 pad = max_ascent + max_descent
 
@@ -1432,7 +1432,7 @@ class AxisArtist(martist.Artist):
 
         #print self._ticklabel_add_angle - self._axislabel_add_angle
         #if abs(self._ticklabel_add_angle - self._axislabel_add_angle)%360 > 90:
-        if self._ticklabel_add_angle !=  self._axislabel_add_angle:
+        if self._ticklabel_add_angle != self._axislabel_add_angle:
             if (self.major_ticks.get_visible() and not self.major_ticks.get_tick_out()) \
                or \
                (self.minor_ticks.get_visible() and not self.major_ticks.get_tick_out()):
@@ -1440,8 +1440,8 @@ class AxisArtist(martist.Artist):
             else:
                 axislabel_pad = 0
         else:
-            axislabel_pad = max([self.major_ticklabels._axislabel_pad,
-                                 self.minor_ticklabels._axislabel_pad])
+            axislabel_pad = max(self.major_ticklabels._axislabel_pad,
+                                self.minor_ticklabels._axislabel_pad)
 
 
         #label_offset =  axislabel_pad + self.LABELPAD
@@ -1477,7 +1477,7 @@ class AxisArtist(martist.Artist):
 
         #print self._ticklabel_add_angle - self._axislabel_add_angle
         #if abs(self._ticklabel_add_angle - self._axislabel_add_angle)%360 > 90:
-        if self._ticklabel_add_angle !=  self._axislabel_add_angle:
+        if self._ticklabel_add_angle != self._axislabel_add_angle:
             if (self.major_ticks.get_visible() and not self.major_ticks.get_tick_out()) \
                or \
                (self.minor_ticks.get_visible() and not self.major_ticks.get_tick_out()):
@@ -1485,9 +1485,8 @@ class AxisArtist(martist.Artist):
             else:
                 axislabel_pad = 0
         else:
-            axislabel_pad = max([self.major_ticklabels._axislabel_pad,
-                                 self.minor_ticklabels._axislabel_pad])
-
+            axislabel_pad = max(self.major_ticklabels._axislabel_pad,
+                                self.minor_ticklabels._axislabel_pad)
 
         #label_offset =  axislabel_pad + self.LABELPAD
 
@@ -1497,8 +1496,7 @@ class AxisArtist(martist.Artist):
         xy, angle_tangent = self._axis_artist_helper.get_axislabel_pos_angle(self.axes)
         if xy is None: return
 
-        angle_label = angle_tangent  - 90
-
+        angle_label = angle_tangent - 90
 
         x, y = xy
         self.label._set_ref_angle(angle_label+self._axislabel_add_angle)

--- a/lib/mpl_toolkits/gtktools.py
+++ b/lib/mpl_toolkits/gtktools.py
@@ -230,7 +230,6 @@ class SortedStringsScrolledWindow(gtk.ScrolledWindow):
         self.model.clear()
         self.datad = dict()
 
-
     def flat(self, row):
         seq = []
         for i,val in enumerate(row):
@@ -239,9 +238,7 @@ class SortedStringsScrolledWindow(gtk.ScrolledWindow):
         return seq
 
     def __delete_selected(self, *unused): # untested
-
-
-        keyd = dict([(thisiter, key) for key, thisiter in self.iterd.values()])
+        keyd = {thisiter: key for key, thisiter in self.iterd.values()}
         for row in self.get_selected():
             key = tuple(row)
             thisiter = self.iterd[key]
@@ -252,8 +249,6 @@ class SortedStringsScrolledWindow(gtk.ScrolledWindow):
 
         for i, thisiter in enumerate(self.iters):
             self.rownumd[i] = keyd[thisiter]
-
-
 
     def delete_row(self, row):
         key = tuple(row)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2599,7 +2599,7 @@ class Axes3D(Axes):
         # must all be ndarray
         assert all(isinstance(k, np.ndarray) for k in input_args)
         # must all in same shape
-        assert len(set([k.shape for k in input_args])) == 1
+        assert len({k.shape for k in input_args}) == 1
 
         shaft_dt = np.linspace(0, length, num=2)
         arrow_dt = shaft_dt * arrow_length_ratio

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -43,7 +43,7 @@ def test_divider_append_axes():
 
     # now determine nice limits by hand:
     binwidth = 0.25
-    xymax = np.max([np.max(np.fabs(x)), np.max(np.fabs(y))])
+    xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))
     lim = (int(xymax/binwidth) + 1) * binwidth
 
     bins = np.arange(-lim, lim + binwidth, binwidth)


### PR DESCRIPTION
- Call min/max directly on a generator or on two arguments rather than via a list.
- Remove old `__cmp__` method.
- Use `reshape` instead of assigning to `shape` at least when it looks more legible.
- Use `np.min` instead of `amin`, `np.max` (`amax`), `np.abs` (`fabs`, `absolute`), `np.conj` (`conjugate`).
- dict/set comprehensions and set literals where appropriate.