### PR TITLE
Simplify mpl.testing._copy_metadata.

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import functools
 import inspect
 import warnings
 from contextlib import contextmanager
@@ -20,34 +21,10 @@ def is_called_from_pytest():
     return getattr(matplotlib, '_called_from_pytest', False)
 
 
-# stolen from pytest
-def _getrawcode(obj, trycall=True):
-    """Return code object for given function."""
-    try:
-        return obj.__code__
-    except AttributeError:
-        obj = getattr(obj, 'im_func', obj)
-        obj = getattr(obj, 'func_code', obj)
-        obj = getattr(obj, 'f_code', obj)
-        obj = getattr(obj, '__code__', obj)
-        if trycall and not hasattr(obj, 'co_firstlineno'):
-            if hasattr(obj, '__call__') and not inspect.isclass(obj):
-                x = getrawcode(obj.__call__, trycall=False)
-                if hasattr(x, 'co_firstlineno'):
-                    return x
-        return obj
-
-
 def _copy_metadata(src_func, tgt_func):
     """Replicates metadata of the function. Returns target function."""
-    tgt_func.__dict__.update(src_func.__dict__)
-    tgt_func.__doc__ = src_func.__doc__
-    tgt_func.__module__ = src_func.__module__
-    tgt_func.__name__ = src_func.__name__
-    if hasattr(src_func, '__qualname__'):
-        tgt_func.__qualname__ = src_func.__qualname__
-    if not hasattr(tgt_func, 'compat_co_firstlineno'):
-        tgt_func.compat_co_firstlineno = _getrawcode(src_func).co_firstlineno
+    functools.update_wrapper(tgt_func, src_func)
+    tgt_func.__wrapped__ = src_func  # Python2 compatibility.
     return tgt_func
 
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -364,7 +364,7 @@ class ImageComparisonDecorator(CleanupTest):
             return _copy_metadata(func, runner_wrapper)
 
 
-def image_comparison(baseline_images=None, extensions=None, tol=0,
+def image_comparison(baseline_images, extensions=None, tol=0,
                      freetype_version=None, remove_text=False,
                      savefig_kwarg=None, style='classic'):
     """
@@ -405,8 +405,6 @@ def image_comparison(baseline_images=None, extensions=None, tol=0,
         if desired. Defaults to the 'classic' style.
 
     """
-    if baseline_images is None:
-        raise ValueError('baseline_images must be specified')
 
     if extensions is None:
         # default extensions to test


### PR DESCRIPTION
`mpl.testing._copy_metadata` was basically doing the job
of `functools.update_wrapper`.  We don't need to specify
`compat_co_firstlineono` either as pytest will look up
the lineno in the wrapped function
(https://github.com/pytest-dev/pytest/blob/master/_pytest/compat.py#L188).
It's also for this reason that we need to make sure
`__wrapped__` is properly set, even on Py2.

Also remove a useless check on `image_comparison` (if we want an
argument to be compulsory then just mark it as such, this does not
prevent it to be passed as keyword).