### PR TITLE
DOC: fix name of toolkit test in API doc

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -211,7 +211,7 @@ To restore installing the tests and images, use a `setup.cfg` with ::
 
    [packages]
    tests = True
-   toolkit_tests = True
+   toolkits_tests = True
 
 in the source directory at build/install time.
 


### PR DESCRIPTION
Give correct name for toolkits_tests parameter to set in setup.cfg.