### PR TITLE
TST: regenerate patheffect2

### DIFF
--- a/lib/matplotlib/tests/baseline_images/test_patheffects/patheffect2.svg
+++ b/lib/matplotlib/tests/baseline_images/test_patheffects/patheffect2.svg
@@ -26,123 +26,123 @@ L 122.4 43.2
 z
 " style="fill:#ffffff;"/>
    </g>
-   <g clip-path="url(#pf52b15eb6f)">
-    <image height="345.6" id="imagecdbca4fff0" transform="scale(1 -1)translate(0 -345.6)" width="345.6" x="122.4" xlink:href="data:image/png;base64,
+   <g clip-path="url(#pc10af623d4)">
+    <image height="345.6" id="imagee950567b1d" transform="scale(1 -1)translate(0 -345.6)" width="345.6" x="122.4" xlink:href="data:image/png;base64,
 iVBORw0KGgoAAAANSUhEUgAAAeAAAAHgCAYAAAB91L6VAAAABHNCSVQICAgIfAhkiAAAIABJREFUeJztnGHIbUtdxmfuOYIfBEMS/CAYkpAgGBKSIBgSkmFYWJIgKCiWJCQYkmFlaKKgYCgiligYIqKhWFmSdEFBMSUjw7ikWBmaKCgYil5dfbCrb8u996x7Z+1Zz/PM7/dJ8GH+z6w9a3733ec9py5PKktJ5O4Nme/utI7aLLU+O81aNmTu3jDrO1vW2ZDZtM6WPu3IpsyWj4J1+tdx7Jy6jjt3HF0AAABgRhAwAADAASBgAACAA0DAAAAAB4CAAQAADgABAwAAHAACBgAAOAAEDAAAcAAIGAAA4AAQMAAAwAEgYAAAgANAwAAAAAeAgAEAAA4AAQMAABwAAgYAADgABAwAAHAACBgAAOAAEDAAAMABIGAAAIADQMAAAAAHgIABAAAOAAEDAAAcAAIGAAA4AAQMAABwAAgYAADgABAwAADAASBgAACAA0DAAAAAB4CAAQAADgABAwAAHAACBgAAOAAEDAAAcAAIGAAA4AAQMAAAwAEgYAAAgANAwAAAAAeAgAEAAA4AAQMAABwAAgYAADgABAwAAHAACBgAAOAAEDAAAMABIGAAAIADQMAAAAAHgIABAAAOAAEDAAAcAAIGAAA4gFwB396QubXTOmqz1PrsNKtuyNzeMOt+W9bZkNm0zpY+7cimzJaPgnX613HsnLqOO3X5xbIcXWIX7t4p893QWWp9dpq1bMjcvWHWd7assyGzaZ0tfdqRTZktHwXr9K/j2Dl1HSdyBHwOMWHIzVLrg5gvr9OOWF6aqes4dnZcx5W6/FKQgA1FITdLrQ9CvrxOOyJ3Wc68jmNnx3VcyBLwKQxlITdLrQ9SvrxOOyJ3Yc68jmNntXVcqcuvBAo4VBhys9T6IObL67Qjlpdv6jqOndXWUSdTwGtCRSE3S60PQr68TjtieemmruPYma+dL1OXXwsUsNgFPvUstT5I+fI67YjcxTvzOo6dkfIPqcszQgSMMLxmqfVBzJfXaUfkLt+Z13HsPMvXzjfJEfAaROE1S60PQr68TjtieXmnruPYeQYh1+WZIQJGFnmz1Pog5cvrtCOWF3jqOo6dE752vkmOgM+BMPJmqfVBzJfXaUfkLvGZ13Hs7Epdnh0kYLWLWa1P6iy1Pgj58jrtiKUEUtdx7OxCloBPoXY5q/VJnaXWBylfXqcdsRRB6jpqnV2py3MDBSx2aVr2SZ2l1gcxX16nHZGTwczrqHVWJ1PAa8QuS8s+qbPU+iDky+u0I3ISmHkdvna+TF1+I1DAhhemZZ/UWWp9kPLlddoRS3mlroOUf0hdfitEwKGXpmWf1FlqfRDz5XXaEUuBpa4zy9fON8kR8JrQy9KyT+ostT4I+fI67YiluFLXmUHIdfntEAGLXWJys0b2GT1vj1mOzxkp9/dpRyzllbpOwtfON8kR8DnELjK5WWp9Umep9UHMl9dpRywFlrqOK3V5UZCAuSzHZFL3znPuXgchN2axzpB1XMgS8Cm4MMdkUvfOc+5eByk3ZrFO9zqu1OXFgQLm0hwzS61P6iy1Poj58jrtiJzAUtdRJ1PAa7gsx8xS65M6S60PQr68TjsiJy7HdRypy+8FCljtglLrw97zZqn1QcqX12lHLCWoto46dfmDEAGLXRyWfdh73iy1Poj58jrtiKUI+dr5NDkCXiN2YVj2Ye95s9T6IOTL67QjcgJUW0eZuvxRiIANLw3LPltm7Tlv1P4dn7PbMx48Cyk3ZoWu40SOgM9heHFY9mHvebPU+iDmy+u0I5ZCdf8p9xJ1+eMgAYdeGJZ92HveLLU+CPnyOu2InEhnE3KWgE8RemlY9mHvebPU+iDly+u0I3IyTfva+SZ1eXWggMVeZrlZan3Ye94stT6I+fI67QhivgKZAl4j9hLLzVLrw97zZqn1QciX12lH5ITsSF1eEyhgwxdZbpZaH/aeN0utD1K+vE47gpTvJXV5XYiAQ19muVlqfdh73iy1Poj58jrtCF87nyFHwGtCX2K5WWp92HveLLU+CPnyOu0IQv4/6vKGEAGLvVxTz9qaU9o/svCapdYHKV9epx2Z5mvnm+QI+BxiL9jUs9T6sPe8WWp9EPPlddoR+59yL1GXNwUJmJfYa5ZaH/aeN0utD0K+vE47EiXkLAGfghfZa5ZaH/aeN0utD1K+vE47Yktd/jRQwLzMebPU+rD3vFlqfRDz5XXaEXkyBbyGlzhvllof9p43S60PQo6jLm8NFLDai6PWZ/RvRO8xz3HvnLG8WWp9kLI1dXl7iIDFDrRln9RZan3Ye94stT4Ti9mJHAGvETvIln1SZ6n1Ye95s9T6IGRJ6vKOEAEbHmbLPlu/9lHam1IXxVlqfVJnqfUJlbITOQI+h+GBtuyTOkutD3vPm6XWx1DMrtTlXUECDj3Iln1SZ6n1Ye95s9T6IOSrkSXgU4QeZss+qbPU+rD3vFlqfcSk7Epd/iJQwGKHTG6WWp/UWWp92HveLLU+iPlekSngNWKHS26WWp/UWWp92HveLLU+A4XsSF3eFyhgwwMmN2uvPlvWUtu743N2nKXWJ3WWWh+k/APq8lchAg49ZHKz1PqkzlLrw97zZqn12WuWETkCXpN6uNRmqfVJnaXWh73nzVLrM4GQ6/K3IQJW+9BnnrU1N6pT6nNW68Pe82ap9Qn4xaub5Aj4HKmHzHGWWp/UWWp92HveLLU+ptTlQ0ECTj1cqbPU+qTOUuvD3vNmqfUxIUvAp0g9YKmz1PqkzlLrw97zZvHnvE3qcmeggFMP2cyz1PqkzlLrw97zZiHmH5Ap4DWph2vmWWp9Umep9WHvebP26mNIXT4SKODUA+Y4a8s8nrPXLLU+7D1v1tacuZjr8rEQATseMrU+qbPU+qTOUuvD3vNmBXztfJMcAa9JPVypLxbPOW+WWh/2njfLXMh1+YcQAc98wNT2PnreHrOUuiTPUuvD3vvXGT3PXLo3yRHwORwPtGOf1FlqfVJnqfVh716zTKnLPwYJOPVwOfZJnaXWJ3WWWh/27jXLhCwBnyL1gDn2SZ2l1id1llof9q4zy5S6/HOggFMPGS+z1yy1Pqmz1Pqwd51Z4mQKeE3q4eIl9pql1id1llof9j5mliF1+UyggDnMYzJ7/Ua02t4dnzOz+jMz772U3P0LU5e7QgSsdqBTD7Nan9RZan1SZ6n1Ye/96xiRI+A1HOQxs9T6pM5S65M6S60Pe+9fR5i6fC5EwGqHR63P6Hlq+2/NctyTWp/UWWp9Rv8DGo77NyFHwOdQOzxqfdh73iy1Pqmz1PrMvHdT6vIfQQJ2PDhqfdh73iy1Pqmz1PrMvHcTsgR8CsfDo9aHvefNUuuTOkutT+reTanLfwUKmAOdN0utT+ostT6ps9T6pO5dnEwBr+Eg581S65M6S61P6iy1Po57N6Qu/x0o4D0/0JkP9B6zZt138iy1Pqmztv6EN/P+zcVcv/fVDAFXxwPmeJgdZ6n1SZ2l1id1lloftb0bESPgNQh5hwx7Z9a1M6l75zmPmWUu5Prtr2UI+PaGD303KZcy94Gede+p+1Z6xqXk7n30H3s57n8C6d4kRsDnGCrm1MOs1oe9581S65M6S63PJL/tfI76zW/kCPjWhg8KIQ/KsHdmXTuTuneec/86JkQJ+BRIedAstT7sPW+WWp/UWWp9zH/T+RL1G9+6I07At+7+3oZMex3EPCjD3pl17Uzq3nnO1kQKeA1CFpql1oe9581S65M6S62PIfXrd98vTsC37m5/6luk/P1cO4OYTboozlLrkzpLrQ//ENC4WcLUry73jxDw7e9uke4+YkbKg2ap9WHvebPU+qTOGtnHiBgBr0HIO6yjNkutD3vPm6XWJ3UWQi6llFK/vDwgQsC3NnwSW6RcCmK2m6X0dXrivmefNVoWavt3fNYmxAj4HHuJGSmbzVLrw97zZqn1SZ1l/lPuJeoXlwfGCPjWhlOBkBvM/BKzd2ZdO5O6d7XnbEKUgE+BlBuovVxqLzJ7Z9a1M6l75zedm9QvLA+KE/A26SLmi6i9YFyaY2ap9UmdpdYndZY49fPLg+0FfHs34SLli6i9XFyYY2ap9UmdpdbHcZYZEQJeg5BbfdoZhLxDhr0z69qZ1L1PIuT62eUhEQLeIkvE3OrTziDmHTLsnVnXzqTuPeivIJUSJOA1CLmVaUYQ8qgMe2fWtTOpez8189bgzHdP/O+N1LuWh0YIeIvgkHIr04wg5VEZ9s6sa2dS925EjIDPgZhbGcQsM0utD3vPm6XWZ5I/6z1H/czysBgB7yU3hNzKNCMIeVSGvTPr2hnHvZsQJeBTIOXGOkjZa5ZaH/aeN0utT9gvXt2kfnp5eJyAR0oOMbcyzQhiHpVh78y6dkZt7+JECngNQm70Qcj966jNUuvD3vNmqfUxpH5qeUScgNUEh5RbmWYEKY/KsHdmXTuDlH9A/eTyyAgBb5KKmOQQcyvTjCDmURn2zqxrZyb7BaxSggS8BiHvkUHIF+GyzJul1id11t5/xntzvdsDMze53fj/T1A/vjwqQsC7CUVMcEi5lWlGkPKoDHtn1rUzAb94dZMYAZ8DMe/RBzFfRO0ic7w0HWep9UmdFfa1803qR5dHxwh4qEzE5IaQW5lmBCGPyrB3Zl07Y0KUgE+BlC+j1hkp77CO2iy1Puw9b5Yp9cPLY+IELCcVsT6IuZVpRhDzqAx7Z1ZPRpxIAa+Rk4lYH4TcyjQjCHlUhr0zK4h65/LYOAE7SlCtD1JuZZoRpDwqw96ZZUr90PK4CAGnilCtD2JuZZoRxDwqw97nnGVEjIDXpApQrQ9CbmWaEYQ8KsPe82a1Zt4Sy6yoH1weHyHgmSWo1gcptzLNCFIelWHvebOMiBHwOWYWoVofxNzKNCOIeVSGvXvNMqV+YHlCjID3u5gzBajWByG3Ms0IQh6VYe9es0yIEvApkLJXH6TcyjQjSHlUZk9Z7DHPce8T/uLVTer7lyfGCXjsBZ0pQrU+iLmVaUYQ86gMe9eZJU6kgNcg5Lw+CLmVaUYQ8qgMex8zy5D63uVJcQLWE0qmBNX6IOVWphlByntktuZGdULKstT3LE+OELCnVBw7+/VBzK1MM4KYR2XYe/86RsQIeI2nTBw7+/VByK1MM4KQR2XY+zbOrXdbLLOivmt5SoSAc4Xi2NmvD1JuZZoRpDwqw95jiBHwOXKl4tjZrw9ibmWaEcQ8KjPz3k2p71ieGiNguYsQIcf1QcitTDOCkEdlZt67CVECPoXcZYiU4/og5VamGUHKe2S25JL3bkh9+/K0OAE7XuKIOa8PYm5lmhHEPCqTundxIgW8xvHyRsh5fRByK9OMIORRGce9G1Lftjw9TsCpFzhSzuuDlFuZZkRPylvXGiUnpS6jZ4lT37I8I0LAM1/iiDmvD2JuZZoRPTE7zlLrs/U/gEyIEfCamS9vhJzXByG3Ms0IQh6VOeLPeM/NvCWWWVHfvDwzQsAIRamPY2e/Pki5lWlGkPKozBFSNiBGwOdAKkp9HDv79UHMrUwzgphHZSb5s95z1Dcuz4oRMDJx6+PY2a8PQm5lmhGEPCozmZCjBHwKhOLWx7GzXx+k3Mo0I5ukXMoGMauJ0lHKptTXL8+JE7DehZh5ifMM8/og5lamGeGn5VGZADFHCniN3kWYeXnzDPP6IORWphlByKMyhtTXLc+LE7DnZejYWa2PY2e/Pki5jZSYkbIs9bXL8yMEnHshOnZW6+PY2a8PYm5lmhF+Wt4jY0SMgNfkXoSOndX6OHb264OQW5lmBCFv5Vz29sDMfaC+enlBhIDlXmSEYtbHsbNfH6TcyjQjSDmIGAGfQ+5lRipmfRw7+/VBzK1MMzK3mE2pr1xeGCNgx4sHmbj1cezs1wchtzLNCEI2IErAp3C8fBCKWx/Hzn59HKVcyjgxTy1lU+rLlxfFCTj1AkIqbn0cO/v1cRQzPy3vsE6AmCMFvCb14kEmbn0cO/v1QcitTDPiKWRD6suWF8cJeObLB6G49XHs7NdnpJS35kaJGSnrUl+6vCRCwGov/Nx9HDur9XHs7NeHn5ZbmWZET8xGxAh4jdxLM3Ufx85qfRw7+/VByK1MMzJWyPdwbuatDZkDqS9Zfj9CwI4v+9x9HDur9XHs7NcHKbcyzcgxUjYgRsDncHzh5+7j2Fmtj2Nnvz6IuZVpRvYTsyn1xcvLYgSc+qLP3cexs1ofx85+fRByK9OMTCfkKAGfIvVln7uPY2e1Po6d/fpsWWtL5+2dLmdSpexKfdHy8jgBz/zCz93HsbNaH8fOfn34abmVaUYixBwp4DUzv+hz93HsrNbHsbNfH4TcyjQjltQXLq+MEzCXD336Mmqd1fo4dh7XZ89Oe3x9jZR1qS9YXh0hYC4g+lw/o9ZZrY9jZ78+/LScQ4yA13Dx0Of6GbXOan0cO/v1Qci+1Ocvr40QsN6Lk/myz93HsbNaH8fOfn1mlrITMQI+h97Lk/nCz93HsbNaH8fOfn1SxexKfd7yuhgBe740jp3p059R66zWx7GzXx+EfCxRAj6F54vj2Jk+/Rm1zmp9/Dpv6aT229eOUnalPmd5fZyAU19mz8706c+odVbr49jZrw9i3p9IAa/JfWkcO9OnP6PWWa2PY2e/PmpCdqQ+a3ljnIDVDiqXD32un1HrrNZnXGe1TkhZl/rM5c0RAtZ74dX6OHamT39GrbNaH8fOfn1GitmJGAGvcTykXDz0uX5GrbNaH8fOfn0Q8vepz1jeEiHg1IPK5UOf62fUOqv1cezs12cvKTsRI+BzpB5WLiD6XD+j1lmtj2Nnvz7uP+Veoj59eVuMgGc+pFw89Ll+Rq2zWh/Hzn59koQcJeBTzHxQx/+DA/29Z36Gen0cO2v12ZIb2Vmtz16fqSv1acvb4wTMBaTUx7Ezffozap3V+jh29uujTqSA1/DSKPVx7Eyf/oxaZ7U+jp21+jhSn7q8I07AvDhufRw706c/o9ZZ8R/iGNNbqcuefdSpT1neFSFgtQ/e8bDq9XHsTJ/+jFpntT6Oncf+ObcLMQJeo3cAtQ6pZx/HzvTpz6h1Vuvj2Bkhl1JKffLynggBq33ojgd1z1982KPTzM9w7j6OndX6OHbe748AXIgR8Dk8D6JjZ7U+jp3p059R66zWx7Gz/287n6M+aXlvjIBzD6BjZ7U+jp3p059R66zWx7FzjpCjBHyK3EOo1Vmx06jnqHb5zN1Hq/OWHM+wP+NKfeLy/jgBcwG1Mmqd1fo4dqZPf0ats1ofv87qRAp4DS9NK6PWWa2PY2f69GfUOqv10ersSH3C8oE4AesdVLU+jp3V+jh2zuyzb6c5n2Pq81OnPn75YISA1T54zz6OndX6OHamT39GrbNan7H/QeZCjIDXeB5StT6OndX6OHamT39GrbNaH4RcSin1ccuHIgSs9qHn9nHsrNbHsTN9+jNqndX67NPZiRgBnyP3sKr1ceys1sexM336M2qd1fp4/5R7ifrY5c4oAfPi6PTZvtaY3kpd9s2odaZPf0ats1qfDCnHCXgNL82YPts76fRW6rJvRq0zffozap21+rhSH7N8OE7AvDxufRw7q/Vx7Eyf/oxaZ60+6kQKeA0vjVsfx85qfRw706c/o9aZv/N7ifro5aNxAtY7hFoH1bOPY2e1Po6d6dOfUeuMlO+hPmr5eISA1T54x8Pq2cexs1ofx8706c+odc7/e79rYgS8xvMAOnZW6+PYWa2PY2f69GfUOucLuT5y+WSEgNU+9JlfHLVOjs9Qr49jZ/r0Z9Q6h/1DHCkCPkfuQXTsrNbHsbNaH8fO9OnPaHV2pT5i+VSMgHlpWhm1zmp9HDur9XHsTJ/+jFZnF6IEfApenFZmvz9nUerk+Axz++zzxxZzP0O1PlqdXakPXz4dJ2C9w6rWx7GzWh/Hzmp9HDvTpz+DmO8hUsBr9A6pWh/Hzmp9HDur9XHsTJ/+TP5vO5+jPmz5TJyAPQ+qWh/Hzmp9HDur9dHqvCWn9wzV+iDle6gPXe6KELDaB5/bx7GzWh/Hzmp9HDvTpz8T9teQUgS8JveQqvVx7KzWx7GzWh/HzvTpz3gLuT5k+WyEgOc+qFp9tq81prdSl30zap0Vf6O+v7fjM8zt4/+1801iBHyOuQ+rWh/Hzmp9HDur9XHsTJ9E6oOXf48RsNqhoM8eGbXOan0cO6v1cexMnwSiBHwKtYOR2mffTnxteP2MWudtf5bn9hzVnmFqH1fqg+7+QpyAb93SOhxqh9Wzj2NntT6OndX6OHaet486kQJeg5AT+zh2Vuvj2Fmtj2PnzD6O1Ad+64txAr51e8OHjpQD+zh2Vuvj2Fmrz5acWufUPurUB3zjyxEC3iRdxDxpH8fOan0cO6v1cezs18eJGAGvQcj06cuodVbr49hZrY9jZ78+ytT7f+2rEQK+vZdwkXL3rL06cRm69Rn71aJapz36uPVV7ONEjIDPgZjpc/2MWme1Po6d1fo4dua3nVvU+33l6zECvnV7wweOkOlz9YxaZ7U+jp3V+jh2RshrogR8CqS8R2bcP5Kg9iI7Xj6efbTO4Z6d+Pr6+n1cqXd86RtxAt4mS8Tcn6FPf0ats1ofx85qfRw7zyHmSAGvQcitdbRemtw+jp3V+jh2Vuvj2Nn7t53PUcsXvhkn4Dt2EyVS7s/Qpz+j1lmtj1bnvTrN/AxnkXItn/92hoA3CAwxX0bt5Zm7j2NntT6OndX6+HV2IkfAaxDy5YzYS0OfPTJqndX6OHZW6+PXWZla/u17GQLeIEGk3MgM/EcSHF9kvT6OnRW/CtbprdRl3wx/BekUOQI+B2K+nOGn5cA+jp3V+jh2Vusz9j/6HanlX5ccAd/esBWEfDmDkAP7OHZW6+PYWa0PQl6TJeBTIOX+zAYpl9J+eea+fNT6OHZW/Hekx/RW6rJvn306u1LLpwMFfHtLBjF3Z/hpObCPY2e1Po6d1frMIeZMAa9ByDvMQshz9nHsrNbHsbNan5yvnW9Sy6cCBbxJuFsySLk7g5QD+zh29vvt65mf4SxSruUTIQLeTbpbMoi5O4OYA/s4dlbr49hZq48TOQJeg5AbGYTcn6FPf0ats1ofx85afZSp5WMhAh4q3C0ZpNydQcqBfbQ6q3VyfIZqfZzIEfA5EPNFEHNrHb8LyLOPY2e1Po6d5/p7v2tq+UiQgOVkuyWDkLszCDmwj2NntT6OnecScpaATyEn3C0ZpNydQcqBfcZe4KM6pT5D/r5vm1ruDBSwnFD3yiDm7gxiDuzj2Fmtj2NnfzFnCniNnEj3yiDk7gxCDuzj2Fmtj19nR2r5u0ABy4lyZAYpd2eQcmCfrV87939dvFcnx2eo1lmdWv4mRMByIlTLIObuDGIO7OPYWa2PVmcncgS8Rk6AahmE3J1ByIF9HDur9dHqrEwtfxkiYDnBOWaQcncGKQf22efr61L26Z36DGf7K0ilJAn4HHKSc8wg5u4MYg7s49hZrc8+nV2p5b1BApYTV2oGIXdnEHJgH8fOan3mEnKWgE8hJ6/UDFLuziDlwD6OndX6ZH3tfJNa3h0oYDk5zZxBzN0ZxBzYx7GzWh9/MWcKeI2clGbOIOTuDEIO7OPYWauPI7W8M1DActIhczmDlLszSHlIn/GdLmccnyFS/iG1/HmIgOWkQqY/g5i7M4g5sI9jZ/7e7ylyBLxGTiZk+jMIuTuDkAP7OHZGyKWUUsvbQgQsJwsyYzJIuTuDlLszIzulPsM5/yGOFAGfQ04YZMZkEHN3BjEH9nHsnPP3ftfU8mdBApaTABmdDELuziDkwD6OnXOEnCXgU8iJgIxOBil3Z5ByYB+/zq7U8qZAActd9GS8Moi5O4OYA/v4dVYnU8Br5C54Ml4ZhNydQciBfbQ6O1LLGwIFLHeBk8nLIOXuTKiU1TohZV1qeV2IgOUuaDJzZhBzdyZUzHP3GdfZiRwBr5G7mMnMmUHI3RmEHNgHIZdSSi2vCRGw3MVLhsy5DFLuzohJeWtO6x/ryJSyEzkCPofc5UuGzLkMYu7OiInZU4Rqfbx/yr1ELa8KErDchUqGTE8GIXdnEHJgnxwhZwn4FHKXKhkyPRmk3J1BynF9XKnlFYEClrs0yZC5dgYxd2cQc1wfdTIFvEbusiRD5toZhNydQchWfRyp5WWBApa7DMmQUcgg5e7MBimX4idCpS579lGnlpeGCFjusiNDxiWDmLsz/LQs08eJHAGvkbvkyJBxySDk7gxClumjTC2/GyJguUuMDJmkDFLepVOgmJW6uJEj4HPIXWRkyCRlEHN3JlDKo/u4UsvvBAlY7nIiQ2a2DELuziDk7owLWQI+hdwFRYbMbBmk3J1BypHU8sJAActdQGTIkPnRDGLuziBmazIFvEbu4iFDhsyPZhByd2ZiITtSywsCBSx3sZAhQ+a+ZZBydwYpy1LLb4YIWO7iIEOGzPUyiLk7EypmJ3IEvEbuwiBDhsz1Mgi5O4OQh1PLc0MELHchkCFD5tjMOCmXgphb8NeQfpQcAZ9D7lIgQ4bMsRl+Wu7OiEnZlVqeHSRguRedDBky+hmE3J1ByPeJLAGfQu5lJ0OGjH4GKXdnBkrZlVqeGShguZeZDBkyGRnE3J1BzD8gU8Br5F5iMmTIZGQQcndmJyE7UsuvBwpY7iUlQ4bMPBmk3J2ZRMq1/GqIgOVeQjJkyJC5mUHM3ZkNYnYiR8CnkHsByZAhM01m81qNKxgpx1LLL4cIWO3lI0OGzDyZXech5J6MEzkCPofai0qGDBky9zrD19eJ1PKUIAHLvTRkyJAhc40MQk4gS8CnkHtxyJAhQ+YamXml7EotvxAoYLkXgwwZMmSOyiBmVTIFvEbuhSBDhgyZozKZQnaklp8PFLDcgSdDhsw0mb3WQsqNjL+Ua/m5EAGrvYRkyJAhY5/xE7MTOQJeI3eQyZAhQ8Y9g5D3pJbHhwhY7qCSIUNmmsxea6mHhs+yAAAHX0lEQVTty1DKTuQI+Bxyh5UMGTJkZsiME7MrtfxskIDlDiAZMmTIkPl+BiGvyRLwKeQOIRkyZMiQ+X5mJymbUsvPBApY7pCRIUOGDJntmTnEnCngNXKHiwwZMmTIbM9kaqqWnw4UsNzhIUOGzDSZLTm1zpYZf3XV8qgQAcsdDjJkyJAhMzxjRI6A16gdCjJkyJAhMz4jTC0/FSJgtQ+dDBky82S25NQ6p2aMyBHwOdQOBxkyZMiQ2TdjSi0/GSRgtUNBhgwZMmTGZ0zIEvAp1A4GGTJkyJDZN2NKLT8RKGC1w0GGDBkyZMZnxMkU8Bq1Q0GGDBkyZPbNGFLLQwMFrHYwyJAhQ4bM+Iw4tTwkRMBqHzwZMmTIkBmfMSJHwGvUDgUZMmTIkBmfEaaWHw8RsNqHToYMGTJkxmeMyBHwOdQOBxkyZMiQ2TdjSi0/FiRgtUNBhgwZMmTGZ0zIEvAp1A4GGTJkyJDZN2NKLQ8IFLDa4SBDhgwZMuMz4mQKeI3aoSBDhgwZMvtmDKnl/oECVjsYZMiQuV5mS06tM5kxGXFquR0iYLUPngwZMmTIjM8YkSPgNWqHggwZMmTIjM8IU0sJEbDah06GDBkyZMZnjMgR8DnUDgcZMmTIkNk3Y0q+gNeoHRwyZMiQIbNvxoT5BHwKtcNDhgwZ/cyWnFrn1IwpCPgSaoeMDBkyZMhsz4iDgO8NaoeLDBkyZMjYgoB7UTuEZMjMltlrLbV9kenPiFNL+V6IgOvRBf4/ageRDBkyZGbIGBEk4DUImQwZMmSmzwhTS/l2iIC3fBJIWSazJafWmQwZMvoZI4IEfA7ETIYMGTLRGVNqKf8TJOD7bcggZDJkyJCJzpgQJuBTIGUyZMiQic6YUkv5eqCAt3xiiJkMGTJkojPihAp4DUImQ4YMmeiMIbWUrwQKeC+ZImUyZKbJ7LWW2r5mzohTS/lSiIBHChUxkyFDhoxkxoggAa9ByN2ovVhkyJAhc28zwtRS/jNEwGoyRcpkyJAhMzxjRJCAz6EmVMRMhgwZMrtmTKmlfC5IwFvkpiZShEyGDBkyu2ZMCBPwKZCyDGovKRkyZDIyptRS7goU8F6SUxMqYiZDhgyZzRlxQgW8BiFfBiGTIUPGPGNILeVfAgU8UnBqMkXKZMiQIeNALeWfQgSsJjk1oSJmMmTITJAxIkjAa9TkpiZShEyGDJkJMsLUUj4RImA1MSFlGdQuBDJkyFwvY0SQgM+hJifELIPaxUGGDJn7ljGllvKxIAE7Sgkhy6B2qZAhQ+a+ZUwIE/ApHMWElGVQu1jIkCETQy3lw4ECVpMKYu5fBzGTIUPmXmbECRXwGjWZIOT+dRAyGTJkvKml/H2ggB2FgpT710HKZMiQ8aGW8sEQAavJwHEdx86ImQwZMp4ECXiNmgQc13HsjJDJkCHjQS3lr0ME7CgCx3UcOyNlMmQiMvcmZ0CQgM/hKAPHdRw7I2YyZCIyptRS3hckYLXLe+Z1HDsjZDJkIjImhAn4FGoX+MzrOHZGymTIyGdMqaW8O1DAM8vAcR3HzoiZDBn5jDihAl4zswQc13HsjJDJkDk0Y0gt5Z2BAkYEees4dkbKZCbLjJ5nLuZayttDBIwM5lzHsTNiJkPmahkjggS8BgnMuY5jZ4RMhszVMsLUUt4aImC1S1XtAp95HcfOSJmMQGb0vAmke5MgAZ9D7WJVu8RnXsexM2ImQyaFWsqbgwSsdhHOLAHHdRw7I2QyZFwJE/Ap1C7DmUXguI5jZ6RMZrKMKbWUNwYK2PFCnFkGjus4dkbMZCbLiBMq4DWOF+HMEnBcx7EzQiYTlDGklvIngQJWu8QcRbDXWo7PUO2z2LLOnmuZiVlNBKOlo9ZJLSNMLeW1IQJWu3zV1nHsnLqOY2czKZeiJwIyYzJGBAl4jeMFhgTmXMexM0ImY5IRppbyqhABq10+juuMnrfHOkpd9lzHsTNS7s6MnpeaMSFIwOdQu4Ac13HsnLqOY2fETObKGVNqKa8IErDjxeO4jmPn1HUcOyNkMlfOmBAm4FM4Xj6O66h13rKW2jNM/SyQMpkrZ0yppfxhoIDVLo6Z13HsnLqOY2fETKYjI06ogNeoXRgzr+PYOXUdx84ImUwOdxxdAAAAYEYQMAAAwAEgYAAAgANAwAAAAAeAgAEAAA4AAQMAABwAAgYAADgABAwAAHAACBgAAOAAEDAAAMABIGAAAIADQMAAAAAHgIABAAAOAAEDAAAcAAIGAAA4AAQMAABwAAgYAADgABAwAADAASBgAACAA0DAAAAAB4CAAQAADgABAwAAHAACBgAAOAAEDAAAcAAIGAAA4AAQMAAAwAEgYAAAgANAwAAAAAeAgAEAAA4AAQMAABwAAgYAADgABAwAAHAACBgAAOAAEDAAAMABIGAAAIADQMAAAAAHgIABAAAOAAEDAAAcAAIGAAA4AAQMAABwAAgYAADgABAwAADAASBgAACAA0DAAAAAB4CAAQAADgABAwAAHAACBgAAOID/BSBJjZRSsSglAAAAAElFTkSuQmCC" y="-43.2"/>
    </g>
    <g id="LineCollection_1">
