### PR TITLE
Allow unhashable keys in AxesStack.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -112,6 +112,8 @@ class AxesStack(Stack):
         """
         Add Axes *a*, with key *key*, to the stack, and return the stack.
 
+        If *key* is unhashable, replace it by a unique, arbitrary object.
+
         If *a* is already on the stack, don't add it again, but
         return *None*.
         """
@@ -122,8 +124,7 @@ class AxesStack(Stack):
         try:
             hash(key)
         except TypeError:
-            raise ValueError(
-                "first argument, {!r}, is not a valid key".format(key))
+            key = object()
 
         a_existing = self.get(key)
         if a_existing is not None:


### PR DESCRIPTION
They simply will compare unequal to anything else.

Closes #8395.
Alternative to #8399 (although the part about removing `Transform.__eq__` in #8399 stays valid).
See discussion starting at https://github.com/matplotlib/matplotlib/pull/7377#issuecomment-260012639 for why this is a reasonable approach.