### PR TITLE
DOC: Disable build against Sphinx 1.5.0

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -6,7 +6,7 @@
 # Install the documentation requirements with:
 #     pip install -r doc-requirements.txt
 #
-sphinx>1.0
+sphinx>1.0,!=1.5.0
 numpydoc
 ipython
 mock

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -241,9 +241,6 @@ html_favicon = '_static/favicon.ico'
 # The paper size ('letter' or 'a4').
 latex_paper_size = 'letter'
 
-# The font size ('10pt', '11pt' or '12pt').
-latex_font_size = '11pt'
-
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 
@@ -258,8 +255,9 @@ latex_documents = [
 # the title page.
 latex_logo = None
 
+latex_elements = {}
 # Additional stuff for the LaTeX preamble.
-latex_preamble = r"""
+latex_elements['preamble'] = r"""
    % In the parameters section, place a newline after the Parameters
    % header.  (This is stolen directly from Numpy's conf.py, since it
    % affects Numpy-style docstrings).
@@ -279,6 +277,7 @@ latex_preamble = r"""
    \usepackage{enumitem}
    \setlistdepth{2048}
 """
+latex_elements['pointsize'] = '11pt'
 
 # Documents to append as an appendix to all manuals.
 latex_appendices = []

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -286,7 +286,10 @@ latex_appendices = []
 # If false, no module index is generated.
 latex_use_modindex = True
 
-latex_use_parts = True
+if hasattr(sphinx, 'version_info') and sphinx.version_info[:2] >= (1, 4):
+    latex_toplevel_sectioning = 'part'
+else:
+    latex_use_parts = True
 
 # Show both class-level docstring and __init__ docstring in class
 # documentation


### PR DESCRIPTION
This was deprecated in Sphinx 1.4 and causes a warning in 1.5, which kills the build due to warnings-as-errors.

This is breaking both [master](https://travis-ci.org/matplotlib/matplotlib/jobs/181256285) and [v2.x](https://travis-ci.org/matplotlib/matplotlib/jobs/181261313) doc builds, so I will self-merge this after CI passes.