### PR TITLE
If text location isn't finite, set it to not visible

### DIFF
--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -29,6 +29,16 @@ def test_logit_scales():
 
 
 @cleanup
+def test_logit_tight_layout():
+    # Check that logit scale works with tight layout
+    fig, axs = plt.subplots(2, 2)
+
+    axs[1, 1].set_yscale('logit')
+    plt.tight_layout()
+    plt.draw()
+
+
+@cleanup
 def test_log_scatter():
     """Issue #1799"""
     fig, ax = plt.subplots(1)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1154,6 +1154,8 @@ class Text(Artist):
         """
         self.set_x(xy[0])
         self.set_y(xy[1])
+        if not np.all(np.isfinite(xy)):
+            self.set_visible(False)
 
     def set_x(self, x):
         """


### PR DESCRIPTION
This fixes #6789. The problem was there was some text at +/- inf locations, which mean that when the `tight_layout` calculation was being done an `inf` was being passed through.

I think it's reasonable to set text with co-ordinates that aren't finite to not visible as I presume it'll never be seen, although this currently just hides the problem without a warning or error. Perhaps this should raise a warning or error too? Thoughts appreciated!