### PR TITLE
Submitting resolution for issue #7617

### DIFF
--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -520,7 +520,7 @@ class GridHelperRectlinear(GridHelperBase):
         _helper = AxisArtistHelperRectlinear.Floating( \
             axes, nth_coord, value, axis_direction)
 
-        axisline = AxisArtist(axes, _helper)
+        axisline = AxisArtist(axes, _helper, axis_direction=axis_direction)
 
         axisline.line.set_clip_on(True)
         axisline.line.set_clip_box(axisline.axes.bbox)


### PR DESCRIPTION
Ref #7617

```
import matplotlib.pyplot as plt
from mpl_toolkits.axes_grid.axislines import SubplotZero

fig = plt.figure()
ax = SubplotZero(fig, 111)
_ = fig.add_subplot(ax)


for direction in ["xzero", "yzero"]:
    ax.axis[direction].set_visible(True)
    ax.axis[direction].set_axisline_style("->")
    # Set outward ticks
    ax.axis[direction].major_ticks.set_tick_out(True)
    ax.axis[direction].minor_ticks.set_tick_out(True)

ax.axis["yzero"].set_axis_direction("left")

plt.plot([0,1], [0,1], c="blue", lw=2)
plt.xlabel('x')
plt.ylabel('y')
```

![fix_7617](https://cloud.githubusercontent.com/assets/14296530/24980577/dba3b4cc-1fa6-11e7-9463-5a1626114b77.png)


1