### PR TITLE
[WiP] ENH: Add a “loose” version of the dashed line styles

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -90,12 +90,24 @@ def _process_plot_format(fmt):
 
     # handle the multi char special cases and strip them from the
     # string
-    if fmt.find('--') >= 0:
+    if fmt.find('--@loose') >= 0:
+        linestyle = '--@loose'
+        fmt = fmt.replace('--@loose', '')
+    elif fmt.find('--') >= 0:
         linestyle = '--'
         fmt = fmt.replace('--', '')
-    if fmt.find('-.') >= 0:
+
+    if fmt.find('-.@loose') >= 0:
+        linestyle = '-.@loose'
+        fmt = fmt.replace('-.@loose', '')
+    elif fmt.find('-.') >= 0:
         linestyle = '-.'
         fmt = fmt.replace('-.', '')
+
+    if fmt.find(':@loose') >= 0:
+        linestyle = ':@loose'
+        fmt = fmt.replace(':@loose', '')
+
     if fmt.find(' ') >= 0:
         linestyle = 'None'
         fmt = fmt.replace(' ', '')

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1896,7 +1896,9 @@ def unmasked_index_ranges(mask, compressed=True):
 
 # The ls_mapper maps short codes for line style to their full name used by
 # backends; the reverse mapper is for mapping full names to short ones.
-ls_mapper = {'-': 'solid', '--': 'dashed', '-.': 'dashdot', ':': 'dotted'}
+ls_mapper = {'-': 'solid', '--': 'dashed', '-.': 'dashdot', ':': 'dotted',
+             '--@loose': 'dashed@loose', '-.@loose': 'dashdot@loose',
+             ':@loose': 'dotted@loose'}
 ls_mapper_r = {v: k for k, v in six.iteritems(ls_mapper)}
 
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -43,7 +43,8 @@ def _get_dash_pattern(style):
     if style in ['solid', 'None']:
         offset, dashes = None, None
     # dashed styles
-    elif style in ['dashed', 'dashdot', 'dotted']:
+    elif style in ['dashed', 'dashdot', 'dotted', 'dashed@loose',
+                   'dashdot@loose', 'dotted@loose']:
         offset = 0
         dashes = tuple(rcParams['lines.{}_pattern'.format(style)])
     #
