### PR TITLE
Fix % formatting and Transform equality.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -118,17 +118,18 @@ class AxesStack(Stack):
         # All the error checking may be unnecessary; but this method
         # is called so seldom that the overhead is negligible.
         if not isinstance(a, Axes):
-            raise ValueError("second argument, %s, is not an Axes" % a)
+            raise ValueError("second argument, {!r}, is not an Axes".format(a))
         try:
             hash(key)
         except TypeError:
-            raise ValueError("first argument, %s, is not a valid key" % key)
+            raise ValueError(
+                "first argument, {!r}, is not a valid key".format(key))
 
         a_existing = self.get(key)
         if a_existing is not None:
             Stack.remove(self, (key, a_existing))
             warnings.warn(
-                "key %s already existed; Axes is being replaced" % key)
+                "key {!r} already existed; Axes is being replaced".format(key))
             # I don't think the above should ever happen.
 
         if a in self:

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1156,11 +1156,9 @@ class Transform(TransformNode):
         raise TypeError(
             "Can not add Transform to object of type '%s'" % type(other))
 
-    def __eq__(self, other):
-        # equality is based on transform object id. Hence:
-        # Transform() != Transform().
-        # Some classes, such as TransformWrapper & AffineBase, will override.
-        return self is other
+    # Equality is based on object identity for `Transform`s (so we don't
+    # override `__eq__`), but some subclasses, such as TransformWrapper &
+    # AffineBase, override this behavior.
 
     def _iter_break_from_left_to_right(self):
         """


### PR DESCRIPTION
Use `.format(key)` instead of `% key` formatting which fails when `key`
is a tuple (one could also use `% (key,)` but we may as well use the
more modern option).

The `Transform` class doesn't need to override `__eq__` as user-defined
classes default to using identity for equality.  This also avoids having
to add a `__hash__` to these classes to make them hashable (by default,
user-defined classes are hashable, but become unhashable (in Py3) if
they define a `__eq__` without defining a `__hash__`).  A more complete
PR should define `__hash__` for all `Transform` subclasses too.

---

Partial fix for #8395 (a full fix needs to restore hashability of most Transform subclasses).