### PR TITLE
Edits to the coding guide

### DIFF
--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -26,10 +26,10 @@ Documentation
 * Every new feature should be documented.  If it's a new module, don't
   forget to add a new rst file to the API docs.
 
-* Each high-level plotting function should have a simple example in
+* Each high-level plotting function should have a small example in
   the `Example` section of the docstring.  This should be as simple as
   possible to demonstrate the method.  More complex examples should go
-  in the `examples` tree.
+  in the `examples` section of the documentation.
 
 * Build the docs and make sure all formatting warnings are addressed.
 
@@ -47,24 +47,23 @@ Documentation
 PR Review guidelines
 ====================
 
-* If you have a commit bit, then you are trusted to use it.  Please
+* If you have commit rights, then you are trusted to use them.  Please
   help review and merge PRs!
 
 * Two developers (those with commit rights) should review all pull
-  requests.  If you are the first to review a PR please and approve of
-  the changes please edit the title to include ``'[MRG+1]'`` and use
+  requests.  If you are the first to review a PR and approve of
+  the changes, please edit the title to include ``'[MRG+1]'`` and use
   the github `'approve review'
   <https://help.github.com/articles/reviewing-changes-in-pull-requests/>`__
   tool to mark it as such.  If you are a subsequent reviewer and you
-  approve either merge (and backport if needed) or increment the
-  number in the title to ask for further review (and trigger the gh
-  'approve review').  If you do the merge please removed the
-  ``'[MRG+N']`` prefix.
+  approve, either merge (and backport if needed) or select ``'approve review'`` and 
+  increment the number in the title to ask for further review.  
+  If you do the merge, please remove the ``'[MRG+N']`` prefix.
 
 * Make sure the Travis tests are passing before merging.
 
-  - The Travis tests automatically test on all of the Python versions
-    Matplotlib supports whenever a pull request is created or updated.
+  - The Travis tests automatically test the code on all of the Python versions
+    Matplotlib supports when a pull request is created or updated.
     The `tox` support in Matplotlib may be useful for testing locally.
 
 * Do not self merge, except for 'small' patches to un-break the CI.
@@ -75,7 +74,7 @@ PR Review guidelines
   about it is to eliminate binary files (ex multiple test image
   re-generations) and to remove upstream merges.
 
-* Be patient with new contributors.
+* Be patient with contributors.
 
 * Do not let perfect be the enemy of the good, particularly for
   documentation or example PRs.  If you find yourself making many


### PR DESCRIPTION
removed a misplaced `please` and some jargony bits it took me a bit long to grok, and made some style choices.