### PR TITLE
[MRG+1] Skip more deprecated colormaps in example.

### DIFF
--- a/examples/pylab_examples/demo_bboximage.py
+++ b/examples/pylab_examples/demo_bboximage.py
@@ -25,9 +25,11 @@ if __name__ == "__main__":
     a = np.linspace(0, 1, 256).reshape(1, -1)
     a = np.vstack((a, a))
 
-    maps = sorted(m for m in plt.cm.cmap_d if not m.endswith("_r"))
-    maps.remove('spectral')  # Deprecated.
-    #nmaps = len(maps) + 1
+    maps = sorted(
+        m for m in plt.cm.cmap_d
+        if not m.endswith("_r") and  # Skip reversed colormaps.
+        not m.startswith(('spectral', 'Vega'))  # Skip deprecated colormaps.
+    )
 
     #fig.subplots_adjust(top=0.99, bottom=0.01, left=0.2, right=0.99)
 


### PR DESCRIPTION
These colormaps were deprecated with 2.0.1 (and never supposed to be in 2.0.0 in the first place.) Using them causes (non-fatal) warnings when building documentation.