### PR TITLE
[MRG+1] BUG: fix checkout_output with non-ascii paths in PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ before_install:
   - pip install --upgrade virtualenv
   - virtualenv --python=python venv
   - source venv/bin/activate
+  # test with non-ascii in path
+  - mkdir /tmp/λ
+  - export PATH=$PATH:/tmp/λ
   - export PATH=/usr/lib/ccache:$PATH
 
 install:

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -354,7 +354,8 @@ verbose = Verbose()
 
 def checkdep_dvipng():
     try:
-        s = subprocess.Popen(['dvipng', '-version'], stdout=subprocess.PIPE,
+        s = subprocess.Popen([str('dvipng'), '-version'],
+                             stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         stdout, stderr = s.communicate()
         line = stdout.decode('ascii').split('\n')[1]
@@ -374,7 +375,7 @@ def checkdep_ghostscript():
         for gs_exec in gs_execs:
             try:
                 s = subprocess.Popen(
-                    [gs_exec, '--version'], stdout=subprocess.PIPE,
+                    [str(gs_exec), '--version'], stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
                 stdout, stderr = s.communicate()
                 if s.returncode == 0:
@@ -390,7 +391,7 @@ checkdep_ghostscript.version = None
 
 def checkdep_tex():
     try:
-        s = subprocess.Popen(['tex', '-version'], stdout=subprocess.PIPE,
+        s = subprocess.Popen([str('tex'), '-version'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         stdout, stderr = s.communicate()
         line = stdout.decode('ascii').split('\n')[0]
@@ -404,7 +405,7 @@ def checkdep_tex():
 
 def checkdep_pdftops():
     try:
-        s = subprocess.Popen(['pdftops', '-v'], stdout=subprocess.PIPE,
+        s = subprocess.Popen([str('pdftops'), '-v'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         stdout, stderr = s.communicate()
         lines = stderr.decode('ascii').split('\n')
@@ -419,7 +420,7 @@ def checkdep_pdftops():
 def checkdep_inkscape():
     if checkdep_inkscape.version is None:
         try:
-            s = subprocess.Popen(['inkscape', '-V'], stdout=subprocess.PIPE,
+            s = subprocess.Popen([str('inkscape'), '-V'], stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             stdout, stderr = s.communicate()
             lines = stdout.decode('ascii').split('\n')
@@ -436,7 +437,7 @@ checkdep_inkscape.version = None
 
 def checkdep_xmllint():
     try:
-        s = subprocess.Popen(['xmllint', '--version'], stdout=subprocess.PIPE,
+        s = subprocess.Popen([str('xmllint'), '--version'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         stdout, stderr = s.communicate()
         lines = stderr.decode('ascii').split('\n')

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -420,7 +420,8 @@ def checkdep_pdftops():
 def checkdep_inkscape():
     if checkdep_inkscape.version is None:
         try:
-            s = subprocess.Popen([str('inkscape'), '-V'], stdout=subprocess.PIPE,
+            s = subprocess.Popen([str('inkscape'), '-V'],
+                                 stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             stdout, stderr = s.communicate()
             lines = stdout.decode('ascii').split('\n')
@@ -437,7 +438,8 @@ checkdep_inkscape.version = None
 
 def checkdep_xmllint():
     try:
-        s = subprocess.Popen([str('xmllint'), '--version'], stdout=subprocess.PIPE,
+        s = subprocess.Popen([str('xmllint'), '--version'],
+                             stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         stdout, stderr = s.communicate()
         lines = stderr.decode('ascii').split('\n')

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -322,7 +322,7 @@ class MovieWriter(object):
         subclass. This is a class method so that the tool can be looked for
         before making a particular MovieWriter subclass available.
         '''
-        return rcParams[cls.exec_key]
+        return str(rcParams[cls.exec_key])
 
     @classmethod
     def isAvailable(cls):

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -179,7 +179,7 @@ def make_pdf_to_png_converter():
     tools_available = []
     # check for pdftocairo
     try:
-        check_output([str("pdftocairo"), str("-v")], stderr=subprocess.STDOUT)
+        check_output([str("pdftocairo"), "-v"], stderr=subprocess.STDOUT)
         tools_available.append("pdftocairo")
     except:
         pass
@@ -194,8 +194,7 @@ def make_pdf_to_png_converter():
             cmd = [str("pdftocairo"), "-singlefile", "-png",
                    "-r %d" % dpi, pdffile, os.path.splitext(pngfile)[0]]
             # for some reason this doesn't work without shell
-            check_output(cmd, shell=True,
-                         stderr=subprocess.STDOUT)
+            check_output(cmd, shell=True, stderr=subprocess.STDOUT)
         return cairo_convert
     elif "gs" in tools_available:
         def gs_convert(pdffile, pngfile, dpi):

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -45,7 +45,7 @@ else:
     # assuming fontconfig is installed and the command 'fc-list' exists
     try:
         # list scalable (non-bitmap) fonts
-        fc_list = check_output(['fc-list', ':outline,scalable', 'family'])
+        fc_list = check_output([str('fc-list'), ':outline,scalable', 'family'])
         fc_list = fc_list.decode('utf8')
         system_fonts = [f.split(',')[0] for f in fc_list.splitlines()]
         system_fonts = list(set(system_fonts))
@@ -179,7 +179,7 @@ def make_pdf_to_png_converter():
     tools_available = []
     # check for pdftocairo
     try:
-        check_output(["pdftocairo", "-v"], stderr=subprocess.STDOUT)
+        check_output([str("pdftocairo"), str("-v")], stderr=subprocess.STDOUT)
         tools_available.append("pdftocairo")
     except:
         pass
@@ -191,14 +191,15 @@ def make_pdf_to_png_converter():
     # pick converter
     if "pdftocairo" in tools_available:
         def cairo_convert(pdffile, pngfile, dpi):
-            cmd = ["pdftocairo", "-singlefile", "-png",
+            cmd = [str("pdftocairo"), "-singlefile", "-png",
                    "-r %d" % dpi, pdffile, os.path.splitext(pngfile)[0]]
             # for some reason this doesn't work without shell
-            check_output(" ".join(cmd), shell=True, stderr=subprocess.STDOUT)
+            check_output(cmd, shell=True,
+                         stderr=subprocess.STDOUT)
         return cairo_convert
     elif "gs" in tools_available:
         def gs_convert(pdffile, pngfile, dpi):
-            cmd = [gs, '-dQUIET', '-dSAFER', '-dBATCH', '-dNOPAUSE', '-dNOPROMPT',
+            cmd = [str(gs), '-dQUIET', '-dSAFER', '-dBATCH', '-dNOPAUSE', '-dNOPROMPT',
                    '-sDEVICE=png16m', '-dUseCIEColor', '-dTextAlphaBits=4',
                    '-dGraphicsAlphaBits=4', '-dDOINTERPOLATE', '-sOutputFile=%s' % pngfile,
                    '-r%d' % dpi, pdffile]
@@ -300,7 +301,7 @@ class LatexManager(object):
         self.latex_header = LatexManager._build_latex_header()
         latex_end = "\n\\makeatletter\n\\@@end\n"
         try:
-            latex = subprocess.Popen([self.texcommand, "-halt-on-error"],
+            latex = subprocess.Popen([str(self.texcommand), "-halt-on-error"],
                                      stdin=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
                                      cwd=self.tmpdir)
@@ -318,7 +319,7 @@ class LatexManager(object):
             raise LatexError("LaTeX returned an error, probably missing font or error in preamble:\n%s" % stdout)
 
         # open LaTeX process for real work
-        latex = subprocess.Popen([self.texcommand, "-halt-on-error"],
+        latex = subprocess.Popen([str(self.texcommand), "-halt-on-error"],
                                  stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                  cwd=self.tmpdir)
         self.latex = latex
@@ -895,7 +896,7 @@ class FigureCanvasPgf(FigureCanvasBase):
                 fh_tex.write(latexcode)
 
             texcommand = get_texcommand()
-            cmdargs = [texcommand, "-interaction=nonstopmode",
+            cmdargs = [str(texcommand), "-interaction=nonstopmode",
                        "-halt-on-error", "figure.tex"]
             try:
                 check_output(cmdargs, stderr=subprocess.STDOUT, cwd=tmpdir)

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1437,7 +1437,7 @@ def report_memory(i=0):  # argument may go away
     pid = os.getpid()
     if sys.platform == 'sunos5':
         try:
-            a2 = Popen('ps -p %d -o osz' % pid, shell=True,
+            a2 = Popen(str('ps -p %d -o osz') % pid, shell=True,
                        stdout=PIPE).stdout.readlines()
         except OSError:
             raise NotImplementedError(
@@ -1446,7 +1446,7 @@ def report_memory(i=0):  # argument may go away
         mem = int(a2[-1].strip())
     elif sys.platform.startswith('linux'):
         try:
-            a2 = Popen('ps -p %d -o rss,sz' % pid, shell=True,
+            a2 = Popen(str('ps -p %d -o rss,sz') % pid, shell=True,
                        stdout=PIPE).stdout.readlines()
         except OSError:
             raise NotImplementedError(
@@ -1455,7 +1455,7 @@ def report_memory(i=0):  # argument may go away
         mem = int(a2[1].split()[1])
     elif sys.platform.startswith('darwin'):
         try:
-            a2 = Popen('ps -p %d -o rss,vsz' % pid, shell=True,
+            a2 = Popen(str('ps -p %d -o rss,vsz') % pid, shell=True,
                        stdout=PIPE).stdout.readlines()
         except OSError:
             raise NotImplementedError(
@@ -1464,7 +1464,7 @@ def report_memory(i=0):  # argument may go away
         mem = int(a2[1].split()[0])
     elif sys.platform.startswith('win'):
         try:
-            a2 = Popen(["tasklist", "/nh", "/fi", "pid eq %d" % pid],
+            a2 = Popen([str("tasklist"), "/nh", "/fi", "pid eq %d" % pid],
                        stdout=PIPE).stdout.read()
         except OSError:
             raise NotImplementedError(

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -853,7 +853,7 @@ def find_tex_file(filename, format=None):
         The library that :program:`kpsewhich` is part of.
     """
 
-    cmd = ['kpsewhich']
+    cmd = [str('kpsewhich')]
     if format is not None:
         cmd += ['--format=' + format]
     cmd += [filename]

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -281,7 +281,7 @@ def _call_fc_list():
         'This may take a moment.'))
     timer.start()
     try:
-        out = subprocess.check_output(['fc-list', '--format=%{file}'])
+        out = subprocess.check_output([str('fc-list'), '--format=%{file}'])
     except (OSError, subprocess.CalledProcessError):
         return []
     finally:

--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -42,7 +42,7 @@ class TestTinyPages(object):
             cls.html_dir = pjoin(cls.page_build, 'html')
             cls.doctree_dir = pjoin(cls.page_build, 'doctrees')
             # Build the pages with warnings turned into errors
-            cmd = ['sphinx-build', '-W', '-b', 'html',
+            cmd = [str('sphinx-build'), '-W', '-b', 'html',
                    '-d', cls.doctree_dir,
                    TINY_PAGES,
                    cls.html_dir]

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -132,14 +132,14 @@ def _update_converter():
     gs, gs_v = matplotlib.checkdep_ghostscript()
     if gs_v is not None:
         def cmd(old, new):
-            return [gs, '-q', '-sDEVICE=png16m', '-dNOPAUSE', '-dBATCH',
+            return [str(gs), '-q', '-sDEVICE=png16m', '-dNOPAUSE', '-dBATCH',
              '-sOutputFile=' + new, old]
         converter['pdf'] = make_external_conversion_command(cmd)
         converter['eps'] = make_external_conversion_command(cmd)
 
     if matplotlib.checkdep_inkscape() is not None:
         def cmd(old, new):
-            return ['inkscape', '-z', old, '--export-png', new]
+            return [str('inkscape'), '-z', old, '--export-png', new]
         converter['svg'] = make_external_conversion_command(cmd)
 
 

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -30,7 +30,7 @@ def check_for(texsystem):
     \\@@end
     """
     try:
-        latex = subprocess.Popen([texsystem, "-halt-on-error"],
+        latex = subprocess.Popen([str(texsystem), "-halt-on-error"],
                                  stdin=subprocess.PIPE,
                                  stdout=subprocess.PIPE)
         stdout, stderr = latex.communicate(header.encode("utf8"))

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -68,7 +68,7 @@ else:
 
 def dvipng_hack_alpha():
     try:
-        p = Popen(['dvipng', '-version'], stdin=PIPE, stdout=PIPE,
+        p = Popen([str('dvipng'), '-version'], stdin=PIPE, stdout=PIPE,
                   stderr=STDOUT, close_fds=(sys.platform != 'win32'))
         stdout, stderr = p.communicate()
     except OSError:


### PR DESCRIPTION
Closes #7715

This ensures that on python2 the values passed into `check_output` are
bytes.  If they are passed in as unicode (due to unicode_literals at
the top of most of our files) they will cause an exception when there
is a path in PATH that has non-ascii values.  The reason is that when
locating possible executable our input (as unicode) is concatenated
with the non-ascii path (as bytes) which then fails to encode as ascii
and raises.

The other two places we currently use `check_output` (setupext.py and
tools/github_stats.py) we do not need this handling as we do not
import unicode_iterals in those files.