### PR TITLE
[MRG+2] DOC: update link to mpl-probscale

### DIFF
--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -105,7 +105,7 @@ Miscellaneous Toolkits
 
 mpl-probscale
 =============
-`mpl-probscale <http://phobson.github.io/mpl-probscale/index.html>`_
+`mpl-probscale <http://matplotlib.org/mpl-probscale/>`_
 is a small extension that allows matplotlib users to specify probabilty
 scales. Simply importing the ``probscale`` module registers the scale
 with matplotlib, making it accessible via e.g.,


### PR DESCRIPTION
Small change to reflect that mpl-probscale has moved into the mpl org.