### PR TITLE
[MRG+1] DOC: Fix invalid nose argument in testing.rst

### DIFF
--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -85,7 +85,7 @@ a colon, e.g., (this is assuming the test is installed)::
 If you want to run the full test suite, but want to save wall time try
 running the tests in parallel::
 
-  python tests.py --nocapture --nose-verbose --processes=5 --process-timeout=300
+  python tests.py --nocapture --verbose --processes=5 --process-timeout=300
 
 
 An alternative implementation that does not look at command line


### PR DESCRIPTION
Fixes #7649 

It looks like the intent of the example was to demonstrate usage of the nose arguments that were mentioned right before. Instead of removing like #7649 suggests, I changed it to the right argument