### PR TITLE
Annotation legend

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -263,7 +263,8 @@ class Axes(_AxesBase):
 
         """
         handles_original = (self.lines + self.patches +
-                            self.collections + self.containers)
+                            self.collections + self.containers +
+                            self.texts)
         handler_map = mlegend.Legend.get_default_handler_map()
 
         if legend_handler_map is not None:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -36,7 +36,8 @@ from matplotlib.artist import Artist, allow_rasterization
 from matplotlib.cbook import is_string_like, silent_list, is_hashable
 from matplotlib.font_manager import FontProperties
 from matplotlib.lines import Line2D
-from matplotlib.patches import Patch, Rectangle, Shadow, FancyBboxPatch
+from matplotlib.patches import Patch, Rectangle, Shadow, FancyBboxPatch, FancyArrowPatch
+from matplotlib.text import Text, Annotation
 from matplotlib.collections import (LineCollection, RegularPolyCollection,
                                     CircleCollection, PathCollection,
                                     PolyCollection)
@@ -493,7 +494,10 @@ class Legend(Artist):
             update_func=legend_handler.update_from_first_child),
         tuple: legend_handler.HandlerTuple(),
         PathCollection: legend_handler.HandlerPathCollection(),
-        PolyCollection: legend_handler.HandlerPolyCollection()
+        PolyCollection: legend_handler.HandlerPolyCollection(),
+        Text:legend_handler.HandlerText(),
+        FancyArrowPatch:legend_handler.HandlerFancyArrowPatch(),
+        Annotation:legend_handler.HandlerAnnotation(),
         }
 
     # (get|set|update)_default_handler_maps are public interfaces to

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -605,8 +605,7 @@ class HandlerTuple(HandlerBase):
 
     handlers : tuple, optionnal
         The list of handlers to call for each section. Must be of length ndivide.
-        If None, the handlers will be fetched automatically fromt the legend handler map.
-        Default is None.
+        If None, the default handlers will be fetched automatically. Default is None.
 
     """
     def __init__(self, ndivide=1, pad=None, width_ratios=None, handlers=None, **kwargs):

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -725,25 +725,27 @@ class HandlerText(HandlerBase):
 
         self._rep_str    = rep_str
         self._rep_maxlen = rep_maxlen
-        print('rep_str', rep_str)
 
         HandlerBase.__init__(self, **kwargs)
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
-        t = Text(x=-xdescent + width / 3,
-                 y=-ydescent + height / 4,
-                 text=self._rep_str)
-
         # Use original text if it is short
         text = orig_handle.get_text()
-        if len(text) <= self._rep_maxlen:
-            t.set_text(text)
-        print('t', text, t.get_text(), self._rep_str)
+        if len(text) > self._rep_maxlen:
+            text = self._rep_str
+
+        # Use smaller fontsize for text repr
+        text_fontsize = 2 * fontsize / 3
+
+        t = Text(x=-xdescent + width / 2 - len(text) * text_fontsize / 4,
+                 y=-ydescent + height / 4,
+                 text=text)
+
         # Copy text attributes, except fontsize
         self.update_prop(t, orig_handle, legend)
         t.set_transform(trans)
-        t.set_fontsize(2 * fontsize / 3)
+        t.set_fontsize(text_fontsize)
 
         return [t]
 

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -34,9 +34,11 @@ from itertools import cycle
 import numpy as np
 
 from matplotlib.lines import Line2D
-from matplotlib.patches import Rectangle
+from matplotlib.patches import Rectangle, FancyArrowPatch
+from matplotlib.text import Text, Annotation
 import matplotlib.collections as mcoll
 import matplotlib.colors as mcolors
+
 
 
 def update_from_first_child(tgt, src):
@@ -713,3 +715,36 @@ class HandlerText(HandlerBase):
         t.set_fontsize(2 * fontsize / 3)
 
         return [t]
