### PR TITLE
MNT: suppress RuntimeWarning for invalid float comparison in images

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -368,6 +368,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     # values to carry the over/under/bad information
                     rgba = np.empty((A.shape[0], A.shape[1], 4), dtype=A.dtype)
                     rgba[..., 0] = A  # normalized data
+                    # this is to work around spurious warnings coming
+                    # out of masked arrays.
                     with np.errstate(invalid='ignore'):
                         rgba[..., 1] = A < 0  # under data
                         rgba[..., 2] = A > 1  # over data

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -368,8 +368,9 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     # values to carry the over/under/bad information
                     rgba = np.empty((A.shape[0], A.shape[1], 4), dtype=A.dtype)
                     rgba[..., 0] = A  # normalized data
-                    rgba[..., 1] = A < 0  # under data
-                    rgba[..., 2] = A > 1  # over data
+                    with np.errstate(invalid='ignore'):
+                        rgba[..., 1] = A < 0  # under data
+                        rgba[..., 2] = A > 1  # over data
                     rgba[..., 3] = ~A.mask  # bad data
                     A = rgba
                     output = np.zeros((out_height, out_width, 4),

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import io
 import os
+import warnings
 
 from nose.plugins.attrib import attr
 
@@ -751,6 +752,13 @@ def test_imshow_endianess():
 
     ax1.imshow(Z.astype('<f8'), **kwargs)
     ax2.imshow(Z.astype('>f8'), **kwargs)
+
+
+@cleanup
+def test_imshow_no_warn_invalid():
+    with warnings.catch_warnings(record=True) as warns:
+        plt.imshow([[1, 2], [3, np.nan]])
+    assert len(warns) == 0
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -757,6 +757,7 @@ def test_imshow_endianess():
 @cleanup
 def test_imshow_no_warn_invalid():
     with warnings.catch_warnings(record=True) as warns:
+        warnings.simplefilter("always")
         plt.imshow([[1, 2], [3, np.nan]])
     assert len(warns) == 0
 


### PR DESCRIPTION
If do not warn for invalid values when looking for over/under pixels
in _ImageBase._make_image.

closes #7746