### PR TITLE
[DOC] [MRG+1] Plural of axis is axes

### DIFF
--- a/doc/users/pyplot_tutorial.rst
+++ b/doc/users/pyplot_tutorial.rst
@@ -288,7 +288,7 @@ details.  More examples can be found in
 :ref:`pylab_examples-annotation_demo`.
 
 
-Logarithmic and other nonlinear axis
+Logarithmic and other nonlinear axes
 ====================================
 
 :mod:`matplotlib.pyplot` supports not only linear axis scales, but also


### PR DESCRIPTION
as already used in the same file (minor edit)