### PR TITLE
Make bars stick to explicitly-specified edges.

### DIFF
--- a/examples/pylab_examples/log_bar.py
+++ b/examples/pylab_examples/log_bar.py
@@ -17,6 +17,5 @@ for i in range(len(data[0])):
     y = [d[i] for d in data]
     b = plt.bar(x + i * dimw, y, dimw, bottom=0.001)
 plt.xticks(x + w / 2)
-plt.ylim((0.001, 1000))
 
 plt.show()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2128,9 +2128,9 @@ or tuple of floats
             r.update(kwargs)
             r.get_path()._interpolation_steps = 100
             if orientation == 'vertical':
-                r.sticky_edges.y.append(0)
+                r.sticky_edges.y.append(b)
             elif orientation == 'horizontal':
-                r.sticky_edges.x.append(0)
+                r.sticky_edges.x.append(l)
             self.add_patch(r)
             patches.append(r)
 


### PR DESCRIPTION
Previously, they would stick to 0 regardless of any explicit bottom/left position specified by the respective keyword arguments. I assume this was just a minor oversight.

The modified example shows what's wrong here; on `v2.x`, it adds margins on all four side once the explicit y-limits are removed. With this change, the bottom margin is removed only. No tests now, but I can try and think one up.