-    <path clip-path="url(#pf52b15eb6f)" d="M 156.96 119.232 
+    <path clip-path="url(#pc10af623d4)" d="M 156.96 119.232 
 L 226.08 105.408 
 L 286.248605 93.374279 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-    <path clip-path="url(#pf52b15eb6f)" d="M 156.96 119.232 
+    <path clip-path="url(#pc10af623d4)" d="M 156.96 119.232 
 L 226.08 105.408 
 L 286.248605 93.374279 
 " style="fill:none;stroke:#000000;"/>
-    <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 89.793721 
+    <path clip-path="url(#pc10af623d4)" d="M 304.151395 89.793721 
 L 364.32 77.76 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-    <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 89.793721 
+    <path clip-path="url(#pc10af623d4)" d="M 304.151395 89.793721 
 L 364.32 77.76 
 " style="fill:none;stroke:#000000;"/>
     <g id="LineCollection_2">
-     <path clip-path="url(#pf52b15eb6f)" d="M 156.96 160.704 
+     <path clip-path="url(#pc10af623d4)" d="M 156.96 160.704 
 L 226.08 146.88 
 L 286.248605 134.846279 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-     <path clip-path="url(#pf52b15eb6f)" d="M 156.96 160.704 
+     <path clip-path="url(#pc10af623d4)" d="M 156.96 160.704 
 L 226.08 146.88 
 L 286.248605 134.846279 
 " style="fill:none;stroke:#000000;"/>
