### PR TITLE
Check for non-finite axis limits placed on converted_limit

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2810,6 +2810,19 @@ class _AxesBase(martist.Artist):
         """
         return tuple(self.viewLim.intervalx)
 
+    def _validate_axis_limits(self, limit, convert):
+        """
+        Raise ValueError if specified axis limits are infinite.
+
+        """
+        if limit is not None:
+            converted_limit = convert(limit)
+            if (isinstance(converted_limit, float) and
+                    (not np.isreal(converted_limit) or
+                        not np.isfinite(converted_limit))):
+                raise ValueError("Axis limits cannot be NaN or Inf")
+            return converted_limit
+
     def set_xlim(self, left=None, right=None, emit=True, auto=False, **kw):
         """
         Set the data limits for the x-axis
@@ -2876,15 +2889,8 @@ class _AxesBase(martist.Artist):
             left, right = left
 
         self._process_unit_info(xdata=(left, right))
-        if left is not None:
-            left = self.convert_xunits(left)
-        if right is not None:
-            right = self.convert_xunits(right)
-
-        if ((left is not None and not np.isfinite(left)) or
-                (right is not None and not np.isfinite(right))):
-            raise ValueError("Specified x limits must be finite; "
-                             "instead, found: (%s, %s)" % (left, right))
+        left = self._validate_axis_limits(left, self.convert_xunits)
+        right = self._validate_axis_limits(right, self.convert_xunits)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -3175,15 +3181,8 @@ class _AxesBase(martist.Artist):
         if top is None and iterable(bottom):
             bottom, top = bottom
 
-        if bottom is not None:
-            bottom = self.convert_yunits(bottom)
-        if top is not None:
-            top = self.convert_yunits(top)
-
-        if ((top is not None and not np.isfinite(top)) or
-                (bottom is not None and not np.isfinite(bottom))):
-            raise ValueError("Specified y limits must be finite; "
-                             "instead, found: (%s, %s)" % (bottom, top))
+        bottom = self._validate_axis_limits(bottom, self.convert_yunits)
+        top = self._validate_axis_limits(top, self.convert_yunits)
 
         old_bottom, old_top = self.get_ylim()
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2814,7 +2814,7 @@ class _AxesBase(martist.Artist):
         """
         Raise ValueError if converted limits are non-finite.
 
-        Note that this functions also accepts None as a limit argument.
+        Note that this function also accepts None as a limit argument.
 
         Returns
         -------

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2810,9 +2810,15 @@ class _AxesBase(martist.Artist):
         """
         return tuple(self.viewLim.intervalx)
 
-    def _validate_axis_limits(self, limit, convert):
+    def _validate_converted_limits(self, limit, convert):
         """
-        Raise ValueError if specified axis limits are infinite.
+        Raise ValueError if converted limits are non-finite.
+
+        Note that this functions also accepts None as a limit argument.
+
+        Returns
+        -------
+        The limit value after call to convert(), or None if limit is None.
 
         """
         if limit is not None:
@@ -2889,8 +2895,8 @@ class _AxesBase(martist.Artist):
             left, right = left
 
         self._process_unit_info(xdata=(left, right))
-        left = self._validate_axis_limits(left, self.convert_xunits)
-        right = self._validate_axis_limits(right, self.convert_xunits)
+        left = self._validate_converted_limits(left, self.convert_xunits)
+        right = self._validate_converted_limits(right, self.convert_xunits)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -3181,8 +3187,8 @@ class _AxesBase(martist.Artist):
         if top is None and iterable(bottom):
             bottom, top = bottom
 
-        bottom = self._validate_axis_limits(bottom, self.convert_yunits)
-        top = self._validate_axis_limits(top, self.convert_yunits)
+        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
+        top = self._validate_converted_limits(top, self.convert_yunits)
 
         old_bottom, old_top = self.get_ylim()
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -587,17 +587,17 @@ class Axes3D(Axes):
             xmax += 0.05
         return (xmin, xmax)
 
-    def _validate_axis_limits(self, limit, convert):
-        """
-        Raise ValueError if specified axis limits are infinite.
+    # def _validate_axis_limits(self, limit, convert):
+    #     """
+    #     Raise ValueError if specified axis limits are infinite.
 
