### PR TITLE
Let imshow handle float128 data.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -299,9 +299,9 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         space.
         """
         if A is None:
-            raise RuntimeError('You must first set the image'
-                               ' array or the image attribute')
-        if any(s == 0 for s in A.shape):
+            raise RuntimeError('You must first set the image '
+                               'array or the image attribute')
+        if A.size == 0:
             raise RuntimeError("_make_image must get a non-empty image. "
                                "Your Artist's draw method must filter before "
                                "this method is called.")
@@ -359,7 +359,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             created_rgba_mask = False
 
             if A.ndim not in (2, 3):
-                raise ValueError("Invalid dimensions, got %s" % (A.shape,))
+                raise ValueError("Invalid dimensions, got {}".format(A.shape))
 
             if A.ndim == 2:
                 A = self.norm(A)
@@ -589,11 +589,11 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             self._A = cbook.safe_masked_invalid(A, copy=True)
 
         if (self._A.dtype != np.uint8 and
-                not np.can_cast(self._A.dtype, float)):
-            raise TypeError("Image data can not convert to float")
+                not np.can_cast(self._A.dtype, float, "same_kind")):
+            raise TypeError("Image data cannot be converted to float")
 
-        if (self._A.ndim not in (2, 3) or
-                (self._A.ndim == 3 and self._A.shape[-1] not in (3, 4))):
+        if not (self._A.ndim == 2
+                or self._A.ndim == 3 and self._A.shape[-1] in [3, 4]):
             raise TypeError("Invalid dimensions for image data")
 
         self._imcache = None

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -505,9 +505,9 @@ def test_jpeg_alpha():
 def test_nonuniformimage_setdata():
     ax = plt.gca()
     im = NonUniformImage(ax)
-    x = np.arange(3, dtype=np.float64)
-    y = np.arange(4, dtype=np.float64)
-    z = np.arange(12, dtype=np.float64).reshape((4, 3))
+    x = np.arange(3, dtype=float)
+    y = np.arange(4, dtype=float)
+    z = np.arange(12, dtype=float).reshape((4, 3))
     im.set_data(x, y, z)
     x[0] = y[0] = z[0, 0] = 9.9
     assert im._A[0, 0] == im._Ax[0] == im._Ay[0] == 0, 'value changed'
@@ -516,7 +516,7 @@ def test_nonuniformimage_setdata():
 def test_axesimage_setdata():
     ax = plt.gca()
     im = AxesImage(ax)
-    z = np.arange(12, dtype=np.float64).reshape((4, 3))
+    z = np.arange(12, dtype=float).reshape((4, 3))
     im.set_data(z)
     z[0, 0] = 9.9
     assert im._A[0, 0] == 0, 'value changed'
@@ -525,7 +525,7 @@ def test_axesimage_setdata():
 def test_figureimage_setdata():
     fig = plt.gcf()
     im = FigureImage(fig)
-    z = np.arange(12, dtype=np.float64).reshape((4, 3))
+    z = np.arange(12, dtype=float).reshape((4, 3))
     im.set_data(z)
     z[0, 0] = 9.9
     assert im._A[0, 0] == 0, 'value changed'
@@ -534,9 +534,9 @@ def test_figureimage_setdata():
 def test_pcolorimage_setdata():
     ax = plt.gca()
     im = PcolorImage(ax)
-    x = np.arange(3, dtype=np.float64)
-    y = np.arange(4, dtype=np.float64)
-    z = np.arange(6, dtype=np.float64).reshape((3, 2))
+    x = np.arange(3, dtype=float)
+    y = np.arange(4, dtype=float)
+    z = np.arange(6, dtype=float).reshape((3, 2))
     im.set_data(x, y, z)
     x[0] = y[0] = z[0, 0] = 9.9
     assert im._A[0, 0] == im._Ax[0] == im._Ay[0] == 0, 'value changed'
@@ -778,3 +778,8 @@ def test_empty_imshow():
 
     with pytest.raises(RuntimeError):
         im.make_image(fig._cachedRenderer)
+
+
+def test_imshow_float128():
+    fig, ax = plt.subplots()
+    ax.imshow(np.zeros((3, 3), dtype=np.longdouble))


### PR DESCRIPTION
The important parts are passing "same_kind" to can_cast (so that float128 is considered castable to float64) and converting float128 (longdouble for windows compat) back to float32 after normalization (as Agg doesn't handle float128).  The rest is just small esthetic fixes.

xref #8445.