### PR TITLE
[MRG+1] Allow scalar height for plt.bar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2025,10 +2025,6 @@ or tuple of floats
                 bottom = [0]
 
             nbars = len(left)
-            if len(height) == 1:
-                height *= nbars
-            if len(width) == 1:
-                width *= nbars
             if len(bottom) == 1:
                 bottom *= nbars
 
@@ -2047,16 +2043,16 @@ or tuple of floats
             nbars = len(bottom)
             if len(left) == 1:
                 left *= nbars
-            if len(height) == 1:
-                height *= nbars
-            if len(width) == 1:
-                width *= nbars
 
             tick_label_axis = self.yaxis
             tick_label_position = bottom
         else:
             raise ValueError('invalid orientation: %s' % orientation)
 
+        if len(height) == 1:
+            height *= nbars
+        if len(width) == 1:
+            width *= nbars
         if len(linewidth) < nbars:
             linewidth *= nbars
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1876,8 +1876,8 @@ or tuple of floats
         left : sequence of scalars
             the x coordinates of the left sides of the bars
 
-        height : sequence of scalars
-            the heights of the bars
+        height : scalar or sequence of scalars
+            the height(s) of the bars
 
         width : scalar or array-like, optional
             the width(s) of the bars
@@ -2025,6 +2025,8 @@ or tuple of floats
                 bottom = [0]
 
             nbars = len(left)
+            if len(height) == 1:
+                height *= nbars
             if len(width) == 1:
                 width *= nbars
             if len(bottom) == 1:
@@ -2047,6 +2049,8 @@ or tuple of floats
                 left *= nbars
             if len(height) == 1:
                 height *= nbars
+            if len(width) == 1:
+                width *= nbars
 
             tick_label_axis = self.yaxis
             tick_label_position = bottom
@@ -2077,7 +2081,7 @@ or tuple of floats
                              "be length %d or scalar" % nbars)
         if len(height) != nbars:
             raise ValueError("incompatible sizes: argument 'height' "
-                              "must be length %d or scalar" % nbars)
+                             "must be length %d or scalar" % nbars)
         if len(width) != nbars:
             raise ValueError("incompatible sizes: argument 'width' "
                              "must be length %d or scalar" % nbars)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4877,3 +4877,11 @@ def test_scatter_color_masking():
 def test_eventplot_legend():
     plt.eventplot([1.0], label='Label')
     plt.legend()
+
+
+@cleanup
+def test_bar_single_height():
+    # Check that a bar chart with a single height for all bars works
+    plt.bar(range(4), 1)
+    # Check that a horizontal chart with one width works
+    plt.bar(0, 1, bottom=range(4), width=1, orientation='horizontal')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4881,7 +4881,8 @@ def test_eventplot_legend():
 
 @cleanup
 def test_bar_single_height():
+    fig, ax = plt.subplots()
     # Check that a bar chart with a single height for all bars works
-    plt.bar(range(4), 1)
+    ax.bar(range(4), 1)
     # Check that a horizontal chart with one width works
-    plt.bar(0, 1, bottom=range(4), width=1, orientation='horizontal')
+    ax.bar(0, 1, bottom=range(4), width=1, orientation='horizontal')


### PR DESCRIPTION
Fixes #6820

- If a vertical bar, allow a scalar height
- If a horizontal bar, allow a scalar width
- Test that doing the above works without errors