### PR TITLE
[MRG+1] The font with the same weight name as the user specified weight name …

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1204,8 +1204,8 @@ class FontManager(object):
 
         # exact match of the weight names (e.g. weight1 == weight2 == "regular")
         if (isinstance(weight1, six.string_types) and
-            isinstance(weight2, six.string_types) and
-            weight1 == weight2):
+                isinstance(weight2, six.string_types) and
+                weight1 == weight2):
             return 0.0
         try:
             weightval1 = int(weight1)

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -439,9 +439,9 @@ def ttfFontProperty(font):
     weight = next((w for w in weight_dict if sfnt4.find(w) >= 0), None)
     if not weight:
         if font.style_flags & ft2font.BOLD:
-            weight = "bold"
+            weight = 700
         else:
-            weight = "normal"
+            weight = 400
 
     #  Stretch can be absolute and relative
     #  Absolute stretches are: ultra-condensed, extra-condensed, condensed,

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -37,13 +37,11 @@ def test_ttflist_weight():
 
 
 def test_score_weight():
-    assert (0 ==
-            fontManager.score_weight("regular", "regular") ==
-            fontManager.score_weight("bold", "bold") <
-            fontManager.score_weight(400, 400) ==
-            # "normal" and "regular" have the same numerical weight
-            fontManager.score_weight("normal", "regular") <
-            fontManager.score_weight("normal", "bold"))
+    assert 0 == fontManager.score_weight("regular", "regular")
+    assert 0 == fontManager.score_weight("bold", "bold")
+    assert 0 < fontManager.score_weight(400, 400) < fontManager.score_weight("normal", "bold")
+    assert 0 < fontManager.score_weight("normal", "regular") < fontManager.score_weight("normal", "bold")
+    assert fontManager.score_weight("normal", "regular") == fontManager.score_weight(400, 400)
 
 
 def test_json_serialization():

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -31,6 +31,20 @@ def test_font_priority():
     assert cmap[8729] == 30
 
 
+def test_ttflist_weight():
+    assert all(isinstance(f.weight, six.string_types)
+               for f in fontManager.ttflist)
+
+
+def test_score_weight():
+    assert (0 ==
+            fontManager.score_weight("regular", "regular") ==
+            fontManager.score_weight("bold", "bold") <
+            fontManager.score_weight("normal", "regular") ==
+            fontManager.score_weight(400, 400) <
+            fontManager.score_weight("normal", "bold"))
+
+
 def test_json_serialization():
     # on windows, we can't open a file twice, so save the name and unlink
     # manually...

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -34,9 +34,12 @@ def test_font_priority():
 def test_score_weight():
     assert 0 == fontManager.score_weight("regular", "regular")
     assert 0 == fontManager.score_weight("bold", "bold")
-    assert 0 < fontManager.score_weight(400, 400) < fontManager.score_weight("normal", "bold")
-    assert 0 < fontManager.score_weight("normal", "regular") < fontManager.score_weight("normal", "bold")
-    assert fontManager.score_weight("normal", "regular") == fontManager.score_weight(400, 400)
+    assert (0 < fontManager.score_weight(400, 400) <
+            fontManager.score_weight("normal", "bold"))
+    assert (0 < fontManager.score_weight("normal", "regular") <
+            fontManager.score_weight("normal", "bold"))
+    assert (fontManager.score_weight("normal", "regular") ==
+            fontManager.score_weight(400, 400))
 
 
 def test_json_serialization():

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -31,11 +31,6 @@ def test_font_priority():
     assert cmap[8729] == 30
 
 
-def test_ttflist_weight():
-    assert all(isinstance(f.weight, six.string_types)
-               for f in fontManager.ttflist)
-
-
 def test_score_weight():
     assert 0 == fontManager.score_weight("regular", "regular")
     assert 0 == fontManager.score_weight("bold", "bold")

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -40,8 +40,9 @@ def test_score_weight():
     assert (0 ==
             fontManager.score_weight("regular", "regular") ==
             fontManager.score_weight("bold", "bold") <
-            fontManager.score_weight("normal", "regular") ==
-            fontManager.score_weight(400, 400) <
+            fontManager.score_weight(400, 400) ==
+            # "normal" and "regular" have the same numerical weight
+            fontManager.score_weight("normal", "regular") <
             fontManager.score_weight("normal", "bold"))
 
 


### PR DESCRIPTION
…should have the highest priority

FiraSans-Hair and FiraSans-Regular has the same numeric weight, 400, and thus they have the same priority for the previous `score_weight` implementation.
However, it is clear that if an user set `rcParams["weight"] = "regular"`, the user wants FiraSans-Regular, not FiraSans-Hair.