### PR TITLE
[MRG+1] Fix cmap deprecation (again)

### DIFF
--- a/lib/matplotlib/_cm.py
+++ b/lib/matplotlib/_cm.py
@@ -1384,11 +1384,11 @@ class _deprecation_datad(dict):
                      "Vega20b_r", "Vega20c", "Vega20c_r"]:
             warn_deprecated(
                 "2.0",
-                name="Vega colormaps",
-                alternative="tab",
+                name=key,
+                alternative="tab" + key[4:],
                 obj_type="colormap"
                 )
- 
+
         return super(_deprecation_datad, self).__getitem__(key)
 
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -83,7 +83,8 @@ LUTSIZE = mpl.rcParams['image.lut']
 
 # Generate the reversed specifications ...
 for cmapname in list(six.iterkeys(datad)):
-    spec = datad[cmapname]
+    # Use superclass method to avoid deprecation warnings during initial load.
+    spec = dict.__getitem__(datad, cmapname)
     spec_reversed = _reverse_cmap_spec(spec)
     datad[cmapname + '_r'] = spec_reversed
 


### PR DESCRIPTION
This is a follow-up to #7982. Unfortunately, `v2.0.x` uses a different loop and I missed one of the accesses which still triggers a warning.

Additionally, fix the deprecation message for the Vega colourmaps, which doesn't quite work when all the parameters are substituted into the message.