### PR TITLE
Use XDG config path on FreeBSD

### DIFF
--- a/doc/users/customizing.rst
+++ b/doc/users/customizing.rst
@@ -140,8 +140,8 @@ locations, in the following order:
 
 3. It next looks in a user-specific place, depending on your platform:
 
-   - On Linux, it looks in :file:`.config/matplotlib/matplotlibrc` (or
-     `$XDG_CONFIG_HOME/matplotlib/matplotlibrc`) if you've customized
+   - On Linux and FreeBSD, it looks in :file:`.config/matplotlib/matplotlibrc`
+     (or `$XDG_CONFIG_HOME/matplotlib/matplotlibrc`) if you've customized
      your environment.
 
    - On other platforms, it looks in :file:`.matplotlib/matplotlibrc`.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -645,7 +645,7 @@ def _get_config_or_cache_dir(xdg_base):
     h = get_home()
     if h is not None:
         p = os.path.join(h, '.matplotlib')
-    if sys.platform.startswith('linux'):
+    if sys.platform.startswith('linux') or sys.platform.startswith('freebsd'):
         p = None
         if xdg_base is not None:
             p = os.path.join(xdg_base, 'matplotlib')


### PR DESCRIPTION
This is a patch that was kindly emailed to us by Adam on the devel-matplotlib mailing list (2017-02-19).
The PR is simply the execution of `git am 0001-Use-XDG-config-path-on-FreeBSD.patch`, which was the patch file attached to Adam's email.

@tacaswell  Should this target 2.0.1 or 2.1?

**Disclaimer:** I do not have any FreeBSD system available, so I could not check it is working properly on this OS. But the patch seems OK to me (hence the PR).