### PR TITLE
[MRG+2] Update MovieWriter dpi default

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -155,7 +155,7 @@ class AbstractMovieWriter(six.with_metaclass(abc.ABCMeta)):
     '''
 
     @abc.abstractmethod
-    def setup(self, fig, outfile, dpi):
+    def setup(self, fig, outfile, dpi=None):
         '''
         Perform setup for writing the movie file.
 
@@ -163,9 +163,9 @@ class AbstractMovieWriter(six.with_metaclass(abc.ABCMeta)):
             The figure object that contains the information for frames
         outfile: string
             The filename of the resulting movie file
-        dpi: int
+        dpi: int, optional
             The DPI (or resolution) for the file.  This controls the size
-            in pixels of the resulting movie file.
+            in pixels of the resulting movie file. Default is fig.dpi.
         '''
 
     @abc.abstractmethod
@@ -281,7 +281,7 @@ class MovieWriter(AbstractMovieWriter):
         verbose.report('frame size in pixels is %s x %s' % self.frame_size,
                        level='debug')
 
-    def setup(self, fig, outfile, dpi):
+    def setup(self, fig, outfile, dpi=None):
         '''
         Perform setup for writing the movie file.
 
@@ -292,12 +292,14 @@ class MovieWriter(AbstractMovieWriter):
             The figure object that contains the information for frames
         outfile : string
             The filename of the resulting movie file
-        dpi : int
+        dpi : int, optional
             The DPI (or resolution) for the file.  This controls the size
-            in pixels of the resulting movie file.
+            in pixels of the resulting movie file. Default is fig.dpi.
         '''
         self.outfile = outfile
         self.fig = fig
+        if dpi is None:
+            dpi = self.fig.dpi
         self.dpi = dpi
         self._adjust_frame_size()
 
@@ -404,7 +406,8 @@ class FileMovieWriter(MovieWriter):
         MovieWriter.__init__(self, *args, **kwargs)
         self.frame_format = rcParams['animation.frame_format']
 
-    def setup(self, fig, outfile, dpi, frame_prefix='_tmp', clear_temp=True):
+    def setup(self, fig, outfile, dpi=None, frame_prefix='_tmp',
+              clear_temp=True):
         '''Perform setup for writing the movie file.
 
         Parameters
@@ -413,9 +416,10 @@ class FileMovieWriter(MovieWriter):
             The figure to grab the rendered frames from.
         outfile : str
             The filename of the resulting movie file.
-        dpi : number
+        dpi : number, optional
             The dpi of the output file. This, with the figure size,
             controls the size in pixels of the resulting movie file.
+            Default is fig.dpi.
         frame_prefix : str, optional
             The filename prefix to use for temporary files.  Defaults to
             '_tmp'.
@@ -427,6 +431,8 @@ class FileMovieWriter(MovieWriter):
         '''
         self.fig = fig
         self.outfile = outfile
+        if dpi is None:
+            dpi = self.fig.dpi
         self.dpi = dpi
         self._adjust_frame_size()
 

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -74,6 +74,26 @@ def test_null_movie_writer():
     assert writer._count == num_frames
 
 
+def test_movie_writer_dpi_default():
+    # Test setting up movie writer with figure.dpi default.
+
+    fig = plt.figure()
+
+    filename = "unused.null"
+    fps = 5
+    codec = "unused"
+    bitrate = 1
+    extra_args = ["unused"]
+
+    def run():
+        pass
+
+    writer = animation.MovieWriter(fps, codec, bitrate, extra_args)
+    writer._run = run
+    writer.setup(fig, filename)
+    assert writer.dpi == fig.dpi
+
+
 @animation.writers.register('null')
 class RegisteredNullMovieWriter(NullMovieWriter):
 


### PR DESCRIPTION
Adds default `dpi=None` argument to *MovieWriter classes, and uses `figure.dpi` as the default if dpi is None.

This is related to issue #7616. @tacaswell please advise if this approach is what you had in mind for resolving the issue. 

I'm a new contributor and I wasn't exactly sure the best way to unit test a change like this. However, I created a test that calls setup with dpi as the default, and makes sure that dpi is set to the `figure.dpi`. I did not add a change log entry because it is such a small change, please let me know if I should.   