### PR TITLE
[MRG+1] FIX: numpy arrays are not 'truthy'

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -251,7 +251,7 @@ class LogScale(ScaleBase):
         axis.set_minor_locator(LogLocator(self.base, self.subs))
         axis.set_minor_formatter(
             LogFormatterSciNotation(self.base,
-                                    labelOnlyBase=bool(self.subs)))
+                                    labelOnlyBase=(self.subs is not None)))
 
     def get_transform(self):
         """

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -48,6 +48,14 @@ def test_log_scatter():
     fig.savefig(buf, format='svg')
 
 
+@cleanup
+def test_logscale_subs():
+    fig, ax = plt.subplots()
+    ax.set_yscale('log', subsy=np.array([2, 3, 4]))
+    # force draw
+    fig.canvas.draw()
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
Check if not None, not the truth value of `self.subs` when setting
up log scales.

closes #8023