-     <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 131.265721 
+     <path clip-path="url(#pc10af623d4)" d="M 304.151395 131.265721 
 L 364.32 119.232 
 L 433.44 105.408 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-     <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 131.265721 
+     <path clip-path="url(#pc10af623d4)" d="M 304.151395 131.265721 
 L 364.32 119.232 
 L 433.44 105.408 
 " style="fill:none;stroke:#000000;"/>
      <g id="LineCollection_3">
-      <path clip-path="url(#pf52b15eb6f)" d="M 156.96 202.176 
+      <path clip-path="url(#pc10af623d4)" d="M 156.96 202.176 
 L 226.08 188.352 
 L 286.248605 176.318279 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-      <path clip-path="url(#pf52b15eb6f)" d="M 156.96 202.176 
+      <path clip-path="url(#pc10af623d4)" d="M 156.96 202.176 
 L 226.08 188.352 
 L 286.248605 176.318279 
 " style="fill:none;stroke:#000000;"/>
-      <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 172.737721 
+      <path clip-path="url(#pc10af623d4)" d="M 304.151395 172.737721 
 L 364.32 160.704 
 L 433.44 146.88 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-      <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 172.737721 
+      <path clip-path="url(#pc10af623d4)" d="M 304.151395 172.737721 
 L 364.32 160.704 
 L 433.44 146.88 
 " style="fill:none;stroke:#000000;"/>
       <g id="LineCollection_4">
