### PR TITLE
Don't bother disconnecting signals in TimerQt.__del__.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -206,16 +206,6 @@ class TimerQT(TimerBase):
         self._timer.timeout.connect(self._on_timer)
         self._timer_set_interval()
 
-    def __del__(self):
-        # Probably not necessary in practice, but is good behavior to
-        # disconnect
-        try:
-            TimerBase.__del__(self)
-            self._timer.timeout.disconnect(self._on_timer)
-        except RuntimeError:
-            # Timer C++ object already deleted
-            pass
-
     def _timer_set_single_shot(self):
         self._timer.setSingleShot(self._single)
 


### PR DESCRIPTION
The current implementation sometimes raises an error at exit.  For
example, run `examples/animations/animate_decay.py` (under the
Qt5Agg backend) and wait after the x-axis has been updated at least
once; then close the window.  *Occasionally*, the following error will
be printed at exit:
```
Exception ignored in: <bound method TimerQT.__del__ of <matplotlib.backends.backend_qt5.TimerQT object at 0x7f74a65f5668>>
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/matplotlib/backends/backend_qt5.py", line 202, in __del__
    self._timer.timeout.disconnect(self._on_timer)
TypeError: 'method' object is not connected
```

As far as I can tell there is no real rationale for bothering to
explicitly disconnect the callback -- the C++-level QTimer object is
about to be garbage-collected anyways.