### PR TITLE
ENH: Add a LockableBbox type.

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -600,3 +600,37 @@ def test_transformed_patch_path():
     # from the transform).
     patch.set_radius(0.5)
     assert_allclose(tpatch.get_fully_transformed_path().vertices, points)
+
+
+@pytest.mark.parametrize('locked_element', ['x0', 'y0', 'x1', 'y1'])
+def test_lockable_bbox(locked_element):
+    other_elements = ['x0', 'y0', 'x1', 'y1']
+    other_elements.remove(locked_element)
+
+    orig = mtransforms.Bbox.unit()
+    locked = mtransforms.LockableBbox(orig, **{locked_element: 2})
+
+    # LockableBbox should keep its locked element as specified in __init__.
+    assert getattr(locked, locked_element) == 2
+    assert getattr(locked, 'get_locked_' + locked_element)() == 2
+    for elem in other_elements:
+        assert getattr(locked, elem) == getattr(orig, elem)
+
+    # Changing underlying Bbox should update everything but locked element.
+    orig.set_points(orig.get_points() + 10)
+    assert getattr(locked, locked_element) == 2
+    assert getattr(locked, 'get_locked_' + locked_element)() == 2
+    for elem in other_elements:
+        assert getattr(locked, elem) == getattr(orig, elem)
+
+    # Unlocking element should revert values back to the underlying Bbox.
+    getattr(locked, 'set_locked_' + locked_element)(None)
+    assert getattr(locked, 'get_locked_' + locked_element)() is None
+    assert np.all(orig.get_points() == locked.get_points())
+
+    # Relocking an element should change its value, but not others.
+    getattr(locked, 'set_locked_' + locked_element)(3)
+    assert getattr(locked, locked_element) == 3
+    assert getattr(locked, 'get_locked_' + locked_element)() == 3
+    for elem in other_elements:
+        assert getattr(locked, elem) == getattr(orig, elem)

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -612,25 +612,25 @@ def test_lockable_bbox(locked_element):
 
     # LockableBbox should keep its locked element as specified in __init__.
     assert getattr(locked, locked_element) == 2
-    assert getattr(locked, 'get_locked_' + locked_element)() == 2
+    assert getattr(locked, 'locked_' + locked_element) == 2
     for elem in other_elements:
         assert getattr(locked, elem) == getattr(orig, elem)
 
     # Changing underlying Bbox should update everything but locked element.
     orig.set_points(orig.get_points() + 10)
     assert getattr(locked, locked_element) == 2
-    assert getattr(locked, 'get_locked_' + locked_element)() == 2
+    assert getattr(locked, 'locked_' + locked_element) == 2
     for elem in other_elements:
         assert getattr(locked, elem) == getattr(orig, elem)
 
     # Unlocking element should revert values back to the underlying Bbox.
-    getattr(locked, 'set_locked_' + locked_element)(None)
-    assert getattr(locked, 'get_locked_' + locked_element)() is None
+    setattr(locked, 'locked_' + locked_element, None)
+    assert getattr(locked, 'locked_' + locked_element) is None
     assert np.all(orig.get_points() == locked.get_points())
 
     # Relocking an element should change its value, but not others.
-    getattr(locked, 'set_locked_' + locked_element)(3)
+    setattr(locked, 'locked_' + locked_element, 3)
     assert getattr(locked, locked_element) == 3
-    assert getattr(locked, 'get_locked_' + locked_element)() == 3
+    assert getattr(locked, 'locked_' + locked_element) == 3
     for elem in other_elements:
         assert getattr(locked, elem) == getattr(orig, elem)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1155,93 +1155,69 @@ class LockableBbox(BboxBase):
             self._check(points)
             return points
 
