### PR TITLE
[MRG+2] Switch to suppress option to True in setup.cfg.template. 

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -18,7 +18,7 @@
 [status]
 # To suppress display of the dependencies and their versions
 # at the top of the build log, uncomment the following line:
-#suppress = False
+#suppress = True 
 
 [packages]
 # There are a number of subpackages of Matplotlib that are considered


### PR DESCRIPTION
In setting up a local dev environment for the first time I noticed that the setup.cfg.template has 'uncomment line to suppess output...', but the line reads suppress = False. so uncommenting the line does not suppress build output, it needs to be switched to True as well. 