### PR TITLE
[MRG+1] MAINT matplotlib -> Matplotlib

### DIFF
--- a/doc/README.txt
+++ b/doc/README.txt
@@ -1,4 +1,4 @@
-maptlotlib documentation
+Matplotlib documentation
 ========================
 
 
@@ -19,7 +19,7 @@ To build the HTML documentation, type ``python make.py html`` in this
 directory. The top file of the results will be ./build/html/index.html
 
 **Note that Sphinx uses the installed version of the package to build the
-documentation**: matplotlib must be installed *before* the docs can be
+documentation**: Matplotlib must be installed *before* the docs can be
 generated.
 
 You can build the documentation with several options:
@@ -31,25 +31,25 @@ You can build the documentation with several options:
 Organization
 -------------
 
-This is the top level build directory for the matplotlib
+This is the top level build directory for the Matplotlib
 documentation.  All of the documentation is written using sphinx, a
 python documentation system built on top of ReST.  This directory contains
 
 * users - the user documentation, e.g., plotting tutorials, configuration
   tips, etc.
 
-* devel - documentation for matplotlib developers
+* devel - documentation for Matplotlib developers
 
 * faq - frequently asked questions
 
 * api - placeholders to automatically generate the api documentation
 
 * mpl_toolkits - documentation of individual toolkits that ship with
-  matplotlib
+  Matplotlib
 
 * make.py - the build script to build the html or PDF docs
 
-* index.rst - the top level include document for matplotlib docs
+* index.rst - the top level include document for Matplotlib docs
 
 * conf.py - the sphinx configuration
 
@@ -59,6 +59,6 @@ python documentation system built on top of ReST.  This directory contains
 
 * sphinxext - Sphinx extensions for the mpl docs
 
-* mpl_examples - a link to the matplotlib examples in case any
+* mpl_examples - a link to the Matplotlib examples in case any
   documentation wants to literal include them
 

--- a/doc/_templates/citing.html
+++ b/doc/_templates/citing.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
-{% set title = "Citing matplotlib" %}
+{% set title = "Citing Matplotlib" %}
 {% block body %}
 
-<h1>Citing matplotlib</h1>
+<h1>Citing Matplotlib</h1>
 <p>
-If matplotlib contributes to a project that leads to a scientific publication,
+If Matplotlib contributes to a project that leads to a scientific publication,
 please acknowledge this fact by citing the project. You can use this
 BibTeX entry:
 </p>

--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -3,11 +3,11 @@
  API Changes
 =============
 
-Log of changes to matplotlib that affect the outward-facing API.  If
-updating matplotlib breaks your scripts, this list may help you figure
+Log of changes to Matplotlib that affect the outward-facing API.  If
+updating Matplotlib breaks your scripts, this list may help you figure
 out what caused the breakage and how to fix it by updating your code.
 
-For new features that were added to matplotlib, please see
+For new features that were added to Matplotlib, please see
 :ref:`whats-new`.
 
 
@@ -196,9 +196,9 @@ The spectral colormap is now nipy_spectral
 ------------------------------------------
 
 The colormaps formerly known as ``spectral`` and ``spectral_r`` have been
-replaced by ``nipy_spectral`` and ``nipy_spectral_r`` since matplotlib
-1.3.0. Even though the colormap was deprecated in matplotlib 1.3.0, it never
-raised a warning. As of matplotlib 2.0.0, using the old names raises a
+replaced by ``nipy_spectral`` and ``nipy_spectral_r`` since Matplotlib
+1.3.0. Even though the colormap was deprecated in Matplotlib 1.3.0, it never
+raised a warning. As of Matplotlib 2.0.0, using the old names raises a
 deprecation warning. In the future, using the old names will raise an error.
 
 Changes in 1.5.3
@@ -314,7 +314,7 @@ demonstrates the difference.  Use of the old contouring algorithm, which is
 obtained with `corner_mask='legacy'`, is now deprecated.
 
 Contour labels may now appear in different places than in earlier versions of
-matplotlib.
+Matplotlib.
 
 In addition, the keyword argument `nchunk` now applies to
 :func:`~matplotlib.pyplot.contour` as well as
