### PR TITLE
[MRG+1] Unify WM_CLASS across backends

### DIFF
--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -560,6 +560,7 @@ class FigureManagerGTK(FigureManagerBase):
         FigureManagerBase.__init__(self, canvas, num)
 
         self.window = gtk.Window()
+        self.window.set_wmclass("matplotlib", "Matplotlib")
         self.set_window_title("Figure %d" % num)
         if window_icon:
             try:

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -399,6 +399,7 @@ class FigureManagerGTK3(FigureManagerBase):
         FigureManagerBase.__init__(self, canvas, num)
 
         self.window = Gtk.Window()
+        self.window.set_wmclass("matplotlib", "Matplotlib")
         self.set_window_title("Figure %d" % num)
         try:
             self.window.set_icon_from_file(window_icon)

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -143,7 +143,7 @@ def _create_qApp():
                 if display is None or not re.search(r':\d', display):
                     raise RuntimeError('Invalid DISPLAY variable')
 
-            qApp = QtWidgets.QApplication([str(" ")])
+            qApp = QtWidgets.QApplication(["matplotlib"])
             qApp.lastWindowClosed.connect(qApp.quit)
         else:
             qApp = app

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -86,7 +86,7 @@ def new_figure_manager_given_figure(num, figure):
     Create a new figure manager instance for the given figure.
     """
     _focus = windowing.FocusManager()
-    window = Tk.Tk()
+    window = Tk.Tk(className="matplotlib")
     window.withdraw()
 
     if Tk.TkVersion >= 8.5:


### PR DESCRIPTION
Qt uses the first argument of sys.argv to set the WM_CLASS attribute. So
far, a space character was used. Replace it with "matplotlib-qt5" to be
more recognizable. This enables interpretable rules for certain window
managers which use WM_CLASS.

This is related to #4746 and #6743.