-    def set_locked_x0(self, x0):
+    @property
+    def locked_x0(self):
         """
-        Set the value to be used for the locked x0.
-
-        Parameters
-        ----------
-        x0 : float or None
-            The locked value for x0, or None to unlock.
-        """
-        self._locked_points.mask[0, 0] = x0 is None
-        self._locked_points.data[0, 0] = x0
-        self.invalidate()
-
-    def get_locked_x0(self):
-        """
-        Get the value used for the locked x0.
+        float or None: The value used for the locked x0.
         """
         if self._locked_points.mask[0, 0]:
             return None
         else:
             return self._locked_points[0, 0]
 
-    def set_locked_y0(self, y0):
-        """
-        Set the value to be used for the locked y0.
-
-        Parameters
-        ----------
-        y0 : float or None
-            The locked value for y0, or None to unlock.
-        """
-        self._locked_points.mask[0, 1] = y0 is None
-        self._locked_points.data[0, 1] = y0
+    @locked_x0.setter
+    def locked_x0(self, x0):
+        self._locked_points.mask[0, 0] = x0 is None
+        self._locked_points.data[0, 0] = x0
         self.invalidate()
 
-    def get_locked_y0(self):
+    @property
+    def locked_y0(self):
         """
-        Get the value used for the locked y0.
+        float or None: The value used for the locked y0.
         """
         if self._locked_points.mask[0, 1]:
             return None
         else:
             return self._locked_points[0, 1]
 
-    def set_locked_x1(self, x1):
-        """
-        Set the value to be used for the locked x1.
-
-        Parameters
-        ----------
-        x1 : float or None
-            The locked value for x1, or None to unlock.
-        """
-        self._locked_points.mask[1, 0] = x1 is None
-        self._locked_points.data[1, 0] = x1
+    @locked_y0.setter
+    def locked_y0(self, y0):
+        self._locked_points.mask[0, 1] = y0 is None
+        self._locked_points.data[0, 1] = y0
         self.invalidate()
 
-    def get_locked_x1(self):
+    @property
+    def locked_x1(self):
         """
-        Get the value used for the locked x1.
+        float or None: The value used for the locked x1.
         """
         if self._locked_points.mask[1, 0]:
             return None
         else:
             return self._locked_points[1, 0]
 
-    def set_locked_y1(self, y1):
-        """
-        Set the value to be used for the locked y1.
-
-        Parameters
-        ----------
-        y1 : float or None
-            The locked value for y1, or None to unlock.
-        """
-        self._locked_points.mask[1, 1] = y1 is None
-        self._locked_points.data[1, 1] = y1
+    @locked_x1.setter
+    def locked_x1(self, x1):
+        self._locked_points.mask[1, 0] = x1 is None
+        self._locked_points.data[1, 0] = x1
         self.invalidate()
 
-    def get_locked_y1(self):
+    @property
+    def locked_y1(self):
         """
-        Get the value used for the locked y1.
+        float or None: The value used for the locked y1.
         """
         if self._locked_points.mask[1, 1]:
             return None
         else:
             return self._locked_points[1, 1]
+
+    @locked_y1.setter
+    def locked_y1(self, y1):
+        self._locked_points.mask[1, 1] = y1 is None
+        self._locked_points.data[1, 1] = y1
+        self.invalidate()
 
 
 class Transform(TransformNode):

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1095,6 +1095,155 @@ class TransformedBbox(BboxBase):
             return points
 
 
