### PR TITLE
Decode error messages from image converters.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -113,8 +113,8 @@ def get_file_hash(path, block_size=2 ** 20):
 def make_external_conversion_command(cmd):
     def convert(old, new):
         cmdline = cmd(old, new)
-        pipe = subprocess.Popen(
-            cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        pipe = subprocess.Popen(cmdline, universal_newlines=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = pipe.communicate()
         errcode = pipe.wait()
         if not os.path.exists(new) or errcode:

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -224,8 +224,8 @@ def verify(filename):
     verifier = verifiers.get(extension, None)
     if verifier is not None:
         cmd = verifier(filename)
-        pipe = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        pipe = subprocess.Popen(cmd, universal_newlines=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = pipe.communicate()
         errcode = pipe.wait()
         if errcode != 0:


### PR DESCRIPTION
They appear as one giant blob right now since they're bytes. This will help make debugging Travis a little easier.