### PR TITLE
[MRG+1] Convert mpl toolkits tests to pytest + minor cleanup

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1531,9 +1531,6 @@ default_test_modules = [
     'matplotlib.tests.test_cycles',
     'matplotlib.tests.test_preprocess_data',
     'matplotlib.sphinxext.tests.test_tinypages',
-    'mpl_toolkits.tests.test_mplot3d',
-    'mpl_toolkits.tests.test_axes_grid1',
-    'mpl_toolkits.tests.test_axes_grid',
     ]
 
 

--- a/lib/mpl_toolkits/tests/__init__.py
+++ b/lib/mpl_toolkits/tests/__init__.py
@@ -1,12 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
-
-import difflib
 import os
-
-from matplotlib import rcParams, rcdefaults, use
 
 
 _multiprocess_can_split_ = True
@@ -20,49 +15,3 @@ if not os.path.exists(os.path.join(
         'This is most likely because the test data is not installed. '
         'You may need to install matplotlib from source to get the '
         'test data.')
-
-
-def setup():
-    # The baseline images are created in this locale, so we should use
-    # it during all of the tests.
-    import locale
-    import warnings
-    from matplotlib.backends import backend_agg, backend_pdf, backend_svg
-
-    try:
-        locale.setlocale(locale.LC_ALL, str('en_US.UTF-8'))
-    except locale.Error:
-        try:
-            locale.setlocale(locale.LC_ALL, str('English_United States.1252'))
-        except locale.Error:
-            warnings.warn(
-                "Could not set locale to English/United States. "
-                "Some date-related tests may fail")
-
-    use('Agg', warn=False)  # use Agg backend for these tests
-
-    # These settings *must* be hardcoded for running the comparison
-    # tests and are not necessarily the default values as specified in
-    # rcsetup.py
-    rcdefaults()  # Start with all defaults
-    rcParams['font.family'] = 'Bitstream Vera Sans'
-    rcParams['text.hinting'] = False
-    rcParams['text.hinting_factor'] = 8
-
-
-def assert_str_equal(reference_str, test_str,
-                     format_str=('String {str1} and {str2} do not '
-                                 'match:\n{differences}')):
-    """
-    Assert the two strings are equal. If not, fail and print their
-    diffs using difflib.
-
-    """
-    if reference_str != test_str:
-        diff = difflib.unified_diff(reference_str.splitlines(1),
-                                    test_str.splitlines(1),
-                                    'Reference', 'Test result',
-                                    '', '', 0)
-        raise ValueError(format_str.format(str1=reference_str,
-                                           str2=test_str,
-                                           differences=''.join(diff)))

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -155,8 +155,3 @@ def test_inset_locator():
                           pad=0.1, borderpad=0.5, sep=5,
                           frameon=False)
     ax.add_artist(asb)
-
-
-if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1,4 +1,5 @@
-from nose.tools import assert_raises
+import pytest
+
 from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d
 from matplotlib import cm
 from matplotlib.testing.decorators import image_comparison, cleanup
@@ -222,7 +223,7 @@ def test_wireframe3dzerostrideraises():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         ax.plot_wireframe(X, Y, Z, rstride=0, cstride=0)
 
 
@@ -231,9 +232,9 @@ def test_mixedsamplesraises():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         ax.plot_wireframe(X, Y, Z, rstride=10, ccount=50)
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         ax.plot_surface(X, Y, Z, cstride=50, rcount=10)
 
 
@@ -316,16 +317,15 @@ def test_quiver3d_pivot_tail():
 
 @image_comparison(baseline_images=['axes3d_labelpad'], extensions=['png'])
 def test_axes3d_labelpad():
-    from nose.tools import assert_equal
     from matplotlib import rcParams
 
     fig = plt.figure()
     ax = Axes3D(fig)
     # labelpad respects rcParams
-    assert_equal(ax.xaxis.labelpad, rcParams['axes.labelpad'])
+    assert ax.xaxis.labelpad == rcParams['axes.labelpad']
     # labelpad can be set in set_label
     ax.set_xlabel('X LABEL', labelpad=10)
-    assert_equal(ax.xaxis.labelpad, 10)
+    assert ax.xaxis.labelpad == 10
     ax.set_ylabel('Y LABEL')
     ax.set_zlabel('Z LABEL')
     # or manually
@@ -354,7 +354,8 @@ def test_plotsurface_1d_raises():
 
     fig = plt.figure(figsize=(14,6))
     ax = fig.add_subplot(1, 2, 1, projection='3d')
-    assert_raises(ValueError, ax.plot_surface, X, Y, z)
+    with pytest.raises(ValueError):
+        ax.plot_surface(X, Y, z)
 
 
 def _test_proj_make_M():
@@ -467,8 +468,3 @@ def test_lines_dists():
 
     ax.set_xlim(-50, 150)
     ax.set_ylim(0, 300)
-
-
-if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
Besides the pytest stuff, drop unnecessary setup and testing functions.