### PR TITLE
Use correct type for Tk addresses.

### DIFF
--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -188,18 +188,18 @@ static PyObject *_tkinit(PyObject *self, PyObject *args)
     Tcl_Interp *interp;
     TkappObject *app;
 
-    Py_ssize_t arg;
+    PyObject *arg;
     int is_interp;
-    if (!PyArg_ParseTuple(args, "ni", &arg, &is_interp)) {
+    if (!PyArg_ParseTuple(args, "Oi", &arg, &is_interp)) {
         return NULL;
     }
 
     if (is_interp) {
-        interp = (Tcl_Interp *)arg;
+        interp = (Tcl_Interp *)PyLong_AsVoidPtr(arg);
     } else {
         /* Do it the hard way.  This will break if the TkappObject
            layout changes */
-        app = (TkappObject *)arg;
+        app = (TkappObject *)PyLong_AsVoidPtr(arg);
         interp = app->interp;
     }
 

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -183,15 +183,6 @@ static int PyAggImagePhoto(ClientData clientdata, Tcl_Interp *interp, int
     return TCL_OK;
 }
 
-static PyObject *_pyobj_addr(PyObject *self, PyObject *args)
-{
-    PyObject *pyobj;
-    if (!PyArg_ParseTuple(args, "O", &pyobj)) {
-        return NULL;
-    }
-    return Py_BuildValue("n", (Py_ssize_t)pyobj);
-}
-
 static PyObject *_tkinit(PyObject *self, PyObject *args)
 {
     Tcl_Interp *interp;
@@ -226,7 +217,7 @@ static PyObject *_tkinit(PyObject *self, PyObject *args)
 
 static PyMethodDef functions[] = {
     /* Tkinter interface stuff */
-    { "_pyobj_addr", (PyCFunction)_pyobj_addr, 1 }, { "tkinit", (PyCFunction)_tkinit, 1 },
+    { "tkinit", (PyCFunction)_tkinit, 1 },
     { NULL, NULL } /* sentinel */
 };
 


### PR DESCRIPTION
CPython has used a long for this address since before 2010 (it is difficult to read the merge from SVN back then), and has been a long-from-void* since 2013 (3.3.3 and 2.7.6).

Fixes #7633.

Also, remove the buggy and unused `_pyobj_addr` which really is not very portable.

I don't have a 32-bit system to actually verify this, but based on the upstream bug report maybe 64-bit Windows could fall prey to this as well. @akkana, please try out this branch if possible.