### PR TITLE
[MRG+2] FIX: always decode bytes as utf-8 in AFM headers

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1472,6 +1472,7 @@ else:
 
 default_test_modules = [
     'matplotlib.tests.test_agg',
+    'matplotlib.tests.test_afm',
     'matplotlib.tests.test_animation',
     'matplotlib.tests.test_arrow_patches',
     'matplotlib.tests.test_artist',

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -57,12 +57,12 @@ from ._mathtext_data import uni2type1
 def _to_int(x):
     return int(float(x))
 
+
 _to_float = float
-if six.PY3:
-    def _to_str(x):
-        return x.decode('utf8')
-else:
-    _to_str = str
+
+
+def _to_str(x):
+    return x.decode('utf8')
 
 
 def _to_list_of_ints(s):

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -1,3 +1,6 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
 import matplotlib.afm as afm
 import six
 

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -8,9 +8,8 @@ import six
 def test_nonascii_str():
     # This tests that we also decode bytes as utf-8 properly.
     # Else, font files with non ascii caracters fail to load.
+    inp_str = "привет"
+    byte_str = inp_str.encode("utf8")
 
-    if six.PY3:
-        string = "привет".encode("utf8")
-    else:
-        string = "привет"
-    afm._to_str(string)
+    ret = afm._to_str(byte_str)
+    assert ret == inp_str

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -2,12 +2,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import matplotlib.afm as afm
-import six
 
 
 def test_nonascii_str():
     # This tests that we also decode bytes as utf-8 properly.
-    # Else, font files with non ascii caracters fail to load.
+    # Else, font files with non ascii characters fail to load.
     inp_str = "привет"
     byte_str = inp_str.encode("utf8")
 


### PR DESCRIPTION
closes #3517