### PR TITLE
[MRG+1] Fix axhspan/axvspan view limits autoscaling

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -851,7 +851,10 @@ or tuple of floats
         p = mpatches.Polygon(verts, **kwargs)
         p.set_transform(trans)
         self.add_patch(p)
-        self.autoscale_view(scalex=False)
+
+        ybmin, ybmax = self.get_ybound()
+        scaley = (ymin < ybmin) or (ymax > ybmax)
+        self.autoscale_view(scalex=False, scaley=scaley)
         return p
 
     def axvspan(self, xmin, xmax, ymin=0, ymax=1, **kwargs):
@@ -916,7 +919,10 @@ or tuple of floats
         p = mpatches.Polygon(verts, **kwargs)
         p.set_transform(trans)
         self.add_patch(p)
-        self.autoscale_view(scaley=False)
+
+        xbmin, xbmax = self.get_xbound()
+        scalex = (xmin < xbmin) or (xmax > xbmax)
+        self.autoscale_view(scalex=scalex, scaley=False)
         return p
 
     @_preprocess_data(replace_names=['y', 'xmin', 'xmax', 'colors'],

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -581,7 +581,7 @@ def test_hexbin_extent():
 
 
 @image_comparison(baseline_images=['hexbin_empty'], remove_text=True,
-	extensions=['png'])
+    extensions=['png'])
 def test_hexbin_empty():
     # From #3886: creating hexbin from empty dataset raises ValueError
     ax = plt.gca()
@@ -1158,14 +1158,14 @@ def test_hist_log():
 
 
 @image_comparison(baseline_images=['hist_bar_empty'], remove_text=True,
-	extensions=['png'])
+    extensions=['png'])
 def test_hist_bar_empty():
     # From #3886: creating hist from empty dataset raises ValueError
     ax = plt.gca()
     ax.hist([], histtype='bar')
 
 @image_comparison(baseline_images=['hist_step_empty'], remove_text=True,
-	extensions=['png'])
+    extensions=['png'])
 def test_hist_step_empty():
     # From #3886: creating hist from empty dataset raises ValueError
     ax = plt.gca()
@@ -4877,3 +4877,21 @@ def test_scatter_color_masking():
 def test_eventplot_legend():
     plt.eventplot([1.0], label='Label')
     plt.legend()
+
+
+@cleanup
+def test_axhspan_autoscale_limits():
+    fig, ax = plt.subplots()
+    ax.imshow(np.zeros((10, 10)))
+    y0, y1 = ax.get_ylim()
+    ax.axhspan(4, 5, xmin=0.4, xmax=0.6)
+    assert ax.get_ylim() == (y0, y1)
+
+
+@cleanup
+def test_axvspan_autoscale_limits():
+    fig, ax = plt.subplots()
+    ax.imshow(np.zeros((10, 10)))
+    x0, x1 = ax.get_xlim()
+    ax.axvspan(4, 5, ymin=0.4, ymax=0.6)
+    assert ax.get_xlim() == (x0, x1)


### PR DESCRIPTION
Currently using `axhspan` or `axvspan` on an image results in the axis view limits being changed even when the `axhspan`/`axvspan` patch is fully within the image.  This PR changes the behavior to match `axhline` and `axvline`.