### PR TITLE
[MRG+1] Tripcolor.py: Remove documentation rendering error

### DIFF
--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -38,7 +38,7 @@ def tripcolor(ax, *args, **kwargs):
     are defined at triangles. If there are the same number of points
     and triangles in the triangulation it is assumed that color
     values are defined at points; to force the use of color values at
-    triangles use the kwarg *facecolors*\=C instead of just *C*.
+    triangles use the kwarg ``facecolors=C`` instead of just ``C``.
 
     *shading* may be 'flat' (the default) or 'gouraud'. If *shading*
     is 'flat' and C values are defined at points, the color values

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -38,7 +38,7 @@ def tripcolor(ax, *args, **kwargs):
     are defined at triangles. If there are the same number of points
     and triangles in the triangulation it is assumed that color
     values are defined at points; to force the use of color values at
-    triangles use the kwarg *facecolors*=C instead of just *C*.
+    triangles use the kwarg *facecolors*\=C instead of just *C*.
 
     *shading* may be 'flat' (the default) or 'gouraud'. If *shading*
     is 'flat' and C values are defined at points, the color values


### PR DESCRIPTION
This commit remove formatting issue in Tripcolor function documentation.

Fixes https://github.com/matplotlib/matplotlib/issues/7803