### PR TITLE
[MRG+1] MaxNLocator 'steps' validation; and documentation. Closes #7578.

### DIFF
--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -968,6 +968,11 @@ or create a new `~matplotlib.ticker.MaxNLocator`::
   import matplotlib.ticker as mticker
   ax.set_major_locator(mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10])
 
+The algorithm used by `~matplotlib.ticker.MaxNLocator` has been
+improved, and this may change the choice of tick locations in some
+cases.  This also affects `~matplotlib.ticker.AutoLocator`, which
+uses ``MaxNLocator`` internally.
+
 For a log-scaled axis the default locator is the
 `~matplotlib.ticker.LogLocator`.  Previously the maximum number
 of ticks was set to 15, and could not be changed. Now there is a

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -32,7 +32,7 @@ def test_MaxNLocator_integer():
     test_value = np.array([-1, 0, 1, 2])
     assert_almost_equal(loc.tick_values(-0.1, 1.1), test_value)
 
-    test_value = np.array([-0.25, 0, 0.25, 0.5, 0.75, 1])
+    test_value = np.array([-0.3, 0, 0.3, 0.6, 0.9, 1.2])
     assert_almost_equal(loc.tick_values(-0.1, 0.95), test_value)
 
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1693,7 +1693,7 @@ class MaxNLocator(Locator):
         steps = np.asarray(steps)
         if np.any(np.diff(steps) <= 0):
             raise ValueError('steps argument must be uniformly increasing')
-        if np.any((steps > 10) | (steps < 1)):
+        if steps[-1] > 10 or steps[0] < 1:
             warnings.warn('Steps argument should be a sequence of numbers\n'
                           'increasing from 1 to 10, inclusive. Behavior with\n'
                           'values outside this range is undefined, and will\n'


### PR DESCRIPTION
This adds validation of the "steps" kwarg, fixes a bug in the implementation of the "integer" kwarg, and adds a note to dflt_style_changes.rst regarding the algorithm change in MaxNLocator.