### PR TITLE
Use backports.functools_lru_cache instead of functools32

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -222,7 +222,7 @@ Required Dependencies
 Dependencies for python 2
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`functools32 <https://pypi.python.org/pypi/functools32>`_
+`backports.functools_lru_cache <https://pypi.python.org/pypi/backports.functools_lru_cache>`_
     Required for compatibility if running on Python 2.7.
 
 `subprocess32 <https://pypi.python.org/pypi/subprocess32/>`_

--- a/README.win.md
+++ b/README.win.md
@@ -27,7 +27,7 @@ conda install pyqt
 # this package is only available in the conda-forge channel
 conda install -c conda-forge msinttypes
 # for python 2.7
-conda install -c conda-forge functools32
+conda install -c conda-forge backports.functools_lru_cache
 
 # copy the libs which have "wrong" names
 set LIBRARY_LIB=%CONDA_DEFAULT_ENV%\Library\lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ install:
     nose mock sphinx
   - activate test-environment
   - cmd: echo %PYTHON_VERSION% %TARGET_ARCH%
-  - cmd: IF %PYTHON_VERSION% == 2.7 conda install -q functools32
+  - cmd: IF %PYTHON_VERSION% == 2.7 conda install -q backports.functools_lru_cache
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
   - if x%USE_PYTEST% == xyes conda install -q pytest "pytest-cov>=2.3.1" pytest-timeout #pytest-xdist
 

--- a/build_alllocal.cmd
+++ b/build_alllocal.cmd
@@ -7,7 +7,7 @@
 :: # this package is only available in the conda-forge channel
 :: conda install -c conda-forge msinttypes
 :: if you build on py2.7:
-:: conda install -c conda-forge functools32
+:: conda install -c conda-forge backports.functools_lru_cache
 
 set TARGET=bdist_wheel
 IF [%1]==[] (

--- a/ci/conda_recipe/meta.yaml
+++ b/ci/conda_recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - zlib 1.2*  # [win]
     - pyqt  # [not osx]
     - tk 8.5* # [linux]
-    - functools32  # [py2k]
+    - backports.functools_lru_cache  # [py2k]
 
   run:
     - python
@@ -54,7 +54,7 @@ requirements:
     - libpng >=1.6.21,<1.7
     - pyqt  # [not osx]
     - tk 8.5*  # [linux and win]
-    - functools32  # [py2k]
+    - backports.functools_lru_cache  # [py2k]
 
 test:
     imports:

--- a/doc/api/api_changes/2017-01-19-BFLC.rst
+++ b/doc/api/api_changes/2017-01-19-BFLC.rst
@@ -1,0 +1,4 @@
+Use backports.functools_lru_cache instead of functools32
+````````````````````````````````````````````````````````
+
+It's better maintained and more widely used (by pylint, jaraco, etc).

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -64,7 +64,7 @@ from matplotlib.fontconfig_pattern import (
 try:
     from functools import lru_cache
 except ImportError:
-    from functools32 import lru_cache
+    from backports.functools_lru_cache import lru_cache
 
 
 USE_FONTCONFIG = False

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ mpl_packages = [
     setupext.Numpy(),
     setupext.Six(),
     setupext.Dateutil(),
-    setupext.FuncTools32(),
+    setupext.BackportsFuncToolsLRUCache(),
     setupext.Subprocess32(),
     setupext.Pytz(),
     setupext.Cycler(),

--- a/setupext.py
+++ b/setupext.py
@@ -1523,25 +1523,25 @@ class Dateutil(SetupPackage):
         return [dateutil]
 
 
-class FuncTools32(SetupPackage):
-    name = "functools32"
+class BackportsFuncToolsLRUCache(SetupPackage):
+    name = "backports.functools_lru_cache"
 
     def check(self):
         if not PY3min:
             try:
-                import functools32
+                import backports.functools_lru_cache
             except ImportError:
                 return (
-                    "functools32 was not found. It is required for"
+                    "backports.functools_lru_cache was not found. It is required for"
                     "Python versions prior to 3.2")
 
-            return "using functools32"
+            return "using backports.functools_lru_cache"
         else:
             return "Not required"
 
     def get_install_requires(self):
         if not PY3min:
-            return ['functools32']
+            return ['backports.functools_lru_cache']
         else:
             return []
 


### PR DESCRIPTION
It's better maintained and more widely used (by pylint, jaraco, etc).