### PR TITLE
[MRG+1] Qt5: Fix event positions on HiDPI screens.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -263,9 +263,16 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         FigureCanvasBase.leave_notify_event(self, guiEvent=event)
 
     def mouseEventCoords(self, pos):
-        x = pos.x() * self._dpi_ratio
+        """
+        Calculate mouse coordinates in logical pixels.
+
+        Qt5 and Matplotlib use logical pixels, but the figure is scaled to
+        physical pixels for rendering. Also, the origin is different and needs
+        to be corrected.
+        """
+        x = pos.x()
         # flip y so y=0 is bottom of canvas
-        y = self.figure.bbox.height - pos.y() * self._dpi_ratio
+        y = self.figure.bbox.height / self._dpi_ratio - pos.y()
         return x, y
 
     def mousePressEvent(self, event):


### PR DESCRIPTION
The event location is in logical pixels, which is the way it should stay for the rest of the stack.

Fixes #8052.