### PR TITLE
MAINT moved some maintenance and helper python scripts to tools/

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,12 +10,11 @@ markers =
 pep8ignore =
     * E111 E114 E115 E116 E121 E122 E123 E124 E125 E126 E127 E128 E129 E131 E226 E240 E241 E242 E243 E244 E245 E246 E247 E248 E249 E265 E266 E704 W503
 
-    boilerplate.py E501
+    tools/boilerplate.py E501
     setup.py E402 E501
     setupext.py E301 E302 E501
     setup_external_compile.py E302 E501 E711
     versioneer.py ALL  # External file.
-
     tools/gh_api.py ALL  # External file.
     tools/github_stats.py ALL  # External file.
     tools/subset.py E221 E231 E251 E261 E302 E501 E701 E703

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -1,0 +1,1 @@
+Tools developed for Matplotlib

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -365,7 +365,7 @@ def boilerplate_gen():
 
 
 def build_pyplot():
-    pyplot_path = os.path.join("../", os.path.dirname(__file__), 'lib',
+    pyplot_path = os.path.join(os.path.dirname(__file__), "..", 'lib',
                                'matplotlib', 'pyplot.py')
 
     pyplot_orig = open(pyplot_path, 'r').readlines()

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -365,7 +365,7 @@ def boilerplate_gen():
 
 
 def build_pyplot():
-    pyplot_path = os.path.join(os.path.dirname(__file__), 'lib',
+    pyplot_path = os.path.join("../", os.path.dirname(__file__), 'lib',
                                'matplotlib', 'pyplot.py')
 
     pyplot_orig = open(pyplot_path, 'r').readlines()


### PR DESCRIPTION
Our root folder is currently a bit messy and overwhelming.
In an attempt to clean it up a bit and make it more clear for contributors what files does what, I attempted to consolidate the organization a bit.

This pull requests moves some of our maintenance and helper python scripts to our tools folder.

Note that license.py only works on python 2.