### PR TITLE
[MRG+1] Added axis limit check for non-finite values

### DIFF
--- a/doc/users/whats_new/invalid_axes_limits_errors.rst
+++ b/doc/users/whats_new/invalid_axes_limits_errors.rst
@@ -1,0 +1,6 @@
+Invalid (Non-finite) Axis Limit Error
+-------------------------------------
+
+When using :func:`set_xlim` and :func:`set_ylim`, passing non-finite values now
+results in a ValueError. The previous behavior resulted in the limits being
+erroneously reset to `(-0.001, 0.001)`.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2877,7 +2877,7 @@ class _AxesBase(martist.Artist):
 
         if ((left is not None and not np.isfinite(left)) or
                 (right is not None and not np.isfinite(right))):
-            raise ValueError("xlim limits must be finite. "
+            raise ValueError("Specified x limits must be finite; "
                              "instead, found: (%s, %s)" % (left, right))
 
         old_left, old_right = self.get_xlim()
@@ -3176,8 +3176,8 @@ class _AxesBase(martist.Artist):
 
         if ((top is not None and not np.isfinite(top)) or
                 (bottom is not None and not np.isfinite(bottom))):
-            raise ValueError("ylim limits must be finite. "
-                             "instead, found: (%s, %s)" % (top, bottom))
+            raise ValueError("Specified y limits must be finite; "
+                             "instead, found: (%s, %s)" % (bottom, top))
 
         old_bottom, old_top = self.get_ylim()
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2875,6 +2875,11 @@ class _AxesBase(martist.Artist):
         if right is not None:
             right = self.convert_xunits(right)
 
+        if ((left is not None and not np.isfinite(left)) or
+                (right is not None and not np.isfinite(right))):
+            raise ValueError("xlim limits must be finite. "
+                             "instead, found: (%s, %s)" % (left, right))
+
         old_left, old_right = self.get_xlim()
         if left is None:
             left = old_left
@@ -3168,6 +3173,11 @@ class _AxesBase(martist.Artist):
             bottom = self.convert_yunits(bottom)
         if top is not None:
             top = self.convert_yunits(top)
+
+        if ((top is not None and not np.isfinite(top)) or
+                (bottom is not None and not np.isfinite(bottom))):
+            raise ValueError("ylim limits must be finite. "
+                             "instead, found: (%s, %s)" % (top, bottom))
 
         old_bottom, old_top = self.get_ylim()
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4931,3 +4931,15 @@ def test_bar_single_height():
     ax.bar(range(4), 1)
     # Check that a horizontal chart with one width works
     ax.bar(0, 1, bottom=range(4), width=1, orientation='horizontal')
+
+
+def test_invalid_axis_limits():
+    plt.plot([0, 1], [0, 1])
+    with pytest.raises(ValueError):
+        plt.xlim(np.nan)
+    with pytest.raises(ValueError):
+        plt.xlim(np.inf)
+    with pytest.raises(ValueError):
+        plt.ylim(np.nan)
+    with pytest.raises(ValueError):
+        plt.ylim(np.inf)


### PR DESCRIPTION
Addresses #7460.

Raises a `ValueError` if non-finite values like `np.nan` or `np.inf` are passed as arguments to `set_xlim` or `set_ylim`.