-        """
-        if limit is not None:
-            converted_limit = convert(limit)
-            if (isinstance(converted_limit, float) and
-                    (not np.isreal(converted_limit) or not np.isfinite(converted_limit))):
-                raise ValueError("Axis limits cannot be NaN or Inf")
-            return converted_limit
+    #     """
+    #     if limit is not None:
+    #         converted_limit = convert(limit)
+    #         if (isinstance(converted_limit, float) and
+    #                 (not np.isreal(converted_limit) or not np.isfinite(converted_limit))):
+    #             raise ValueError("Axis limits cannot be NaN or Inf")
+    #         return converted_limit
 
     def set_xlim3d(self, left=None, right=None, emit=True, auto=False, **kw):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -605,8 +605,8 @@ class Axes3D(Axes):
             left, right = left
 
         self._process_unit_info(xdata=(left, right))
-        left = self._validate_axis_limits(left, self.convert_xunits)
-        right = self._validate_axis_limits(right, self.convert_xunits)
+        left = self._validate_converted_limits(left, self.convert_xunits)
+        right = self._validate_converted_limits(right, self.convert_xunits)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -657,14 +657,14 @@ class Axes3D(Axes):
             bottom, top = bottom
 
         self._process_unit_info(ydata=(bottom, top))
-        if bottom is not None:
-            bottom = self.convert_yunits(bottom)
-        if top is not None:
-            top = self.convert_yunits(top)
+        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
+        top = self._validate_converted_limits(top, self.convert_yunits)
 
         old_bottom, old_top = self.get_ylim()
-        bottom = self._validate_axis_limits(bottom, self.convert_yunits)
-        top = self._validate_axis_limits(top, self.convert_yunits)
+        if bottom is None:
+            bottom = old_bottom
+        if top is None:
+            top = old_top
 
         if top == bottom:
             warnings.warn(('Attempting to set identical bottom==top results\n'
@@ -709,8 +709,8 @@ class Axes3D(Axes):
             bottom, top = bottom
 
         self._process_unit_info(zdata=(bottom, top))
-        bottom = self._validate_axis_limits(bottom, self.convert_yunits)
-        top = self._validate_axis_limits(top, self.convert_yunits)
+        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
+        top = self._validate_converted_limits(top, self.convert_yunits)
 
         old_bottom, old_top = self.get_zlim()
         if bottom is None:

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -587,18 +587,6 @@ class Axes3D(Axes):
             xmax += 0.05
         return (xmin, xmax)
 
-    # def _validate_axis_limits(self, limit, convert):
-    #     """
-    #     Raise ValueError if specified axis limits are infinite.
-
-    #     """
-    #     if limit is not None:
-    #         converted_limit = convert(limit)
-    #         if (isinstance(converted_limit, float) and
-    #                 (not np.isreal(converted_limit) or not np.isfinite(converted_limit))):
-    #             raise ValueError("Axis limits cannot be NaN or Inf")
-    #         return converted_limit
-
     def set_xlim3d(self, left=None, right=None, emit=True, auto=False, **kw):
         """
         Set 3D x limits.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -709,8 +709,8 @@ class Axes3D(Axes):
             bottom, top = bottom
 
         self._process_unit_info(zdata=(bottom, top))
-        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
-        top = self._validate_converted_limits(top, self.convert_yunits)
+        bottom = self._validate_converted_limits(bottom, self.convert_zunits)
+        top = self._validate_converted_limits(top, self.convert_zunits)
 
         old_bottom, old_top = self.get_zlim()
         if bottom is None:

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -593,11 +593,11 @@ class Axes3D(Axes):
 
         """
         if limit is not None:
-            converted_limits = convert(limit)
-            if (isinstance(limit, float) and
-                    (not np.isreal(limit) or not np.isfinite(limit))):
+            converted_limit = convert(limit)
+            if (isinstance(converted_limit, float) and
+                    (not np.isreal(converted_limit) or not np.isfinite(converted_limit))):
                 raise ValueError("Axis limits cannot be NaN or Inf")
-            return converted_limits
+            return converted_limit
 
     def set_xlim3d(self, left=None, right=None, emit=True, auto=False, **kw):
         """


### PR DESCRIPTION
In addition to my previous PR ( #8022 ), this one places the check in the `_validate_axes_limits()` function in `/lib/mpl_toolkits/mplot3d/axes3d.py` on the converted limits rather than on the limits passed to the function