### PR TITLE
[MRG+1] bugfix for wx backend: release mouse on loss of focus and before trying to recapture

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -685,6 +685,9 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         self.Bind(wx.EVT_MIDDLE_DCLICK, self._onMiddleButtonDClick)
         self.Bind(wx.EVT_MIDDLE_UP, self._onMiddleButtonUp)
 
+        self.Bind(wx.EVT_MOUSE_CAPTURE_CHANGED, self._onCaptureLost)
+        self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._onCaptureLost)
+
         if wx.VERSION_STRING < "2.9":
             # only needed in 2.8 to reduce flicker
             self.SetBackgroundStyle(wx.BG_STYLE_CUSTOM)
@@ -1023,12 +1026,23 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         evt.Skip()
         FigureCanvasBase.key_release_event(self, key, guiEvent=evt)
 
+    def _set_capture(self, capture=True):
+        """control wx mouse capture """
+        if self.HasCapture():
+            self.ReleaseMouse()
+        if capture:
+            self.CaptureMouse()
+
+    def _onCaptureLost(self, evt):
+        """Capture changed or lost"""
+        self._set_capture(False)
+
     def _onRightButtonDown(self, evt):
         """Start measuring on an axis."""
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        self._set_capture(True)
         FigureCanvasBase.button_press_event(self, x, y, 3, guiEvent=evt)
 
     def _onRightButtonDClick(self, evt):
@@ -1036,7 +1050,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        self._set_capture(True)
         FigureCanvasBase.button_press_event(self, x, y, 3,
                                             dblclick=True, guiEvent=evt)
 
@@ -1045,8 +1059,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        if self.HasCapture():
-            self.ReleaseMouse()
+        self._set_capture(False)
         FigureCanvasBase.button_release_event(self, x, y, 3, guiEvent=evt)
 
     def _onLeftButtonDown(self, evt):
@@ -1054,7 +1067,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        self._set_capture(True)
         FigureCanvasBase.button_press_event(self, x, y, 1, guiEvent=evt)
 
     def _onLeftButtonDClick(self, evt):
@@ -1062,7 +1075,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        self._set_capture(True)
         FigureCanvasBase.button_press_event(self, x, y, 1,
                                             dblclick=True, guiEvent=evt)
 
@@ -1072,8 +1085,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         # print 'release button', 1
         evt.Skip()
-        if self.HasCapture():
-            self.ReleaseMouse()
+        self._set_capture(False)
         FigureCanvasBase.button_release_event(self, x, y, 1, guiEvent=evt)
 
     # Add middle button events
@@ -1082,7 +1094,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        self._set_capture(True)
         FigureCanvasBase.button_press_event(self, x, y, 2, guiEvent=evt)
 
     def _onMiddleButtonDClick(self, evt):
@@ -1090,7 +1102,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         x = evt.GetX()
         y = self.figure.bbox.height - evt.GetY()
         evt.Skip()
-        self.CaptureMouse()
+        self._set_capture(True)
         FigureCanvasBase.button_press_event(self, x, y, 2,
                                             dblclick=True, guiEvent=evt)
 
@@ -1100,8 +1112,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         y = self.figure.bbox.height - evt.GetY()
         # print 'release button', 1
         evt.Skip()
-        if self.HasCapture():
-            self.ReleaseMouse()
+        self._set_capture(False)
         FigureCanvasBase.button_release_event(self, x, y, 2, guiEvent=evt)
 
     def _onMouseWheel(self, evt):


### PR DESCRIPTION
This PR replaces #7652 to address #7636 in which  wx._core.PyAssertionError would be raised with a message of
```
CaptureMouse(): Recapturing the mouse in the same window?
```

For more background, see the discussion in the above links and also at  https://groups.google.com/forum/#!topic/wxpython-users/-NrlWBMNkwM .  

WxPython "mouse capture" events are quite different on Windows and Posix, and there could be OS-specific code to achieve the same desired behavior (that the mouse can move out of a mpl canvas and back in without errors and without losing mouse events).  The solution here is simple enough and works (AFAICT) on all platforms.
