### PR TITLE
[MRG+1] Ignore invalid limits on log scaled axes

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2888,10 +2888,19 @@ class _AxesBase(martist.Artist):
                  'left=%s, right=%s') % (left, right))
         left, right = mtransforms.nonsingular(left, right, increasing=False)
 
-        if self.get_xscale() == 'log' and (left <= 0.0 or right <= 0.0):
-            warnings.warn(
-                'Attempted to set non-positive xlimits for log-scale axis; '
-                'invalid limits will be ignored.')
+        if self.get_xscale() == 'log':
+            if left <= 0.0:
+                left = old_left
+                warnings.warn(
+                    ('Attempted to set non-positive xlimit %s for left of '
+                     'log-scale axis; invalid limit will be ignored.') %
+                    (left))
+            if right <= 0.0:
+                right = old_right
+                warnings.warn(
+                    ('Attempted to set non-positive xlimit %s for right of '
+                     'log-scale axis; invalid limit will be ignored.') %
+                    (right))
         left, right = self.xaxis.limit_range_for_scale(left, right)
 
         self.viewLim.intervalx = (left, right)
@@ -3168,11 +3177,19 @@ class _AxesBase(martist.Artist):
                  'bottom=%s, top=%s') % (bottom, top))
 
         bottom, top = mtransforms.nonsingular(bottom, top, increasing=False)
+        if self.get_yscale() == 'log':
+            if bottom <= 0.0:
+                bottom = old_bottom
+                warnings.warn(
+                    ('Attempted to set non-positive ylimit %s for bottom of '
+                     'log-scale axis; invalid limit will be ignored.') %
+                    (bottom))
+            if top <= 0.0:
+                top = old_top
+                warnings.warn(
+                    ('Attempted to set non-positive ylimit %s for top of '
+                     'log-scale axis; invalid limit will be ignored.') % (top))
 
-        if self.get_yscale() == 'log' and (bottom <= 0.0 or top <= 0.0):
-            warnings.warn(
-                'Attempted to set non-positive ylimits for log-scale axis; '
-                'invalid limits will be ignored.')
         bottom, top = self.yaxis.limit_range_for_scale(bottom, top)
 
         self.viewLim.intervaly = (bottom, top)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4877,3 +4877,28 @@ def test_scatter_color_masking():
 def test_eventplot_legend():
     plt.eventplot([1.0], label='Label')
     plt.legend()
+
+
+@cleanup
+def test_invalid_log_limits():
+    # Check that limits <= 0 are ignored on log scale plots
+    fig, ax = plt.subplots()
+    ax.scatter([0, 1, 2], [0, 1, 2])
+
+    ax.set_xscale('log')
+    old_lims = ax.get_xlim()
+    with warnings.catch_warnings(record=True) as w:
+        ax.set_xlim(left=-2, right=0)
+        # Check that a warning for each limit is raised
+        assert len(w) == 2
+    new_lims = ax.get_xlim()
+    assert old_lims == new_lims
+
+    ax.set_yscale('log')
+    old_lims = ax.get_ylim()
+    with warnings.catch_warnings(record=True) as w:
+        ax.set_ylim(bottom=-2, top=0)
+        # Check that a warning for each limit is raised
+        assert len(w) == 2
+    new_lims = ax.get_ylim()
+    assert old_lims == new_lims


### PR DESCRIPTION
Fixes #7733 

If invalid limits are passed, just use the old limits instead (similar to if `None` is passed as a limit)