### PR TITLE
Add autoclass entry for Artist API doc.

### DIFF
--- a/doc/api/artist_api.rst
+++ b/doc/api/artist_api.rst
@@ -16,6 +16,7 @@
 ``Artist`` class
 ================
 
+.. autoclass:: Artist
 
 Interactive
 -----------


### PR DESCRIPTION
Adding an autoclass entry in the Artist API ensures that that class
appears in the intersphinx `build/html/object.inv`, as can be checked by
```
"matplotlib.artist.Artist" in (
    sphinx.ext.intersphinx.read_inventory(
        open("build/html/objects.inv", "rb"), None, lambda *args: None)[
            "py:class"])
```
(now returns True).

This allows other projects to link to that class in their docs using
```
`Artist` <matplotlib.artist.Artist>
```

This possibility used to be present, but disappeared when the Artist API
doc got refactored.  (Other classes that appear in the API docs are fine
as they already use autoclass.)

-----

The relevant section is now rendered as
![screenshot_20170228_213915](https://cloud.githubusercontent.com/assets/1322974/23447254/83fef03e-fdfe-11e6-9f22-4a65d1f9ce1f.png)
