### PR TITLE
Revert #5392

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1252,7 +1252,7 @@ class FancyArrow(Polygon):
                     # The half-arrows contain the midpoint of the stem,
                     # which we can omit from the full arrow. Including it
                     # twice caused a problem with xpdf.
-                    coords = np.concatenate([left_half_arrow[:-2],
+                    coords = np.concatenate([left_half_arrow[:-1],
                                              right_half_arrow[-2::-1]])
                 else:
                     raise ValueError("Got unknown shape: %s" % shape)


### PR DESCRIPTION
#5392 was introduced in an attempt to fix (slightly) arrows in polar plots, but it broke drawing arrows normally (see #8406).

This fixes #8406, which I think is more important than having polar arrows slightly fixed.