### PR TITLE
Fix testing with tests.py on Py3.6.

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -87,7 +87,7 @@ units : [ 'width' | 'height' | 'dots' | 'inches' | 'x' | 'y' | 'xy' ]
 
     'dots' or 'inches': pixels or inches, based on the figure dpi
 
-    'x', 'y', or 'xy': respectively *X*, *Y*, or :math:`\sqrt{X^2 + Y^2}`
+    'x', 'y', or 'xy': respectively *X*, *Y*, or :math:`\\sqrt{X^2 + Y^2}`
     in data units
 
     The arrows scale differently depending on the units.  For

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -32,7 +32,7 @@ BASE_LIBRARY_PATH = os.path.join(mpl.get_data_path(), 'stylelib')
 # Users may want multiple library paths, so store a list of paths.
 USER_LIBRARY_PATHS = [os.path.join(mpl._get_configdir(), 'stylelib')]
 STYLE_EXTENSION = 'mplstyle'
-STYLE_FILE_PATTERN = re.compile('([\S]+).%s$' % STYLE_EXTENSION)
+STYLE_FILE_PATTERN = re.compile(r'([\S]+).%s$' % STYLE_EXTENSION)
 
 
 # A list of rcParams that should not be applied from styles

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -94,12 +94,6 @@ def test_too_many_date_ticks():
     # setting equal datetimes triggers and expander call in
     # transforms.nonsingular which results in too many ticks in the
     # DayLocator.  This should trigger a Locator.MAXTICKS RuntimeError
-    warnings.filterwarnings(
-        'ignore',
-        'Attempting to set identical left==right results\\nin singular '
-        'transformations; automatically expanding.\\nleft=\d*\.\d*, '
-        'right=\d*\.\d*',
-        UserWarning, module='matplotlib.axes')
     t0 = datetime.datetime(2000, 1, 20)
     tf = datetime.datetime(2000, 1, 20)
     fig = plt.figure()

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -30,7 +30,7 @@ def test_font_styles():
     from matplotlib.font_manager import FontProperties, findfont
     warnings.filterwarnings(
         'ignore',
-        "findfont: Font family \[u?'Foo'\] not found. Falling back to .",
+        r"findfont: Font family \[u?'Foo'\] not found. Falling back to .",
         UserWarning,
         module='matplotlib.font_manager')
 

--- a/tests.py
+++ b/tests.py
@@ -14,15 +14,16 @@ import argparse
 
 if __name__ == '__main__':
 
+    import dateutil.parser
     try:
         import setuptools
     except ImportError:
         pass
 
     # The warnings need to be before any of matplotlib imports, but after
-    # setuptools (if present) which has syntax error with the warnings enabled.
-    # Filtering by module does not work as this will be raised by Python itself
-    # so `module=matplotlib.*` is out of questions.
+    # dateutil.parser and setuptools (if present) which has syntax error with
+    # the warnings enabled.  Filtering by module does not work as this will be
+    # raised by Python itself so `module=matplotlib.*` is out of question.
 
     import warnings
 


### PR DESCRIPTION
Invoking `tests.py` used to fail on Py3.6 due to the use of deprecated
invalid escapes both in the codebase and in third-party code (dateutil).
Fix the codebase, skip the checks on dateutil.

It is strange (and should be worth investigating...) that the CI did not
fail before, as it also uses `tests.py` on Py3.6...

xref #8271.