### PR TITLE
STY: increase axes.titlepad from 4 to 6; closes #7660

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1074,7 +1074,7 @@ defaultParams = {
     'axes.titlesize':        ['large', validate_fontsize],  # fontsize of the
                                                             # axes title
     'axes.titleweight':      ['normal', six.text_type],  # font weight of axes title
-    'axes.titlepad':         [4.0, validate_float],  # pad from axes top to title in points
+    'axes.titlepad':         [6.0, validate_float],  # pad from axes top to title in points
     'axes.grid':             [False, validate_bool],   # display grid or not
     'axes.grid.which':       ['major', validate_axis_locator],  # set wether the gid are by
                                                                 # default draw on 'major'

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -297,7 +297,7 @@ backend      : $TEMPLATE_BACKEND
 #axes.linewidth      : 0.8     # edge linewidth
 #axes.grid           : False   # display grid or not
 #axes.titlesize      : large   # fontsize of the axes title
-#axes.titlepad       : 4.0     # pad between axes and title in points
+#axes.titlepad       : 6.0     # pad between axes and title in points
 #axes.labelsize      : medium  # fontsize of the x any y labels
 #axes.labelpad       : 4.0     # space between label and axis
 #axes.labelweight    : normal  # weight of the x and y labels


### PR DESCRIPTION
With the default Axes title font this leaves plenty of room for
descenders, and barely enough room for a subscript.  I'm reluctant
to make the pad any larger because I think that in the most common
cases it would elevate the title too much, and take too much room.