### PR TITLE
Convert test decorators to pytest fixtures

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1476,7 +1476,6 @@ def _jupyter_nbextension_paths():
 default_test_modules = [
     'matplotlib.tests.test_png',
     'matplotlib.tests.test_units',
-    'matplotlib.tests.test_widgets',
     ]
 
 

--- a/lib/matplotlib/sphinxext/tests/conftest.py
+++ b/lib/matplotlib/sphinxext/tests/conftest.py
@@ -1,0 +1,4 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from matplotlib.tests.conftest import mpl_test_settings

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -13,6 +13,14 @@ def mpl_test_settings(request):
     original_units_registry = matplotlib.units.registry.copy()
     original_settings = matplotlib.rcParams.copy()
 
+    backend = None
+    backend_marker = request.keywords.get('backend')
+    if backend_marker is not None:
+        assert len(backend_marker.args) == 1, \
+            "Marker 'backend' must specify 1 backend."
+        backend = backend_marker.args[0]
+        prev_backend = matplotlib.get_backend()
+
     style = 'classic'
     style_marker = request.keywords.get('style')
     if style_marker is not None:
@@ -20,9 +28,18 @@ def mpl_test_settings(request):
             "Marker 'style' must specify 1 style."
         style = style_marker.args[0]
 
+    matplotlib.testing.setup()
+    if backend is not None:
+        # This import must come after setup() so it doesn't load the default
+        # backend prematurely.
+        import matplotlib.pyplot as plt
+        plt.switch_backend(backend)
     matplotlib.style.use(style)
     try:
         yield
     finally:
+        if backend is not None:
+            import matplotlib.pyplot as plt
+            plt.switch_backend(prev_backend)
         _do_cleanup(original_units_registry,
                     original_settings)

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import pytest
+
+import matplotlib
+
+
+@pytest.fixture(autouse=True)
+def mpl_test_settings(request):
+    from matplotlib.testing.decorators import _do_cleanup
+
+    original_units_registry = matplotlib.units.registry.copy()
+    original_settings = matplotlib.rcParams.copy()
+
+    style = 'classic'
+    style_marker = request.keywords.get('style')
+    if style_marker is not None:
+        assert len(style_marker.args) == 1, \
+            "Marker 'style' must specify 1 style."
+        style = style_marker.args[0]
+
+    matplotlib.style.use(style)
+    try:
+        yield
+    finally:
+        _do_cleanup(original_units_registry,
+                    original_settings)

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -11,14 +11,13 @@ import pytest
 from matplotlib.image import imread
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 from matplotlib import pyplot as plt
 from matplotlib import collections
 from matplotlib import path
 from matplotlib import transforms as mtransforms
 
 
-@cleanup
 def test_repeated_save_with_alpha():
     # We want an image which has a background color of bluish green, with an
     # alpha of 0.25.
@@ -51,7 +50,6 @@ def test_repeated_save_with_alpha():
                               decimal=3)
 
 
-@cleanup
 def test_large_single_path_collection():
     buff = io.BytesIO()
 
@@ -66,7 +64,6 @@ def test_large_single_path_collection():
     plt.savefig(buff)
 
 
-@cleanup
 def test_marker_with_nan():
     # This creates a marker with nans in it, which was segfaulting the
     # Agg backend (see #3722)
@@ -79,7 +76,6 @@ def test_marker_with_nan():
     fig.savefig(buf, format='png')
 
 
-@cleanup
 def test_long_path():
     buff = io.BytesIO()
 
@@ -218,7 +214,6 @@ def test_agg_filter():
     ax.yaxis.set_visible(False)
 
 
-@cleanup
 def test_too_large_image():
     fig = plt.figure(figsize=(300, 1000))
     buff = io.BytesIO()

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -13,7 +13,6 @@ import pytest
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 from matplotlib import animation
-from matplotlib.testing.decorators import cleanup
 
 
 class NullMovieWriter(animation.AbstractMovieWriter):
@@ -109,7 +108,6 @@ WRITER_OUTPUT = [
 # Smoke test for saving animations.  In the future, we should probably
 # design more sophisticated tests which compare resulting frames a-la
 # matplotlib.testing.image_comparison
-@cleanup
 @pytest.mark.parametrize('writer, extension', WRITER_OUTPUT)
 def test_save_animation_smoketest(tmpdir, writer, extension):
     try:
@@ -148,7 +146,6 @@ def test_save_animation_smoketest(tmpdir, writer, extension):
                          "see issues #1891 and #2679")
 
 
-@cleanup
 def test_no_length_frames():
     fig, ax = plt.subplots()
     line, = ax.plot([], [])

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -14,10 +14,9 @@ import matplotlib.path as mpath
 import matplotlib.transforms as mtrans
 import matplotlib.collections as mcollections
 import matplotlib.artist as martist
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 
 
-@cleanup
 def test_patch_transform_of_none():
     # tests the behaviour of patches added to an Axes with various transform
     # specifications
@@ -60,7 +59,6 @@ def test_patch_transform_of_none():
     assert e._transform == ax.transData
 
 
-@cleanup
 def test_collection_transform_of_none():
     # tests the behaviour of collections added to an Axes with various
     # transform specifications
@@ -127,7 +125,6 @@ def test_clipping():
     ax1.set_ylim([-3, 3])
 
 
-@cleanup
 def test_cull_markers():
     x = np.random.random(20000)
     y = np.random.random(20000)
@@ -175,7 +172,6 @@ def test_hatching():
     ax.set_ylim(0, 9)
 
 
-@cleanup
 def test_remove():
     fig, ax = plt.subplots()
     im = ax.imshow(np.arange(36).reshape(6, 6))
@@ -224,7 +220,6 @@ def test_default_edges():
     ax4.add_patch(pp1)
 
 
-@cleanup
 def test_properties():
     ln = mlines.Line2D([], [])
     with warnings.catch_warnings(record=True) as w:
@@ -234,7 +229,6 @@ def test_properties():
         assert len(w) == 0
 
 
-@cleanup
 def test_setp():
     # Check empty list
     plt.setp([])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -20,7 +20,7 @@ import pytest
 import warnings
 
 import matplotlib
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
@@ -120,7 +120,6 @@ def test_twin_axis_locaters_formatters():
     ax3 = ax1.twinx()
 
 
-@cleanup
 def test_twinx_cla():
     fig, ax = plt.subplots()
     ax2 = ax.twinx()
@@ -162,7 +161,6 @@ def test_twinx_axis_scales():
     ax2.margins(0, 0)
 
 
-@cleanup
 def test_twin_inherit_autoscale_setting():
     fig, ax = plt.subplots()
     ax_x_on = ax.twinx()
@@ -263,7 +261,6 @@ def test_basic_annotate():
                 xytext=(3, 3), textcoords='offset points')
 
 
-@cleanup
 def test_annotate_default_arrow():
     # Check that we can make an annotation arrow with only default properties.
     fig, ax = plt.subplots()
@@ -622,7 +619,6 @@ def test_hexbin_empty():
     ax = plt.gca()
     ax.hexbin([], [])
 
-@cleanup
 def test_hexbin_pickable():
     # From #1973: Test that picking a hexbin collection works
     class FauxMouseEvent:
@@ -656,7 +652,6 @@ def test_hexbin_log():
     ax.hexbin(x, y, yscale='log')
 
 
-@cleanup
 def test_inverted_limits():
     # Test gh:1553
     # Calling invert_xaxis prior to plotting should not disable autoscaling
@@ -760,7 +755,6 @@ def test_polycollection_joinstyle():
     ax.set_ybound(0, 3)
 
 
-@cleanup
 def test_fill_between_2d_x_input():
     x = np.zeros((2, 2))
     y1 = 3
@@ -773,7 +767,6 @@ def test_fill_between_2d_x_input():
         ax.fill_between(x, y1, y2)
 
 
-@cleanup
 def test_fill_between_2d_y1_input():
     x = np.arange(0.0, 2, 0.02)
     y1 = np.zeros((2, 2))
@@ -786,7 +779,6 @@ def test_fill_between_2d_y1_input():
         ax.fill_between(x, y1, y2)
 
 
-@cleanup
 def test_fill_between_2d_y2_input():
     x = np.arange(0.0, 2, 0.02)
     y1 = 3
@@ -874,7 +866,6 @@ def test_symlog2():
     ax.set_ylim(-0.1, 0.1)
 
 
-@cleanup
 def test_pcolorargs():
     # Smoketest to catch issue found in gh:5205
     x = [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5]
@@ -967,7 +958,6 @@ def test_pcolor_datetime_axis():
             label.set_rotation(30)
 
 
-@cleanup
 def test_pcolorargs():
     n = 12
     x = np.linspace(-1.5, 1.5, n)
@@ -1197,7 +1187,6 @@ def test_bar_tick_label_single():
     ax.bar("a", "b", tick_label='0', data=data)
 
 
-@cleanup
 def test_bar_ticklabel_fail():
     fig, ax = plt.subplots()
     ax.bar([], [])
@@ -1432,7 +1421,6 @@ def test_scatter_2D():
     ax.scatter(x, y, c=z, s=200, edgecolors='face')
 
 
-@cleanup
 def test_scatter_color():
     # Try to catch cases where 'c' kwarg should have been used.
     with pytest.raises(ValueError):
@@ -1441,7 +1429,6 @@ def test_scatter_color():
         plt.scatter([1, 2, 3], [1, 2, 3], color=[1, 2, 3])
 
 
-@cleanup
 def test_as_mpl_axes_api():
     # tests the _as_mpl_axes api
     from matplotlib.projections.polar import PolarAxes
@@ -1921,7 +1908,6 @@ def test_bxp_custompositions():
     ax.bxp(logstats, positions=[1, 5, 6, 7])
 
 
-@cleanup
 def test_bxp_bad_widths():
     np.random.seed(937)
     logstats = matplotlib.cbook.boxplot_stats(
@@ -1934,7 +1920,6 @@ def test_bxp_bad_widths():
         ax.bxp(logstats, widths=[1])
 
 
-@cleanup
 def test_bxp_bad_positions():
     np.random.seed(937)
     logstats = matplotlib.cbook.boxplot_stats(
@@ -2124,7 +2109,6 @@ def test_boxplot_no_weird_whisker():
     ax1.xaxis.grid(False)
 
 
-@cleanup
 def test_boxplot_bad_medians_1():
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
@@ -2133,7 +2117,6 @@ def test_boxplot_bad_medians_1():
         ax.boxplot(x, usermedians=[1, 2])
 
 
-@cleanup
 def test_boxplot_bad_medians_2():
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
@@ -2142,7 +2125,6 @@ def test_boxplot_bad_medians_2():
         ax.boxplot([x, x], usermedians=[[1, 2], [1, 2]])
 
 
-@cleanup
 def test_boxplot_bad_ci_1():
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
@@ -2151,7 +2133,6 @@ def test_boxplot_bad_ci_1():
         ax.boxplot([x, x], conf_intervals=[[1, 2]])
 
 
-@cleanup
 def test_boxplot_zorder():
     x = np.arange(10)
     fix, ax = plt.subplots()
@@ -2159,7 +2140,6 @@ def test_boxplot_zorder():
     assert ax.boxplot(x, zorder=10)['boxes'][0].get_zorder() == 10
 
 
-@cleanup
 def test_boxplot_bad_ci_2():
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
@@ -2342,7 +2322,6 @@ def test_horiz_violinplot_custompoints_200():
                   showextrema=0, showmedians=0, points=200)
 
 
-@cleanup
 def test_violinplot_bad_positions():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(47))