@@ -545,7 +545,7 @@ Removed `Lena` images from sample_data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``lena.png`` and ``lena.jpg`` images have been removed from
-matplotlib's sample_data directory. The images are also no longer
+Matplotlib's sample_data directory. The images are also no longer
 available from `matplotlib.cbook.get_sample_data`. We suggest using
 `matplotlib.cbook.get_sample_data('grace_hopper.png')` or
 `matplotlib.cbook.get_sample_data('grace_hopper.jpg')` instead.
@@ -715,7 +715,7 @@ original location:
 
 * The Sphinx extensions `ipython_directive` and
   `ipython_console_highlighting` have been moved to the IPython
-  project itself.  While they remain in matplotlib for this release,
+  project itself.  While they remain in Matplotlib for this release,
   they have been deprecated.  Update your extensions in `conf.py` to
   point to `IPython.sphinxext.ipython_directive` instead of
   `matplotlib.sphinxext.ipython_directive`.
@@ -850,7 +850,7 @@ original location:
 
 * Clipping is now off by default on offset boxes.
 
-* matplotlib now uses a less-aggressive call to ``gc.collect(1)`` when
+* Matplotlib now uses a less-aggressive call to ``gc.collect(1)`` when
   closing figures to avoid major delays with large numbers of user objects
   in memory.
 
@@ -964,7 +964,7 @@ Code deprecation
 * The `ScalarMappable` class' `set_colorbar` is now
   deprecated. Instead, the
   :attr:`matplotlib.cm.ScalarMappable.colorbar` attribute should be
-  used.  In previous matplotlib versions this attribute was an
+  used.  In previous Matplotlib versions this attribute was an
   undocumented tuple of ``(colorbar_instance, colorbar_axes)`` but is
   now just ``colorbar_instance``. To get the colorbar axes it is
   possible to just use the
@@ -1150,7 +1150,7 @@ Changes in 1.2.x
       ax = projection_class(self, rect, **kwargs)
 
   This change means that third party objects can expose themselves as
-  matplotlib axes by providing a ``_as_mpl_axes`` method. See
+  Matplotlib axes by providing a ``_as_mpl_axes`` method. See
   :ref:`adding-new-scales` for more detail.
 
 * A new keyword *extendfrac* in :meth:`~matplotlib.pyplot.colorbar` and
@@ -1405,7 +1405,7 @@ Changes in 0.99
 * Polar plots no longer accept a resolution kwarg.  Instead, each Path
   must specify its own number of interpolation steps.  This is
   unlikely to be a user-visible change -- if interpolation of data is
-  required, that should be done before passing it to matplotlib.
+  required, that should be done before passing it to Matplotlib.
 
 Changes for 0.98.x
 ==================
@@ -1542,7 +1542,7 @@ Changes for 0.98.0
   color cycle: :func:`matplotlib.axes.set_default_color_cycle` and
   :meth:`matplotlib.axes.Axes.set_color_cycle`.
 
-* matplotlib now requires Python 2.4, so :mod:`matplotlib.cbook` will
+* Matplotlib now requires Python 2.4, so :mod:`matplotlib.cbook` will
   no longer provide :class:`set`, :func:`enumerate`, :func:`reversed`
   or :func:`izip` compatibility functions.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ try:
     from IPython.sphinxext import ipython_console_highlighting
 except ImportError:
     raise ImportError(
-        "IPython must be installed to build the matplotlib docs")
+        "IPython must be installed to build the Matplotlib docs")
 else:
     extensions.append('IPython.sphinxext.ipython_console_highlighting')
     extensions.append('IPython.sphinxext.ipython_directive')
@@ -70,7 +70,7 @@ except ImportError:
 try:
     import matplotlib
 except ImportError:
-    msg = "Error: matplotlib must be installed before building the documentation"
+    msg = "Error: Matplotlib must be installed before building the documentation"
     sys.exit(msg)
 
 
