### PR TITLE
Clarify that Image.set_data doesn't update normalization.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -578,9 +578,11 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def set_data(self, A):
         """
-        Set the image array
+        Set the image array.
 
         ACCEPTS: numpy/PIL Image A
+
+        Note that this function does *not* update the normalization used.
         """
         # check if data is PIL Image without importing Image
         if hasattr(A, 'getpixel'):


### PR DESCRIPTION
See #8467.

PIL images are array-likes (in the sense that they can be passed to `asarray`) so we don't need to mention them explicitly.