### PR TITLE
 Make rounding behavior consistent

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -40,6 +40,12 @@ CocoaAgg backend removed
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The deprecated and not fully functional CocoaAgg backend has been removed.
 
+`round` removed from TkAgg Backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The TkAgg backend had its own implementation of the `round` function. This
+was unused internally and has been removed. Instead, use either the
+`round` builtin function or `numpy.round`.
+
 'hold' functionality deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'hold' keyword argument and all functions and methods related

--- a/examples/pylab_examples/date_index_formatter.py
+++ b/examples/pylab_examples/date_index_formatter.py
@@ -9,7 +9,7 @@ Formatter to get the appropriate date string for a given index.
 """
 
 from __future__ import print_function
-import numpy
+import numpy as np
 from matplotlib.mlab import csv2rec
 import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
@@ -27,7 +27,7 @@ class MyFormatter(Formatter):
 
     def __call__(self, x, pos=0):
         'Return the label for time x at position pos'
-        ind = int(round(x))
+        ind = int(np.round(x))
         if ind >= len(self.dates) or ind < 0:
             return ''
 
@@ -37,6 +37,6 @@ formatter = MyFormatter(r.date)
 
 fig, ax = plt.subplots()
 ax.xaxis.set_major_formatter(formatter)
-ax.plot(numpy.arange(len(r)), r.close, 'o-')
+ax.plot(np.arange(len(r)), r.close, 'o-')
 fig.autofmt_xdate()
 plt.show()

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -210,7 +210,7 @@ class RendererAgg(RendererBase):
 
         #print x, y, int(x), int(y), s
         self._renderer.draw_text_image(
-            font, round(x - xd + xo), round(y + yd + yo) + 1, angle, gc)
+            font, np.round(x - xd + xo), np.round(y + yd + yo) + 1, angle, gc)
 
     def get_text_width_height_descent(self, s, prop, ismath):
         """
@@ -257,8 +257,8 @@ class RendererAgg(RendererBase):
         w, h, d = self.get_text_width_height_descent(s, prop, ismath)
         xd = d * sin(radians(angle))
         yd = d * cos(radians(angle))
-        x = round(x + xd)
-        y = round(y + yd)
+        x = np.round(x + xd)
+        y = np.round(y + yd)
 
         self._renderer.draw_text_image(Z, x, y, angle, gc)
 

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -50,9 +50,6 @@ cursord = {
     }
 
 
-def round(x):
-    return int(math.floor(x+0.5))
-
 def raise_msg_to_str(msg):
     """msg is a return arg from a raise.  Join with new lines"""
     if not is_string_like(msg):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -152,7 +152,7 @@ def _draw_list_compositing_images(
                     gc = renderer.new_gc()
                     gc.set_clip_rectangle(parent.bbox)
                     gc.set_clip_path(parent.get_clip_path())
-                    renderer.draw_image(gc, round(l), round(b), data)
+                    renderer.draw_image(gc, np.round(l), np.round(b), data)
                     gc.restore()
             del image_group[:]
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1760,8 +1760,8 @@ class MaxNLocator(Locator):
                 step = max(1, step)
             best_vmin = (_vmin // step) * step
 
-            low = round(Base(step).le(_vmin - best_vmin) / step)
-            high = round(Base(step).ge(_vmax - best_vmin) / step)
+            low = np.round(Base(step).le(_vmin - best_vmin) / step)
+            high = np.round(Base(step).ge(_vmax - best_vmin) / step)
             ticks = np.arange(low, high + 1) * step + best_vmin + offset
             nticks = ((ticks <= vmax) & (ticks >= vmin)).sum()
             if nticks >= self._min_n_ticks:


### PR DESCRIPTION
The behavior of the builtin `round()` function changed between python 2 and 3. There are a few places in our code base that use it, resulting in occasional pixel jumps in things like text positioning; this makes image tests have needless noise. The easy solution is to use numpy's round *everywhere* to give us consistent behavior (and behavior which matches python 3's.) It looks like this had been done in some places, but not these last few.

I also removed an implementation of `round()` in the TkAgg backend which was unused. Some may consider this an API break, so I'm open to eliminating this commit or making TkAgg's an alias to numpy's.