### PR TITLE
Allow adding artist to axes with `+=` operator (issue #7082)

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -593,6 +593,10 @@ class _AxesBase(martist.Artist):
                 artist._remove_method = container.remove
         self._stale = True
 
+    def __iadd__(self, artist):
+        self.add_artist(artist)
+        return self
+
     def get_window_extent(self, *args, **kwargs):
         """
         get the axes bounding box in display space; *args* and

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5047,3 +5047,11 @@ def test_invalid_axis_limits():
         plt.ylim(np.nan)
     with pytest.raises(ValueError):
         plt.ylim(np.inf)
+
+
+def test_iadd():
+    # Addresses issue 7082
+    from matplotlib.patches import Circle
+    fig, ax = plt.subplots()
+    ax += Circle((.5, .5), .3)
+    assert len(ax.artists) == 1


### PR DESCRIPTION
This addresses issue [#7082](https://github.com/matplotlib/matplotlib/issues/7082).

I'm wondering whether this is even a feature that the devs are willing to accept, with the current discussion of reorganizing how artists are held internally.