### PR TITLE
MAINT moved g-i-l* modules to pytest

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1498,7 +1498,6 @@ default_test_modules = [
     'matplotlib.tests.test_figure',
     'matplotlib.tests.test_font_manager',
     'matplotlib.tests.test_gridspec',
-    'matplotlib.tests.test_lines',
     'matplotlib.tests.test_mathtext',
     'matplotlib.tests.test_mlab',
     'matplotlib.tests.test_offsetbox',

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1498,7 +1498,6 @@ default_test_modules = [
     'matplotlib.tests.test_figure',
     'matplotlib.tests.test_font_manager',
     'matplotlib.tests.test_gridspec',
-    'matplotlib.tests.test_image',
     'matplotlib.tests.test_legend',
     'matplotlib.tests.test_lines',
     'matplotlib.tests.test_mathtext',

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1497,7 +1497,6 @@ default_test_modules = [
     'matplotlib.tests.test_dviread',
     'matplotlib.tests.test_figure',
     'matplotlib.tests.test_font_manager',
-    'matplotlib.tests.test_gridspec',
     'matplotlib.tests.test_mathtext',
     'matplotlib.tests.test_mlab',
     'matplotlib.tests.test_offsetbox',

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1498,7 +1498,6 @@ default_test_modules = [
     'matplotlib.tests.test_figure',
     'matplotlib.tests.test_font_manager',
     'matplotlib.tests.test_gridspec',
-    'matplotlib.tests.test_legend',
     'matplotlib.tests.test_lines',
     'matplotlib.tests.test_mathtext',
     'matplotlib.tests.test_mlab',

--- a/lib/matplotlib/tests/test_gridspec.py
+++ b/lib/matplotlib/tests/test_gridspec.py
@@ -1,5 +1,6 @@
 import matplotlib.gridspec as gridspec
-from numpy.testing import assert_raises, assert_equal
+from numpy.testing import assert_equal
+import pytest
 
 
 def test_equal():
@@ -13,8 +14,8 @@ def test_width_ratios():
     Addresses issue #5835.
     See at https://github.com/matplotlib/matplotlib/issues/5835.
     """
-    assert_raises(ValueError, gridspec.GridSpec,
-                  1, 1, width_ratios=[2, 1, 3])
+    with pytest.raises(ValueError):
+        gridspec.GridSpec(1, 1, width_ratios=[2, 1, 3])
 
 
 def test_height_ratios():
@@ -22,5 +23,5 @@ def test_height_ratios():
     Addresses issue #5835.
     See at https://github.com/matplotlib/matplotlib/issues/5835.
     """
-    assert_raises(ValueError, gridspec.GridSpec,
-                  1, 1, height_ratios=[2, 1, 3])
+    with pytest.raises(ValueError):
+        gridspec.GridSpec(1, 1, height_ratios=[2, 1, 3])

--- a/lib/matplotlib/tests/test_gridspec.py
+++ b/lib/matplotlib/tests/test_gridspec.py
@@ -1,5 +1,5 @@
 import matplotlib.gridspec as gridspec
-from nose.tools import assert_raises, assert_equal
+from numpy.testing import assert_raises, assert_equal
 
 
 def test_equal():

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -20,17 +20,11 @@ from matplotlib import patches
 import matplotlib.pyplot as plt
 
 from matplotlib import mlab
-from nose.tools import assert_raises
-from numpy.testing import (
-    assert_array_equal, assert_array_almost_equal, assert_allclose)
+
 from copy import copy
 from numpy import ma
 import matplotlib.colors as colors
-import matplotlib.pyplot as plt
-import matplotlib.mlab as mlab
-import numpy as np
 
-import nose
 
 try:
     from PIL import Image
@@ -753,7 +747,3 @@ def test_imshow_no_warn_invalid():
         warnings.simplefilter("always")
         plt.imshow([[1, 2], [3, np.nan]])
     assert len(warns) == 0
-
-
-if __name__ == '__main__':
-    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -6,7 +6,6 @@ import io
 import os
 import warnings
 
-from nose.plugins.attrib import attr
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -21,6 +20,7 @@ from matplotlib import patches
 import matplotlib.pyplot as plt
 
 from matplotlib import mlab
+import pytest
 
 from copy import copy
 from numpy import ma
@@ -587,7 +587,7 @@ def test_minimized_rasterized():
                 assert False
 
 
-@attr('network')
+@pytest.mark.network
 def test_load_from_url():
     req = six.moves.urllib.request.urlopen(
         "http://matplotlib.org/_static/logo_sidebar_horiz.png")

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -9,6 +9,7 @@ import warnings
 from nose.plugins.attrib import attr
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from matplotlib.testing.decorators import (image_comparison,
                                            knownfailureif, cleanup)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from six.moves import xrange
 try:
     # mock in python 3.3+
     from unittest import mock
@@ -58,9 +57,9 @@ def test_various_labels():
     # tests all sorts of label types
     fig = plt.figure()
     ax = fig.add_subplot(121)
-    ax.plot(list(xrange(4)), 'o', label=1)
+    ax.plot(np.arage(4), 'o', label=1)
     ax.plot(np.linspace(4, 4.1), 'o', label='D\xe9velopp\xe9s')
-    ax.plot(list(xrange(4, 1, -1)), 'o', label='__nolegend__')
+    ax.plot(np.arage(4, 1, -1), 'o', label='__nolegend__')
     ax.legend(numpoints=1, loc=0)
 
 
@@ -122,9 +121,9 @@ def test_alpha_rcparam():
 def test_fancy():
     # using subplot triggers some offsetbox functionality untested elsewhere
     plt.subplot(121)
-    plt.scatter(list(xrange(10)), list(xrange(10, 0, -1)), label='XX\nXX')
+    plt.scatter(np.arange(10), np.arange(10, 0, -1), label='XX\nXX')
     plt.plot([5] * 10, 'o--', label='XX')
-    plt.errorbar(list(xrange(10)), list(xrange(10)), xerr=0.5,
+    plt.errorbar(np.arange(10), np.arange(10), xerr=0.5,
                  yerr=0.5, label='XX')
     plt.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
                ncol=2, shadow=True, title="My legend", numpoints=1)
@@ -144,14 +143,14 @@ def test_rc():
     # using subplot triggers some offsetbox functionality untested elsewhere
     plt.figure()
     ax = plt.subplot(121)
-    ax.scatter(list(xrange(10)), list(xrange(10, 0, -1)), label='three')
+    ax.scatter(np.arange(10), np.arange(10, 0, -1), label='three')
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 
     mpl.rcParams['legend.scatterpoints'] = 1
     plt.figure()
     ax = plt.subplot(121)
-    ax.scatter(list(xrange(10)), list(xrange(10, 0, -1)), label='one')
+    ax.scatter(np.arange(10), np.arange(10, 0, -1), label='one')
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -57,9 +57,9 @@ def test_various_labels():
     # tests all sorts of label types
     fig = plt.figure()
     ax = fig.add_subplot(121)
-    ax.plot(np.arage(4), 'o', label=1)
+    ax.plot(np.arange(4), 'o', label=1)
     ax.plot(np.linspace(4, 4.1), 'o', label='D\xe9velopp\xe9s')
-    ax.plot(np.arage(4, 1, -1), 'o', label='__nolegend__')
+    ax.plot(np.arange(4, 1, -1), 'o', label='__nolegend__')
     ax.legend(numpoints=1, loc=0)
 
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1,14 +1,13 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
 from six.moves import xrange
 try:
     # mock in python 3.3+
     from unittest import mock
 except ImportError:
     import mock
-from nose.tools import assert_equal
+from numpy.testing import assert_equal
 import numpy as np
 
 from matplotlib.testing.decorators import image_comparison, cleanup
@@ -143,14 +142,14 @@ def test_framealpha():
                   remove_text=True)
 def test_rc():
     # using subplot triggers some offsetbox functionality untested elsewhere
-    fig = plt.figure()
+    plt.figure()
     ax = plt.subplot(121)
     ax.scatter(list(xrange(10)), list(xrange(10, 0, -1)), label='three')
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 
     mpl.rcParams['legend.scatterpoints'] = 1
-    fig = plt.figure()
+    plt.figure()
     ax = plt.subplot(121)
     ax.scatter(list(xrange(10)), list(xrange(10, 0, -1)), label='one')
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -4,11 +4,9 @@ Tests specific to the lines module.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
 import itertools
 import matplotlib.lines as mlines
-import nose
-from nose.tools import assert_true, assert_raises
+from numpy.testing import assert_raises
 from timeit import repeat
 import numpy as np
 from cycler import cycler
@@ -59,7 +57,7 @@ def test_invisible_Line_rendering():
 
     slowdown_factor = (t_unvisible_line/t_no_line)
     slowdown_threshold = 2 # trying to avoid false positive failures
-    assert_true(slowdown_factor < slowdown_threshold)
+    assert slowdown_factor < slowdown_threshold
 
 
 @cleanup
@@ -186,10 +184,6 @@ def test_lw_scaling():
 
 def test_nan_is_sorted():
     line = mlines.Line2D([], [])
-    assert_true(line._is_sorted(np.array([1, 2, 3])))
-    assert_true(line._is_sorted(np.array([1, np.nan, 3])))
-    assert_true(not line._is_sorted([3, 5] + [np.nan] * 100 + [0, 2]))
-
-
-if __name__ == '__main__':
-    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)
+    assert line._is_sorted(np.array([1, 2, 3]))
+    assert line._is_sorted(np.array([1, np.nan, 3]))
+    assert not line._is_sorted([3, 5] + [np.nan] * 100 + [0, 2])


### PR DESCRIPTION
This continues the migration from pytest to nose.