### PR TITLE
setup.py test as test entry point.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,10 +132,21 @@ classifiers = [
     ]
 
 
-class NoopTestCommand(TestCommand):
-    def run(self):
-        print("Matplotlib does not support running tests with "
-              "'python setup.py test'. Please run 'python tests.py'")
+class PyTestCommand(TestCommand):
+    user_options = [
+        ("pytest-args=", "a", "Arguments to pass to pytest"),
+        ("local-freetype", None, "setup.cfg back-compatibility; do not use")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ""
+        self.local_freetype = ""
+
+    def run_tests(self):
+        import shlex
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
 
 
 class BuildExtraLibraries(BuildExtCommand):
@@ -147,7 +158,7 @@ class BuildExtraLibraries(BuildExtCommand):
 
 
 cmdclass = versioneer.get_cmdclass()
-cmdclass['test'] = NoopTestCommand
+cmdclass['test'] = PyTestCommand
 cmdclass['build_ext'] = BuildExtraLibraries
 
 # One doesn't normally see `if __name__ == '__main__'` blocks in a setup.py,

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,8 @@ class PyTestCommand(TestCommand):
         self.pytest_args = ""
         self.local_freetype = ""
 
+    install_dists = staticmethod(lambda dist: [])
+
     def run_tests(self):
         import shlex
         import pytest

--- a/setupext.py
+++ b/setupext.py
@@ -100,19 +100,25 @@ if os.path.exists(setup_cfg):
         config = configparser.SafeConfigParser()
     config.read(setup_cfg)
 
-    if config.has_option('status', 'suppress'):
+    try:
         options['display_status'] = not config.getboolean("status", "suppress")
-
-    if config.has_option('rc_options', 'backend'):
+    except configparser.Error:
+        pass
+    try:
         options['backend'] = config.get("rc_options", "backend")
-
-    if config.has_option('directories', 'basedirlist'):
+    except configparser.Error:
+        pass
+    try:
         options['basedirlist'] = [
             x.strip() for x in
             config.get("directories", "basedirlist").split(',')]
-
-    if config.has_option('test', 'local_freetype'):
-        options['local_freetype'] = config.getboolean("test", "local_freetype")
+    except configparser.Error:
+        pass
+    try:
+        options['local_freetype'] = config.getboolean(
+            "test_build", "local_freetype")
+    except configparser.Error:
+        pass
 else:
     config = None
 


### PR DESCRIPTION
This is a proof of concept that `python setup.py test` can be used as
entry point to the test suite.

`python setup.py test` will build matplotlib and run `pytest` locally.
There is no need to install matplotlib in a venv, `setup.py test`
apparently handles `PYTHONPATH` itself (and even the `mpl_toolkits`
namespace package seems to be handled properly).  (In my opinion, this
is an unexpected big plus.)

The `test` section of `setup.cfg` had to be renamed to `test_build` as
it is otherwise interpreted as an option passed to `setup.py test`,
which it is not, right now.  It may be advantageous to make

    setup.py test --local-freetype=true

"work", but this would require more refactoring as `setupext` is
currently imported, and thus the choice of whether to use a local
freetype done, at the top of `setup.py`, before we know whether we are
going to run the test suite.  This needs to be
documented.

Arguments to `pytest` are passed as

    python setup.py test -a "$PYTEST_ARGS"

(as `setup.py` will swallow unspecified arguments itself).

The remaining setups in `tests.py` are setting the recursion limit and
turning on some deprecation warnings.  I think the former can be
implemented as a local pytest plugin, and the latter as a session-scoped
fixture.

If we switch to this method, the CI scripts would need to be adjusted as
well.

The implementation is essentially copy-pasted from
http://doc.pytest.org/en/latest/goodpractices.html#manual-integration.

attn @tacaswell @phobson @QuLogic @Kojoley 