### PR TITLE
Increase ToC-level of bar(h) style change entry.

### DIFF
--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -562,7 +562,7 @@ or by setting::
 in your :file:`matplotlibrc` file.
 
 ``bar`` and ``barh``
-====================
+--------------------
 
 The default value of the ``align`` kwarg for both
 `~matplotlib.Axes.bar` and `~matplotlib.Axes.barh` is changed from


### PR DESCRIPTION
This seems like it should go under the "Plotting functions" section, not as its own top-level entry.

I wonder if we should sort this section, since the ToC looks a bit haphazard?