### PR TITLE
Fix broken backported test

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1502,6 +1502,7 @@ default_test_modules = [
     'matplotlib.tests.test_image',
     'matplotlib.tests.test_legend',
     'matplotlib.tests.test_lines',
+    'matplotlib.tests.test_marker',
     'matplotlib.tests.test_mathtext',
     'matplotlib.tests.test_mlab',
     'matplotlib.tests.test_offsetbox',

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -2,6 +2,7 @@ import numpy as np
 from matplotlib import markers
 from nose.tools import assert_raises
 
+
 def test_markers_valid():
     marker_style = markers.MarkerStyle()
     mrk_array = np.array([[-0.5, 0],
@@ -12,7 +13,7 @@ def test_markers_valid():
 
 def test_markers_invalid():
     marker_style = markers.MarkerStyle()
-    mrk_array = np.array([[-0.5, 0,  1, 2, 3]])
+    mrk_array = np.array([[-0.5, 0, 1, 2, 3]])
     # Checking this does fail.
     with assert_raises(ValueError):
         marker_style.set_marker(mrk_array)

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -1,8 +1,6 @@
 import numpy as np
 from matplotlib import markers
-
-import pytest
-
+from nose.tools import assert_raises
 
 def test_markers_valid():
     marker_style = markers.MarkerStyle()
@@ -16,5 +14,5 @@ def test_markers_invalid():
     marker_style = markers.MarkerStyle()
     mrk_array = np.array([[-0.5, 0,  1, 2, 3]])
     # Checking this does fail.
-    with pytest.raises(ValueError):
+    with assert_raises(ValueError):
         marker_style.set_marker(mrk_array)


### PR DESCRIPTION
The backport of #7809 had a broken test, that was never tested. This fixes it by:

- Using nose instead of pytest
- Correcting test discovery. The travis tests on my personal branch ran +2 tests relative to current `2.0.x`, so the new tests are being collected properly.