### PR TITLE
Declare Python 3.6 support via classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ classifiers = [
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Scientific/Engineering :: Visualization',
     ]
 


### PR DESCRIPTION
This PR adds the classifier declaring that Python 3.6 is supported to setup.py.

If Python 3.6 is supported by MPL 2.0, this commit should be added to the 2.0 branch, so that Python 3.6 support also shows up on PyPI:
https://pypi.python.org/pypi/matplotlib/2.0.0rc2