### PR TITLE
fix StixSans mapping bug

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1002,7 +1002,10 @@ class StixFonts(UnicodeFonts):
 
         if mapping is not None:
             if isinstance(mapping, dict):
-                mapping = mapping.get(font_class, 'rm')
+                try:
+                    mapping = mapping[font_class]
+                except KeyError:
+                    mapping = mapping['rm']
 
             # Binary search for the source glyph
             lo = 0


### PR DESCRIPTION
Use default map 'rm' if given font class is not found,
Fix for issue [#7939](https://github.com/matplotlib/matplotlib/issues/7939)