### PR TITLE
[MRG+1] Convert preprocess tests to pytest

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1518,7 +1518,6 @@ default_test_modules = [
     'matplotlib.tests.test_usetex',
     'matplotlib.tests.test_widgets',
     'matplotlib.tests.test_cycles',
-    'matplotlib.tests.test_preprocess_data',
     'matplotlib.sphinxext.tests.test_tinypages',
     'mpl_toolkits.tests.test_mplot3d',
     'mpl_toolkits.tests.test_axes_grid1',

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -22,7 +22,7 @@ def plot_func(ax, x, y, ls="x", label=None, w="xyz"):
 
 @_preprocess_data(replace_names=["x", "y"], label_namer="y",
                   positional_parameter_names=["x", "y", "ls", "label", "w"])
-def plot_func_varags(ax, *args, **kwargs):
+def plot_func_varargs(ax, *args, **kwargs):
     all_args = [None, None, "x", None, "xyz"]
     for i, v in enumerate(args):
         all_args[i] = v
@@ -34,7 +34,8 @@ def plot_func_varags(ax, *args, **kwargs):
         list(x), list(y), ls, w, label))
 
 
-all_funcs = [plot_func, plot_func_varags]
+all_funcs = [plot_func, plot_func_varargs]
+all_func_ids = ['plot_func', 'plot_func_varargs']
 
 
 def test_compiletime_checks():
@@ -106,78 +107,78 @@ def test_label_problems_at_runtime():
         func(None, x="a", y="b")
 
 
-def test_function_call_without_data():
+@pytest.mark.parametrize('func', all_funcs, ids=all_func_ids)
+def test_function_call_without_data(func):
     """test without data -> no replacements"""