@@ -2352,7 +2331,6 @@ def test_violinplot_bad_positions():
         ax.violinplot(data, positions=range(5))
 
 
-@cleanup
 def test_violinplot_bad_widths():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(53))
@@ -2362,7 +2340,6 @@ def test_violinplot_bad_widths():
         ax.violinplot(data, positions=range(4), widths=[1, 2, 3])
 
 
-@cleanup
 def test_manage_xticks():
     _, ax = plt.subplots()
     ax.set_xlim(0, 4)
@@ -2376,7 +2353,6 @@ def test_manage_xticks():
     assert_array_equal(old_xlim, new_xlim)
 
 
-@cleanup
 def test_tick_space_size_0():
     # allow font size to be zero, which affects ticks when there is
     # no other text in the figure.
@@ -2440,7 +2416,6 @@ def test_errorbar():
     ax.set_title("Simplest errorbars, 0.2 in x, 0.4 in y")
 
 
-@cleanup
 def test_errorbar_shape():
     fig = plt.figure()
     ax = fig.gca()
@@ -2568,7 +2543,6 @@ def test_hist_stacked_weighted():
     ax.hist((d1, d2), weights=(w1, w2), histtype="stepfilled", stacked=True)
 
 
-@cleanup
 def test_stem_args():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -2583,7 +2557,6 @@ def test_stem_args():
     ax.stem(x, y, 'r--', basefmt='b--')
 
 
-@cleanup
 def test_stem_dates():
     fig, ax = plt.subplots(1, 1)
     from dateutil import parser
@@ -2653,7 +2626,6 @@ def test_hist_stacked_bar():
     ax.legend(loc='upper right', bbox_to_anchor=(1.0, 1.0), ncol=1)
 
 
-@cleanup
 def test_hist_emptydata():
     fig = plt.figure()
     ax = fig.add_subplot(111)
@@ -2695,7 +2667,6 @@ def test_mollweide_grid():
     ax.grid()
 
 
-@cleanup
 def test_mollweide_forward_inverse_closure():
     # test that the round-trip Mollweide forward->inverse transformation is an
     # approximate identity
@@ -2718,7 +2689,6 @@ def test_mollweide_forward_inverse_closure():
     np.testing.assert_array_almost_equal(ll, ll2, 3)
 
 
-@cleanup
 def test_mollweide_inverse_forward_closure():
     # test that the round-trip Mollweide inverse->forward transformation is an
     # approximate identity
@@ -2866,7 +2836,6 @@ def test_eventplot_problem_kwargs():
         assert all(issubclass(wi.category, IgnoredKeywordWarning) for wi in w)
 
 
-@cleanup
 def test_empty_eventplot():
     fig, ax = plt.subplots(1, 1)
     ax.eventplot([[]], colors=[(0.0, 0.0, 0.0, 0.0)])
@@ -3084,7 +3053,6 @@ def test_mixed_collection():
     ax.set_ylim(0, 16)
 
 
-@cleanup
 def test_subplot_key_hash():
     ax = plt.subplot(np.float64(5.5), np.int64(1), np.float64(1.2))
     ax.twinx()
@@ -4027,7 +3995,6 @@ def test_twin_spines_on_top():
     ax2.fill_between("i", "j", color='#7FC97F', alpha=.5, data=data)
 
 
-@cleanup
 def test_rcparam_grid_minor():
     orig_grid = matplotlib.rcParams['axes.grid']
     orig_locator = matplotlib.rcParams['axes.grid.which']
@@ -4050,7 +4017,6 @@ def test_rcparam_grid_minor():
     matplotlib.rcParams['axes.grid.which'] = orig_locator
 
 
-@cleanup
 def test_vline_limit():
     fig = plt.figure()
     ax = fig.gca()
@@ -4060,7 +4026,6 @@ def test_vline_limit():
     assert_allclose(ax.get_ylim(), (-.1, .2))
 
 
-@cleanup
 def test_empty_shared_subplots():
     # empty plots with shared axes inherit limits from populated plots
     fig, axes = plt.subplots(nrows=1, ncols=2, sharex=True, sharey=True)
@@ -4073,7 +4038,6 @@ def test_empty_shared_subplots():
     assert y1 >= 6
 
 
-@cleanup
 def test_relim_visible_only():
     x1 = (0., 10.)
     y1 = (0., 10.)
@@ -4099,7 +4063,6 @@ def test_relim_visible_only():
     assert ax.get_ylim() == y1
 
 