-       <path clip-path="url(#pf52b15eb6f)" d="M 156.96 243.648 
+       <path clip-path="url(#pc10af623d4)" d="M 156.96 243.648 
 L 226.08 229.824 
 L 286.248605 217.790279 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-       <path clip-path="url(#pf52b15eb6f)" d="M 156.96 243.648 
+       <path clip-path="url(#pc10af623d4)" d="M 156.96 243.648 
 L 226.08 229.824 
 L 286.248605 217.790279 
 " style="fill:none;stroke:#000000;"/>
-       <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 214.209721 
+       <path clip-path="url(#pc10af623d4)" d="M 304.151395 214.209721 
 L 364.32 202.176 
 L 433.44 188.352 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-       <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 214.209721 
+       <path clip-path="url(#pc10af623d4)" d="M 304.151395 214.209721 
 L 364.32 202.176 
 L 433.44 188.352 
 " style="fill:none;stroke:#000000;"/>
        <g id="LineCollection_5">
-        <path clip-path="url(#pf52b15eb6f)" d="M 156.96 285.12 
+        <path clip-path="url(#pc10af623d4)" d="M 156.96 285.12 
 L 226.08 271.296 
 L 286.248605 259.262279 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-        <path clip-path="url(#pf52b15eb6f)" d="M 156.96 285.12 
+        <path clip-path="url(#pc10af623d4)" d="M 156.96 285.12 
 L 226.08 271.296 
 L 286.248605 259.262279 
 " style="fill:none;stroke:#000000;"/>
-        <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 255.681721 
+        <path clip-path="url(#pc10af623d4)" d="M 304.151395 255.681721 
 L 364.32 243.648 
 L 433.44 229.824 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-        <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 255.681721 
+        <path clip-path="url(#pc10af623d4)" d="M 304.151395 255.681721 
 L 364.32 243.648 
 L 433.44 229.824 
 " style="fill:none;stroke:#000000;"/>
         <g id="LineCollection_6">
-         <path clip-path="url(#pf52b15eb6f)" d="M 156.96 326.592 
+         <path clip-path="url(#pc10af623d4)" d="M 156.96 326.592 
 L 226.08 312.768 
 L 286.248605 300.734279 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-         <path clip-path="url(#pf52b15eb6f)" d="M 156.96 326.592 
+         <path clip-path="url(#pc10af623d4)" d="M 156.96 326.592 
 L 226.08 312.768 
 L 286.248605 300.734279 
 " style="fill:none;stroke:#000000;"/>
-         <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 297.153721 
+         <path clip-path="url(#pc10af623d4)" d="M 304.151395 297.153721 
 L 364.32 285.12 
 L 433.44 271.296 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-         <path clip-path="url(#pf52b15eb6f)" d="M 304.151395 297.153721 
+         <path clip-path="url(#pc10af623d4)" d="M 304.151395 297.153721 
 L 364.32 285.12 
 L 433.44 271.296 
 " style="fill:none;stroke:#000000;"/>
          <g id="LineCollection_7">
-          <path clip-path="url(#pf52b15eb6f)" d="M 226.08 354.24 
+          <path clip-path="url(#pc10af623d4)" d="M 226.08 354.24 
 L 295.2 340.416 
 L 355.368605 328.382279 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-          <path clip-path="url(#pf52b15eb6f)" d="M 226.08 354.24 
+          <path clip-path="url(#pc10af623d4)" d="M 226.08 354.24 
 L 295.2 340.416 
 L 355.368605 328.382279 
 " style="fill:none;stroke:#000000;"/>
-          <path clip-path="url(#pf52b15eb6f)" d="M 373.271395 324.801721 
+          <path clip-path="url(#pc10af623d4)" d="M 373.271395 324.801721 
 L 433.44 312.768 
 " style="fill:none;stroke:#ffffff;stroke-width:3;"/>
-          <path clip-path="url(#pf52b15eb6f)" d="M 373.271395 324.801721 
+          <path clip-path="url(#pc10af623d4)" d="M 373.271395 324.801721 
 L 433.44 312.768 
 " style="fill:none;stroke:#000000;"/>
           <g id="patch_3">
@@ -171,68 +171,68 @@ L 468 43.2
              <defs>
               <path d="M 0 0 
 L 0 -4 
-" id="m3267c14310" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m2f3d5f40a4" style="stroke:#000000;stroke-width:0.5;"/>
              </defs>
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="156.96" xlink:href="#m3267c14310" y="388.8"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="156.96" xlink:href="#m2f3d5f40a4" y="388.8"/>
              </g>
             </g>
             <g id="line2d_2">
              <defs>
               <path d="M 0 0 
 L 0 4 
-" id="m6ff33dbe7f" style="stroke:#000000;stroke-width:0.5;"/>
+" id="md9f387142a" style="stroke:#000000;stroke-width:0.5;"/>
              </defs>
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="156.96" xlink:href="#m6ff33dbe7f" y="43.2"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="156.96" xlink:href="#md9f387142a" y="43.2"/>
              </g>
             </g>
            </g>
            <g id="xtick_2">
             <g id="line2d_3">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="226.08" xlink:href="#m3267c14310" y="388.8"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="226.08" xlink:href="#m2f3d5f40a4" y="388.8"/>
              </g>
             </g>
             <g id="line2d_4">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="226.08" xlink:href="#m6ff33dbe7f" y="43.2"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="226.08" xlink:href="#md9f387142a" y="43.2"/>
              </g>
             </g>
            </g>
            <g id="xtick_3">
             <g id="line2d_5">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m3267c14310" y="388.8"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m2f3d5f40a4" y="388.8"/>
              </g>
             </g>
             <g id="line2d_6">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#m6ff33dbe7f" y="43.2"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="295.2" xlink:href="#md9f387142a" y="43.2"/>
              </g>
             </g>
            </g>
            <g id="xtick_4">
             <g id="line2d_7">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="364.32" xlink:href="#m3267c14310" y="388.8"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="364.32" xlink:href="#m2f3d5f40a4" y="388.8"/>
              </g>
             </g>
             <g id="line2d_8">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="364.32" xlink:href="#m6ff33dbe7f" y="43.2"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="364.32" xlink:href="#md9f387142a" y="43.2"/>
              </g>
             </g>
            </g>
            <g id="xtick_5">
             <g id="line2d_9">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="433.44" xlink:href="#m3267c14310" y="388.8"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="433.44" xlink:href="#m2f3d5f40a4" y="388.8"/>
              </g>
             </g>
             <g id="line2d_10">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="433.44" xlink:href="#m6ff33dbe7f" y="43.2"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="433.44" xlink:href="#md9f387142a" y="43.2"/>
              </g>
             </g>
            </g>
@@ -243,564 +243,564 @@ L 0 4
              <defs>
               <path d="M 0 0 
 L 4 0 
-" id="mfa1092764e" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mce72a29dd7" style="stroke:#000000;stroke-width:0.5;"/>
              </defs>
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mfa1092764e" y="77.76"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mce72a29dd7" y="77.76"/>
              </g>
             </g>
             <g id="line2d_12">
              <defs>
               <path d="M 0 0 
 L -4 0 
-" id="m40efb1c0e1" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mb5516eb2ed" style="stroke:#000000;stroke-width:0.5;"/>
              </defs>
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#m40efb1c0e1" y="77.76"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#mb5516eb2ed" y="77.76"/>
              </g>
             </g>
            </g>
            <g id="ytick_2">
             <g id="line2d_13">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mfa1092764e" y="146.88"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mce72a29dd7" y="146.88"/>
              </g>
             </g>
             <g id="line2d_14">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#m40efb1c0e1" y="146.88"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#mb5516eb2ed" y="146.88"/>
              </g>
             </g>
            </g>
            <g id="ytick_3">
             <g id="line2d_15">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mfa1092764e" y="216"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mce72a29dd7" y="216"/>
              </g>
             </g>
             <g id="line2d_16">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#m40efb1c0e1" y="216"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#mb5516eb2ed" y="216"/>
              </g>
             </g>
            </g>
            <g id="ytick_4">
             <g id="line2d_17">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mfa1092764e" y="285.12"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mce72a29dd7" y="285.12"/>
              </g>
             </g>
             <g id="line2d_18">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#m40efb1c0e1" y="285.12"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#mb5516eb2ed" y="285.12"/>
              </g>
             </g>
            </g>
            <g id="ytick_5">
             <g id="line2d_19">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mfa1092764e" y="354.24"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="122.4" xlink:href="#mce72a29dd7" y="354.24"/>
              </g>
             </g>
             <g id="line2d_20">
              <g>
