### PR TITLE
MNT: tweak MovieWriter.saving to be more cautious

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -236,8 +236,10 @@ class MovieWriter(object):
         '''
         # This particular sequence is what contextlib.contextmanager wants
         self.setup(*args, **kw)
-        yield
-        self.finish()
+        try:
+            yield self
+        finally:
+            self.finish()
 
     def _run(self):
         # Uses subprocess to call the program for assembling frames into a


### PR DESCRIPTION
 - always try to call `finish` even if an exception is raised.
 - return `self` so that

    with writer.saving(...) as mv:
        mv.grab_frame()

   works as expected.

This should go in after #7589 (if it gets in for 2.0 at all).