-    for func in all_funcs:
-        assert (func(None, "x", "y") ==
-                "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
-        assert (func(None, x="x", y="y") ==
-                "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
-        assert (func(None, "x", "y", label="") ==
-                "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
-        assert (func(None, "x", "y", label="text") ==
-                "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
-        assert (func(None, x="x", y="y", label="") ==
-                "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
-        assert (func(None, x="x", y="y", label="text") ==
-                "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
+    assert (func(None, "x", "y") ==
+            "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
+    assert (func(None, x="x", y="y") ==
+            "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
+    assert (func(None, "x", "y", label="") ==
+            "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
+    assert (func(None, "x", "y", label="text") ==
+            "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
+    assert (func(None, x="x", y="y", label="") ==
+            "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
+    assert (func(None, x="x", y="y", label="text") ==
+            "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
 
 
-def test_function_call_with_dict_data():
+@pytest.mark.parametrize('func', all_funcs, ids=all_func_ids)
+def test_function_call_with_dict_data(func):
     """Test with dict data -> label comes from the value of 'x' parameter """
     data = {"a": [1, 2], "b": [8, 9], "w": "NOT"}
-    for func in all_funcs:
-        assert (func(None, "a", "b", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert (func(None, x="a", y="b", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert (func(None, "a", "b", label="", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert (func(None, "a", "b", label="text", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
-        assert (func(None, x="a", y="b", label="", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert (func(None, x="a", y="b", label="text", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+    assert (func(None, "a", "b", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (func(None, x="a", y="b", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (func(None, "a", "b", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (func(None, "a", "b", label="text", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+    assert (func(None, x="a", y="b", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (func(None, x="a", y="b", label="text", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
 
-def test_function_call_with_dict_data_not_in_data():
+@pytest.mark.parametrize('func', all_funcs, ids=all_func_ids)
+def test_function_call_with_dict_data_not_in_data(func):
     "test for the case that one var is not in data -> half replaces, half kept"
     data = {"a": [1, 2], "w": "NOT"}
-    for func in all_funcs:
-        assert (func(None, "a", "b", data=data) ==
-                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
-        assert (func(None, x="a", y="b", data=data) ==
-                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
-        assert (func(None, "a", "b", label="", data=data) ==
-                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
-        assert (func(None, "a", "b", label="text", data=data) ==
-                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
-        assert (func(None, x="a", y="b", label="", data=data) ==
-                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
-        assert (func(None, x="a", y="b", label="text", data=data) ==
-                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
+    assert (func(None, "a", "b", data=data) ==
+            "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
+    assert (func(None, x="a", y="b", data=data) ==
+            "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
+    assert (func(None, "a", "b", label="", data=data) ==
+            "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
+    assert (func(None, "a", "b", label="text", data=data) ==
+            "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
+    assert (func(None, x="a", y="b", label="", data=data) ==
+            "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
+    assert (func(None, x="a", y="b", label="text", data=data) ==
+            "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
 
 
-def test_function_call_with_pandas_data():
+@pytest.mark.parametrize('func', all_funcs, ids=all_func_ids)
+def test_function_call_with_pandas_data(func):
     """test with pandas dataframe -> label comes from data["col"].name """
     pd = pytest.importorskip('pandas')
 
     data = pd.DataFrame({"a": [1, 2], "b": [8, 9], "w": ["NOT", "NOT"]})
 
-    for func in all_funcs:
-        assert (func(None, "a", "b", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert (func(None, x="a", y="b", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert (func(None, "a", "b", label="", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert (func(None, "a", "b", label="text", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
-        assert (func(None, x="a", y="b", label="", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert (func(None, x="a", y="b", label="text", data=data) ==
-                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+    assert (func(None, "a", "b", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (func(None, x="a", y="b", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (func(None, "a", "b", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (func(None, "a", "b", label="text", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+    assert (func(None, x="a", y="b", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (func(None, x="a", y="b", label="text", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
 
 def test_function_call_replace_all():

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -1,16 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 
-from nose.tools import (assert_raises, assert_equal)
-from nose.plugins.skip import SkipTest
+import re
 
-try:
-    # 3.2+ versions
-    from nose.tools import assert_regex, assert_not_regex
-except ImportError:
-    # 2.7 versions
-    from nose.tools import assert_regexp_matches, assert_not_regexp_matches
-    assert_regex = assert_regexp_matches
-    assert_not_regex = assert_not_regexp_matches
+import pytest
+from nose.tools import assert_raises
 
 from ..testing import assert_produces_warning
 
@@ -131,78 +124,75 @@ def test_label_problems_at_runtime():
 def test_function_call_without_data():
     """test without data -> no replacements"""
     for func in all_funcs:
-        assert_equal(func(None, "x", "y"),
-                     "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
-        assert_equal(func(None, x="x", y="y"),
-                     "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
-        assert_equal(func(None, "x", "y", label=""),
-                     "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
-        assert_equal(func(None, "x", "y", label="text"),
-                     "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
-        assert_equal(func(None, x="x", y="y", label=""),
-                     "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
-        assert_equal(func(None, x="x", y="y", label="text"),
-                     "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
+        assert (func(None, "x", "y") ==
+                "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
+        assert (func(None, x="x", y="y") ==
+                "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
+        assert (func(None, "x", "y", label="") ==
+                "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
+        assert (func(None, "x", "y", label="text") ==
+                "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
+        assert (func(None, x="x", y="y", label="") ==
+                "x: ['x'], y: ['y'], ls: x, w: xyz, label: ")
+        assert (func(None, x="x", y="y", label="text") ==
+                "x: ['x'], y: ['y'], ls: x, w: xyz, label: text")
 
 
 def test_function_call_with_dict_data():
     """Test with dict data -> label comes from the value of 'x' parameter """
     data = {"a": [1, 2], "b": [8, 9], "w": "NOT"}
     for func in all_funcs:
-        assert_equal(func(None, "a", "b", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert_equal(func(None, x="a", y="b", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert_equal(func(None, "a", "b", label="", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert_equal(func(None, "a", "b", label="text", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
-        assert_equal(func(None, x="a", y="b", label="", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert_equal(func(None, x="a", y="b", label="text", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+        assert (func(None, "a", "b", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+        assert (func(None, x="a", y="b", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+        assert (func(None, "a", "b", label="", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+        assert (func(None, "a", "b", label="text", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+        assert (func(None, x="a", y="b", label="", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+        assert (func(None, x="a", y="b", label="text", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
 
 def test_function_call_with_dict_data_not_in_data():
     "test for the case that one var is not in data -> half replaces, half kept"
     data = {"a": [1, 2], "w": "NOT"}
     for func in all_funcs:
-        assert_equal(func(None, "a", "b", data=data),
-                     "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
-        assert_equal(func(None, x="a", y="b", data=data),
-                     "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
-        assert_equal(func(None, "a", "b", label="", data=data),
-                     "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
-        assert_equal(func(None, "a", "b", label="text", data=data),
-                     "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
-        assert_equal(func(None, x="a", y="b", label="", data=data),
-                     "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
-        assert_equal(func(None, x="a", y="b", label="text", data=data),
-                     "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
+        assert (func(None, "a", "b", data=data) ==
+                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
+        assert (func(None, x="a", y="b", data=data) ==
+                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
+        assert (func(None, "a", "b", label="", data=data) ==
+                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
+        assert (func(None, "a", "b", label="text", data=data) ==
+                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
+        assert (func(None, x="a", y="b", label="", data=data) ==
+                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: ")
+        assert (func(None, x="a", y="b", label="text", data=data) ==
+                "x: [1, 2], y: ['b'], ls: x, w: xyz, label: text")
 
 
 def test_function_call_with_pandas_data():
     """test with pandas dataframe -> label comes from data["col"].name """
-    try:
-        import pandas as pd
-    except ImportError:
-        raise SkipTest("Pandas not installed")
+    pd = pytest.importorskip('pandas')
 
     data = pd.DataFrame({"a": [1, 2], "b": [8, 9], "w": ["NOT", "NOT"]})
 
     for func in all_funcs:
-        assert_equal(func(None, "a", "b", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert_equal(func(None, x="a", y="b", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-        assert_equal(func(None, "a", "b", label="", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert_equal(func(None, "a", "b", label="text", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
-        assert_equal(func(None, x="a", y="b", label="", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-        assert_equal(func(None, x="a", y="b", label="text", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+        assert (func(None, "a", "b", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+        assert (func(None, x="a", y="b", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+        assert (func(None, "a", "b", label="", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+        assert (func(None, "a", "b", label="text", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+        assert (func(None, x="a", y="b", label="", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+        assert (func(None, x="a", y="b", label="text", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
 
 def test_function_call_replace_all():
@@ -214,20 +204,20 @@ def test_function_call_replace_all():
         return "x: %s, y: %s, ls: %s, w: %s, label: %s" % (
             list(x), list(y), ls, w, label)
 
-    assert_equal(func_replace_all(None, "a", "b", w="x", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-    assert_equal(func_replace_all(None, x="a", y="b", w="x", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-    assert_equal(func_replace_all(None, "a", "b", w="x", label="", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-    assert_equal(
-        func_replace_all(None, "a", "b", w="x", label="text", data=data),
+    assert (func_replace_all(None, "a", "b", w="x", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (func_replace_all(None, x="a", y="b", w="x", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (func_replace_all(None, "a", "b", w="x", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (
+        func_replace_all(None, "a", "b", w="x", label="text", data=data) ==
         "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
-    assert_equal(
-        func_replace_all(None, x="a", y="b", w="x", label="", data=data),
+    assert (
+        func_replace_all(None, x="a", y="b", w="x", label="", data=data) ==
         "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-    assert_equal(
-        func_replace_all(None, x="a", y="b", w="x", label="text", data=data),
+    assert (
+        func_replace_all(None, x="a", y="b", w="x", label="text", data=data) ==
         "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
     @_preprocess_data(label_namer="y")
@@ -244,27 +234,27 @@ def test_function_call_replace_all():
 
     # in the first case, we can't get a "y" argument,
     # as we don't know the names of the *args
-    assert_equal(func_varags_replace_all(None, x="a", y="b", w="x", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-    assert_equal(
-        func_varags_replace_all(None, "a", "b", w="x", label="", data=data),
+    assert (func_varags_replace_all(None, x="a", y="b", w="x", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (
+        func_varags_replace_all(None, "a", "b", w="x", label="", data=data) ==
         "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-    assert_equal(
+    assert (
         func_varags_replace_all(None, "a", "b", w="x", label="text",
-                                data=data),
+                                data=data) ==
         "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
-    assert_equal(
+    assert (
         func_varags_replace_all(None, x="a", y="b", w="x", label="",
-                                data=data),
+                                data=data) ==
         "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-    assert_equal(
+    assert (
         func_varags_replace_all(None, x="a", y="b", w="x", label="text",
-                                data=data),
+                                data=data) ==
         "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
     with assert_produces_warning():
-        assert_equal(func_varags_replace_all(None, "a", "b", w="x", data=data),
-                     "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: None")
+        assert (func_varags_replace_all(None, "a", "b", w="x", data=data) ==
+                "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: None")
 
 
 def test_no_label_replacements():
@@ -276,14 +266,14 @@ def test_no_label_replacements():
             list(x), list(y), ls, w, label)
 
     data = {"a": [1, 2], "b": [8, 9], "w": "NOT"}
-    assert_equal(func_no_label(None, "a", "b", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: None")
-    assert_equal(func_no_label(None, x="a", y="b", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: None")
-    assert_equal(func_no_label(None, "a", "b", label="", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-    assert_equal(func_no_label(None, "a", "b", label="text", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+    assert (func_no_label(None, "a", "b", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: None")
+    assert (func_no_label(None, x="a", y="b", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: None")
+    assert (func_no_label(None, "a", "b", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (func_no_label(None, "a", "b", label="text", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
 
 def test_more_args_than_pos_parameter():
@@ -317,10 +307,10 @@ def test_function_call_with_replace_all_args():
     func = _preprocess_data(replace_all_args=True, replace_names=["w"],
                                label_namer="y")(funcy)
 
-    assert_equal(func(None, "a", "b", w="x", label="", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-    assert_equal(func(None, "a", "b", w="x", label="text", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+    assert (func(None, "a", "b", w="x", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (func(None, "a", "b", w="x", label="text", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
     func2 = _preprocess_data(replace_all_args=True, replace_names=["w"],
                                 label_namer="y",
@@ -328,12 +318,12 @@ def test_function_call_with_replace_all_args():
                                                             "label", "w"])(
         funcy)
 
-    assert_equal(func2(None, "a", "b", w="x", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
-    assert_equal(func2(None, "a", "b", w="x", label="", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
-    assert_equal(func2(None, "a", "b", w="x", label="text", data=data),
-                 "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
+    assert (func2(None, "a", "b", w="x", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
+    assert (func2(None, "a", "b", w="x", label="", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
+    assert (func2(None, "a", "b", w="x", label="text", data=data) ==
+            "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
 
 def test_docstring_addition():
@@ -342,33 +332,34 @@ def test_docstring_addition():
         """Funcy does nothing"""
         pass
 
-    assert_regex(funcy.__doc__,
-                          r".*All positional and all keyword arguments\.")
-    assert_not_regex(funcy.__doc__, r".*All positional arguments\.")
-    assert_not_regex(funcy.__doc__,
-                              r".*All arguments with the following names: .*")
+    assert re.search(r".*All positional and all keyword arguments\.",
+                     funcy.__doc__)
+    assert not re.search(r".*All positional arguments\.", funcy.__doc__)
+    assert not re.search(r".*All arguments with the following names: .*",
+                         funcy.__doc__)
 
     @_preprocess_data(replace_all_args=True, replace_names=[])
     def funcy(ax, x, y, z, bar=None):
         """Funcy does nothing"""
         pass
 
-    assert_regex(funcy.__doc__, r".*All positional arguments\.")
-    assert_not_regex(funcy.__doc__,
-                              r".*All positional and all keyword arguments\.")
-    assert_not_regex(funcy.__doc__,
-                              r".*All arguments with the following names: .*")
+    assert re.search(r".*All positional arguments\.",
+                     funcy.__doc__)
+    assert not re.search(r".*All positional and all keyword arguments\.",
+                         funcy.__doc__)
+    assert not re.search(r".*All arguments with the following names: .*",
+                         funcy.__doc__)
 
     @_preprocess_data(replace_all_args=True, replace_names=["bar"])
     def funcy(ax, x, y, z, bar=None):
         """Funcy does nothing"""
         pass
 
-    assert_regex(funcy.__doc__, r".*All positional arguments\.")
-    assert_regex(funcy.__doc__,
-                          r".*All arguments with the following names: 'bar'\.")
-    assert_not_regex(funcy.__doc__,
-                              r".*All positional and all keyword arguments\.")
+    assert re.search(r".*All positional arguments\.", funcy.__doc__)
+    assert re.search(r".*All arguments with the following names: 'bar'\.",
+                     funcy.__doc__)
+    assert not re.search(r".*All positional and all keyword arguments\.",
+                         funcy.__doc__)
 
     @_preprocess_data(replace_names=["x", "bar"])
     def funcy(ax, x, y, z, bar=None):
@@ -376,13 +367,14 @@ def test_docstring_addition():
         pass
 
     # lists can print in any order, so test for both x,bar and bar,x
-    assert_regex(funcy.__doc__,
-                    r".*All arguments with the following names: '.*', '.*'\.")
-    assert_regex(funcy.__doc__, r".*'x'.*")
-    assert_regex(funcy.__doc__, r".*'bar'.*")
-    assert_not_regex(funcy.__doc__,
-                              r".*All positional and all keyword arguments\.")
-    assert_not_regex(funcy.__doc__, r".*All positional arguments\.")
+    assert re.search(r".*All arguments with the following names: '.*', '.*'\.",
+                     funcy.__doc__)
+    assert re.search(r".*'x'.*", funcy.__doc__)
+    assert re.search(r".*'bar'.*", funcy.__doc__)
+    assert not re.search(r".*All positional and all keyword arguments\.",
+                         funcy.__doc__)
+    assert not re.search(r".*All positional arguments\.",
+                         funcy.__doc__)
 
 
 def test_positional_parameter_names_as_function():
@@ -396,20 +388,17 @@ def test_positional_parameter_names_as_function():
 
     # the normal case...
     data = {"x": "X", "hy1": "Y"}
-    assert_equal(funcy(None, "x", "hy1", data=data),
-                 "('X', 'Y') | {}")
-    assert_equal(funcy(None, "x", "hy1", "c", data=data),
-                 "('X', 'Y', 'c') | {}")
+    assert funcy(None, "x", "hy1", data=data) == "('X', 'Y') | {}"
+    assert funcy(None, "x", "hy1", "c", data=data) == "('X', 'Y', 'c') | {}"
 
     # no arbitrary long args with data
     def f():
-        assert_equal(funcy(None, "x", "y", "c", "x", "y", "x", "y", data=data),
-                     "('X', 'Y', 'c', 'X', 'Y', 'X', 'Y') | {}")
+        assert (funcy(None, "x", "y", "c", "x", "y", "x", "y", data=data) ==
+                "('X', 'Y', 'c', 'X', 'Y', 'X', 'Y') | {}")
     assert_raises(ValueError, f)
 
     # In the two arg case, if a valid color spec is in data, we warn but use
     # it as data...
     data = {"x": "X", "y": "Y", "ro": "!!"}
     with assert_produces_warning(RuntimeWarning):
-        assert_equal(funcy(None, "y", "ro", data=data),
-                     "('Y', '!!') | {}")
+        assert funcy(None, "y", "ro", data=data) == "('Y', '!!') | {}"

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -21,7 +21,7 @@ def plot_func(ax, x, y, ls="x", label=None, w="xyz"):
 
 
 @_preprocess_data(replace_names=["x", "y"], label_namer="y",
-                     positional_parameter_names=["x", "y", "ls", "label", "w"])
+                  positional_parameter_names=["x", "y", "ls", "label", "w"])
 def plot_func_varags(ax, *args, **kwargs):
     all_args = [None, None, "x", None, "xyz"]
     for i, v in enumerate(args):
@@ -287,7 +287,7 @@ def test_function_call_with_replace_all_args():
             list(x), list(y), ls, w, label)
 
     func = _preprocess_data(replace_all_args=True, replace_names=["w"],
-                               label_namer="y")(funcy)
+                            label_namer="y")(funcy)
 
     assert (func(None, "a", "b", w="x", label="", data=data) ==
             "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: ")
@@ -295,10 +295,9 @@ def test_function_call_with_replace_all_args():
             "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: text")
 
     func2 = _preprocess_data(replace_all_args=True, replace_names=["w"],
-                                label_namer="y",
-                                positional_parameter_names=["x", "y", "ls",
-                                                            "label", "w"])(
-        funcy)
+                             label_namer="y",
+                             positional_parameter_names=["x", "y", "ls",
+                                                         "label", "w"])(funcy)
 
     assert (func2(None, "a", "b", w="x", data=data) ==
             "x: [1, 2], y: [8, 9], ls: x, w: xyz, label: b")
@@ -364,7 +363,7 @@ def test_positional_parameter_names_as_function():
     from matplotlib.axes._axes import _plot_args_replacer
 
     @_preprocess_data(replace_names=["x", "y"],
-                         positional_parameter_names=_plot_args_replacer)
+                      positional_parameter_names=_plot_args_replacer)
     def funcy(ax, *args, **kwargs):
         return "{args} | {kwargs}".format(args=args, kwargs=kwargs)
 


### PR DESCRIPTION
Second largest change after mlab, but mostly automated. Using contexts allows us to drop a whole bunch of extra nested functions in the tests, which cuts down the line-count a bit.