### PR TITLE
[MRG+1] Example: remove overlapping text from image_masked.py

### DIFF
--- a/examples/pylab_examples/image_masked.py
+++ b/examples/pylab_examples/image_masked.py
@@ -12,8 +12,10 @@ import matplotlib.mlab as mlab
 import numpy as np
 
 # compute some interesting data
-delta = 0.025
-x = y = np.arange(-3.0, 3.0, delta)
+x0, x1 = -5, 5
+y0, y1 = -3, 3
+x = np.linspace(x0, x1, 500)
+y = np.linspace(y0, y1, 500)
 X, Y = np.meshgrid(x, y)
 Z1 = mlab.bivariate_normal(X, Y, 1.0, 1.0, 0.0, 0.0)
 Z2 = mlab.bivariate_normal(X, Y, 1.5, 0.5, 1, 1)
@@ -38,24 +40,33 @@ Zm = ma.masked_where(Z > 1.2, Z)
 # Anything above that range is colored based on palette.set_over, etc.
 
 # set up the axes
-fig, (ax1, ax2) = plt.subplots(1, 2)
+fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 5.4))
 
 # plot using 'continuous' color map
 im = ax1.imshow(Zm, interpolation='bilinear',
                 cmap=palette,
-                norm=colors.Normalize(vmin=-1.0, vmax=1.0, clip=False),
-                origin='lower', extent=[-3, 3, -3, 3])
-ax1.set_title('Green=low, Red=high, Blue=bad')
-fig.colorbar(im, extend='both', orientation='horizontal', shrink=0.8, ax=ax1)
+                norm=colors.Normalize(vmin=-1.0, vmax=1.0),
+                aspect='auto',
+                origin='lower',
+                extent=[x0, x1, y0, y1])
+ax1.set_title('Green=low, Red=high, Blue=masked')
+cbar = fig.colorbar(im, extend='both', shrink=0.9, ax=ax1)
+cbar.set_label('uniform')
+for ticklabel in ax1.xaxis.get_ticklabels():
+    ticklabel.set_visible(False)
 
-# plot using 'discrete' color map
+# Plot using a small number of colors, with unevenly spaced boundaries.
 im = ax2.imshow(Zm, interpolation='nearest',
                 cmap=palette,
                 norm=colors.BoundaryNorm([-1, -0.5, -0.2, 0, 0.2, 0.5, 1],
-                                         ncolors=256, clip=False),
-                origin='lower', extent=[-3, 3, -3, 3])
+                                         ncolors=palette.N),
+                aspect='auto',
+                origin='lower',
+                extent=[x0, x1, y0, y1])
 ax2.set_title('With BoundaryNorm')
-fig.colorbar(im, extend='both', spacing='proportional',
-             orientation='horizontal', shrink=0.8, ax=ax2)
+cbar = fig.colorbar(im, extend='both', spacing='proportional',
+                    shrink=0.9, ax=ax2)
+cbar.set_label('proportional')
 
+fig.suptitle('imshow, with out-of-range and masked data')
 plt.show()

--- a/examples/pylab_examples/image_masked.py
+++ b/examples/pylab_examples/image_masked.py
@@ -5,11 +5,11 @@ The second subplot illustrates the use of BoundaryNorm to
 get a filled contour effect.
 """
 from copy import copy
-from numpy import ma
-import matplotlib.colors as colors
-import matplotlib.pyplot as plt
-import matplotlib.mlab as mlab
+
 import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.mlab as mlab
 
 # compute some interesting data
 x0, x1 = -5, 5
@@ -33,14 +33,14 @@ palette.set_bad('b', 1.0)
 # If you comment out all the palette.set* lines, you will see
 # all the defaults; under and over will be colored with the
 # first and last colors in the palette, respectively.
-Zm = ma.masked_where(Z > 1.2, Z)
+Zm = np.ma.masked_where(Z > 1.2, Z)
 
 # By setting vmin and vmax in the norm, we establish the
 # range to which the regular palette color scale is applied.
 # Anything above that range is colored based on palette.set_over, etc.
 
 # set up the axes
-fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 5.4))
+fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(6, 5.4))
 
 # plot using 'continuous' color map
 im = ax1.imshow(Zm, interpolation='bilinear',


### PR DESCRIPTION
This also makes several other changes that clarify the example
and improve the code.