### PR TITLE
[MRG+1] DOC: Add bug report reqs and template to contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,39 @@
 To help us understand and resolve your issue please check that you have provided
-the information below.
+the information that corresponds to the type of issue that you are submitting. You can feel free to delete the sections that do not apply to your issue.
+
+###Bug report
+
+**Bug summary**
+
+- [ ] A short 1-2 sentences that succinctly describes the bug
+
+**Code for reproduction**
+
+- [ ] A minimum code snippet required to reproduce the bug, also minimizing the number of dependencies required
+
+```python
+# Paste your code here
+#
+#
+```
+
+**Actual outcome**
+
+- [ ] The output produced by the above code, which may be a screenshot, console output, etc.
+
+```
+# If applicable, paste the console output here
+#
+#
+```
+
+**Expected outcome**
+
+- [ ] A description of the expected outcome from the code snippet
+- [ ] If this used to work in an earlier version of Matplotlib, please note the version it used to work on
+
+**Matplotlib version**
 
 - [ ] Matplotlib version, Python version and Platform (Windows, OSX, Linux ...)
 - [ ] How did you install Matplotlib and Python (pip, anaconda, from source ...)
-- [ ] If possible please supply a [Short, Self Contained, Correct, Example](http://sscce.org/)
-      that demonstrates the issue i.e a small piece of code which reproduces the issue
-      and can be run with out any other (or as few as possible) external dependencies.
-- [ ] If this is an image generation bug attach a screenshot demonstrating the issue.
-- [ ] If this is a regression (Used to work in an earlier version of Matplotlib), please 
-      note where it used to work.
+

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -17,6 +17,60 @@ ticket to the
 `Bug Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are
 also welcome to post feature requests or pull requests.
 
+If you are reporting a bug, please do your best to include each of the following:
+
+ 1. A short, top-level summary of the bug. In most cases, this should be 1-2
+    sentences.
+
+ 2. A short, self-contained code snippet to reproduce the bug, ideally allowing
+    a simple copy and paste to reproduce. Please do your best to reduce the code 
+    snippet to the minimum required.
+
+ 3. The actual outcome of the code snippet
+
+ 4. The expected outcome of the code snippet
+
+ 5. The version of matplotlib that you are using. You can grab the version with
+    the following command::
+
+        >>> import matplotlib
+        >>> matplotlib.__version__
+        '1.5.3'
+
+If you would like a template to organize this information in the issue, you may paste the following into your issue::
+
+        **Bug summary**
+        
+        A short 1-2 sentences that succinctly describes the bug.
+        
+        **Code for reproduction**
+        
+        ```python
+        # Paste your code here
+        #
+        #
+        ```
+
+        **Actual outcome**
+        
+        Ideally, a direct paste of the output produced by the above code.
+
+        ```python
+        # You can use this if it is a piece of console output
+        #
+        #
+        ```
+
+        **Expected outcome**
+        
+        A description of the expected outcome
+
+        **Matplotlib version**
+
+        1.5.3
+        
+Thank you for your help in keeping bug reports complete, targeted and descriptive.
+
 
 Retrieving and installing the latest version of the code
 ========================================================

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -14,7 +14,8 @@ Submitting a bug report
 
 If you find a bug in the code or documentation, do not hesitate to submit a
 ticket to the
-`Bug Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are also welcome to post feature requests or pull requests.
+`Bug Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are also 
+welcome to post feature requests or pull requests.
 
 If you are reporting a bug, please do your best to include the following:
 
@@ -29,8 +30,8 @@ If you are reporting a bug, please do your best to include the following:
 
  4. The expected outcome of the code snippet
 
- 5. The Matplotlib version, Python version and platform that you are using. You can grab the 
-    version with the following commands::
+ 5. The Matplotlib version, Python version and platform that you are using. You
+    can grab the version with the following commands::
 
         >>> import matplotlib
         >>> matplotlib.__version__
@@ -39,7 +40,8 @@ If you are reporting a bug, please do your best to include the following:
         >>> platform.python_version()
         '2.7.12'
 
-We have preloaded the issue creation page with a Markdown template that you can use to organize this information.
+We have preloaded the issue creation page with a Markdown template that you can
+use to organize this information.
         
 Thank you for your help in keeping bug reports complete, targeted and descriptive.
 

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -14,10 +14,9 @@ Submitting a bug report
 
 If you find a bug in the code or documentation, do not hesitate to submit a
 ticket to the
-`Bug Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are
-also welcome to post feature requests or pull requests.
+`Bug Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are also welcome to post feature requests or pull requests.
 
-If you are reporting a bug, please do your best to include each of the following:
+If you are reporting a bug, please do your best to include the following:
 
  1. A short, top-level summary of the bug. In most cases, this should be 1-2
     sentences.
@@ -30,47 +29,19 @@ If you are reporting a bug, please do your best to include each of the following
 
  4. The expected outcome of the code snippet
 
- 5. The version of matplotlib that you are using. You can grab the version with
-    the following command::
+ 5. The Matplotlib version, Python version and platform that you are using. You can grab the 
+    version with the following commands::
 
         >>> import matplotlib
         >>> matplotlib.__version__
         '1.5.3'
+        >>> import platform
+        >>> platform.python_version()
+        '2.7.12'
 
-If you would like a template to organize this information in the issue, you may paste the following into your issue::
-
-        **Bug summary**
-        
-        A short 1-2 sentences that succinctly describes the bug.
-        
-        **Code for reproduction**
-        
-        ```python
-        # Paste your code here
-        #
-        #
-        ```
-
-        **Actual outcome**
-        
-        Ideally, a direct paste of the output produced by the above code.
-
-        ```python
-        # You can use this if it is a piece of console output
-        #
-        #
-        ```
-
-        **Expected outcome**
-        
-        A description of the expected outcome
-
-        **Matplotlib version**
-
-        1.5.3
+We have preloaded the issue creation page with a Markdown template that you can use to organize this information.
         
 Thank you for your help in keeping bug reports complete, targeted and descriptive.
-
 
 Retrieving and installing the latest version of the code
 ========================================================


### PR DESCRIPTION
Hopefully this doesn't conflict with #7699 at all (it shouldn't).

This adds a few recommendations for information to include when submitting bug reports. It also provides a Markdown-formatted template for anyone who wants to neatly organize their information in their issue.