### PR TITLE
[MRG+1] Finish removing nose

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -20,28 +20,6 @@ def is_called_from_pytest():
     return getattr(matplotlib, '_called_from_pytest', False)
 
 
-def xfail(msg=""):
-    """Explicitly fail an currently-executing test with the given message."""
-    __tracebackhide__ = True
-    if is_called_from_pytest():
-        import pytest
-        pytest.xfail(msg)
-    else:
-        from .nose import knownfail
-        knownfail(msg)
-
-
-def skip(msg=""):
-    """Skip an executing test with the given message."""
-    __tracebackhide__ = True
-    if is_called_from_pytest():
-        import pytest
-        pytest.skip(msg)
-    else:
-        from nose import SkipTest
-        raise SkipTest(msg)
-
-
 # stolen from pytest
 def getrawcode(obj, trycall=True):
     """Return code object for given function."""

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -21,7 +21,7 @@ def is_called_from_pytest():
 
 
 # stolen from pytest
-def getrawcode(obj, trycall=True):
+def _getrawcode(obj, trycall=True):
     """Return code object for given function."""
     try:
         return obj.__code__
@@ -38,7 +38,7 @@ def getrawcode(obj, trycall=True):
         return obj
 
 
-def copy_metadata(src_func, tgt_func):
+def _copy_metadata(src_func, tgt_func):
     """Replicates metadata of the function. Returns target function."""
     tgt_func.__dict__.update(src_func.__dict__)
     tgt_func.__doc__ = src_func.__doc__
@@ -47,7 +47,7 @@ def copy_metadata(src_func, tgt_func):
     if hasattr(src_func, '__qualname__'):
         tgt_func.__qualname__ = src_func.__qualname__
     if not hasattr(tgt_func, 'compat_co_firstlineno'):
-        tgt_func.compat_co_firstlineno = getrawcode(src_func).co_firstlineno
+        tgt_func.compat_co_firstlineno = _getrawcode(src_func).co_firstlineno
     return tgt_func
 
 

--- a/lib/matplotlib/testing/_nose/decorators.py
+++ b/lib/matplotlib/testing/_nose/decorators.py
@@ -9,45 +9,6 @@ from . import knownfail
 from .exceptions import KnownFailureDidNotFailTest
 
 
-def skipif(skip_condition, *args, **kwargs):
-    if isinstance(skip_condition, bool) and 'reason' not in kwargs:
-        raise ValueError("you need to specify reason=STRING "
-                         "when using booleans as conditions.")
-
-    def skip_decorator(func):
-        import inspect
-
-        def skipper(*_args, **_kwargs):
-            condition, msg = skip_condition, kwargs.get('reason')  # local copy
-            if isinstance(condition, six.string_types):
-                globs = {'os': os, 'sys': sys}
-                try:
-                    globs.update(func.__globals__)
-                except AttributeError:
-                    globs.update(func.func_globals)
-                if msg is None:
-                    msg = condition
-                condition = eval(condition, globs)
-            else:
-                condition = bool(condition)
-
-            if condition:
-                skip(msg)
-            else:
-                return func(*_args, **_kwargs)
-
-        if inspect.isclass(func):
-            setup = getattr(func, 'setup_class', classmethod(lambda _: None))
-            setup = skip_decorator(setup.__func__)
-            setup = setup.__get__(func)
-            setattr(func, 'setup_class', setup)
-            return func
-
-        return copy_metadata(func, skipper)
-
-    return skip_decorator
-
-
 def knownfailureif(fail_condition, msg=None, known_exception_class=None):
     # based on numpy.testing.dec.knownfailureif
     if msg is None:

--- a/lib/matplotlib/testing/_nose/decorators.py
+++ b/lib/matplotlib/testing/_nose/decorators.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import six
 import sys
-from .. import copy_metadata, skip
+from .. import copy_metadata
 from . import knownfail
 from .exceptions import KnownFailureDidNotFailTest
 

--- a/lib/matplotlib/testing/_nose/decorators.py
+++ b/lib/matplotlib/testing/_nose/decorators.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import six
 import sys
-from .. import copy_metadata
+from .. import _copy_metadata
 from . import knownfail
 from .exceptions import KnownFailureDidNotFailTest
 
