### PR TITLE
[MRG+1] TST: Clean up figure tests

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -10,6 +10,7 @@ from matplotlib.testing.decorators import image_comparison, cleanup
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import numpy as np
+import warnings
 
 
 @cleanup
@@ -83,7 +84,10 @@ def test_gca():
 
     # the final request for a polar axes will end up creating one
     # with a spec of 111.
-    assert_true(fig.gca(polar=True) is not ax3)
+    with warnings.catch_warnings(record=True) as w:
+        # Changing the projection will throw a warning
+        assert_true(fig.gca(polar=True) is not ax3)
+        assert len(w) == 1
     assert_true(fig.gca(polar=True) is not ax2)
     assert_equal(fig.gca().get_geometry(), (1, 1, 1))
 
@@ -133,8 +137,6 @@ def test_alpha():
 
 @cleanup
 def test_too_many_figures():
-    import warnings
-
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         for i in range(rcParams['figure.max_open_warning'] + 1):
@@ -142,6 +144,7 @@ def test_too_many_figures():
         assert len(w) == 1
 
 
+@cleanup
 def test_iterability_axes_argument():
 
     # This is a regression test for matplotlib/matplotlib#3196. If one of the
@@ -205,6 +208,7 @@ def test_axes_remove():
     assert_equal(len(fig.axes), 3)
 
 
+@cleanup
 def test_figaspect():
     w, h = plt.figaspect(np.float64(2) / np.float64(1))
     assert h / w == 2

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -85,6 +85,7 @@ def test_gca():
     # the final request for a polar axes will end up creating one
     # with a spec of 111.
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         # Changing the projection will throw a warning
         assert_true(fig.gca(polar=True) is not ax3)
         assert len(w) == 1
@@ -208,7 +209,6 @@ def test_axes_remove():
     assert_equal(len(fig.axes), 3)
 
 
-@cleanup
 def test_figaspect():
     w, h = plt.figaspect(np.float64(2) / np.float64(1))
     assert h / w == 2


### PR DESCRIPTION
Add a couple of `@cleanup` decorators, and catch a newish warning. This gets rid of a couple of warnings from the tests.