### PR TITLE
Eventplot edgecases

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1110,10 +1110,12 @@ or tuple of floats
           "vertical' : lines will be horizontal and arranged in columns
 
         *lineoffsets* :
-          A float or array-like containing floats.
+          A float or array-like containing floats. If a zero length array,
+          defaults to 0.
 
         *linelengths* :
-          A float or array-like containing floats.
+          A float or array-like containing floats. If a zero length array,
+          defaults to 1.
 
         *linewidths* :
           A float or array-like containing floats.
@@ -1124,7 +1126,7 @@ or tuple of floats
 
         *linestyles* :
           [ 'solid' | 'dashed' | 'dashdot' | 'dotted' ] or an array of these
-          values
+          values. If a zero length array, defaults to 'solid'.
 
         For linelengths, linewidths, colors, and linestyles, if only a single
         value is given, that value is applied to all lines.  If an array-like

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1183,13 +1183,13 @@ or tuple of floats
         linewidths = np.asarray(linewidths)
 
         if len(lineoffsets) == 0:
-            lineoffsets = [None]
+            lineoffsets = [0]
         if len(linelengths) == 0:
-            linelengths = [None]
+            linelengths = [1]
         if len(linewidths) == 0:
             linewidths = [None]
         if len(linestyles) == 0:
-            linestyles = [None]
+            linestyles = ['solid']
         if len(colors) == 0:
             colors = [None]
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1187,9 +1187,9 @@ or tuple of floats
         if len(linelengths) == 0:
             linelengths = [None]
         if len(linewidths) == 0:
-            lineoffsets = [None]
-        if len(linewidths) == 0:
-            lineoffsets = [None]
+            linewidths = [None]
+        if len(linestyles) == 0:
+            linestyles = [None]
         if len(colors) == 0:
             colors = [None]
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2770,6 +2770,13 @@ def test_empty_eventplot():
     plt.draw()
 
 
+@cleanup
+def test_eventplot_empty_args():
+    fig, ax = plt.subplots()
+    ax.eventplot([1, 2, 3], lineoffsets=[], linelengths=[], linewidths=[],
+                 linestyles=[], colors=[])
+
+
 @image_comparison(baseline_images=['marker_styles'], extensions=['png'], remove_text=True)
 def test_marker_styles():
     fig = plt.figure()


### PR DESCRIPTION
Fixes #7560 

matplotlib.collections.EventCollection doesn't like being handed `None` for `lineoffsets`, `linelengths`, or `linestyles`, so if a zero-length array is provided I've set it to just pass the default values.

Possibly in the future matplotlib.collections.EventCollection wants to be able to accept `None` for these kwargs?