### PR TITLE
[MRG+1] ENH: Stricter validation of line style rcParams (and extended accepted types for `grid.linestyle`)

### DIFF
--- a/doc/users/whats_new/validation_of_linestyle_rcparams.rst
+++ b/doc/users/whats_new/validation_of_linestyle_rcparams.rst
@@ -27,5 +27,5 @@ Examples of use
 ```````````````
 ::
 
-....grid.linestyle             : (1, 3)   # loosely dotted grid lines
+    grid.linestyle             : (1, 3)   # loosely dotted grid lines
     contour.negative_linestyle : dashdot  # previously only solid or dashed

--- a/doc/users/whats_new/validation_of_linestyle_rcparams.rst
+++ b/doc/users/whats_new/validation_of_linestyle_rcparams.rst
@@ -1,0 +1,31 @@
+Validation of line style rcParams
+---------------------------------
+
+Stricter validation
+```````````````````
+The validation of rcParams that are related to line styles
+(``lines.linestyle``, ``boxplot.*.linestyle``, ``grid.linestyle`` and
+``contour.negative_linestyle``) now effectively checks that the values
+are valid line styles. Strings like ``dashed`` or ``--`` are accepted,
+as well as even-length sequences of on-off ink like ``[1, 1.65]``. In
+this latter case, the offset value is handled internally and should *not*
+be provided by the user.
+
+The validation is case-insensitive.
+
+Deprecation of the former validators for ``contour.negative_linestyle``
+```````````````````````````````````````````````````````````````````````
+The new validation scheme replaces the former one used for the
+``contour.negative_linestyle`` rcParams, that was limited to ``solid``
+and ``dashed`` line styles.
+
+The former public validation functions ``validate_negative_linestyle``
+and ``validate_negative_linestyle_legacy`` will be deprecated in 2.1 and
+may be removed in 2.3. There are no public functions to replace them.
+
+Examples of use
+```````````````
+::
+
+....grid.linestyle             : (1, 3)   # loosely dotted grid lines
+    contour.negative_linestyle : dashdot  # previously only solid or dashed

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -530,22 +530,6 @@ validate_fillstyle = ValidateInStrings('markers.fillstyle',
                                         'top', 'none'])
 validate_fillstylelist = _listify_validator(validate_fillstyle)
 
-validate_negative_linestyle = ValidateInStrings('negative_linestyle',
-                                                ['solid', 'dashed'],
-                                                ignorecase=True)
-
-
-def validate_negative_linestyle_legacy(s):
-    try:
-        res = validate_negative_linestyle(s)
-        return res
-    except ValueError:
-        dashes = validate_nseq_float(2)(s)
-        warnings.warn("Deprecated negative_linestyle specification; use "
-                      "'solid' or 'dashed'",
-                      mplDeprecation)
-        return (0, dashes)  # (offset, (solid, blank))
-
 
 def validate_corner_mask(s):
     if s == 'legacy':
