### PR TITLE
Ignore images that doc build produces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ doc/api/_as_gen
 lib/dateutil
 examples/*/*.pdf
 examples/*/*.png
+examples/*/*.svg
+examples/*/*.eps
+examples/*/*.svgz
 examples/tests/*
 !examples/tests/backend_driver.py
 texput.log


### PR DESCRIPTION
Building the docs puts some images in examples/misc that aren't ignored. This should ignore them.

`git status` before this change:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	examples/misc/svg_filter_line.svg
	examples/misc/svg_filter_pie.svg
	examples/misc/test_rasterization.eps
	examples/misc/test_rasterization.svg
	examples/misc/tight_bbox_test.eps
	examples/misc/tight_bbox_test.svg
	examples/misc/tight_bbox_test.svgz
```