### PR TITLE
[MRG+1] Ensure that pyenv command is in a literal block

### DIFF
--- a/doc/faq/osx_framework.rst
+++ b/doc/faq/osx_framework.rst
@@ -47,7 +47,7 @@ Otherwise you will need one of the workarounds below.
 Pyenv
 -----
 
-If you are using pyenv and virtualenv you can enable your python version to be installed as a framework:
+If you are using pyenv and virtualenv you can enable your python version to be installed as a framework::
 
     PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install x.x.x
 


### PR DESCRIPTION
Otherwise the `--` is rendered incorrectly see http://matplotlib.org/devdocs/faq/osx_framework.html

I think this should be backported to 2.0 