### PR TITLE
[MRG+1] Fix pyplot.axis(ax) when ax is in other figure.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -875,7 +875,8 @@ def axes(*args, **kwargs):
       color for the axis, default white.
 
     - ``axes(h)`` where *h* is an axes instance makes *h* the current
-      axis.  An :class:`~matplotlib.axes.Axes` instance is returned.
+      axis and the parent of *h* the current figure.
+      An :class:`~matplotlib.axes.Axes` instance is returned.
 
     =========   ==============   ==============================================
     kwarg       Accepts          Description
@@ -909,7 +910,8 @@ def axes(*args, **kwargs):
     arg = args[0]
 
     if isinstance(arg, Axes):
-        a = gcf().sca(arg)
+        sca(arg)
+        a = arg
     else:
         rect = arg
         a = gcf().add_axes(rect, **kwargs)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1476,6 +1476,15 @@ def test_as_mpl_axes_api():
         'Expected a PolarAxesSubplot, got %s' % type(ax)
     plt.close()
 
+    # test focusing of Axes in other Figure
+    fig1, ax1 = subplots()
+    fig2, ax2 = subplots()
+    assert ax1 is plt.axes(ax1)
+    assert ax1 is plt.gca()
+    assert fig1 is plt.gcf()
+    plt.close(fig1)
+    plt.close(fig2)
+
 
 @image_comparison(baseline_images=['log_scales'])
 def test_log_scales():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1476,6 +1476,8 @@ def test_as_mpl_axes_api():
         'Expected a PolarAxesSubplot, got %s' % type(ax)
     plt.close()
 
+
+def test_pyplot_axes():
     # test focusing of Axes in other Figure
     fig1, ax1 = plt.subplots()
     fig2, ax2 = plt.subplots()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1477,8 +1477,8 @@ def test_as_mpl_axes_api():
     plt.close()
 
     # test focusing of Axes in other Figure
-    fig1, ax1 = subplots()
-    fig2, ax2 = subplots()
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
     assert ax1 is plt.axes(ax1)
     assert ax1 is plt.gca()
     assert fig1 is plt.gcf()


### PR DESCRIPTION
Avoid crash when `ax` belongs to some other than the current figure.
Make the `ax` owner the current figure instead.

This resolves crash in `axes` call in the following stanza

```python
from matplotlib.pyplot import *
f1, a1 = subplots()
f2, a2 = subplots()
axes(a1)
assert gca() is a1
assert gcf() is f1
```