-@cleanup
 def test_text_labelsize():
     """
     tests for issue #1172
@@ -4254,7 +4217,6 @@ def test_o_marker_path_snap():
         ax.plot([3, 4, ], np.ones(2) + ms, 'o', ms=ms)
 
 
-@cleanup
 def test_margins():
     # test all ways margins can be called
     data = [1, 10]
@@ -4275,14 +4237,12 @@ def test_margins():
     assert ax3.margins() == (1, 0.5)
 
 
-@cleanup
 def test_length_one_hist():
     fig, ax = plt.subplots()
     ax.hist(1)
     ax.hist([1])
 
 
-@cleanup
 def test_pathological_hexbin():
     # issue #2863
     out = io.BytesIO()
@@ -4296,14 +4256,12 @@ def test_pathological_hexbin():
         assert len(w) == 0
 
 
-@cleanup
 def test_color_None():
     # issue 3855
     fig, ax = plt.subplots()
     ax.plot([1,2], [1,2], color=None)
 
 
-@cleanup
 def test_color_alias():
     # issues 4157 and 4162
     fig, ax = plt.subplots()
@@ -4311,14 +4269,12 @@ def test_color_alias():
     assert 'lime' == line.get_color()
 
 
-@cleanup
 def test_numerical_hist_label():
     fig, ax = plt.subplots()
     ax.hist([range(15)] * 5, label=range(5))
     ax.legend()
 
 
-@cleanup
 def test_unicode_hist_label():
     fig, ax = plt.subplots()
     a = (b'\xe5\xbe\x88\xe6\xbc\x82\xe4\xba\xae, ' +
@@ -4333,7 +4289,6 @@ def test_unicode_hist_label():
     ax.legend()
 
 
-@cleanup
 def test_move_offsetlabel():
     data = np.random.random(10) * 1e-22
     fig, ax = plt.subplots()
@@ -4379,7 +4334,6 @@ def test_rc_grid():
             i += 1
 
 
-@cleanup
 def test_rc_tick():
     d = {'xtick.bottom': False, 'xtick.top': True,
          'ytick.left': True, 'ytick.right': False}
@@ -4400,7 +4354,6 @@ def test_rc_tick():
         assert yax._minor_tick_kw['tick2On'] == False
 
 
-@cleanup
 def test_rc_major_minor_tick():
     d = {'xtick.top': True, 'ytick.right': True,  # Enable all ticks
          'xtick.bottom': True, 'ytick.left': True,
@@ -4424,7 +4377,6 @@ def test_rc_major_minor_tick():
         assert yax._minor_tick_kw['tick2On'] == True
 
 
-@cleanup
 def test_bar_negative_width():
     fig, ax = plt.subplots()
     res = ax.bar(range(1, 5), range(1, 5), width=-1)
@@ -4435,7 +4387,6 @@ def test_bar_negative_width():
         assert b._height == indx + 1
 
 
-@cleanup
 def test_square_plot():
     x = np.arange(4)
     y = np.array([1., 3., 5., 7.])
@@ -4447,7 +4398,6 @@ def test_square_plot():
     assert ax.get_aspect() == 'equal'
 
 
-@cleanup
 def test_no_None():
     fig, ax = plt.subplots()
     with pytest.raises(ValueError):
@@ -4456,7 +4406,6 @@ def test_no_None():
         plt.plot(None, None)
 
 
-@cleanup
 def test_pcolor_fast_non_uniform():
     Z = np.arange(6).reshape((3, 2))
     X = np.array([0, 1, 2, 10])
@@ -4467,7 +4416,6 @@ def test_pcolor_fast_non_uniform():
     ax.pcolorfast(X, Y, Z.T)
 
 
-@cleanup
 def test_shared_scale():
     fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
 
@@ -4486,7 +4434,6 @@ def test_shared_scale():
         assert ax.get_xscale() == 'linear'
 
 
-@cleanup
 def test_violin_point_mass():
     """Violin plot should handle point mass pdf gracefully."""
     plt.violinplot(np.array([0, 0]))
@@ -4518,7 +4465,6 @@ def generate_errorbar_inputs():
     return test_cyclers
 
 
-@cleanup
 @pytest.mark.parametrize('kwargs', generate_errorbar_inputs())
 def test_errorbar_inputs_shotgun(kwargs):
     ax = plt.gca()
@@ -4526,7 +4472,6 @@ def test_errorbar_inputs_shotgun(kwargs):
     eb.remove()
 
 
-@cleanup
 def test_axisbg_warning():
     fig = plt.figure()
     with warnings.catch_warnings(record=True) as w:
@@ -4546,7 +4491,6 @@ def test_dash_offset():
         ax.plot(x, j*y, ls=(j, (10, 10)), lw=5, color='k')
 
 
-@cleanup
 def test_title_location_roundtrip():
     fig, ax = plt.subplots()
     ax.set_title('aardvark')
@@ -4651,14 +4595,12 @@ def shared_axes_generator(request):
     return fig, ax
 
 
-@cleanup
 def test_remove_shared_axes(shared_axes_generator, shared_axis_remover):
     # test all of the ways to get fig/ax sets
     fig, ax = shared_axes_generator
     shared_axis_remover(ax)
 
 
-@cleanup
 def test_remove_shared_axes_relim():
     fig, ax_lst = plt.subplots(2, 2, sharex='all', sharey='all')
     ax = ax_lst[0][0]
@@ -4668,7 +4610,6 @@ def test_remove_shared_axes_relim():
     assert_array_equal(ax_lst[0][1].get_xlim(), orig_xlim)
 
 
-@cleanup
 def test_adjust_numtick_aspect():
     fig, ax = plt.subplots()
     ax.yaxis.get_major_locator().set_params(nbins='auto')
@@ -4697,13 +4638,11 @@ def test_auto_numticks_log():
     ax.loglog([1e-20, 1e5], [1e-16, 10])
 
 
-@cleanup
 def test_broken_barh_empty():
     fig, ax = plt.subplots()
     ax.broken_barh([], (.1, .5))
 
 
-@cleanup
 def test_pandas_indexing_dates():
     try:
         import pandas as pd
@@ -4720,7 +4659,6 @@ def test_pandas_indexing_dates():
     ax.plot('dates', 'values', data=without_zero_index)
 
 
-@cleanup
 def test_pandas_errorbar_indexing():
     try:
         import pandas as pd
@@ -4734,7 +4672,6 @@ def test_pandas_errorbar_indexing():
     ax.errorbar('x', 'y', xerr='xe', yerr='ye', data=df)
 
 
-@cleanup
 def test_pandas_indexing_hist():
     try:
         import pandas as pd
@@ -4747,7 +4684,6 @@ def test_pandas_indexing_hist():
     axes.hist(ser_2)
 
 
-@cleanup
 def test_axis_set_tick_params_labelsize_labelcolor():
     # Tests fix for issue 4346
     axis_1 = plt.subplot()
@@ -4760,14 +4696,12 @@ def test_axis_set_tick_params_labelsize_labelcolor():
     assert axis_1.yaxis.majorTicks[0]._labelcolor == 'red'
 
 
-@cleanup
 def test_none_kwargs():
     fig, ax = plt.subplots()
     ln, = ax.plot(range(32), linestyle=None)
     assert ln.get_linestyle() == '-'
 
 
-@cleanup
 def test_ls_ds_conflict():
     with pytest.raises(ValueError):
         plt.plot(range(32), linestyle='steps-pre:', drawstyle='steps-post')
@@ -4845,7 +4779,6 @@ def test_axisbelow():
         ax.set_axisbelow(setting)
 
 
-@cleanup
 def test_offset_label_color():
     # Tests issue 6440
     fig = plt.figure()
@@ -4855,14 +4788,12 @@ def test_offset_label_color():
     assert ax.yaxis.get_offset_text().get_color() == 'red'
 
 
-@cleanup
 def test_large_offset():
     fig, ax = plt.subplots()
     ax.plot((1 + np.array([0, 1.e-12])) * 1.e27)
     fig.canvas.draw()
 
 
-@cleanup
 def test_bar_color_cycle():
     ccov = mcolors.colorConverter.to_rgb
     fig, ax = plt.subplots()
@@ -4873,7 +4804,6 @@ def test_bar_color_cycle():
             assert ccov(ln.get_color()) == ccov(br.get_facecolor())
 
 
-@cleanup
 def test_tick_param_label_rotation():
     fix, ax = plt.subplots()
     plt.plot([0, 1], [0, 1])
@@ -4885,7 +4815,6 @@ def test_tick_param_label_rotation():
         assert text.get_rotation() == 90
 
 
-@cleanup
 def test_fill_betweenx_2d_y_input():
     y = np.zeros((2, 2))
     x1 = 3
@@ -4898,7 +4827,6 @@ def test_fill_betweenx_2d_y_input():
         ax.fill_betweenx(y, x1, x2)
 
 
-@cleanup
 def test_fill_betweenx_2d_x1_input():
     y = np.arange(0.0, 2, 0.02)
     x1 = np.zeros((2, 2))
@@ -4911,7 +4839,6 @@ def test_fill_betweenx_2d_x1_input():
         ax.fill_betweenx(y, x1, x2)
 
 
-@cleanup
 def test_fill_betweenx_2d_x2_input():
     y = np.arange(0.0, 2, 0.02)
     x1 = 3
@@ -4952,7 +4879,6 @@ def test_fillbetween_cycle():
         assert tuple(cc.get_edgecolors().squeeze()) == tuple(edge_target)
 
 
-@cleanup
 def test_log_margins():
     plt.rcParams['axes.autolimit_mode'] = 'data'
     fig, ax = plt.subplots()
@@ -4967,7 +4893,6 @@ def test_log_margins():
     assert_allclose([xlim0t + delta, xlim1t - delta], [x0t, x1t])
 
 
-@cleanup
 def test_color_length_mismatch():
     N = 5
     x, y = np.arange(N), np.arange(N)
@@ -4980,7 +4905,6 @@ def test_color_length_mismatch():
     ax.scatter(x, y, c=[c_rgb] * N)
 
 
-@cleanup
 def test_scatter_color_masking():
     x = np.array([1, 2, 3])
     y = np.array([1, np.nan, 3])
@@ -4996,13 +4920,11 @@ def test_scatter_color_masking():
     assert linewidths[1] == 3
 
 
-@cleanup
 def test_eventplot_legend():
     plt.eventplot([1.0], label='Label')
     plt.legend()
 
 
-@cleanup
 def test_bar_single_height():
     fig, ax = plt.subplots()
     # Check that a bar chart with a single height for all bars works

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -200,7 +200,7 @@ def test_autoscale_tiny_range():
         ax[i].plot([0, 1], [1, 1 + y1])
 
 
-@cleanup(style='default')
+@pytest.mark.style('default')
 def test_autoscale_tight():
     fig, ax = plt.subplots(1, 1)
     ax.plot([1, 2, 3, 4])
@@ -210,7 +210,7 @@ def test_autoscale_tight():
     assert_allclose(ax.get_ylim(), (1.0, 4.0))
 
 
-@cleanup(style='default')
+@pytest.mark.style('default')
 def test_autoscale_log_shared():
     # related to github #7587
     # array starts at zero to trigger _minpos handling
@@ -228,7 +228,7 @@ def test_autoscale_log_shared():
     assert_allclose(ax2.get_ylim(), (x[0], x[-1]))
 
 
-@cleanup(style='default')
+@pytest.mark.style('default')
 def test_use_sticky_edges():
     fig, ax = plt.subplots()
     ax.imshow([[0, 1], [2, 3]], origin='lower')
@@ -4573,7 +4573,7 @@ def test_loglog():
     ax.tick_params(length=15, width=2, which='minor')
 
 
-@cleanup('default')
+@pytest.mark.style('default')
 def test_axes_margins():
     fig, ax = plt.subplots()
     ax.plot([0, 1, 2, 3])
@@ -4924,7 +4924,7 @@ def test_fill_betweenx_2d_x2_input():
         ax.fill_betweenx(y, x1, x2)
 
 
-@cleanup(style='default')
+@pytest.mark.style('default')
 def test_fillbetween_cycle():
     fig, ax = plt.subplots()
 

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -1,6 +1,6 @@
 from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.backend_bases import RendererBase
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 
 import matplotlib.pyplot as plt
 import matplotlib.transforms as transforms
@@ -53,7 +53,6 @@ def test_uses_per_path():
     check(id, paths, tforms, offsets, facecolors[0:1], edgecolors)
 
 
-@cleanup
 def test_get_default_filename():
     try:
         test_dir = tempfile.mkdtemp()
@@ -66,7 +65,6 @@ def test_get_default_filename():
         shutil.rmtree(test_dir)
 
 
-@cleanup
 def test_get_default_filename_already_exists():
     # From #3068: Suggest non-existing default filename
     try:

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -17,7 +17,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib import pyplot as plt
 from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 from matplotlib import dviread
 
 
@@ -48,7 +48,6 @@ and containing some French characters and the euro symbol:
     ax.axhline(0.5, linewidth=0.5)
 
 
-@cleanup
 def test_type42():
     rcParams['pdf.fonttype'] = 42
 
@@ -58,7 +57,6 @@ def test_type42():
     fig.savefig(io.BytesIO())
 
 
-@cleanup
 def test_multipage_pagecount():
     with PdfPages(io.BytesIO()) as pdf:
         assert pdf.get_pagecount() == 0
@@ -71,7 +69,6 @@ def test_multipage_pagecount():
         assert pdf.get_pagecount() == 2
 
 
-@cleanup
 def test_multipage_keep_empty():
     from matplotlib.backends.backend_pdf import PdfPages
     from tempfile import NamedTemporaryFile
@@ -106,7 +103,6 @@ def test_multipage_keep_empty():
     os.remove(filename)
 
 
-@cleanup
 def test_composite_image():
     # Test that figures can be saved with and without combining multiple images
     # (on a single set of axes) into a single composite image.
@@ -127,37 +123,31 @@ def test_composite_image():
         assert len(pdf._file._images) == 2
 
 
-@cleanup
 def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PDF output"""
     _determinism_source_date_epoch("pdf", b"/CreationDate (D:20000101000000Z)")
 
 
-@cleanup
 def test_determinism_plain():
     """Test for reproducible PDF output: simple figure"""
     _determinism_check('', format="pdf")
 
 
-@cleanup
 def test_determinism_images():
     """Test for reproducible PDF output: figure with different images"""
     _determinism_check('i', format="pdf")
 
 
-@cleanup
 def test_determinism_hatches():
     """Test for reproducible PDF output: figure with different hatches"""
     _determinism_check('h', format="pdf")
 
 
-@cleanup
 def test_determinism_markers():
     """Test for reproducible PDF output: figure with different markers"""
     _determinism_check('m', format="pdf")
 
 
-@cleanup
 def test_determinism_all():
     """Test for reproducible PDF output"""
     _determinism_check(format="pdf")
@@ -188,7 +178,6 @@ def test_grayscale_alpha():
     ax.set_yticks([])
 
 
-@cleanup
 @needs_tex
 def test_missing_psfont(monkeypatch):
     """An error is raised if a TeX font lacks a Type-1 equivalent"""

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -12,7 +12,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.compat import subprocess
 from matplotlib.testing.compare import compare_images, ImageComparisonFailure
-from matplotlib.testing.decorators import _image_directories, switch_backend
+from matplotlib.testing.decorators import _image_directories
 
 baseline_dir, result_dir = _image_directories(lambda: 'dummy func')
 
@@ -82,8 +82,8 @@ def create_figure():
 
 # test compiling a figure to pdf with xelatex
 @needs_xelatex
-@pytest.mark.style('classic')
-@switch_backend('pgf')
+@pytest.mark.style('default')
+@pytest.mark.backend('pgf')
 def test_xelatex():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}
@@ -94,8 +94,8 @@ def test_xelatex():
 
 # test compiling a figure to pdf with pdflatex
 @needs_pdflatex
-@pytest.mark.style('classic')
-@switch_backend('pgf')
+@pytest.mark.style('default')
+@pytest.mark.backend('pgf')
 def test_pdflatex():
     import os
     if os.environ.get('APPVEYOR', False):
@@ -116,8 +116,8 @@ def test_pdflatex():
 # test updating the rc parameters for each figure
 @needs_xelatex
 @needs_pdflatex
