### PR TITLE
MAINT: add ability to specify recursionlimit

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,7 @@
 import os
 import sys
 import time
+import argparse
 
 import matplotlib
 matplotlib.use('agg')
@@ -50,5 +51,11 @@ if __name__ == '__main__':
         disable_internet.turn_off_internet()
         extra_args.extend(['-a', '!network'])
         sys.argv.remove('--no-network')
-
+    # Get recursion limit
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--recursionlimit', type=int, default=0,
+                        help='Specify recursionlimit for test run')
+    found_args, sys.argv = parser.parse_known_args(sys.argv)
+    if found_args.recursionlimit:
+        sys.setrecursionlimit(found_args.recursionlimit)
     run(extra_args)


### PR DESCRIPTION
Sort-of backport of recursionlimit argument to tests - see PR #7843.

We're getting a test failure on OSX and Python 3.6 where parsing reaches the
recursion limit: https://github.com/matplotlib/matplotlib/issues/7799

Upping the recursionlimit resolves the error.

Add command line argument to tests to up the recursion limit for the
test run.