### PR TITLE
FIX: add __setstate__ function

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -711,11 +711,12 @@ class rrulewrapper(object):
         self._rrule = rrule(**self._construct)
 
     def __getattr__(self, name):
-        if name in ['__getstate__', '__setstate__']:
-            return object.__getattr__(self, name)
         if name in self.__dict__:
             return self.__dict__[name]
         return getattr(self._rrule, name)
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
 
 class DateLocator(ticker.Locator):


### PR DESCRIPTION
To prevent an infinite recursion add a __setstate__ method
so that we do not consult `_rrule` before it exists


follow on to #7854