### PR TITLE
Rename duplicate test class name in test_ticker

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -239,7 +239,7 @@ class TestScalarFormatter(object):
             assert use_offset == tmp_form.get_useOffset()
 
 
-class TestLogFormatter(object):
+class TestLogFormatterSubLabel(object):
     def _sub_labels(self, axis, subs=()):
         "Test whether locator marks subs to be labeled"
         fmt = axis.get_minor_formatter()


### PR DESCRIPTION
There were two `Class TestLogFormatter(object)` classes, so only one was ever being run. This renames one of them, so they both run.