### PR TITLE
[MRG+1] FIX: in errorbar discard any kwargs which have None value

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2798,6 +2798,9 @@ or tuple of floats
         .. plot:: mpl_examples/statistics/errorbar_demo.py
         """
         kwargs = cbook.normalize_kwargs(kwargs, _alias_map)
+        # anything that comes in as 'None', drop so the default thing
+        # happens down stream
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
         kwargs.setdefault('zorder', 2)
 
         if errorevery < 1:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2366,6 +2366,22 @@ def test_errorbar():
 
 
 @cleanup
+def test_errorbar_colorcycle():
+
+    f, ax = plt.subplots()
+    x = np.arange(10)
+    y = 2*x
+
+    e1, _, _ = ax.errorbar(x, y, c=None)
+    e2, _, _ = ax.errorbar(x, 2*y, c=None)
+    ln1, = ax.plot(x, 4*y)
+
+    assert mcolors.to_rgba(e1.get_color()) == mcolors.to_rgba('C0')
+    assert mcolors.to_rgba(e2.get_color()) == mcolors.to_rgba('C1')
+    assert mcolors.to_rgba(ln1.get_color()) == mcolors.to_rgba('C2')
+
+
+@cleanup
 def test_errorbar_shape():
     fig = plt.figure()
     ax = fig.gca()


### PR DESCRIPTION
Passing in `None` is a request from the user to 'do the default
thing', but by keeping the key:value in the kwargs dict it prevents
the default errorbar behavior and falls through to default Line2D
behavior which is likely not what is wanted.

closes #7899