### PR TITLE
Fix warning when setting markeredgecolor to a numpy array

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1157,7 +1157,7 @@ class Line2D(Artist):
         """
         if ec is None:
             ec = 'auto'
-        if self._markeredgecolor != ec:
+        if self._markeredgecolor is None or self._markeredgecolor != ec:
             self.stale = True
         self._markeredgecolor = ec
 


### PR DESCRIPTION
If self._markeregecolor is set to `None`, when ec is a numpy array it is compared to `None`. Avoid this comparison by always setting `self.stale = True` if `self._markeredgecolor == None`.

Fixes #6480 