### PR TITLE
[MRG+1] Fix check for DISPLAY on PyQt5.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -130,7 +130,15 @@ def _create_qApp():
         app = QtWidgets.QApplication.instance()
         if app is None:
             # check for DISPLAY env variable on X11 build of Qt
-            if hasattr(QtGui, "QX11Info"):
+            if is_pyqt5():
+                try:
+                    from PyQt5 import QtX11Extras
+                    is_x11_build = True
+                except ImportError:
+                    is_x11_build = False
+            else:
+                is_x11_build = hasattr(QtGui, "QX11Info")
+            if is_x11_build:
                 display = os.environ.get('DISPLAY')
                 if display is None or not re.search(r':\d', display):
                     raise RuntimeError('Invalid DISPLAY variable')


### PR DESCRIPTION
This check avoids a fatal error when the DISPLAY environment variable is
not set using PyQt5, e.g.
```
MPLBACKEND=qt5agg DISPLAY= python -c 'from pylab import *; plot(); show()'
```

(The previous check only worked on PyQt4.)