@@ -31,5 +31,5 @@ def knownfailureif(fail_condition, msg=None, known_exception_class=None):
             if fail_condition and fail_condition != 'indeterminate':
                 raise KnownFailureDidNotFailTest(msg)
             return result
-        return copy_metadata(f, failer)
+        return _copy_metadata(f, failer)
     return known_fail_decorator

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -174,8 +174,14 @@ def convert(filename, cache):
     """
     base, extension = filename.rsplit('.', 1)
     if extension not in converter:
-        from nose import SkipTest
-        raise SkipTest("Don't know how to convert %s files to png" % extension)
+        reason = "Don't know how to convert %s files to png" % extension
+        from . import is_called_from_pytest
+        if is_called_from_pytest():
+            import pytest
+            pytest.skip(reason)
+        else:
+            from nose import SkipTest
+            raise SkipTest(reason)
     newname = base + '_' + extension + '.png'
     if not os.path.exists(filename):
         raise IOError("'%s' does not exist" % filename)

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -26,7 +26,7 @@ from matplotlib import pyplot as plt
 from matplotlib import ft2font
 from matplotlib.testing.compare import comparable_formats, compare_images, \
      make_test_filename
-from . import copy_metadata, is_called_from_pytest
+from . import _copy_metadata, is_called_from_pytest
 from .exceptions import ImageComparisonFailure
 
 
@@ -335,7 +335,7 @@ class ImageComparisonDecorator(CleanupTest):
     def __call__(self, func):
         self.delayed_init(func)
         if is_called_from_pytest():
-            return copy_metadata(func, self.pytest_runner())
+            return _copy_metadata(func, self.pytest_runner())
         else:
             import nose.tools
 
@@ -348,7 +348,7 @@ class ImageComparisonDecorator(CleanupTest):
                     # nose bug...
                     self.teardown()
 
-            return copy_metadata(func, runner_wrapper)
+            return _copy_metadata(func, runner_wrapper)
 
 
 def image_comparison(baseline_images=None, extensions=None, tol=0,
@@ -484,7 +484,7 @@ def switch_backend(backend):
                 plt.switch_backend(prev_backend)
             return result
 
-        return copy_metadata(func, backend_switcher)
+        return _copy_metadata(func, backend_switcher)
     return switch_backend_decorator
 
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -30,20 +30,6 @@ from . import copy_metadata, is_called_from_pytest, xfail
 from .exceptions import ImageComparisonFailure
 
 
-def skipif(condition, *args, **kwargs):
-    """Skip the given test function if eval(condition) results in a True
-    value.
-
-    Optionally specify a reason for better reporting.
-    """
-    if is_called_from_pytest():
-        import pytest
-        return pytest.mark.skipif(condition, *args, **kwargs)
-    else:
-        from ._nose.decorators import skipif
-        return skipif(condition, *args, **kwargs)
-
-
 def knownfailureif(fail_condition, msg=None, known_exception_class=None):
     """
 
@@ -516,6 +502,7 @@ def skip_if_command_unavailable(cmd):
     try:
         check_output(cmd)
     except:
-        return skipif(True, reason='missing command: %s' % cmd[0])
+        import pytest
+        return pytest.mark.skip(reason='missing command: %s' % cmd[0])
 
     return lambda f: f

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -26,7 +26,7 @@ from matplotlib import pyplot as plt
 from matplotlib import ft2font
 from matplotlib.testing.compare import comparable_formats, compare_images, \
      make_test_filename
-from . import copy_metadata, is_called_from_pytest, xfail
+from . import copy_metadata, is_called_from_pytest
 from .exceptions import ImageComparisonFailure
 
 
@@ -270,9 +270,10 @@ class ImageComparisonDecorator(CleanupTest):
         if os.path.exists(orig_expected_fname):
             shutil.copyfile(orig_expected_fname, expected_fname)
         else:
-            xfail("Do not have baseline image {0} because this "
-                  "file does not exist: {1}".format(expected_fname,
-                                                    orig_expected_fname))
+            from .nose import knownfail
+            knownfail("Do not have baseline image {0} because this "
+                      "file does not exist: {1}".format(expected_fname,
+                                                        orig_expected_fname))
         return expected_fname
 
     def compare(self, idx, baseline, extension):

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -11,7 +11,6 @@ import pytest
 from matplotlib.image import imread
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
-from matplotlib.testing import skip
 from matplotlib.testing.decorators import cleanup, image_comparison
 from matplotlib import pyplot as plt
 from matplotlib import collections
@@ -181,7 +180,7 @@ def test_agg_filter():
             return t2
 
     if LooseVersion(np.__version__) < LooseVersion('1.7.0'):
-        skip('Disabled on Numpy < 1.7.0')
+        pytest.skip('Disabled on Numpy < 1.7.0')
 
     fig = plt.figure()
     ax = fig.add_subplot(111)

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -179,9 +179,6 @@ def test_agg_filter():
             t2 = self.offset_filter.process_image(t1, dpi)
             return t2
 
-    if LooseVersion(np.__version__) < LooseVersion('1.7.0'):
-        pytest.skip('Disabled on Numpy < 1.7.0')
-
     fig = plt.figure()
     ax = fig.add_subplot(111)
 

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -13,7 +13,6 @@ import pytest
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 from matplotlib import animation
-from matplotlib.testing import xfail, skip
 from matplotlib.testing.decorators import cleanup
 
 
@@ -121,7 +120,7 @@ def test_save_animation_smoketest(tmpdir, writer, extension):
     except AttributeError:
         pass
     if not animation.writers.is_available(writer):
-        skip("writer '%s' not available on this system" % writer)
+        pytest.skip("writer '%s' not available on this system" % writer)
     fig, ax = plt.subplots()
     line, = ax.plot([], [])
 
@@ -145,8 +144,8 @@ def test_save_animation_smoketest(tmpdir, writer, extension):
         try:
             anim.save('movie.' + extension, fps=30, writer=writer, bitrate=500)
         except UnicodeDecodeError:
-            xfail("There can be errors in the numpy import stack, "
-                  "see issues #1891 and #2679")
+            pytest.xfail("There can be errors in the numpy import stack, "
+                         "see issues #1891 and #2679")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -21,7 +21,6 @@ import warnings
 
 import matplotlib
 from matplotlib.testing.decorators import image_comparison, cleanup
-from matplotlib.testing import skip
 import matplotlib.pyplot as plt
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
@@ -90,7 +89,7 @@ def test_formatter_ticker():
 def test_formatter_large_small():
     # github issue #617, pull #619
     if LooseVersion(np.__version__) >= LooseVersion('1.11.0'):
-        skip("Fall out from a fixed numpy bug")
+        pytest.skip("Fall out from a fixed numpy bug")
     fig, ax = plt.subplots(1)
     x = [0.500000001, 0.500000002]
     y = [1e64, 1.1e64]

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -17,9 +17,13 @@ from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib import pyplot as plt
 from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
-from matplotlib.testing.decorators import (image_comparison, knownfailureif,
-                                           cleanup)
+from matplotlib.testing.decorators import image_comparison, cleanup
 from matplotlib import dviread
+
+
+needs_tex = pytest.mark.xfail(
+    not checkdep_tex(),
+    reason="This test needs a TeX installation")
 
 
 @image_comparison(baseline_images=['pdf_use14corefonts'],
@@ -42,10 +46,6 @@ and containing some French characters and the euro symbol:
             verticalalignment='bottom',
             fontsize=14)
     ax.axhline(0.5, linewidth=0.5)
-
-needs_tex = knownfailureif(
-    not checkdep_tex(),
-    "This test needs a TeX installation")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -5,7 +5,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import io
 import re
+
 import numpy as np
+import pytest
 import six
 
 import matplotlib
@@ -13,17 +15,17 @@ import matplotlib.pyplot as plt
 from matplotlib import patheffects
 from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