@@ -93,8 +93,8 @@ master_doc = 'contents'
 # General substitutions.
 project = 'Matplotlib'
 copyright = ('2002 - 2012 John Hunter, Darren Dale, Eric Firing, '
-             'Michael Droettboom and the matplotlib development '
-             'team; 2012 - 2016 The matplotlib development team')
+             'Michael Droettboom and the Matplotlib development '
+             'team; 2012 - 2016 The Matplotlib development team')
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -64,8 +64,8 @@ PR Review guidelines
 * Make sure the Travis tests are passing before merging.
 
   - The Travis tests automatically test on all of the Python versions
-    matplotlib supports whenever a pull request is created or updated.
-    The `tox` support in matplotlib may be useful for testing locally.
+    Matplotlib supports whenever a pull request is created or updated.
+    The `tox` support in Matplotlib may be useful for testing locally.
 
 * Do not self merge, except for 'small' patches to un-break the CI.
 

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -19,7 +19,7 @@ Plotting: howto
 Plot `numpy.datetime64` values
 ------------------------------
 
-For matplotlib to plot dates (or any scalar with units) a converter
+For Matplotlib to plot dates (or any scalar with units) a converter
 to float needs to be registered with the `matplolib.units` module.  The
 current best converters for `datetime64` values are in `pandas`.  Simply
 importing `pandas` ::
@@ -48,7 +48,7 @@ If you only want to use the `pandas` converter for `datetime64` values ::
 Find all objects in a figure of a certain type
 ----------------------------------------------
 
-Every matplotlib artist (see :ref:`artist-tutorial`) has a method
+Every Matplotlib artist (see :ref:`artist-tutorial`) has a method
 called :meth:`~matplotlib.artist.Artist.findobj` that can be used to
 recursively search the artist for any artists it may contain that meet
 some criteria (e.g., match all :class:`~matplotlib.lines.Line2D`
@@ -240,7 +240,7 @@ over so that the tick labels fit in the figure
 Configure the tick linewidths
 -----------------------------
 
-In matplotlib, the ticks are *markers*.  All
+In Matplotlib, the ticks are *markers*.  All
 :class:`~matplotlib.lines.Line2D` objects support a line (solid,
 dashed, etc) and a marker (circle, square, tick).  The tick linewidth
 is controlled by the "markeredgewidth" property::
@@ -269,7 +269,7 @@ Align my ylabels across multiple subplots
 If you have multiple subplots over one another, and the y data have
 different scales, you can often get ylabels that do not align
 vertically across the multiple subplots, which can be unattractive.
-By default, matplotlib positions the x location of the ylabel so that
+By default, Matplotlib positions the x location of the ylabel so that
 it does not overlap any of the y ticks.  You can override this default
 behavior by specifying the coordinates of the label.  The example
 below shows the default behavior in the left subplots, and the manual
@@ -372,7 +372,7 @@ The approach uses :func:`~matplotlib.pyplot.twinx` (and its sister
 :func:`~matplotlib.pyplot.twiny`) to use *2 different axes*,
 turning the axes rectangular frame off on the 2nd axes to keep it from
 obscuring the first, and manually setting the tick locs and labels as
-desired.  You can use separate matplotlib.ticker formatters and
+desired.  You can use separate ``matplotlib.ticker`` formatters and
 locators as desired because the two axes are independent.
 
 .. plot::
@@ -430,11 +430,11 @@ Use :func:`~matplotlib.pyplot.show`
 When you want to view your plots on your display,
 the user interface backend will need to start the GUI mainloop.
 This is what :func:`~matplotlib.pyplot.show` does.  It tells
-matplotlib to raise all of the figure windows created so far and start
+Matplotlib to raise all of the figure windows created so far and start
 the mainloop. Because this mainloop is blocking by default (i.e., script
 execution is paused), you should only call this once per script, at the end.
 Script execution is resumed after the last window is closed. Therefore, if
-you are using matplotlib to generate only images and do not want a user
+you are using Matplotlib to generate only images and do not want a user
 interface window, you do not need to call ``show``  (see :ref:`howto-batch`
 and :ref:`what-is-a-backend`).
 
@@ -448,7 +448,7 @@ and :ref:`what-is-a-backend`).
    Therefore, multiple calls to ``show`` are now allowed.
 
 Having ``show`` block further execution of the script or the python
