### PR TITLE
Drop None from Container.get_children().

### DIFF
--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -32,9 +32,8 @@ class Container(tuple):
         self._remove_method = f
 
     def remove(self):
-        for c in cbook.flatten(self,
-                               scalarp=lambda x: isinstance(x,
-                                                            martist.Artist)):
+        for c in cbook.flatten(
+                self, scalarp=lambda x: isinstance(x, martist.Artist)):
             c.remove()
 
         if self._remove_method:
@@ -102,7 +101,7 @@ class Container(tuple):
             func(self)
 
     def get_children(self):
-        return list(cbook.flatten(self))
+        return [child for child in cbook.flatten(self) if child is not None]
 
 
 class BarContainer(Container):


### PR DESCRIPTION
Before the patch,
```
ec = plt.errorbar([1, 2], [3, 4], [5, 6], capsize=2, fmt="none")
print(ec.get_children())
```
would print `None` (corresponding to the "not drawn" line connecting the
data points), two `Line2D` and one `LineCollection`.

This patch drops the `None` out, as it is arguably not a child of the
Container.  (It is still possible to access the individual members of
the Container by unpacking it as a tuple.)

Also reformat an overly indented piece of code in the vicinity.