### PR TITLE
[MRG+1] Force Qt5 toolbar minimum height to 48.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -611,7 +611,15 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         if is_pyqt5():
             self.setIconSize(QtCore.QSize(24, 24))
             self.layout().setSpacing(12)
-            self.setMinimumHeight(48)
+
+    if is_pyqt5():
+        # For some reason, self.setMinimumHeight doesn't seem to carry over to
+        # the actual sizeHint, so override it instead in order to make the
+        # aesthetic adjustments noted above.
+        def sizeHint(self):
+            size = super().sizeHint()
+            size.setHeight(max(48, size.height()))
+            return size
 
     def edit_parameters(self):
         allaxes = self.canvas.figure.get_axes()


### PR DESCRIPTION
Even though the minimum height is set, that doesn't seem to carry over to the size hint that gets used later to determine the size of the entire window, causing the window to be a bit too short and changing the size of the canvas.

Fixes #7353. Probably also fixes #7472.