### PR TITLE
Fix table identation in docs

### DIFF
--- a/doc/users/mathtext.rst
+++ b/doc/users/mathtext.rst
@@ -214,11 +214,6 @@ When using the `STIX <http://www.stixfonts.org/>`_ fonts, you also have the choi
     ``\mathfrak{Fraktur}``                 :math-stix:`\mathfrak{Fraktur}`
     ``\mathsf{sansserif}``                 :math-stix:`\mathsf{sansserif}`
     ``\mathrm{\mathsf{sansserif}}``        :math-stix:`\mathrm{\mathsf{sansserif}}`
-    ====================================== =========================================
-
-.. htmlonly::
-
-    ====================================== =========================================
     ``\mathcircled{circled}``              :math-stix:`\mathcircled{circled}`
     ====================================== =========================================
 


### PR DESCRIPTION
Remove htmlonly directive which breaks table identation as described at #7300

'htmlonly' directive is used only in 17 files in matplotlib docs. As every other usage preceeds some additional information like release date, I belive this to be some sort of typo. But I am not completely sure.