### PR TITLE
Remove support for -dbackend argv.

### DIFF
--- a/doc/api/api_changes/2017-02-25-AL_dbackend.rst
+++ b/doc/api/api_changes/2017-02-25-AL_dbackend.rst
@@ -1,0 +1,4 @@
+``-d$backend`` no longer sets the backend
+`````````````````````````````````````````
+
+It is no longer possible to set the backend by passing ``-d$backend`` at the command line.  Use the ``MPLBACKEND`` environment variable instead.

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -415,7 +415,7 @@ Developing a new backend
 
 If you are working on a custom backend, the *backend* setting in
 :file:`matplotlibrc` (:ref:`customizing-matplotlib`) supports an
-external backend via the ``module`` directive.  if
+external backend via the ``module`` directive.  If
 :file:`my_backend.py` is a Matplotlib backend in your
 :envvar:`PYTHONPATH`, you can set it on one of several ways
 
@@ -423,15 +423,10 @@ external backend via the ``module`` directive.  if
 
     backend : module://my_backend
 
-
 * with the :envvar:`MPLBACKEND` environment variable::
 
     > export MPLBACKEND="module://my_backend"
     > python simple_plot.py
-
-* from the command shell with the `-d` flag::
-
-    > python simple_plot.py -dmodule://my_backend
 
 * with the use directive in your script::
 

--- a/doc/faq/environment_variables_faq.rst
+++ b/doc/faq/environment_variables_faq.rst
@@ -33,9 +33,8 @@ Environment Variables
 
 .. envvar:: MPLBACKEND
 
-  This optional variable can be set to choose the matplotlib backend. Using the
-  `-d` command line parameter or the :func:`~matplotlib.use` function will
-  override this value. See :ref:`what-is-a-backend`.
+  This optional variable can be set to choose the matplotlib backend.  See
+  :ref:`what-is-a-backend`.
 
 .. _setting-linux-osx-environment-variables:
 

--- a/doc/faq/usage_faq.rst
+++ b/doc/faq/usage_faq.rst
@@ -326,16 +326,6 @@ the method mentioned last in the following list will be used, e.g. calling
    globally, e.g. in your ``.bashrc`` or ``.profile``, is discouraged as it
    might lead to counter-intuitive behavior.
 
-#. To set the backend for a single script, you can alternatively use the `-d`
-   command line argument::
-
-       > python script.py -dbackend
-
-   This method is **deprecated** as the `-d` argument might conflict with
-   scripts which parse command line arguments (see issue
-   `#1986 <https://github.com/matplotlib/matplotlib/issues/1986>`_). You
-   should use :envvar:`MPLBACKEND` instead.
-
 #. If your script depends on a specific backend you can use the
    :func:`~matplotlib.use` function::
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1338,6 +1338,7 @@ def rc_file_defaults():
     """
     rcParams.update(rcParamsOrig)
 
+
 _use_error_msg = """
 This call to matplotlib.use() has no effect because the backend has already
 been chosen; matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
@@ -1408,6 +1409,12 @@ def use(arg, warn=True, force=False):
         reload(sys.modules['matplotlib.backends'])
 
 
+try:
+    use(os.environ['MPLBACKEND'])
+except KeyError:
+    pass
+
+
 def get_backend():
     """Return the name of the current backend."""
     return rcParams['backend']
@@ -1434,33 +1441,6 @@ def tk_window_focus():
     if rcParams['backend'] != 'TkAgg':
         return False
     return rcParams['tk.window_focus']
-
-# Now allow command line to override
-
-# Allow command line access to the backend with -d (MATLAB compatible
-# flag)
-
-for s in sys.argv[1:]:
-    # cast to str because we are using unicode_literals,
-    # and argv is always str
-    if s.startswith(str('-d')) and len(s) > 2:  # look for a -d flag
-        try:
-            use(s[2:])
-            warnings.warn("Using the -d command line argument to select a "
-                          "matplotlib backend is deprecated. Please use the "
-                          "MPLBACKEND environment variable instead.",
-                          mplDeprecation)
-            break
-        except (KeyError, ValueError):
-            pass
-        # we don't want to assume all -d flags are backends, e.g., -debug
-else:
-    # no backend selected from the command line, so we check the environment
-    # variable MPLBACKEND
-    try:
-        use(os.environ['MPLBACKEND'])
-    except KeyError:
-        pass
 
 
 # Jupyter extension paths


### PR DESCRIPTION
Support for setting the backend with `-dbackend` was deprecated in 1.5 (#3710).