### PR TITLE
[MRG+1] Don't check `iterable()` before `len()`.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import reduce, xrange, zip, zip_longest
 
+from collections import Sized
 import itertools
 import math
 import warnings
@@ -2940,8 +2941,11 @@ or tuple of floats
             data : iterable
                 x or y from errorbar
             '''
-            if (iterable(err) and len(err) == 2):
+            try:
                 a, b = err
+            except (TypeError, ValueError):
+                pass
+            else:
                 if iterable(a) and iterable(b):
                     # using list comps rather than arrays to preserve units
                     low = [thisx - thiserr for (thisx, thiserr)
@@ -2955,8 +2959,8 @@ or tuple of floats
             # special case for empty lists
             if len(err) > 1:
                 fe = safe_first_element(err)
-                if not ((len(err) == len(data) and not (iterable(fe) and
-                                                        len(fe) > 1))):
+                if (len(err) != len(data)
+                        or isinstance(fe, Sized) and len(fe) > 1):
                     raise ValueError("err must be [ scalar | N, Nx1 "
                                      "or 2xN array-like ]")
             # using list comps rather than arrays to preserve units

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1925,11 +1925,9 @@ class _AxesBase(martist.Artist):
         # limits and set the bound to be the bounds of the xydata.
         # Otherwise, it will compute the bounds of it's current data
         # and the data in xydata
-
-        if iterable(xys) and not len(xys):
+        xys = np.asarray(xys)
+        if not len(xys):
             return
-        if not isinstance(xys, np.ma.MaskedArray):
-            xys = np.asarray(xys)
         self.dataLim.update_from_data_xy(xys, self.ignore_existing_data_limits,
                                          updatex=updatex, updatey=updatey)
         self.ignore_existing_data_limits = False

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -305,10 +305,11 @@ class ScalarMappable(object):
 
         ACCEPTS: a length 2 sequence of floats
         """
-        if (vmin is not None and vmax is None and
-                cbook.iterable(vmin) and len(vmin) == 2):
-            vmin, vmax = vmin
-
+        if vmax is None:
+            try:
+                vmin, vmax = vmin
+            except (TypeError, ValueError):
+                pass
         if vmin is not None:
             self.norm.vmin = vmin
         if vmax is not None:

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -156,31 +156,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self.update(kwargs)
         self._paths = None
 
-    @staticmethod
-    def _get_value(val):
-        try:
-            return (float(val), )
-        except TypeError:
-            if cbook.iterable(val) and len(val):
-                try:
-                    float(cbook.safe_first_element(val))
-                except (TypeError, ValueError):
-                    pass  # raise below
-                else:
-                    return val
-
-        raise TypeError('val must be a float or nonzero sequence of floats')
-
-    @staticmethod
-    def _get_bool(val):
-        if not cbook.iterable(val):
-            val = (val,)
-        try:
-            bool(cbook.safe_first_element(val))
-        except (TypeError, IndexError):
-            raise TypeError('val must be a bool or nonzero sequence of them')
-        return val
-
     def get_paths(self):
         return self._paths
 
@@ -486,7 +461,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             if lw is None:
                 lw = mpl.rcParams['lines.linewidth']
         # get the un-scaled/broadcast lw
-        self._us_lw = self._get_value(lw)
+        self._us_lw = np.atleast_1d(np.asarray(lw))
 
         # scale all of the dash patterns.
         self._linewidths, self._linestyles = self._bcast_lwls(
@@ -608,7 +583,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         """
         if aa is None:
             aa = mpl.rcParams['patch.antialiased']
-        self._antialiaseds = self._get_bool(aa)
+        self._antialiaseds = np.atleast_1d(np.asarray(aa, bool))
         self.stale = True
 
     def set_antialiaseds(self, aa):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -58,9 +58,11 @@ are supported.
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import re
 import six
 from six.moves import zip
+
+from collections import Sized
+import re
 import warnings
 
 import numpy as np
@@ -693,12 +695,12 @@ class LinearSegmentedColormap(Colormap):
         if not cbook.iterable(colors):
             raise ValueError('colors must be iterable')
 
-        if cbook.iterable(colors[0]) and len(colors[0]) == 2 and \
-                not cbook.is_string_like(colors[0]):
+        if (isinstance(colors[0], Sized) and len(colors[0]) == 2
+                and not cbook.is_string_like(colors[0])):
             # List of value, color pairs
-            vals, colors = list(zip(*colors))
+            vals, colors = zip(*colors)
         else:
-            vals = np.linspace(0., 1., len(colors))
+            vals = np.linspace(0, 1, len(colors))
 
         cdict = dict(red=[], green=[], blue=[], alpha=[])
         for val, color in zip(vals, colors):

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -89,10 +89,12 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import xrange
 
+from collections import Sized
+
 import numpy as np
 
-from .cbook import is_math_text, is_string_like, is_numlike, iterable
-from matplotlib import rcParams
+from . import rcParams
+from .cbook import is_math_text, is_string_like, is_numlike
 from .path import Path
 from .transforms import IdentityTransform, Affine2D
 
@@ -247,7 +249,7 @@ class MarkerStyle(object):
         return self._marker
 
     def set_marker(self, marker):
-        if (iterable(marker) and len(marker) in (2, 3) and
+        if (isinstance(marker, Sized) and len(marker) in (2, 3) and
                 marker[1] in (0, 1, 2, 3)):
             self._marker_function = self._set_tuple_marker
         elif isinstance(marker, np.ndarray):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -18,17 +18,12 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
+from collections import Iterable, Mapping
 from functools import reduce
 import operator
 import os
 import warnings
 import re
-
-try:
-    import collections.abc as abc
-except ImportError:
-    # python 2
-    import collections as abc
 
 from matplotlib.cbook import mplDeprecation
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
@@ -92,7 +87,7 @@ def _listify_validator(scalar_validator, allow_stringlist=False):
         # Numpy ndarrays, and pandas data structures.  However, unordered
         # sequences, such as sets, should be allowed but discouraged unless the
         # user desires pseudorandom behavior.
-        elif isinstance(s, abc.Iterable) and not isinstance(s, abc.Mapping):
+        elif isinstance(s, Iterable) and not isinstance(s, Mapping):
             # The condition on this list comprehension will preserve the
             # behavior of filtering out any empty strings (behavior was
             # from the original validate_stringlist()), while allowing

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -7,8 +7,8 @@ from __future__ import (absolute_import, division, print_function,
 import io
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from numpy.testing import assert_equal
+from numpy.testing import (
+    assert_array_equal, assert_array_almost_equal, assert_equal)
 import pytest
 
 import matplotlib.pyplot as plt
@@ -641,9 +641,9 @@ def test_lslw_bcast():
     col.set_linestyles(['-', '-'])
     col.set_linewidths([1, 2, 3])
 
-    assert col.get_linestyles() == [(None, None)] * 6
-    assert col.get_linewidths() == [1, 2, 3] * 2
+    assert_equal(col.get_linestyles(), [(None, None)] * 6)
+    assert_equal(col.get_linewidths(), [1, 2, 3] * 2)
 
     col.set_linestyles(['-', '-', '-'])
-    assert col.get_linestyles() == [(None, None)] * 3
-    assert col.get_linewidths() == [1, 2, 3]
+    assert_equal(col.get_linestyles(), [(None, None)] * 3)
+    assert_equal(col.get_linewidths(), [1, 2, 3])

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -157,11 +157,15 @@ class Registry(dict):
                     converter = self.get_converter(next_item)
                 return converter
 
-        if converter is None and iterable(x) and (len(x) > 0):
-            thisx = safe_first_element(x)
-            if classx and classx != getattr(thisx, '__class__', None):
-                converter = self.get_converter(thisx)
-                return converter
+        if converter is None:
+            try:
+                thisx = safe_first_element(x)
+            except (TypeError, StopIteration):
+                pass
+            else:
+                if classx and classx != getattr(thisx, '__class__', None):
+                    converter = self.get_converter(thisx)
+                    return converter
 
         # DISABLED self._cached[idx] = converter
         return converter


### PR DESCRIPTION
... because the former does not imply the latter anyways, e.g.
generators are iterables but unsized.

Now `plot(zip([1, 2], [3, 4]))` (py3) raises `RuntimeError: matplotlib
does not support generators` (from `cbook.safe_first_element`) which is
probably the intended exception, rather than `TypeError: object of type
'zip' has no len()`.  Perhaps this exception should be changed to a
`TypeError`, by the way...