### PR TITLE
[WIP] Merge pull request #7907 from jkseppan/fc-list-format

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -281,7 +281,7 @@ def _call_fc_list():
         'This may take a moment.'))
     timer.start()
     try:
-        out = subprocess.check_output([str('fc-list'), '--format=%{file}'])
+        out = subprocess.check_output([str('fc-list'), '--format=%{file}\\n'])
     except (OSError, subprocess.CalledProcessError):
         return []
     finally:

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -6,8 +6,10 @@ import six
 
 import os
 import os.path
-from matplotlib.font_manager import (findfont, FontProperties, get_font,
-                                     is_opentype_cff_font, fontManager as fm)
+import sys
+from matplotlib.font_manager import (
+    findfont, FontProperties, get_font, get_fontconfig_fonts,
+    is_opentype_cff_font, fontManager as fm)
 from matplotlib import rc_context
 
 
@@ -36,3 +38,8 @@ def test_otf():
         with open(f, 'rb') as fd:
             res = fd.read(4) == b'OTTO'
         assert res == is_opentype_cff_font(f)
+
+
+def test_get_fontconfig_fonts():
+    if sys.platform != 'win32':
+        assert len(get_fontconfig_fonts()) > 1


### PR DESCRIPTION
BUG: Add a newline separator in fc-list call

Conflicts:
	lib/matplotlib/tests/test_font_manager.py
	 - only backport the fix not the test as it uses a decorator
	that does not exist in 2.0.x

This needs to have a test added, but putting here as a place holder so I do not forget.