### PR TITLE
ENH: Added FuncNorm

### DIFF
--- a/examples/color/colormap_normalizations_funcnorm.py
+++ b/examples/color/colormap_normalizations_funcnorm.py
@@ -1,0 +1,85 @@
+"""
+=====================================================================
+Examples of normalization using  :class:`~matplotlib.colors.FuncNorm`
+=====================================================================
+
+This is an example on how to perform a normalization using an arbitrary
+function with :class:`~matplotlib.colors.FuncNorm`. A logarithm normalization
+and a square root normalization will be use as examples.
+
+"""
+
+import matplotlib.cm as cm
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+
+def main():
+    fig, axes = plt.subplots(3, 2, gridspec_kw={
+              'width_ratios': [1, 3.5]}, figsize=plt.figaspect(0.6))
+
+    # Example of logarithm normalization using FuncNorm
+    norm_log = colors.FuncNorm(f='log10', vmin=0.01)
+    # The same can be achieved with
+    # norm_log = colors.FuncNorm(f=np.log10,
+    #                            finv=lambda x: 10.**(x), vmin=0.01)
+
+    # Example of root normalization using FuncNorm
+    norm_sqrt = colors.FuncNorm(f='sqrt', vmin=0.0)
+    # The same can be achieved with
+    # norm_sqrt = colors.FuncNorm(f='root{2}', vmin=0.)
+    # or with
+    # norm_sqrt = colors.FuncNorm(f=lambda x: x**0.5,
+    #                             finv=lambda x: x**2, vmin=0.0)
+
+    normalizations = [(None, 'Regular linear scale'),
+                      (norm_log, 'Log normalization'),
+                      (norm_sqrt, 'Root normalization')]
+
+    for i, (norm, title) in enumerate(normalizations):
+        X, Y, data = get_data()
+
+        # Showing the normalization effect on an image
+        ax2 = axes[i][1]
+        cax = ax2.imshow(data, cmap=cm.afmhot, norm=norm)
+        ticks = cax.norm.ticks(5) if norm else np.linspace(0, 1, 6)
+        fig.colorbar(cax, format='%.3g', ticks=ticks, ax=ax2)
+        ax2.set_title(title)
+        ax2.axes.get_xaxis().set_ticks([])
+        ax2.axes.get_yaxis().set_ticks([])
+
+        # Plotting the behaviour of the normalization
+        ax1 = axes[i][0]
+        d_values = np.linspace(cax.norm.vmin, cax.norm.vmax, 100)
+        cm_values = cax.norm(d_values)
+        ax1.plot(d_values, cm_values)
+        ax1.set_xlabel('Data values')
+        ax1.set_ylabel('Colormap values')
+
+    plt.show()
+
+
+def get_data(_cache=[]):
+    if len(_cache) > 0:
+        return _cache[0]
+    x = np.linspace(0, 1, 300)
+    y = np.linspace(-1, 1, 90)
+    X, Y = np.meshgrid(x, y)
+
+    data = np.zeros(X.shape)
+
+    def gauss2d(x, y, a0, x0, y0, wx, wy):
+        return a0 * np.exp(-(x - x0)**2 / wx**2 - (y - y0)**2 / wy**2)
+    N = 15
+    for x in np.linspace(0., 1, N):
+        data += gauss2d(X, Y, x, x, 0, 0.25 / N, 0.25)
+
+    data = data - data.min()
+    data = data / data.max()
+    _cache.append((X, Y, data))
+
+    return _cache[0]
+
+main()

--- a/examples/color/colormap_normalizations_funcnorm.py
+++ b/examples/color/colormap_normalizations_funcnorm.py
@@ -57,8 +57,7 @@ for (ax_left, ax_right), (norm, title) in zip(axes, normalizations):
 
     # Showing the normalization effect on an image
     cax = ax_right.imshow(data, cmap=cm.afmhot, norm=norm, aspect='auto')