+
+
+class HandlerAnnotation(HandlerBase):
+    """
+    Handler for FancyArrowPatch instances.
+    """
+    def create_artists(self, legend, orig_handle,
+                       xdescent, ydescent, width, height, fontsize, trans):
+        if (orig_handle.arrow_patch is not None) and (orig_handle.get_text() is not ""):
+            # Draw a tuple (text, arrow)
+            handler = HandlerTuple(ndivide=2, pad=None, width_ratios=[1,4])
+
+            # Create a Text instance from annotation text
+            text_handle = Text(text=orig_handle.get_text())
+            text_handle.update_from(orig_handle)
+            handle  = (text_handle, orig_handle.arrow_patch)
+        elif orig_handle.arrow_patch is not None:
+            # Arrow without text
+            handler = HandlerFancyArrowPatch()
+            handle  = orig_handle.arrow_patch
+        elif orig_handle.get_text() is not "":
+            # Text without arrow
+            handler = HandlerText()
+            handle  = orig_handle
+        else:
+            # No text, no arrow
+            handler = HandlerPatch()
+            handle  = Rectangle(xy=[0,0],width=0,height=0,color='w')
+
+        return handler.create_artists(legend, handle,
+                                       xdescent, ydescent,
+                                       width, height,
+                                       fontsize, trans)

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -690,3 +690,26 @@ class HandlerPolyCollection(HandlerBase):
         self.update_prop(p, orig_handle, legend)
         p.set_transform(trans)
         return [p]
+
+
+class HandlerText(HandlerBase):
+    """
+    Handler for Text instances.
+    """
+    def create_artists(self, legend, orig_handle,
+                       xdescent, ydescent, width, height, fontsize, trans):
+        t = Text(x=-xdescent + width / 3,
+                 y=-ydescent + height / 4,
+                 text="a")
+
+        # Use original text if it is short
+        text = orig_handle.get_text()
+        if len(text) < 2:
+            t.set_text(text)
+
+        # Copy text attributes, except fontsize
+        self.update_prop(t, orig_handle, legend)
+        t.set_transform(trans)
+        t.set_fontsize(2 * fontsize / 3)
+
+        return [t]

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -697,18 +697,39 @@ class HandlerPolyCollection(HandlerBase):
 class HandlerText(HandlerBase):
     """
     Handler for Text instances.
+
+    Additional kwargs are passed through to `HandlerBase`.
+
+    Parameters
+    ----------
+
+    rep_str : string, optional
+        Replacement string used in the legend when the Text string is longer than rep_maxlen.
+        Default is 'Aa'.
+
+    rep_maxlen : int, optional
+        Maximum length of Text string to be used in the legend. Default is 2.
+
     """
+    def __init__(self, rep_str='Aa', rep_maxlen=2, **kwargs):
+
+        self._rep_str    = rep_str
+        self._rep_maxlen = rep_maxlen
+        print('rep_str', rep_str)
+
+        HandlerBase.__init__(self, **kwargs)
+
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
         t = Text(x=-xdescent + width / 3,
                  y=-ydescent + height / 4,
-                 text="a")
+                 text=self._rep_str)
 
         # Use original text if it is short
         text = orig_handle.get_text()
-        if len(text) < 2:
+        if len(text) <= self._rep_maxlen:
             t.set_text(text)
-
+        print('t', text, t.get_text(), self._rep_str)
         # Copy text attributes, except fontsize
         self.update_prop(t, orig_handle, legend)
         t.set_transform(trans)

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -719,7 +719,11 @@ class HandlerText(HandlerBase):
 
 class HandlerAnnotation(HandlerBase):
     """
-    Handler for FancyArrowPatch instances.
+    Handler for Annotation instances.
+
+    Defers to HandlerText to draw the annotation text (if any).
+    Defers to HandlerFancyArrowPatch to draw the annotation arrow (if any).
+    For annotations made of both text and arrow, HandlerTuple is used to draw them side by side.
     """
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -256,6 +256,21 @@ class HandlerPatch(HandlerBase):
         return [p]
 
 
+class HandlerFancyArrowPatch(HandlerPatch):
+    """
+    Handler for FancyArrowPatch instances.
+    """
+    def _create_patch(self, legend, orig_handle,
+                      xdescent, ydescent, width, height, fontsize):
+        arrow = FancyArrowPatch( [-xdescent,
+                                 -ydescent + height / 2],
+                                [-xdescent + width,
+                                 -ydescent + height / 2],
+                                mutation_scale=width / 3)
+        arrow.set_arrowstyle(orig_handle.get_arrowstyle())
+        return arrow
+
+
 class HandlerLineCollection(HandlerLine2D):
     """
     Handler for LineCollection instances.

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -746,7 +746,7 @@ class HandlerAnnotation(HandlerBase):
         else:
             # No text, no arrow
             handler = HandlerPatch()
-            handle  = Rectangle(xy=[0,0],width=0,height=0,color='w')
+            handle  = Rectangle(xy=[0, 0], width=0, height=0, color='w', alpha=0.0)
 
         return handler.create_artists(legend, handle,
                                        xdescent, ydescent,

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -603,11 +603,17 @@ class HandlerTuple(HandlerBase):
         The relative width of sections. Must be of length ndivide.
         If None, all sections will have the same width. Default is None.
 
-    """
-    def __init__(self, ndivide=1, pad=None, width_ratios=None, **kwargs):
+    handlers : tuple, optionnal
+        The list of handlers to call for each section. Must be of length ndivide.
+        If None, the handlers will be fetched automatically fromt the legend handler map.
+        Default is None.
 
