### PR TITLE
[MRG+1] Set __name__ for list validators in rcsetup.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -95,8 +95,13 @@ def _listify_validator(scalar_validator, allow_stringlist=False):
             return [scalar_validator(v) for v in s
                     if not isinstance(v, six.string_types) or v]
         else:
-            msg = "{0!r} must be of type: string or non-dictionary iterable.".format(s)
-            raise ValueError(msg)
+            raise ValueError("{!r} must be of type: string or non-dictionary "
+                             "iterable".format(s))
+    # Cast `str` to keep Py2 happy despite `unicode_literals`.
+    try:
+        f.__name__ = str("{}list".format(scalar_validator.__name__))
+    except AttributeError:  # class instance.
+        f.__name__ = str("{}List".format(type(scalar_validator).__name__))
     f.__doc__ = scalar_validator.__doc__
     return f
 


### PR DESCRIPTION
This avoids having many validators all named `f`, which makes profiling
a bit difficult (it appears that repeated validation of rcparams when
resetting the style at the beginning of each test instance contributes
quite a bit to the total test time).  Instead, the list validator
based on scalar validator function `validate_foo` is now `__name__`d
`validate_foolist`, and the list validator based on scalar validator
class `ValidateFoo` is now `__name__`d `ValidateFooList`.