-    ticks = cax.norm.ticks(5) if norm else np.linspace(0, 1, 6)
-    fig.colorbar(cax, format='%.3g', ticks=ticks, ax=ax_right)
+    fig.colorbar(cax, format='%.3g', ax=ax_right)
     ax_right.set_title(title)
     ax_right.xaxis.set_ticks([])
     ax_right.yaxis.set_ticks([])

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -583,6 +583,9 @@ class ColorbarBase(cm.ScalarMappable):
                     locator = ticker.FixedLocator(b, nbins=10)
                 elif isinstance(self.norm, colors.LogNorm):
                     locator = ticker.LogLocator(subs='all')
+                elif isinstance(self.norm, colors.FuncNorm):
+                    locator = ticker.FuncLocator(self.norm.__call__,
+                                                 self.norm.inverse)
                 elif isinstance(self.norm, colors.SymLogNorm):
                     # The subs setting here should be replaced
                     # by logic in the locator.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -974,8 +974,8 @@ class FuncNorm(Normalize):
         Function to be used for the normalization receiving a single
         parameter, compatible with scalar values and arrays.
         Alternatively some predefined functions may be specified
-        as a string (See Notes). The chosen function must
-        be strictly increasing in the [`vmin`, `vmax`] interval.
+        as a string (See Notes). The chosen function must be strictly
+        increasing and bounded in the [`vmin`, `vmax`] interval.
     finv : callable, optional
         Inverse of `f` satisfying finv(f(x)) == x. Optional and ignored
         when `f` is a string; otherwise, required.
@@ -1070,8 +1070,8 @@ class FuncNorm(Normalize):
 
         if clip:
             result = np.clip(result, vmin, vmax)
-            resultnorm = (self._f(result) - self._f(vmin)) / \
-                         (self._f(vmax) - self._f(vmin))
+            resultnorm = ((self._f(result) - self._f(vmin)) /
+                          (self._f(vmax) - self._f(vmin)))
         else:
             resultnorm = result.copy()
             mask_over = result > vmax
@@ -1116,41 +1116,6 @@ class FuncNorm(Normalize):
         if self.vmin >= self.vmax:
             raise ValueError("vmin must be smaller than vmax")
         return float(self.vmin), float(self.vmax)
-
-    def ticks(self, nticks=13):
-        """
-        Returns an automatic list of `nticks` points in the data space
-        to be used as ticks in the colorbar.
-
-        Parameters
-        ----------
-        nticks : integer, optional
-            Number of ticks to be returned. Default 13.
-
-        Returns
-        -------
-        ticks : ndarray
-            1d array of length `nticks` with the proposed tick locations.
-
-        """
-        ticks = self.inverse(np.linspace(0, 1, nticks))
-        finalticks = np.zeros(ticks.shape, dtype=np.bool)
-        finalticks[0] = True
-        ticks = FuncNorm._round_ticks(ticks, finalticks)
-        return ticks
-
-    @staticmethod
-    def _round_ticks(ticks, permanenttick):
-        ticks = ticks.copy()
-        for i in range(len(ticks)):
-            if i == 0 or i == len(ticks) - 1 or permanenttick[i]:
-                continue
-            d1 = ticks[i] - ticks[i - 1]
-            d2 = ticks[i + 1] - ticks[i]
-            d = min([d1, d2])
-            order = -np.floor(np.log10(d))
-            ticks[i] = float(np.round(ticks[i] * 10**order)) / 10**order
-        return ticks
 
 
 class LogNorm(Normalize):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -193,6 +193,15 @@ class TestFuncNorm(object):
         x = np.linspace(0.01, 2, 10)
         assert_array_almost_equal(x, norm.inverse(norm(x)))
 
