### PR TITLE
[MRG+1] MAINT tests should not use relative imports

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -13,8 +13,8 @@ import pytest
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 from matplotlib import animation
-from ..testing import xfail, skip
-from ..testing.decorators import cleanup
+from matplotlib.testing import xfail, skip
+from matplotlib.testing.decorators import cleanup
 
 
 class NullMovieWriter(animation.AbstractMovieWriter):


### PR DESCRIPTION
If they do, they cannot be run independently.