-from matplotlib.testing.decorators import cleanup, knownfailureif
+from matplotlib.testing.decorators import cleanup
 
 
-needs_ghostscript = knownfailureif(
+needs_ghostscript = pytest.mark.xfail(
     matplotlib.checkdep_ghostscript()[0] is None,
-    "This test needs a ghostscript installation")
+    reason="This test needs a ghostscript installation")
 
 
-needs_tex = knownfailureif(
+needs_tex = pytest.mark.xfail(
     not matplotlib.checkdep_tex(),
-    "This test needs a TeX installation")
+    reason="This test needs a TeX installation")
 
 
 def _test_savefig_to_stringio(format='ps', use_log=False):

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -13,14 +13,14 @@ import pytest
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
-from matplotlib.testing.decorators import image_comparison, knownfailureif
+from matplotlib.testing.decorators import image_comparison
 import matplotlib
 from matplotlib import dviread
 
 
-needs_tex = knownfailureif(
+needs_tex = pytest.mark.xfail(
     not matplotlib.checkdep_tex(),
-    "This test needs a TeX installation")
+    reason="This test needs a TeX installation")
 
 
 @cleanup

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -4,51 +4,9 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import sys
 
-from ..testing.decorators import skipif
-
-
-SKIPIF_CONDITION = []
-
-
-def setup_module():
-    SKIPIF_CONDITION.append(None)
-
 
 def test_simple():
     assert 1 + 1 == 2
-
-
-@skipif(True, reason="skipif decorator test with bool condition passed")
-def test_skipif_bool():
-    assert False, "skipif decorator does not work with bool condition"
-
-
-@skipif('SKIPIF_CONDITION',
-        reason="skipif decorator test with string condition passed")
-def test_skipif_string():
-    assert False, "skipif decorator does not work with string condition"
-
-
-@skipif(True, reason="skipif decorator on class test passed")
-class Test_skipif_on_class(object):
-    def test(self):
-        assert False, "skipif decorator does not work on classes"
-
-
-class Test_skipif_on_method(object):
-    @skipif(True, reason="skipif decorator on method test passed")
-    def test(self):
-        assert False, "skipif decorator does not work on methods"
-
-
-@skipif(True, reason="skipif decorator on classmethod test passed")
-class Test_skipif_on_classmethod(object):
-    @classmethod
-    def setup_class(cls):
-        pass
-
-    def test(self):
-        assert False, "skipif decorator does not work on classmethods"
 
 
 def test_override_builtins():

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import sys
 
-from ..testing.decorators import knownfailureif, skipif
+from ..testing.decorators import skipif
 
 
 SKIPIF_CONDITION = []
@@ -16,12 +16,6 @@ def setup_module():
 
 def test_simple():
     assert 1 + 1 == 2
-
-
-@knownfailureif(True)
-def test_simple_knownfail():
-    # Test the known fail mechanism.
-    assert 1 + 1 == 3
 
 
 @skipif(True, reason="skipif decorator test with bool condition passed")

--- a/lib/matplotlib/tests/test_coding_standards.py
+++ b/lib/matplotlib/tests/test_coding_standards.py
@@ -5,7 +5,6 @@ from fnmatch import fnmatch
 import os
 
 import pytest
-from ..testing import xfail
 
 try:
     import pep8
@@ -249,8 +248,8 @@ def test_pep8_conformance_examples():
             fp, tail = os.path.split(fp)
 
     if mpldir is None:
-        xfail("can not find the examples, set env MPL_REPO_DIR to point "
-              "to the top-level path of the source tree")
+        pytest.xfail("can not find the examples, set env MPL_REPO_DIR to "
+                     "point to the top-level path of the source tree")
 
     exdir = os.path.join(mpldir, 'examples')
     blacklist = ()

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -18,8 +18,7 @@ import matplotlib.cm as cm
 import matplotlib.colorbar as mcolorbar
 import matplotlib.cbook as cbook
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import (image_comparison,
-                                           cleanup, knownfailureif)
+from matplotlib.testing.decorators import image_comparison, cleanup
 
 
 def test_resample():
@@ -448,8 +447,8 @@ def test_light_source_shading_default():
     assert_array_almost_equal(rgb, expect, decimal=2)
 
 
-@knownfailureif((V(np.__version__) <= V('1.9.0')
-                and V(np.__version__) >= V('1.7.0')))
+@pytest.mark.xfail(V('1.7.0') <= V(np.__version__) <= V('1.9.0'),
+                   reason='NumPy version is not buggy')
 # Numpy 1.9.1 fixed a bug in masked arrays which resulted in
 # additional elements being masked when calculating the gradient thus
 # the output is different with earlier numpy versions.

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -8,11 +8,12 @@ import sys
 import tempfile
 import warnings
 
