### PR TITLE
MAINT: add ability to specify recursionlimit

### DIFF
--- a/lib/matplotlib/testing/nose/__init__.py
+++ b/lib/matplotlib/testing/nose/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import sys
+
 
 def get_extra_test_plugins():
     from .plugins.performgc import PerformGC
@@ -29,12 +31,16 @@ def check_deps():
         raise
 
 
-def test(verbosity=None, coverage=False, switch_backend_warn=True, **kwargs):
+def test(verbosity=None, coverage=False, switch_backend_warn=True,
+         recursionlimit=0, **kwargs):
     from ... import default_test_modules, get_backend, use
 
     old_backend = get_backend()
+    old_recursionlimit = sys.getrecursionlimit()
     try:
         use('agg')
+        if recursionlimit:
+            sys.setrecursionlimit(recursionlimit)
         import nose
         from nose.plugins import multiprocess
 
@@ -60,6 +66,8 @@ def test(verbosity=None, coverage=False, switch_backend_warn=True, **kwargs):
     finally:
         if old_backend.lower() != 'agg':
             use(old_backend, warn=switch_backend_warn)
+        if recursionlimit:
+            sys.setrecursionlimit(old_recursionlimit)
 
     return success
 

--- a/tests.py
+++ b/tests.py
@@ -25,6 +25,8 @@ if __name__ == '__main__':
                         help='Run tests without network connection')
     parser.add_argument('-j', type=int,
                         help='Shortcut for specifying number of test processes')
+    parser.add_argument('--recursionlimit', type=int, default=0,
+                        help='Specify recursionlimit for test run')
     args, extra_args = parser.parse_known_args()
 
     if args.no_pep8:
@@ -43,5 +45,6 @@ if __name__ == '__main__':
 
     print('Python byte-compilation optimization level: %d' % sys.flags.optimize)
 
-    success = test(argv=sys.argv[0:1] + extra_args, switch_backend_warn=False)
+    success = test(argv=sys.argv[0:1] + extra_args, switch_backend_warn=False,
+                   recursionlimit=args.recursionlimit)
     sys.exit(not success)


### PR DESCRIPTION
We're getting a test failure on OSX and Python 3.6 where parsing reaches the
recursion limit: https://github.com/matplotlib/matplotlib/issues/7799

Upping the recursionlimit resolves the error.

Add command line argument to tests to up the recursion limit for the
test run.