### PR TITLE
MAINT: mappingview check for Python 3.4

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2281,9 +2281,7 @@ def safe_first_element(obj):
 
 def sanitize_sequence(data):
     """Converts dictview object to list"""
-    if six.PY3 and isinstance(data, collections.abc.MappingView):
-        return list(data)
-    return data
+    return list(data) if isinstance(data, collections.MappingView) else data
 
 
 def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),


### PR DESCRIPTION
Python 3.4 does not autoamatically import module `abc` into
`collections`, causing an error when checking for
`collections.abc.MappingView`.  Do more explicit import of `MappingView`
to work round this difference.

See: https://travis-ci.org/MacPython/matplotlib-wheels/jobs/205713297#L582 for
error on Python 3.4.