### PR TITLE
Fix IOError: Could not find bitmap file "stock_left.xpm"

### DIFF
--- a/examples/user_interfaces/embedding_in_wx4.py
+++ b/examples/user_interfaces/embedding_in_wx4.py
@@ -37,11 +37,11 @@ class MyNavigationToolbar(NavigationToolbar2WxAgg):
         # probably want to add your own.
         if 'phoenix' in wx.PlatformInfo:
             self.AddTool(self.ON_CUSTOM, 'Click me',
-                         _load_bitmap('stock_left.xpm'),
+                         _load_bitmap('back.png'),
                          'Activate custom contol')
             self.Bind(wx.EVT_TOOL, self._on_custom, id=self.ON_CUSTOM)
         else:
-            self.AddSimpleTool(self.ON_CUSTOM, _load_bitmap('stock_left.xpm'),
+            self.AddSimpleTool(self.ON_CUSTOM, _load_bitmap('back.png'),
                                'Click me', 'Activate custom contol')
             self.Bind(wx.EVT_TOOL, self._on_custom, id=self.ON_CUSTOM)
 


### PR DESCRIPTION
The file `stock_left.xpm` is no longer part of matplotlib 2.0.
```
Traceback (most recent call last):
  File "D:\Build\matplotlib\matplotlib-2.0.0rc1\examples\user_interfaces\embedding_in_wx4.py", line 110, in <module>
    app = App(0)
  File "X:\Python27-x64\lib\site-packages\wx-3.0-msw\wx\_core.py", line 8628, in __init__
    self._BootstrapApp()
  File "X:\Python27-x64\lib\site-packages\wx-3.0-msw\wx\_core.py", line 8196, in _BootstrapApp
    return _core_.PyApp__BootstrapApp(*args, **kwargs)
  File "D:\Build\matplotlib\matplotlib-2.0.0rc1\examples\user_interfaces\embedding_in_wx4.py", line 105, in OnInit
    frame = CanvasFrame()
  File "D:\Build\matplotlib\matplotlib-2.0.0rc1\examples\user_interfaces\embedding_in_wx4.py", line 86, in __init__
    self.toolbar = MyNavigationToolbar(self.canvas, True)
  File "D:\Build\matplotlib\matplotlib-2.0.0rc1\examples\user_interfaces\embedding_in_wx4.py", line 44, in __init__
    self.AddSimpleTool(self.ON_CUSTOM, _load_bitmap('stock_left.xpm'),
  File "X:\Python27-x64\lib\site-packages\matplotlib\backends\backend_wx.py", line 1423, in _load_bitmap
    raise IOError('Could not find bitmap file "%s"; dying' % bmpFilename)
IOError: Could not find bitmap file "X:\Python27-x64\lib\site-packages\matplotlib\mpl-data\images\stock_left.xpm"; dying
```