@@ -1081,8 +1065,7 @@ defaultParams = {
     'image.composite_image': [True, validate_bool],
 
     # contour props
-    'contour.negative_linestyle': ['dashed',
-                                    validate_negative_linestyle_legacy],
+    'contour.negative_linestyle': ['dashed', validate_linestyle],
     'contour.corner_mask':        [True, validate_corner_mask],
 
     # errorbar props

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -889,11 +889,12 @@ def validate_animation_writer_path(p):
     return p
 
 
-def validate_grid_linestyle(ls):
+def validate_linestyle(ls):
     # Named line style, like u'--' or u'solid'
     if isinstance(ls, six.text_type):
         return ls
-    # Sequence of even length of on and off ink in points.
+
+    # Sequence *of even length* of on and off ink (in points).
     # Offset is set to None.
     try:
         if len(ls) % 2 != 0:
@@ -905,7 +906,7 @@ def validate_grid_linestyle(ls):
         # (called inside the instance of validate_nseq_float).
         pass
 
-    raise ValueError("'grid.linestyle' must be a string or " +
+    raise ValueError("linestyle must be a string or " +
                      "an even-length sequence of floats.")
 
 
@@ -932,7 +933,7 @@ defaultParams = {
 
     # line props
     'lines.linewidth':       [1.5, validate_float],  # line width in points
-    'lines.linestyle':       ['-', six.text_type],             # solid line
+    'lines.linestyle':       ['-', validate_linestyle],  # solid line
     'lines.color':           ['C0', validate_color],  # first color in color cycle
     'lines.marker':          ['None', six.text_type],  # marker name
     'lines.markeredgewidth': [1.0, validate_float],
@@ -981,31 +982,31 @@ defaultParams = {
     'boxplot.flierprops.markerfacecolor': ['none', validate_color_or_auto],
     'boxplot.flierprops.markeredgecolor': ['k', validate_color],
     'boxplot.flierprops.markersize': [6, validate_float],
-    'boxplot.flierprops.linestyle': ['none', six.text_type],
+    'boxplot.flierprops.linestyle': ['none', validate_linestyle],
     'boxplot.flierprops.linewidth': [1.0, validate_float],
 
     'boxplot.boxprops.color': ['k', validate_color],
     'boxplot.boxprops.linewidth': [1.0, validate_float],
-    'boxplot.boxprops.linestyle': ['-', six.text_type],
+    'boxplot.boxprops.linestyle': ['-', validate_linestyle],
 
     'boxplot.whiskerprops.color': ['k', validate_color],
     'boxplot.whiskerprops.linewidth': [1.0, validate_float],
-    'boxplot.whiskerprops.linestyle': ['-', six.text_type],
+    'boxplot.whiskerprops.linestyle': ['-', validate_linestyle],
 
     'boxplot.capprops.color': ['k', validate_color],
     'boxplot.capprops.linewidth': [1.0, validate_float],
-    'boxplot.capprops.linestyle': ['-', six.text_type],
+    'boxplot.capprops.linestyle': ['-', validate_linestyle],
 
     'boxplot.medianprops.color': ['C1', validate_color],
     'boxplot.medianprops.linewidth': [1.0, validate_float],
-    'boxplot.medianprops.linestyle': ['-', six.text_type],
+    'boxplot.medianprops.linestyle': ['-', validate_linestyle],
 
     'boxplot.meanprops.color': ['C2', validate_color],
     'boxplot.meanprops.marker': ['^', six.text_type],
     'boxplot.meanprops.markerfacecolor': ['C2', validate_color],
     'boxplot.meanprops.markeredgecolor': ['C2', validate_color],
     'boxplot.meanprops.markersize': [6, validate_float],
-    'boxplot.meanprops.linestyle': ['--', six.text_type],
+    'boxplot.meanprops.linestyle': ['--', validate_linestyle],
     'boxplot.meanprops.linewidth': [1.0, validate_float],
 
     ## font props
@@ -1235,7 +1236,7 @@ defaultParams = {
     'ytick.direction':   ['out', six.text_type],            # direction of yticks
 
     'grid.color':        ['#b0b0b0', validate_color],  # grid color
-    'grid.linestyle':    ['-', validate_grid_linestyle],      # solid
+    'grid.linestyle':    ['-', validate_linestyle],  # solid
     'grid.linewidth':    [0.8, validate_float],     # in points
     'grid.alpha':        [1.0, validate_float],
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -535,14 +535,14 @@ _validate_negative_linestyle = ValidateInStrings('negative_linestyle',
                                                  ignorecase=True)
 
 
-@deprecated('3.0.0?', pending=True,
+@deprecated('2.1',
             addendum=(" See 'validate_negative_linestyle_legacy' " +
                       "deprecation warning for more information."))
 def validate_negative_linestyle(s):
     return _validate_negative_linestyle(s)
 
 
-@deprecated('3.0.0?', pending=True,
+@deprecated('2.1',
             addendum=(" The 'contour.negative_linestyle' rcParam now " +
                       "follows the same validation as the other rcParams " +
                       "that are related to line style."))

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -541,9 +541,6 @@ def validate_negative_linestyle_legacy(s):
         return res
     except ValueError:
         dashes = validate_nseq_float(2)(s)
-        warnings.warn("Deprecated negative_linestyle specification; use "
-                      "'solid' or 'dashed'",
-                      mplDeprecation)
         return (0, dashes)  # (offset, (solid, blank))
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -906,7 +906,7 @@ def validate_grid_linestyle(ls):
         pass
 
     raise ValueError("'grid.linestyle' must be a string or " +
-                     "a even-length sequence of floats.")
+                     "an even-length sequence of floats.")
 
 
 # a map from key -> value, converter

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -539,7 +539,7 @@ _validate_negative_linestyle = ValidateInStrings('negative_linestyle',
             addendum=(" See 'validate_negative_linestyle_legacy' " +
                       "deprecation warning for more information."))
 def validate_negative_linestyle(s):
-    _validate_negative_linestyle(s)
+    return _validate_negative_linestyle(s)
 
 
 @deprecated('3.0.0?', pending=True,

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -530,6 +530,22 @@ validate_fillstyle = ValidateInStrings('markers.fillstyle',
                                         'top', 'none'])
 validate_fillstylelist = _listify_validator(validate_fillstyle)
 
+validate_negative_linestyle = ValidateInStrings('negative_linestyle',
+                                                ['solid', 'dashed'],
+                                                ignorecase=True)
+
+
+def validate_negative_linestyle_legacy(s):
+    try:
+        res = validate_negative_linestyle(s)
+        return res
+    except ValueError:
+        dashes = validate_nseq_float(2)(s)
+        warnings.warn("Deprecated negative_linestyle specification; use "
+                      "'solid' or 'dashed'",
+                      mplDeprecation)
+        return (0, dashes)  # (offset, (solid, blank))
+
 
 def validate_corner_mask(s):
     if s == 'legacy':

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -890,18 +890,21 @@ def validate_animation_writer_path(p):
 
 # A validator dedicated to the named line styles, based on the items in
 # ls_mapper, and a list of possible strings read from Line2D.set_linestyle
-validate_named_linestyle = ValidateInStrings('linestyle',
-                                             list(six.iterkeys(ls_mapper)) +
-                                             list(six.itervalues(ls_mapper)) +
-                                             ['None', 'none', ' ', ''],
-                                             ignorecase=False)
+_validate_named_linestyle = ValidateInStrings('linestyle',
+                                              list(six.iterkeys(ls_mapper)) +
+                                              list(six.itervalues(ls_mapper)) +
+                                              ['None', 'none', ' ', ''],
+                                              ignorecase=True)
 
-# A validator for all possible line styles, the named ones *and*
-# the on-off ink sequences.
-def validate_linestyle(ls):
+
+def _validate_linestyle(ls):
+    """
+    A validator for all possible line styles, the named ones *and*
+    the on-off ink sequences.
+    """
     # Named line style, like u'--' or u'solid'
     if isinstance(ls, six.text_type):
-        return validate_named_linestyle(ls)
+        return _validate_named_linestyle(ls)
 
     # On-off ink (in points) sequence *of even length*.
     # Offset is set to None.
@@ -942,7 +945,7 @@ defaultParams = {
 
     # line props
     'lines.linewidth':       [1.5, validate_float],  # line width in points
-    'lines.linestyle':       ['-', validate_linestyle],  # solid line
+    'lines.linestyle':       ['-', _validate_linestyle],  # solid line
     'lines.color':           ['C0', validate_color],  # first color in color cycle
     'lines.marker':          ['None', six.text_type],  # marker name
     'lines.markeredgewidth': [1.0, validate_float],
@@ -991,31 +994,31 @@ defaultParams = {
     'boxplot.flierprops.markerfacecolor': ['none', validate_color_or_auto],
     'boxplot.flierprops.markeredgecolor': ['k', validate_color],
     'boxplot.flierprops.markersize': [6, validate_float],
-    'boxplot.flierprops.linestyle': ['none', validate_linestyle],
+    'boxplot.flierprops.linestyle': ['none', _validate_linestyle],
     'boxplot.flierprops.linewidth': [1.0, validate_float],
 
     'boxplot.boxprops.color': ['k', validate_color],
     'boxplot.boxprops.linewidth': [1.0, validate_float],
-    'boxplot.boxprops.linestyle': ['-', validate_linestyle],
+    'boxplot.boxprops.linestyle': ['-', _validate_linestyle],
 
     'boxplot.whiskerprops.color': ['k', validate_color],
     'boxplot.whiskerprops.linewidth': [1.0, validate_float],
-    'boxplot.whiskerprops.linestyle': ['-', validate_linestyle],
+    'boxplot.whiskerprops.linestyle': ['-', _validate_linestyle],
 
     'boxplot.capprops.color': ['k', validate_color],
     'boxplot.capprops.linewidth': [1.0, validate_float],
-    'boxplot.capprops.linestyle': ['-', validate_linestyle],
+    'boxplot.capprops.linestyle': ['-', _validate_linestyle],
 
     'boxplot.medianprops.color': ['C1', validate_color],
     'boxplot.medianprops.linewidth': [1.0, validate_float],
-    'boxplot.medianprops.linestyle': ['-', validate_linestyle],
+    'boxplot.medianprops.linestyle': ['-', _validate_linestyle],
 
     'boxplot.meanprops.color': ['C2', validate_color],
     'boxplot.meanprops.marker': ['^', six.text_type],
     'boxplot.meanprops.markerfacecolor': ['C2', validate_color],
     'boxplot.meanprops.markeredgecolor': ['C2', validate_color],
     'boxplot.meanprops.markersize': [6, validate_float],
-    'boxplot.meanprops.linestyle': ['--', validate_linestyle],
+    'boxplot.meanprops.linestyle': ['--', _validate_linestyle],
     'boxplot.meanprops.linewidth': [1.0, validate_float],
 
     ## font props
@@ -1081,7 +1084,7 @@ defaultParams = {
     'image.composite_image': [True, validate_bool],
 
     # contour props
-    'contour.negative_linestyle': ['dashed', validate_linestyle],
+    'contour.negative_linestyle': ['dashed', _validate_linestyle],
     'contour.corner_mask':        [True, validate_corner_mask],
 
     # errorbar props
@@ -1244,7 +1247,7 @@ defaultParams = {
     'ytick.direction':   ['out', six.text_type],            # direction of yticks
 
     'grid.color':        ['#b0b0b0', validate_color],  # grid color
-    'grid.linestyle':    ['-', validate_linestyle],  # solid
+    'grid.linestyle':    ['-', _validate_linestyle],  # solid
     'grid.linewidth':    [0.8, validate_float],     # in points
     'grid.alpha':        [1.0, validate_float],
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -25,7 +25,7 @@ import os
 import warnings
 import re
 
-from matplotlib.cbook import mplDeprecation
+from matplotlib.cbook import mplDeprecation, ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
 from matplotlib.colors import is_color_like
 
@@ -888,13 +888,22 @@ def validate_animation_writer_path(p):
         modules["matplotlib.animation"].writers.set_dirty()
     return p
 
+# A validator dedicated to the named line styles, based on the items in
+# ls_mapper, and a list of possible strings read from Line2D.set_linestyle
+validate_named_linestyle = ValidateInStrings('linestyle',
+                                             list(six.iterkeys(ls_mapper)) +
+                                             list(six.itervalues(ls_mapper)) +
+                                             ['None', 'none', ' ', ''],
+                                             ignorecase=False)
 
+# A validator for all possible line styles, the named ones *and*
+# the on-off ink sequences.
 def validate_linestyle(ls):
     # Named line style, like u'--' or u'solid'
     if isinstance(ls, six.text_type):
-        return ls
+        return validate_named_linestyle(ls)
 
-    # Sequence *of even length* of on and off ink (in points).
+    # On-off ink (in points) sequence *of even length*.
     # Offset is set to None.
     try:
         if len(ls) % 2 != 0:

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -25,7 +25,7 @@ import os
 import warnings
 import re
 
-from matplotlib.cbook import mplDeprecation, ls_mapper
+from matplotlib.cbook import mplDeprecation, deprecated, ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
 from matplotlib.colors import is_color_like
 
@@ -530,11 +530,22 @@ validate_fillstyle = ValidateInStrings('markers.fillstyle',
                                         'top', 'none'])
 validate_fillstylelist = _listify_validator(validate_fillstyle)
 
-validate_negative_linestyle = ValidateInStrings('negative_linestyle',
-                                                ['solid', 'dashed'],
-                                                ignorecase=True)
+_validate_negative_linestyle = ValidateInStrings('negative_linestyle',
+                                                 ['solid', 'dashed'],
+                                                 ignorecase=True)
 
 
+@deprecated('3.0.0?', pending=True,
+            addendum=(" See 'validate_negative_linestyle_legacy' " +
+                      "deprecation warning for more information."))
+def validate_negative_linestyle(s):
+    _validate_negative_linestyle(s)
+
+
+@deprecated('3.0.0?', pending=True,
+            addendum=(" The 'contour.negative_linestyle' rcParam now " +
+                      "follows the same validation as the other rcParams " +
+                      "that are related to line style."))
 def validate_negative_linestyle_legacy(s):
     try:
         res = validate_negative_linestyle(s)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -889,6 +889,26 @@ def validate_animation_writer_path(p):
     return p
 
 
+def validate_grid_linestyle(ls):
+    # Named line style, like u'--' or u'solid'
+    if isinstance(ls, six.text_type):
+        return ls
+    # Sequence of even length of on and off ink in points.
+    # Offset is set to None.
+    try:
+        if len(ls) % 2 != 0:
+            # Expecting a sequence of even length
+            raise ValueError
+        return (None, validate_nseq_float()(ls))
+    except (ValueError, TypeError):
+        # TypeError can be raised by wrong types passed to float()
+        # (called inside the instance of validate_nseq_float).
+        pass
+
+    raise ValueError("'grid.linestyle' must be a string or " +
+                     "a even-length sequence of floats.")
+
+
 # a map from key -> value, converter
 defaultParams = {
     'backend':           ['Agg', validate_backend],  # agg is certainly
@@ -1215,7 +1235,7 @@ defaultParams = {
     'ytick.direction':   ['out', six.text_type],            # direction of yticks
 
     'grid.color':        ['#b0b0b0', validate_color],  # grid color
-    'grid.linestyle':    ['-', six.text_type],      # solid
+    'grid.linestyle':    ['-', validate_grid_linestyle],      # solid
     'grid.linewidth':    [0.8, validate_float],     # in points
     'grid.alpha':        [1.0, validate_float],
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -336,18 +336,23 @@ def generate_validator_testcases(valid):
                   )
          },
          {'validator': validate_linestyle,
-         'success': (('--', '--'),
-                     ('dotted', 'dotted'),
-                     ('aardvark', 'aardvark'),
+         'success': (('-', '-'), ('solid', 'solid'),
+                     ('--', '--'), ('dashed', 'dashed'),
+                     ('-.', '-.'), ('dashdot', 'dashdot'),
+                     (':', ':'), ('dotted', 'dotted'),
+                     ('', ''), (' ', ' '),
+                     ('None', 'None'), ('none', 'none'),
                      (['1.23', '4.56'], (None, [1.23, 4.56])),
                      ([1.23, 456], (None, [1.23, 456.0])),
                      ([1, 2, 3, 4], (None, [1.0, 2.0, 3.0, 4.0])),
                      ),
-         'fail': (((None, [1, 2]), ValueError),
-                  ((0, [1, 2]), ValueError),
-                  ((-1, [1, 2]), ValueError),
-                  ([1, 2, 3], ValueError),
-                  (1.23, ValueError)
+         'fail': (('aardvark', ValueError),  # not a valid string
+                  ('DoTtEd', ValueError),  # validation is case-sensitive
+                  ((None, [1, 2]), ValueError),  # (offset, dashes) is not OK
+                  ((0, [1, 2]), ValueError),  # idem
+                  ((-1, [1, 2]), ValueError),  # idem
+                  ([1, 2, 3], ValueError), # not a sequence of even length
+                  (1.23, ValueError)  # not a sequence
                   )
          }
     )

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -30,7 +30,7 @@ from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_cycler,
                                 validate_hatch,
                                 validate_hist_bins,
-                                validate_linestyle)
+                                _validate_linestyle)
 
 
 mpl.rc('text', usetex=False)
@@ -335,19 +335,19 @@ def generate_validator_testcases(valid):
          'fail': (('aardvark', ValueError),
                   )
          },
-         {'validator': validate_linestyle,
+         {'validator': _validate_linestyle,  # NB: case-insensitive
          'success': (('-', '-'), ('solid', 'solid'),
                      ('--', '--'), ('dashed', 'dashed'),
                      ('-.', '-.'), ('dashdot', 'dashdot'),
                      (':', ':'), ('dotted', 'dotted'),
                      ('', ''), (' ', ' '),
-                     ('None', 'None'), ('none', 'none'),
+                     ('None', 'none'), ('none', 'none'),
+                     ('DoTtEd', 'dotted'),
                      (['1.23', '4.56'], (None, [1.23, 4.56])),
                      ([1.23, 456], (None, [1.23, 456.0])),
                      ([1, 2, 3, 4], (None, [1.0, 2.0, 3.0, 4.0])),
                      ),
          'fail': (('aardvark', ValueError),  # not a valid string
-                  ('DoTtEd', ValueError),  # validation is case-sensitive
                   ((None, [1, 2]), ValueError),  # (offset, dashes) is not OK
                   ((0, [1, 2]), ValueError),  # idem
                   ((-1, [1, 2]), ValueError),  # idem

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -30,7 +30,7 @@ from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_cycler,
                                 validate_hatch,
                                 validate_hist_bins,
-                                validate_grid_linestyle)
+                                validate_linestyle)
 
 
 mpl.rc('text', usetex=False)
@@ -335,7 +335,7 @@ def generate_validator_testcases(valid):
          'fail': (('aardvark', ValueError),
                   )
          },
-         {'validator': validate_grid_linestyle,
+         {'validator': validate_linestyle,
          'success': (('--', '--'),
                      ('dotted', 'dotted'),
                      ('aardvark', 'aardvark'),

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -351,7 +351,7 @@ def generate_validator_testcases(valid):
                   ((None, [1, 2]), ValueError),  # (offset, dashes) is not OK
                   ((0, [1, 2]), ValueError),  # idem
                   ((-1, [1, 2]), ValueError),  # idem
-                  ([1, 2, 3], ValueError), # not a sequence of even length
+                  ([1, 2, 3], ValueError),  # not a sequence of even length
                   (1.23, ValueError)  # not a sequence
                   )
          }

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -29,7 +29,8 @@ from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_nseq_float,
                                 validate_cycler,
                                 validate_hatch,
-                                validate_hist_bins)
+                                validate_hist_bins,
+                                validate_grid_linestyle)
 
 
 mpl.rc('text', usetex=False)
@@ -332,6 +333,21 @@ def generate_validator_testcases(valid):
                      (np.arange(15), np.arange(15))
                      ),
          'fail': (('aardvark', ValueError),
+                  )
+         },
+         {'validator': validate_grid_linestyle,
+         'success': (('--', '--'),
+                     ('dotted', 'dotted'),
+                     ('aardvark', 'aardvark'),
+                     (['1.23', '4.56'], (None, [1.23, 4.56])),
+                     ([1.23, 456], (None, [1.23, 456.0])),
+                     ([1, 2, 3, 4], (None, [1.0, 2.0, 3.0, 4.0])),
+                     ),
+         'fail': (((None, [1, 2]), ValueError),
+                  ((0, [1, 2]), ValueError),
+                  ((-1, [1, 2]), ValueError),
+                  ([1, 2, 3], ValueError),
+                  (1.23, ValueError)
                   )
          }
     )

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -471,7 +471,7 @@ backend      : $TEMPLATE_BACKEND
                                   # such as a PDF.
 
 ### CONTOUR PLOTS
-#contour.negative_linestyle : dashed # dashed | solid
+#contour.negative_linestyle : dashed # string or on-off ink sequence
 #contour.corner_mask        : True   # True | False | legacy
 
 ### ERRORBAR PLOTS


### PR DESCRIPTION
A possible “solution” to #7991 (suggested by @tacaswell on Gitter, [February 7, 2017 12:09 PM](https://gitter.im/matplotlib/matplotlib?at=5899aadc6b2d8dd5521103fc)) . The user could now use a sequence like [1.0, 3.0] for the rcParam `grid.linestyle`.

The validation is not extensive, partly because I was not sure it should be performed here. For example, one can perfectly pass a value like u'Hello world' without the new function `validate_grid_linestyle` raising an error. Should I set the only accepted strings to be in `cbook.ls_mapper` and `cbook.ls_mapper_r`?

**Edit:** typo + link to Gitter.