### PR TITLE
DOC: add example plot for LogFormatter in dflt_style_changes

### DIFF
--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -1057,6 +1057,28 @@ ticks.  See `~matplotlib.ticker.LogFormatter` for details. The
 minor tick labeling is turned off when using ``mpl.style.use('classic')``,
 but cannot be controlled independently via ``rcParams``.
 
+.. plot::
+
+   import numpy as np
+   import matplotlib.pyplot as plt
+
+   np.random.seed(2)
+
+   fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(6, 3))
+   fig.subplots_adjust(wspace=0.35, left=0.09, right=0.95)
+
+   x = np.linspace(0.9, 1.7, 10)
+   y = 10 ** x[np.random.randint(0, 10, 10)]
+
+   ax2.semilogy(x, y)
+   ax2.set_title('v2.0')
+
+   with plt.style.context('classic'):
+       ax1.semilogy(x, y)
+       ax1.set_xlim(ax2.get_xlim())
+       ax1.set_ylim(ax2.get_ylim())
+       ax1.set_title('classic')
+
 
 ``ScalarFormatter`` tick label formatting with offsets
 ======================================================


### PR DESCRIPTION
I only added an example plot:

![logformatter](https://cloud.githubusercontent.com/assets/85125/21477330/c7a52a8a-cae4-11e6-84ff-813be9443d86.png)