-              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#m40efb1c0e1" y="354.24"/>
+              <use style="stroke:#000000;stroke-width:0.5;" x="468" xlink:href="#mb5516eb2ed" y="354.24"/>
              </g>
             </g>
            </g>
           </g>
           <g id="text_1">
-           <path clip-path="url(#pf52b15eb6f)" d="M 297.826194 89.624662 
-Q 298.694744 89.636429 299.274635 90.107476 
-Q 299.855996 90.576316 300.021469 91.403681 
-Q 300.275195 92.672307 299.54123 93.543798 
-Q 298.806898 94.413451 297.198132 94.735204 
+           <path clip-path="url(#pc10af623d4)" d="M 297.826194 89.624662 
+Q 298.694744 89.636429 299.274634 90.107475 
+Q 299.855996 90.576315 300.021469 91.40368 
+Q 300.275194 92.672307 299.54123 93.543798 
+Q 298.806897 94.41345 297.198132 94.735203 
 Q 296.659426 94.842945 296.066297 94.850667 
 Q 295.473168 94.858389 294.82194 94.766827 
-L 294.598 93.647127 
-Q 295.135971 93.832089 295.738293 93.860771 
+L 294.598 93.647126 
+Q 295.135971 93.832088 295.738293 93.86077 
 Q 296.342453 93.889085 296.969412 93.763693 
-Q 298.059695 93.545637 298.54545 93.001047 
-Q 299.031205 92.456457 298.866836 91.634608 
-Q 298.714968 90.87527 298.098306 90.554988 
+Q 298.059695 93.545636 298.54545 93.001046 
+Q 299.031205 92.456456 298.866835 91.634607 
+Q 298.714968 90.87527 298.098305 90.554988 
 Q 297.481275 90.232867 296.534402 90.422242 
-L 295.53421 90.62228 
+L 295.534209 90.62228 
 L 295.343364 89.668053 
 L 296.389521 89.458821 
-Q 297.244465 89.287833 297.630201 88.855029 
-Q 298.015937 88.422225 297.887236 87.778719 
-Q 297.755225 87.118666 297.215783 86.859425 
+Q 297.244465 89.287832 297.630201 88.855029 
+Q 298.015937 88.422225 297.887235 87.778719 
+Q 297.755225 87.118665 297.215783 86.859424 
 Q 296.677812 86.597977 295.804482 86.772643 
-Q 295.326449 86.86825 294.801348 87.082262 
-Q 294.27588 87.294435 293.664733 87.642296 
+Q 295.326449 86.86825 294.801348 87.082261 
+Q 294.275879 87.294435 293.664732 87.642296 
 L 293.458075 86.609009 
-Q 294.083196 86.292772 294.642127 86.085379 
-Q 295.201058 85.877986 295.712185 85.77576 
-Q 297.034131 85.511371 297.922904 85.958884 
-Q 298.813149 86.40419 299.0176 87.426446 
-Q 299.160275 88.139818 298.850288 88.712355 
+Q 294.083195 86.292771 294.642126 86.085379 
+Q 295.201057 85.877986 295.712185 85.77576 
+Q 297.03413 85.511371 297.922904 85.958884 
+Q 298.813149 86.40419 299.0176 87.426445 
+Q 299.160274 88.139818 298.850288 88.712354 
 Q 298.540302 89.284891 297.826194 89.624662 
 " style="stroke:#ffffff;stroke-width:3;"/>
-           <path clip-path="url(#pf52b15eb6f)" d="M 297.826194 89.624662 
-Q 298.694744 89.636429 299.274635 90.107476 
-Q 299.855996 90.576316 300.021469 91.403681 
-Q 300.275195 92.672307 299.54123 93.543798 
-Q 298.806898 94.413451 297.198132 94.735204 
+           <path clip-path="url(#pc10af623d4)" d="M 297.826194 89.624662 
+Q 298.694744 89.636429 299.274634 90.107475 
+Q 299.855996 90.576315 300.021469 91.40368 
+Q 300.275194 92.672307 299.54123 93.543798 
+Q 298.806897 94.41345 297.198132 94.735203 
 Q 296.659426 94.842945 296.066297 94.850667 
 Q 295.473168 94.858389 294.82194 94.766827 
-L 294.598 93.647127 
-Q 295.135971 93.832089 295.738293 93.860771 
+L 294.598 93.647126 
+Q 295.135971 93.832088 295.738293 93.86077 
 Q 296.342453 93.889085 296.969412 93.763693 
-Q 298.059695 93.545637 298.54545 93.001047 
-Q 299.031205 92.456457 298.866836 91.634608 
-Q 298.714968 90.87527 298.098306 90.554988 
+Q 298.059695 93.545636 298.54545 93.001046 
+Q 299.031205 92.456456 298.866835 91.634607 
+Q 298.714968 90.87527 298.098305 90.554988 
 Q 297.481275 90.232867 296.534402 90.422242 
-L 295.53421 90.62228 
+L 295.534209 90.62228 
 L 295.343364 89.668053 
 L 296.389521 89.458821 
-Q 297.244465 89.287833 297.630201 88.855029 
-Q 298.015937 88.422225 297.887236 87.778719 
-Q 297.755225 87.118666 297.215783 86.859425 
+Q 297.244465 89.287832 297.630201 88.855029 
+Q 298.015937 88.422225 297.887235 87.778719 
+Q 297.755225 87.118665 297.215783 86.859424 
 Q 296.677812 86.597977 295.804482 86.772643 
-Q 295.326449 86.86825 294.801348 87.082262 
-Q 294.27588 87.294435 293.664733 87.642296 
+Q 295.326449 86.86825 294.801348 87.082261 
+Q 294.275879 87.294435 293.664732 87.642296 
 L 293.458075 86.609009 
-Q 294.083196 86.292772 294.642127 86.085379 
-Q 295.201058 85.877986 295.712185 85.77576 
-Q 297.034131 85.511371 297.922904 85.958884 
-Q 298.813149 86.40419 299.0176 87.426446 
-Q 299.160275 88.139818 298.850288 88.712355 
+Q 294.083195 86.292771 294.642126 86.085379 
+Q 295.201057 85.877986 295.712185 85.77576 
+Q 297.03413 85.511371 297.922904 85.958884 
+Q 298.813149 86.40419 299.0176 87.426445 
+Q 299.160274 88.139818 298.850288 88.712354 
 Q 298.540302 89.284891 297.826194 89.624662 
 "/>
           </g>
           <g id="text_2">
-           <path clip-path="url(#pf52b15eb6f)" d="M 296.911313 131.149614 
-Q 296.129912 131.305894 295.77911 131.932485 
+           <path clip-path="url(#pc10af623d4)" d="M 296.911312 131.149613 
+Q 296.129912 131.305893 295.77911 131.932484 
 Q 295.429778 132.556869 295.615843 133.487195 
 Q 295.800805 134.412005 296.364516 134.859518 
 Q 296.929698 135.304824 297.711099 135.148544 
 Q 298.492499 134.992264 298.841095 134.364202 
-Q 299.189324 133.734302 299.004362 132.809492 
-Q 298.818297 131.879166 298.255689 131.437169 
-Q 297.692713 130.993334 296.911313 131.149614 
+Q 299.189324 133.734301 299.004362 132.809491 
+Q 298.818297 131.879165 298.255689 131.437169 
+Q 297.692713 130.993333 296.911312 131.149613 
 M 298.487351 127.050296 
-L 298.698789 128.107485 
-Q 298.22002 127.98908 297.753387 127.96959 
-Q 297.286385 127.948263 296.848801 128.03578 
-Q 295.699683 128.265603 295.248125 129.162834 
-Q 294.798407 130.059698 295.025656 131.645297 
+L 298.698788 128.107484 
+Q 298.22002 127.989079 297.753386 127.96959 
+Q 297.286385 127.948263 296.8488 128.035779 
+Q 295.699682 128.265603 295.248125 129.162834 
+Q 294.798406 130.059698 295.025656 131.645297 
 Q 295.263937 131.077541 295.721746 130.70872 
-Q 296.181393 130.339531 296.795482 130.216714 
-Q 298.08801 129.958208 298.995169 130.593257 
-Q 299.901961 131.226467 300.171866 132.575991 
+Q 296.181393 130.339531 296.795481 130.216713 
+Q 298.088009 129.958208 298.995169 130.593256 
+Q 299.901961 131.226466 300.171866 132.57599 
 Q 300.436255 133.897936 299.814812 134.854002 
-Q 299.193001 135.80823 297.894957 136.067839 
+Q 299.193001 135.80823 297.894957 136.067838 
 Q 296.405701 136.36569 295.3908 135.383148 
-Q 294.375531 134.398768 293.94236 132.23291 
-Q 293.535664 130.199431 294.258965 128.796588 
-Q 294.982266 127.393744 296.607578 127.068682 
+Q 294.375531 134.398767 293.942359 132.23291 
+Q 293.535663 130.199431 294.258964 128.796587 
+Q 294.982265 127.393744 296.607578 127.068682 
 Q 297.045162 126.981165 297.507383 126.978591 
-Q 297.969605 126.976017 298.487351 127.050296 
+Q 297.969604 126.976017 298.487351 127.050296 
 " style="stroke:#ffffff;stroke-width:3;"/>
-           <path clip-path="url(#pf52b15eb6f)" d="M 296.911313 131.149614 
-Q 296.129912 131.305894 295.77911 131.932485 
+           <path clip-path="url(#pc10af623d4)" d="M 296.911312 131.149613 
+Q 296.129912 131.305893 295.77911 131.932484 
 Q 295.429778 132.556869 295.615843 133.487195 
 Q 295.800805 134.412005 296.364516 134.859518 
 Q 296.929698 135.304824 297.711099 135.148544 
 Q 298.492499 134.992264 298.841095 134.364202 
-Q 299.189324 133.734302 299.004362 132.809492 
-Q 298.818297 131.879166 298.255689 131.437169 
-Q 297.692713 130.993334 296.911313 131.149614 
+Q 299.189324 133.734301 299.004362 132.809491 
+Q 298.818297 131.879165 298.255689 131.437169 
+Q 297.692713 130.993333 296.911312 131.149613 
 M 298.487351 127.050296 
-L 298.698789 128.107485 
-Q 298.22002 127.98908 297.753387 127.96959 
-Q 297.286385 127.948263 296.848801 128.03578 
-Q 295.699683 128.265603 295.248125 129.162834 
-Q 294.798407 130.059698 295.025656 131.645297 
+L 298.698788 128.107484 
+Q 298.22002 127.989079 297.753386 127.96959 
+Q 297.286385 127.948263 296.8488 128.035779 
+Q 295.699682 128.265603 295.248125 129.162834 
+Q 294.798406 130.059698 295.025656 131.645297 
 Q 295.263937 131.077541 295.721746 130.70872 
