### PR TITLE
Interactive setting of savefig rcParams (Qt only).

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -509,10 +509,8 @@ validate_ps_papersize = ValidateInStrings(
 def validate_ps_distiller(s):
     if isinstance(s, six.string_types):
         s = s.lower()
-    if s in ('none', None):
+    if s in ('none', None, 'false', False):
         return None
-    elif s in ('false', False):
-        return False
     elif s in ('ghostscript', 'xpdf'):
         return s
     else:
@@ -1337,7 +1335,7 @@ defaultParams = {
     'ps.papersize':     ['letter', validate_ps_papersize],
     'ps.useafm':        [False, validate_bool],  # Set PYTHONINSPECT
     # use ghostscript or xpdf to distill ps output
-    'ps.usedistiller':  [False, validate_ps_distiller],
+    'ps.usedistiller':  [None, validate_ps_distiller],
     'ps.distiller.res': [6000, validate_int],     # dpi
     'ps.fonttype':      [3, validate_fonttype],  # 3 (Type3) or 42 (Truetype)
     # compression level from 0 to 9; 0 to disable

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -531,12 +531,12 @@ backend      : $TEMPLATE_BACKEND
 # ps backend params
 #ps.papersize      : letter   # auto, letter, legal, ledger, A0-A10, B0-B10
 #ps.useafm         : False    # use of afm fonts, results in small files
-#ps.usedistiller   : False    # can be: None, ghostscript or xpdf
-                                          # Experimental: may produce smaller files.
-                                          # xpdf intended for production of publication quality files,
-                                          # but requires ghostscript, xpdf and ps2eps
-#ps.distiller.res  : 6000      # dpi
-#ps.fonttype       : 3         # Output Type 3 (Type3) or Type 42 (TrueType)
+#ps.usedistiller   : None     # can be: None, ghostscript or xpdf
+                              # Experimental: may produce smaller files.
+                              # xpdf intended for production of publication quality files,
+                              # but requires ghostscript, xpdf and ps2eps
+#ps.distiller.res  : 6000     # dpi
+#ps.fonttype       : 3        # Output Type 3 (Type3) or Type 42 (TrueType)
 
 ## pdf backend params
 #pdf.compression   : 6 # integer from 0 to 9


### PR DESCRIPTION
An additional window pops after selecting the filename to allow setting
of savefig-related rcParams.

For simplicity and consistency, the "ps.usedistiller" rcParam is now
normalized to `None` when not set.

Closes #7352.