### PR TITLE
[MRG+1] use plt.gca instead of plt.axes for already exhisting implicit axes

### DIFF
--- a/examples/pylab_examples/equal_aspect_ratio.py
+++ b/examples/pylab_examples/equal_aspect_ratio.py
@@ -14,7 +14,7 @@ plt.ylabel('voltage (mV)')
 plt.title('About as simple as it gets, folks')
 plt.grid(True)
 
-plt.axes().set_aspect('equal', 'datalim')
+plt.gca().set_aspect('equal', 'datalim')
 
 
 plt.show()


### PR DESCRIPTION
refs #7956 
use plt.gca instead of plt.axes for already exhisting implicit axes