### PR TITLE
DOC: Original documentation was misleading

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -649,7 +649,7 @@ class Figure(Artist):
         (:meth:`~matplotlib.axes.Axes.imshow`) which will be resampled
         to fit the current axes.  If you want a resampled image to
         fill the entire figure, you can define an
-        :class:`~matplotlib.axes.Axes` with size [0,1,0,1].
+        :class:`~matplotlib.axes.Axes` with extent [0,0,1,1].
 
         An :class:`matplotlib.image.FigureImage` instance is returned.
 


### PR DESCRIPTION
Doing `figure.add_axes([0, 1, 0, 1])` would create axes that are in the upper left corner with width zero.