### PR TITLE
[MRG+1] BUG: fix minpos handling and other log ticker problems

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -141,8 +141,8 @@ the kwarg is None which internally sets it to the 'auto' string,
 triggering a new algorithm for adjusting the maximum according
 to the axis length relative to the ticklabel font size.
 
-`matplotlib.ticker.LogFormatter` gains minor_thresholds kwarg
--------------------------------------------------------------
+`matplotlib.ticker.LogFormatter`: two new kwargs
+------------------------------------------------
 
 Previously, minor ticks on log-scaled axes were not labeled by
 default.  An algorithm has been added to the
@@ -150,6 +150,9 @@ default.  An algorithm has been added to the
 ticks between integer powers of the base.  The algorithm uses
 two parameters supplied in a kwarg tuple named 'minor_thresholds'.
 See the docstring for further explanation.
+
+To improve support for axes using `~matplotlib.ticker.SymmetricLogLocator`,
+a 'linthresh' kwarg was added.
 
 
 New defaults for 3D quiver function in mpl_toolkits.mplot3d.axes3d.py

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -264,6 +264,10 @@ class LogScale(ScaleBase):
         """
         Limit the domain to positive values.
         """
+        if not np.isfinite(minpos):
+            minpos = 1e-300  # This value should rarely if ever
+                             # end up with a visible effect.
+
         return (minpos if vmin <= 0 else vmin,
                 minpos if vmax <= 0 else vmax)
 
@@ -499,7 +503,10 @@ class LogitScale(ScaleBase):
         """
         Limit the domain to values between 0 and 1 (excluded).
         """
-        return (minpos if vmin <= 0 else minpos,
+        if not np.isfinite(minpos):
+            minpos = 1e-7    # This value should rarely if ever
+                             # end up with a visible effect.
+        return (minpos if vmin <= 0 else vmin,
                 1 - minpos if vmax >= 1 else vmax)
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -176,6 +176,25 @@ def test_autoscale_tight():
     assert_allclose(ax.get_xlim(), (-0.15, 3.15))
     assert_allclose(ax.get_ylim(), (1.0, 4.0))
 
+
+@cleanup(style='default')
+def test_autoscale_log_shared():
+    # related to github #7587
+    # array starts at zero to trigger _minpos handling
+    x = np.arange(100, dtype=float)
+    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+    ax1.loglog(x, x)
+    ax2.semilogx(x, x)
+    ax1.autoscale(tight=True)
+    ax2.autoscale(tight=True)
+    plt.draw()
+    lims = (x[1], x[-1])
+    assert_allclose(ax1.get_xlim(), lims)
+    assert_allclose(ax1.get_ylim(), lims)
+    assert_allclose(ax2.get_xlim(), lims)
+    assert_allclose(ax2.get_ylim(), (x[0], x[-1]))
+
+
 @cleanup(style='default')
 def test_use_sticky_edges():
     fig, ax = plt.subplots()

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -792,7 +792,7 @@ class Bbox(BboxBase):
             raise ValueError('Bbox points must be of the form '
                              '"[[x0, y0], [x1, y1]]".')
         self._points = points
-        self._minpos = np.array([0.0000001, 0.0000001])
+        self._minpos = np.array([np.inf, np.inf])
         self._ignore = True
         # it is helpful in some contexts to know if the bbox is a
         # default or has been mutated; we store the orig points to


### PR DESCRIPTION
Closes #7595, #7493, #7587.
Bbox._minpos is now initialized to [np.inf, np.inf] instead of
[1e-7, 1e-7].
Old code with a colorbar in which the formatter is set to
a LogFormatter and a SymlogNorm is used now works again (although
the results are better in 2.0 if the colorbar is left to handle
the formatter automatically).
LogLocator now has its own nonsingular() method which provides
a reasonable starting point for a log axis when no data have
been plotted.