-@pytest.mark.style('classic')
-@switch_backend('pgf')
+@pytest.mark.style('default')
+@pytest.mark.backend('pgf')
 def test_rcupdate():
     rc_sets = []
     rc_sets.append({'font.family': 'sans-serif',
@@ -147,8 +147,8 @@ def test_rcupdate():
 
 # test backend-side clipping, since large numbers are not supported by TeX
 @needs_xelatex
-@pytest.mark.style('classic')
-@switch_backend('pgf')
+@pytest.mark.style('default')
+@pytest.mark.backend('pgf')
 def test_pathclip():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}
@@ -164,8 +164,8 @@ def test_pathclip():
 
 # test mixed mode rendering
 @needs_xelatex
-@pytest.mark.style('classic')
-@switch_backend('pgf')
+@pytest.mark.style('default')
+@pytest.mark.backend('pgf')
 def test_mixedmode():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}
@@ -179,8 +179,8 @@ def test_mixedmode():
 
 # test bbox_inches clipping
 @needs_xelatex
-@pytest.mark.style('classic')
-@switch_backend('pgf')
+@pytest.mark.style('default')
+@pytest.mark.backend('pgf')
 def test_bbox_inches():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -12,8 +12,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.compat import subprocess
 from matplotlib.testing.compare import compare_images, ImageComparisonFailure
-from matplotlib.testing.decorators import (_image_directories, switch_backend,
-                                           cleanup)
+from matplotlib.testing.decorators import _image_directories, switch_backend
 
 baseline_dir, result_dir = _image_directories(lambda: 'dummy func')
 
