### PR TITLE
[MRG+1] Allow AnchoredOffset to take a string-like location code

### DIFF
--- a/examples/axes_grid1/inset_locator_demo.py
+++ b/examples/axes_grid1/inset_locator_demo.py
@@ -31,7 +31,7 @@ plt.yticks(visible=False)
 # second subplot
 ax2.set_aspect(1.)
 
-axins = zoomed_inset_axes(ax2, 0.5, loc=1)  # zoom = 0.5
+axins = zoomed_inset_axes(ax2, 0.5, loc='upper right')  # zoom = 0.5
 # fix the number of ticks on the inset axes
 axins.yaxis.get_major_locator().set_params(nbins=7)
 axins.xaxis.get_major_locator().set_params(nbins=7)

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1043,12 +1043,12 @@ class AnchoredOffsetbox(OffsetBox):
         self.set_child(child)
 
         if is_string_like(loc):
-            if loc not in self.codes:
+            try:
+                loc = self.codes[loc]
+            except KeyError:
                 raise RuntimeError('Unrecognized location "%s". Valid '
                                    'locations are\n\t%s\n'
                                    % (loc, '\n\t'.join(self.codes)))
-            else:
-                loc = self.codes[loc]
 
         self.loc = loc
         self.borderpad = borderpad

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1046,9 +1046,9 @@ class AnchoredOffsetbox(OffsetBox):
             try:
                 loc = self.codes[loc]
             except KeyError:
-                raise RuntimeError('Unrecognized location "%s". Valid '
-                                   'locations are\n\t%s\n'
-                                   % (loc, '\n\t'.join(self.codes)))
+                raise ValueError('Unrecognized location "%s". Valid '
+                                 'locations are\n\t%s\n'
+                                 % (loc, '\n\t'.join(self.codes)))
 
         self.loc = loc
         self.borderpad = borderpad

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -33,6 +33,7 @@ from matplotlib.patches import FancyBboxPatch, FancyArrowPatch
 from matplotlib import rcParams
 
 from matplotlib import docstring
+from matplotlib.cbook import is_string_like
 
 #from bboximage import BboxImage
 from matplotlib.image import BboxImage
@@ -986,6 +987,19 @@ class AnchoredOffsetbox(OffsetBox):
     """
     zorder = 5  # zorder of the legend
 
+    # Location codes
+    codes = {'upper right': 1,
+             'upper left': 2,
+             'lower left': 3,
+             'lower right': 4,
+             'right': 5,
+             'center left': 6,
+             'center right': 7,
+             'lower center': 8,
+             'upper center': 9,
+             'center': 10,
+             }
+
     def __init__(self, loc,
                  pad=0.4, borderpad=0.5,
                  child=None, prop=None, frameon=True,
@@ -1027,6 +1041,14 @@ class AnchoredOffsetbox(OffsetBox):
 
         self.set_bbox_to_anchor(bbox_to_anchor, bbox_transform)
         self.set_child(child)
+
+        if is_string_like(loc):
+            if loc not in self.codes:
+                raise RuntimeError('Unrecognized location "%s". Valid '
+                                   'locations are\n\t%s\n'
+                                   % (loc, '\n\t'.join(self.codes)))
+            else:
+                loc = self.codes[loc]
 
         self.loc = loc
         self.borderpad = borderpad

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -82,5 +82,27 @@ def test_offsetbox_clip_children():
     da.clip_children = True
     assert_true(fig.stale)
 
+
+@cleanup
+def test_offsetbox_loc_codes():
+    # Check that valid string location codes all work with an AnchoredOffsetbox
+    codes = {'upper right': 1,
+             'upper left': 2,
+             'lower left': 3,
+             'lower right': 4,
+             'right': 5,
+             'center left': 6,
+             'center right': 7,
+             'lower center': 8,
+             'upper center': 9,
+             'center': 10,
+             }
+    fig, ax = plt.subplots()
+    da = DrawingArea(100, 100)
+    for code in codes:
+        anchored_box = AnchoredOffsetbox(loc=code, child=da)
+        ax.add_artist(anchored_box)
+    fig.canvas.draw()
+
 if __name__ == '__main__':
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
Fixes #6207. New code directly lifted from axes.legend.

(note to self: work out the difference between 'right' and 'centre right' at some point)