### PR TITLE
Custom error message for draw_path. issues : #8131 (bad error message from pyplot.plot)

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -165,12 +165,12 @@ class RendererAgg(RendererBase):
                 p = Path(v, c)
                 try:
                     self._renderer.draw_path(gc, p, transform, rgbFace)
-                except OverflowError as e:
+                except OverflowError:
                     raise OverflowError("Exceeded cell block limit (set 'agg.path.chunksize' rcparam)")
         else:
             try:
                 self._renderer.draw_path(gc, path, transform, rgbFace)
-            except OverflowError as e:
+            except OverflowError:
                 raise OverflowError("Exceeded cell block limit (set 'agg.path.chunksize' rcparam)")
 
 

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -147,24 +147,32 @@ class RendererAgg(RendererBase):
         """
         nmax = rcParams['agg.path.chunksize'] # here at least for testing
         npts = path.vertices.shape[0]
+
         if (nmax > 100 and npts > nmax and path.should_simplify and
                 rgbFace is None and gc.get_hatch() is None):
-            nch = np.ceil(npts/float(nmax))
-            chsize = int(np.ceil(npts/nch))
+            nch = np.ceil(npts / float(nmax))
+            chsize = int(np.ceil(npts / nch))
             i0 = np.arange(0, npts, chsize)
             i1 = np.zeros_like(i0)
             i1[:-1] = i0[1:] - 1
             i1[-1] = npts
             for ii0, ii1 in zip(i0, i1):
-                v = path.vertices[ii0:ii1,:]
+                v = path.vertices[ii0:ii1, :]
                 c = path.codes
                 if c is not None:
                     c = c[ii0:ii1]
-                    c[0] = Path.MOVETO # move to end of last chunk
+                    c[0] = Path.MOVETO  # move to end of last chunk
                 p = Path(v, c)
-                self._renderer.draw_path(gc, p, transform, rgbFace)
+                try:
+                    self._renderer.draw_path(gc, p, transform, rgbFace)
+                except OverflowError as e:
+                    raise OverflowError("Exceeded cell block limit (set 'agg.path.chunksize' rcparam)")
         else:
-            self._renderer.draw_path(gc, path, transform, rgbFace)
+            try:
+                self._renderer.draw_path(gc, path, transform, rgbFace)
+            except OverflowError as e:
+                raise OverflowError("Exceeded cell block limit (set 'agg.path.chunksize' rcparam)")
+
 
     def draw_mathtext(self, gc, x, y, s, prop, angle):
         """

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -14,7 +14,7 @@ from matplotlib.figure import Figure
 from matplotlib.testing.decorators import image_comparison
 from matplotlib import pyplot as plt
 from matplotlib import collections
-from matplotlib import path
+from matplotlib import path, rcParams
 from matplotlib import transforms as mtransforms
 
 
@@ -219,3 +219,23 @@ def test_too_large_image():
     buff = io.BytesIO()
     with pytest.raises(ValueError):
         fig.savefig(buff)
+
+
+def test_chunksize():
+    x = range(9000000)
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+
+    # Test with small chunksize
+    tmp = rcParams['agg.path.chunksize']
+    rcParams['agg.path.chunksize'] = 500
+    ax.plot(x, np.sin(x))
+    plt.show()
+
+    # Test with big chunksize
+    rcParams['agg.path.chunksize'] = 8000000
+    with pytest.raises(OverflowError):
+        ax.plot(x, np.sin(x))
+        plt.show()
+
+    rcParams['agg.path.chunksize'] = tmp

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -222,7 +222,7 @@ def test_too_large_image():
 
 
 def test_chunksize():
-    x = range(110)
+    x = range(200)
 
     # Test without chunksize
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -222,14 +222,15 @@ def test_too_large_image():
 
 
 def test_chunksize():
-    x = range(9000000)
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    x = range(110)
 
-    # Test with small chunksize
-    tmp = rcParams['agg.path.chunksize']
-    rcParams['agg.path.chunksize'] = 500
+    # Test without chunksize
+    fig, ax = plt.subplots()
     ax.plot(x, np.sin(x))
-    plt.show()
+    fig.canvas.draw()
 
-    rcParams['agg.path.chunksize'] = tmp
+    # Test with chunksize
+    fig, ax = plt.subplots()
+    rcParams['agg.path.chunksize'] = 105
+    ax.plot(x, np.sin(x))
+    fig.canvas.draw()

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -232,10 +232,4 @@ def test_chunksize():
     ax.plot(x, np.sin(x))
     plt.show()
 
-    # Test with big chunksize
-    rcParams['agg.path.chunksize'] = 8000000
-    with pytest.raises(OverflowError):
-        ax.plot(x, np.sin(x))
-        plt.show()
-
     rcParams['agg.path.chunksize'] = tmp


### PR DESCRIPTION
Addressing the issue #8131, this PR adds reference to the agg.path.chunksize params in the overflow error message.