### PR TITLE
[MRG+2] Update Slider docs and type check slidermin and slidermax.

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -302,3 +302,14 @@ def test_slider_slidermin_slidermax():
     slider = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
                             valinit=10.0, slidermax=slider_)
     assert slider.val == slider_.val
+
+
+def test_slider_valmin_valmax():
+    fig, ax = plt.subplots()
+    slider = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                            valinit=-10.0)
+    assert slider.val == slider.valmin
+
+    slider = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                            valinit=25.0)
+    assert slider.val == slider.valmax

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -13,6 +13,8 @@ from matplotlib.testing.decorators import image_comparison
 
 from numpy.testing import assert_allclose
 
+import pytest
+
 
 def get_ax():
     fig, ax = plt.subplots(1, 1)
@@ -275,3 +277,28 @@ def test_check_radio_buttons_image():
     widgets.RadioButtons(rax1, ('Radio 1', 'Radio 2', 'Radio 3'))
     widgets.CheckButtons(rax2, ('Check 1', 'Check 2', 'Check 3'),
                          (False, True, True))
+
+
+def test_slider_slidermin_slidermax_invalid():
+    fig, ax = plt.subplots()
+    # test min/max with floats
+    with pytest.raises(ValueError):
+        widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                       slidermin=10.0)
+    with pytest.raises(ValueError):
+        widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                       slidermax=10.0)
+
+
+def test_slider_slidermin_slidermax():
+    fig, ax = plt.subplots()
+    slider_ = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                             valinit=5.0)
+
+    slider = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                            valinit=1.0, slidermin=slider_)
+    assert slider.val == slider_.val
+
+    slider = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                            valinit=10.0, slidermax=slider_)
+    assert slider.val == slider_.val

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -370,6 +370,29 @@ class Slider(AxesWidget):
         self.slidermin = slidermin
         self.slidermax = slidermax
         self.drag_active = False
+	self._value_in_bounds(valinit)
+
+    def _value_in_bounds(self, val):
+        """ Makes sure self.val is with given bounds."""
+	if val <= self.valmin:
+            if not self.closedmin:
+                return
+            val = self.valmin
+        elif val >= self.valmax:
+            if not self.closedmax:
+                return
+            val = self.valmax
+
+        if self.slidermin is not None and val <= self.slidermin.val:
+            if not self.closedmin:
+                return
+            val = self.slidermin.val
+
+        if self.slidermax is not None and val >= self.slidermax.val:
+            if not self.closedmax:
+                return
+            val = self.slidermax.val
+        self.set_val(val)
 
     def _update(self, event):
         """update the slider position"""
@@ -392,29 +415,9 @@ class Slider(AxesWidget):
             self.drag_active = False
             event.canvas.release_mouse(self.ax)
             return
-
         val = event.xdata
-        if val <= self.valmin:
-            if not self.closedmin:
-                return
-            val = self.valmin
-        elif val >= self.valmax:
-            if not self.closedmax:
-                return
-            val = self.valmax
-
-        if self.slidermin is not None and val <= self.slidermin.val:
-            if not self.closedmin:
-                return
-            val = self.slidermin.val
-
-        if self.slidermax is not None and val >= self.slidermax.val:
-            if not self.closedmax:
-                return
-            val = self.slidermax.val
-
-        self.set_val(val)
-
+	self._value_in_bounds(val)
+        
     def set_val(self, val):
         xy = self.poly.xy
         xy[2] = val, 1

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -291,11 +291,11 @@ class Slider(AxesWidget):
 
         valinit : float, optional
             The slider initial position.
-	    Default: 0.5
+        Default: 0.5
 
         valfmt : str, optional
             Used to format the slider value, fprint format string.
-	    Default: '%1.2f' 
+            Default: '%1.2f'
 
         closedmin : bool, optional
             Indicate whether the slider interval is closed on the bottom.
@@ -370,11 +370,11 @@ class Slider(AxesWidget):
         self.slidermin = slidermin
         self.slidermax = slidermax
         self.drag_active = False
-	self._value_in_bounds(valinit)
+        self._value_in_bounds(valinit)
 
     def _value_in_bounds(self, val):
         """ Makes sure self.val is with given bounds."""
-	if val <= self.valmin:
+        if val <= self.valmin:
             if not self.closedmin:
                 return
             val = self.valmin
@@ -416,8 +416,8 @@ class Slider(AxesWidget):
             event.canvas.release_mouse(self.ax)
             return
         val = event.xdata
