### PR TITLE
Bump font cache version.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1024,7 +1024,7 @@ class FontManager(object):
     # Increment this version number whenever the font cache data
     # format or behavior has changed and requires a existing font
     # cache files to be rebuilt.
-    __version__ = 200
+    __version__ = 201
 
     def __init__(self, size=None, weight='normal'):
         self._version = self.__version__


### PR DESCRIPTION
Due to #7907, the font cache is outdated and should be re-created.

@tacaswell already ran into this on gitter a few days ago.