### PR TITLE
[MRG+1] Fix leak of filedescriptor if fontsize cannot be set.

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -508,6 +508,7 @@ FT2Font::FT2Font(FT_Open_Args &open_args, long hinting_factor_) : image(), face(
 
     error = FT_Set_Char_Size(face, 12 * 64, 0, 72 * (unsigned int)hinting_factor, 72);
     if (error) {
+        FT_Done_Face(face);
         throw "Could not set the fontsize";
     }
 


### PR DESCRIPTION
Closes #7922

Should prevent resources warnings from poping up in scipts of the type:

    import warnings
    warnings.simplefilter('default')
    from matplotlib.ft2font import FT2Font
    FT2Font('/System/Library/Fonts/Apple Color Emoji.ttf')