@@ -83,7 +82,7 @@ def create_figure():
 
 # test compiling a figure to pdf with xelatex
 @needs_xelatex
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 @switch_backend('pgf')
 def test_xelatex():
     rc_xelatex = {'font.family': 'serif',
@@ -95,7 +94,7 @@ def test_xelatex():
 
 # test compiling a figure to pdf with pdflatex
 @needs_pdflatex
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 @switch_backend('pgf')
 def test_pdflatex():
     import os
@@ -117,7 +116,7 @@ def test_pdflatex():
 # test updating the rc parameters for each figure
 @needs_xelatex
 @needs_pdflatex
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 @switch_backend('pgf')
 def test_rcupdate():
     rc_sets = []
@@ -148,7 +147,7 @@ def test_rcupdate():
 
 # test backend-side clipping, since large numbers are not supported by TeX
 @needs_xelatex
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 @switch_backend('pgf')
 def test_pathclip():
     rc_xelatex = {'font.family': 'serif',
@@ -165,7 +164,7 @@ def test_pathclip():
 
 # test mixed mode rendering
 @needs_xelatex
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 @switch_backend('pgf')
 def test_mixedmode():
     rc_xelatex = {'font.family': 'serif',
@@ -180,7 +179,7 @@ def test_mixedmode():
 
 # test bbox_inches clipping
 @needs_xelatex
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 @switch_backend('pgf')
 def test_bbox_inches():
     rc_xelatex = {'font.family': 'serif',

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -15,7 +15,6 @@ import matplotlib.pyplot as plt
 from matplotlib import patheffects
 from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
-from matplotlib.testing.decorators import cleanup
 
 
 needs_ghostscript = pytest.mark.xfail(
@@ -61,19 +60,16 @@ def _test_savefig_to_stringio(format='ps', use_log=False):
         buffer.close()
 
 
-@cleanup
 def test_savefig_to_stringio():
     _test_savefig_to_stringio()
 
 
-@cleanup
 @needs_ghostscript
 def test_savefig_to_stringio_with_distiller():
     matplotlib.rcParams['ps.usedistiller'] = 'ghostscript'
     _test_savefig_to_stringio()
 
 
-@cleanup
 @needs_tex
 @needs_ghostscript
 def test_savefig_to_stringio_with_usetex():
@@ -82,18 +78,15 @@ def test_savefig_to_stringio_with_usetex():
     _test_savefig_to_stringio()
 
 
-@cleanup
 def test_savefig_to_stringio_eps():
     _test_savefig_to_stringio(format='eps')
 
 
-@cleanup
 def test_savefig_to_stringio_eps_afm():
     matplotlib.rcParams['ps.useafm'] = True
     _test_savefig_to_stringio(format='eps', use_log=True)
 
 
-@cleanup
 @needs_tex
 @needs_ghostscript
 def test_savefig_to_stringio_with_usetex_eps():
@@ -102,7 +95,6 @@ def test_savefig_to_stringio_with_usetex_eps():
     _test_savefig_to_stringio(format='eps')
 
 
-@cleanup
 def test_composite_image():
     # Test that figures can be saved with and without combining multiple images
     # (on a single set of axes) into a single composite image.
@@ -127,7 +119,6 @@ def test_composite_image():
         assert buff.count(six.b(' colorimage')) == 2
 
 
-@cleanup
 def test_patheffects():
     with matplotlib.rc_context():
         matplotlib.rcParams['path.effects'] = [
@@ -138,7 +129,6 @@ def test_patheffects():
             fig.savefig(ps, format='ps')
 
 
-@cleanup
 @needs_tex
 @needs_ghostscript
 def test_tilde_in_tempfilename():
@@ -178,7 +168,6 @@ def test_tilde_in_tempfilename():
                 print(e)
 
 
-@cleanup
 def test_source_date_epoch():
     """Test SOURCE_DATE_EPOCH support for PS output"""
     # SOURCE_DATE_EPOCH support is not tested with text.usetex,
@@ -189,13 +178,11 @@ def test_source_date_epoch():
         "ps", b"%%CreationDate: Sat Jan 01 00:00:00 2000")
 
 
-@cleanup
 def test_determinism_all():
     """Test for reproducible PS output"""
     _determinism_check(format="ps")
 
 
-@cleanup
 @needs_tex
 @needs_ghostscript
 def test_determinism_all_tex():

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from matplotlib import pyplot as plt
-from matplotlib.testing.decorators import cleanup, switch_backend
+from matplotlib.testing.decorators import switch_backend
 from matplotlib._pylab_helpers import Gcf
 import matplotlib
 import copy
@@ -34,7 +34,6 @@ if py_qt_ver != 4:
     pytestmark = pytest.mark.xfail(reason='Qt4 is not available')
 
 
-@cleanup
 @switch_backend('Qt4Agg')
 def test_fig_close():
     # save the state of Gcf.figs
@@ -84,7 +83,6 @@ def test_fig_close():
         'non_unicode_key',
     ]
 )
-@cleanup
 @switch_backend('Qt4Agg')
 def test_correct_key(qt_key, qt_mods, answer):
     """

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from matplotlib import pyplot as plt
-from matplotlib.testing.decorators import switch_backend
 from matplotlib._pylab_helpers import Gcf
 import matplotlib
 import copy
@@ -34,7 +33,7 @@ if py_qt_ver != 4:
     pytestmark = pytest.mark.xfail(reason='Qt4 is not available')
 
 
-@switch_backend('Qt4Agg')
+@pytest.mark.backend('Qt4Agg')
 def test_fig_close():
     # save the state of Gcf.figs
     init_figs = copy.copy(Gcf.figs)
@@ -83,7 +82,7 @@ def test_fig_close():
         'non_unicode_key',
     ]
 )
-@switch_backend('Qt4Agg')
+@pytest.mark.backend('Qt4Agg')
 def test_correct_key(qt_key, qt_mods, answer):
     """
     Make a figure

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from matplotlib import pyplot as plt
-from matplotlib.testing.decorators import cleanup, switch_backend
+from matplotlib.testing.decorators import switch_backend
 from matplotlib._pylab_helpers import Gcf
 import matplotlib
 import copy
@@ -27,7 +27,6 @@ _, SuperModifier, SuperKey = MODIFIER_KEYS[SUPER]
 _, ShiftModifier, ShiftKey = MODIFIER_KEYS[SHIFT]
 
 
-@cleanup
 @switch_backend('Qt5Agg')
 def test_fig_close():
     # save the state of Gcf.figs
@@ -77,7 +76,6 @@ def test_fig_close():
         'non_unicode_key',
     ]
 )
-@cleanup
 @switch_backend('Qt5Agg')
 def test_correct_key(qt_key, qt_mods, answer):
     """

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from matplotlib import pyplot as plt
-from matplotlib.testing.decorators import switch_backend
 from matplotlib._pylab_helpers import Gcf
 import matplotlib
 import copy
@@ -27,7 +26,7 @@ _, SuperModifier, SuperKey = MODIFIER_KEYS[SUPER]
 _, ShiftModifier, ShiftKey = MODIFIER_KEYS[SHIFT]
 
 
-@switch_backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg')
 def test_fig_close():
     # save the state of Gcf.figs
     init_figs = copy.copy(Gcf.figs)
@@ -76,7 +75,7 @@ def test_fig_close():
         'non_unicode_key',
     ]
 )
-@switch_backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg')
 def test_correct_key(qt_key, qt_mods, answer):
     """
     Make a figure

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -12,7 +12,6 @@ import xml.parsers.expat
 import pytest
 
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
 from matplotlib.testing.decorators import image_comparison
 import matplotlib
 from matplotlib import dviread
@@ -23,7 +22,6 @@ needs_tex = pytest.mark.xfail(
     reason="This test needs a TeX installation")
 
 
-@cleanup
 def test_visibility():
     fig = plt.figure()
     ax = fig.add_subplot(111)
@@ -65,7 +63,6 @@ def test_noscale():
     ax.imshow(Z, cmap='gray', interpolation='none')
 
 
-@cleanup
 def test_composite_images():
     #Test that figures can be saved with and without combining multiple images
     #(on a single set of axes) into a single composite image.
@@ -90,7 +87,6 @@ def test_composite_images():
         assert buff.count(six.b('<image ')) == 2
 
 
-@cleanup
 def test_text_urls():
     fig = plt.figure()
 
@@ -187,20 +183,17 @@ def _test_determinism(filename, usetex):
         assert p == plots[0]
 
 
-@cleanup
 def test_determinism_notex():
     # unique filename to allow for parallel testing
     _test_determinism('determinism_notex.svg', usetex=False)
 
 
-@cleanup
 @needs_tex
 def test_determinism_tex():
     # unique filename to allow for parallel testing
     _test_determinism('determinism_tex.svg', usetex=True)
 
 
-@cleanup
 @needs_tex
 def test_missing_psfont(monkeypatch):
     """An error is raised if a TeX font lacks a Type-1 equivalent"""

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -7,7 +7,6 @@ import pytest
 import numpy as np
 
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
 import matplotlib.category as cat
 
 import unittest
@@ -144,7 +143,6 @@ class TestPlot(object):
         np.testing.assert_array_equal(axis.unit_data.locs, unit_data.locs)
         assert axis.unit_data.seq == unit_data.seq
 
-    @cleanup
     def test_plot_unicode(self):
         words = ['Здравствуйте', 'привет']
         locs = [0.0, 1.0]
@@ -156,7 +154,6 @@ class TestPlot(object):
 
         self.axis_test(ax.yaxis, locs, words, unit_data)
 
-    @cleanup
     @pytest.mark.usefixtures("data")
     def test_plot_1d(self):
         fig, ax = plt.subplots()
@@ -165,7 +162,6 @@ class TestPlot(object):
 
         self.axis_test(ax.yaxis, self.dticks, self.dlabels, self.dunit_data)
 
-    @cleanup
     @pytest.mark.usefixtures("missing_data")
     def test_plot_1d_missing(self):
         fig, ax = plt.subplots()
@@ -174,7 +170,6 @@ class TestPlot(object):
 
         self.axis_test(ax.yaxis, self.dmticks, self.dmlabels, self.dmunit_data)
 
-    @cleanup
     @pytest.mark.usefixtures("data")
     @pytest.mark.parametrize("bars",
                              [['a', 'b', 'c'],
@@ -191,7 +186,6 @@ class TestPlot(object):
 
         self.axis_test(ax.xaxis, self.dticks, self.dlabels, self.dunit_data)
 
-    @cleanup
     @pytest.mark.parametrize("bars",
                              [['1', '11', '3'],
                               np.array(['1', '11', '3']),
@@ -209,7 +203,6 @@ class TestPlot(object):
         unitmap = MockUnitData([('1', 0), ('11', 1), ('3', 2)])
         self.axis_test(ax.xaxis, [0, 1, 2], ['1', '11', '3'], unitmap)
 
-    @cleanup
     @pytest.mark.usefixtures("data", "missing_data")
     def test_plot_2d(self):
         fig, ax = plt.subplots()
@@ -219,7 +212,6 @@ class TestPlot(object):
         self.axis_test(ax.xaxis, self.dmticks, self.dmlabels, self.dmunit_data)
         self.axis_test(ax.yaxis, self.dticks, self.dlabels, self.dunit_data)
 
-    @cleanup
     @pytest.mark.usefixtures("data", "missing_data")
     def test_scatter_2d(self):
 
@@ -230,7 +222,6 @@ class TestPlot(object):
         self.axis_test(ax.xaxis, self.dmticks, self.dmlabels, self.dmunit_data)
         self.axis_test(ax.yaxis, self.dticks, self.dlabels, self.dunit_data)
 
-    @cleanup
     def test_plot_update(self):
         fig, ax = plt.subplots()
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 import matplotlib.collections as mcollections
 import matplotlib.transforms as mtransforms
 from matplotlib.collections import Collection, EventCollection
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 
 
 def generate_EventCollection_plot():
@@ -74,7 +74,6 @@ def test__EventCollection__get_segments():
                    props['orientation'])
 
 
-@cleanup
 def test__EventCollection__get_positions():
     '''
     check to make sure the default positions match the input positions
@@ -83,7 +82,6 @@ def test__EventCollection__get_positions():
     np.testing.assert_array_equal(props['positions'], coll.get_positions())
 
 
-@cleanup
 def test__EventCollection__get_orientation():
     '''
     check to make sure the default orientation matches the input
@@ -93,7 +91,6 @@ def test__EventCollection__get_orientation():
     assert_equal(props['orientation'], coll.get_orientation())
 
 
-@cleanup
 def test__EventCollection__is_horizontal():
     '''
     check to make sure the default orientation matches the input
@@ -103,7 +100,6 @@ def test__EventCollection__is_horizontal():
     assert_equal(True, coll.is_horizontal())
 
 
-@cleanup
 def test__EventCollection__get_linelength():
     '''
     check to make sure the default linelength matches the input linelength
@@ -112,7 +108,6 @@ def test__EventCollection__get_linelength():
     assert_equal(props['linelength'], coll.get_linelength())
 
 
-@cleanup
 def test__EventCollection__get_lineoffset():
     '''
     check to make sure the default lineoffset matches the input lineoffset
@@ -121,7 +116,6 @@ def test__EventCollection__get_lineoffset():
     assert_equal(props['lineoffset'], coll.get_lineoffset())
 
 
-@cleanup
 def test__EventCollection__get_linestyle():
     '''
     check to make sure the default linestyle matches the input linestyle
@@ -130,7 +124,6 @@ def test__EventCollection__get_linestyle():
     assert_equal(coll.get_linestyle(), [(None, None)])
 
 
-@cleanup
 def test__EventCollection__get_color():
     '''
     check to make sure the default color matches the input color
@@ -417,7 +410,6 @@ def test_null_collection_datalim():
                        mtransforms.Bbox.null().get_points())
 
 
-@cleanup
 def test_add_collection():
     # Test if data limits are unchanged by adding an empty collection.
     # Github issue #1490, pull #1497.
@@ -430,7 +422,6 @@ def test_add_collection():
     assert_equal(ax.dataLim.bounds, bounds)
 
 
-@cleanup
 def test_quiver_limits():
     ax = plt.axes()
     x, y = np.arange(8), np.arange(10)
@@ -448,7 +439,6 @@ def test_quiver_limits():
     assert_equal(ax.dataLim.bounds, (20.0, 30.0, 15.0, 6.0))
 
 
-@cleanup
 def test_barb_limits():
     ax = plt.axes()
     x = np.linspace(-5, 10, 20)
@@ -573,7 +563,6 @@ def test_regularpolycollection_scale():
     ax.axis([-1, 1, -1, 1])
 
 
-@cleanup
 def test_picking():
     fig, ax = plt.subplots()
     col = ax.scatter([0], [0], [1000], picker=True)
@@ -590,7 +579,6 @@ def test_picking():
     assert_array_equal(indices['ind'], [0])
 
 
-@cleanup
 def test_linestyle_single_dashes():
     plt.scatter([0, 1, 2], [0, 1, 2], linestyle=(0., [2., 2.]))
     plt.draw()
@@ -616,7 +604,6 @@ def test_size_in_xy():
     ax.set_ylim(0, 30)
 
 
-@cleanup
 def test_pandas_indexing():
     pd = pytest.importorskip('pandas')
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -635,7 +635,7 @@ def test_pandas_indexing():
     Collection(antialiaseds=aa)
 
 
-@cleanup(style='default')
+@pytest.mark.style('default')
 def test_lslw_bcast():
     col = mcollections.PathCollection([])
     col.set_linestyles(['-', '-'])

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from matplotlib import rc_context
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 from matplotlib.colors import BoundaryNorm, LogNorm
 from matplotlib.cm import get_cmap
@@ -224,7 +224,6 @@ def _test_remove_from_figure(use_gridspec):
     assert (pre_figbox == post_figbox).all()
 
 
-@cleanup
 def test_remove_from_figure_with_gridspec():
     """
     Make sure that `remove_from_figure` removes the colorbar and properly
@@ -233,7 +232,6 @@ def test_remove_from_figure_with_gridspec():
     _test_remove_from_figure(True)
 
 
-@cleanup
 def test_remove_from_figure_no_gridspec():
     """
     Make sure that `remove_from_figure` removes a colorbar that was created
@@ -242,7 +240,6 @@ def test_remove_from_figure_no_gridspec():
     _test_remove_from_figure(False)
 
 
-@cleanup
 def test_colorbarbase():
     # smoke test from #3805
     ax = plt.gca()
@@ -276,7 +273,6 @@ def test_colorbar_closed_patch():
                      extend='neither', values=values)
 
 
-@cleanup
 def test_colorbar_ticks():
     # test fix for #5673
     fig, ax = plt.subplots()
@@ -292,7 +288,6 @@ def test_colorbar_ticks():
     assert len(cbar.ax.xaxis.get_ticklocs()) == len(clevs)
 
 
-@cleanup
 def test_colorbar_get_ticks():
     # test feature for #5792
     plt.figure()
@@ -319,7 +314,6 @@ def test_colorbar_get_ticks():
     assert defTicks.get_ticks().tolist() == levels
 
 
-@cleanup
 def test_colorbar_lognorm_extension():
     # Test that colorbar with lognorm is extended correctly
     f, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -19,7 +19,7 @@ import matplotlib.cm as cm
 import matplotlib.colorbar as mcolorbar
 import matplotlib.cbook as cbook
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 
 
 def test_resample():
@@ -226,7 +226,6 @@ def test_SymLogNorm():
     assert_array_almost_equal(normed_vals, expected)
 
 
-@cleanup
 def test_SymLogNorm_colorbar():
     """
     Test un-called SymLogNorm in a colorbar.
@@ -350,7 +349,6 @@ def test_rgb_hsv_round_trip():
             mcolors.rgb_to_hsv(mcolors.hsv_to_rgb(tt)))
 
 
-@cleanup
 def test_autoscale_masked():
     # Test for #2336. Previously fully masked data would trigger a ValueError.
     data = np.ma.masked_all((12, 20))
@@ -626,7 +624,6 @@ def test_colormap_reversing(name):
     assert_array_almost_equal(cmap._lut[:-3], cmap_r._lut[-4::-1])
 
 
-@cleanup
 def test_cn():
     matplotlib.rcParams['axes.prop_cycle'] = cycler('color',
                                                     ['blue', 'r'])

--- a/lib/matplotlib/tests/test_container.py
+++ b/lib/matplotlib/tests/test_container.py
@@ -4,10 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import matplotlib.pyplot as plt
 
-from matplotlib.testing.decorators import cleanup
 
-
-@cleanup
 def test_stem_remove():
     ax = plt.gca()
     st = ax.stem([1, 2], [1, 2])

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -5,7 +5,7 @@ import datetime
 
 import numpy as np
 from matplotlib import mlab
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 from matplotlib import pyplot as plt
 from numpy.testing import assert_array_almost_equal
 import pytest
@@ -14,7 +14,6 @@ import warnings
 import re
 
 
-@cleanup
 def test_contour_shape_1d_valid():
 
     x = np.arange(10)
@@ -26,7 +25,6 @@ def test_contour_shape_1d_valid():
     ax.contour(x, y, z)
 
 
-@cleanup
 def test_contour_shape_2d_valid():
 
     x = np.arange(10)
@@ -39,7 +37,6 @@ def test_contour_shape_2d_valid():
     ax.contour(xg, yg, z)
 
 
-@cleanup
 def test_contour_shape_mismatch_1():
 
     x = np.arange(9)
@@ -55,7 +52,6 @@ def test_contour_shape_mismatch_1():
         assert exc.args[0] == 'Length of x must be number of columns in z.'
 
 
-@cleanup
 def test_contour_shape_mismatch_2():
 
     x = np.arange(10)
@@ -71,7 +67,6 @@ def test_contour_shape_mismatch_2():
         assert exc.args[0] == 'Length of y must be number of rows in z.'
 
 
-@cleanup
 def test_contour_shape_mismatch_3():
 
     x = np.arange(10)
@@ -93,7 +88,6 @@ def test_contour_shape_mismatch_3():
         assert exc.args[0] == 'Number of dimensions of x and y should match.'
 
 
-@cleanup
 def test_contour_shape_mismatch_4():
 
     g = np.random.random((9, 10))
@@ -120,7 +114,6 @@ def test_contour_shape_mismatch_4():
             exc.args[0]) is not None, exc.args[0]
 
 
-@cleanup
 def test_contour_shape_invalid_1():
 
     x = np.random.random((3, 3, 3))
@@ -136,7 +129,6 @@ def test_contour_shape_invalid_1():
         assert exc.args[0] == 'Inputs x and y must be 1D or 2D.'
 
 
-@cleanup
 def test_contour_shape_invalid_2():
 
     x = np.random.random((3, 3, 3))
@@ -277,7 +269,6 @@ def test_corner_mask():
         plt.contourf(z, corner_mask=corner_mask)
 
 
-@cleanup
 def test_contourf_decreasing_levels():
     # github issue 5477.
     z = [[0.1, 0.3], [0.5, 0.7]]
@@ -292,7 +283,6 @@ def test_contourf_decreasing_levels():
         assert len(w) == 2
 
 
-@cleanup
 def test_vminvmax_warning():
     z = [[0.1, 0.3], [0.5, 0.7]]
     plt.figure()
@@ -313,7 +303,6 @@ def test_vminvmax_warning():
         assert str(w[0].message).startswith(msg)
 
 
-@cleanup
 def test_contourf_symmetric_locator():
     # github issue 7271
     z = np.arange(12).reshape((3, 4))

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -1,6 +1,6 @@
 import warnings
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.pyplot as plt
 import numpy as np
@@ -148,7 +148,6 @@ def test_property_collision_fill():
     ax.fill(xs, 5 * ys)
 
 
-@cleanup
 def test_valid_input_forms():
     fig, ax = plt.subplots()
     # These should not raise an error.
@@ -170,7 +169,6 @@ def test_valid_input_forms():
     assert True
 
 
-@cleanup
 def test_cycle_reset():
     fig, ax = plt.subplots()
 
@@ -195,7 +193,6 @@ def test_cycle_reset():
         assert prop == got, "expected %s, got %s" % (prop, got)
 
 
-@cleanup
 def test_invalid_input_forms():
     fig, ax = plt.subplots()
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -19,7 +19,7 @@ except ImportError:
 
 from numpy.testing import assert_equal
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
@@ -88,7 +88,6 @@ def test_date_axvline():
     fig.autofmt_xdate()
 
 
-@cleanup
 def test_too_many_date_ticks():
     # Attempt to test SF 2715172, see
     # https://sourceforge.net/tracker/?func=detail&aid=2715172&group_id=80706&atid=560720
@@ -250,7 +249,6 @@ def test_drange():
     assert_equal(mdates.num2date(daterange[-1]), end - delta)
 
 
-@cleanup
 def test_empty_date_with_year_formatter():
     # exposes sf bug 2861426:
     # https://sourceforge.net/tracker/?func=detail&aid=2861426&group_id=80706&atid=560720

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -3,14 +3,13 @@ from __future__ import (absolute_import, division, print_function,
 
 from numpy.testing import assert_equal
 from matplotlib import rcParams
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import numpy as np
 import warnings
 
 
-@cleanup
 def test_figure_label():
     # pyplot figure creation, selection and closing with figure label and
     # number
@@ -32,7 +31,6 @@ def test_figure_label():
     assert_equal(plt.get_figlabels(), ['', 'today'])
 
 
-@cleanup
 def test_fignum_exists():
     # pyplot figure creation, selection and closing with fignum_exists
     plt.figure('one')
@@ -49,7 +47,6 @@ def test_fignum_exists():
     assert_equal(plt.fignum_exists(4), False)
 
 
-@cleanup
 def test_clf_keyword():
     # test if existing figure is cleared with figure() and subplots()
     fig0 = plt.figure(num=1)
@@ -94,7 +91,6 @@ def test_figure_legend():
     fig.legend()
 
 
-@cleanup
 def test_gca():
     fig = plt.figure()
 
@@ -131,7 +127,6 @@ def test_suptitle():
     fig.suptitle('title', color='g', rotation='30')
 
 
-@cleanup
 def test_suptitle_fontproperties():
     from matplotlib.font_manager import FontProperties
     fig, ax = plt.subplots()
@@ -161,7 +156,6 @@ def test_alpha():
                                               facecolor='red'))
 
 
-@cleanup
 def test_too_many_figures():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
@@ -170,7 +164,6 @@ def test_too_many_figures():
         assert len(w) == 1
 
 
-@cleanup
 def test_iterability_axes_argument():
 
     # This is a regression test for matplotlib/matplotlib#3196. If one of the
@@ -201,7 +194,6 @@ def test_iterability_axes_argument():
     plt.close(fig)
 
 
-@cleanup
 def test_set_fig_size():
     fig = plt.figure()
 
@@ -224,7 +216,6 @@ def test_set_fig_size():
     assert_equal(fig.get_figheight(), 3)
 
 
-@cleanup
 def test_axes_remove():
     fig, axes = plt.subplots(2, 2)
     axes[-1, -1].remove()

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
 from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
@@ -90,7 +90,6 @@ def test_figimage():
         fig.figimage(img[:,::-1], xo=100, yo=0, origin='lower')
         fig.figimage(img[::-1,::-1], xo=100, yo=100, origin='lower')
 
-@cleanup
 def test_image_python_io():
     fig = plt.figure()
     ax = fig.add_subplot(111)
@@ -109,7 +108,6 @@ def test_imread_pil_uint16():
     assert np.sum(img) == 134184960
 
 
-@cleanup
 def test_imsave():
     # The goal here is that the user can specify an output logical DPI
     # for the image, but this will not actually add any extra pixels
@@ -180,7 +178,6 @@ def test_image_alpha():
     plt.subplot(133)
     plt.imshow(Z, alpha=0.5, interpolation='nearest')
 
-@cleanup
 def test_cursor_data():
     from matplotlib.backend_bases import MouseEvent
 
@@ -308,7 +305,6 @@ def test_image_shift():
               extent=(tMin, tMax, 1, 100))
     ax.set_aspect('auto')
 
-@cleanup
 def test_image_edges():
     f = plt.figure(figsize=[1, 1])
     ax = f.add_axes([0, 0, 1, 1], frameon=False)
@@ -430,7 +426,6 @@ def test_bbox_image_inverted():
     ax.add_artist(bbox_im)
 
 
-@cleanup
 def test_get_window_extent_for_AxisImage():
     # Create a figure of known size (1000x1000 pixels), place an image
     # object at a given location and check that get_window_extent()
@@ -466,14 +461,12 @@ def test_zoom_and_clip_upper_origin():
     ax.set_xlim(-0.5, 2.0)
 
 
-@cleanup
 def test_nonuniformimage_setcmap():
     ax = plt.gca()
     im = NonUniformImage(ax)
     im.set_cmap('Blues')
 
 
-@cleanup
 def test_nonuniformimage_setnorm():
     ax = plt.gca()
     im = NonUniformImage(ax)
@@ -481,7 +474,6 @@ def test_nonuniformimage_setnorm():
 
 
 @needs_pillow
-@cleanup
 def test_jpeg_alpha():
     plt.figure(figsize=(1, 1), dpi=300)
     # Create an image that is all black, with a gradient from 0-1 in
@@ -508,7 +500,6 @@ def test_jpeg_alpha():
     assert corner_pixel == (254, 0, 0), "corner pixel: %r" % (corner_pixel, )
 
 
-@cleanup
 def test_nonuniformimage_setdata():
     ax = plt.gca()
     im = NonUniformImage(ax)
@@ -520,7 +511,6 @@ def test_nonuniformimage_setdata():
     assert im._A[0, 0] == im._Ax[0] == im._Ay[0] == 0, 'value changed'
 
 
-@cleanup
 def test_axesimage_setdata():
     ax = plt.gca()
     im = AxesImage(ax)
@@ -530,7 +520,6 @@ def test_axesimage_setdata():
     assert im._A[0, 0] == 0, 'value changed'
 
 
-@cleanup
 def test_figureimage_setdata():
     fig = plt.gcf()
     im = FigureImage(fig)
@@ -540,7 +529,6 @@ def test_figureimage_setdata():
     assert im._A[0, 0] == 0, 'value changed'
 
 
-@cleanup
 def test_pcolorimage_setdata():
     ax = plt.gca()
     im = PcolorImage(ax)
@@ -552,7 +540,6 @@ def test_pcolorimage_setdata():
     assert im._A[0, 0] == im._Ax[0] == im._Ay[0] == 0, 'value changed'
 
 
-@cleanup
 def test_minimized_rasterized():
     # This ensures that the rasterized content in the colorbars is
     # only as thick as the colorbar, and doesn't extend to other parts
@@ -636,7 +623,6 @@ def test_rotate_image():
     ax1.set_ylim(0, 4)
 
 
-@cleanup
 def test_image_preserve_size():
     buff = io.BytesIO()
 
@@ -649,7 +635,6 @@ def test_image_preserve_size():
     assert img.shape[:2] == im.shape
 
 
-@cleanup
 def test_image_preserve_size2():
     n = 7
     data = np.identity(n, float)
@@ -741,7 +726,6 @@ def test_imshow_endianess():
     ax2.imshow(Z.astype('>f8'), **kwargs)
 
 
-@cleanup
 def test_imshow_no_warn_invalid():
     with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -9,7 +9,7 @@ except ImportError:
 from numpy.testing import assert_equal
 import numpy as np
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import matplotlib.transforms as mtrans
@@ -171,7 +171,6 @@ def test_legend_expand():
         ax.legend(loc=3, mode=mode, ncol=2)
 
 
-@cleanup
 def test_legend_remove():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -186,28 +185,24 @@ def test_legend_remove():
 
 class TestLegendFunction(object):
     # Tests the legend function on the Axes and pyplot.
-    @cleanup
     def test_legend_handle_label(self):
         lines = plt.plot(range(10))
         with mock.patch('matplotlib.legend.Legend') as Legend:
             plt.legend(lines, ['hello world'])
         Legend.assert_called_with(plt.gca(), lines, ['hello world'])
 
-    @cleanup
     def test_legend_no_args(self):
         lines = plt.plot(range(10), label='hello world')
         with mock.patch('matplotlib.legend.Legend') as Legend:
             plt.legend()
         Legend.assert_called_with(plt.gca(), lines, ['hello world'])
 
-    @cleanup
     def test_legend_label_args(self):
         lines = plt.plot(range(10), label='hello world')
         with mock.patch('matplotlib.legend.Legend') as Legend:
             plt.legend(['foobar'])
         Legend.assert_called_with(plt.gca(), lines, ['foobar'])
 
-    @cleanup
     def test_legend_handler_map(self):
         lines = plt.plot(range(10), label='hello world')
         with mock.patch('matplotlib.axes.Axes.'
@@ -216,7 +211,6 @@ class TestLegendFunction(object):
             plt.legend(handler_map={'1': 2})
         handles_labels.assert_called_with({'1': 2})
 
-    @cleanup
     def test_kwargs(self):
         fig, ax = plt.subplots(1, 1)
         th = np.linspace(0, 2*np.pi, 1024)
@@ -226,7 +220,6 @@ class TestLegendFunction(object):
             ax.legend(handles=(lnc, lns), labels=('a', 'b'))
         Legend.assert_called_with(ax, (lnc, lns), ('a', 'b'))
 
-    @cleanup
     def test_warn_args_kwargs(self):
         fig, ax = plt.subplots(1, 1)
         th = np.linspace(0, 2*np.pi, 1024)
@@ -256,7 +249,6 @@ def test_legend_stackplot():
     ax.legend(loc=0)
 
 
-@cleanup
 def test_cross_figure_patch_legend():
     fig, ax = plt.subplots()
     fig2, ax2 = plt.subplots()
@@ -265,7 +257,6 @@ def test_cross_figure_patch_legend():
     fig2.legend(brs, 'foo')
 
 
-@cleanup
 def test_nanscatter():
     fig, ax = plt.subplots()
 
@@ -311,7 +302,6 @@ def test_not_covering_scatter_transform():
     plt.legend(['foo', 'bar'], loc='best')
 
 
-@cleanup
 def test_linecollection_scaled_dashes():
     lines1 = [[(0, .5), (.5, 1)], [(.3, .6), (.2, .2)]]
     lines2 = [[[0.7, .2], [.8, .4]], [[.5, .7], [.6, .1]]]

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -13,10 +13,9 @@ from cycler import cycler
 
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 
 
-@cleanup
 def test_invisible_Line_rendering():
     """
     Github issue #1256 identified a bug in Line.draw method
@@ -60,7 +59,6 @@ def test_invisible_Line_rendering():
     assert slowdown_factor < slowdown_threshold
 
 
-@cleanup
 def test_set_line_coll_dash():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -81,7 +79,6 @@ def test_line_dashes():
     ax.plot(range(10), linestyle=(0, (3, 3)), lw=5)
 
 
-@cleanup
 def test_line_colors():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -94,7 +91,6 @@ def test_line_colors():
     assert True
 
 
-@cleanup
 def test_linestyle_variants():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -106,7 +102,6 @@ def test_linestyle_variants():
     assert True
 
 
-@cleanup
 def test_valid_linestyles():
     line = mlines.Line2D([], [])
     with pytest.raises(ValueError):
@@ -127,7 +122,6 @@ def test_drawstyle_variants():
         ax.set(xlim=(0, 2), ylim=(0, 2))
 
 
-@cleanup
 def test_valid_drawstyles():
     line = mlines.Line2D([], [])
     with pytest.raises(ValueError):

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import matplotlib
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 from matplotlib import mathtext
 
@@ -253,7 +253,6 @@ def test_mathtext_exceptions(math, msg):
     excinfo.match(re.escape(msg))
 
 
-@cleanup
 def test_single_minus_sign():
     plt.figure(figsize=(0.3, 0.3))
     plt.text(0.5, 0.5, '$-$')

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.lines as mlines
@@ -43,7 +43,6 @@ def test_offsetbox_clipping():
     ax.set_ylim((0, 1))
 
 
-@cleanup
 def test_offsetbox_clip_children():
     # - create a plot
     # - put an AnchoredOffsetbox with a child DrawingArea
@@ -81,7 +80,6 @@ def test_offsetbox_clip_children():
     assert fig.stale
 
 
-@cleanup
 def test_offsetbox_loc_codes():
     # Check that valid string location codes all work with an AnchoredOffsetbox
     codes = {'upper right': 1,

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -12,7 +12,7 @@ import pytest
 
 from matplotlib.patches import Polygon
 from matplotlib.patches import Rectangle
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.collections as mcollections
@@ -213,7 +213,6 @@ def test_patch_custom_linestyle():
     ax.set_ylim([-1, 2])
 
 
-@cleanup
 def test_patch_linestyle_accents():
     #: Test if linestyle can also be specified with short menoics
     #: like "--"

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -8,6 +8,7 @@ import six
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
+import pytest
 
 from matplotlib.patches import Polygon
 from matplotlib.patches import Rectangle
@@ -174,7 +175,7 @@ def test_patch_alpha_override():
     ax.set_ylim([-1, 2])
 
 
-@cleanup(style='default')
+@pytest.mark.style('default')
 def test_patch_color_none():
     # Make sure the alpha kwarg does not override 'none' facecolor.
     # Addresses issue #7478.

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 import pytest
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.patheffects as path_effects
 
@@ -75,7 +75,6 @@ def test_patheffect3():
     t.set_path_effects(pe)
 
 
-@cleanup
 @pytest.mark.xfail
 def test_PathEffect_points_to_pixels():
     fig = plt.figure(dpi=150)

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -9,7 +9,7 @@ from io import BytesIO
 
 import numpy as np
 
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 from matplotlib.dates import rrulewrapper
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
@@ -93,7 +93,6 @@ def recursive_pickle(top_obj):
             raise
 
 
-@cleanup
 def test_simple():
     fig = plt.figure()
     # un-comment to debug
@@ -195,7 +194,6 @@ def test_complete():
     assert fig.get_label() == 'Figure with a label?'
 
 
-@cleanup
 def test_no_pyplot():
     # tests pickle-ability of a figure not created with pyplot
     from matplotlib.backends.backend_pdf import FigureCanvasPdf as fc
@@ -208,14 +206,12 @@ def test_no_pyplot():
     pickle.dump(fig, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
 
-@cleanup
 def test_renderer():
     from matplotlib.backends.backend_agg import RendererAgg
     renderer = RendererAgg(10, 20, 30)
     pickle.dump(renderer, BytesIO())
 
 
-@cleanup
 def test_image():
     # Prior to v1.4.0 the Image would cache data which was not picklable
     # once it had been drawn.
@@ -228,7 +224,6 @@ def test_image():
     pickle.dump(fig, BytesIO())
 
 
-@cleanup
 def test_polar():
     ax = plt.subplot(111, polar=True)
     fig = plt.gcf()

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 import sys
 from matplotlib import pyplot as plt
-from matplotlib.testing.decorators import cleanup
 from matplotlib.testing.decorators import image_comparison
 
 
@@ -18,7 +17,6 @@ def draw_quiver(ax, **kw):
     return Q
 
 
-@cleanup
 def test_quiver_memory_leak():
     fig, ax = plt.subplots()
 
@@ -31,7 +29,6 @@ def test_quiver_memory_leak():
     assert sys.getrefcount(ttX) == 2
 
 
-@cleanup
 def test_quiver_key_memory_leak():
     fig, ax = plt.subplots()
 
@@ -45,7 +42,6 @@ def test_quiver_key_memory_leak():
     assert sys.getrefcount(qk) == 2
 
 
-@cleanup
 def test_no_warnings():
     fig, ax = plt.subplots()
 
@@ -59,7 +55,6 @@ def test_no_warnings():
     assert len(w) == 0
 
 
-@cleanup
 def test_zero_headlength():
     # Based on report by Doug McNeil:
     # http://matplotlib.1069221.n5.nabble.com/quiver-warnings-td28107.html
@@ -111,7 +106,6 @@ def test_quiver_single():
     ax.quiver([1], [1], [2], [2])
 
 
-@cleanup
 def test_quiver_copy():
     fig, ax = plt.subplots()
     uv = dict(u=np.array([1.1]), v=np.array([2.0]))
@@ -148,7 +142,6 @@ def test_barbs():
              cmap='viridis')
 
 
-@cleanup
 def test_bad_masked_sizes():
     'Test error handling when given differing sized masked arrays'
     x = np.arange(3)
@@ -162,7 +155,6 @@ def test_bad_masked_sizes():
         ax.barbs(x, y, u, v)
 
 
-@cleanup
 def test_quiverkey_angles():
     # Check that only a single arrow is plotted for a quiverkey when an array
     # of angles is given to the original quiver plot

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -18,7 +18,6 @@ except ImportError:
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.tests import assert_str_equal
-from matplotlib.testing.decorators import cleanup
 import matplotlib.colors as mcolors
 from itertools import chain
 import numpy as np
@@ -138,7 +137,6 @@ def test_rcparams_init():
             mpl.RcParams({'figure.figsize': (3.5, 42, 1)})
 
 
-@cleanup
 def test_Bug_2543():
     # Test that it possible to add all values to itself / deepcopy
     # This was not possible because validate_bool_maybe_none did not
@@ -197,7 +195,6 @@ legend_color_test_ids = [
 ]
 
 
-@cleanup
 @pytest.mark.parametrize('color_type, param_dict, target', legend_color_tests,
                          ids=legend_color_test_ids)
 def test_legend_colors(color_type, param_dict, target):

--- a/lib/matplotlib/tests/test_sankey.py
+++ b/lib/matplotlib/tests/test_sankey.py
@@ -2,10 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from matplotlib.sankey import Sankey
-from matplotlib.testing.decorators import cleanup
 
 
-@cleanup
 def test_sankey():
     # lets just create a sankey instance and check the code runs
     sankey = Sankey()

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import numpy as np
 import io
@@ -28,7 +28,6 @@ def test_logit_scales():
     ax.grid(True)
 
 
-@cleanup
 def test_log_scatter():
     """Issue #1799"""
     fig, ax = plt.subplots(1)

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -6,7 +6,7 @@ import io
 import numpy as np
 import pytest
 
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 
 from matplotlib import patches, transforms
@@ -47,7 +47,6 @@ def test_diamond():
     ax.set_ylim(ymin=-0.6, ymax=0.6)
 
 
-@cleanup
 def test_noise():
     np.random.seed(0)
     x = np.random.uniform(size=(5000,)) * 50
@@ -63,7 +62,6 @@ def test_noise():
     assert len(simplified) == 3884
 
 
-@cleanup
 def test_sine_plus_noise():
     np.random.seed(0)
     x = (np.sin(np.linspace(0, np.pi * 2.0, 1000)) +
@@ -117,7 +115,6 @@ def test_fft_peaks():
     assert len(simplified) == 20
 
 
-@cleanup
 def test_start_with_moveto():
     # Should be entirely clipped away to a single MOVETO
     data = b"""
@@ -160,7 +157,6 @@ AAj1//+nPwAA/////w=="""
     assert segs[0][1] == Path.MOVETO
 
 
-@cleanup
 def test_throw_rendering_complexity_exceeded():
     plt.rcParams['path.simplify'] = False
     xx = np.arange(200000)

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 
 
 @image_comparison(baseline_images=['spines_axes_positions'])
@@ -46,7 +46,6 @@ def test_spines_capstyle():
     ax.set_yticks([])
 
 
-@cleanup
 def test_label_without_ticks():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.transforms as mtransforms
 
 
@@ -82,7 +82,6 @@ def test_direction():
                    linewidth=2, density=2)
 
 
-@cleanup
 def test_streamplot_limits():
     ax = plt.axes()
     x = np.linspace(-5, 10, 20)

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 
 import pytest
 
@@ -40,7 +40,6 @@ def check_visible(axs, x_visible, y_visible):
                     "Y axis was incorrectly %s" % (tostr(vy))
 
 
-@cleanup
 def test_shared():
     rdim = (4, 4, 2)
     share = {
@@ -102,7 +101,6 @@ def test_shared():
     check_visible(axs, [False, False, True, True], [True, False, True, False])
 
 
-@cleanup
 def test_exceptions():
     # TODO should this test more options?
     with pytest.raises(ValueError):

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -5,13 +5,12 @@ import six
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 
 from matplotlib.table import CustomCell
 from matplotlib.path import Path
 
 
-@cleanup
 def test_non_square():
     # Check that creating a non-square table works
     cellcolors = ['b', 'r']

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -11,7 +11,7 @@ import pytest
 from matplotlib.transforms import Bbox
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 from matplotlib.figure import Figure
 from matplotlib.text import Annotation, Text
 from matplotlib.backends.backend_agg import RendererAgg
@@ -232,7 +232,6 @@ def test_axes_titles():
     ax.set_title('right', loc='right', fontsize=12, fontweight=400)
 
 
-@cleanup
 def test_set_position():
     fig, ax = plt.subplots()
 
@@ -366,7 +365,6 @@ def test_annotation_negative_fig_coords():
                 va='top')
 
 
-@cleanup
 def test_text_stale():
     fig, (ax1, ax2) = plt.subplots(1, 2)
     plt.draw_all()
@@ -401,7 +399,6 @@ def test_agg_text_clip():
     plt.show()
 
 
-@cleanup
 def test_text_size_binding():
     from matplotlib.font_manager import FontProperties
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -8,7 +8,6 @@ import pytest
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
-from matplotlib.testing.decorators import cleanup
 
 import warnings
 
@@ -26,7 +25,6 @@ def test_MaxNLocator():
     assert_almost_equal(loc.tick_values(-1e15, 1e15), test_value)
 
 
-@cleanup
 def test_MaxNLocator_integer():
     loc = mticker.MaxNLocator(nbins=5, integer=True)
     test_value = np.array([-1, 0, 1, 2])
@@ -53,7 +51,6 @@ def test_MultipleLocator():
     assert_almost_equal(loc.tick_values(-7, 10), test_value)
 
 
-@cleanup
 def test_AutoMinorLocator():
     fig, ax = plt.subplots()
     ax.set_xlim(0, 1.39)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -13,7 +13,7 @@ from matplotlib.testing.decorators import cleanup
 import warnings
 
 
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 def test_MaxNLocator():
     loc = mticker.MaxNLocator(nbins=5)
     test_value = np.array([20., 40., 60., 80., 100.])
@@ -174,7 +174,7 @@ def test_SymmetricalLogLocator_set_params():
     assert sym.numticks == 8
 
 
-@cleanup(style='classic')
+@pytest.mark.style('classic')
 @pytest.mark.parametrize('left, right, offset',
                          [(123, 189, 0),
                           (-189, -123, 0),
@@ -240,7 +240,7 @@ def _sub_labels(axis, subs=()):
     assert label_test == label_expected
 
 
-@cleanup(style='default')
+@pytest.mark.style('default')
 def test_LogFormatter_sublabel():
     # test label locator
     fig, ax = plt.subplots()
@@ -318,6 +318,7 @@ def test_LogFormatterExponent_blank():
     assert formatter(10**0.1) == ''
 
 
+@pytest.mark.style('default')
 def test_LogFormatterSciNotation():
     test_cases = {
         10: (

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -15,10 +15,9 @@ import matplotlib.patches as mpatches
 import matplotlib.transforms as mtrans
 from matplotlib.path import Path
 from matplotlib.scale import LogScale
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 
 
-@cleanup
 def test_non_affine_caching():
     class AssertingNonAffineTransform(mtrans.Transform):
         """
@@ -57,7 +56,6 @@ def test_non_affine_caching():
     plt.draw()
 
 
-@cleanup
 def test_external_transform_api():
     class ScaledBy(object):
         def __init__(self, scale_factor):
@@ -112,7 +110,6 @@ def test_pre_transform_plotting():
     ax.barbs(x - 3, y + 5, u**2, v**2, transform=times10 + ax.transData)
 
 
-@cleanup
 def test_contour_pre_transform_limits():
     ax = plt.axes()
     xs, ys = np.meshgrid(np.linspace(15, 20, 15), np.linspace(12.4, 12.5, 20))
@@ -124,7 +121,6 @@ def test_contour_pre_transform_limits():
     assert_almost_equal(expected, ax.dataLim.get_points())
 
 
-@cleanup
 def test_pcolor_pre_transform_limits():
     # Based on test_contour_pre_transform_limits()
     ax = plt.axes()
@@ -137,7 +133,6 @@ def test_pcolor_pre_transform_limits():
     assert_almost_equal(expected, ax.dataLim.get_points())
 
 
-@cleanup
 def test_pcolormesh_pre_transform_limits():
     # Based on test_contour_pre_transform_limits()
     ax = plt.axes()
@@ -503,7 +498,6 @@ def test_transform_single_point():
     assert r.shape == (2,)
 
 
-@cleanup
 def test_log_transform():
     # Tests that the last line runs without exception (previously the
     # transform would fail if one of the axes was logarithmic).
@@ -512,7 +506,6 @@ def test_log_transform():
     ax.transData.transform((1, 1))
 
 
-@cleanup
 def test_nan_overlap():
     a = mtrans.Bbox([[0, 0], [1, 1]])
     b = mtrans.Bbox([[0, 0], [1, np.nan]])

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -10,7 +10,7 @@ import pytest
 from numpy.testing import assert_array_equal, assert_array_almost_equal,\
     assert_array_less
 import numpy.ma.testutils as matest
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 import matplotlib.cm as cm
 from matplotlib.path import Path
 
@@ -1029,7 +1029,6 @@ def test_trianalyzer_mismatched_indices():
     triang2 = analyser._get_compressed_triangulation()
 
 
-@cleanup
 def test_tricontourf_decreasing_levels():
     # github issue 5477.
     x = [0.0, 1.0, 1.0]

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 import matplotlib.units as munits
 import numpy as np
-from matplotlib.testing.decorators import cleanup
 
 try:
     # mock in python 3.3+
@@ -12,7 +11,6 @@ except ImportError:
 
 # Tests that the conversion machinery works properly for classes that
 # work as a facade over numpy arrays (like pint)
-@cleanup
 def test_numpy_facade():
     # Basic class that wraps numpy array and has units
     class Quantity(object):

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -9,7 +9,7 @@ except ImportError:
 
 import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup, image_comparison
+from matplotlib.testing.decorators import image_comparison
 
 from numpy.testing import assert_allclose
 
@@ -76,7 +76,6 @@ def do_event(tool, etype, button=1, xdata=0, ydata=0, key=None, step=1):
     func(event)
 
 
-@cleanup
 def check_rectangle(**kwargs):
     ax = get_ax()
 
@@ -111,7 +110,6 @@ def test_rectangle_selector():
     check_rectangle(rectprops=dict(fill=True))
 
 
-@cleanup
 def test_ellipse():
     """For ellipse, test out the key modifiers"""
     ax = get_ax()
@@ -166,7 +164,6 @@ def test_ellipse():
     assert_allclose(tool.geometry[:, 0], [70., 100])
 
 
-@cleanup
 def test_rectangle_handles():
     ax = get_ax()
 
@@ -203,7 +200,6 @@ def test_rectangle_handles():
     assert tool.extents == (10, 100, 10, 100)
 
 
-@cleanup
 def check_span(*args, **kwargs):
     ax = get_ax()
 
@@ -237,7 +233,6 @@ def test_span_selector():
     check_span('horizontal', rectprops=dict(fill=True))
 
 
-@cleanup
 def check_lasso_selector(**kwargs):
     ax = get_ax()
 
@@ -259,7 +254,6 @@ def test_lasso_selector():
     check_lasso_selector(useblit=True, button=1)
 
 
-@cleanup
 def test_CheckButtons():
     ax = get_ax()
     check = widgets.CheckButtons(ax, ('a', 'b', 'c'), (True, False, True))

--- a/lib/mpl_toolkits/tests/conftest.py
+++ b/lib/mpl_toolkits/tests/conftest.py
@@ -1,0 +1,4 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from matplotlib.tests.conftest import mpl_test_settings

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -5,7 +5,7 @@ import six
 
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 
 from mpl_toolkits.axes_grid1 import host_subplot
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -91,7 +91,6 @@ def test_twin_axes_empty_and_removed():
     plt.subplots_adjust(wspace=0.5, hspace=1)
 
 
-@cleanup
 def test_axesgrid_colorbar_log_smoketest():
     fig = plt.figure()
     grid = AxesGrid(fig, 111,  # modified to be only subplot

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -2,7 +2,7 @@ import pytest
 
 from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d
 from matplotlib import cm
-from matplotlib.testing.decorators import image_comparison, cleanup
+from matplotlib.testing.decorators import image_comparison
 from matplotlib.collections import LineCollection
 from matplotlib.patches import Circle
 import matplotlib.pyplot as plt
@@ -21,7 +21,6 @@ def test_bar3d():
         ax.bar(xs, ys, zs=z, zdir='y', color=cs, alpha=0.8)
 
 
-@cleanup
 def test_bar3d_dflt_smoke():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -218,7 +217,6 @@ def test_wireframe3dzerorstride():
     ax.plot_wireframe(X, Y, Z, rstride=0, cstride=10)
 
 
-@cleanup
 def test_wireframe3dzerostrideraises():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -227,7 +225,6 @@ def test_wireframe3dzerostrideraises():
         ax.plot_wireframe(X, Y, Z, rstride=0, cstride=0)
 
 
-@cleanup
 def test_mixedsamplesraises():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -345,7 +342,6 @@ def test_axes3d_cla():
     ax.set_axis_off()
     ax.cla()  # make sure the axis displayed is 3D (not 2D)
 
-@cleanup
 def test_plotsurface_1d_raises():
     x = np.linspace(0.5, 10, num=100)
     y = np.linspace(0.5, 10, num=100)
@@ -470,7 +466,6 @@ def test_lines_dists():
     ax.set_ylim(0, 300)
 
 
-@cleanup
 def test_autoscale():
     fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
     ax.margins(x=0, y=.1, z=.2)


### PR DESCRIPTION
~~I'm pre-opening this PR to verify that tests continue to build correctly. However, it still depends on #7935.~~

This PR converts the test decorators `@cleanup` and `@switch_backend` into a single pytest fixture that does both things at the same time. In order to set a different style or backend, tests must be marked with `@pytest.mark.style('name')` or `@pytest.mark.backend('name')`.

Due to the way `matplotlib.testing.setup` works, it turns out that 'default' is the style used for any tests _not_ decorated. Since this fixture uses 'classic', some additional tests needed to be marked by the 'default' style.

Additionally, because `switch_backend` calls `matplotlib.testing.setup`, the PGF tests (which use `@cleanup('classic')` do _not_ actually use that style, so they've been set to 'default' here.