### PR TITLE
Example for Equal_aspect_ratio, changed from plt.axes to plt.gca

### DIFF
--- a/examples/subplots_axes_and_figures/plot_equal_aspect_ratio.py
+++ b/examples/subplots_axes_and_figures/plot_equal_aspect_ratio.py
@@ -12,15 +12,13 @@ import numpy as np
 t = np.arange(0.0, 1.0 + 0.01, 0.01)
 s = np.cos(2 * 2 * np.pi * t)
 
-fig, ax = plt.subplots()
-ax.plot(t, s, '-', lw=2)
+plt.plot(t, s, '-', lw=2)
 
-ax.set_xlabel('Time (s)')
-ax.set_ylabel('Voltage (mV)')
-ax.set_title('About as simple as it gets, folks')
-ax.grid(True)
+plt.xlabel('time (s)')
+plt.ylabel('voltage (mV)')
+plt.title('About as simple as it gets, folks')
+plt.grid(True)
 
-ax.set_aspect('equal', 'datalim')
+plt.gca().set_aspect('equal', 'datalim')
 
-fig.tight_layout()
 plt.show()


### PR DESCRIPTION
Improvement of gallery issue #7956 
Changed plt.axes to plt.gca for simple line plot.
