### PR TITLE
Set sticky_edges correctly for negative height bar().

### DIFF
--- a/doc/api/api_changes/2017-01-30-AL_negative_bar_height_width.rst
+++ b/doc/api/api_changes/2017-01-30-AL_negative_bar_height_width.rst
@@ -1,0 +1,7 @@
+`bar` now returns rectangles of negative height or width if the corresponding input is negative
+```````````````````````````````````````````````````````````````````````````````````````````````
+
+`plt.bar` used to normalize the coordinates of the rectangles that it created,
+to keep their height and width positives, even if the corresponding input was
+negative.  This normalization has been removed to permit a simpler computation
+of the correct `sticky_edges` to use.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2114,12 +2114,6 @@ or tuple of floats
 
         args = zip(left, bottom, width, height, color, edgecolor, linewidth)
         for l, b, w, h, c, e, lw in args:
-            if h < 0:
-                b += h
-                h = abs(h)
-            if w < 0:
-                l += w
-                w = abs(w)
             r = mpatches.Rectangle(
                 xy=(l, b), width=w, height=h,
                 facecolor=c,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4388,16 +4388,6 @@ def test_rc_major_minor_tick():
         assert yax._minor_tick_kw['tick2On'] == True
 
 
-def test_bar_negative_width():
-    fig, ax = plt.subplots()
-    res = ax.bar(range(1, 5), range(1, 5), width=-1)
-    assert len(res) == 4
-    for indx, b in enumerate(res):
-        assert b._x == indx
-        assert b._width == 1
-        assert b._height == indx + 1
-
-
 def test_square_plot():
     x = np.arange(4)
     y = np.array([1., 3., 5., 7.])

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -82,6 +82,14 @@ def test_rotate_rect():
     assert_almost_equal(rect1.get_verts(), new_verts)
 
 
+def test_negative_rect():
+    # These two rectangles have the same vertices, but starting from a
+    # different point.  (We also drop the last vertex, which is a duplicate.)
+    pos_vertices = Rectangle((-3, -2), 3, 2).get_verts()[:-1]
+    neg_vertices = Rectangle((0, 0), -3, -2).get_verts()[:-1]
+    assert_array_equal(np.roll(neg_vertices, 2, 0), pos_vertices)
+
+
 @image_comparison(baseline_images=['clip_to_bbox'])
 def test_clip_to_bbox():
     fig = plt.figure()


### PR DESCRIPTION
The patch correctly sets the sticky edge to 0 instead of -1 for
 `bar(0, height=-1)`.

Noticed the issue the plots in https://github.com/matplotlib/matplotlib/issues/7994#issue-204093719.