### PR TITLE
ENH: Fixed PercentFormatter usage with latex

### DIFF
--- a/examples/pylab_examples/histogram_percent_demo.py
+++ b/examples/pylab_examples/histogram_percent_demo.py
@@ -1,30 +1,19 @@
 import matplotlib
 from numpy.random import randn
 import matplotlib.pyplot as plt
-from matplotlib.ticker import FuncFormatter
+from matplotlib.ticker import PercentFormatter
 
-
-def to_percent(y, position):
-    # Ignore the passed in position. This has the effect of scaling the default
-    # tick locations.
-    s = str(100 * y)
-
-    # The percent symbol needs escaping in latex
-    if matplotlib.rcParams['text.usetex'] is True:
-        return s + r'$\%$'
-    else:
-        return s + '%'
 
 x = randn(5000)
 
+# Create a figure with some axes. This makes it easier to set the
+# formatter later, since that is only available through the OO API.
+fig, ax = plt.subplots()
+
 # Make a normed histogram. It'll be multiplied by 100 later.
-plt.hist(x, bins=50, normed=True)
+ax.hist(x, bins=50, normed=True)
 
-# Create the formatter using the function to_percent. This multiplies all the
-# default labels by 100, making them all percentages
-formatter = FuncFormatter(to_percent)
-
-# Set the formatter
-plt.gca().yaxis.set_major_formatter(formatter)
+# Set the formatter. `xmax` sets the value that maps to 100%.
+ax.yaxis.set_major_formatter(PercentFormatter(xmax=1))
 
 plt.show()

--- a/examples/ticks_and_spines/tick-formatters.py
+++ b/examples/ticks_and_spines/tick-formatters.py
@@ -21,8 +21,8 @@ def setup(ax):
     ax.patch.set_alpha(0.0)
 
 
-plt.figure(figsize=(8, 5))
-n = 6
+plt.figure(figsize=(8, 6))
+n = 7
 
 # Null formatter
 ax = plt.subplot(n, 1, 1)
@@ -85,6 +85,15 @@ ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
 ax.xaxis.set_major_formatter(ticker.StrMethodFormatter("{x}"))
 ax.text(0.0, 0.1, "StrMethodFormatter('{x}')",
+        fontsize=15, transform=ax.transAxes)
+
+# Percent formatter
+ax = plt.subplot(n, 1, 7)
+setup(ax)
+ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
+ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
+ax.xaxis.set_major_formatter(ticker.PercentFormatter(xmax=5))
+ax.text(0.0, 0.1, "PercentFormatter(xmax=5)",
         fontsize=15, transform=ax.transAxes)
 
 # Push the top of the top axes outside the figure because we only show the


### PR DESCRIPTION
This PR addresses a nagging issue that I have had with PercentFormatter, namely that it does not handle LaTeX labels correctly unless preconfigured to do so. The proposed solution allows the labels to be generated correctly with the same formatter even if `rcParams['text.usetex']` changes between calls.

I also added it to the big formatter example and modified one of the existing pylab examples where it clearly belongs.

 This PR also includes the of IDs to `test_percentformatter` that I made in #7482.