### PR TITLE
Implement blocking Qt event loop.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -430,16 +430,17 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         global qApp
         qApp.processEvents()
 
-    def start_event_loop(self, timeout):
-        FigureCanvasBase.start_event_loop_default(self, timeout)
+    def start_event_loop(self, timeout=0):
+        if hasattr(self, "_event_loop") and self._event_loop.isRunning():
+            raise RuntimeError("Event loop already running")
+        self._event_loop = event_loop = QtCore.QEventLoop()
+        if timeout:
+            timer = QtCore.QTimer.singleShot(timeout * 1000, event_loop.quit)
+        event_loop.exec_()
 
-    start_event_loop.__doc__ = \
-                             FigureCanvasBase.start_event_loop_default.__doc__
-
-    def stop_event_loop(self):
-        FigureCanvasBase.stop_event_loop_default(self)
-
-    stop_event_loop.__doc__ = FigureCanvasBase.stop_event_loop_default.__doc__
+    def stop_event_loop(self, event=None):
+        if hasattr(self, "_event_loop"):
+            self._event_loop.quit()
 
 
 class MainWindow(QtWidgets.QMainWindow):


### PR DESCRIPTION
Avoids raising a deprecation warning (due to use of the default busy
waiting loop) when running e.g.
```
plt.gca(); plt.gcf().ginput(4)
```
or
```
plt.gca(); plt.gcf().ginput(4, timeout=2)
```

The implementation is similar to the one for the Wx backend.