### PR TITLE
Backend base classes don't support multiple inheritance.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -212,6 +212,7 @@ class RendererBase(object):
 
     """
     def __init__(self):
+        super(RendererBase, self).__init__()
         self._texmanager = None
 
         self._text2path = textpath.TextToPath()
@@ -805,6 +806,7 @@ class GraphicsContextBase(object):
     """
 
     def __init__(self):
+        super(GraphicsContextBase, self).__init__()
         self._alpha = 1.0
         self._forced_alpha = False  # if True, _alpha overrides A from RGBA
         self._antialiased = 1  # use 0,1 not True, False for extension code
@@ -1224,6 +1226,7 @@ class TimerBase(object):
 
     '''
     def __init__(self, interval=None, callbacks=None):
+        super(TimerBase, self).__init()
         #Initialize empty callbacks list and setup default settings if necssary
         if callbacks is None:
             self.callbacks = []
@@ -1713,6 +1716,7 @@ class FigureCanvasBase(object):
                          'Tagged Image File Format')
 
     def __init__(self, figure):
+        super(FigureCanvasBase, self).__init__()
         self._is_idle_drawing = True
         self._is_saving = False
         figure.set_canvas(self)
@@ -2641,6 +2645,7 @@ class FigureManagerBase(object):
 
     """
     def __init__(self, canvas, num):
+        super(FigureManagerBase, self).__init__()
         self.canvas = canvas
         canvas.manager = self  # store a pointer to parent
         self.num = num
@@ -2777,6 +2782,7 @@ class NavigationToolbar2(object):
       )
 
     def __init__(self, canvas):
+        super(NavigationToolbar2, self).__init__()
         self.canvas = canvas
         canvas.toolbar = self
         # a dict from axes index to a list of view limits
@@ -3240,6 +3246,7 @@ class ToolContainerBase(object):
     """
 
     def __init__(self, toolmanager):
+        super(ToolContainerBase, self).__init__()
         self.toolmanager = toolmanager
         self.toolmanager.toolmanager_connect('tool_removed_event',
                                              self._remove_tool_cbk)
@@ -3369,6 +3376,7 @@ class ToolContainerBase(object):
 class StatusbarBase(object):
     """Base class for the statusbar"""
     def __init__(self, toolmanager):
+        super(StatusbarBase, self).__init__()
         self.toolmanager = toolmanager
         self.toolmanager.toolmanager_connect('tool_message_event',
                                              self._message_cbk)


### PR DESCRIPTION
This was discovered when trying to get the Qt5 backend, which uses:
```
class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase)
```
to work under PythonQt.

A PythonQt issue (or feature??) means that QWidget (or its base, PythonQtInstanceWrapper) doesn't use the MRO to initialise FigureCanvasBase. However things work if the class declaration in `backend_qt5.py` is changed to:
 ```
class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget)
```
**provided** FigureCanvasBase calls `super()`...

Shouldn't all base classes call super() as part of initialisation??