### PR TITLE
Fix a few broken links in docs

### DIFF
--- a/doc/devel/MEP/MEP11.rst
+++ b/doc/devel/MEP/MEP11.rst
@@ -117,7 +117,7 @@ Implementation
 For installing from source, and assuming the user has all of the
 C-level compilers and dependencies, this can be accomplished fairly
 easily using `distribute` and following the instructions `here
-<http://packages.python.org/distribute/>`_.  The only anticipated
+<https://pypi.python.org/pypi/distribute>`_.  The only anticipated
 change to the matplotlib library code will be to import `pyparsing`
 from the top-level namespace rather than from within matplotlib.  Note
 that `distribute` will also allow us to remove the direct dependency

--- a/doc/devel/gitwash/git_links.inc
+++ b/doc/devel/gitwash/git_links.inc
@@ -22,7 +22,7 @@
 .. _network graph visualizer: http://github.com/blog/39-say-hello-to-the-network-graph-visualizer
 .. _git user manual: http://schacon.github.com/git/user-manual.html
 .. _git tutorial: http://schacon.github.com/git/gittutorial.html
-.. _git community book: http://book.git-scm.com/
+.. _git community book: https://git-scm.com/book/en/v2
 .. _git ready: http://www.gitready.com/
 .. _git casts: http://www.gitcasts.com/
 .. _Fernando's git page: http://www.fperez.org/py4science/git.html

--- a/doc/devel/license.rst
+++ b/doc/devel/license.rst
@@ -6,7 +6,7 @@ Licenses
 Matplotlib only uses BSD compatible code.  If you bring in code from
 another project make sure it has a PSF, BSD, MIT or compatible license
 (see the Open Source Initiative `licenses page
-<http://www.opensource.org/licenses>`_ for details on individual
+<http://opensource.org/licenses>`_ for details on individual
 licenses).  If it doesn't, you may consider contacting the author and
 asking them to relicense it.  GPL and LGPL code are not acceptable in
 the main code base, though we are considering an alternative way of

--- a/doc/users/colormaps.rst
+++ b/doc/users/colormaps.rst
@@ -168,7 +168,8 @@ Color vision deficiencies
 
 There is a lot of information available about color blindness (*e.g.*,
 [colorblindness]_). Additionally, there are tools available to convert images to
-how they look for different types of color vision deficiencies (*e.g.*, [asp]_).
+how they look for different types of color vision deficiencies (*e.g.*,
+[vischeck]_).
 
 The most common form of color vision deficiency involves differentiating between
 red and green. Thus, avoiding colormaps with both red and green will avoid many
@@ -187,5 +188,5 @@ References
 .. [mycarta-cubelaw] http://mycarta.wordpress.com/2013/02/21/perceptual-rainbow-palette-the-method/
 .. [bw] http://www.tannerhelland.com/3643/grayscale-image-algorithm-vb6/
 .. [colorblindness] http://www.color-blindness.com/
-.. [asp] http://aspnetresources.com/tools/colorBlindness
+.. [vischeck] http://www.vischeck.com/vischeck/
 .. [IBM] http://www.research.ibm.com/people/l/lloydt/color/color.HTM


### PR DESCRIPTION
Probably a little bit easier to review than #7693 ;)

The only one I can't think of a replacement for is https://github.com/matplotlib/matplotlib/tree/master/test at https://github.com/matplotlib/matplotlib/blame/master/doc/users/credits.rst#L132