### PR TITLE
Correctly skip colors for nan points given to scatter

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3996,7 +3996,7 @@ or tuple of floats
             colors = None  # use cmap, norm after collection is created
 
         # c will be unchanged unless it is the same length as x:
-        x, y, s, colors = cbook.delete_masked_points(x, y, s, c)
+        x, y, s, c, colors = cbook.delete_masked_points(x, y, s, c, colors)
 
         scales = s   # Renamed for readability below.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3995,8 +3995,10 @@ or tuple of floats
         else:
             colors = None  # use cmap, norm after collection is created
 
-        # c will be unchanged unless it is the same length as x:
-        x, y, s, c, colors = cbook.delete_masked_points(x, y, s, c, colors)
+        # s, c, colors, or edgecolors will be unchanged unless they are the
+        # same length as x:
+        maskargs = x, y, s, c, colors, edgecolors
+        x, y, s, c, colors, edgecolors = cbook.delete_masked_points(*maskargs)
 
         scales = s   # Renamed for readability below.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3996,7 +3996,7 @@ or tuple of floats
             colors = None  # use cmap, norm after collection is created
 
         # c will be unchanged unless it is the same length as x:
-        x, y, s, c = cbook.delete_masked_points(x, y, s, c)
+        x, y, s, colors = cbook.delete_masked_points(x, y, s, c)
 
         scales = s   # Renamed for readability below.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3995,10 +3995,11 @@ or tuple of floats
         else:
             colors = None  # use cmap, norm after collection is created
 
-        # s, c, colors, or edgecolors will be unchanged unless they are the
-        # same length as x:
-        maskargs = x, y, s, c, colors, edgecolors
-        x, y, s, c, colors, edgecolors = cbook.delete_masked_points(*maskargs)
+        # Anything in maskargs will be unchanged unless it is the same length
+        # as x:
+        maskargs = x, y, s, c, colors, edgecolors, linewidths
+        x, y, s, c, colors, edgecolors, linewidths =\
+            cbook.delete_masked_points(*maskargs)
 
         scales = s   # Renamed for readability below.
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4849,7 +4849,7 @@ def test_scatter_color_masking():
     y = np.array([1, np.nan, 3])
     colors = np.array(['k', 'w', 'k'])
     linewidths = np.array([1, 2, 3])
-    s = plt.scatter(x, y, color=colors)
+    s = plt.scatter(x, y, color=colors, linewidths=linewidths)
 
     facecolors = s.get_facecolors()
     linecolors = s.get_edgecolors()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4849,5 +4849,8 @@ def test_scatter_color_masking():
     y = np.array([1, np.nan, 3])
     colors = np.array(['k', 'w', 'k'])
     s = plt.scatter(x, y, color=colors)
+
     facecolors = s.get_facecolors()
+    linecolors = s.get_edgecolors()
     assert_array_equal(facecolors[1], np.array([0, 0, 0, 1]))
+    assert_array_equal(linecolors[1], np.array([0, 0, 0, 1]))

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4841,3 +4841,13 @@ def test_color_length_mismatch():
     c_rgb = (0.5, 0.5, 0.5)
     ax.scatter(x, y, c=c_rgb)
     ax.scatter(x, y, c=[c_rgb] * N)
+
+
+@cleanup
+def test_scatter_color_masking():
+    x = np.array([1, 2, 3])
+    y = np.array([1, np.nan, 3])
+    colors = np.array(['k', 'w', 'k'])
+    s = plt.scatter(x, y, color=colors)
+    facecolors = s.get_facecolors()
+    assert_array_equal(facecolors[1], np.array([0, 0, 0, 1]))

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4848,9 +4848,12 @@ def test_scatter_color_masking():
     x = np.array([1, 2, 3])
     y = np.array([1, np.nan, 3])
     colors = np.array(['k', 'w', 'k'])
+    linewidths = np.array([1, 2, 3])
     s = plt.scatter(x, y, color=colors)
 
     facecolors = s.get_facecolors()
     linecolors = s.get_edgecolors()
+    linewidths = s.get_linewidths()
     assert_array_equal(facecolors[1], np.array([0, 0, 0, 1]))
     assert_array_equal(linecolors[1], np.array([0, 0, 0, 1]))
+    assert linewidths[1] == 3


### PR DESCRIPTION
Fixes #3489. As far as I can tell the only problem was that `colors` was never being masked.