### PR TITLE
[MRG+1] DOC: add SOURCELINK_SUFFIX for compatibility with Sphinx 1.5

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -82,7 +82,8 @@ alt="Logo"/>
         VERSION:     '{{ release|e }}',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }}
+        HAS_SOURCE:  {{ has_source|lower }},
+        SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
       };
     </script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
With Sphinx 1.5, this is needed by `searchtools.js` to display the source snippets (see sphinx-doc/sphinx#2454, and especially sphinx-doc/sphinx@71dd8bfbf).

With earlier Sphinx versions, this is a no-op because the undefined variable will evaluate to an empty string.