### PR TITLE
Fix for marker verts bug

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -255,7 +255,8 @@ class MarkerStyle(object):
         elif (isinstance(marker, Sized) and len(marker) in (2, 3) and
                 marker[1] in (0, 1, 2, 3)):
             self._marker_function = self._set_tuple_marker
-        elif not isinstance(marker, list) and marker in self.markers:
+        elif (not isinstance(marker, (np.ndarray, list)) and
+              marker in self.markers):
             self._marker_function = getattr(
                 self, '_set_' + self.markers[marker])
         elif is_string_like(marker) and is_math_text(marker):

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -249,11 +249,12 @@ class MarkerStyle(object):
         return self._marker
 
     def set_marker(self, marker):
-        if (isinstance(marker, Sized) and len(marker) in (2, 3) and
+        if (isinstance(marker, np.ndarray) and marker.ndim == 2 and
+                marker.shape[1] == 2):
+            self._marker_function = self._set_vertices
+        elif (isinstance(marker, Sized) and len(marker) in (2, 3) and
                 marker[1] in (0, 1, 2, 3)):
             self._marker_function = self._set_tuple_marker
-        elif isinstance(marker, np.ndarray):
-            self._marker_function = self._set_vertices
         elif not isinstance(marker, list) and marker in self.markers:
             self._marker_function = getattr(
                 self, '_set_' + self.markers[marker])

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -15,6 +15,6 @@ def test_markers_valid():
 def test_markers_invalid():
     marker_style = markers.MarkerStyle()
     mrk_array = np.array([[-0.5, 0,  1, 2, 3]])
-    # Checking this doesn't fail.
+    # Checking this does fail.
     with pytest.raises(ValueError):
         marker_style.set_marker(mrk_array)

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -1,0 +1,20 @@
+import numpy as np
+from matplotlib import markers
+
+import pytest
+
+
+def test_markers_valid():
+    marker_style = markers.MarkerStyle()
+    mrk_array = np.array([[-0.5, 0],
+                          [0.5, 0]])
+    # Checking this doesn't fail.
+    marker_style.set_marker(mrk_array)
+
+
+def test_markers_invalid():
+    marker_style = markers.MarkerStyle()
+    mrk_array = np.array([[-0.5, 0,  1, 2, 3]])
+    # Checking this doesn't fail.
+    with pytest.raises(ValueError):
+        marker_style.set_marker(mrk_array)


### PR DESCRIPTION
This is a proposed solution for #7807 . I added the checks for array ndim and shape, so that the `ValueError('Unrecognized marker style...)'` error is raised if an incorrectly-shaped np.ndarray is specified as input.