### PR TITLE
Use rounding instead of truncation to calculate the frame size

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -267,7 +267,7 @@ class MovieWriter(AbstractMovieWriter):
     def frame_size(self):
         'A tuple (width,height) in pixels of a movie frame.'
         w, h = self.fig.get_size_inches()
-        return int(w * self.dpi), int(h * self.dpi)
+        return round(w * self.dpi), round(h * self.dpi)
 
     def _adjust_frame_size(self):
         if self.codec == 'h264':


### PR DESCRIPTION
This fixes an issue I ran into where the frame sizes were supposed to be adjusted to integers by `_adjust_frame_size`, but because the `frame_size` property uses truncation, the vagaries of floating point math means that the frame size adjustment didn't work. Here's a snippet from my debugging session that illustrates the issue:

```
(Pdb) self.fig.get_size_inches()[1]*self.dpi
919.99999999999989
```

I think it's safe just to use rounding here instead of truncation? Maybe we need to add epsilon somewhere instead if this could cause issues.

Yay floating point math!