### PR TITLE
STY: fix poor date-time format defaults

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1135,10 +1135,10 @@ defaultParams = {
     'date.autoformatter.year': ['%Y', six.text_type],
     'date.autoformatter.month': ['%Y-%m', six.text_type],
     'date.autoformatter.day': ['%Y-%m-%d', six.text_type],
-    'date.autoformatter.hour': ['%H:%M', six.text_type],
-    'date.autoformatter.minute': ['%H:%M:%S', six.text_type],
+    'date.autoformatter.hour': ['%m-%d %H', six.text_type],
+    'date.autoformatter.minute': ['%d %H:%M', six.text_type],
     'date.autoformatter.second': ['%H:%M:%S', six.text_type],
-    'date.autoformatter.microsecond': ['%H:%M:%S.%f', six.text_type],
+    'date.autoformatter.microsecond': ['%M:%S.%f', six.text_type],
 
     #legend properties
     'legend.fancybox': [True, validate_bool],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -363,10 +363,10 @@ backend      : $TEMPLATE_BACKEND
 # date.autoformatter.year     : %Y
 # date.autoformatter.month    : %Y-%m
 # date.autoformatter.day      : %Y-%m-%d
-# date.autoformatter.hour     : %H:%M
-# date.autoformatter.minute   : %H:%M:%S
+# date.autoformatter.hour     : %m-%d %H
+# date.autoformatter.minute   : %d %H:%M
 # date.autoformatter.second   : %H:%M:%S
-# date.autoformatter.microsecond   : %H:%M:%S.%f
+# date.autoformatter.microsecond   : %M:%S.%f
 
 ### TICKS
 # see http://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick


### PR DESCRIPTION
Without this change, zooming in from ticks separated by
days to ticks separated by multiples of hours leaves tick
labels with no date information, even when the time period
covers several days.

With the change there is a systematic progression from one
level to the next, dropping the largest unit and adding a
smaller unit.