### PR TITLE
Addresses #8045 (set_yscale("log") inconsistent with semilogy())

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2943,7 +2943,7 @@ class _AxesBase(martist.Artist):
         # If the scale is being set to log, clip nonposx to prevent headaches
         # around zero
         if value.lower() == 'log' and 'nonposx' not in kwargs:
-            kwargs['nonposx'] = 'clip'
+            kwargs['nonposx'] = 'mask'
 
         g = self.get_shared_x_axes()
         for ax in g.get_siblings(self):
@@ -3239,7 +3239,7 @@ class _AxesBase(martist.Artist):
         # If the scale is being set to log, clip nonposy to prevent headaches
         # around zero
         if value.lower() == 'log' and 'nonposy' not in kwargs:
-            kwargs['nonposy'] = 'clip'
+            kwargs['nonposy'] = 'mask'
 
         g = self.get_shared_y_axes()
         for ax in g.get_siblings(self):


### PR DESCRIPTION
See: #8045 "setting yscale to log, after drawing a plot with values equal to zero, results in incorrect handling of zero values "