### PR TITLE
[MRG+1] Cleanup visual_tests and disable browser opening

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -139,7 +139,7 @@ test_script:
   - if x%USE_PYTEST% == xyes py.test %PYTEST_ARGS%
   - if x%USE_PYTEST% == xno python tests.py %PYTEST_ARGS%
   # Generate a html for visual tests
-  - python visual_tests.py
+  - python visual_tests.py --no-browser
   - pip install codecov
   - codecov -e PYTHON_VERSION PLATFORM
 
@@ -180,7 +180,7 @@ artifacts:
 on_finish:
 
 on_failure:
-  - python visual_tests.py
+  - python visual_tests.py --no-browser
   - echo zipping images after a failure...
   - 7z a result_images.zip result_images\ |grep -v "Compressing"
   - appveyor PushArtifact result_images.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -139,7 +139,7 @@ test_script:
   - if x%USE_PYTEST% == xyes py.test %PYTEST_ARGS%
   - if x%USE_PYTEST% == xno python tests.py %PYTEST_ARGS%
   # Generate a html for visual tests
-  - python visual_tests.py --no-browser
+  - python tools/visualize_tests.py --no-browser
   - pip install codecov
   - codecov -e PYTHON_VERSION PLATFORM
 
@@ -180,7 +180,7 @@ artifacts:
 on_finish:
 
 on_failure:
-  - python visual_tests.py --no-browser
+  - python tools/visualize_tests.py --no-browser
   - echo zipping images after a failure...
   - 7z a result_images.zip result_images\ |grep -v "Compressing"
   - appveyor PushArtifact result_images.zip

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,7 +15,6 @@ pep8ignore =
     setupext.py E301 E302 E501
     setup_external_compile.py E302 E501 E711
     versioneer.py ALL  # External file.
-    visual_tests.py E302 E501
 
     matplotlib/backends/qt_editor/formlayout.py E301 E402 E501
     matplotlib/backends/backend_agg.py E225 E228 E231 E261 E301 E302 E303 E501 E701

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-norecursedirs = .git build ci dist doc extern lib/mpl_examples release tools unit venv
+norecursedirs = .git build ci dist doc extern lib/mpl_examples release unit venv
 python_files = test_*.py
 
 markers =
@@ -15,6 +15,10 @@ pep8ignore =
     setupext.py E301 E302 E501
     setup_external_compile.py E302 E501 E711
     versioneer.py ALL  # External file.
+
+    tools/gh_api.py ALL  # External file.
+    tools/github_stats.py ALL  # External file.
+    tools/subset.py E221 E231 E251 E261 E302 E501 E701 E703
 
     matplotlib/backends/qt_editor/formlayout.py E301 E402 E501
     matplotlib/backends/backend_agg.py E225 E228 E231 E261 E301 E302 E303 E501 E701