-interpreter depends on whether matplotlib is set for interactive mode
+interpreter depends on whether Matplotlib is set for interactive mode
 or not.  In non-interactive mode (the default setting), execution is paused
 until the last figure window is closed.  In interactive mode, the execution
 is not paused, which allows you to create additional figures (but the script
@@ -462,7 +462,7 @@ won't finish until the last figure window is closed).
    because it does not support non-interactive mode.
 
 
-Because it is expensive to draw, you typically will not want matplotlib
+Because it is expensive to draw, you typically will not want Matplotlib
 to redraw a figure many times in a script such as the following::
 
     plot([1,2,3])            # draw here ?
@@ -472,12 +472,12 @@ to redraw a figure many times in a script such as the following::
     show()
 
 
-However, it is *possible* to force matplotlib to draw after every command,
+However, it is *possible* to force Matplotlib to draw after every command,
 which might be what you want when working interactively at the
 python console (see :ref:`mpl-shell`), but in a script you want to
 defer all drawing until the call to ``show``.  This is especially
 important for complex figures that take some time to draw.
-:func:`~matplotlib.pyplot.show` is designed to tell matplotlib that
+:func:`~matplotlib.pyplot.show` is designed to tell Matplotlib that
 you're all done issuing commands and you want to draw the figure now.
 
 .. note::
@@ -519,7 +519,7 @@ Tukey's `box plots <http://matplotlib.org/examples/pylab_examples/boxplot_demo.h
 .. figure:: ../_static/boxplot_explanation.png
 
 `Violin plots <http://matplotlib.org/examples/statistics/violinplot_demo.html>`_ are closely related to box plots but add useful information such as the distribution of the sample data (density trace).
-Violin plots were added in matplotlib 1.4.
+Violin plots were added in Matplotlib 1.4.
 
 
 .. _howto-contribute:
@@ -532,7 +532,7 @@ Contributing: howto
 Request a new feature
 ---------------------
 
-Is there a feature you wish matplotlib had?  Then ask!  The best
+Is there a feature you wish Matplotlib had?  Then ask!  The best
 way to get started is to email the developer `mailing
 list <matplotlib-devel@python.org>`_ for discussion.
 This is an open source project developed primarily in the
@@ -545,7 +545,7 @@ you need added is to contribute it your self.
 Reporting a bug or submitting a patch
 -------------------------------------
 
-The development of matplotlib is organized through `github
+The development of Matplotlib is organized through `github
 <https://github.com/matplotlib/matplotlib>`_.  If you would like
 to report a bug or submit a patch please use that interface.
 
@@ -560,16 +560,16 @@ register with github, please email bug reports to the `mailing list
 <matplotlib-devel@python.org>`_.
 
 
-The easiest way to submit patches to matplotlib is through pull
+The easiest way to submit patches to Matplotlib is through pull
 requests on github.  Please see the :ref:`developers-guide-index` for
 the details.
 
 .. _how-to-contribute-docs:
 
-Contribute to matplotlib documentation
+Contribute to Matplotlib documentation
 --------------------------------------
 
-matplotlib is a big library, which is used in many ways, and the
+Matplotlib is a big library, which is used in many ways, and the
 documentation has only scratched the surface of everything it can
 do.  So far, the place most people have learned all these features are
 through studying the examples (:ref:`how-to-search-examples`), which is a
@@ -577,20 +577,20 @@ recommended and great way to learn, but it would be nice to have more
 official narrative documentation guiding people through all the dark
 corners.  This is where you come in.
 
-There is a good chance you know more about matplotlib usage in some
+There is a good chance you know more about Matplotlib usage in some
 areas, the stuff you do every day, than many of the core developers
 who wrote most of the documentation.  Just pulled your hair out
-compiling matplotlib for windows?  Write a FAQ or a section for the
+compiling Matplotlib for windows?  Write a FAQ or a section for the
 :ref:`installing-faq` page.  Are you a digital signal processing wizard?
 Write a tutorial on the signal analysis plotting functions like
 :func:`~matplotlib.pyplot.xcorr`, :func:`~matplotlib.pyplot.psd` and
-:func:`~matplotlib.pyplot.specgram`.  Do you use matplotlib with
+:func:`~matplotlib.pyplot.specgram`.  Do you use Matplotlib with
 `django <https://www.djangoproject.com/>`_ or other popular web
 application servers?  Write a FAQ or tutorial and we'll find a place
-for it in the :ref:`users-guide-index`.  Bundle matplotlib in a
+for it in the :ref:`users-guide-index`.  Bundle Matplotlib in a
 `py2exe <http://www.py2exe.org/>`_ app?  ... I think you get the idea.
 
-matplotlib is documented using the `sphinx
+Matplotlib is documented using the `sphinx
 <http://www.sphinx-doc.org/index.html>`_ extensions to restructured text
 `(ReST) <http://docutils.sourceforge.net/rst.html>`_.  sphinx is an
 extensible python framework for documentation projects which generates
@@ -600,7 +600,7 @@ at the end of the page in the sidebar.
 
 The sphinx website is a good resource for learning sphinx, but we have
 put together a cheat-sheet at :ref:`documenting-matplotlib` which
-shows you how to get started, and outlines the matplotlib conventions
+shows you how to get started, and outlines the Matplotlib conventions
 and extensions, e.g., for including plots directly from external code in
 your documents.
 
@@ -619,10 +619,10 @@ Matplotlib in a web application server
 ======================================
 
 Many users report initial problems trying to use maptlotlib in web
-application servers, because by default matplotlib ships configured to
+application servers, because by default Matplotlib ships configured to
 work with a graphical user interface which may require an X11
 connection.  Since many barebones application servers do not have X11
-enabled, you may get errors if you don't configure matplotlib for use
+enabled, you may get errors if you don't configure Matplotlib for use
 in these environments.  Most importantly, you need to decide what
 kinds of images you want to generate (PNG, PDF, SVG) and configure the
 appropriate default backend.  For 99% of users, this will be the Agg
@@ -630,7 +630,7 @@ backend, which uses the C++
 `antigrain <http://antigrain.com>`_
 rendering engine to make nice PNGs.  The Agg backend is also
 configured to recognize requests to generate other output formats
-(PDF, PS, EPS, SVG).  The easiest way to configure matplotlib to use
+(PDF, PS, EPS, SVG).  The easiest way to configure Matplotlib to use
 Agg is to call::
 
     # do this before importing pylab or pyplot
@@ -673,17 +673,17 @@ Pillow for further processing::
     im = Image.open(imgdata)
 
 
-matplotlib with apache
+Matplotlib with apache
 ----------------------
 
 TODO; see :ref:`how-to-contribute-docs`.
 
-matplotlib with django
+Matplotlib with django
 ----------------------
 
 TODO; see :ref:`how-to-contribute-docs`.
 
-matplotlib with zope
+Matplotlib with zope
 --------------------
 
 TODO; see :ref:`how-to-contribute-docs`.
@@ -696,7 +696,7 @@ Clickable images for HTML
 Andrew Dalke of `Dalke Scientific <http://www.dalkescientific.com>`_
 has written a nice `article
 <http://www.dalkescientific.com/writings/diary/archive/2005/04/24/interactive_html.html>`_
-on how to make html click maps with matplotlib agg PNGs.  We would
+on how to make html click maps with Matplotlib agg PNGs.  We would
 also like to add this functionality to SVG.  If you are interested in
 contributing to these efforts that would be great.
 
@@ -706,7 +706,7 @@ contributing to these efforts that would be great.
 Search examples
 ===============
 
-The nearly 300 code :ref:`examples-index` included with the matplotlib
+The nearly 300 code :ref:`examples-index` included with the Matplotlib
 source distribution are full-text searchable from the :ref:`search`
 page, but sometimes when you search, you get a lot of results from the
 :ref:`api-index` or other documentation that you may not be interested
@@ -723,7 +723,7 @@ ellipse, :ref:`search` for ``codex ellipse``.
 Cite Matplotlib
 ===============
 
-If you want to refer to matplotlib in a publication, you can use
+If you want to refer to Matplotlib in a publication, you can use
 "Matplotlib: A 2D Graphics Environment" by J. D. Hunter In Computing
 in Science & Engineering, Vol. 9, No. 3. (2007), pp. 90-95 (see `this
 reference page <http://dx.doi.org/10.1109/MCSE.2007.55>`_)::

--- a/doc/users/intro.rst
+++ b/doc/users/intro.rst
@@ -1,18 +1,18 @@
 Introduction
 ============
 
-matplotlib is a library for making 2D plots of arrays in `Python
+Matplotlib is a library for making 2D plots of arrays in `Python
 <https://www.python.org>`_.  Although it has its origins in emulating
 the MATLAB |reg| [#]_ graphics commands, it is
 independent of MATLAB, and can be used in a Pythonic, object oriented
-way.  Although matplotlib is written primarily in pure Python, it
+way.  Although Matplotlib is written primarily in pure Python, it
 makes heavy use of `NumPy <http://www.numpy.org>`_ and other extension
 code to provide good performance even for large arrays.
 
 .. |reg| unicode:: 0xAE
    :ltrim:
 
-matplotlib is designed with the philosophy that you should be able to
+Matplotlib is designed with the philosophy that you should be able to
 create simple plots with just a few commands, or just one!  If you
 want to see a histogram of your data, you shouldn't need to
 instantiate objects, call methods, set properties, and so on; it
@@ -58,11 +58,11 @@ perspective, having a fixed user interface (the pylab interface) has
 been very useful, because the guts of the code base can be redesigned
 without affecting user code.
 
-The matplotlib code is conceptually divided into three parts: the
+The Matplotlib code is conceptually divided into three parts: the
 *pylab interface* is the set of functions provided by
 :mod:`matplotlib.pylab` which allow the user to create plots with code
 quite similar to MATLAB figure generating code
-(:ref:`pyplot-tutorial`).  The *matplotlib frontend* or *matplotlib
+(:ref:`pyplot-tutorial`).  The *Matplotlib frontend* or *Matplotlib
 API* is the set of classes that do the heavy lifting, creating and
 managing figures, text, lines, plots and so on
 (:ref:`artist-tutorial`).  This is an abstract interface that knows
@@ -74,7 +74,7 @@ backends: PS creates `PostScript®
 creates `Scalable Vector Graphics <http://www.w3.org/Graphics/SVG/>`_
 hardcopy, Agg creates PNG output using the high quality `Anti-Grain
 Geometry <http://antigrain.com/>`_
-library that ships with matplotlib, GTK embeds matplotlib in a
+library that ships with Matplotlib, GTK embeds Matplotlib in a
 `Gtk+ <https://www.gtk.org/>`_
 application, GTKAgg uses the Anti-Grain renderer to create a figure
 and embed it in a Gtk+ application, and so on for `PDF
@@ -82,13 +82,13 @@ and embed it in a Gtk+ application, and so on for `PDF
 <https://www.wxpython.org/>`_, `Tkinter
 <https://docs.python.org/library/tkinter.html>`_, etc.
 
-matplotlib is used by many people in many different contexts.  Some
+Matplotlib is used by many people in many different contexts.  Some
 people want to automatically generate PostScript files to send
-to a printer or publishers.  Others deploy matplotlib on a web
+to a printer or publishers.  Others deploy Matplotlib on a web
 application server to generate PNG output for inclusion in
-dynamically-generated web pages.  Some use matplotlib interactively
+dynamically-generated web pages.  Some use Matplotlib interactively
 from the Python shell in Tkinter on Windows™. My primary use is to
-embed matplotlib in a Gtk+ EEG application that runs on Windows, Linux
+embed Matplotlib in a Gtk+ EEG application that runs on Windows, Linux
 and Macintosh OS X.
 
 .. [#] MATLAB is a registered trademark of The MathWorks, Inc.


### PR DESCRIPTION
Here is a useless pull request that renames matplotlib to Matplotlib everytime I found it. I only did the files that seemed the most likely to attract attention, as I think the hardest is going to be to propagate this change else where.

Feel free to commit to my branch with additional renaming.