### PR TITLE
[MRG+1] Fix a bug in TextBox where shortcut keys were not being reenabled

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -879,7 +879,7 @@ class TextBox(AxesWidget):
         if self.ignore(event):
             return
         if event.inaxes != self.ax:
-             self.stop_typing()
+            self.stop_typing()
             return
         if not self.eventson:
             return

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -879,8 +879,7 @@ class TextBox(AxesWidget):
         if self.ignore(event):
             return
         if event.inaxes != self.ax:
-            self.capturekeystrokes = False
-            self.stop_typing()
+             self.stop_typing()
             return
         if not self.eventson:
             return


### PR DESCRIPTION

in _click(), the self.capturekeystrokes flag was being set false before
calling stop_typing() when the click was outside the textbox axes. 
stop_typing() expects this flag to still be set if the textbox was 
capturing keystrokes, and does not reenable shortcut keys
if it is not set. The line setting self.capturekeystrokes false in _click()
is deleted, which fixes the behavior of /examples/widgets/textbox.py. There
is no test suite set up for the textbox class and I'm not prepared to start
one now, so no tests submitted for this bugfix.

This is babby's first pull request so let me know if I'm doing it wrong.