### PR TITLE
Contouring 1x1 array (issue #8197)

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1542,6 +1542,8 @@ class QuadContourSet(ContourSet):
 
         if z.ndim != 2:
             raise TypeError("Input z must be a 2D array.")
+        elif z.shape[0] < 2 or z.shape[1] < 2:
+            raise TypeError("Input z must be at least a 2x2 array.")
         else:
             Ny, Nx = z.shape
 
@@ -1590,6 +1592,8 @@ class QuadContourSet(ContourSet):
         """
         if z.ndim != 2:
             raise TypeError("Input must be a 2D array.")
+        elif z.shape[0] < 2 or z.shape[1] < 2:
+            raise TypeError("Input z must be at least a 2x2 array.")
         else:
             Ny, Nx = z.shape
         if self.origin is None:  # Not for image-matching.

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1048,3 +1048,78 @@ def test_tricontourf_decreasing_levels():
     plt.figure()
     with pytest.raises(ValueError):
         plt.tricontourf(x, y, z, [1.0, 0.0])
+
+
+def test_internal_cpp_api():
+    # Following github issue 8197.
+    import matplotlib._tri as _tri
+
+    # C++ Triangulation.
+    with pytest.raises(TypeError) as excinfo:
+        triang = _tri.Triangulation()
+    excinfo.match(r'function takes exactly 7 arguments \(0 given\)')
+
+    with pytest.raises(ValueError) as excinfo:
+        triang = _tri.Triangulation([], [1], [[]], None, None, None, False)
+    excinfo.match(r'x and y must be 1D arrays of the same length')
+
+    x = [0, 1, 1]
+    y = [0, 0, 1]
+    with pytest.raises(ValueError) as excinfo:
+        triang = _tri.Triangulation(x, y, [[0, 1]], None, None, None, False)
+    excinfo.match(r'triangles must be a 2D array of shape \(\?,3\)')
+
+    tris = [[0, 1, 2]]
+    with pytest.raises(ValueError) as excinfo:
+        triang = _tri.Triangulation(x, y, tris, [0, 1], None, None, False)
+    excinfo.match(r'mask must be a 1D array with the same length as the ' +
+                  r'triangles array')
+
+    with pytest.raises(ValueError) as excinfo:
+        triang = _tri.Triangulation(x, y, tris, None, [[1]], None, False)
+    excinfo.match(r'edges must be a 2D array with shape \(\?,2\)')
+
+    with pytest.raises(ValueError) as excinfo:
+        triang = _tri.Triangulation(x, y, tris, None, None, [[-1]], False)
+    excinfo.match(r'neighbors must be a 2D array with the same shape as the ' +
+                  r'triangles array')
+
+    triang = _tri.Triangulation(x, y, tris, None, None, None, False)
+
+    with pytest.raises(ValueError) as excinfo:
+        triang.calculate_plane_coefficients([])
+    excinfo.match(r'z array must have same length as triangulation x and y ' +
+                  r'arrays')
+
+    with pytest.raises(ValueError) as excinfo:
+        triang.set_mask([0, 1])
+    excinfo.match(r'mask must be a 1D array with the same length as the ' +
+                  r'triangles array')
+
+    # C++ TriContourGenerator.
+    with pytest.raises(TypeError) as excinfo:
+        tcg = _tri.TriContourGenerator()
+    excinfo.match(r'function takes exactly 2 arguments \(0 given\)')
+
+    with pytest.raises(ValueError) as excinfo:
+        tcg = _tri.TriContourGenerator(triang, [1])
+    excinfo.match(r'z must be a 1D array with the same length as the x and ' +
+                  r'y arrays')
+
+    z = [0, 1, 2]
+    tcg = _tri.TriContourGenerator(triang, z)
+
+    with pytest.raises(ValueError) as excinfo:
+        tcg.create_filled_contour(1, 0)
+    excinfo.match(r'filled contour levels must be increasing')
+
+    # C++ TrapezoidMapTriFinder.
+    with pytest.raises(TypeError) as excinfo:
+        trifinder = _tri.TrapezoidMapTriFinder()
+    excinfo.match(r'function takes exactly 1 argument \(0 given\)')
+
+    trifinder = _tri.TrapezoidMapTriFinder(triang)
+
+    with pytest.raises(ValueError) as excinfo:
+        trifinder.find_many([0], [0, 1])
+    excinfo.match(r'x and y must be array_like with same shape')

--- a/lib/matplotlib/tri/_tri_wrapper.cpp
+++ b/lib/matplotlib/tri/_tri_wrapper.cpp
@@ -53,24 +53,28 @@ static int PyTriangulation_init(PyTriangulation* self, PyObject* args, PyObject*
     if (x.empty() || y.empty() || x.dim(0) != y.dim(0)) {
         PyErr_SetString(PyExc_ValueError,
             "x and y must be 1D arrays of the same length");
+        return -1;
     }
 
     // triangles.
     if (triangles.empty() || triangles.dim(1) != 3) {
         PyErr_SetString(PyExc_ValueError,
             "triangles must be a 2D array of shape (?,3)");
+        return -1;
     }
 
     // Optional mask.
     if (!mask.empty() && mask.dim(0) != triangles.dim(0)) {
         PyErr_SetString(PyExc_ValueError,
             "mask must be a 1D array with the same length as the triangles array");
+        return -1;
     }
 
     // Optional edges.
     if (!edges.empty() && edges.dim(1) != 2) {
         PyErr_SetString(PyExc_ValueError,
             "edges must be a 2D array with shape (?,2)");
+        return -1;
     }
 
     // Optional neighbors.
@@ -78,6 +82,7 @@ static int PyTriangulation_init(PyTriangulation* self, PyObject* args, PyObject*
                                neighbors.dim(1) != triangles.dim(1))) {
         PyErr_SetString(PyExc_ValueError,
             "neighbors must be a 2D array with the same shape as the triangles array");
+        return -1;
     }
 
     CALL_CPP_INIT("Triangulation",
@@ -109,6 +114,7 @@ static PyObject* PyTriangulation_calculate_plane_coefficients(PyTriangulation* s
     if (z.empty() || z.dim(0) != self->ptr->get_npoints()) {
         PyErr_SetString(PyExc_ValueError,
             "z array must have same length as triangulation x and y arrays");
+        return NULL;
     }
 
     Triangulation::TwoCoordinateArray result;
@@ -167,6 +173,7 @@ static PyObject* PyTriangulation_set_mask(PyTriangulation* self, PyObject* args,
     if (!mask.empty() && mask.dim(0) != self->ptr->get_ntri()) {
         PyErr_SetString(PyExc_ValueError,
             "mask must be a 1D array with the same length as the triangles array");
+        return NULL;
     }
 
     CALL_CPP("set_mask", (self->ptr->set_mask(mask)));
@@ -251,6 +258,7 @@ static int PyTriContourGenerator_init(PyTriContourGenerator* self, PyObject* arg
     if (z.empty() || z.dim(0) != triangulation.get_npoints()) {
         PyErr_SetString(PyExc_ValueError,
             "z must be a 1D array with the same length as the x and y arrays");
+        return -1;
     }
 
     CALL_CPP_INIT("TriContourGenerator",
@@ -299,6 +307,7 @@ static PyObject* PyTriContourGenerator_create_filled_contour(PyTriContourGenerat
     {
         PyErr_SetString(PyExc_ValueError,
             "filled contour levels must be increasing");
+        return NULL;
     }
 
     PyObject* result;
@@ -407,6 +416,7 @@ static PyObject* PyTrapezoidMapTriFinder_find_many(PyTrapezoidMapTriFinder* self
     if (x.empty() || y.empty() || x.dim(0) != y.dim(0)) {
         PyErr_SetString(PyExc_ValueError,
             "x and y must be array_like with same shape");
+        return NULL;
     }
 
     TrapezoidMapTriFinder::TriIndexArray result;

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -47,12 +47,20 @@ static int PyQuadContourGenerator_init(PyQuadContourGenerator* self, PyObject* a
         y.dim(1) != x.dim(1) || z.dim(1) != x.dim(1)) {
         PyErr_SetString(PyExc_ValueError,
             "x, y and z must all be 2D arrays with the same dimensions");
+        return -1;
+    }
+
+    if (z.dim(0) < 2 || z.dim(1) < 2) {
+        PyErr_SetString(PyExc_ValueError,
+            "x, y and z must all be at least 2x2 arrays");
+        return -1;
     }
 
     // Mask array is optional, if set must be same size as other arrays.
     if (!mask.empty() && (mask.dim(0) != x.dim(0) || mask.dim(1) != x.dim(1))) {
         PyErr_SetString(PyExc_ValueError,
             "If mask is set it must be a 2D array with the same dimensions as x.");
+        return -1;
     }
 
     CALL_CPP_INIT("QuadContourGenerator",
@@ -101,6 +109,7 @@ static PyObject* PyQuadContourGenerator_create_filled_contour(PyQuadContourGener
     {
         PyErr_SetString(PyExc_ValueError,
             "filled contour levels must be increasing");
+        return NULL;
     }
 
     PyObject* result;


### PR DESCRIPTION
There are two underlying problems here.  Firstly, we've never bothered to explicitly check if contour/contourf are called with a 2D array that is smaller than 2x2, but have instead relied upon later code to raise an error.  There are different code paths for the legacy and new contouring algorithms, hence two different errors reported by OP.  Secondly, in the new contour code (and also tricontour too) I haven't correctly handled all errors raised; I've called PyErr_SetString in each case but not necessarily returned -1 or NULL (depending on context) correctly.  This shouldn't really matter as all such C++ code is private and covered by checks in the python wrappers - well it should be be, but evidently isn't in this case.

Hence there are two parts to the fix.  Firstly, I've added explicit checks in the python contour code for arrays smaller than 2x2, and this is done twice as there are 2 code paths.  I've also put a new test in test_contour.py to test that these errors are correctly raised.  Secondly, I've corrected _contour_wrapper.cpp and _tri_wrapper.cpp to correctly report errors, and added a set of tests for each so that each raising of a python error in the C++ code is tested at least once.