### PR TITLE
[MRG+1] MAINT pytest now exit on first failure on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
     - NPROC=2
     - TEST_ARGS=--no-pep8
     - NOSE_ARGS="-j $NPROC"
-    - PYTEST_ARGS="-ra --timeout=300 --durations=25 --cov-report= --cov=lib -n $NPROC"
+    - PYTEST_ARGS="-ra --maxfail=1 --timeout=300 --durations=25 --cov-report= --cov=lib -n $NPROC"
     - PYTHON_ARGS=
     - DELETE_FONT_CACHE=
     - USE_PYTEST=false


### PR DESCRIPTION
This pull request configures travis to exit after the first failure: this should allow us to gain time on the travis build.

I have only activated this for py.test, as nose requires a plugin and we will hopefully not have to support nose anymore.