### PR TITLE
Add new downsample method for lines

### DIFF
--- a/doc/users/whats_new/plot_downsample.rst
+++ b/doc/users/whats_new/plot_downsample.rst
@@ -1,0 +1,7 @@
+Downsample line plots
+---------------------
+
+A ``downsample`` parameter now exists for the method :func:`plot`.  This
+allows line plots to be intelligently downsampled so that rendering and
+interaction is faster. The downsampling algorithm will render an image
+very similar to a non-downsampled image.

--- a/examples/pyplots/pyplot_downsample.py
+++ b/examples/pyplots/pyplot_downsample.py
@@ -1,3 +1,12 @@
+"""
+Demo of downsampling line plots.
+
+This method of downsampling will greatly speed up interaction
+and rendering time, without changing the actual rasterization too much.
+Try interacting with the two figures (panning, zooming, etc.) to see
+the difference.
+
+"""
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/examples/pyplots/pyplot_downsample.py
+++ b/examples/pyplots/pyplot_downsample.py
@@ -1,0 +1,21 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Fixing random state for reproducibility
+np.random.seed(8675309)
+
+# make up some data
+y = np.random.normal(loc=0.5, scale=0.4, size=1000000)
+x = np.arange(len(y))
+
+# plot without downsampling
+plt.figure(1)
+plt.plot(x, y)
+
+# plot with downsampling
+plt.figure(2)
+plt.plot(x, y, downsample=True)
+
+plt.show()
+
+# interact with both figures to compare snapiness

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -612,11 +612,9 @@ class Line2D(Artist):
         Recommended *only* when plotting with a solid line (e.g. no dashes,
         no markers).
 
-        ACCEPTS: [True | False]
-
         Parameters
         ----------
-        downsample: True | False
+        downsample : True | False
             Whether or not to downsample.
 
             - downsample=True, a downsampled set of points will be plotted.
@@ -624,9 +622,9 @@ class Line2D(Artist):
 
         Notes
         -----
-        If the x values of the line are monotonic, then the downsampling
+        If the x-values of the line are monotonic, then the downsampling
         algorithm will plot at most 4 times the width of the parent
-        :class:`matplotlib.axes.Axes` in pixels of vertices. If the x values
+        :class:`matplotlib.axes.Axes` in pixels of vertices. If the x-values
         are not monotonic, the plot will still render correctly, but you are
         not guaranteed any faster rendering.
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -842,20 +842,12 @@ class Line2D(Artist):
         keep_inds = np.zeros((split_indices.size + 1, 4), dtype=int)
         for i, y_pixel_col in enumerate(np.split(verts_trans[:, 1],
                                                  split_indices)):
-            if i == 0:
-                pixel_col_start = 0
-            else:
-                pixel_col_start = split_indices[i - 1]
+            keep_inds[i, 1:3] = np.argmin(y_pixel_col), np.argmax(y_pixel_col)
 
-            if i == split_indices.size:
-                pixel_col_end = verts_trans.shape[0]
-            else:
-                pixel_col_end = split_indices[i]
-
-            keep_inds[i] = (pixel_col_start,
-                            pixel_col_start + np.argmin(y_pixel_col),
-                            pixel_col_start + np.argmax(y_pixel_col),
-                            pixel_col_end - 1)
+        starts = np.hstack((0, split_indices))
+        ends = np.hstack((split_indices, verts_trans.shape[0]))
+        keep_inds[:, :3] += starts[:, np.newaxis]
+        keep_inds[:, 3] = ends - 1
 
         keep_inds = keep_inds.flatten()
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -825,7 +825,7 @@ class Line2D(Artist):
         # Don't waste time downsampling if it won't give us any benefit
         x0, x1 = self.axes.get_xbound()
         pixel_width = np.diff(self.axes.transData.transform([[x0, 0],
-                                                             [x1, 0]])[:,0])
+                                                             [x1, 0]])[:, 0])
         if verts.shape[0] <= pixel_width * 4:
             return tpath
 
@@ -834,16 +834,16 @@ class Line2D(Artist):
         verts_trans = self.axes.transData.transform(verts)
 
         # Find where the pixel column of the x data changes
-        split_indices = np.diff(np.floor(verts_trans[:,0]).astype(int)) != 0
-        split_indices = np.where(split_indices)[0]+1
+        split_indices = np.diff(np.floor(verts_trans[:, 0]).astype(int)) != 0
+        split_indices = np.where(split_indices)[0] + 1
 
         keep_inds = np.zeros((split_indices.size + 1, 4), dtype=int)
