### PR TITLE
Warn about unused kwargs in contour methods

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1986,6 +1986,7 @@ class _AxesBase(martist.Artist):
                 # we need to update.
                 if ydata is not None:
                     self.yaxis.update_units(ydata)
+        return kwargs
 
     def in_axes(self, mouseevent):
         """

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -962,9 +962,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         self.changed()  # set the colors
 
         if kwargs:
-            s = ''
-            for key, value in kwargs.items():
-                s += '"' + str(key) + '"' + ', '
+            s = ", ".join(map(repr, kwargs))
             warnings.warn('The following kwargs were not used by contour: ' +
                           s)
 

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -54,6 +54,7 @@ class TriContourSet(ContourSet):
             self._maxs = [tri.x.max(), tri.y.max()]
 
         self.cppContourGenerator = C
+        return kwargs
 
     def _get_allsegs_and_allkinds(self):
         """


### PR DESCRIPTION
I got interested in #1963 (and I think there's another similar bug somewhere out there...), so thought I'd have a go.

The general method behind what I've done is

- Every time a kwarg is retrieved, make sure it is ``pop``ed
- This *should* mean that by the end of the ``__init__`` block, all the kwargs that are used have gone, and any unused kwargs are left behind

I think it should be in theory fairly easy (but very tedious) to roll this out to all methods.

This is probably fairly experimental, so happy for it to be discussed/reviewed and not necessarily merged!