### PR TITLE
Including Additional Metadata using the SVG Backend

### DIFF
--- a/doc/mpl_examples
+++ b/doc/mpl_examples
@@ -1,1 +1,0 @@
-../examples/

--- a/doc/mpl_toolkits/axes_grid1/examples
+++ b/doc/mpl_toolkits/axes_grid1/examples
@@ -1,1 +1,0 @@
-../../../examples/axes_grid1/

--- a/doc/mpl_toolkits/axisartist/examples
+++ b/doc/mpl_toolkits/axisartist/examples
@@ -1,1 +1,0 @@
-../../../examples/axisartist/

--- a/doc/users/whats_new/semantic_data_for_svg.rst
+++ b/doc/users/whats_new/semantic_data_for_svg.rst
@@ -1,0 +1,37 @@
+Semantic Data for SVG
+---------------------
+
+The SVG backend now supports embedding additional semantic data in the generated
+XML. :func:`~matplotlib.pyplot.savefig` and :meth:`~matplotlib.figure.Figure.savefig`
+Now accepts a `svg_gid_data` as a keyword argument expecting a :class:`dict`-like
+object with string keys and :class:`dict` values. For each Artist, if the result of
+:meth:`~matplotlib.artist.Artist.get_gid` is found in `svg_gid_data`, its value :class:`dict`
+will be included as attributes of the Artist's container element.
+
+Additionally these functions also now accept a `svg_attribs` keyword argument also
+taking a :class:`dict` object to add and override attributes on the top-level `<svg>`
+element. A special key in this dictionary, `"extra_content"` will be included as arbitrary
+XML directly under the top-level `<svg>`.
+
+
+Example
+```````
+
+.. code-block:: python
+
+    plt.savefig("test.svg", format='svg', svg_attribs={"class": "svg-figure"},
+                svg_gid_data={"target-geom": {
+                    "class": "target",
+                    "data-charge-level": 77.5,
+                    "onclick": "alert(this.dataset.chargeLevel)"
+                }})
+
+produces
+
+.. code-block:: xml
+
+    <svg class="svg-figure">
+        <g id="target-geom" data-charge-level="77.5" onclick="alert(this.dataset.chargeLevel)">
+            ...
+        </g>
+    </svg>

--- a/doc/users/whats_new/semantic_data_for_svg.rst
+++ b/doc/users/whats_new/semantic_data_for_svg.rst
@@ -3,15 +3,15 @@ Semantic Data for SVG
 
 The SVG backend now supports embedding additional semantic data in the generated
 XML. :func:`~matplotlib.pyplot.savefig` and :meth:`~matplotlib.figure.Figure.savefig`
-Now accepts a `svg_gid_data` as a keyword argument expecting a :class:`dict`-like
+Now accepts ``svg_gid_data`` as a keyword argument expecting a :class:`dict`-like
 object with string keys and :class:`dict` values. For each Artist, if the result of
-:meth:`~matplotlib.artist.Artist.get_gid` is found in `svg_gid_data`, its value :class:`dict`
+:meth:`~matplotlib.artist.Artist.get_gid` is found in ``svg_gid_data``, the value :class:`dict`
 will be included as attributes of the Artist's container element.
 
-Additionally these functions also now accept a `svg_attribs` keyword argument also
-taking a :class:`dict` object to add and override attributes on the top-level `<svg>`
-element. A special key in this dictionary, `"extra_content"` will be included as arbitrary
-XML directly under the top-level `<svg>`.
+Additionally these functions also now accept ``svg_attribs`` keyword argument also
+taking a :class:`dict` object to add and override attributes on the top-level ``<svg>``
+element. A special key in this dictionary, ``"extra_content"`` will be included as arbitrary
+XML directly under the top-level ``<svg>``.
 
 
 Example

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -74,7 +74,7 @@ backend_version = __version__
 # --------------------------------------------------------------------
 
 def escape_cdata(s):
-    s = force_str(s)
+    s = force_textual(s)
     s = s.replace("&", "&amp;")
     s = s.replace("<", "&lt;")
     s = s.replace(">", "&gt;")
@@ -86,7 +86,7 @@ def escape_comment(s):
     return _escape_xml_comment.sub('- ', s)
 
 def escape_attrib(s):
-    s = force_str(s)
+    s = force_textual(s)
     s = s.replace("&", "&amp;")
     s = s.replace("'", "&apos;")
     s = s.replace("\"", "&quot;")
@@ -125,7 +125,7 @@ def validate_xml(text):
     return True
 
 
-def force_str(obj):
+def force_textual(obj):
     """Convert `obj` into a `str` at all costs. Need
     to ensure that XML santitization functions receive
     the expected API and encoding assumptions.
@@ -147,7 +147,7 @@ def force_str(obj):
         else:
             return str(obj)
     else:
-        return str(obj)
+        return unicode(obj)
 
 ##
 # XML writer class.

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -139,10 +139,13 @@ def force_str(obj):
     -------
     str
     """
-    if isinstance(obj, str):
-        return obj
-    elif isinstance(obj, bytes):
-        return obj.decode("utf8")
+    if six.PY3:
+        if isinstance(obj, str):
+            return obj
+        elif isinstance(obj, bytes):
+            return obj.decode("utf8")
+        else:
+            return str(obj)
     else:
         return str(obj)
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -229,7 +229,7 @@ class XMLWriter(object):
         Returns
         -------
         int
-            The size of the :attrib:`__tags`, the current tag stack, - 1
+            The size of the :attr:`__tags`, the current tag stack, - 1
         """
         self.__flush()
         tag = escape_cdata(tag)
@@ -277,7 +277,7 @@ class XMLWriter(object):
         """Closes the current element (opened by the most recent call to
         :meth:`start`).
 
-        This method will pop the end off :attrib:`__tags`, and should not
+        This method will pop the end off :attr:`__tags`, and should not
         be used without at least one open element on the stack.
 
         This method will flush the internal buffer.
@@ -319,8 +319,8 @@ class XMLWriter(object):
             self.end()
 
     def element(self, tag, text=None, attrib={}, **extra):
-        """Adds an entire element.  This is the same as calling :meth:`__start`,
-        :meth:`__data`, and :meth:`__end` in sequence. The `text` argument can
+        """Adds an entire element.  This is the same as calling :meth:`__start` ,
+        :meth:`__data` , and :meth:`__end` in sequence. The `text` argument can
         be omitted.
 
         Parameters

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -330,9 +330,9 @@ class XMLWriter(object):
         text : str, optional
             The text content of the element to write
         attrib : dict, optional
-            As `attrib` of :meth:`start`
+            As attrib argument of :meth:`start`
         **extra
-            As `**extra` of :meth:`start`
+            As extra argument of :meth:`start`
         """
         self.start(*(tag, attrib), **extra)
         if text:

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -322,7 +322,7 @@ class XMLWriter(object):
         """Adds an entire element.  This is the same as calling :meth:`__start`,
         :meth:`__data`, and :meth:`__end` in sequence. The `text` argument can
         be omitted.
-        
+
         Parameters
         ----------
         tag : str

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from collections import OrderedDict, deque
+from collections import OrderedDict
 
 import six
 from six import unichr, raise_from
@@ -607,7 +607,7 @@ class RendererSVG(RendererBase):
         """
         Open a grouping element with label *s*. If *gid* is given, use
         *gid* as the id of the group.
-    
+
         If *gid* is a key in `self.gid_data`,
         include the value of *gid* in `self.gid_data` in  the attributes of
         the new group.

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -253,7 +253,8 @@ def test_gid_data():
         "rectangle-of-paint": {
             "class": "wet-paint",
             "data-lead-level": 77.5,
-            "onclick": "alert(\"Caution! Wet Paint. Lead Level: \" + this.dataset.leadLevel)"
+            "onclick": ("alert(\"Caution! Wet Paint. Lead Level:"
+                        " \" + this.dataset.leadLevel)")
         },
         "warning-message": {
             "onmouseover": "foo(this)"
@@ -268,7 +269,9 @@ def test_gid_data():
     assert root.attrib['viewBox'] == "-30 30 144 144"
 
     figure_buffer = BytesIO()
-    svg_attribs['extra_content'] = svg_attribs['extra_content'].replace(b"<defs>", b"<defs")
+    svg_attribs['extra_content'] = svg_attribs['extra_content'].replace(
+        b"<defs>", b"<defs")
     with pytest.raises(ValueError):
-        fig.savefig(figure_buffer, format='svg', svg_attribs=svg_attribs.copy(),
+        fig.savefig(figure_buffer, format='svg',
+                    svg_attribs=svg_attribs.copy(),
                     svg_gid_data=svg_gid_data.copy())

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -227,13 +227,13 @@ def test_gid_data():
         for spine in ax.spines.values():
             spine.set_visible(False)
 
-    fig = figure.Figure((2, 2))
+    fig = plt.figure(figsize=(2, 2))
     canvas = FigureCanvasSVG(fig)
     ax = fig.add_subplot(1, 1, 1)
     draw_graphics(ax)
     figure_buffer = BytesIO()
     svg_attribs = {
-        'extra_content': b"""
+        'extra_content': """
     <defs>
         <style id='my-style'>
             #rectangle-of-paint path {
@@ -252,7 +252,7 @@ def test_gid_data():
     svg_gid_data = {
         "rectangle-of-paint": {
             "class": "wet-paint",
-            "data-lead-level": 77.5,
+            "data-lead-level": "77.5",
             "onclick": ("alert(\"Caution! Wet Paint. Lead Level:"
                         " \" + this.dataset.leadLevel)")
         },
@@ -270,7 +270,7 @@ def test_gid_data():
 
     figure_buffer = BytesIO()
     svg_attribs['extra_content'] = svg_attribs['extra_content'].replace(
-        b"<defs>", b"<defs")
+        "<defs>", "<defs")
     with pytest.raises(ValueError):
         fig.savefig(figure_buffer, format='svg',
                     svg_attribs=svg_attribs.copy(),


### PR DESCRIPTION
This PR implements a new feature, adding the ability to include additional data for each Artist when rendered to `SVG`.  This additional information is provided as a `dict` keyed by `Artist.get_gid()`, mapping to a `dict` of attributes to be included in the resulting XML start tag. This lets users include arbitrary additional semantic data for use in downstream documents. The keyword argument for this feature is `svg_gid_data`, passed to `Figure.savefig`/`pyplot.savefig`

Additional information may be added directly to the top-level `<svg>` element containing the figure, by passing a `dict`. The keyword argument for this feature is `svg_attribs`, passed to `Figure.savefig`/`pyplot.savefig`.

```python
plt.savefig("test.svg", format='svg', svg_attribs={"class": "svg-figure"},
             svg_gid_data={"target-geom": {
                 "class": "target",
                 "data-charge-level": 77.5,
                 "onclick": "alert(this.dataset.chargeLevel)"
             }})
```

Produces

```svg
 <svg class="svg-figure">
     <g id="target-geom" data-charge-level="77.5" onclick="alert(this.dataset.chargeLevel)">
         ...
     </g>
 </svg>
```
