### PR TITLE
Remove deprecated get_example_data.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -755,15 +755,6 @@ get_data_path = verbose.wrap('matplotlib data path %s', _get_data_path_cached,
                              always=False)
 
 
-def get_example_data(fname):
-    """
-    get_example_data is deprecated -- use matplotlib.cbook.get_sample_data
-                                      instead
-    """
-    raise NotImplementedError('get_example_data is deprecated -- use '
-                              'matplotlib.cbook.get_sample_data instead')
-
-
 def get_py2exe_datafiles():
     datapath = get_data_path()
     _, tail = os.path.split(datapath)


### PR DESCRIPTION
The function has been raising NotImplementedError since 2009 (e45f34c8b7).