### PR TITLE
Remove deprecated shims from matplotlib 1.3

### DIFF
--- a/doc/api/api_changes/code_removal.rst
+++ b/doc/api/api_changes/code_removal.rst
@@ -22,6 +22,20 @@ removed.
 The ``ArtistInspector.findobj`` method, which was never working due to the lack
 of a ``get_children`` method, has been removed.
 
+The following deprecated methods of :any:`matplotlib.path` have been removed.
+All were deprecated since version Matplotlib  1.3. Replacement is shown in
+bracket:
+
+  - ``point_in_path`` (use :any:`path.Path.contains_point`)
+  - ``get_path_extents`` (use :any:`path.Path.get_extents`)
+  - ``point_in_path_collection`` (use :any:`collection.Collection.contains`)
+  - ``path_in_path`` (use :any:`path.Path.contains_path`)
+  - ``path_intersects_path`` (use :any:`path.Path.intersects_path`)
+  - ``convert_path_to_polygons`` (use :any:`path.Path.to_polygons`)
+  - ``cleanup_path`` (use :any:`path.Path.cleaned`)
+  - ``points_in_path`` (use :any:`path.Path.contains_points`)
+  - ``clip_path_to_rect`` (use :any:`path.Path.clip_to_bbox`)
+
 
 `Axes.set_aspect("normal")`
 ---------------------------

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1024,26 +1024,3 @@ def get_paths_extents(paths, transforms=[]):
         raise ValueError("No paths provided")
     return Bbox.from_extents(*_path.get_path_collection_extents(
         Affine2D(), paths, transforms, [], Affine2D()))
-
-
-def _define_deprecated_functions(ns):
-    from .cbook import deprecated
-
-    # The C++ functions are not meant to be used directly.
-    # Users should use the more pythonic wrappers in the Path
-    # class instead.
-    for func, alternative in [
-            ('point_in_path', 'path.Path.contains_point'),
-            ('get_path_extents', 'path.Path.get_extents'),
-            ('point_in_path_collection', 'collection.Collection.contains'),
-            ('path_in_path', 'path.Path.contains_path'),
-            ('path_intersects_path', 'path.Path.intersects_path'),
-            ('convert_path_to_polygons', 'path.Path.to_polygons'),
-            ('cleanup_path', 'path.Path.cleaned'),
-            ('points_in_path', 'path.Path.contains_points'),
-            ('clip_path_to_rect', 'path.Path.clip_to_bbox')]:
-        ns[func] = deprecated(
-            since='1.3', alternative=alternative)(getattr(_path, func))
-
-
-_define_deprecated_functions(locals())


### PR DESCRIPTION
None of these shims seem to be used in the codebase.

---- 

Found as a custom tools of mine choked on one of the function that did not had a signature. 