### PR TITLE
[MRG+1] DOC: Fix typos in gridspec tutorial

### DIFF
--- a/doc/users/gridspec.rst
+++ b/doc/users/gridspec.rst
@@ -5,25 +5,26 @@
 Customizing Location of Subplot Using GridSpec
 **********************************************
 
-    ``GridSpec``
+    :class:`~matplotlib.gridspec.GridSpec`
         specifies the geometry of the grid that a subplot will be
         placed. The number of rows and number of columns of the grid
         need to be set. Optionally, the subplot layout parameters
         (e.g., left, right, etc.) can be tuned.
 
-    ``SubplotSpec``
+    :class:`~matplotlib.gridspec.SubplotSpec`
         specifies the location of the subplot in the given *GridSpec*.
 
-    ``subplot2grid``
-        a helper function that is similar to "pyplot.subplot" but uses
-        0-based indexing and let subplot to occupy multiple cells.
+    :func:`~matplotlib.pyplot.subplot2grid`
+        a helper function that is similar to :func:`~matplotlib.pyplot.subplot`
+        but uses 0-based indexing and let subplot to occupy multiple cells.
 
 
 Basic Example of using subplot2grid
 ===================================
 
-To use subplot2grid, you provide geometry of the grid and the location
-of the subplot in the grid. For a simple single-cell subplot::
+To use :func:`~matplotlib.pyplot.subplot2grid`, you provide geometry of
+the grid and the location of the subplot in the grid. For a simple
+single-cell subplot::
 
   ax = plt.subplot2grid((2, 2), (0, 0))
 
@@ -31,7 +32,7 @@ is identical to ::
 
   ax = plt.subplot(2, 2, 1)
 
-Note that, unlike matplotlib's subplot, the index starts from 0 in GridSpec.
+Note that, unlike Matplotlib's subplot, the index starts from 0 in GridSpec.
 
 To create a subplot that spans multiple cells, ::
 
@@ -54,11 +55,12 @@ creates
 GridSpec and SubplotSpec
 ========================
 
-You can create GridSpec explicitly and use them to create a Subplot.
+You can create :class:`~matplotlib.gridspec.GridSpec` explicitly and use
+them to create a subplot.
 
 For example, ::
 
-  ax = plt.subplot2grid((2, 2),(0, 0))
+  ax = plt.subplot2grid((2, 2), (0, 0))
 
 is equal to ::
 
@@ -67,7 +69,7 @@ is equal to ::
   ax = plt.subplot(gs[0, 0])
 
 A GridSpec instance provides array-like (2d or 1d) indexing that
-returns the SubplotSpec instance. For, SubplotSpec that spans multiple
+returns the SubplotSpec instance. For a SubplotSpec that spans multiple
 cells, use slice. ::
 
   ax2 = plt.subplot(gs[1, :-1])
@@ -93,8 +95,8 @@ parameters of subplots that are created from the GridSpec. ::
   gs1 = gridspec.GridSpec(3, 3)
   gs1.update(left=0.05, right=0.48, wspace=0.05)
 
-This is similar to *subplots_adjust*, but it only affects the subplots
-that are created from the given GridSpec.
+This is similar to :func:`~matplotlib.pyplot.subplots_adjust`, but it only
+affects the subplots that are created from the given GridSpec.
 
 The code below ::
 
@@ -117,8 +119,9 @@ creates
 GridSpec using SubplotSpec
 ==========================
 
-You can create GridSpec from the SubplotSpec, in which case its layout
-parameters are set to that of the location of the given SubplotSpec. ::
+You can create GridSpec from the :class:`~matplotlib.gridspec.SubplotSpec`,
+in which case its layout parameters are set to that of the location of
+the given SubplotSpec. ::
 
   gs0 = gridspec.GridSpec(1, 2)
 

--- a/doc/users/gridspec.rst
+++ b/doc/users/gridspec.rst
@@ -31,7 +31,7 @@ is identical to ::
 
   ax = plt.subplot(2, 2, 1)
 
-Note that, unlike matplotlib's subplot, the index starts from 0 in gridspec.
+Note that, unlike matplotlib's subplot, the index starts from 0 in GridSpec.
 
 To create a subplot that spans multiple cells, ::
 
@@ -66,7 +66,7 @@ is equal to ::
   gs = gridspec.GridSpec(2, 2)
   ax = plt.subplot(gs[0, 0])
 
-A gridspec instance provides array-like (2d or 1d) indexing that
+A GridSpec instance provides array-like (2d or 1d) indexing that
 returns the SubplotSpec instance. For, SubplotSpec that spans multiple
 cells, use slice. ::
 
@@ -88,7 +88,7 @@ Adjust GridSpec layout
 ======================
 
 When a GridSpec is explicitly used, you can adjust the layout
-parameters of subplots that are created from the gridspec. ::
+parameters of subplots that are created from the GridSpec. ::
 
   gs1 = gridspec.GridSpec(3, 3)
   gs1.update(left=0.05, right=0.48, wspace=0.05)
