### PR TITLE
[MRG+1] Allow zero sized ticks

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2020,7 +2020,10 @@ class XAxis(Axis):
         # There is a heuristic here that the aspect ratio of tick text
         # is no more than 3:1
         size = tick.label1.get_size() * 3
-        return int(np.floor(length / size))
+        if size > 0:
+            return int(np.floor(length / size))
+        else:
+            return 2**31 - 1
 
 
 class YAxis(Axis):
@@ -2353,4 +2356,7 @@ class YAxis(Axis):
         tick = self._get_tick(True)
         # Having a spacing of at least 2 just looks good.
         size = tick.label1.get_size() * 2.0
-        return int(np.floor(length / size))
+        if size > 0:
+            return int(np.floor(length / size))
+        else:
+            return 2**31 - 1

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2341,6 +2341,16 @@ def test_manage_xticks():
     assert_array_equal(old_xlim, new_xlim)
 
 
+@cleanup
+def test_size0_ticks():
+    # allow font size to be zero, which affects ticks when there is
+    # no other text in the figure.
+    plt.plot([0, 1], [0, 1])
+    matplotlib.rcParams.update({'font.size': 0})
+    b = io.BytesIO()
+    plt.savefig(b, dpi=80, format='raw')
+
+
 @image_comparison(baseline_images=['errorbar_basic', 'errorbar_mixed',
                                    'errorbar_basic'])
 def test_errorbar():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2342,7 +2342,7 @@ def test_manage_xticks():
 
 
 @cleanup
-def test_size0_ticks():
+def test_tick_space_size_0():
     # allow font size to be zero, which affects ticks when there is
     # no other text in the figure.
     plt.plot([0, 1], [0, 1])


### PR DESCRIPTION
This addresses an issue with savefig() when there are no ticks present. In axis.py,

```python
    def get_tick_space(self):
        ends = self.axes.transAxes.transform([[0, 0], [1, 0]])
        length = ((ends[1][0] - ends[0][0]) / self.axes.figure.dpi) * 72.0
        tick = self._get_tick(True)
        # There is a heuristic here that the aspect ratio of tick text
        # is no more than 3:1
        size = tick.label1.get_size() * 3
       return int(np.floor(length / size))
```

if `size == 0`, then the this will be effectively, `int(np.floor(np.infty))` which fails on integer conversion with,

```
>>> int(np.floor(np.infty))
OverflowError: cannot convert float infinity to integer
```

Since this is directly used in `ticker.py` in `_raw_ticks.py` in a minimization, it is sufficient to just return a 'big' number.  The full traceback we are seeing in the xonsh test suite is, 

```
__________________________________ test_mpl_preserve_image_tight ___________________________________

    def test_mpl_preserve_image_tight():
        """Make sure that the figure preserves height settings"""
        f = create_figure()
        exp = mplhooks.figure_to_rgb_array(f)
        width, height = f.canvas.get_width_height()
>       s = mplhooks.figure_to_tight_array(f, 0.5*width, 0.5*height, True)

test_mpl.py:94: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../xontrib/mplhooks.py:105: in figure_to_tight_array
    array = figure_to_rgb_array(fig, shape=(height, width, 4))
../xontrib/mplhooks.py:48: in figure_to_rgb_array
    array = np.frombuffer(_get_buffer(fig, dpi=fig.dpi, format='raw').read(), dtype='uint8')
../xontrib/mplhooks.py:24: in _get_buffer
    fig.savefig(b, **kwargs)
../../miniconda/lib/python3.5/site-packages/matplotlib/figure.py:1572: in savefig
    self.canvas.print_figure(*args, **kwargs)
../../miniconda/lib/python3.5/site-packages/matplotlib/backends/backend_qt5agg.py:222: in print_figure
    FigureCanvasAgg.print_figure(self, *args, **kwargs)
../../miniconda/lib/python3.5/site-packages/matplotlib/backend_bases.py:2244: in print_figure
    **kwargs)
../../miniconda/lib/python3.5/site-packages/matplotlib/backends/backend_agg.py:526: in print_raw
    FigureCanvasAgg.draw(self)
../../miniconda/lib/python3.5/site-packages/matplotlib/backends/backend_agg.py:464: in draw
    self.figure.draw(self.renderer)
../../miniconda/lib/python3.5/site-packages/matplotlib/artist.py:63: in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
../../miniconda/lib/python3.5/site-packages/matplotlib/figure.py:1143: in draw
    renderer, self, dsu, self.suppressComposite)
../../miniconda/lib/python3.5/site-packages/matplotlib/image.py:139: in _draw_list_compositing_images
    a.draw(renderer)
../../miniconda/lib/python3.5/site-packages/matplotlib/artist.py:63: in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
../../miniconda/lib/python3.5/site-packages/matplotlib/axes/_base.py:2409: in draw
    mimage._draw_list_compositing_images(renderer, self, dsu)
../../miniconda/lib/python3.5/site-packages/matplotlib/image.py:139: in _draw_list_compositing_images
    a.draw(renderer)
../../miniconda/lib/python3.5/site-packages/matplotlib/artist.py:63: in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
../../miniconda/lib/python3.5/site-packages/matplotlib/axis.py:1136: in draw
    ticks_to_draw = self._update_ticks(renderer)
../../miniconda/lib/python3.5/site-packages/matplotlib/axis.py:969: in _update_ticks
    tick_tups = [t for t in self.iter_ticks()]
../../miniconda/lib/python3.5/site-packages/matplotlib/axis.py:969: in <listcomp>
    tick_tups = [t for t in self.iter_ticks()]
../../miniconda/lib/python3.5/site-packages/matplotlib/axis.py:912: in iter_ticks
    majorLocs = self.major.locator()
../../miniconda/lib/python3.5/site-packages/matplotlib/ticker.py:1794: in __call__
    return self.tick_values(vmin, vmax)
../../miniconda/lib/python3.5/site-packages/matplotlib/ticker.py:1802: in tick_values
    locs = self._raw_ticks(vmin, vmax)
../../miniconda/lib/python3.5/site-packages/matplotlib/ticker.py:1744: in _raw_ticks
    nbins = max(min(self.axis.get_tick_space(), 9),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <matplotlib.axis.XAxis object at 0x7fe9effe7390>

    def get_tick_space(self):
        ends = self.axes.transAxes.transform([[0, 0], [1, 0]])
        length = ((ends[1][0] - ends[0][0]) / self.axes.figure.dpi) * 72.0
        tick = self._get_tick(True)
        # There is a heuristic here that the aspect ratio of tick text
        # is no more than 3:1
        size = tick.label1.get_size() * 3
>       return int(np.floor(length / size))
E       OverflowError: cannot convert float infinity to integer

../../miniconda/lib/python3.5/site-packages/matplotlib/axis.py:2024: OverflowError
```