### PR TITLE
Added axes inversion to cla()

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -997,6 +997,7 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
+            self.viewLim.intervalx = (0, 1)
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -1020,6 +1021,7 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
+            self.viewLim.intervaly = (0, 1)
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):
@@ -1110,6 +1112,7 @@ class _AxesBase(martist.Artist):
         if self._sharey:
             self.yaxis.set_visible(yaxis_visible)
             self.patch.set_visible(patch_visible)
+
         self.stale = True
 
     @cbook.deprecated("2.1", alternative="Axes.patch")

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -997,8 +997,7 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
-            #self.viewLim.intervalx = (0, 1)
-            self.set_xlim(0,1)
+            self.set_xlim(0, 1)
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -1022,8 +1021,7 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
-            #self.viewLim.intervaly = (0, 1)
-            self.set_ylim(0,1)
+            self.set_ylim(0, 1)
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -997,7 +997,10 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
-            self.set_xlim(0, 1)
+            try:
+                self.set_xlim(0, 1)
+            except TypeError:
+                pass
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -1021,7 +1024,10 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
-            self.set_ylim(0, 1)
+            try:
+                self.set_ylim(0, 1)
+            except TypeError:
+                pass
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -997,7 +997,8 @@ class _AxesBase(martist.Artist):
             self.xaxis.set_minor_locator(minl)
         else:
             self.xaxis._set_scale('linear')
-            self.viewLim.intervalx = (0, 1)
+            #self.viewLim.intervalx = (0, 1)
+            self.set_xlim(0,1)
 
         if self._sharey is not None:
             self.yaxis.major = self._sharey.yaxis.major
@@ -1021,7 +1022,8 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_minor_locator(minl)
         else:
             self.yaxis._set_scale('linear')
-            self.viewLim.intervaly = (0, 1)
+            #self.viewLim.intervaly = (0, 1)
+            self.set_ylim(0,1)
 
         # update the minor locator for x and y axis based on rcParams
         if (rcParams['xtick.minor.visible']):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -185,28 +185,30 @@ def test_inverted_cla():
     # plotting an image, then 1d graph, axis is now down
     fig = plt.figure(0)
     ax = fig.gca()
-    # test that a new axis is not inverted per default
+    # 1. test that a new axis is not inverted per default
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
     img = np.random.random((100, 100))
     ax.imshow(img)
-    # test that a image axis is inverted
+    # 2. test that a image axis is inverted
     assert not(ax.xaxis_inverted())
     assert ax.yaxis_inverted()
+    # 3. test that clearing and plotting a line, axes are
+    # not inverted
     ax.cla()
     x = np.linspace(0, 2*np.pi, 100)
     ax.plot(x, np.cos(x))
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
 
-    # autoscaling should not bring back axes to normal
+    # 4. autoscaling should not bring back axes to normal
     ax.cla()
     ax.imshow(img)
     plt.autoscale()
     assert not(ax.xaxis_inverted())
     assert ax.yaxis_inverted()
 
-    # two shared axes. Clearing the master axis should bring axes in shared
+    # 5. two shared axes. Clearing the master axis should bring axes in shared
     # axies back to normal
     ax0 = plt.subplot(211)
     ax1 = plt.subplot(212, sharey=ax0)
@@ -215,7 +217,7 @@ def test_inverted_cla():
     ax0.cla()
     assert not(ax1.yaxis_inverted())
     ax1.cla()
-    # clearing the nonmaster should not touch limits
+    # 6. clearing the nonmaster should not touch limits
     ax0.imshow(img)
     ax1.plot(x, np.cos(x))
     ax1.cla()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -177,6 +177,48 @@ def test_twin_inherit_autoscale_setting():
     assert ax_y_on.get_autoscaley_on()
     assert not ax_y_off.get_autoscaley_on()
 