@@ -239,13 +240,16 @@ class Line2D(Artist):
 
     """
     lineStyles = _lineStyles = {  # hidden names deprecated
-        '-':    '_draw_solid',
-        '--':   '_draw_dashed',
-        '-.':   '_draw_dash_dot',
-        ':':    '_draw_dotted',
-        'None': '_draw_nothing',
-        ' ':    '_draw_nothing',
-        '':     '_draw_nothing',
+        '-':        '_draw_solid',
+        '--':       '_draw_dashed',
+        '-.':       '_draw_dash_dot',
+        ':':        '_draw_dotted',
+        'None':     '_draw_nothing',
+        ' ':        '_draw_nothing',
+        '':         '_draw_nothing',
+        '--@loose': '_draw_dashed_loose',
+        '-.@loose': '_draw_dash_dot_loose',
+        ':@loose':  '_draw_dotted_loose',
     }
 
     _drawStyles_l = {
@@ -1262,6 +1266,21 @@ class Line2D(Artist):
         gc.set_dashes(self._dashOffset, self._dashSeq)
         renderer.draw_path(gc, path, trans)
 
+    def _draw_dashed_loose(self, renderer, gc, path, trans):
+        gc.set_linestyle('dashed@loose')
+        gc.set_dashes(self._dashOffset, self._dashSeq)
+        renderer.draw_path(gc, path, trans)
+
+    def _draw_dash_dot_loose(self, renderer, gc, path, trans):
+        gc.set_linestyle('dashdot@loose')
+        gc.set_dashes(self._dashOffset, self._dashSeq)
+        renderer.draw_path(gc, path, trans)
+
+    def _draw_dotted_loose(self, renderer, gc, path, trans):
+        gc.set_linestyle('dotted@loose')
+        gc.set_dashes(self._dashOffset, self._dashSeq)
+        renderer.draw_path(gc, path, trans)
+
     def update_from(self, other):
         """copy properties from other to self"""
         Artist.update_from(self, other)
@@ -1452,7 +1471,8 @@ class Line2D(Artist):
 
     def is_dashed(self):
         'return True if line is dashstyle'
-        return self._linestyle in ('--', '-.', ':')
+        return self._linestyle in ('--', '-.', ':', '--@loose', '-.@loose',
+                                   ':@loose')
 
 
 class VertexSelector(object):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -925,6 +925,10 @@ defaultParams = {
     'lines.dashed_pattern':  [[2.8, 1.2], validate_nseq_float()],
     'lines.dashdot_pattern': [[4.8, 1.2, 0.8, 1.2], validate_nseq_float()],
     'lines.dotted_pattern':  [[1.1, 1.1], validate_nseq_float()],
+    'lines.dashed@loose_pattern':  [[2.8, 3.6], validate_nseq_float()],
+    'lines.dashdot@loose_pattern': [[4.8, 3.6, 0.8, 3.6],
+                                    validate_nseq_float()],
+    'lines.dotted@loose_pattern':  [[1.1, 3.3], validate_nseq_float()],
     'lines.scale_dashes':  [True, validate_bool],
 
     # marker props

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -94,6 +94,9 @@ backend      : $TEMPLATE_BACKEND
 #lines.dashed_pattern : 2.8, 1.2
 #lines.dashdot_pattern : 4.8, 1.2, 0.8, 1.2
 #lines.dotted_pattern : 1.1, 1.1
+#lines.dashed@loose_pattern : 2.8, 3.6
+#lines.dashdot@loose_pattern : 4.8, 3.6, 0.8, 3.6
+#lines.dotted@loose_pattern : 1.1, 3.3
 #lines.scale_dashes : True
 
 #markers.fillstyle: full # full|left|right|bottom|top|none


### PR DESCRIPTION
Rationale
-----------
Several tickets pointed out that the defaults dashed line styles have a “frequency” that is too high (#7991), especially when using a “dotted” style for grid lines (#6515). This PR aims at introducing a “loose” version of these dashed line styles, in the spirit of what had been suggested in #7087 . Coupled to sane defaults (still to be found/discussed), “casual users” (or myself :) ) could have access in an easy fashion to “less frequently” dashed lines. And “power-users” could even tweak these additional dash patterns in their matplotlibrc file to get a fast & easy access to supplementary dash patterns.

**PS:** not sure if it belong to the “API Changes” flag, so feel free to remove if it does not…

Implementation
-------------------
Three new rcParams are added: `lines.dashed@loose_pattern`, `lines.dashdot@loose_pattern` and `lines.dotted@loose_pattern`. Currently, they are similar to the rcParams `lines.dashed_pattern`, `lines.dashdot_pattern` and `lines.dotted_pattern` but with off inks parts that have been *tripled* in length. **This specific value can of course be discussed.**

One can now use these three new line styles by adding “@loose” after the line style “ID string”. Here is for example the case for loosely dotted lines:
- `ax.plot(…, linestyle="dotted@loose")`
- `ax.plot(…, linestyle=":@loose")`
- `ax.plot(…, ":@looseob")  # MATLAB-style` (yes, it starts to become verbose/hard to read…)

**Feel free to suggest anything better than using the suffix “@loose” to specify that one wants a loosely dashed line style.**

Still to be done
-----------------

- [ ] update the `Line2D` docstring in `matplotlib.lines`
- [ ] update the test `test_linestyle_variants` in `tests/test_lines.py` (_I do not really understand how this test works_: it looks like an image test but does not have the `@image_comparison` decorator)
- [ ] show this new functionality somewhere in the documentation
- [ ] **optional** (could be done in a further PR): add a new line style variant “dashdotdot”/“-..” (and its “loose” variant) 

Example
----------
A small example of what it does currently looks like:
- PDF: [Testing_named_line_styles.pdf](https://github.com/matplotlib/matplotlib/files/761015/Testing_named_line_styles.pdf)
- PNG (100 DPI): ![testing_named_line_styles](https://cloud.githubusercontent.com/assets/17270724/22745169/f04d3db6-ee1f-11e6-86d2-b3aa8cdc2e56.png)

Script source:
```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots(num="Testing named line styles", figsize=(9.6, 6.4))

for ii, ls in enumerate(['-', 'solid',
                         '--', 'dashed',
                         '-.', 'dashdot',
                         ':', 'dotted',
                         '--@loose', 'dashed@loose',
                         '-.@loose', 'dashdot@loose',
                         ':@loose', 'dotted@loose'
                        ]):
    ax.plot([ii, ii + 1], linestyle=ls,
            color='tab:red' if 'loose' in ls else 'tab:blue', label=ls)

    # MATLAB-like all in one line style
    if any(special_char in ls for special_char in ('-', '.', ':')):
        allinone_ls = ls + ">k"
        ax.plot([-ii//2, -(ii//2 + 1)], allinone_ls, label=allinone_ls)

ax.legend(loc='lower center', bbox_to_anchor=(0.5, 1.02), ncol=7,
          columnspacing=1)
fig.subplots_adjust(top=0.85)  # make space for top legend

for ext, dpi in (('.png', 100), ('.pdf', None)):
    fig.savefig(fig.get_label().replace(" ", "_") + ext, dpi=dpi)
```

**Edit:** typo…