### PR TITLE
[MRG+1] Clean up BoundaryNorm docstring

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1269,7 +1269,7 @@ class BoundaryNorm(Normalize):
         is mapped to the color with the same index.
 
         If the number of bins doesn't equal *ncolors*, the color is chosen
-        by linear inpolation of the bin number onto color numbers.
+        by linear interpolation of the bin number onto color numbers.
         """
         self.clip = clip
         self.vmin = boundaries[0]

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1246,7 +1246,7 @@ class BoundaryNorm(Normalize):
     between integer and floating point.
     """
     def __init__(self, boundaries, ncolors, clip=False):
-        r"""
+        """
         Parameters
         ----------
         boundaries : sequence
@@ -1254,9 +1254,9 @@ class BoundaryNorm(Normalize):
         ncolors : int
             Number of colors in the colormap to be used
         clip : bool, optional
-            If clip is *True*, out of range values are mapped to *0* if they
-            are below *boundaries[0]* or mapped to *ncolors - 1* if they are
-            above *boundaries[-1]*.
+            If *clip* is ``True``, out of range values are mapped to 0 if they
+            are below ``boundaries[0]`` or mapped to *ncolors* - 1 if they are
+            above ``boundaries[-1]``.
 
             If clip is *False*, out of range values are mapped to *-1* if they
             are below *boundaries[0]* or mapped to *ncolors* if they are
@@ -1265,9 +1265,11 @@ class BoundaryNorm(Normalize):
 
         Notes
         -----
-        If :code:`b[i] <= v < b[i+1]` then v is mapped to
-        floor( :math:`\frac{n_{colors}- 1}{n_{bins} - 1} * i`), where nbins is
-        is ``len(boundaries) - 2``.
+        *boundaries* defines the edges of bins, and data falling within a bin
+        is mapped to the color with the same index.
+
+        If the number of bins doesn't equal *ncolors*, the color is chosen
+        by linear inpolation of the bin number onto color numbers.
         """
         self.clip = clip
         self.vmin = boundaries[0]

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1249,17 +1249,17 @@ class BoundaryNorm(Normalize):
         """
         Parameters
         ----------
-        boundaries : sequence
+        boundaries : array-like
             Monotonically increasing sequence of boundaries
         ncolors : int
             Number of colors in the colormap to be used
         clip : bool, optional
-            If *clip* is ``True``, out of range values are mapped to 0 if they
-            are below ``boundaries[0]`` or mapped to *ncolors* - 1 if they are
+            If clip is ``True``, out of range values are mapped to 0 if they
+            are below ``boundaries[0]`` or mapped to ncolors - 1 if they are
             above ``boundaries[-1]``.
 
-            If *clip* is ``False``, out of range values are mapped to -1 if
-            they are below ``boundaries[0]`` or mapped to *ncolors* if they are
+            If clip is ``False``, out of range values are mapped to -1 if
+            they are below ``boundaries[0]`` or mapped to ncolors if they are
             above ``boundaries[-1]``. These are then converted to valid indices
             by :meth:`Colormap.__call__`.
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1258,9 +1258,9 @@ class BoundaryNorm(Normalize):
             are below ``boundaries[0]`` or mapped to *ncolors* - 1 if they are
             above ``boundaries[-1]``.
 
-            If clip is *False*, out of range values are mapped to *-1* if they
-            are below *boundaries[0]* or mapped to *ncolors* if they are
-            above *boundaries[-1]*. These are then converted to valid indices
+            If *clip* is ``False``, out of range values are mapped to -1 if
+            they are below ``boundaries[0]`` or mapped to *ncolors* if they are
+            above ``boundaries[-1]``. These are then converted to valid indices
             by :meth:`Colormap.__call__`.
 
         Notes

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1246,7 +1246,7 @@ class BoundaryNorm(Normalize):
     between integer and floating point.
     """
     def __init__(self, boundaries, ncolors, clip=False):
-        """
+        r"""
         Parameters
         ----------
         boundaries : sequence
@@ -1265,9 +1265,9 @@ class BoundaryNorm(Normalize):
 
         Notes
         -----
-        If :code:`b[i] <= v < b[i+1]` then v is mapped to color j;
-        as i varies from 0 to len(boundaries)-2,
-        j goes from 0 to ncolors-1.
+        If :code:`b[i] <= v < b[i+1]` then v is mapped to
+        floor( :math:`\frac{n_{colors}- 1}{n_{bins} - 1} * i`), where nbins is
+        is ``len(boundaries) - 2``.
         """
         self.clip = clip
         self.vmin = boundaries[0]

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1247,25 +1247,27 @@ class BoundaryNorm(Normalize):
     """
     def __init__(self, boundaries, ncolors, clip=False):
         """
-        *boundaries*
-            a monotonically increasing sequence
-        *ncolors*
-            number of colors in the colormap to be used
+        Parameters
+        ----------
+        boundaries : sequence
+            Monotonically increasing sequence of boundaries
+        ncolors : int
+            Number of colors in the colormap to be used
+        clip : bool, optional
+            If clip is *True*, out of range values are mapped to *0* if they
+            are below *boundaries[0]* or mapped to *ncolors - 1* if they are
+            above *boundaries[-1]*.
 
-        If::
+            If clip is *False*, out of range values are mapped to *-1* if they
+            are below *boundaries[0]* or mapped to *ncolors* if they are
+            above *boundaries[-1]*. These are then converted to valid indices
+            by :meth:`Colormap.__call__`.
 
-            b[i] <= v < b[i+1]
-
-        then v is mapped to color j;
+        Notes
+        -----
+        If :code:`b[i] <= v < b[i+1]` then v is mapped to color j;
         as i varies from 0 to len(boundaries)-2,
         j goes from 0 to ncolors-1.
-
-        Out-of-range values are mapped
-        to -1 if low and ncolors if high; these are converted
-        to valid indices by
-        :meth:`Colormap.__call__` .
-        If clip == True, out-of-range values
-        are mapped to 0 if low and ncolors-1 if high.
         """
         self.clip = clip
         self.vmin = boundaries[0]
@@ -1304,6 +1306,13 @@ class BoundaryNorm(Normalize):
         return ret
 
     def inverse(self, value):
+        """
+        Raises
+        ------
+        ValueError
+            BoundaryNorm is not invertible, so calling this method will always
+            raise an error
+        """
         return ValueError("BoundaryNorm is not invertible")
 
 


### PR DESCRIPTION
- Make numpydoc compatible
- Add note that calling `invert` will always raise a `ValueError`