### PR TITLE
By default, don't include tests in binary distributions.

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -22,10 +22,10 @@
 
 [packages]
 # There are a number of subpackages of matplotlib that are considered
-# optional.  They are all installed by default, but they may be turned
-# off here.
+# optional. All except tests are installed by default, but that can
+# be changed here.
 #
-#tests = True
+#tests = False
 #sample_data = True
 #toolkits = True
 # Tests for the toolkits are only automatically installed

--- a/setupext.py
+++ b/setupext.py
@@ -604,6 +604,7 @@ class OptionalPackage(SetupPackage):
     optional = True
     force = False
     config_category = "packages"
+    default_config = "auto"
 
     @classmethod
     def get_config(cls):
@@ -613,7 +614,7 @@ class OptionalPackage(SetupPackage):
         insensitively defined as 1, true, yes, on for True) or opted-out (case
         insensitively defined as 0, false, no, off for False).
         """
-        conf = "auto"
+        conf = cls.default_config
         if config is not None and config.has_option(cls.config_category, cls.name):
             try:
                 conf = config.getboolean(cls.config_category, cls.name)
@@ -788,6 +789,7 @@ class Toolkits(OptionalPackage):
 class Tests(OptionalPackage):
     name = "tests"
     nose_min_version = '0.11.1'
+    default_config = False
 
     def check(self):
         super(Tests, self).check()


### PR DESCRIPTION
Following the discussion in #7745, I have changed the default for the packaging of tests.

Before this patch:

    $ ls -lh dist
    total 65M
    -rw-r--r-- 1 vagrant vagrant 32M Jan  6 22:56 matplotlib-2.0.0rc2+2914.g1fa4dd7-cp27-cp27mu-linux_x86_64.whl
    -rw-r--r-- 1 vagrant vagrant 33M Jan  6 22:53 matplotlib-2.0.0rc2+2914.g1fa4dd7.tar.gz

With this patch:

    $ ls -lh dist
    total 43M
    -rw-r--r-- 1 vagrant vagrant 11M Jan  6 23:03 matplotlib-2.0.0rc2+2914.g1fa4dd7.dirty-cp27-cp27mu-linux_x86_64.whl
    -rw-r--r-- 1 vagrant vagrant 33M Jan  6 23:02 matplotlib-2.0.0rc2+2914.g1fa4dd7.dirty.tar.gz