### PR TITLE
FIX: Clean up in the new quiverkey test; make new figs in scale tests

### DIFF
--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -162,6 +162,7 @@ def test_bad_masked_sizes():
     ax.barbs(x, y, u, v)
 
 
+@cleanup
 def test_quiverkey_angles():
     # Check that only a single arrow is plotted for a quiverkey when an array
     # of angles is given to the original quiver plot

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -8,7 +8,7 @@ import io
 
 @image_comparison(baseline_images=['log_scales'], remove_text=True)
 def test_log_scales():
-    ax = plt.subplot(122, yscale='log', xscale='symlog')
+    ax = plt.figure().add_subplot(122, yscale='log', xscale='symlog')
 
     ax.axvline(24.1)
     ax.axhline(24.1)
@@ -17,7 +17,7 @@ def test_log_scales():
 @image_comparison(baseline_images=['logit_scales'], remove_text=True,
                   extensions=['png'])
 def test_logit_scales():
-    ax = plt.subplot(111, xscale='logit')
+    ax = plt.figure().add_subplot(111, xscale='logit')
 
     # Typical extinction curve for logit
     x = np.array([0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5,


### PR DESCRIPTION
Merging the new quiverkey test seemed to cause nondeterministic
failures of test_log_scales and test_logit_scales. I couldn't reproduce
but here's a guess: the new test creates a figure and doesn't close it,
and the scale tests just call plt.subplot which would usually create
a new figure but if the test gets executed right after the new test,
they just add a subplot on the existing figure.