### PR TITLE
FIX Preserve title case when saving through GUI (issue #7824)

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2267,7 +2267,7 @@ class FigureCanvasBase(object):
         a default filename.
         """
         default_basename = self.get_window_title() or 'image'
-        default_basename = default_basename.lower().replace(' ', '_')
+        default_basename = default_basename.replace(' ', '_')
         default_filetype = self.get_default_filetype()
         default_filename = default_basename + '.' + default_filetype
 


### PR DESCRIPTION
A quick fix to preserve the title case when saving a figure through the GUI (before issue #7824 slips through the cracks).

Currently, it addresses the initial problem stated in #7824 but not the one raised in the discussion by @jkseppan about adding some way of dealing with forbidden characters. My viewpoint is that this could be done in another PR if we define a list of the forbidden characters in file names on the different OSes and which valid character to replace them with.
