### PR TITLE
Configure AppVeyor to fail fast

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -187,3 +187,6 @@ on_failure:
   - echo zipping images after a failure...
   - 7z a result_images.zip result_images\ |grep -v "Compressing"
   - appveyor PushArtifact result_images.zip
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
If one job fails, this cancels the rest of the jobs for the same build, freeing some resources for other builds.