### PR TITLE
BF: Convert namespace path to list

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -461,7 +461,7 @@ def _image_directories(func):
                         file.close()
                 except ImportError:
                     # assume namespace package
-                    path = sys.modules[sub_mod].__path__
+                    path = list(sys.modules[sub_mod].__path__)
                     res = None, path, None
             return res
 


### PR DESCRIPTION
For some reason, on some systems, the ``__path__`` attribute of a module
is a _NamespacePath, not a list, as we expected - see:
https://github.com/MacPython/matplotlib-wheels/issues/2