--- a/tools/make_icons.py
+++ b/tools/make_icons.py
@@ -11,7 +11,7 @@ Generates SVG, PDF in one size (size they are vectors) and PNG, PPM and GIF in
 """
 
 import matplotlib
-matplotlib.use('agg')
+matplotlib.use('agg')  # noqa
 
 import six
 

--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -187,8 +187,8 @@ class Dialog(QtWidgets.QDialog):
     def set_large_image(self, index):
         self.thumbnails[self.current_thumbnail].setFrameShape(0)
         self.current_thumbnail = index
-        pixmap = QtGui.QPixmap(
-            self.entries[self.current_entry].thumbnails[self.current_thumbnail])
+        pixmap = QtGui.QPixmap(self.entries[self.current_entry]
+                                   .thumbnails[self.current_thumbnail])
         self.image_display.setPixmap(pixmap)
         self.thumbnails[self.current_thumbnail].setFrameShape(1)
 
@@ -212,9 +212,9 @@ class Dialog(QtWidgets.QDialog):
         elif e.key() == QtCore.Qt.Key_Right:
             self.set_large_image((self.current_thumbnail + 1) % 3)
         elif e.key() == QtCore.Qt.Key_Up:
-            self.set_entry(max((self.current_entry - 1), 0))
+            self.set_entry(max(self.current_entry - 1, 0))
         elif e.key() == QtCore.Qt.Key_Down:
-            self.set_entry(min((self.current_entry + 1), len(self.entries) - 1))
+            self.set_entry(min(self.current_entry + 1, len(self.entries) - 1))
         elif e.key() == QtCore.Qt.Key_A:
             self.accept_test()
         elif e.key() == QtCore.Qt.Key_R:
@@ -249,7 +249,8 @@ class Entry(object):
         self.extension = extension
         self.generated = basename + '.' + extension
         self.expected = basename + '-expected.' + extension
-        self.expected_display = basename + '-expected' + display_extension + '.png'
+        self.expected_display = (basename + '-expected' + display_extension +
+                                 '.png')
         self.generated_display = basename + display_extension + '.png'
         self.name = os.path.join(self.reldir, self.basename)
         self.destdir = self.get_dest_dir(self.reldir)

--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -11,7 +11,7 @@ To start:
 
     If you ran the tests from the top-level of a source checkout, simply run:
 
-        python tools/test_triage.py
+        python tools/triage_tests.py
 
     Otherwise, you can manually select the location of `result_images`
     on the commandline.

--- a/tools/visualize_tests.py
+++ b/tools/visualize_tests.py
@@ -3,7 +3,7 @@
 # This builds a html page of all images from the image comparison tests
 # and opens that page in the browser.
 #
-#   $ python visual_tests.py
+#   $ python tools/visualize_tests.py
 #
 
 import argparse

--- a/visual_tests.py
+++ b/visual_tests.py
@@ -77,30 +77,31 @@ def run():
 
         subdir_rows = []
         for name, test in six.iteritems(pictures):
-            if test.get("f", None):
+            expected_image = test.get('e', '')
+            actual_image = test.get('c', '')
+
+            if 'f' in test:
                 # a real failure in the image generation, resulting in different images
                 _has_failure = True
                 status = " (failed)"
-                failed = '<a href="{0}">diff</a>'.format(test.get("f", ""))
-                current = linked_image_template.format(test.get("c", ""))
+                failed = '<a href="{0}">diff</a>'.format(test['f'])
+                current = linked_image_template.format(actual_image)
                 failed_rows.append(row_template.format(name, "", current,
-                                                       test.get("e", ""),
-                                                       failed))
-            elif test.get("c", None) is None:
+                                                       expected_image, failed))
+            elif 'c' not in test:
                 # A failure in the test, resulting in no current image
                 _has_failure = True
                 status = " (failed)"
                 failed = '--'
                 current = '(Failure in test, no image produced)'
                 failed_rows.append(row_template.format(name, "", current,
-                                                       test.get("e", ""),
-                                                       failed))
+                                                       expected_image, failed))
             else:
                 status = " (passed)"
                 failed = '--'
-                current = linked_image_template.format(test.get("c", ""))
+                current = linked_image_template.format(actual_image)
             subdir_rows.append(row_template.format(name, status, current,
-                                                   test.get("e", ""), failed))
+                                                   expected_image, failed))
 
         body_sections.append(
             subdir_template.format(subdir=subdir, rows='\n'.join(subdir_rows)))

--- a/visual_tests.py
+++ b/visual_tests.py
@@ -7,8 +7,6 @@
 #
 
 import os
-import six
-
 from collections import defaultdict
 
 
@@ -57,7 +55,7 @@ def run():
 
     failed_rows = []
     body_sections = []
-    for subdir in _subdirs:
+    for subdir in sorted(_subdirs):
         if subdir == "test_compare_images":
             # These are the images which test the image comparison functions.
             continue
@@ -78,7 +76,7 @@ def run():
                 pictures[fn]["c"] = "/".join((subdir, file))
 
         subdir_rows = []
-        for name, test in six.iteritems(pictures):
+        for name, test in sorted(pictures.items()):
             expected_image = test.get('e', '')
             actual_image = test.get('c', '')
 

--- a/visual_tests.py
+++ b/visual_tests.py
@@ -38,7 +38,7 @@ failed_template = """<h2>Only Failed</h2><table>
 """
 
 row_template = ('<tr>'
-                '<td>{0} {1}</td>'
+                '<td>{0}{1}</td>'
                 '<td>{2}</td>'
                 '<td><a href="{3}"><img src="{3}"></a></td>'
                 '<td>{4}</td>'
@@ -80,7 +80,7 @@ def run():
             if test.get("f", None):
                 # a real failure in the image generation, resulting in different images
                 _has_failure = True
-                s = "(failed)"
+                status = " (failed)"
                 failed = '<a href="{0}">diff</a>'.format(test.get("f", ""))
                 current = linked_image_template.format(test.get("c", ""))
                 failed_rows.append(row_template.format(name, "", current,
@@ -89,17 +89,17 @@ def run():
             elif test.get("c", None) is None:
                 # A failure in the test, resulting in no current image
                 _has_failure = True
-                s = "(failed)"
+                status = " (failed)"
                 failed = '--'
                 current = '(Failure in test, no image produced)'
                 failed_rows.append(row_template.format(name, "", current,
                                                        test.get("e", ""),
                                                        failed))
             else:
-                s = "(passed)"
+                status = " (passed)"
                 failed = '--'
                 current = linked_image_template.format(test.get("c", ""))
-            subdir_rows.append(row_template.format(name, "", current,
+            subdir_rows.append(row_template.format(name, status, current,
                                                    test.get("e", ""), failed))
 
         body_sections.append(

--- a/visual_tests.py
+++ b/visual_tests.py
@@ -12,26 +12,50 @@ import six
 
 from collections import defaultdict
 
+
+html_template = """<html><head><style media="screen" type="text/css">
+img{{
+  width:100%;
+  max-width:800px;
+}}
+</style>
+</head><body>
+{failed}
+{body}
+</body></html>
+"""
+
+subdir_template = """<h2>{subdir}</h2><table>
+<thead><td>name</td><td>actual</td><td>expected</td><td>diff</td></thead>
+{rows}
+</table>
+"""
+
+failed_template = """<h2>Only Failed</h2><table>
+<thead><td>name</td><td>actual</td><td>expected</td><td>diff</td></thead>
+{rows}
+</table>
+"""
+
+row_template = ('<tr>'
+                '<td>{0} {1}</td>'
+                '<td>{2}</td>'
+                '<td><a href="{3}"><img src="{3}"></a></td>'
+                '<td>{4}</td>'
+                '</tr>')
+
+linked_image_template = '<a href="{0}"><img src="{0}"></a>'
+
+
 def run():
     # Build a website for visual comparison
     image_dir = "result_images"
     # build the website
-    _html = ""
-    _html += """<html><head><style media="screen" type="text/css">
-    img{
-        width:100%;
-        max-width:800px;
-    }
-    </style>
-    </head><body>\n"""
     _subdirs = [name for name in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, name))]
     # loop over all pictures
-    _row = '<tr><td>{0} {1}</td><td>{2}</td><td><a href="{3}"><img src="{3}"></a></td><td>{4}</td>\n'
-    _failed = ""
-    _failed += "<h2>Only Failed</h2>"
-    _failed += "<table>\n<thead><td>name</td><td>actual</td><td>expected</td><td>diff</td></thead>\n"
     _has_failure = False
-    _body = ""
+    failed_rows = []
+    body_sections = []
     for subdir in _subdirs:
         if subdir == "test_compare_images":
             # these are the image which test the image comparison functions...
@@ -51,37 +75,46 @@ def run():
             else:
                 pictures[fn]["c"] = "/".join((subdir, file))
 
-        _body += "<h2>{0}</h2>".format(subdir)
-        _body += "<table>\n<thead><td>name</td><td>actual</td><td>expected</td><td>diff</td></thead>\n"
+        subdir_rows = []
         for name, test in six.iteritems(pictures):
             if test.get("f", None):
                 # a real failure in the image generation, resulting in different images
                 _has_failure = True
                 s = "(failed)"
                 failed = '<a href="{0}">diff</a>'.format(test.get("f", ""))
-                current = '<a href="{0}"><img src="{0}"></a>'.format(test.get("c", ""))
-                _failed += _row.format(name, "", current, test.get("e", ""), failed)
+                current = linked_image_template.format(test.get("c", ""))
+                failed_rows.append(row_template.format(name, "", current,
+                                                       test.get("e", ""),
+                                                       failed))
             elif test.get("c", None) is None:
                 # A failure in the test, resulting in no current image
                 _has_failure = True
                 s = "(failed)"
                 failed = '--'
                 current = '(Failure in test, no image produced)'
-                _failed += _row.format(name, "", current, test.get("e", ""), failed)
+                failed_rows.append(row_template.format(name, "", current,
+                                                       test.get("e", ""),
+                                                       failed))
             else:
                 s = "(passed)"
                 failed = '--'
-                current = '<a href="{0}"><img src="{0}"></a>'.format(test.get("c", ""))
-            _body += _row.format(name, "", current, test.get("e", ""), failed)
-        _body += "</table>\n"
-    _failed += "</table>\n"
+                current = linked_image_template.format(test.get("c", ""))
+            subdir_rows.append(row_template.format(name, "", current,
+                                                   test.get("e", ""), failed))
+
+        body_sections.append(
+            subdir_template.format(subdir=subdir, rows='\n'.join(subdir_rows)))
+
     if _has_failure:
-        _html += _failed
-    _html += _body
-    _html += "\n</body></html>"
+        failed = failed_template.format(rows='\n'.join(failed_rows))
+    else:
+        failed = ''
+    body = ''.join(body_sections)
+    html = html_template.format(failed=failed, body=body)
     index = os.path.join(image_dir, "index.html")
     with open(index, "w") as f:
-        f.write(_html)
+        f.write(html)
+
     try:
         import webbrowser
         webbrowser.open(index)

--- a/visual_tests.py
+++ b/visual_tests.py
@@ -7,7 +7,6 @@
 #
 
 import os
-import time
 import six
 
 from collections import defaultdict
@@ -48,18 +47,21 @@ linked_image_template = '<a href="{0}"><img src="{0}"></a>'
 
 
 def run():
-    # Build a website for visual comparison
+    """
+    Build a website for visual comparison
+    """
     image_dir = "result_images"
-    # build the website
-    _subdirs = [name for name in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, name))]
-    # loop over all pictures
-    _has_failure = False
+    _subdirs = (name
+                for name in os.listdir(image_dir)
+                if os.path.isdir(os.path.join(image_dir, name)))
+
     failed_rows = []
     body_sections = []
     for subdir in _subdirs:
         if subdir == "test_compare_images":
-            # these are the image which test the image comparison functions...
+            # These are the images which test the image comparison functions.
             continue
+
         pictures = defaultdict(dict)
         for file in os.listdir(os.path.join(image_dir, subdir)):
             if os.path.isdir(os.path.join(image_dir, subdir, file)):
@@ -81,8 +83,8 @@ def run():
             actual_image = test.get('c', '')
 
             if 'f' in test:
-                # a real failure in the image generation, resulting in different images
-                _has_failure = True
+                # A real failure in the image generation, resulting in
+                # different images.
                 status = " (failed)"
                 failed = '<a href="{0}">diff</a>'.format(test['f'])
                 current = linked_image_template.format(actual_image)
@@ -90,7 +92,6 @@ def run():
                                                        expected_image, failed))
             elif 'c' not in test:
                 # A failure in the test, resulting in no current image
-                _has_failure = True
                 status = " (failed)"
                 failed = '--'
                 current = '(Failure in test, no image produced)'
@@ -100,13 +101,14 @@ def run():
                 status = " (passed)"
                 failed = '--'
                 current = linked_image_template.format(actual_image)
+
             subdir_rows.append(row_template.format(name, status, current,
                                                    expected_image, failed))
 
         body_sections.append(
             subdir_template.format(subdir=subdir, rows='\n'.join(subdir_rows)))
 
-    if _has_failure:
+    if failed_rows:
         failed = failed_template.format(rows='\n'.join(failed_rows))
     else:
         failed = ''
@@ -121,6 +123,7 @@ def run():
         webbrowser.open(index)
     except:
         print("Open {} in a browser for a visual comparison.".format(index))
+
 
 if __name__ == '__main__':
     run()

--- a/visual_tests.py
+++ b/visual_tests.py
@@ -6,6 +6,7 @@
 #   $ python visual_tests.py
 #
 
+import argparse
 import os
 from collections import defaultdict
 
@@ -44,7 +45,7 @@ row_template = ('<tr>'
 linked_image_template = '<a href="{0}"><img src="{0}"></a>'
 
 
-def run():
+def run(show_browser=True):
     """
     Build a website for visual comparison
     """
@@ -116,12 +117,21 @@ def run():
     with open(index, "w") as f:
         f.write(html)
 
-    try:
-        import webbrowser
-        webbrowser.open(index)
-    except:
+    show_message = not show_browser
+    if show_browser:
+        try:
+            import webbrowser
+            webbrowser.open(index)
+        except:
+            show_message = True
+
+    if show_message:
         print("Open {} in a browser for a visual comparison.".format(index))
 
 
 if __name__ == '__main__':
-    run()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--no-browser', action='store_true',
+                        help="Don't show browser after creating index page.")
+    args = parser.parse_args()
+    run(show_browser=not args.no_browser)


### PR DESCRIPTION
Intermixing HTML and code makes this file very difficult to read (for me, at least), so change it to use some simple template forms.

Also, don't automatically open the browser on CI because AppVeyor has one installed and it's a waste to open it.