-        self._ndivide = ndivide
-        self._pad = pad
+    """
+    def __init__(self, ndivide=1, pad=None, width_ratios=None, handlers=None, **kwargs):
+
+        self._ndivide  = ndivide
+        self._pad      = pad
+        self._handlers = handlers
 
         if (width_ratios is not None) and (len(width_ratios) == ndivide):
             self._width_ratios = width_ratios
@@ -645,8 +651,12 @@ class HandlerTuple(HandlerBase):
         xds_cycle = cycle(xds)
 
         a_list = []
-        for handle1 in orig_handle:
-            handler = legend.get_legend_handler(handler_map, handle1)
+        for i, handle1 in enumerate(orig_handle):
+            if self._handlers is not None:
+                handler = self._handlers[i]
+            else:
+                handler = legend.get_legend_handler(handler_map, handle1)
+
             _a_list = handler.create_artists(legend, handle1,
                                              six.next(xds_cycle),
                                              ydescent,


### PR DESCRIPTION
Fixes #8236 

I added new legend handlers for Text, FancyArrowPatch and Annotation artists (HandlerText, HandlerFancyArrowPatch and HandlerAnnotation).

HandlerAnnotation can draw different artists in the legend:
- if the annotation has no text and no arrow, it draws a white Rectangle
- if the annotation has only text, it uses HandlerText to draw a text. The text is replaced by 'Aa' if it is longer than one character. (This is configurable by setting rep_str and rep_maxlen.)
- if the annotation has only an arrow, it uses HandlerFancyArrowPatch to draw an arrow
- If the annotation has both text and arrow, it uses HandlerTuple to draw both.

In HandlerTuple, I added the possibility of different width ratios for the artists. HandlerAnnotation uses a width_ratios=[1,4] (ie. the arrow is 4 times wider than the text).

Example code:
```python

import matplotlib
import matplotlib.pylab as plt
from matplotlib.patches import FancyArrowPatch
from matplotlib.legend_handler import HandlerAnnotation

fig, ax = plt.subplots(1)
ax.plot([0, 1], [0, 0], label='line1')
ax.plot([0, 1], [1, 1], label='line2')

# no text, no arrow
ax.annotate("",
            xy=(0.1,0.5),
            xytext=(0.1,0.5),
            label='annotation (empty)')

# text, no arrow
my_annotation = ax.annotate("X",
            xy=(0.1,0.5),
            xytext=(0.1,0.5),
            color='C2',
            label='annotation (text, no arrow)')

# no text, arrow
ax.annotate("",
            xy=(0.3,1.0),
            xytext=(0.3,0.0),
            arrowprops={'arrowstyle':'<->', 'color':'C7' },
            label='annotation (no text, arrow)')

# text, arrow
ax.annotate("Some long string",
            xy=(0.4,1.0),
            xytext=(0.35,0.1),
            arrowprops={'arrowstyle':'->', 'color':'C2' },
            color='C1',
            label='annotation (text + arrow)')

# Fancy arrow patch
arrpatch = FancyArrowPatch([0.5, 0.8], [0.9, 0.9],
                           arrowstyle='<|-',
                           mutation_scale=20,
                           color='C3',
                           label='arrowpatch')
ax.add_patch(arrpatch)

# Long text, will not be used in legend
ax.text(x=0.1, y=0.1,
        s='Hello',
        color='C5',
        label='text')

# Short text, copied in legend
ax.text(x=0.1, y=0.2,
        s='Z',
        color='C0',
        label='short text')

ax.legend(handler_map={my_annotation: HandlerAnnotation(rep_str='Abcde', rep_maxlen=0)})
fig.show()
```
output:
![annotate](https://cloud.githubusercontent.com/assets/1379463/23942349/412bbee4-096c-11e7-929c-ee338c254e2d.png)
