### PR TITLE
Fixed bug with default parameters NFFT and noverlap in specgram()

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7234,6 +7234,11 @@ or tuple of floats
         Z = np.flipud(Z)
 
         if xextent is None:
+            # define default values:
+            if noverlap is None:
+                noverlap = 128  # defined in mlab.specgram
+            if NFFT is None:
+                NFFT = 256  # defined in mlab._spectral_helper
             # padding is needed for first and last segment:
             pad_xextent = (NFFT-noverlap) / Fs / 2
             xextent = np.min(t) - pad_xextent, np.max(t) + pad_xextent

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7200,8 +7200,12 @@ or tuple of floats
         if not self._hold:
             self.cla()
 
+        if NFFT is None:
+            NFFT = 256  # same default as in mlab.specgram()
         if Fc is None:
-            Fc = 0
+            Fc = 0  # same default as in mlab._spectral_helper()
+        if noverlap is None:
+            noverlap = 128  # same default as in mlab.specgram()
 
         if mode == 'complex':
             raise ValueError('Cannot plot a complex specgram')
@@ -7234,11 +7238,6 @@ or tuple of floats
         Z = np.flipud(Z)
 
         if xextent is None:
-            # define default values:
-            if noverlap is None:
-                noverlap = 128  # defined in mlab.specgram
-            if NFFT is None:
-                NFFT = 256  # defined in mlab._spectral_helper
             # padding is needed for first and last segment:
             pad_xextent = (NFFT-noverlap) / Fs / 2
             xextent = np.min(t) - pad_xextent, np.max(t) + pad_xextent

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1273,8 +1273,10 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
 
     """
     if noverlap is None:
-        noverlap = 128
-    if len(x) <= (256 if NFFT is None else NFFT):  # see _spectral_helper()
+        noverlap = 128  # default in _spectral_helper() is noverlap = 0
+    if NFFT is None:
+        NFFT = 256  # same default as in _spectral_helper()
+    if len(x) <= NFFT:
         warnings.warn("Only one segment is calculated since parameter NFFT " +
                       "(=%d) >= signal length (=%d)." % (NFFT, len(x)))
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1274,6 +1274,9 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
     """
     if noverlap is None:
         noverlap = 128
+    if len(x) <= (256 if NFFT is None else NFFT):  # see _spectral_helper()
+        warnings.warn("Only one segment is calculated since parameter NFFT " +
+                      "(=%d) >= signal length (=%d)." % (NFFT, len(x)))
 
     spec, freqs, t = _spectral_helper(x=x, y=None, NFFT=NFFT, Fs=Fs,
                                       detrend_func=detrend, window=window,


### PR DESCRIPTION
While looking at Bug #6064 I stumbled upon the following problem:
The default parameter in `specgram()` of `NFFT` and `noverlap` is ``None``. The fix in #7692 assumes these parameters to be integers. This pull request fixes that.

Also a warning was added to fix Bug #6064.