+    def test_scalar(self):
+        norm = mcolors.FuncNorm(f='linear', vmin=1., vmax=2.,
+                                clip=True)
+        assert_equal(norm(1.5), 0.5)
+        assert_equal(norm(1.), 0.)
+        assert_equal(norm(0.5), 0.)
+        assert_equal(norm(2.), 1.)
+        assert_equal(norm(2.5), 1.)
+
     def test_ticks(self):
         norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.)
         expected = [0.01, 0.016, 0.024, 0.04, 0.06,

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -169,6 +169,20 @@ class TestFuncNorm(object):
         norm = mcolors.FuncNorm(f='log10', vmin=0.01)
         assert_array_equal(norm([0.01, 2]), [0, 1.0])
 
+    def test_clip_true(self):
+        norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.,
+                                clip=True)
+        assert_array_equal(norm([0.0, 2.5]), [0.0, 1.0])
+
+    def test_clip_false(self):
+        norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.,
+                                clip=False)
+        assert_array_equal(norm([0.0, 2.5]), [-0.1, 1.1])
+
+    def test_clip_default_false(self):
+        norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.)
+        assert_array_equal(norm([0.0, 2.5]), [-0.1, 1.1])
+
     def test_intermediate_values(self):
         norm = mcolors.FuncNorm(f='log10')
         assert_array_almost_equal(norm([0.01, 0.5, 2]),

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -202,13 +202,6 @@ class TestFuncNorm(object):
         assert_equal(norm(2.), 1.)
         assert_equal(norm(2.5), 1.)
 
-    def test_ticks(self):
-        norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.)
-        expected = [0.01, 0.016, 0.024, 0.04, 0.06,
-                    0.09, 0.14, 0.22, 0.3, 0.5,
-                    0.8, 1.3, 2.]
-        assert_array_almost_equal(norm.ticks(), expected)
-
 
 def test_LogNorm():
     """

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -146,6 +146,47 @@ def test_BoundaryNorm():
     assert_true(np.all(bn(vals).mask))
 
 
+class TestFuncNorm(object):
+    def test_limits_with_string(self):
+        norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.)
+        assert_array_equal(norm([0.01, 2]), [0, 1.0])
+
+    def test_limits_with_lambda(self):
+        norm = mcolors.FuncNorm(f=lambda x: np.log10(x),
+                                finv=lambda x: 10.**(x),
+                                vmin=0.01, vmax=2.)
+        assert_array_equal(norm([0.01, 2]), [0, 1.0])
+
+    def test_limits_without_vmin_vmax(self):
+        norm = mcolors.FuncNorm(f='log10')
+        assert_array_equal(norm([0.01, 2]), [0, 1.0])
+
+    def test_limits_without_vmin(self):
+        norm = mcolors.FuncNorm(f='log10', vmax=2.)
+        assert_array_equal(norm([0.01, 2]), [0, 1.0])
+
+    def test_limits_without_vmax(self):
+        norm = mcolors.FuncNorm(f='log10', vmin=0.01)
+        assert_array_equal(norm([0.01, 2]), [0, 1.0])
+
+    def test_intermediate_values(self):
+        norm = mcolors.FuncNorm(f='log10')
+        assert_array_almost_equal(norm([0.01, 0.5, 2]),
+                                  [0, 0.73835195870437, 1.0])
+
+    def test_inverse(self):
+        norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.)
+        x = np.linspace(0.01, 2, 10)
+        assert_array_almost_equal(x, norm.inverse(norm(x)))
+
+    def test_ticks(self):
+        norm = mcolors.FuncNorm(f='log10', vmin=0.01, vmax=2.)
+        expected = [0.01, 0.016, 0.024, 0.04, 0.06,
+                    0.09, 0.14, 0.22, 0.3, 0.5,
+                    0.8, 1.3, 2.]
+        assert_array_almost_equal(norm.ticks(), expected)
+
+
 def test_LogNorm():
     """
     LogNorm ignored clip, now it has the same

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,7 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from numpy.testing import assert_almost_equal
+from numpy.testing import (assert_almost_equal,
+                           assert_array_almost_equal)
 import numpy as np
 import pytest
 
