### PR TITLE
[MRG+2] MNT: reference the proper variable in bootstrapper

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1941,8 +1941,8 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
         M = len(data)
         percentiles = [2.5, 97.5]
 
-        ii = np.random.randint(M, size=(N, M))
-        bsData = x[ii]
+        bs_index = np.random.randint(M, size=(N, M))
+        bsData = data[bs_index]
         estimate = np.median(bsData, axis=1, overwrite_input=True)
 
         CI = np.percentile(estimate, percentiles)


### PR DESCRIPTION
Cleans up some unclear code that magically worked due to python's scoping rules.

[ref comment](https://github.com/matplotlib/matplotlib/commit/da97eab4f73cad517d52f8d02200e69f11826f99#commitcomment-20524587)