### PR TITLE
[MRG+1] Display relative image paths when tests fail.

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -203,9 +203,11 @@ def _raise_on_image_difference(expected, actual, tol):
         raise ImageComparisonFailure('image does not exist: %s' % expected)
 
     if err:
+        for key in ["actual", "expected"]:
+            err[key] = os.path.relpath(err[key])
         raise ImageComparisonFailure(
-            'images not close: %(actual)s vs. %(expected)s '
-            '(RMS %(rms).3f)' % err)
+            'images not close (RMS %(rms).3f):\n\t%(actual)s\n\t%(expected)s '
+             % err)
 
 
 def _xfail_if_format_is_uncomparable(extension):


### PR DESCRIPTION
Before the PR, an image comparison failure was reported as
```
E   matplotlib.testing.exceptions.ImageComparisonFailure: images not close: /home/antony/src/extern/matplotlib/result_images/test_axes/pcolormesh_svg.png vs. /home/antony/src/extern/matplotlib/result_images/test_axes/pcolormesh-expected_svg.png (RMS 0.001)
```
This PR changes it to
```
E   matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 0.001):
E       result_images/test_axes/pcolormesh_svg.png
E       result_images/test_axes/pcolormesh-expected_svg.png
```
which I believe more legible.

(It would be nice to just display a single path but parts of the testing
machinery seem to accept arbitrary image paths, not necessarily in the
same folder, even though this is not done in practice.)