### PR TITLE
DOC: Changes to screenshots plots.

### DIFF
--- a/examples/pie_and_polar_charts/pie_demo_features.py
+++ b/examples/pie_and_polar_charts/pie_demo_features.py
@@ -16,7 +16,6 @@ positive x-axis. This example sets ``startangle = 90`` such that everything is
 rotated counter-clockwise by 90 degrees, and the frog slice starts on the
 positive y-axis.
 """
-import numpy as np
 import matplotlib.pyplot as plt
 
 # Pie chart, where the slices will be ordered and plotted counter-clockwise:
@@ -24,32 +23,9 @@ labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
 sizes = [15, 30, 45, 10]
 explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
 
-fg1, ax1 = plt.subplots()
+fig1, ax1 = plt.subplots()
 ax1.pie(sizes, explode=explode, labels=labels, autopct='%1.1f%%',
         shadow=True, startangle=90)
 ax1.axis('equal')  # Equal aspect ratio ensures that pie is drawn as a circle.
-
-
-# Plot four Pie charts in a 2x2 grid:
-pie_data = [np.roll(sizes, i) for i in range(4)]  # generate some data
-pie_centerpos = [(0, 0), (0, 1), (1, 0), (1, 1)]  # the grid positions
-
-fg2, ax2 = plt.subplots()
-for data, cpos in zip(pie_data, pie_centerpos):
-    _, txts = ax2.pie(data, explode=explode, shadow=True, startangle=90,
-                      radius=0.35, center=cpos, frame=True, labeldistance=.7)
-    # Make texts include number and labels:
-    for t, l, d in zip(txts, labels, data):
-        t.set_text("%s\n %.1f%%" % (l, d))
-        t.set_horizontalalignment("center")
-        t.set_fontsize(8)
-
-ax2.set_xticks([0, 1])
-ax2.set_yticks([0, 1])
-ax2.set_xticklabels(["Sunny", "Cloudy"])
-ax2.set_yticklabels(["Dry", "Rainy"])
-ax2.set_xlim((-0.5, 1.5))
-ax2.set_ylim((-0.5, 1.5))
-ax2.set_aspect('equal')  # Equal aspect ratio ensures that the pie is a circle.
 
 plt.show()

--- a/examples/pylab_examples/scatter_demo2.py
+++ b/examples/pylab_examples/scatter_demo2.py
@@ -21,8 +21,8 @@ close = 0.003 * price_data.close[:-2] / 0.003 * price_data.open[:-2]
 fig, ax = plt.subplots()
 ax.scatter(delta1[:-1], delta1[1:], c=close, s=volume, alpha=0.5)
 
-ax.set_xlabel(r'$\Delta_i$', fontsize=20)
-ax.set_ylabel(r'$\Delta_{i+1}$', fontsize=20)
+ax.set_xlabel(r'$\Delta_i$', fontsize=15)
+ax.set_ylabel(r'$\Delta_{i+1}$', fontsize=15)
 ax.set_title('Volume and percent change')
 
 ax.grid(True)

--- a/examples/pylab_examples/simple_plot.py
+++ b/examples/pylab_examples/simple_plot.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 t = np.arange(0.0, 2.0, 0.01)
-s = np.sin(2*np.pi*t)
+s = 1 + np.sin(2*np.pi*t)
 plt.plot(t, s)
 
 plt.xlabel('time (s)')


### PR DESCRIPTION

* Removed ugly pie chart as [requested](https://github.com/matplotlib/matplotlib/pull/7740#issuecomment-272525100) from @efiring in PR #7740 and bug #7704.
* Reduced the font size from 20 pt to 15 pt of the labels in the [scatter plot](http://matplotlib.org/devdocs/users/screenshots.html#scatter-demo) (which is matter of taste, I guess).
* Changed y-range in the [simple plot](http://matplotlib.org/devdocs/users/screenshots.html#simple-plot) to work around a strange bounding box problem of the y-label (I did not understand what's going on here - it seems to have something to do with the minus sign):

Before:

 ![simple_plot1_before](https://cloud.githubusercontent.com/assets/12721170/21947025/46c8dab6-d9e3-11e6-9883-e035386e9e8d.png)

After: 

![simple_plot1_after](https://cloud.githubusercontent.com/assets/12721170/21947047/58cee930-d9e3-11e6-85cd-fa5494837313.png)


@NelleV As stated in #7740, I don't have strong preferences concerning `doc/make.py`. If it helps with your future work, I can restore the original behavior of utilizing static images for the front page plots (If you prefer to do that yourself in this pull request, feel free).
