### PR TITLE
Cleanup appveyor.yml.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,9 +11,9 @@ environment:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
+    CMD_IN_ENV: cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd
     # Workaround for https://github.com/conda/conda-build/issues/636
-    PYTHONIOENCODING: "UTF-8"
+    PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -ra --timeout=300 --durations=25 -n %NUMBER_OF_PROCESSORS% --cov-report= --cov=lib -m "not network"
     PYTHONHASHSEED: 0  # Workaround for pytest-xdist flaky collection order
                        # https://github.com/pytest-dev/pytest/issues/920
@@ -60,27 +60,27 @@ cache:
   - '%USERPROFILE%\.cache\matplotlib'
 
 init:
-  - cmd: "ECHO %PYTHON_VERSION% %CONDA_INSTALL_LOCN%"
+  - echo %PYTHON_VERSION% %CONDA_INSTALL_LOCN%
 
 install:
-  - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
-  - cmd: set PYTHONUNBUFFERED=1
+  - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
+  - set PYTHONUNBUFFERED=1
   # for obvci_appveyor_python_build_env.cmd
-  - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
+  - conda install -c pelson/channel/development --yes --quiet obvious-ci
   # for msinttypes and newer stuff
   # conda-forge may serve outdated versions of certain packages (e.g. conda
   # itself), so append it to the end of the list.
-  - cmd: conda config --append channels conda-forge
-  - cmd: conda config --set show_channel_urls yes
-  - cmd: conda config --set always_yes true
+  - conda config --append channels conda-forge
+  - conda config --set show_channel_urls yes
+  - conda config --set always_yes true
   # For building conda packages
-  - cmd: conda install --yes conda-build jinja2 anaconda-client
+  - conda install --yes conda-build jinja2 anaconda-client
   # this is now the downloaded conda...
   - conda info -a
 
   # Fix the appveyor build environment to work with conda build
   # workaround for missing vcvars64.bat in py34 64bit
-  - cmd: copy ci\appveyor\vcvars64.bat "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64"
+  - copy ci\appveyor\vcvars64.bat "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64"
 
   # For building, use a new environment which only includes the requirements for mpl
   # same things as the requirements in ci/conda_recipe/meta.yaml
@@ -91,16 +91,16 @@ install:
     pyparsing pytz tornado "libpng>=1.6.21,<1.7" "zlib=1.2" "cycler>=0.10"
     mock sphinx
   - activate test-environment
-  - cmd: echo %PYTHON_VERSION% %TARGET_ARCH%
-  - cmd: IF %PYTHON_VERSION% == 2.7 conda install -q backports.functools_lru_cache
+  - echo %PYTHON_VERSION% %TARGET_ARCH%
+  - if %PYTHON_VERSION% == 2.7 conda install -q backports.functools_lru_cache
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
   - conda install -q pytest "pytest-cov>=2.3.1" pytest-timeout pytest-xdist
 
   # Let the install prefer the static builds of the libs
   - set LIBRARY_LIB=%CONDA_PREFIX%\Library\lib
-  - cmd: 'mkdir lib || cmd /c "exit /b 0"'
-  - copy /Y %LIBRARY_LIB%\zlibstatic.lib lib\z.lib
-  - copy /Y %LIBRARY_LIB%\libpng_static.lib lib\png.lib
+  - mkdir lib || cmd /c "exit /b 0"
+  - copy /y %LIBRARY_LIB%\zlibstatic.lib lib\z.lib
+  - copy /y %LIBRARY_LIB%\libpng_static.lib lib\png.lib
   # These z.lib / png.lib are not static versions but files which end up as
   # dependencies to the dll file. This is fine for the conda build, but not here
   # and for the wheels
@@ -117,18 +117,15 @@ test_script:
   - '%CMD_IN_ENV% pip install --no-deps -ve .'
   # these should show no z, png, or freetype dll...
   - set "DUMPBIN=%VS140COMNTOOLS%\..\..\VC\bin\dumpbin.exe"
