### PR TITLE
FIX: do not try to render empty images

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -488,7 +488,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             return
 
         # for empty images, there is nothing to draw!
-        if any(s == 0 for s in self.get_size()):
+        if self.get_array().size == 0:
             self.stale = False
             return
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -301,6 +301,10 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         if A is None:
             raise RuntimeError('You must first set the image'
                                ' array or the image attribute')
+        if any(s == 0 for s in A.shape):
+            raise RuntimeError("_make_image must get a non-empty image. "
+                               "Your Artist's draw method must filter before "
+                               "this method is called.")
 
         clipped_bbox = Bbox.intersection(out_bbox, clip_bbox)
 
@@ -478,9 +482,17 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     @allow_rasterization
     def draw(self, renderer, *args, **kwargs):
+        # if not visible, declare victory and return
         if not self.get_visible():
+            self.stale = False
             return
 
+        # for empty images, there is nothing to draw!
+        if any(s == 0 for s in self.get_size()):
+            self.stale = False
+            return
+
+        # actually render the image.
         gc = renderer.new_gc()
         self._set_gc_clip(gc)
         gc.set_alpha(self.get_alpha())

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -773,8 +773,7 @@ def test_empty_imshow():
     im.set_extent([-5, 5, -5, 5])
     fig.canvas.draw()
 
-    with nose.tools.raises(RuntimeError):
-        im.make_image(fig._cachedRenderer)
+    nose.tools.assert_raises(RuntimeError, im.make_image, fig._cachedRenderer)
 
 
 if __name__ == '__main__':

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -32,6 +32,7 @@ import matplotlib.mlab as mlab
 import numpy as np
 
 import nose
+import nose.tools
 
 try:
     from PIL import Image
@@ -763,6 +764,17 @@ def test_imshow_no_warn_invalid():
         warnings.simplefilter("always")
         plt.imshow([[1, 2], [3, np.nan]])
     assert len(warns) == 0
+
+
+@cleanup
+def test_empty_imshow():
+    fig, ax = plt.subplots()
+    im = ax.imshow([[]])
+    im.set_extent([-5, 5, -5, 5])
+    fig.canvas.draw()
+
+    with nose.tools.raises(RuntimeError):
+        im.make_image(fig._cachedRenderer)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Do not bother trying to render Images which have zero-dimension in any
direction.  Simply return from the `draw` method early

closes #7886