### PR TITLE
WIP: Fix artifact upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ cache:
     - $HOME/.cache/matplotlib
 
 addons:
+  artifacts:
+    paths:
+    - result_images.tar.bz2
   apt:
     packages:
       - inkscape
@@ -32,7 +35,7 @@ addons:
 env:
   global:
     - ARTIFACTS_AWS_REGION=us-east-1
-    - ARTIFACTS_S3_BUCKET=matplotlib-test-results
+    - ARTIFACTS_BUCKET=matplotlib-test-results
     - secure: RgJI7BBL8aX5FTOQe7xiXqWHMxWokd6GNUWp1NUV2mRLXPb9dI0RXqZt3UJwKTAzf1z/OtlHDmEkBoTVK81E9iUxK5npwyyjhJ8yTJmwfQtQF2n51Q1Ww9p+XSLORrOzZc7kAo6Kw6FIXN1pfctgYq2bQkrwJPRx/oPR8f6hcbY=
     - secure: E7OCdqhZ+PlwJcn+Hd6ns9TDJgEUXiUNEI0wu7xjxB2vBRRIKtZMbuaZjd+iKDqCKuVOJKu0ClBUYxmgmpLicTwi34CfTUYt6D4uhrU+8hBBOn1iiK51cl/aBvlUUrqaRLVhukNEBGZcyqAjXSA/Qsnp2iELEmAfOUa92ZYo1sk=
     - secure: "dfjNqGKzQG5bu3FnDNwLG8H/C4QoieFo4PfFmZPdM2RY7WIzukwKFNT6kiDfOrpwt+2bR7FhzjOGlDECGtlGOtYPN8XuXGjhcP4a4IfakdbDfF+D3NPIpf5VlE6776k0VpvcZBTMYJKNFIMc7QPkOwjvNJ2aXyfe3hBuGlKJzQU="
@@ -162,11 +165,8 @@ before_cache:
 after_failure:
   - |
     if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == 'matplotlib/matplotlib' ]]; then
-      gem install travis-artifacts
-      cd $TRAVIS_BUILD_DIR/../tmp_test_dir
       tar cjf result_images.tar.bz2 result_images
-      travis-artifacts upload --path result_images.tar.bz2
-      echo https://s3.amazonaws.com/matplotlib-test-results/artifacts/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/result_images.tar.bz2
+      echo 'See "Uploading Artifacts" near the end of the log for the download URL'
     else
       echo "The result images will only be uploaded if they are on the matplotlib/matplotlib repo - this is for security reasons to prevent arbitrary PRs echoing security details."
     fi


### PR DESCRIPTION
I noticed that the artifact upload isn't working: https://travis-ci.org/matplotlib/matplotlib/jobs/188282794#L1227

"gem install travis-artifacts" no longer works, now you have to use the artifacts addon and set some variables. The encrypted variables may need to be updated too. See documentation at https://docs.travis-ci.com/user/uploading-artifacts/

This worked when I tested with my own setup: https://travis-ci.org/jkseppan/matplotlib/builds/188857981

@mdboom, @tacaswell: do you have access to the matplotlib AWS organization and can you ensure that the encrypted Travis variables here are correct? The variable names should be `ARTIFACTS_KEY` and `ARTIFACTS_SECRET`.
