### PR TITLE
[MRG+1] Named Matplotlib module in windows instructions

### DIFF
--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -61,7 +61,7 @@ On windows, both the config directory and the cache directory are
 the same and are in your :file:`Documents and Settings` or :file:`Users`
 directory by default::
 
-    >>> import matplotlib
+    >>> import matplotlib as mpl
     >>> mpl.get_configdir()
     'C:\\Documents and Settings\\jdhunter\\.matplotlib'
     >>> mpl.get_cachedir()


### PR DESCRIPTION
I was on the troubleshooting page and noticed that in the windows instructions, matplotlib was imported without a local name and then later referred to as mpl.  Repaired the import statement to remain consistent with the other instructions.