### PR TITLE
[MRG+1] Add short-circuit return to matplotlib.artist.setp if input is length 0

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1427,6 +1427,9 @@ def setp(obj, *args, **kwargs):
     else:
         objs = list(cbook.flatten(obj))
 
+    if not objs:
+        return
+
     insp = ArtistInspector(objs[0])
 
     # file has to be popped before checking if kwargs is empty

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -239,6 +239,10 @@ def test_properties():
 
 @cleanup
 def test_setp():
+    # Check empty list
+    plt.setp([])
+    plt.setp([[]])
+
     # Check arbitrary iterables
     fig, axes = plt.subplots()
     lines1 = axes.plot(range(3))


### PR DESCRIPTION
Fixes #7784 

Before this patch, an IndexError is raised in matplotlib.artist.setp if argument is an empty list,

```
import matplotlib
matplotlib.artist.setp([])
```