### PR TITLE
[MRG+1] MAINT added early checks for dependencies for doc building

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,13 @@ except ImportError:
                           "mock to build the documentation")
 
 try:
+    from PIL import Image
+except ImportError:
+    raise ImportError("No module named Image - you need to install "
+                      "pillow to build the documentation")
+
+
+try:
     import matplotlib
 except ImportError:
     msg = "Error: matplotlib must be installed before building the documentation"


### PR DESCRIPTION
This patch addresses at least partially #7793 by adding an early check on the presence of pillow's dependencies. It avoids the documentation to fail building after 20 minutes.

I was not able to build the documentation at this point and am thus unable to confirm that all dependencies are checked for early on.