### PR TITLE
DOC: Show off FuncFormatter as a decorator

### DIFF
--- a/examples/ticks_and_spines/tick-formatters.py
+++ b/examples/ticks_and_spines/tick-formatters.py
@@ -25,11 +25,11 @@ def setup(ax):
     ax.patch.set_alpha(0.0)
 
 
-plt.figure(figsize=(8, 6))
+fig = plt.figure(figsize=(8, 6))
 n = 7
 
 # Null formatter
-ax = plt.subplot(n, 1, 1)
+ax = fig.add_subplot(n, 1, 1)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
@@ -38,7 +38,7 @@ ax.xaxis.set_minor_formatter(ticker.NullFormatter())
 ax.text(0.0, 0.1, "NullFormatter()", fontsize=16, transform=ax.transAxes)
 
 # Fixed formatter
-ax = plt.subplot(n, 1, 2)
+ax = fig.add_subplot(n, 1, 2)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.MultipleLocator(1.0))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
@@ -57,7 +57,7 @@ def major_formatter(x, pos):
     return "[%.2f]" % x
 
 
-ax = plt.subplot(n, 1, 3)
+ax = fig.add_subplot(n, 1, 3)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
@@ -67,7 +67,7 @@ ax.text(0.0, 0.1, 'FuncFormatter(lambda x, pos: "[%.2f]" % x)',
 
 
 # FormatStr formatter
-ax = plt.subplot(n, 1, 4)
+ax = fig.add_subplot(n, 1, 4)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
@@ -76,7 +76,7 @@ ax.text(0.0, 0.1, "FormatStrFormatter('>%d<')",
         fontsize=15, transform=ax.transAxes)
 
 # Scalar formatter
-ax = plt.subplot(n, 1, 5)
+ax = fig.add_subplot(n, 1, 5)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.AutoLocator())
 ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())
@@ -84,7 +84,7 @@ ax.xaxis.set_major_formatter(ticker.ScalarFormatter(useMathText=True))
 ax.text(0.0, 0.1, "ScalarFormatter()", fontsize=15, transform=ax.transAxes)
 
 # StrMethod formatter
-ax = plt.subplot(n, 1, 6)
+ax = fig.add_subplot(n, 1, 6)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
@@ -93,7 +93,7 @@ ax.text(0.0, 0.1, "StrMethodFormatter('{x}')",
         fontsize=15, transform=ax.transAxes)
 
 # Percent formatter
-ax = plt.subplot(n, 1, 7)
+ax = fig.add_subplot(n, 1, 7)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
@@ -103,6 +103,6 @@ ax.text(0.0, 0.1, "PercentFormatter(xmax=5)",
 
 # Push the top of the top axes outside the figure because we only show the
 # bottom spine.
-plt.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=1.05)
+fig.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=1.05)
 
 plt.show()

--- a/examples/ticks_and_spines/tick-formatters.py
+++ b/examples/ticks_and_spines/tick-formatters.py
@@ -51,7 +51,8 @@ ax.text(0.0, 0.1, "FixedFormatter(['', '0', '1', ...])",
         fontsize=15, transform=ax.transAxes)
 
 
-# Func formatter
+# FuncFormatter can be used as a decorator
+@ticker.FuncFormatter
 def major_formatter(x, pos):
     return "[%.2f]" % x
 
@@ -60,7 +61,7 @@ ax = plt.subplot(n, 1, 3)
 setup(ax)
 ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
 ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
-ax.xaxis.set_major_formatter(ticker.FuncFormatter(major_formatter))
+ax.xaxis.set_major_formatter(major_formatter)
 ax.text(0.0, 0.1, 'FuncFormatter(lambda x, pos: "[%.2f]" % x)',
         fontsize=15, transform=ax.transAxes)
 


### PR DESCRIPTION
Just a minor update to an example that shows how to use `ticker.FuncFormatter` as a decorator.

Also modified example to use the figure object instead of the state machine.