### PR TITLE
fix axes barh default align option document

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2259,10 +2259,12 @@ or tuple of floats
             dictionary of kwargs to be passed to errorbar method. `ecolor` and
             `capsize` may be specified here rather than as independent kwargs.
 
-        align : ['edge' | 'center'], optional
-            If `edge`, aligns bars by their left edges (for vertical bars) and
-            by their bottom edges (for horizontal bars). If `center`, interpret
-            the `left` argument as the coordinates of the centers of the bars.
+        align : {'center', 'edge'}, optional
+            If 'edge', aligns bars by their left edges (for vertical bars) and
+            by their bottom edges (for horizontal bars). If 'center', interpret
+            the `bottom` argument as the coordinates of the centers of the bars.
+            To align on the align bars on the top edge pass a negative
+            `height`.
 
         log : boolean, optional, default: False
             If true, sets the axis to be log scale

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2197,8 +2197,7 @@ or tuple of floats
 
     @docstring.dedent_interpd
     def barh(self, bottom, width, height=0.8, left=None, **kwargs):
-        """
-        Make a horizontal bar plot.
+        """Make a horizontal bar plot.
 
         Make a horizontal bar plot with rectangles bounded by:
 
@@ -2260,11 +2259,11 @@ or tuple of floats
             `capsize` may be specified here rather than as independent kwargs.
 
         align : {'center', 'edge'}, optional
-            If 'edge', aligns bars by their left edges (for vertical bars) and
-            by their bottom edges (for horizontal bars). If 'center', interpret
-            the `bottom` argument as the coordinates of the centers of the bars.
-            To align on the align bars on the top edge pass a negative
-            `height`.
+            If 'edge', aligns bars by their left edges (for vertical
+            bars) and by their bottom edges (for horizontal bars). If
+            'center', interpret the `bottom` argument as the
+            coordinates of the centers of the bars.  To align on the
+            align bars on the top edge pass a negative `height`.
 
         log : boolean, optional, default: False
             If true, sets the axis to be log scale
@@ -2286,6 +2285,7 @@ or tuple of floats
         See also
         --------
         bar: Plot a vertical bar plot.
+
         """
 
         patches = self.bar(left=left, height=height, width=width,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2197,7 +2197,8 @@ or tuple of floats
 
     @docstring.dedent_interpd
     def barh(self, bottom, width, height=0.8, left=None, **kwargs):
-        """Make a horizontal bar plot.
+        """
+        Make a horizontal bar plot.
 
         Make a horizontal bar plot with rectangles bounded by:
 
@@ -2263,7 +2264,7 @@ or tuple of floats
             bars) and by their bottom edges (for horizontal bars). If
             'center', interpret the `bottom` argument as the
             coordinates of the centers of the bars.  To align on the
-            align bars on the top edge pass a negative `height`.
+            align bars on the top edge pass a negative 'height'.
 
         log : boolean, optional, default: False
             If true, sets the axis to be log scale
@@ -2285,7 +2286,6 @@ or tuple of floats
         See also
         --------
         bar: Plot a vertical bar plot.
-
         """
 
         patches = self.bar(left=left, height=height, width=width,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2259,7 +2259,7 @@ or tuple of floats
             dictionary of kwargs to be passed to errorbar method. `ecolor` and
             `capsize` may be specified here rather than as independent kwargs.
 
-        align : ['edge' | 'center'], optional, default: 'edge'
+        align : ['edge' | 'center'], optional
             If `edge`, aligns bars by their left edges (for vertical bars) and
             by their bottom edges (for horizontal bars). If `center`, interpret
             the `left` argument as the coordinates of the centers of the bars.


### PR DESCRIPTION
Since 2.0, default `align` option of `bar` and `barh`  have changed to 'center',  and the docstring of `bar` has been updated,  but that of `barh` is not.  This PR fix the docstring as `bar`.

In addition, the default `align` option of `bar` is not presented in the docstring like:
> default: 'center'

I'm not quite sure this will be appended to end of the docstring, because some other options in this page give the default value while some are not. If this default value should be appended, I will update this PR.