### PR TITLE
[MRG+1] Fix PYTHONHASHSEED setup on OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ script:
       # Workaround for pytest-xdist flaky collection order
       # https://github.com/pytest-dev/pytest/issues/920
       # https://github.com/pytest-dev/pytest/issues/1075
-      export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+      export PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
       echo PYTHONHASHSEED=$PYTHONHASHSEED
 
       echo The following args are passed to pytest $PYTEST_ARGS $RUN_PEP8


### PR DESCRIPTION
The shuf command does not exist there, though it can be installed with brew. But we've got Python already...

Honestly, I don't know how this never seemed to have failed, since `NPROC=2` on OSX.