### PR TITLE
Save SVG test directly to file instead of its name.

### DIFF
--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -217,8 +217,8 @@ def test_missing_psfont(mock):
     rc('text', usetex=True)
     fig, ax = plt.subplots()
     ax.text(0.5, 0.5, 'hello')
-    with tempfile.NamedTemporaryFile(suffix='.svg') as tmpfile:
-        fig.savefig(tmpfile.name)
+    with tempfile.TemporaryFile() as tmpfile:
+        fig.savefig(tmpfile, format='svg')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Windows doesn't like opening files twice, so this needs to save to the file name _outside_ the context (after it's been closed), or simply write to the file object directly. There doesn't seem to be any pressing need to use the file name, so just use the file object.

Hopefully, this will fix AppVeyor.