### PR TITLE
[MRG+1] LogFormatter bugfix, docs, support classic

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -141,6 +141,16 @@ the kwarg is None which internally sets it to the 'auto' string,
 triggering a new algorithm for adjusting the maximum according
 to the axis length relative to the ticklabel font size.
 
+`matplotlib.ticker.LogFormatter` gains minor_thresholds kwarg
+-------------------------------------------------------------
+
+Previously, minor ticks on log-scaled axes were not labeled by
+default.  An algorithm has been added to the
+`~matplotlib.ticker.LogFormatter` to control the labeling of
+ticks between integer powers of the base.  The algorithm uses
+two parameters supplied in a kwarg tuple named 'minor_thresholds'.
+See the docstring for further explanation.
+
 
 New defaults for 3D quiver function in mpl_toolkits.mplot3d.axes3d.py
 ---------------------------------------------------------------------

--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -1042,6 +1042,15 @@ Z-order
   ``rcParams['axes.axisbelow'] = False``.
 
 
+``LogFormatter`` labeling of minor ticks
+========================================
+
+Minor ticks on a log axis are now labeled when the axis view limits
+span a range less than or equal to the interval between two major
+ticks.  See `~matplotlib.ticker.LogFormatter` for details. The
+minor tick labeling is turned off when using ``mpl.style.use('classic')``,
+but cannot be controlled independently via ``rcParams``.
+
 
 ``ScalarFormatter`` tick label formatting with offsets
 ======================================================

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -251,7 +251,7 @@ class LogScale(ScaleBase):
         axis.set_minor_locator(LogLocator(self.base, self.subs))
         axis.set_minor_formatter(
             LogFormatterSciNotation(self.base,
-                                    labelOnlyBase=self.subs))
+                                    labelOnlyBase=bool(self.subs)))
 
     def get_transform(self):
         """

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -231,7 +231,7 @@ def _sub_labels(axis, subs=()):
     assert_equal(label_test, label_expected)
 
 
-@cleanup
+@cleanup(style='default')
 def test_LogFormatter_sublabel():
     # test label locator
     fig, ax = plt.subplots()


### PR DESCRIPTION
Closes #7590.
Classic style, with no minor tick labeling on a log axis,
is supported via rcParams['_internal.classic'].
LogFormatter changes are documented in api_changes and
dflt_style_changes.
An implicit boolean is made explicit in scale.py.
A LogFormatter attribute that was sometimes, but not always,
set by set_locs, but used only in __call__, is replaced by
a local variable calculated in __call__.  (set_locs doesn't
have to be called prior to __call__, so this would have been
a bug even if the attribute were always calculated by set_locs.)