### PR TITLE
Fix Appveyor build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,9 @@ install:
   # for obvci_appveyor_python_build_env.cmd
   - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
   # for msinttypes and newer stuff
-  - cmd: conda config --add channels conda-forge
+  # conda-forge may serve outdated versions of certain packages (e.g. conda
+  # itself), so append it to the end of the list.
+  - cmd: conda config --append channels conda-forge
   - cmd: conda config --set show_channel_urls yes
   - cmd: conda config --set always_yes true
   # For building conda packages


### PR DESCRIPTION
Recent condas prefer (by default) packages in higher priority channels
to packages in lower priority channels regardless of their versions.
conda-forge sometimes serves older condas than the official repos, so we
need to put it at the end to avoid accidentally downgrading conda.

Do not depend on the user name to construct a temporary cache directory
when needed, as e.g. conda-build hides the required environment variable
(`%USERNAME%`) on Windows.