### PR TITLE
Implemented Ticklabel selection when formatting - #8128

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -440,7 +440,7 @@ class Figure(Artist):
         self._tight_parameters = tight if isinstance(tight, dict) else {}
         self.stale = True
 
-    def autofmt_xdate(self, bottom=0.2, rotation=30, ha='right'):
+    def autofmt_xdate(self, bottom=0.2, rotation=30, ha='right', which=None):
         """
         Date ticklabels often overlap, so it is useful to rotate them
         and right align them.  Also, a common use case is a number of
@@ -449,29 +449,39 @@ class Figure(Artist):
         bottom subplot and turn them off on other subplots, as well as
         turn off xlabels.
 
-        *bottom*
+        Parameters
+        ----------
+
+        bottom : bottom of the subplots, optional
             The bottom of the subplots for :meth:`subplots_adjust`
+            default: 0.2
 
-        *rotation*
-            The rotation of the xtick labels
+        rotation : the angle of rotation(in degrees), optional
+            The angle of rotation of the xtick labels (in degrees)
+            default: 30
 
-        *ha*
+        ha : horizontal alignment of xtick labels, optional
             The horizontal alignment of the xticklabels
+            default: 'right'
+
+        which : {None, 'minor', 'major', 'both'}, optional
+            Selects which ticklabels to format
+            default: None
         """
         allsubplots = all(hasattr(ax, 'is_last_row') for ax in self.axes)
         if len(self.axes) == 1:
-            for label in self.axes[0].get_xticklabels():
+            for label in self.axes[0].get_xticklabels(False, which):
                 label.set_ha(ha)
                 label.set_rotation(rotation)
         else:
             if allsubplots:
                 for ax in self.get_axes():
                     if ax.is_last_row():
-                        for label in ax.get_xticklabels():
+                        for label in ax.get_xticklabels(False, which):
                             label.set_ha(ha)
                             label.set_rotation(rotation)
                     else:
-                        for label in ax.get_xticklabels():
+                        for label in ax.get_xticklabels(False, which):
                             label.set_visible(False)
                         ax.set_xlabel('')
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4984,3 +4984,32 @@ def test_invalid_axis_limits():
         plt.ylim(np.nan)
     with pytest.raises(ValueError):
         plt.ylim(np.inf)
+
+
+def test_tick_label_selection():
+    #test feature #8128
+    pd = pytest.importorskip('pandas')
+    # all posibilities for the parameter we are testing
+    which = {None, 'minor', 'major', 'both'}
+
+    for w in which:
+        fig, ax = plt.subplots()
+        df = pd.DataFrame(data=[1] * 5,
+                     index=pd.date_range(start='2017-01-01', periods=5),
+                     columns=['A'])
+        df.plot(ax=ax)
+
+        #format the tick labels with the given parameter value
+        fig.autofmt_xdate(0.2, 30, 'right', w)
+
+        #keep a boolean of whether or not the major & minor axis should be rotated
+        is_rotated_minor = (w == 'both') or (w == 'minor')
+        is_rotated_major = (w == 'both') or (w == 'major') or (w == None)
+
+        #check if the major axis were formatted (or not) as expected
+        for label in fig.axes[0].get_xticklabels(False, 'major'):
+            assert (label.get_rotation() == 30) == is_rotated_major
+
+        #check if the minor axis were formatted (or not) as expected
+        for label in fig.axes[0].get_xticklabels(False, 'minor'):
+            assert (label.get_rotation() == 30) == is_rotated_minor


### PR DESCRIPTION
This is simple feature implementation which allows the user to select which tick labels to format when using figure.Figure. autofmt_xdate() - see #8128 