### PR TITLE
Warn if different axis projection requested

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1485,6 +1485,10 @@ class Figure(Artist):
                 # continue and a new axes will be created
                 if key == ckey and isinstance(cax, projection_class):
                     return cax
+                else:
+                    warnings.warn('Requested projection is different from '
+                                  'current axis projection, creating new axis '
+                                  'with requested projection.')
 
         # no axes found, so create one which spans the figure
         return self.add_subplot(1, 1, 1, **kwargs)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2279,6 +2279,11 @@ def polar(*args, **kwargs):
     strings, as in :func:`~matplotlib.pyplot.plot`.
 
     """
+    # If an axis already exists, check if it has a polar projection
+    if gcf().get_axes():
+        if not isinstance(gca(), PolarAxes):
+            warnings.warn('Trying to create polar plot on an axis that does '
+                          'not have a polar projection.')
     ax = gca(polar=True)
     ret = ax.plot(*args, **kwargs)
     return ret


### PR DESCRIPTION
A first step towards #312 (I think), without breaking any compatibility.

- Warn if plt.polar is called and current axis doesn't have a polar projection
- Warn if plt.gca() is called with a requested projection which is different from the axis projection