### PR TITLE
MAINT: Deterministic SVG and PDF tests

### DIFF
--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -5,7 +5,7 @@ The ``SOURCE_DATE_EPOCH`` environment variable can now be used to set
 the timestamp value in the PS and PDF outputs. See
 https://reproducible-builds.org/specs/source-date-epoch/
 
-Alternatively, calling ``savefig`` with ``metadata={creationDate=None}``
+Alternatively, calling ``savefig`` with ``metadata={'creationDate': None}``
 will omit the timestamp altogether.
 
 The reproducibility of the output from the PS and PDF backends has so
@@ -17,10 +17,10 @@ versions need to be kept constant for reproducibility, and they may
 add sources of nondeterminism outside the control of matplotlib.
 
 For SVG output, the ``svg.hashsalt`` rc parameter has been added in an
-earlier release. In can be used to change some random id values in the
+earlier release. It can be used to change some random id values in the
 output to be deterministic, at the cost that including multiple such
-svg files in one document can lead to collisions.
+SVG files in one document can lead to collisions.
 
-These features are now enabled in the tests for the pdf and svg
+These features are now enabled in the tests for the PDF and SVG
 backends, so most test output files (but not all of them) are now
 deterministic.

--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -17,9 +17,11 @@ versions need to be kept constant for reproducibility, and they may
 add sources of nondeterminism outside the control of matplotlib.
 
 For SVG output, the ``svg.hashsalt`` rc parameter has been added in an
-earlier release. It can be used to change some random id values in the
-output to be deterministic, at the cost that including multiple such
-SVG files in one document can lead to collisions.
+earlier release. This parameter changes some random identifiers in the
+SVG file to be deterministic. The downside of this setting is that if
+more than one file is generated using with deterministic identifiers
+and they end up as parts of one larger document, the identifiers can
+collide and cause the different parts to affect each other.
 
 These features are now enabled in the tests for the PDF and SVG
 backends, so most test output files (but not all of them) are now

--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -19,7 +19,7 @@ add sources of nondeterminism outside the control of matplotlib.
 For SVG output, the ``svg.hashsalt`` rc parameter has been added in an
 earlier release. This parameter changes some random identifiers in the
 SVG file to be deterministic. The downside of this setting is that if
-more than one file is generated using with deterministic identifiers
+more than one file is generated using deterministic identifiers
 and they end up as parts of one larger document, the identifiers can
 collide and cause the different parts to affect each other.
 

--- a/doc/users/whats_new/reproducible_ps_pdf.rst
+++ b/doc/users/whats_new/reproducible_ps_pdf.rst
@@ -1,9 +1,12 @@
-Reproducible PS and PDF output
-------------------------------
+Reproducible PS, PDF and SVG output
+-----------------------------------
 
 The ``SOURCE_DATE_EPOCH`` environment variable can now be used to set
 the timestamp value in the PS and PDF outputs. See
 https://reproducible-builds.org/specs/source-date-epoch/
+
+Alternatively, calling ``savefig`` with ``metadata={creationDate=None}``
+will omit the timestamp altogether.
 
 The reproducibility of the output from the PS and PDF backends has so
 far been tested using various plot elements but only default values of
@@ -12,3 +15,12 @@ low level, and not with the mathtext or usetex features. When
 matplotlib calls external tools (such as PS distillers or LaTeX) their
 versions need to be kept constant for reproducibility, and they may
 add sources of nondeterminism outside the control of matplotlib.
+
+For SVG output, the ``svg.hashsalt`` rc parameter has been added in an
+earlier release. In can be used to change some random id values in the
+output to be deterministic, at the cost that including multiple such
+svg files in one document can lead to collisions.
+
+These features are now enabled in the tests for the pdf and svg
+backends, so most test output files (but not all of them) are now
+deterministic.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -472,7 +472,6 @@ class PdfFile(object):
                 'Pages': self.pagesObject}
         self.writeObject(self.rootObject, root)
 
-        revision = ''
         # get source date from SOURCE_DATE_EPOCH, if set
         # See https://reproducible-builds.org/specs/source-date-epoch/
         source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
@@ -484,11 +483,13 @@ class PdfFile(object):
 
         self.infoDict = {
             'Creator': 'matplotlib %s, http://matplotlib.org' % __version__,
-            'Producer': 'matplotlib pdf backend%s' % revision,
+            'Producer': 'matplotlib pdf backend %s' % __version__,
             'CreationDate': source_date
         }
         if metadata is not None:
             self.infoDict.update(metadata)
+        self.infoDict = {k: v for (k, v) in self.infoDict.items()
+                         if v is not None}
 
         self.fontNames = {}     # maps filenames to internal font names
         self.nextFont = 1       # next free internal font name
@@ -2459,6 +2460,13 @@ class PdfPages(object):
             'Document Information Dictionary'), e.g.:
             `{'Creator': 'My software', 'Author': 'Me',
             'Title': 'Awesome fig'}`
+
+            The standard keys are `'Title'`, `'Author'`, `'Subject'`,
+            `'Keywords'`, `'Creator'`, `'Producer'`, `'CreationDate'`,
+            `'ModDate'`, and `'Trapped'`. Values have been predefined
+            for `'Creator'`, `'Producer'` and `'CreationDate'`. They
+            can be removed by setting them to `None`.
+
         """
         self._file = PdfFile(filename, metadata=metadata)
         self.keep_empty = keep_empty

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -136,6 +136,10 @@ def set_font_settings_for_testing():
     rcParams['text.hinting_factor'] = 8
 
 
+def set_reproducibility_for_testing():
+    rcParams['svg.hashsalt'] = 'matplotlib'
+
+
 def setup():
     # The baseline images are created in this locale, so we should use
     # it during all of the tests.
@@ -161,3 +165,4 @@ def setup():
     rcdefaults()  # Start with all defaults
 
     set_font_settings_for_testing()
+    set_reproducibility_for_testing()

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -298,7 +298,12 @@ class ImageComparisonDecorator(CleanupTest):
             remove_ticks_and_titles(fig)
 
         actual_fname = os.path.join(self.result_dir, baseline) + '.' + extension
-        fig.savefig(actual_fname, **self.savefig_kwargs)
+        kwargs = self.savefig_kwargs.copy()
+        if extension == 'pdf':
+            kwargs.setdefault('metadata',
+                              {'Creator': None, 'Producer': None,
+                               'CreationDate': None})
+        fig.savefig(actual_fname, **kwargs)
 
         expected_fname = self.copy_baseline(baseline, extension)
         raise_on_image_difference(expected_fname, actual_fname, self.tol)


### PR DESCRIPTION
There has been plenty of work (at least #4434, #5671, #5766, #6597) to make it possible to have deterministic svg and pdf output, or at least closer to deterministic than before. This change adds one related feature: callers can remove the bits of pdf metadata that contain the date and matplotlib version, so that new releases don't necessarily change the result of every test. Furthermore, this change enables all the optional pdf and svg determinism features in tests.

I am developing some improvements to test-result caching on another branch, and in my tests only the following test files still change from run to run after this patch (although in my environment I get KNOWNFAIL=27, SKIP=8 so some more are possible):

    clip_path_clipping.svg
    hatching.svg
    pgf_bbox_inches.pdf
    pgf_mixedmode.pdf
    pgf_pdflatex.pdf
    pgf_rcupdate1.pdf
    pgf_rcupdate2.pdf
    pgf_xelatex.pdf
    bbox_inches_tight_clipping.svg
    image_clip.svg
    scaled_lines.svg
    offsetbox_clipping.svg
    skew_axes.pdf
    skew_axes.svg
