### PR TITLE
[MRG+2] symlog + minor ticks = exception

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3413,7 +3413,7 @@ class _AxesBase(martist.Artist):
             elif scale == 'symlog':
                 s = ax._scale
                 ax.set_minor_locator(
-                    mticker.SymmetricalLogLocator(s.base, s.subs))
+                    mticker.SymmetricalLogLocator(s._transform, s.subs))
             else:
                 ax.set_minor_locator(mticker.AutoMinorLocator())
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5047,3 +5047,14 @@ def test_invalid_axis_limits():
         plt.ylim(np.nan)
     with pytest.raises(ValueError):
         plt.ylim(np.inf)
+
+
+# Test all 4 combinations of logs/symlogs for minorticks_on()
+@pytest.mark.parametrize('xscale', ['symlog', 'log'])
+@pytest.mark.parametrize('yscale', ['symlog', 'log'])
+def test_minorticks_on(xscale, yscale):
+    ax = plt.subplot(111)
+    ax.plot([1, 2, 3, 4])
+    ax.set_xscale(xscale)
+    ax.set_yscale(yscale)
+    ax.minorticks_on()


### PR DESCRIPTION
This is the reopened pull request for https://github.com/matplotlib/matplotlib/pull/8353
Issues with commits should now be resolved. 

Calling minorticks_on() with symlog previously caused an exception. This fix passes a transform object into the SymmetricalLogLocator instead of a float type. Appended tests to verify minorticks_on() works with various combinations of log and symlog. I believe this should solve the issue described in #6967.