### PR TITLE
Only byte-swap 16-bit PNGs on little-endian (#7792)

### DIFF
--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -532,10 +532,12 @@ static PyObject *_read_png(PyObject *filein, bool float_result)
         png_set_shift(png_ptr, sig_bit);
     }
 
+#if NPY_BYTE_ORDER == NPY_LITTLE_ENDIAN
     // Convert big endian to little
     if (bit_depth == 16) {
         png_set_swap(png_ptr);
     }
+#endif
 
     // Convert palletes to full RGB
     if (png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE) {


### PR DESCRIPTION
_png has some code that unconditionally byte-swaps 16-bit PNG
data (which is, per the spec, stored in big-endian order). This
isn't appropriate on a big-endian platform, though: this swap
being done unconditionally breaks the handling of 16-bit PNGs
on big-endian platforms (e.g. Fedora ppc64) (#7792). So, let's
use some macros numpy kindly defines for us to decide whether to
do this swap or not.

@QuLogic suggested using `PyArray_EquivByteorders`, but for some reason I kinda preferred using the underlying macros. If you would prefer doing it with `PyArray_EquivByteorders(NPY_LITTLE, NPY_NATIVE)` or so, I can do that, just ask. This gets the failure count for a Fedora ppc64 build down to 14 (and I checked it doesn't break x86_64).