-	self._value_in_bounds(val)
-        
+        self._value_in_bounds(val)
+
     def set_val(self, val):
         xy = self.poly.xy
         xy[2] = val, 1

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -266,36 +266,8 @@ class Slider(AxesWidget):
     """
     A slider representing a floating point range.
 
-    For the slider to remain responsive you must maintain a
-    reference to it.
-
-    The following attributes are defined
-      *ax*        : the slider :class:`matplotlib.axes.Axes` instance
-
-      *val*       : the current slider value
-
-      *vline*     : a :class:`matplotlib.lines.Line2D` instance
-                     representing the initial value of the slider
-
-      *poly*      : A :class:`matplotlib.patches.Polygon` instance
-                     which is the slider knob
-
-      *valfmt*    : the format string for formatting the slider text
-
-      *label*     : a :class:`matplotlib.text.Text` instance
-                     for the slider label
-
-      *closedmin* : whether the slider is closed on the minimum
-
-      *closedmax* : whether the slider is closed on the maximum
-
-      *slidermin* : another slider - if not *None*, this slider must be
-                     greater than *slidermin*
-
-      *slidermax* : another slider - if not *None*, this slider must be
-                     less than *slidermax*
-
-      *dragging*  : allow for mouse dragging on slider
+    Create a slider from *valmin* to *valmax* in axes *ax*. For the slider to
+    remain responsive you must maintain a reference to it.
 
     Call :meth:`on_changed` to connect to the slider event
     """
@@ -303,54 +275,56 @@ class Slider(AxesWidget):
                  closedmin=True, closedmax=True, slidermin=None,
                  slidermax=None, dragging=True, **kwargs):
         """
-        Create a slider from *valmin* to *valmax* in axes *ax*.
+        Parameters
+        ----------
+        ax : Axes
+            The Axes to put the slider in.
 
+        label : str
+            Slider label.
+
+        valmin : float
+            The minimum value of the slider.
+
+        valmax : float
+            The maximum value of the slider.
+
+        valinit : float, optional
+            The slider initial position.
+	    Default: 0.5
+
+        valfmt : str, optional
+            Used to format the slider value, fprint format string.
+	    Default: '%1.2f' 
+
+        closedmin : bool, optional
+            Indicate whether the slider interval is closed on the bottom.
+            Default: True
+
+        closedmax : bool, optional
+            Indicate whether the slider interval is closed on the top.
+            Default: True
+
+        slidermin : Slider, optional
+            Do not allow the current slider to have a value less than
+            `slidermin.val`.
+            Default: None
+
+        slidermax : Slider, optional
+            Do not allow the current slider to have a value greater than
+            `slidermax.val`.
+            Default: None
+
+        dragging : bool, optional
+            If True the slider can be dragged by the mouse.
+            Default: True
+
+        Notes
+        ----------
         Additional kwargs are passed on to ``self.poly`` which is the
         :class:`matplotlib.patches.Rectangle` that draws the slider
         knob.  See the :class:`matplotlib.patches.Rectangle` documentation for
         valid property names (e.g., *facecolor*, *edgecolor*, *alpha*, ...).
-
-        Parameters
-        ----------
-        ax : Axes
-            The Axes to put the slider in
-
-        label : str
-            Slider label
-
-        valmin : float
-            The minimum value of the slider
-
-        valmax : float
-            The maximum value of the slider
-
-        valinit : float
-            The slider initial position
-
-        label : str
-            The slider label
-
-        valfmt : str
-            Used to format the slider value, fprint format string
-
-        closedmin : bool
-            Indicate whether the slider interval is closed on the bottom
-
-        closedmax : bool
-            Indicate whether the slider interval is closed on the top
-
-        slidermin : Slider or None
-            Do not allow the current slider to have a value less than
-            `slidermin`
-
-        slidermax : Slider or None
-            Do not allow the current slider to have a value greater than
-            `slidermax`
-
-
-        dragging : bool
-            if the slider can be dragged by the mouse
-
         """
         AxesWidget.__init__(self, ax)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -266,7 +266,7 @@ class Slider(AxesWidget):
     """
     A slider representing a floating point range.
 
-    Create a slider from *valmin* to *valmax* in axes *ax*. For the slider to
+    Create a slider from `valmin` to `valmax` in axes `ax`. For the slider to
     remain responsive you must maintain a reference to it.
 
     Call :meth:`on_changed` to connect to the slider event
@@ -290,8 +290,7 @@ class Slider(AxesWidget):
             The maximum value of the slider.
 
         valinit : float, optional
-            The slider initial position.
-        Default: 0.5
+            The slider initial position. Default: 0.5
 
         valfmt : str, optional
             Used to format the slider value, fprint format string.
@@ -307,24 +306,21 @@ class Slider(AxesWidget):
 
         slidermin : Slider, optional
             Do not allow the current slider to have a value less than
-            `slidermin.val`.
-            Default: None
+            the value of the Slider `slidermin`. Default: None
 
         slidermax : Slider, optional
             Do not allow the current slider to have a value greater than
-            `slidermax.val`.
-            Default: None
+            the value of the Slider `slidermax`. Default: None
 
         dragging : bool, optional
-            If True the slider can be dragged by the mouse.
-            Default: True
+            If True the slider can be dragged by the mouse. Default: True
 
         Notes
-        ----------
+        -----
         Additional kwargs are passed on to ``self.poly`` which is the
-        :class:`matplotlib.patches.Rectangle` that draws the slider
-        knob.  See the :class:`matplotlib.patches.Rectangle` documentation for
-        valid property names (e.g., *facecolor*, *edgecolor*, *alpha*, ...).
+        :class:`~matplotlib.patches.Rectangle` that draws the slider
+        knob.  See the :class:`~matplotlib.patches.Rectangle` documentation for
+        valid property names (e.g., `facecolor`, `edgecolor`, `alpha`).
         """
         AxesWidget.__init__(self, ax)
 