@@ -73,6 +74,31 @@ def test_LogLocator():
     loc = mticker.LogLocator(base=2)
     test_value = np.array([0.5, 1., 2., 4., 8., 16., 32., 64., 128., 256.])
     assert_almost_equal(loc.tick_values(1, 100), test_value)
+
+
+class TestFuncLocator(object):
+    def test_call(self):
+        loc = mticker.FuncLocator(np.sqrt, lambda x: x**2)
+        expected = [0., 0.01, 0.04, 0.09, 0.16, 0.25, 0.4,
+                    0.49, 0.6, 0.8, 1.]
+        assert_array_almost_equal(loc(), expected)
+
+    def test_tick_values(self):
+        loc = mticker.FuncLocator(np.sqrt, lambda x: x**2)
+        expected = [0., 0.01, 0.04, 0.09, 0.16, 0.25, 0.4,
+                    0.49, 0.6, 0.8, 1.]
+        assert_array_almost_equal(loc.tick_values(), expected)
+
+    def test_set_params(self):
+        loc = mticker.FuncLocator(lambda x: x, lambda x: x, 6)
+        expected = [0., 0.2, 0.4, 0.6, 0.8, 1.]
+        assert_array_almost_equal(loc.tick_values(), expected)
+        loc.set_params(function=np.sqrt,
+                       inverse=lambda x: x**2,
+                       numticks=11)
+        expected = [0., 0.01, 0.04, 0.09, 0.16, 0.25, 0.4,
+                    0.49, 0.6, 0.8, 1.]
+        assert_array_almost_equal(loc.tick_values(), expected)
 
 
 def test_LinearLocator_set_params():


### PR DESCRIPTION
This PR is part of a [larger PR](https://github.com/matplotlib/matplotlib/pull/7294) originally proposed to include FuncNorm and PiecewiseNorm. It was decided to split it into several PRs for easier review starting from the simpler classes.

In this case the functionality added is `FuncNorm`, a normalization class (inheriting from `Normalize`), that allows using any arbitrary function as a normalization, by specifying a callable (and a callable of the inverse function), or a string compatible with the brand new `_StringFuncParser`.

Examples of usage for log normalization:
```python
    norm_log = colors.FuncNorm(f='log10', vmin=0.01)
```
the same can be achieved with
```python
    norm_log = colors.FuncNorm(f=np.log10,
                               finv=lambda x: 10.**(x), vmin=0.01)
```

For root normalization:
```python
    norm_sqrt = colors.FuncNorm(f='sqrt', vmin=0.0)
```
the same can be achieved with
```python
    norm_sqrt = colors.FuncNorm(f='root{2}', vmin=0.)
```
or with
```python
    norm_sqrt = colors.FuncNorm(f=lambda x: x**0.5,
                                finv=lambda x: x**2, vmin=0.0)
```

Tests have been added, as well as an example producing this output this output:

![funcnorm](https://cloud.githubusercontent.com/assets/12649253/21963626/eb4f26d2-db35-11e6-9dd7-a6e943be05cd.png)

Possible caveat:

Most of the behaviour provided by this class does not change the existing interfaces for normalizations, as most public methods of the new class are just overridden methods from `Normalize`.

<del>The only exception to this is the ticks methods, returning an educated guess on where to add tick values, which would be a new public method in the class. 

<del>On the other hand I think it works quite well (even for very non-linear normalizations) and it is important to give the user a good guess at where to put the ticks, so it is not required to manually enter values (or come up with his own automated algorithm). This way the only thing the user needs to specify is a number of ticks, which may also be easily set to a default value. We should think whether we want to include this or no, or maybe do it in a different way.

<del>The way it is done now is by an explicit call to `norm.ticks()`:

<del>```python
<del>fig.colorbar(cax, format='%.3g', ticks=cax.norm.ticks(5), ax=ax2)
<del>```

A FuncLocator class has now been implemented, so ticks are set automatically to the suggested positions without explicit user input, in exactly the same way it was done for other normalizations like `LogNorm`.