+class LockableBbox(BboxBase):
+    """
+    A :class:`Bbox` where some elements may be locked at certain values.
+
+    When the child bounding box changes, the bounds of this bbox will update
+    accordingly with the exception of the locked elements.
+    """
+    def __init__(self, bbox, x0=None, y0=None, x1=None, y1=None, **kwargs):
+        """
+        Parameters
+        ----------
+        bbox : Bbox
+            The child bounding box to wrap.
+
+        x0 : float or None
+            The locked value for x0, or None to leave unlocked.
+
+        y0 : float or None
+            The locked value for y0, or None to leave unlocked.
+
+        x1 : float or None
+            The locked value for x1, or None to leave unlocked.
+
+        y1 : float or None
+            The locked value for y1, or None to leave unlocked.
+
+        """
+        if not bbox.is_bbox:
+            raise ValueError("'bbox' is not a bbox")
+
+        BboxBase.__init__(self, **kwargs)
+        self._bbox = bbox
+        self.set_children(bbox)
+        self._points = None
+        fp = [x0, y0, x1, y1]
+        mask = [val is None for val in fp]
+        self._locked_points = np.ma.array(fp, np.float_,
+                                          mask=mask).reshape((2, 2))
+
+    def __repr__(self):
+        return "LockableBbox(%r, %r)" % (self._bbox, self._locked_points)
+
+    def get_points(self):
+        if self._invalid:
+            points = self._bbox.get_points()
+            self._points = np.where(self._locked_points.mask,
+                                    points,
+                                    self._locked_points)
+            self._invalid = 0
+        return self._points
+    get_points.__doc__ = Bbox.get_points.__doc__
+
+    if DEBUG:
+        _get_points = get_points
+
+        def get_points(self):
+            points = self._get_points()
+            self._check(points)
+            return points
+
+    def set_locked_x0(self, x0):
+        """
+        Set the value to be used for the locked x0.
+
+        Parameters
+        ----------
+        x0 : float or None
+            The locked value for x0, or None to unlock.
+        """
+        self._locked_points.mask[0, 0] = x0 is None
+        self._locked_points.data[0, 0] = x0
+        self.invalidate()
+
+    def get_locked_x0(self):
+        """
+        Get the value used for the locked x0.
+        """
+        if self._locked_points.mask[0, 0]:
+            return None
+        else:
+            return self._locked_points[0, 0]
+
+    def set_locked_y0(self, y0):
+        """
+        Set the value to be used for the locked y0.
+
+        Parameters
+        ----------
+        y0 : float or None
+            The locked value for y0, or None to unlock.
+        """
+        self._locked_points.mask[0, 1] = y0 is None
+        self._locked_points.data[0, 1] = y0
+        self.invalidate()
+
+    def get_locked_y0(self):
+        """
+        Get the value used for the locked y0.
+        """
+        if self._locked_points.mask[0, 1]:
+            return None
+        else:
+            return self._locked_points[0, 1]
+
+    def set_locked_x1(self, x1):
+        """
+        Set the value to be used for the locked x1.
+
+        Parameters
+        ----------
+        x1 : float or None
+            The locked value for x1, or None to unlock.
+        """
+        self._locked_points.mask[1, 0] = x1 is None
+        self._locked_points.data[1, 0] = x1
+        self.invalidate()
+
+    def get_locked_x1(self):
+        """
+        Get the value used for the locked x1.
+        """
+        if self._locked_points.mask[1, 0]:
+            return None
+        else:
+            return self._locked_points[1, 0]
+
+    def set_locked_y1(self, y1):
+        """
+        Set the value to be used for the locked y1.
+
+        Parameters
+        ----------
+        y1 : float or None
+            The locked value for y1, or None to unlock.
+        """
+        self._locked_points.mask[1, 1] = y1 is None
+        self._locked_points.data[1, 1] = y1
+        self.invalidate()
+
+    def get_locked_y1(self):
+        """
+        Get the value used for the locked y1.
+        """
+        if self._locked_points.mask[1, 1]:
+            return None
+        else:
+            return self._locked_points[1, 1]
+
+
 class Transform(TransformNode):
     """
     The base class of all :class:`TransformNode` instances that


### PR DESCRIPTION
This class encapsulates another `Bbox` and locks one or more ends so that they cannot be changed even if the corresponding element in the underlying `Bbox` does.

This PR is cherry-picked out of #4699 for easier review. This class is used to implement the non-zero/non-minimum origin via the transform stack instead of some complicated draw function or alternate state tracking.

There are no tests at the moment as I'm not sure whether this should be a general class, but if we're okay with adding it, then I will write some. I'm also open to alternate naming suggestions; also not sure if some of these things should be properties instead.