@@ -392,7 +388,7 @@ class Slider(AxesWidget):
             if not self.closedmax:
                 return
             val = self.slidermax.val
-        self.set_val(val)
+        return val
 
     def _update(self, event):
         """update the slider position"""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -328,6 +328,13 @@ class Slider(AxesWidget):
         """
         AxesWidget.__init__(self, ax)
 
+        if slidermin is not None and not hasattr(slidermin, 'val'):
+            raise ValueError("Argument slidermin ({}) has no 'val'"
+                             .format(type(slidermin)))
+        if slidermax is not None and not hasattr(slidermax, 'val'):
+            raise ValueError("Argument slidermax ({}) has no 'val'"
+                             .format(type(slidermax)))
+
         self.valmin = valmin
         self.valmax = valmax
         self.val = valinit

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -330,13 +330,17 @@ class Slider(AxesWidget):
         if slidermax is not None and not hasattr(slidermax, 'val'):
             raise ValueError("Argument slidermax ({}) has no 'val'"
                              .format(type(slidermax)))
-
+        self.closedmin = closedmin
+        self.closedmax = closedmax
+        self.slidermin = slidermin
+        self.slidermax = slidermax
+        self.drag_active = False
         self.valmin = valmin
         self.valmax = valmax
+        valinit = self._value_in_bounds(valinit)
         self.val = valinit
         self.valinit = valinit
         self.poly = ax.axvspan(valmin, valinit, 0, 1, **kwargs)
-
         self.vline = ax.axvline(valinit, 0, 1, color='r', lw=1)
 
         self.valfmt = valfmt
@@ -361,12 +365,7 @@ class Slider(AxesWidget):
         self.cnt = 0
         self.observers = {}
 
-        self.closedmin = closedmin
-        self.closedmax = closedmax
-        self.slidermin = slidermin
-        self.slidermax = slidermax
-        self.drag_active = False
-        self._value_in_bounds(valinit)
+        self.set_val(valinit)
 
     def _value_in_bounds(self, val):
         """ Makes sure self.val is with given bounds."""
@@ -388,7 +387,7 @@ class Slider(AxesWidget):
             if not self.closedmax:
                 return
             val = self.slidermax.val
-        return val
+	return val
 
     def _update(self, event):
         """update the slider position"""
@@ -412,7 +411,7 @@ class Slider(AxesWidget):
             event.canvas.release_mouse(self.ax)
             return
         val = event.xdata
-        self._value_in_bounds(val)
+        self.set_val(self._value_in_bounds(val))
 
     def set_val(self, val):
         xy = self.poly.xy

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -289,31 +289,28 @@ class Slider(AxesWidget):
         valmax : float
             The maximum value of the slider.
 
-        valinit : float, optional
-            The slider initial position. Default: 0.5
+        valinit : float, optional, default: 0.5
+            The slider initial position.
 
-        valfmt : str, optional
+        valfmt : str, optional, default: "%1.2f"
             Used to format the slider value, fprint format string.
-            Default: '%1.2f'
 
-        closedmin : bool, optional
+        closedmin : bool, optional, default: True
             Indicate whether the slider interval is closed on the bottom.
-            Default: True
 
-        closedmax : bool, optional
+        closedmax : bool, optional, default: True
             Indicate whether the slider interval is closed on the top.
-            Default: True
 
-        slidermin : Slider, optional
+        slidermin : Slider, optional, default: None
             Do not allow the current slider to have a value less than
-            the value of the Slider `slidermin`. Default: None
+            the value of the Slider `slidermin`.
 
-        slidermax : Slider, optional
+        slidermax : Slider, optional, default: None
             Do not allow the current slider to have a value greater than
-            the value of the Slider `slidermax`. Default: None
+            the value of the Slider `slidermax`.
 
-        dragging : bool, optional
-            If True the slider can be dragged by the mouse. Default: True
+        dragging : bool, optional, default: True
+            If True the slider can be dragged by the mouse.
 
         Notes
         -----

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -384,7 +384,7 @@ class Slider(AxesWidget):
             if not self.closedmax:
                 return
             val = self.slidermax.val
-	return val
+        return val
 
     def _update(self, event):
         """update the slider position"""


### PR DESCRIPTION
This addresses  #7687. 

* I tried to improve the doc strings of the widgets.slider class using numpydoc format. Let me know if it should be handled differently or I missed something. I built the docs and it rendered cleaner than previously using the current version.

* Raises a ValueError if the slidermin or slidermax objects are not a compatible type (None or hasattr( 'val')). 

* Adds a test to make sure exception is raised in appropriate cases.

As I was testing this I noticed that the initial value can be outside of the bounds, and it will not be updated until _update gets called. To correct this I wrapped the statements that ensure the value is within the provided bounds into a function and called it in the the constructor. Currently there is no validation on the bounds, but I would be willing to add that if you think it will help.

 
