### PR TITLE
Invalid escape sequences are deprecated in Py3.6.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -141,7 +141,7 @@ del get_versions
 
 __version__numpy__ = str('1.7.1')  # minimum required numpy version
 
-__bibtex__ = """@Article{Hunter:2007,
+__bibtex__ = r"""@Article{Hunter:2007,
   Author    = {Hunter, J. D.},
   Title     = {Matplotlib: A 2D graphics environment},
   Journal   = {Computing In Science \& Engineering},
@@ -398,7 +398,7 @@ def checkdep_tex():
                              stderr=subprocess.PIPE)
         stdout, stderr = s.communicate()
         line = stdout.decode('ascii').split('\n')[0]
-        pattern = '3\.1\d+'
+        pattern = r'3\.1\d+'
         match = re.search(pattern, line)
         v = match.group(0)
         return v

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6501,7 +6501,7 @@ or tuple of floats
     def psd(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
             sides=None, scale_by_freq=None, return_line=None, **kwargs):
-        """
+        r"""
         Plot the power spectral density.
 
         Call signature::

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -887,7 +887,7 @@ docstring.interpd.update(PSD=cbook.dedent("""
 @docstring.dedent_interpd
 def psd(x, NFFT=None, Fs=None, detrend=None, window=None,
         noverlap=None, pad_to=None, sides=None, scale_by_freq=None):
-    """
+    r"""
     Compute the power spectral density.
 
     Call signature::


### PR DESCRIPTION
... so mark the strings with r"".  For `psd`, the backslashes appear a
bit lower, in `\mathrm` and `\log`.