### PR TITLE
Issue 6830 fix

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -1232,7 +1232,18 @@ class AxisArtist(martist.Artist):
         ticklabel_add_angle = self._ticklabel_add_angle
 
         for loc, angle_normal, angle_tangent, label in tick_iter:
-            angle_label = angle_tangent  - 90
+            angle_label = angle_tangent - 90
+
+            if (self._axis_direction == "top" or self._axis_direction == "bottom"):
+                for x in self.axes.get_xticklabels():
+                    if label == x.get_text():
+                        angle_label += x.get_rotation()
+                    angle_label += ticklabel_add_angle
+            elif (self._axis_direction == "right" or self._axis_direction == "left"):
+                for x in self.axes.get_yticklabels():
+                    if label == x.get_text():
+                        angle_label += x.get_rotation()
+                    angle_label += ticklabel_add_angle
             angle_label += ticklabel_add_angle
 
             if np.cos((angle_label - angle_normal)/180.*np.pi) < 0.:

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -520,7 +520,7 @@ class GridHelperRectlinear(GridHelperBase):
         _helper = AxisArtistHelperRectlinear.Floating( \
             axes, nth_coord, value, axis_direction)
 
-        axisline = AxisArtist(axes, _helper)
+        axisline = AxisArtist(axes, _helper, axis_direction=axis_direction)
 
         axisline.line.set_clip_on(True)
         axisline.line.set_clip_box(axisline.axes.bbox)


### PR DESCRIPTION
This PR relates to issue #6830

Now it rotates the parasite axis texts for the ticks.

'''
import matplotlib.pyplot as plt
from mpl_toolkits.axes_grid1 import host_subplot
import mpl_toolkits.axisartist as AA
import numpy as np

host = host_subplot(111,axes_class=AA.Axes)
plt.subplots_adjust(bottom=0.15)
host.plot(10,10)
host.set_xticks([10.2,10.4,10.6])
host.set_xticklabels(['A','B','C'],rotation=45)
'''
![6830_fixed](https://cloud.githubusercontent.com/assets/14296530/24981721/f277ef60-1fab-11e7-97a2-eef5effa3e49.png)

