### PR TITLE
Handle floating point round-off error when converting to pixels for h264 animations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
     packages:
       - inkscape
       - libav-tools
-      - libavcodec-extra-53
       - gdb
       - mencoder
       - dvipng

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     packages:
       - inkscape
       - libav-tools
+      - libavcodec-extra-53
       - gdb
       - mencoder
       - dvipng

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -62,10 +62,19 @@ else:
 # how-to-encode-series-of-images-into-h264-using-x264-api-c-c )
 
 
+def correct_roundoff(x, dpi, n):
+    if int(x*dpi) % n != 0:
+        if int(np.nextafter(x, np.inf)*dpi) % n == 0:
+            x = np.nextafter(x, np.inf)
+        if int(np.nextafter(x, -np.inf)*dpi) % n == 0:
+            x = np.nextafter(x, -np.inf)
+    return x
+
+
 def adjusted_figsize(w, h, dpi, n):
-    wnew = np.round(int(w * dpi / n) * n / dpi)
-    hnew = np.round(int(h * dpi / n) * n / dpi)
-    return wnew, hnew
+    wnew = int(w * dpi / n) * n / dpi
+    hnew = int(h * dpi / n) * n / dpi
+    return (correct_roundoff(wnew, dpi, n), correct_roundoff(hnew, dpi, n))
 
 
 # A registry for available MovieWriter classes

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -23,6 +23,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import xrange, zip
 
+import numpy as np
 import os
 import platform
 import sys
@@ -62,8 +63,8 @@ else:
 
 
 def adjusted_figsize(w, h, dpi, n):
-    wnew = int(w * dpi / n) * n / dpi
-    hnew = int(h * dpi / n) * n / dpi
+    wnew = np.round(int(w * dpi / n) * n / dpi)
+    hnew = np.round(int(h * dpi / n) * n / dpi)
     return wnew, hnew
 
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -66,7 +66,7 @@ def correct_roundoff(x, dpi, n):
     if int(x*dpi) % n != 0:
         if int(np.nextafter(x, np.inf)*dpi) % n == 0:
             x = np.nextafter(x, np.inf)
-        if int(np.nextafter(x, -np.inf)*dpi) % n == 0:
+        elif int(np.nextafter(x, -np.inf)*dpi) % n == 0:
             x = np.nextafter(x, -np.inf)
     return x
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -288,8 +288,11 @@ class MovieWriter(AbstractMovieWriter):
                 verbose.report('figure size (inches) has been adjusted '
                                'from %s x %s to %s x %s' % (wo, ho, w, h),
                                level='helpful')
+        else:
+            w, h = self.fig.get_size_inches()
         verbose.report('frame size in pixels is %s x %s' % self.frame_size,
                        level='debug')
+        return w, h
 
     def setup(self, fig, outfile, dpi=None):
         '''
@@ -311,7 +314,7 @@ class MovieWriter(AbstractMovieWriter):
         if dpi is None:
             dpi = self.fig.dpi
         self.dpi = dpi
-        self._adjust_frame_size()
+        self._w, self._h = self._adjust_frame_size()
 
         # Run here so that grab_frame() can write the data to a pipe. This
         # eliminates the need for temp files.
@@ -347,7 +350,7 @@ class MovieWriter(AbstractMovieWriter):
         verbose.report('MovieWriter.grab_frame: Grabbing frame.',
                        level='debug')
         try:
-            self._adjust_frame_size()
+            self.fig.set_size_inches(self._w, self._h)
             # Tell the figure to save its data to the sink, using the
             # frame format and dpi.
             self.fig.savefig(self._frame_sink(), format=self.frame_format,

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -338,6 +338,7 @@ class MovieWriter(AbstractMovieWriter):
         verbose.report('MovieWriter.grab_frame: Grabbing frame.',
                        level='debug')
         try:
+            self._adjust_frame_size()
             # Tell the figure to save its data to the sink, using the
             # frame format and dpi.
             self.fig.savefig(self._frame_sink(), format=self.frame_format,

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -145,6 +145,14 @@ def test_save_animation_smoketest(tmpdir, writer, extension):
     ax.set_xlim(0, 10)
     ax.set_ylim(-1, 1)
 
+    dpi = None
+    codec = None
+    if writer == 'ffmpeg':
+        # Issue #8253
+        fig.set_size_inches((10.85, 9.2000000000000011))
+        dpi = 100.
+        codec = 'h264'
+
     def init():
         line.set_data([], [])
         return line,
@@ -160,7 +168,8 @@ def test_save_animation_smoketest(tmpdir, writer, extension):
     with tmpdir.as_cwd():
         anim = animation.FuncAnimation(fig, animate, init_func=init, frames=5)
         try:
-            anim.save('movie.' + extension, fps=30, writer=writer, bitrate=500)
+            anim.save('movie.' + extension, fps=30, writer=writer, bitrate=500,
+                      dpi=dpi, codec=codec)
         except UnicodeDecodeError:
             pytest.xfail("There can be errors in the numpy import stack, "
                          "see issues #1891 and #2679")

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -149,7 +149,7 @@ def test_save_animation_smoketest(tmpdir, writer, extension):
     codec = None
     if writer == 'ffmpeg':
         # Issue #8253
-        fig.set_size_inches((10.85, 9.2000000000000011))
+        fig.set_size_inches((10.85, 9.21))
         dpi = 100.
         codec = 'h264'
 


### PR DESCRIPTION
Rather than handling the rescaling in matplotlib, tell ffmpeg to do the rescaling for us. This avoids issues described in #8250 where the rescaling is susceptible to round-off error. It also allows us to delete some code.

EDIT:

Now let's try rounding the output of `adjusted_figsize`. In addition I found that to get this to work properly with yt (and I guess in general any other library that calls `set_size_inches` after matplotlib does) I needed another call to `_adjust_frame_size` before actually writing each frame. This avoids the crazy corrupted video I saw in the original issue I opened about this.