-Q 296.181393 130.339531 296.795482 130.216714 
-Q 298.08801 129.958208 298.995169 130.593257 
-Q 299.901961 131.226467 300.171866 132.575991 
+Q 296.181393 130.339531 296.795481 130.216713 
+Q 298.088009 129.958208 298.995169 130.593256 
+Q 299.901961 131.226466 300.171866 132.57599 
 Q 300.436255 133.897936 299.814812 134.854002 
-Q 299.193001 135.80823 297.894957 136.067839 
+Q 299.193001 135.80823 297.894957 136.067838 
 Q 296.405701 136.36569 295.3908 135.383148 
-Q 294.375531 134.398768 293.94236 132.23291 
-Q 293.535664 130.199431 294.258965 128.796588 
-Q 294.982266 127.393744 296.607578 127.068682 
+Q 294.375531 134.398767 293.942359 132.23291 
+Q 293.535663 130.199431 294.258964 128.796587 
+Q 294.982265 127.393744 296.607578 127.068682 
 Q 297.045162 126.981165 297.507383 126.978591 
-Q 297.969605 126.976017 298.487351 127.050296 
+Q 297.969604 126.976017 298.487351 127.050296 
 "/>
           </g>
           <g id="text_3">
-           <path clip-path="url(#pf52b15eb6f)" d="M 295.233416 177.712666 
+           <path clip-path="url(#pc10af623d4)" d="M 295.233416 177.712666 
 L 295.021979 176.655477 
 Q 295.501115 176.775721 295.969587 176.794842 
 Q 296.439898 176.813596 296.871967 176.727182 
-Q 298.021085 176.497359 298.471539 175.604172 
-Q 298.923832 174.710618 298.695112 173.117665 
+Q 298.021085 176.497358 298.471539 175.604172 
+Q 298.923832 174.710618 298.695111 173.117665 
 Q 298.461243 173.678802 298.001228 174.046152 
 Q 297.543052 174.413134 296.923447 174.537055 
-Q 295.636435 174.794458 294.730746 174.166763 
-Q 293.82469 173.537231 293.554417 172.185868 
-Q 293.290396 170.865761 293.912207 169.911534 
-Q 294.53365 168.955467 295.831694 168.695859 
+Q 295.636435 174.794457 294.730746 174.166763 
+Q 293.82469 173.53723 293.554417 172.185868 
+Q 293.290396 170.865761 293.912206 169.911533 
+Q 294.533649 168.955467 295.831693 168.695859 
 Q 297.32095 168.398007 298.332542 169.383123 
 Q 299.345604 170.366033 299.779879 172.537406 
-Q 300.185472 174.56537 299.464009 175.967845 
-Q 298.744386 177.369953 297.119073 177.695015 
-Q 296.681489 177.782532 296.215591 177.785842 
+Q 300.185471 174.565369 299.464009 175.967845 
+Q 298.744385 177.369953 297.119073 177.695015 
+Q 296.681489 177.782532 296.21559 177.785841 
 Q 295.751531 177.788783 295.233416 177.712666 
-M 296.815338 173.614084 
-Q 297.596739 173.457804 297.94607 172.833419 
+M 296.815338 173.614083 
+Q 297.596738 173.457803 297.94607 172.833419 
 Q 298.296873 172.206828 298.11044 171.274663 
 Q 297.925478 170.349853 297.360296 169.904547 
-Q 296.796953 169.458873 296.015552 169.615153 
-Q 295.234152 169.771433 294.885556 170.399495 
+Q 296.796952 169.458873 296.015552 169.615153 
+Q 295.234152 169.771433 294.885555 170.399495 
 Q 294.536959 171.027557 294.721921 171.952367 
-Q 294.908354 172.884532 295.47133 173.328367 
-Q 296.033938 173.770364 296.815338 173.614084 
+Q 294.908354 172.884531 295.47133 173.328367 
+Q 296.033938 173.770364 296.815338 173.614083 
 " style="stroke:#ffffff;stroke-width:3;"/>
-           <path clip-path="url(#pf52b15eb6f)" d="M 295.233416 177.712666 
+           <path clip-path="url(#pc10af623d4)" d="M 295.233416 177.712666 
 L 295.021979 176.655477 
 Q 295.501115 176.775721 295.969587 176.794842 
 Q 296.439898 176.813596 296.871967 176.727182 
-Q 298.021085 176.497359 298.471539 175.604172 
-Q 298.923832 174.710618 298.695112 173.117665 
+Q 298.021085 176.497358 298.471539 175.604172 
+Q 298.923832 174.710618 298.695111 173.117665 
 Q 298.461243 173.678802 298.001228 174.046152 
 Q 297.543052 174.413134 296.923447 174.537055 
-Q 295.636435 174.794458 294.730746 174.166763 
-Q 293.82469 173.537231 293.554417 172.185868 
-Q 293.290396 170.865761 293.912207 169.911534 
-Q 294.53365 168.955467 295.831694 168.695859 
+Q 295.636435 174.794457 294.730746 174.166763 
+Q 293.82469 173.53723 293.554417 172.185868 
+Q 293.290396 170.865761 293.912206 169.911533 
+Q 294.533649 168.955467 295.831693 168.695859 
 Q 297.32095 168.398007 298.332542 169.383123 
 Q 299.345604 170.366033 299.779879 172.537406 
-Q 300.185472 174.56537 299.464009 175.967845 
-Q 298.744386 177.369953 297.119073 177.695015 
-Q 296.681489 177.782532 296.215591 177.785842 
+Q 300.185471 174.565369 299.464009 175.967845 
+Q 298.744385 177.369953 297.119073 177.695015 
+Q 296.681489 177.782532 296.21559 177.785841 
 Q 295.751531 177.788783 295.233416 177.712666 
-M 296.815338 173.614084 
-Q 297.596739 173.457804 297.94607 172.833419 
+M 296.815338 173.614083 
+Q 297.596738 173.457803 297.94607 172.833419 
 Q 298.296873 172.206828 298.11044 171.274663 
 Q 297.925478 170.349853 297.360296 169.904547 
-Q 296.796953 169.458873 296.015552 169.615153 
-Q 295.234152 169.771433 294.885556 170.399495 
+Q 296.796952 169.458873 296.015552 169.615153 
+Q 295.234152 169.771433 294.885555 170.399495 
 Q 294.536959 171.027557 294.721921 171.952367 
-Q 294.908354 172.884532 295.47133 173.328367 
-Q 296.033938 173.770364 296.815338 173.614084 
+Q 294.908354 172.884531 295.47133 173.328367 
+Q 296.033938 173.770364 296.815338 173.614083 
 "/>
           </g>
           <g id="text_4">
-           <path clip-path="url(#pf52b15eb6f)" d="M 289.627238 219.476036 
-L 291.522823 219.096919 
-L 290.213748 212.551543 
+           <path clip-path="url(#pc10af623d4)" d="M 289.627237 219.476036 
+L 291.522822 219.096919 
+L 290.213747 212.551543 
 L 288.233587 213.377805 
-L 288.02215 212.320616 
+L 288.022149 212.320616 
 L 289.991278 211.496561 
 L 291.151428 211.264531 
-L 292.671941 218.867096 
-L 294.567526 218.487979 
+L 292.67194 218.867095 
+L 294.567525 218.487978 
 L 294.762784 219.464269 
 L 289.822496 220.452327 
 z
 M 297.911689 217.819146 
-L 301.9621 217.009064 
-L 302.157358 217.985355 
+L 301.9621 217.009063 
+L 302.157358 217.985354 
 L 296.711458 219.074534 
-L 296.5162 218.098244 
-Q 297.039462 217.282278 297.949196 215.903337 
-Q 298.860401 214.522189 299.085812 214.129098 
-Q 299.51788 213.39256 299.651729 212.914527 
-Q 299.787417 212.436126 299.703578 212.016928 
-Q 299.566787 211.332973 299.000869 210.998717 
-Q 298.434584 210.662623 297.664215 210.816697 
-Q 297.118154 210.925909 296.549295 211.236631 
-Q 295.982274 211.546984 295.370024 212.070982 
+L 296.5162 218.098243 
+Q 297.039462 217.282278 297.949196 215.903336 
+Q 298.8604 214.522188 299.085811 214.129098 
+Q 299.51788 213.392559 299.651729 212.914526 
+Q 299.787417 212.436125 299.703577 212.016927 
+Q 299.566786 211.332972 299.000869 210.998717 
+Q 298.434583 210.662623 297.664215 210.816697 
+Q 297.118154 210.925909 296.549294 211.23663 
+Q 295.982274 211.546984 295.370023 212.070982 
 L 295.13542 210.897962 
 Q 295.779661 210.476558 296.359552 210.211433 
-Q 296.941282 209.945941 297.446894 209.844819 
-Q 298.779871 209.578224 299.705784 210.087145 
-Q 300.63133 210.594228 300.854166 211.708413 
-Q 300.960069 212.237926 300.856373 212.751996 
-Q 300.754147 213.263859 300.358851 214.012164 
-Q 300.248903 214.208158 299.637756 215.15834 
-Q 299.028448 216.108155 297.911689 217.819146 
+Q 296.941281 209.945941 297.446893 209.844818 
+Q 298.77987 209.578223 299.705784 210.087144 
+Q 300.631329 210.594227 300.854166 211.708412 
+Q 300.960069 212.237926 300.856372 212.751995 
+Q 300.754147 213.263858 300.35885 214.012164 
+Q 300.248903 214.208157 299.637756 215.15834 
+Q 299.028447 216.108155 297.911689 217.819146 
 " style="stroke:#ffffff;stroke-width:3;"/>
-           <path clip-path="url(#pf52b15eb6f)" d="M 289.627238 219.476036 
-L 291.522823 219.096919 
-L 290.213748 212.551543 
+           <path clip-path="url(#pc10af623d4)" d="M 289.627237 219.476036 
+L 291.522822 219.096919 
+L 290.213747 212.551543 
 L 288.233587 213.377805 
-L 288.02215 212.320616 
+L 288.022149 212.320616 
 L 289.991278 211.496561 
 L 291.151428 211.264531 
-L 292.671941 218.867096 
-L 294.567526 218.487979 
+L 292.67194 218.867095 
+L 294.567525 218.487978 
 L 294.762784 219.464269 
 L 289.822496 220.452327 
 z
 M 297.911689 217.819146 
-L 301.9621 217.009064 
-L 302.157358 217.985355 
+L 301.9621 217.009063 
+L 302.157358 217.985354 
 L 296.711458 219.074534 
