### PR TITLE
[MRG+1] Remove redundant pep8 entry in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,6 @@ matrix:
     - python: 3.5
       env: PANDAS=pandas NOSE_ARGS=--with-coverage DELETE_FONT_CACHE=1
     - python: 3.5
-      env: TEST_ARGS=--pep8
-    - python: 3.5
       env: BUILD_DOCS=true
     - python: 3.5
       env: USE_PYTEST=true PANDAS=pandas DELETE_FONT_CACHE=1 TEST_ARGS=


### PR DESCRIPTION
pytest-based tests already run pep8 (as can be checked with `pytest -k
pep8`).

(Alternatively the pep8-only runner could be kept and the corresponding
tests removed from the pytest runners.)