-        for i, y_pixel_col in enumerate(np.split(verts_trans[:,1],
+        for i, y_pixel_col in enumerate(np.split(verts_trans[:, 1],
                                                  split_indices)):
             if i == 0:
                 pixel_col_start = 0
             else:
-                pixel_col_start = split_indices[i-1]
+                pixel_col_start = split_indices[i - 1]
 
             if i == split_indices.size:
                 pixel_col_end = verts_trans.shape[0]
@@ -853,7 +853,7 @@ class Line2D(Artist):
             keep_inds[i] = (pixel_col_start,
                             pixel_col_start + np.argmin(y_pixel_col),
                             pixel_col_start + np.argmax(y_pixel_col),
-                            pixel_col_end-1)
+                            pixel_col_end - 1)
 
         keep_inds = keep_inds.flatten()
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -615,7 +615,7 @@ class Line2D(Artist):
 
         Parameters
         ----------
-        downsample: None | boolean-like
+        downsample: True | False
             Whether or not to downsample.
 
             - downsample=True, a downsampled set of points will be plotted.
@@ -651,6 +651,8 @@ class Line2D(Artist):
     def get_downsample(self):
         """return the downsample setting"""
         return self._downsample
+
+    downsample = property(get_downsample, set_downsample)
 
     def set_picker(self, p):
         """Sets the event picker details for the line.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -456,6 +456,7 @@ class Line2D(Artist):
         self._marker = MarkerStyle(marker, fillstyle)
 
         self._markevery = None
+        self._downsample = None
         self._markersize = None
         self._antialiased = None
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -199,15 +199,12 @@ def test_downsample_lines():
 
     line = mlines.Line2D(x, y, downsample=True)
 
-    fig, ax = plt.subplots()
-
-    # Adjust size of figure to ensure downsampling occurs
-    fig.set_dpi(1)
-    fig.set_size_inches([2, 1])
+    _, ax = plt.subplots()
 
     ax.add_line(line)
 
-    tpath, affine = line._get_transformed_path().get_transformed_path_and_affine()
+    transf_path = line._get_transformed_path()
+    tpath, affine = transf_path.get_transformed_path_and_affine()
     down_verts = line._downsample_path(tpath, affine).vertices
 
     expected_down_verts = np.array([

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -8,7 +8,7 @@ import six
 import itertools
 import matplotlib.lines as mlines
 import nose
-from nose.tools import assert_true, assert_raises
+from nose.tools import assert_true, assert_raises, assert_equal
 from timeit import repeat
 import numpy as np
 from cycler import cycler
@@ -189,6 +189,37 @@ def test_nan_is_sorted():
     assert_true(line._is_sorted(np.array([1, 2, 3])))
     assert_true(line._is_sorted(np.array([1, np.nan, 3])))
     assert_true(not line._is_sorted([3, 5] + [np.nan] * 100 + [0, 2]))
+
+
+@cleanup
+def test_downsample_lines():
+    x = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1.0])
+    y = np.array([2, 8, 3, 6, 1, 5, 5, 8, 7, 6, 6, 7.0])
+
+    line = mlines.Line2D(x, y, downsample=True)
+
+    fig, ax = plt.subplots()
+
+    # Adjust size of figure to ensure downsampling occurs
+    fig.set_dpi(1)
+    fig.set_size_inches([2,1])
+
+    ax.add_line(line)
+
+    tpath, _ = line._get_transformed_path().get_transformed_path_and_affine()
+    down_verts = line._downsample_path(tpath).vertices
+
+    expected_down_verts = np.array([
+        [0.0, 2.0],
+        [0.0, 1.0],
+        [0.0, 8.0],
+        [0.0, 5.0],
+        [1.0, 5.0],
+        [1.0, 5.0],
+        [1.0, 8.0],
+        [1.0, 7.0]
+    ])
+    assert_equal(down_verts, expected_down_verts)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -8,7 +8,7 @@ import six
 import itertools
 import matplotlib.lines as mlines
 import nose
-from nose.tools import assert_true, assert_raises, assert_equal
+from nose.tools import assert_true, assert_raises
 from timeit import repeat
 import numpy as np
 from cycler import cycler
@@ -193,8 +193,8 @@ def test_nan_is_sorted():
 
 @cleanup
 def test_downsample_lines():
-    x = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1.0])
-    y = np.array([2, 8, 3, 6, 1, 5, 5, 8, 7, 6, 6, 7.0])
+    x = np.array([0.0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
+    y = np.array([2.0, 8, 3, 6, 1, 5, 5, 8, 7, 6, 6, 7])
 
     line = mlines.Line2D(x, y, downsample=True)
 
@@ -202,7 +202,7 @@ def test_downsample_lines():
 
     # Adjust size of figure to ensure downsampling occurs
     fig.set_dpi(1)
-    fig.set_size_inches([2,1])
+    fig.set_size_inches([2, 1])
 
     ax.add_line(line)
 
@@ -219,7 +219,7 @@ def test_downsample_lines():
         [1.0, 8.0],
         [1.0, 7.0]
     ])
-    assert_equal(down_verts, expected_down_verts)
+    assert_true(np.all(down_verts == expected_down_verts))
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -206,8 +206,8 @@ def test_downsample_lines():
 
     ax.add_line(line)
 
-    tpath, _ = line._get_transformed_path().get_transformed_path_and_affine()
-    down_verts = line._downsample_path(tpath).vertices
+    tpath, affine = line._get_transformed_path().get_transformed_path_and_affine()
+    down_verts = line._downsample_path(tpath, affine).vertices
 
     expected_down_verts = np.array([
         [0.0, 2.0],

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -193,8 +193,9 @@ def test_nan_is_sorted():
 
 @cleanup
 def test_downsample_lines():
-    x = np.array([0.0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
-    y = np.array([2.0, 8, 3, 6, 1, 5, 5, 8, 7, 6, 6, 7])
+    x = np.hstack((np.zeros(99), np.ones(99)))
+    y = np.hstack([2.0, 8.0, 3 * np.ones(95), 1.0, 5.0,
+                   5.0, 5.5, 6 * np.ones(95), 8.0, 7.0])
 
     line = mlines.Line2D(x, y, downsample=True)
 
@@ -220,6 +221,27 @@ def test_downsample_lines():
         [1.0, 7.0]
     ])
     assert_true(np.all(down_verts == expected_down_verts))
+
+
+@cleanup
+def test_downsample_nan_lines():
+    # Creates x and y data, add some NaN values
+    N = 10**5
+    x = np.linspace(0,1,N)
+    y = np.random.normal(size=N)
+    x[10000:30000] = np.nan
+    y[20000:40000] = np.nan
+
+    line = mlines.Line2D(x, y, downsample=True)
+
+    fig, ax = plt.subplots()
+
+    ax.add_line(line)
+
+    fig.canvas.draw()
+
+    # Nothing to assert here, we are just making sure NaN values
+    # do not raise any errors.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Overview
This PR adds a new downsample method for lines. This is an improved version of the algorithm found [here](https://github.com/tuckermcclure/matlab-plot-big).

When the `x`-values of the line are monotonic, then this downsampling method will render at most 4 times the width of the parent `Axis` in pixels vertices. The downsampling is done such that the rendering of the downsampled plot looks very similar to the rending of the non-downsampled plot. In fact, if there is no anti-aliasing and plotting uses a solid line only, then the renderings will be identical.

# Possible Use Case(s)
I created this PR because I plot a lot of ECG data over large timespans. Typically, I might want to plot 12 or 24 hours of ECG data sampled at 125 Hz, resulting in `125 * 12 * 60 * 60 = 5400000` points of data. This is painfully slow to render, and interaction is very slow. Further, naive downsampling (e.g. `plt.plot(x[::100], y[::100])`) is not sufficient in this case, as artifacts of interest in this plot might only last 1 sample.

Of course, this is just a specific instance, and any plotting of large datasets could benefit.

# Algorithm Description

This algorithm makes use of the fact that for large data-sets, lots of `x`-values will lie on the same column of pixels. We really only need to draw the minimum and maximum `y`-values from all of the `x`-values that get mapped to the same column of pixels. A little more book-keeping is required to ensure that the connecting lines between two columns of pixels render correctly, but this just amounts to keeping the first and last pairs that are mapped to that column of pixels.

An image will probably help:

```
legend:        +--+
        pixels |  |
               +--+
        discarded data points  o
        kept data points       x
        
+------+------+------+------+
|      |      |      |      |
|      |      |      |      |
|      |      |      |      |
|   x  |      |      |      |
+------+------+------+------+
|  o   |      | x    |      |
| o    |      |      |      |
|x     |      |      |      |
|     x|      |x     |     x|
+------+------+------+------+
|      |      |      |    o |
|      |      |      |   o  |
|      |      |  o   |  o   |
|    x |      |     x| o    |
+------+------+------+------+
|      |      |      |      |
|      |      |   xo |x     |
|      |      |      |      |
|      |      |      |      |
+------+------+------+------+
```

# Caveats
This downsampling works best for plotting large amounts of data using a solid line and no markers.

If the `x`-values of the line are not monotonic, then there are no guarantees that rendering will be any faster. The "less monotonic" (for some definition of "less monotonic") the `x`-values are, the less downsampling that will be able to occur.

# Questions
I have marked with a `TODO` in the code a question I had. I am recomputing `self.axes.transData.transform(verts)` each update (verts is the vertices of the path). Is that cached somewhere already?

# TODO:
* More complete testing when the axis is transformed (i.e. polar, etc.). This will probably end up with me just restricting the use of this downsampling to only be guaranteed to work on axes that have a set list of transformations.
* More edge case testing.
* Would be nice to have benchmarks.