### PR TITLE
Improve hexbin performance

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4273,13 +4273,18 @@ or tuple of floats
             lattice1 = np.zeros((nx1, ny1))
             lattice2 = np.zeros((nx2, ny2))
 
-            for i in xrange(len(x)):
-                if bdist[i]:
-                    if 0 <= ix1[i] < nx1 and 0 <= iy1[i] < ny1:
-                        lattice1[ix1[i], iy1[i]] += 1
-                else:
-                    if 0 <= ix2[i] < nx2 and 0 <= iy2[i] < ny2:
-                        lattice2[ix2[i], iy2[i]] += 1
+            cond1 = (0 <= ix1) * (ix1 < nx1) * (0 <= iy1) * (iy1 < ny1)
+            cond2 = (0 <= ix2) * (ix2 < nx2) * (0 <= iy2) * (iy2 < ny2)
+
+            cond1 *= bdist
+            cond2 *= np.logical_not(bdist)
+            ix1, iy1 = ix1[cond1], iy1[cond1]
+            ix2, iy2 = ix2[cond2], iy2[cond2]
+
+            for i in xrange(ix1.size):
+                lattice1[ix1[i], iy1[i]] += 1
+            for i in xrange(ix2.size):
+                lattice2[ix2[i], iy2[i]] += 1
 
             # threshold
             if mincnt is not None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4281,10 +4281,10 @@ or tuple of floats
             ix1, iy1 = ix1[cond1], iy1[cond1]
             ix2, iy2 = ix2[cond2], iy2[cond2]
 
-            for i in xrange(ix1.size):
-                lattice1[ix1[i], iy1[i]] += 1
-            for i in xrange(ix2.size):
-                lattice2[ix2[i], iy2[i]] += 1
+            for ix, iy in zip(ix1, iy1):
+                lattice1[ix, iy] += 1
+            for ix, iy in zip(ix2, iy2):
+                lattice2[ix, iy] += 1
 
             # threshold
             if mincnt is not None:


### PR DESCRIPTION
A large chunk of time in `hexbin` is spent binning the data. This PR speeds that up by converting some if statements to matrix multiplication, and reducing the length of the remaining for loops.

I've tested the speedup using the following code:
```
import matplotlib.pyplot as plt
import numpy as np
import time

for i in range(1, 7):
    x = np.random.rand(10**i)
    y = np.random.rand(10**i)
    start = time.time()
    plt.hexbin(x, y)
    end = time.time()
    print(i, end - start)
```

Before, this prints
```
1 0.07006597518920898
2 0.0029900074005126953
3 0.0072820186614990234
4 0.0190579891204834
5 0.19024014472961426
6 1.8048720359802246
```

After my changes it prints
```
1 0.06623506546020508
2 0.002410888671875
3 0.006618022918701172
4 0.009796142578125
5 0.1008000373840332
6 0.9016518592834473
```

so for large arrays there's ~50% speedup.