### PR TITLE
In ginput(), don't call show() if we can't.

### DIFF
--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -104,8 +104,9 @@ class BlockingInput(object):
         self.events = []
         self.callbacks = []
 
-        # Ensure that the figure is shown
-        self.fig.show()
+        if hasattr(self.fig, "manager"):
+            # Ensure that the figure is shown, if we are managing it.
+            self.fig.show()
 
         # connect the events to the on_event function call
         for n in self.eventslist:


### PR DESCRIPTION
`ginput` works even for figures that are not created by `plt.figure()`
(and friends -- typically, that means we're embedding matplotlib in a
GUI app)... except that `ginput` tries to call `fig.show()` to raise the
figure, which would fail.

Instead, only call `fig.show` if the figure has a manager (i.e., was
created by `plt.figure`).

Example (click once to start point selection, then make further clicks
as in a normal `ginput` call):

```
import matplotlib; matplotlib.use("qt5agg")
from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
from matplotlib.figure import Figure
from PyQt5.QtCore import Qt
from PyQt5.QtWidgets import *

class Win(QMainWindow):
    def __init__(self):
        super().__init__()
        self.fig = fig = Figure()
        canvas = FigureCanvasQTAgg(fig)
        self.setCentralWidget(canvas)
        fig.add_subplot(111)
        self._cid = fig.canvas.mpl_connect(
            "button_press_event", self._start_ginput)

    def _start_ginput(self, event):
        self.fig.canvas.mpl_disconnect(self._cid)
        # Workaround for now; patch makes this unnecessary.
        self.fig.show = lambda: None
        print(self.fig.ginput(-1, timeout=3))

app = QApplication([])
win = Win()
win.show()
app.exec_()
```