### PR TITLE
[MRG+1] Fix inverted expected/found FreeType version warning.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1565,8 +1565,8 @@ def _init_tests():
             "Expected freetype version {0}. "
             "Found freetype version {1}. "
             "Freetype build type is {2}local".format(
-                ft2font.__freetype_version__,
                 LOCAL_FREETYPE_VERSION,
+                ft2font.__freetype_version__,
                 "" if ft2font.__freetype_build_type__ == 'local' else "not "
             )
         )


### PR DESCRIPTION
I've always been confused by this message, and it turns out it's backwards.