@@ -132,8 +132,8 @@ parameters are set to that of the location of the given SubplotSpec. ::
 A Complex Nested GridSpec using SubplotSpec
 ===========================================
 
-Here's a more sophisticated example of nested gridspec where we put
-a box around each cell of the outer 4x4 grid, by hiding appropriate 
+Here's a more sophisticated example of nested GridSpec where we put
+a box around each cell of the outer 4x4 grid, by hiding appropriate
 spines in each of the inner 3x3 grids.
 
 .. plot:: users/plotting/examples/demo_gridspec06.py

--- a/doc/users/gridspec.rst
+++ b/doc/users/gridspec.rst
@@ -25,26 +25,26 @@ Basic Example of using subplot2grid
 To use subplot2grid, you provide geometry of the grid and the location
 of the subplot in the grid. For a simple single-cell subplot::
 
-  ax = plt.subplot2grid((2,2),(0, 0))
+  ax = plt.subplot2grid((2, 2), (0, 0))
 
 is identical to ::
 
-  ax = plt.subplot(2,2,1)
+  ax = plt.subplot(2, 2, 1)
 
 Note that, unlike matplotlib's subplot, the index starts from 0 in gridspec.
 
 To create a subplot that spans multiple cells, ::
 
-  ax2 = plt.subplot2grid((3,3), (1, 0), colspan=2)
-  ax3 = plt.subplot2grid((3,3), (1, 2), rowspan=2)
+  ax2 = plt.subplot2grid((3, 3), (1, 0), colspan=2)
+  ax3 = plt.subplot2grid((3, 3), (1, 2), rowspan=2)
 
 For example, the following commands  ::
 
-  ax1 = plt.subplot2grid((3,3), (0,0), colspan=3)
-  ax2 = plt.subplot2grid((3,3), (1,0), colspan=2)
-  ax3 = plt.subplot2grid((3,3), (1, 2), rowspan=2)
-  ax4 = plt.subplot2grid((3,3), (2, 0))
-  ax5 = plt.subplot2grid((3,3), (2, 1))
+  ax1 = plt.subplot2grid((3, 3), (0, 0), colspan=3)
+  ax2 = plt.subplot2grid((3, 3), (1, 0), colspan=2)
+  ax3 = plt.subplot2grid((3, 3), (1, 2), rowspan=2)
+  ax4 = plt.subplot2grid((3, 3), (2, 0))
+  ax5 = plt.subplot2grid((3, 3), (2, 1))
 
 creates
 
@@ -58,7 +58,7 @@ You can create GridSpec explicitly and use them to create a Subplot.
 
 For example, ::
 
-  ax = plt.subplot2grid((2,2),(0, 0))
+  ax = plt.subplot2grid((2, 2),(0, 0))
 
 is equal to ::
 
@@ -70,17 +70,17 @@ A gridspec instance provides array-like (2d or 1d) indexing that
 returns the SubplotSpec instance. For, SubplotSpec that spans multiple
 cells, use slice. ::
 
-  ax2 = plt.subplot(gs[1,:-1])
+  ax2 = plt.subplot(gs[1, :-1])
   ax3 = plt.subplot(gs[1:, -1])
 
 The above example becomes ::
 
   gs = gridspec.GridSpec(3, 3)
   ax1 = plt.subplot(gs[0, :])
-  ax2 = plt.subplot(gs[1,:-1])
+  ax2 = plt.subplot(gs[1, :-1])
   ax3 = plt.subplot(gs[1:, -1])
-  ax4 = plt.subplot(gs[-1,0])
-  ax5 = plt.subplot(gs[-1,-2])
+  ax4 = plt.subplot(gs[-1, 0])
+  ax5 = plt.subplot(gs[-1, -2])
 
 .. plot:: users/plotting/examples/demo_gridspec02.py
 
@@ -147,8 +147,8 @@ relative heights and widths of rows and columns. Note that absolute
 values are meaningless, only their relative ratios matter. ::
 
   gs = gridspec.GridSpec(2, 2,
-                         width_ratios=[1,2],
-                         height_ratios=[4,1]
+                         width_ratios=[1, 2],
+                         height_ratios=[4, 1]
                          )
 
   ax1 = plt.subplot(gs[0])


### PR DESCRIPTION
I just had to use the [tutorial](http://matplotlib.org/devdocs/users/gridspec.html) about `matplotlib.gridspec` and notice a few typos (I think). So here is a PR that should fix them. Being there, I tried to add a few Sphinx cross-references where I think they might be relevant. I tried to build the docs to see if everything was working properly, but I was thrown an error (`subprocess.CalledProcessError: Command '['python', '../examples/frontpage/plot_contour.py']' returned non-zero exit status 1`) and I have no time to investigate it at the moment. But maybe it is just me and my first try of working on the v2.0.0-doc branch ^^…

I had the feeling that the English is not perfect (some sentences sound weird to my ears), but I am quite out of my depth when it comes to this field…