### PR TITLE
TST: fail on missing baseline file

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -281,12 +281,7 @@ class ImageComparisonDecorator(CleanupTest):
             reason = ("Do not have baseline image {0} because this "
                       "file does not exist: {1}".format(expected_fname,
                                                         orig_expected_fname))
-            if is_called_from_pytest():
-                import pytest
-                pytest.xfail(reason)
-            else:
-                from ._nose import knownfail
-                knownfail(reason)
+            raise ImageComparisonFailure(reason)
         return expected_fname
 
     def compare(self, idx, baseline, extension):


### PR DESCRIPTION
The change from a fail to knownfail on missing file come in via 3f3991a1bc084df59d92a72293eec2b36c738c47 which I apparently did not review carefully enough, sorry.