### PR TITLE
Remove unused verification code.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -438,21 +438,6 @@ def checkdep_inkscape():
 checkdep_inkscape.version = None
 
 
-def checkdep_xmllint():
-    try:
-        s = subprocess.Popen(['xmllint', '--version'], stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-        stdout, stderr = s.communicate()
-        lines = stderr.decode('ascii').split('\n')
-        for line in lines:
-            if 'version' in line:
-                v = line.split()[-1]
-                break
-        return v
-    except (IndexError, ValueError, UnboundLocalError, OSError):
-        return None
-
-
 def checkdep_ps_distiller(s):
     if not s:
         return False

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -204,38 +204,6 @@ def convert(filename, cache):
 
     return newname
 
-#: Maps file extensions to a function which takes a filename as its
-#: only argument to return a list suitable for execution with Popen.
-#: The purpose of this is so that the result file (with the given
-#: extension) can be verified with tools such as xmllint for svg.
-verifiers = {}
-
-# Turning this off, because it seems to cause multiprocessing issues
-if matplotlib.checkdep_xmllint() and False:
-    verifiers['svg'] = lambda filename: [
-        'xmllint', '--valid', '--nowarning', '--noout', filename]
-
-
-def verify(filename):
-    """Verify the file through some sort of verification tool."""
-    if not os.path.exists(filename):
-        raise IOError("'%s' does not exist" % filename)
-    base, extension = filename.rsplit('.', 1)
-    verifier = verifiers.get(extension, None)
-    if verifier is not None:
-        cmd = verifier(filename)
-        pipe = subprocess.Popen(cmd, universal_newlines=True,
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = pipe.communicate()
-        errcode = pipe.wait()
-        if errcode != 0:
-            msg = "File verification command failed:\n%s\n" % ' '.join(cmd)
-            if stdout:
-                msg += "Standard output:\n%s\n" % stdout
-            if stderr:
-                msg += "Standard error:\n%s\n" % stderr
-            raise IOError(msg)
-
 
 def crop_to_same(actual_path, actual_image, expected_path, expected_image):
     # clip the images to the same size -- this is useful only when
@@ -298,8 +266,6 @@ def compare_images(expected, actual, tol, in_decorator=False):
     if os.stat(actual).st_size == 0:
         msg = "Output image file %s is empty." % actual
         raise Exception(msg)
-
-    verify(actual)
 
     # Convert the image to png
     extension = expected.split('.')[-1]


### PR DESCRIPTION
See #7816.  Let me know if you think this should go through a standard deprecation cycle.

xmllint tests were disabled in 2009.

attn @tacaswell @Kojoley 