-L 296.5162 218.098244 
-Q 297.039462 217.282278 297.949196 215.903337 
-Q 298.860401 214.522189 299.085812 214.129098 
-Q 299.51788 213.39256 299.651729 212.914527 
-Q 299.787417 212.436126 299.703578 212.016928 
-Q 299.566787 211.332973 299.000869 210.998717 
-Q 298.434584 210.662623 297.664215 210.816697 
-Q 297.118154 210.925909 296.549295 211.236631 
-Q 295.982274 211.546984 295.370024 212.070982 
+L 296.5162 218.098243 
+Q 297.039462 217.282278 297.949196 215.903336 
+Q 298.8604 214.522188 299.085811 214.129098 
+Q 299.51788 213.392559 299.651729 212.914526 
+Q 299.787417 212.436125 299.703577 212.016927 
+Q 299.566786 211.332972 299.000869 210.998717 
+Q 298.434583 210.662623 297.664215 210.816697 
+Q 297.118154 210.925909 296.549294 211.23663 
+Q 295.982274 211.546984 295.370023 212.070982 
 L 295.13542 210.897962 
 Q 295.779661 210.476558 296.359552 210.211433 
-Q 296.941282 209.945941 297.446894 209.844819 
-Q 298.779871 209.578224 299.705784 210.087145 
-Q 300.63133 210.594228 300.854166 211.708413 
-Q 300.960069 212.237926 300.856373 212.751996 
-Q 300.754147 213.263859 300.358851 214.012164 
-Q 300.248903 214.208158 299.637756 215.15834 
-Q 299.028448 216.108155 297.911689 217.819146 
+Q 296.941281 209.945941 297.446893 209.844818 
+Q 298.77987 209.578223 299.705784 210.087144 
+Q 300.631329 210.594227 300.854166 211.708412 
+Q 300.960069 212.237926 300.856372 212.751995 
+Q 300.754147 213.263858 300.35885 214.012164 
+Q 300.248903 214.208157 299.637756 215.15834 
+Q 299.028447 216.108155 297.911689 217.819146 
 "/>
           </g>
           <g id="text_5">
-           <path clip-path="url(#pf52b15eb6f)" d="M 289.627238 260.948036 
-L 291.522823 260.568919 
-L 290.213748 254.023543 
+           <path clip-path="url(#pc10af623d4)" d="M 289.627237 260.948036 
+L 291.522822 260.568919 
+L 290.213747 254.023543 
 L 288.233587 254.849805 
-L 288.02215 253.792616 
+L 288.022149 253.792616 
 L 289.991278 252.968561 
 L 291.151428 252.736531 
-L 292.671941 260.339096 
-L 294.567526 259.959979 
+L 292.67194 260.339095 
+L 294.567525 259.959978 
 L 294.762784 260.936269 
 L 289.822496 261.924327 
 z
 M 295.403854 251.886046 
-L 299.959877 250.974841 
-L 300.155503 251.952971 
+L 299.959876 250.974841 
+L 300.155502 251.95297 
 L 296.662184 252.651634 
 L 297.082485 254.753141 
 Q 297.317089 254.61635 297.560518 254.523685 
-Q 297.805786 254.430653 298.059511 254.379908 
+Q 297.805786 254.430652 298.059511 254.379907 
 Q 299.495449 254.09272 300.491229 254.711957 
-Q 301.488847 255.330826 301.757649 256.674834 
-Q 302.03454 258.059292 301.325948 259.000281 
-Q 300.616988 259.939433 299.048672 260.253096 
-Q 298.508127 260.361205 297.928971 260.381429 
-Q 297.351655 260.401286 296.717341 260.336935 
+Q 301.488847 255.330825 301.757649 256.674834 
+Q 302.03454 258.059291 301.325948 259.000281 
+Q 300.616988 259.939432 299.048672 260.253095 
+Q 298.508127 260.361204 297.928971 260.381429 
+Q 297.351654 260.401286 296.717341 260.336935 
 L 296.483841 259.169431 
-Q 297.056745 259.347407 297.6359 259.374986 
-Q 298.215056 259.402565 298.829145 259.279747 
-Q 299.823821 259.080812 300.298545 258.442821 
-Q 300.775107 257.804463 300.595661 256.907232 
-Q 300.416582 256.011839 299.731156 255.605879 
+Q 297.056745 259.347407 297.6359 259.374985 
+Q 298.215056 259.402564 298.829144 259.279746 
+Q 299.823821 259.080811 300.298545 258.442821 
+Q 300.775107 257.804463 300.59566 256.907231 
+Q 300.416582 256.011839 299.731156 255.605878 
 Q 299.047201 255.197712 298.052525 255.396647 
-Q 297.587362 255.48968 297.14463 255.685306 
+Q 297.587362 255.48968 297.144629 255.685305 
 Q 296.703736 255.880564 296.265784 256.195698 
 z
 " style="stroke:#ffffff;stroke-width:3;"/>
-           <path clip-path="url(#pf52b15eb6f)" d="M 289.627238 260.948036 
-L 291.522823 260.568919 
-L 290.213748 254.023543 
+           <path clip-path="url(#pc10af623d4)" d="M 289.627237 260.948036 
+L 291.522822 260.568919 
+L 290.213747 254.023543 
 L 288.233587 254.849805 
-L 288.02215 253.792616 
+L 288.022149 253.792616 
 L 289.991278 252.968561 
 L 291.151428 252.736531 
-L 292.671941 260.339096 
-L 294.567526 259.959979 
+L 292.67194 260.339095 
+L 294.567525 259.959978 
 L 294.762784 260.936269 
 L 289.822496 261.924327 
 z
 M 295.403854 251.886046 
-L 299.959877 250.974841 
-L 300.155503 251.952971 
+L 299.959876 250.974841 
+L 300.155502 251.95297 
 L 296.662184 252.651634 
 L 297.082485 254.753141 
 Q 297.317089 254.61635 297.560518 254.523685 
-Q 297.805786 254.430653 298.059511 254.379908 
+Q 297.805786 254.430652 298.059511 254.379907 
 Q 299.495449 254.09272 300.491229 254.711957 
-Q 301.488847 255.330826 301.757649 256.674834 
-Q 302.03454 258.059292 301.325948 259.000281 
-Q 300.616988 259.939433 299.048672 260.253096 
-Q 298.508127 260.361205 297.928971 260.381429 
-Q 297.351655 260.401286 296.717341 260.336935 
+Q 301.488847 255.330825 301.757649 256.674834 
+Q 302.03454 258.059291 301.325948 259.000281 
+Q 300.616988 259.939432 299.048672 260.253095 
+Q 298.508127 260.361204 297.928971 260.381429 
+Q 297.351654 260.401286 296.717341 260.336935 
 L 296.483841 259.169431 
-Q 297.056745 259.347407 297.6359 259.374986 
-Q 298.215056 259.402565 298.829145 259.279747 
-Q 299.823821 259.080812 300.298545 258.442821 
-Q 300.775107 257.804463 300.595661 256.907232 
-Q 300.416582 256.011839 299.731156 255.605879 
+Q 297.056745 259.347407 297.6359 259.374985 
+Q 298.215056 259.402564 298.829144 259.279746 
+Q 299.823821 259.080811 300.298545 258.442821 
+Q 300.775107 257.804463 300.59566 256.907231 
+Q 300.416582 256.011839 299.731156 255.605878 
 Q 299.047201 255.197712 298.052525 255.396647 
-Q 297.587362 255.48968 297.14463 255.685306 
+Q 297.587362 255.48968 297.144629 255.685305 
 Q 296.703736 255.880564 296.265784 256.195698 
 z
 "/>
           </g>
           <g id="text_6">
-           <path clip-path="url(#pf52b15eb6f)" d="M 289.627237 302.420036 
-L 291.522823 302.040919 
-L 290.213748 295.495543 
+           <path clip-path="url(#pc10af623d4)" d="M 289.627237 302.420036 
+L 291.522822 302.040919 
+L 290.213747 295.495543 
 L 288.233587 296.321805 
-L 288.02215 295.264616 
+L 288.022149 295.264616 
 L 289.991278 294.440561 
 L 291.151428 294.208531 
-L 292.671941 301.811095 
-L 294.567526 301.431979 
+L 292.67194 301.811095 
+L 294.567525 301.431978 
 L 294.762784 302.408269 
 L 289.822496 303.396327 
 z
-M 298.773987 297.368744 
-Q 297.946622 297.534217 297.560886 298.072188 
-Q 297.176989 298.609791 297.331798 299.383837 
-Q 297.486975 300.159721 298.048112 300.508318 
+M 298.773987 297.368743 
+Q 297.946622 297.534216 297.560886 298.072187 
+Q 297.176989 298.609791 297.331798 299.383836 
+Q 297.486975 300.159721 298.048112 300.508317 
 Q 298.611088 300.856546 299.438453 300.691073 
-Q 300.265818 300.525601 300.653025 299.985423 
-Q 301.041702 299.443039 300.887629 298.672671 
-Q 300.732819 297.898625 300.169844 297.550396 
-Q 299.608706 297.2018 298.773987 297.368744 
-M 297.515289 297.108032 
+Q 300.265818 300.5256 300.653024 299.985423 
+Q 301.041702 299.443039 300.887628 298.67267 
+Q 300.732819 297.898624 300.169843 297.550396 
+Q 299.608706 297.201799 298.773987 297.368743 
+M 297.515289 297.108031 
 Q 296.73205 297.073466 296.212465 296.64581 
-Q 295.694351 296.215948 295.547264 295.480513 
-Q 295.34171 294.452742 295.95396 293.708849 
-Q 296.568048 292.964588 297.84219 292.70976 
-Q 299.123687 292.45346 299.973115 292.905018 
-Q 300.822543 293.356575 301.028097 294.384346 
-Q 301.175184 295.119782 300.860418 295.71622 
-Q 300.547122 296.310452 299.842943 296.642501 
+Q 295.694351 296.215948 295.547263 295.480512 
+Q 295.341709 294.452741 295.953959 293.708848 
+Q 296.568048 292.964588 297.84219 292.709759 
+Q 299.123686 292.45346 299.973114 292.905017 
+Q 300.822542 293.356575 301.028097 294.384346 
+Q 301.175184 295.119781 300.860417 295.71622 
+Q 300.547122 296.310451 299.842942 296.642501 
 Q 300.720317 296.669712 301.301311 297.146274 
-Q 301.883776 297.62063 302.047778 298.440641 
-Q 302.297458 299.689043 301.669764 300.508686 
-Q 301.041702 301.32649 299.622312 301.610368 
-Q 298.20476 301.893878 297.308632 301.380912 
+Q 301.883776 297.62063 302.047778 298.44064 
+Q 302.297458 299.689042 301.669764 300.508685 
+Q 301.041702 301.326489 299.622312 301.610367 
+Q 298.20476 301.893878 297.308631 301.380912 
 Q 296.413974 300.865739 296.164294 299.617337 
 Q 296.000292 298.797327 296.357346 298.135067 