+import pytest
+
 from matplotlib.font_manager import (
     findfont, FontProperties, fontManager, json_dump, json_load, get_font,
     get_fontconfig_fonts, is_opentype_cff_font, fontManager as fm)
 from matplotlib import rc_context
-from matplotlib.testing.decorators import skipif
 
 
 def test_font_priority():
@@ -64,6 +65,6 @@ def test_otf():
         assert res == is_opentype_cff_font(f)
 
 
-@skipif(sys.platform == 'win32', reason='no fontconfig on Windows')
+@pytest.mark.skipif(sys.platform == 'win32', reason='no fontconfig on Windows')
 def test_get_fontconfig_fonts():
     assert len(get_fontconfig_fonts()) > 1

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -9,8 +9,7 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from matplotlib.testing.decorators import (image_comparison,
-                                           knownfailureif, cleanup)
+from matplotlib.testing.decorators import image_comparison, cleanup
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
 from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
@@ -31,6 +30,7 @@ try:
     HAS_PIL = True
 except ImportError:
     HAS_PIL = False
+needs_pillow = pytest.mark.xfail(not HAS_PIL, reason='Test requires Pillow')
 
 
 @image_comparison(baseline_images=['image_interps'])
@@ -101,7 +101,7 @@ def test_image_python_io():
     plt.imread(buffer)
 
 
-@knownfailureif(not HAS_PIL)
+@needs_pillow
 def test_imread_pil_uint16():
     img = plt.imread(os.path.join(os.path.dirname(__file__),
                      'baseline_images', 'test_image', 'uint16.tif'))
@@ -480,7 +480,7 @@ def test_nonuniformimage_setnorm():
     im.set_norm(plt.Normalize())
 
 
-@knownfailureif(not HAS_PIL)
+@needs_pillow
 @cleanup
 def test_jpeg_alpha():
     plt.figure(figsize=(1, 1), dpi=300)

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import matplotlib
-from matplotlib.testing.decorators import image_comparison, knownfailureif, cleanup
+from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 from matplotlib import mathtext
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -14,7 +14,7 @@ import pytest
 
 import matplotlib.mlab as mlab
 import matplotlib.cbook as cbook
-from matplotlib.testing.decorators import knownfailureif, CleanupTestCase
+from matplotlib.testing.decorators import CleanupTestCase
 
 
 try:
@@ -2837,7 +2837,7 @@ def test_griddata_linear():
                                   np.ma.getmask(correct_zi_masked))
 
 
-@knownfailureif(not HAS_NATGRID)
+@pytest.mark.xfail(not HAS_NATGRID, reason='natgrid not installed')
 def test_griddata_nn():
     # z is a linear function of x and y.
     def get_z(x, y):

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -2,9 +2,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+import pytest
 
-from matplotlib.testing.decorators import (image_comparison, cleanup,
-                                           knownfailureif)
+from matplotlib.testing.decorators import image_comparison, cleanup
 import matplotlib.pyplot as plt
 import matplotlib.patheffects as path_effects
 
@@ -76,7 +76,7 @@ def test_patheffect3():
 
 
 @cleanup
-@knownfailureif(True)
+@pytest.mark.xfail
 def test_PathEffect_points_to_pixels():
     fig = plt.figure(dpi=150)
     p1, = plt.plot(range(10))

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -18,7 +18,7 @@ except ImportError:
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.tests import assert_str_equal
-from matplotlib.testing.decorators import cleanup, knownfailureif
+from matplotlib.testing.decorators import cleanup
 import matplotlib.colors as mcolors
 from itertools import chain
 import numpy as np

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from matplotlib.testing.decorators import image_comparison, knownfailureif
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 from matplotlib.offsetbox import AnchoredOffsetbox, DrawingArea
 from matplotlib.patches import Rectangle


### PR DESCRIPTION
I tried to keep anything in `testing` compatible with both nose and pytest for now, but anything _new_ has been either removed/replaced or privatized so that people don't depend on it any further.

It works locally on Python 3, but let's see how CI likes it.