### PR TITLE
Doc change banner

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -159,11 +159,11 @@ parents[-1].link|e }}" />
   <body>
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
-<h3>We're updating the default styles for Matplotlib 2.0</h3>
+<h3>Matplotlib 2.0.0rc1 is available</h3>
 
-<p>Learn what to expect in the <a href="{{ pathto('style_changes.html', 1) }}"
+<p><a href="{{ pathto('style_changes.html', 1) }}"
 style="font-weight: bold;
-color: #11557C;">new updates</a></p>
+color: #11557C;">Install the release candidate now!</a></p>
 
 </div>
 {%- block header %}{% endblock %}

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -8,6 +8,8 @@ Overview
     :Release: |version|
     :Date: |today|
 
+    Download `PDF <Matplotlib.pdf>`_
+
 
 .. toctree::
    :maxdepth: 2

--- a/doc/style_changes.rst
+++ b/doc/style_changes.rst
@@ -1,33 +1,42 @@
-Default Style Changes
-=====================
+Matplotlib v2.0
+===============
 
-Colormap
---------
+Changing the default colors and style of matplotlib has proven to be a
+much larger task than initially thought, but we are finally
+approaching the release.
 
-``matplotlib`` is changing the default colormap and styles in the
-upcoming 2.0 release!
+For the full details of what has been changed see a `draft of the
+release notes
+<http://matplotlib.org/2.0.0rc1/users/dflt_style_changes.html>`_.
 
-The new default color map will be 'viridis' (aka `option
-D <http://bids.github.io/colormap/>`_).  For an introduction to color
-theory and how 'viridis' was generated watch Nathaniel Smith and
-Stéfan van der Walt's talk from SciPy2015
+The current pre-release is
+`v2.0.0rc1 <https://github.com/matplotlib/matplotlib/releases/tag/v2.0.0rc1>`_
 
-.. raw:: html
+You can install pre-releases via ::
 
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/xAoljeRJ3lU" frameborder="0" allowfullscreen></iframe>
+  pip install --pre matplotlib
 
-All four color maps will be included in matplotlib 1.5.
+which has source + wheels for Mac, Win, and manylinux or
 
+using ::
 
-Everything Else
----------------
+  conda install -c conda-forge/label/rc -c conda-forge matplotlib
 
-We have collected proposals to change any and all visual defaults
-(including adding new rcParams as needed).
+which has binaries for Mac, Win, and linux.  You can also install from
+`source
+<http://matplotlib.org/users/installing.html#installing-from-source>` from
+git ::
 
-Michael Droettboom and Thomas Caswell will decide on the new default
-styles to appear in the upcoming 2.0 release.
+  git clone https://github.com/matplotlib/matplotlib.git
+  cd matplotlib
+  git checkout v2.0.0rc1
 
-A 'classic' style sheet will be provided so reverting to the 1.x
-default values will be a single line of python
-(`mpl.style.use('classic')`).
+or tarball ::
+
+  wget https://github.com/matplotlib/matplotlib/archive/v2.0.0rc1.tar.gz -O matplotlib-v2.0.0rc1.tar.gz
+  tar -xzvf matplotlib-v2.0.0rc1.tar.gz
+  cd matplotlib-v2.0.0rc1
+
+via ::
+
+  pip install -v .


### PR DESCRIPTION
The plan is to once rc1 is built and up everywhere rebuild / deploy the 1.5.3 docs with this content.

We have a very nice platform to advertise the rc (and we know _everyone_ who lands there might be interested).

Tagging as 2.0 even though it is aimed at 1.5.3-doc so we can keep track of it.