-Q 296.715871 297.470601 297.515289 297.108032 
-M 296.723961 295.359901 
-Q 296.857074 296.025471 297.347242 296.3156 
-Q 297.839249 296.605361 298.591231 296.454965 
-Q 299.339537 296.305304 299.685927 295.847863 
-Q 300.034156 295.390054 299.901042 294.724485 
-Q 299.767561 294.057078 299.270038 293.768419 
-Q 298.774355 293.479393 298.026049 293.629054 
+Q 296.71587 297.470601 297.515289 297.108031 
+M 296.72396 295.359901 
+Q 296.857074 296.02547 297.347242 296.315599 
+Q 297.839248 296.605361 298.591231 296.454965 
+Q 299.339537 296.305303 299.685927 295.847862 
+Q 300.034155 295.390054 299.901042 294.724485 
+Q 299.76756 294.057077 299.270038 293.768419 
+Q 298.774354 293.479392 298.026049 293.629054 
 Q 297.274066 293.77945 296.931353 294.236156 
-Q 296.590479 294.692494 296.723961 295.359901 
+Q 296.590479 294.692493 296.72396 295.359901 
 " style="stroke:#ffffff;stroke-width:3;"/>
-           <path clip-path="url(#pf52b15eb6f)" d="M 289.627237 302.420036 
-L 291.522823 302.040919 
-L 290.213748 295.495543 
+           <path clip-path="url(#pc10af623d4)" d="M 289.627237 302.420036 
+L 291.522822 302.040919 
+L 290.213747 295.495543 
 L 288.233587 296.321805 
-L 288.02215 295.264616 
+L 288.022149 295.264616 
 L 289.991278 294.440561 
 L 291.151428 294.208531 
-L 292.671941 301.811095 
-L 294.567526 301.431979 
+L 292.67194 301.811095 
+L 294.567525 301.431978 
 L 294.762784 302.408269 
 L 289.822496 303.396327 
 z
-M 298.773987 297.368744 
-Q 297.946622 297.534217 297.560886 298.072188 
-Q 297.176989 298.609791 297.331798 299.383837 
-Q 297.486975 300.159721 298.048112 300.508318 
+M 298.773987 297.368743 
+Q 297.946622 297.534216 297.560886 298.072187 
+Q 297.176989 298.609791 297.331798 299.383836 
+Q 297.486975 300.159721 298.048112 300.508317 
 Q 298.611088 300.856546 299.438453 300.691073 
-Q 300.265818 300.525601 300.653025 299.985423 
-Q 301.041702 299.443039 300.887629 298.672671 
-Q 300.732819 297.898625 300.169844 297.550396 
-Q 299.608706 297.2018 298.773987 297.368744 
-M 297.515289 297.108032 
+Q 300.265818 300.5256 300.653024 299.985423 
+Q 301.041702 299.443039 300.887628 298.67267 
+Q 300.732819 297.898624 300.169843 297.550396 
+Q 299.608706 297.201799 298.773987 297.368743 
+M 297.515289 297.108031 
 Q 296.73205 297.073466 296.212465 296.64581 
-Q 295.694351 296.215948 295.547264 295.480513 
-Q 295.34171 294.452742 295.95396 293.708849 
-Q 296.568048 292.964588 297.84219 292.70976 
-Q 299.123687 292.45346 299.973115 292.905018 
-Q 300.822543 293.356575 301.028097 294.384346 
-Q 301.175184 295.119782 300.860418 295.71622 
-Q 300.547122 296.310452 299.842943 296.642501 
+Q 295.694351 296.215948 295.547263 295.480512 
+Q 295.341709 294.452741 295.953959 293.708848 
+Q 296.568048 292.964588 297.84219 292.709759 
+Q 299.123686 292.45346 299.973114 292.905017 
+Q 300.822542 293.356575 301.028097 294.384346 
+Q 301.175184 295.119781 300.860417 295.71622 
+Q 300.547122 296.310451 299.842942 296.642501 
 Q 300.720317 296.669712 301.301311 297.146274 
-Q 301.883776 297.62063 302.047778 298.440641 
-Q 302.297458 299.689043 301.669764 300.508686 
-Q 301.041702 301.32649 299.622312 301.610368 
-Q 298.20476 301.893878 297.308632 301.380912 
+Q 301.883776 297.62063 302.047778 298.44064 
+Q 302.297458 299.689042 301.669764 300.508685 
+Q 301.041702 301.326489 299.622312 301.610367 
+Q 298.20476 301.893878 297.308631 301.380912 
 Q 296.413974 300.865739 296.164294 299.617337 
 Q 296.000292 298.797327 296.357346 298.135067 
-Q 296.715871 297.470601 297.515289 297.108032 
-M 296.723961 295.359901 
-Q 296.857074 296.025471 297.347242 296.3156 
-Q 297.839249 296.605361 298.591231 296.454965 
-Q 299.339537 296.305304 299.685927 295.847863 
-Q 300.034156 295.390054 299.901042 294.724485 
-Q 299.767561 294.057078 299.270038 293.768419 
-Q 298.774355 293.479393 298.026049 293.629054 
+Q 296.71587 297.470601 297.515289 297.108031 
+M 296.72396 295.359901 
+Q 296.857074 296.02547 297.347242 296.315599 
+Q 297.839248 296.605361 298.591231 296.454965 
+Q 299.339537 296.305303 299.685927 295.847862 
+Q 300.034155 295.390054 299.901042 294.724485 
+Q 299.76756 294.057077 299.270038 293.768419 
+Q 298.774354 293.479392 298.026049 293.629054 
 Q 297.274066 293.77945 296.931353 294.236156 
-Q 296.590479 294.692494 296.723961 295.359901 
+Q 296.590479 294.692493 296.72396 295.359901 
 "/>
           </g>
           <g id="text_7">
-           <path clip-path="url(#pf52b15eb6f)" d="M 359.545185 329.908446 
+           <path clip-path="url(#pc10af623d4)" d="M 359.545185 329.908446 
 L 363.595596 329.098364 
 L 363.790854 330.074655 
 L 358.344954 331.163835 
 L 358.149696 330.187544 
-Q 358.672959 329.371579 359.582692 327.992637 
+Q 358.672958 329.371578 359.582692 327.992637 
 Q 360.493897 326.611489 360.719308 326.218399 
-Q 361.151376 325.48186 361.285226 325.003827 
-Q 361.420914 324.525426 361.337074 324.106228 
+Q 361.151376 325.48186 361.285225 325.003827 
+Q 361.420913 324.525426 361.337074 324.106228 
 Q 361.200283 323.422273 360.634365 323.088018 
-Q 360.06808 322.751924 359.297711 322.905997 
+Q 360.06808 322.751923 359.297711 322.905997 
 Q 358.75165 323.015209 358.182791 323.325931 
 Q 357.61577 323.636285 357.00352 324.160282 
 L 356.768916 322.987263 
-Q 357.413158 322.565858 357.993049 322.300734 
+Q 357.413157 322.565858 357.993048 322.300734 
 Q 358.574778 322.035242 359.08039 321.934119 
 Q 360.413367 321.667524 361.33928 322.176445 
-Q 362.264826 322.683528 362.487663 323.797713 
-Q 362.593565 324.327227 362.489869 324.841296 
+Q 362.264825 322.683528 362.487662 323.797713 
+Q 362.593565 324.327226 362.489869 324.841296 
 Q 362.387643 325.353159 361.992347 326.101465 
 Q 361.882399 326.297458 361.271252 327.247641 
 Q 360.661944 328.197456 359.545185 329.908446 
-M 366.233741 328.570736 
-L 368.129326 328.191619 
-L 366.820251 321.646243 
+M 366.233741 328.570735 
+L 368.129326 328.191618 
+L 366.820251 321.646242 
 L 364.840091 322.472504 
-L 364.628654 321.415316 
+L 364.628653 321.415315 
 L 366.597782 320.59126 
-L 367.757932 320.35923 
+L 367.757931 320.35923 
 L 369.278444 327.961795 
 L 371.174029 327.582678 
-L 371.369287 328.558969 
+L 371.369287 328.558968 
 L 366.428999 329.547026 
 z
 " style="stroke:#ffffff;stroke-width:3;"/>
-           <path clip-path="url(#pf52b15eb6f)" d="M 359.545185 329.908446 
+           <path clip-path="url(#pc10af623d4)" d="M 359.545185 329.908446 
 L 363.595596 329.098364 
 L 363.790854 330.074655 
 L 358.344954 331.163835 
 L 358.149696 330.187544 
-Q 358.672959 329.371579 359.582692 327.992637 
+Q 358.672958 329.371578 359.582692 327.992637 
 Q 360.493897 326.611489 360.719308 326.218399 
-Q 361.151376 325.48186 361.285226 325.003827 
-Q 361.420914 324.525426 361.337074 324.106228 
+Q 361.151376 325.48186 361.285225 325.003827 
+Q 361.420913 324.525426 361.337074 324.106228 
 Q 361.200283 323.422273 360.634365 323.088018 
-Q 360.06808 322.751924 359.297711 322.905997 
+Q 360.06808 322.751923 359.297711 322.905997 
 Q 358.75165 323.015209 358.182791 323.325931 
 Q 357.61577 323.636285 357.00352 324.160282 
 L 356.768916 322.987263 
-Q 357.413158 322.565858 357.993049 322.300734 
+Q 357.413157 322.565858 357.993048 322.300734 
 Q 358.574778 322.035242 359.08039 321.934119 
 Q 360.413367 321.667524 361.33928 322.176445 
-Q 362.264826 322.683528 362.487663 323.797713 
-Q 362.593565 324.327227 362.489869 324.841296 
+Q 362.264825 322.683528 362.487662 323.797713 
+Q 362.593565 324.327226 362.489869 324.841296 
 Q 362.387643 325.353159 361.992347 326.101465 
 Q 361.882399 326.297458 361.271252 327.247641 
 Q 360.661944 328.197456 359.545185 329.908446 
-M 366.233741 328.570736 
-L 368.129326 328.191619 
-L 366.820251 321.646243 
+M 366.233741 328.570735 
+L 368.129326 328.191618 
+L 366.820251 321.646242 
 L 364.840091 322.472504 
-L 364.628654 321.415316 
+L 364.628653 321.415315 
 L 366.597782 320.59126 
-L 367.757932 320.35923 
+L 367.757931 320.35923 
 L 369.278444 327.961795 
 L 371.174029 327.582678 
-L 371.369287 328.558969 
+L 371.369287 328.558968 
 L 366.428999 329.547026 
 z
 "/>
@@ -808,7 +808,7 @@ z
          </g>
         </g>
         <defs>
-         <clipPath id="pf52b15eb6f">
+         <clipPath id="pc10af623d4">
           <rect height="345.6" width="345.6" x="122.4" y="43.2"/>
          </clipPath>
         </defs>


### PR DESCRIPTION
There are differences in the 6th decimal place which are causing
failures on windows (but not linux).  Presumably there is a system
dependent rounding behavior that we are hitting the edge of.