### PR TITLE
[MRG] scatter: disable the margin override except in classic mode

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4043,16 +4043,16 @@ or tuple of floats
             else:
                 collection.autoscale_None()
 
-        # The margin adjustment is a hack to deal with the fact that we don't
-        # want to transform all the symbols whose scales are in points
-        # to data coords to get the exact bounding box for efficiency
-        # reasons.  It can be done right if this is deemed important.
-        # Also, only bother with this padding if there is anything to draw.
-        if self._xmargin < 0.05 and x.size > 0:
-            self.set_xmargin(0.05)
-
-        if self._ymargin < 0.05 and x.size > 0:
-            self.set_ymargin(0.05)
+        # Classic mode only:
+        # ensure there are margins to allow for the
+        # finite size of the symbols.  In v2.x, margins
+        # are present by default, so we disable this
+        # scatter-specific override.
+        if rcParams['_internal.classic_mode']:
+            if self._xmargin < 0.05 and x.size > 0:
+                self.set_xmargin(0.05)
+            if self._ymargin < 0.05 and x.size > 0:
+                self.set_ymargin(0.05)
 
         self.add_collection(collection)
         self.autoscale_view()


### PR DESCRIPTION
With margins by default in v2.x, removing this override makes for
a simpler and more predictable API.