-  #- cmd: '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\_png*.pyd'
-  #- cmd: '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd'
-  - cmd: '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit  /b 1 || exit /b 0'
-  - cmd: '"%DUMPBIN%" /DEPENDENTS lib\\matplotlib\\_png*.pyd | findstr z.*.dll && exit /b 1 || exit /b 0'
-  - cmd: '"%DUMPBIN%" /DEPENDENTS lib\\matplotlib\\_png*.pyd | findstr png.*.dll && exit /b 1 || exit /b 0'
+  - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit /b 1 || exit /b 0'
+  - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\_png*.pyd | findstr z.*.dll && exit /b 1 || exit /b 0'
+  - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\_png*.pyd | findstr png.*.dll && exit /b 1 || exit /b 0'
 
   # this are optional dependencies so that we don't skip so many tests...
-  - cmd: if x%TEST_ALL% == xyes; conda install -q pillow miktex inkscape
-  # missing packages on conda-forge for ffmpeg avconv mencoder imagemagick
-  - cmd: if x%TEST_ALL% == xyes; conda install -q -c menpo ffmpeg # a repackaged version
+  - if x%TEST_ALL% == xyes conda install -q ffmpeg inkscape miktex pillow
+  # missing packages on conda-forge for avconv mencoder imagemagick
   # This install sometimes failed randomly :-(
-  #- cmd: choco install imagemagick
+  #- choco install imagemagick
 
   # Test import of tkagg backend
   - python -c "import matplotlib as m; m.use('tkagg'); import matplotlib.pyplot as plt; print(plt.get_backend())"
@@ -145,26 +142,26 @@ after_test:
 
   # Build the wheel with the static libs
   # Hide the output, the copied files really clutter the build log...
-  - cmd: '%CMD_IN_ENV% python setup.py bdist_wheel > NUL:'
+  - '%CMD_IN_ENV% python setup.py bdist_wheel > NUL:'
 
   # And now the conda build after a cleanup...
   # cleanup build files so that they don't pollute the conda build but keep the wheel in dist...
-  - cmd: git clean -d -x -f -e dist/
+  - git clean -xdfq -e dist/
   # cleanup the environment so that the test-environment does not leak into the conda build...
-  - cmd: set MPLBASEDIRLIST=
-  - cmd: set LIBRARY_LIB=
-  - cmd: deactivate
-  - cmd: path
-  - cmd: where python
-  - cmd: '%CMD_IN_ENV% conda config --get channels'
-  - cmd: '%CMD_IN_ENV% conda build -q .\ci\conda_recipe'
+  - set MPLBASEDIRLIST=
+  - set LIBRARY_LIB=
+  - deactivate
+  - path
+  - where python
+  - '%CMD_IN_ENV% conda config --get channels'
+  - '%CMD_IN_ENV% conda build -q .\ci\conda_recipe'
 
   # Move the conda package into the dist directory, to register it
   # as an "artifact" for Appveyor.
-  - cmd: 'copy /Y %CONDA_INSTALL_LOCN%\conda-bld\win-32\*.bz2 dist || cmd /c "exit /b 0"'
-  - cmd: 'copy /Y %CONDA_INSTALL_LOCN%\conda-bld\win-64\*.bz2 dist || cmd /c "exit /b 0"'
-  - cmd: dir dist\
-  - cmd: echo finished...
+  - copy /y %CONDA_INSTALL_LOCN%\conda-bld\win-32\*.bz2 dist || cmd /c "exit /b 0"
+  - copy /y %CONDA_INSTALL_LOCN%\conda-bld\win-64\*.bz2 dist || cmd /c "exit /b 0"
+  - dir dist\
+  - echo finished...
 
 artifacts:
   - path: dist\*
@@ -179,7 +176,7 @@ on_finish:
 on_failure:
   - python tools/visualize_tests.py --no-browser
   - echo zipping images after a failure...
-  - 7z a result_images.zip result_images\ |grep -v "Compressing"
+  - 7z a result_images.zip result_images\ | grep -v "Compressing"
   - appveyor PushArtifact result_images.zip
 
 matrix:


### PR DESCRIPTION
- Rename to `.appveyor.yml`, consistently with `.travis.yml` (https://www.appveyor.com/docs/build-configuration/#yaml-file-alternative-naming).
- Remove redundant leading `cmd:` (https://www.appveyor.com/docs/build-configuration/#script-blocks-in-build-configuration "By default, script line is treated as batch command").
- Remove redundant quotes (w.r.t. yaml format); minor formatting changes.
- Replace `git clean -d -x -f` by `git clean -xdfq` to shorten the log.