### PR TITLE
Backport spectral/spectral_r deprecations fixes from #7857

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -10,7 +10,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import os
-import warnings as _warnings  # To remove once spectral is removed
 import numpy as np
 from numpy import ma
 import matplotlib as mpl
@@ -69,7 +68,8 @@ def _generate_cmap(name, lutsize):
     """Generates the requested cmap from its *name*.  The lut size is
     *lutsize*."""
 
-    spec = datad[name]
+    # Use superclass method to avoid deprecation warnings during initial load.
+    spec = dict.__getitem__(datad, name)
 
     # Generate the colormap object.
     if 'red' in spec:
@@ -81,22 +81,18 @@ def _generate_cmap(name, lutsize):
 
 LUTSIZE = mpl.rcParams['image.lut']
 
-# We silence warnings here to avoid raising the deprecation warning for
-# spectral/spectral_r when this module is imported.
-with _warnings.catch_warnings():
-    _warnings.simplefilter("ignore")
-    # Generate the reversed specifications ...
-    for cmapname in list(six.iterkeys(datad)):
-        spec = datad[cmapname]
-        spec_reversed = _reverse_cmap_spec(spec)
-        datad[cmapname + '_r'] = spec_reversed
+# Generate the reversed specifications ...
+for cmapname in list(six.iterkeys(datad)):
+    spec = datad[cmapname]
+    spec_reversed = _reverse_cmap_spec(spec)
+    datad[cmapname + '_r'] = spec_reversed
 
-    # Precache the cmaps with ``lutsize = LUTSIZE`` ...
+# Precache the cmaps with ``lutsize = LUTSIZE`` ...
 
-    # Use datad.keys() to also add the reversed ones added in the section
-    # above:
-    for cmapname in six.iterkeys(datad):
-        cmap_d[cmapname] = _generate_cmap(cmapname, LUTSIZE)
+# Use datad.keys() to also add the reversed ones added in the section
+# above:
+for cmapname in six.iterkeys(datad):
+    cmap_d[cmapname] = _generate_cmap(cmapname, LUTSIZE)
 
 cmap_d.update(cmaps_listed)
 


### PR DESCRIPTION
There were some minor conflicts, so I thought I'd run it through CI first.

The test that triggers this deprecation doesn't exist on the `v2.0.x` branch, so I did not backport the changes to it.