### PR TITLE
DOC: Fix small typos in 'eventplot' docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1106,9 +1106,9 @@ or tuple of floats
         arrival times of people to a business on each day of the month or the
         date of hurricanes each year of the last century.
 
-        *orientation* : [ 'horizonal' | 'vertical' ]
-          'horizonal' : the lines will be vertical and arranged in rows
-          "vertical' : lines will be horizontal and arranged in columns
+        *orientation* : [ 'horizontal' | 'vertical' ]
+          'horizontal' : the lines will be vertical and arranged in rows
+          'vertical' : lines will be horizontal and arranged in columns
 
         *lineoffsets* :
           A float or array-like containing floats.


### PR DESCRIPTION
Summary: `'horizonal'` <- `'horizontal'` and make a quote symbol consistent with the other ones of the docstring.

The whole docstring would definitely need some love (i.e. a significant overhaul), but this may be done later in another PR. Especially if one wants to avoid conflict with changes that may be done in #7602.