+@cleanup
+def test_inverted_cla():
+    # Github PR #5450. Setting autoscale should reset 
+    # axes to be non-inverted.
+    # plotting an image, then 1d graph, axis is now down
+    fig = plt.figure(0);
+    ax = fig.gca()
+    # test that a new axis is not inverted per default
+    assert not(ax.xaxis_inverted())
+    assert not(ax.yaxis_inverted())
+    img = np.random.random((100,100))
+    ax.imshow(img)
+    # test that a image axis is inverted
+    assert not(ax.xaxis_inverted())
+    assert ax.yaxis_inverted()
+    ax.cla()
+    x = np.linspace(0,2*np.pi,100);
+    ax.plot(x,np.cos(x))
+    assert not(ax.xaxis_inverted())
+    assert not(ax.yaxis_inverted())
+
+    # autoscaling should not bring back axes to normal
+    ax.cla()
+    ax.imshow(img)
+    plt.autoscale()
+    assert not(ax.xaxis_inverted())
+    assert ax.yaxis_inverted()
+
+    # two shared axes. Clearing the master axis should bring axes in shared
+    # axies back to normal
+    ax0 = plt.subplot(211)
+    ax1 = plt.subplot(212, sharey=ax0)
+    ax0.imshow(img)
+    ax1.plot(x,np.cos(x))
+    ax0.cla()
+    assert not(ax1.yaxis_inverted())
+    ax1.cla()
+    # clearing the nonmaster should not touch limits
+    ax0.imshow(img)
+    ax1.plot(x,np.cos(x))
+    ax1.cla()
+    assert ax.yaxis_inverted()
 
 @image_comparison(baseline_images=["minorticks_on_rcParams_both"],
                   extensions=['png'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2153,7 +2153,6 @@ def test_boxplot_autorange_whiskers():
     ax2.set_ylim((-5, 5))
 
 
-
 def _rc_test_bxp_helper(ax, rc_dict):
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -178,7 +178,6 @@ def test_twin_inherit_autoscale_setting():
     assert not ax_y_off.get_autoscaley_on()
 
 
-@cleanup
 def test_inverted_cla():
     # Github PR #5450. Setting autoscale should reset
     # axes to be non-inverted.
@@ -222,6 +221,9 @@ def test_inverted_cla():
     ax1.plot(x, np.cos(x))
     ax1.cla()
     assert ax.yaxis_inverted()
+
+    # clean up
+    plt.close(fig)
 
 @image_comparison(baseline_images=["minorticks_on_rcParams_both"],
                   extensions=['png'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -208,7 +208,7 @@ def test_inverted_cla():
     assert ax.yaxis_inverted()
 
     # 5. two shared axes. Clearing the master axis should bring axes in shared
-    # axies back to normal
+    # axes back to normal
     ax0 = plt.subplot(211)
     ax1 = plt.subplot(212, sharey=ax0)
     ax0.imshow(img)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -177,24 +177,25 @@ def test_twin_inherit_autoscale_setting():
     assert ax_y_on.get_autoscaley_on()
     assert not ax_y_off.get_autoscaley_on()
 
+
 @cleanup
 def test_inverted_cla():
-    # Github PR #5450. Setting autoscale should reset 
+    # Github PR #5450. Setting autoscale should reset
     # axes to be non-inverted.
     # plotting an image, then 1d graph, axis is now down
-    fig = plt.figure(0);
+    fig = plt.figure(0)
     ax = fig.gca()
     # test that a new axis is not inverted per default
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
-    img = np.random.random((100,100))
+    img = np.random.random((100, 100))
     ax.imshow(img)
     # test that a image axis is inverted
     assert not(ax.xaxis_inverted())
     assert ax.yaxis_inverted()
     ax.cla()
-    x = np.linspace(0,2*np.pi,100);
-    ax.plot(x,np.cos(x))
+    x = np.linspace(0, 2*np.pi, 100)
+    ax.plot(x, np.cos(x))
     assert not(ax.xaxis_inverted())
     assert not(ax.yaxis_inverted())
 
@@ -210,13 +211,13 @@ def test_inverted_cla():
     ax0 = plt.subplot(211)
     ax1 = plt.subplot(212, sharey=ax0)
     ax0.imshow(img)
-    ax1.plot(x,np.cos(x))
+    ax1.plot(x, np.cos(x))
     ax0.cla()
     assert not(ax1.yaxis_inverted())
     ax1.cla()
     # clearing the nonmaster should not touch limits
     ax0.imshow(img)
-    ax1.plot(x,np.cos(x))
+    ax1.plot(x, np.cos(x))
     ax1.cla()
     assert ax.yaxis_inverted()
 
@@ -2146,6 +2147,7 @@ def test_boxplot_autorange_whiskers():
     fig2, ax2 = plt.subplots()
     ax2.boxplot([x, x], bootstrap=10000, notch=1, autorange=True)
     ax2.set_ylim((-5, 5))
+
 
 
 def _rc_test_bxp_helper(ax, rc_dict):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -225,6 +225,7 @@ def test_inverted_cla():
     # clean up
     plt.close(fig)
 
+
 @image_comparison(baseline_images=["minorticks_on_rcParams_both"],
                   extensions=['png'])
 def test_minorticks_on_rcParams_both():

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1086,6 +1086,10 @@ class Axes3D(Axes):
             self.zaxis._set_scale(self._sharez.zaxis.get_scale())
         else:
             self.zaxis._set_scale('linear')
+            try:
+                self.set_zlim(0, 1)
+            except TypeError:
+                pass
 
         self._autoscaleZon = True
         self._zmargin = 0

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1076,6 +1076,7 @@ class Axes3D(Axes):
         # Disabling mouse interaction might have been needed a long
         # time ago, but I can't find a reason for it now - BVR (2012-03)
         #self.disable_mouse_rotation()
+        Axes.cla(self)
         self.zaxis.cla()
 
         if self._sharez is not None:
@@ -1096,7 +1097,6 @@ class Axes3D(Axes):
         self._autoscaleZon = True
         self._zmargin = 0
 
-        Axes.cla(self)
 
         self.grid(rcParams['axes3d.grid'])
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1090,6 +1090,8 @@ class Axes3D(Axes):
                 self.set_zlim(0, 1)
             except TypeError:
                 pass
+            except AttributeError:
+                pass
 
         self._autoscaleZon = True
         self._zmargin = 0

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1091,8 +1091,6 @@ class Axes3D(Axes):
                 self.set_zlim(0, 1)
             except TypeError:
                 pass
-            except AttributeError:
-                pass
 
         self._autoscaleZon = True
         self._zmargin = 0

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -564,3 +564,23 @@ def test_invalid_axes_limits(setter, side, value):
     obj = fig.add_subplot(111, projection='3d')
     with pytest.raises(ValueError):
         getattr(obj, setter)(**limit)
+
+
+def test_inverted_cla():
+    # Github PR #5450. Setting autoscale should reset
+    # axes to be non-inverted.
+    fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+    # 1. test that a new axis is not inverted per default
+    assert not ax.xaxis_inverted()
+    assert not ax.yaxis_inverted()
+    assert not ax.zaxis_inverted()
+    ax.set_xlim(1, 0)
+    ax.set_ylim(1, 0)
+    ax.set_zlim(1, 0)
+    assert ax.xaxis_inverted()
+    assert ax.yaxis_inverted()
+    assert ax.zaxis_inverted()
+    ax.cla()
+    assert not ax.xaxis_inverted()
+    assert not ax.yaxis_inverted()
+    assert not ax.zaxis_inverted()


### PR DESCRIPTION
Continuation of #5450 
When calling `cla()`, axes inversion should be cleared (if any).

(I rebased the PR and could not figure out how to re-open once this was done, github won't let me)