### PR TITLE
Add pep 519

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -38,7 +38,8 @@ import abc
 import contextlib
 import tempfile
 import warnings
-from matplotlib.cbook import iterable, is_string_like, deprecated
+from matplotlib.cbook import (iterable, is_string_like, deprecated,
+                              fspath_no_except)
 from matplotlib.compat import subprocess
 from matplotlib import verbose
 from matplotlib import rcParams, rcParamsDefault, rc_context
@@ -349,6 +350,7 @@ class MovieWriter(AbstractMovieWriter):
             output = sys.stdout
         else:
             output = subprocess.PIPE
+        command = [fspath_no_except(cmd) for cmd in command]
         verbose.report('MovieWriter.run: running command: %s' %
                        ' '.join(command))
         self._proc = subprocess.Popen(command, shell=False,

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -31,7 +31,8 @@ from math import radians, cos, sin
 from matplotlib import verbose, rcParams, __version__
 from matplotlib.backend_bases import (RendererBase, FigureManagerBase,
                                       FigureCanvasBase)
-from matplotlib.cbook import is_string_like, maxdict, restrict_dict
+from matplotlib.cbook import (is_string_like, maxdict, restrict_dict,
+                              fspath_no_except, to_filehandle)
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, get_font
 from matplotlib.ft2font import (LOAD_FORCE_AUTOHINT, LOAD_NO_HINTING,
@@ -563,8 +564,9 @@ class FigureCanvasAgg(FigureCanvasBase):
             metadata.update(user_metadata)
 
         try:
-            _png.write_png(renderer._renderer, filename_or_obj,
-                           self.figure.dpi, metadata=metadata)
+            _png.write_png(
+                renderer._renderer, fspath_no_except(filename_or_obj),
+                self.figure.dpi, metadata=metadata)
         finally:
             if close:
                 filename_or_obj.close()
@@ -620,7 +622,8 @@ class FigureCanvasAgg(FigureCanvasBase):
             if 'quality' not in options:
                 options['quality'] = rcParams['savefig.jpeg_quality']
 
-            return background.save(filename_or_obj, format='jpeg', **options)
+            return background.save(to_filehandle(filename_or_obj), format='jpeg',
+                              **options)
         print_jpeg = print_jpg
 
         # add TIFF support
@@ -630,7 +633,7 @@ class FigureCanvasAgg(FigureCanvasBase):
                 return
             image = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
             dpi = (self.figure.dpi, self.figure.dpi)
-            return image.save(filename_or_obj, format='tiff',
+            return image.save(to_filehandle(filename_or_obj), format='tiff',
                               dpi=dpi)
         print_tiff = print_tif
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -35,7 +35,7 @@ from matplotlib.backend_bases import (RendererBase, GraphicsContextBase,
                                       FigureManagerBase, FigureCanvasBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.cbook import (Bunch, is_string_like, get_realpath_and_stat,
-                              is_writable_file_like, maxdict)
+                              is_writable_file_like, maxdict, fspath_no_except)
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, is_opentype_cff_font, get_font
 from matplotlib.afm import AFM
@@ -434,6 +434,7 @@ class PdfFile(object):
         self.passed_in_file_object = False
         self.original_file_like = None
         self.tell_base = 0
+        filename = fspath_no_except(filename)
         if is_string_like(filename):
             fh = open(filename, 'wb')
         elif is_writable_file_like(filename):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -574,7 +574,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         """Write the image to png file with fname"""
         im = self.to_rgba(self._A[::-1] if self.origin == 'lower' else self._A,
                           bytes=True, norm=True)
-        _png.write_png(im, fname)
+        _png.write_png(im, cbook.fspath_no_except(fname))
 
     def set_data(self, A):
         """

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -4,6 +4,8 @@ from __future__ import (absolute_import, division, print_function,
 import inspect
 import warnings
 from contextlib import contextmanager
+import shutil
+import tempfile
 
 import matplotlib
 from matplotlib.cbook import is_string_like, iterable
@@ -144,3 +146,21 @@ def setup():
 
     set_font_settings_for_testing()
     set_reproducibility_for_testing()
+
+
+@contextmanager
+def closed_tempfile(suffix='', text=None):
+    """
+    Context manager which yields the path to a closed temporary file with the
+    suffix `suffix`. The file will be deleted on exiting the context. An
+    additional argument `text` can be provided to have the file contain `text`.
+    """
+    with tempfile.NamedTemporaryFile(
+        'w+t', suffix=suffix, delete=False
+    ) as test_file:
+        file_name = test_file.name
+        if text is not None:
+            test_file.write(text)
+            test_file.flush()
+    yield file_name
+    shutil.rmtree(file_name, ignore_errors=True)

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -191,3 +191,37 @@ def test_missing_psfont(monkeypatch):
     ax.text(0.5, 0.5, 'hello')
     with tempfile.TemporaryFile() as tmpfile, pytest.raises(ValueError):
         fig.savefig(tmpfile, format='pdf')
+
+
+def test_pdfpages_accept_pep_519():
+    from tempfile import NamedTemporaryFile
+
+    class FakeFSPathClass(object):
+        def __init__(self, path):
+            self._path = path
+
+        def __fspath__(self):
+            return self._path
+    tmpfile = NamedTemporaryFile(suffix='.pdf')
+    tmpfile.close()
+    with PdfPages(FakeFSPathClass(tmpfile.name)) as pdf:
+        fig, ax = plt.subplots()
+        ax.plot([1, 2], [3, 4])
+        pdf.savefig(fig)
+
+
+def test_savefig_accept_pathlib():
+    try:
+        from pathlib import Path
+    except ImportError:
+        raise pytest.skip("pathlib not installed")
+    from tempfile import NamedTemporaryFile
+
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [3, 4])
+    tmpfile = NamedTemporaryFile(suffix='.pdf')
+    tmpfile.close()
+    with PdfPages(Path(tmpfile.name)) as pdf:
+        fig, ax = plt.subplots()
+        ax.plot([1, 2], [3, 4])
+        pdf.savefig(fig)

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -533,3 +533,32 @@ class TestFuncParser(object):
         func_parser = cbook._StringFuncParser(string)
         b = func_parser.is_bounded_0_1
         assert_array_equal(b, bounded)
+
+
+def test_to_filehandle_accept_pep_519():
+    from tempfile import NamedTemporaryFile
+
+    class FakeFSPathClass(object):
+        def __init__(self, path):
+            self._path = path
+
+        def __fspath__(self):
+            return self._path
+
+    tmpfile = NamedTemporaryFile(delete=False)
+    tmpfile.close()
+    pep519_path = FakeFSPathClass(tmpfile.name)
+    cbook.to_filehandle(pep519_path)
+
+
+def test_to_filehandle_accept_pathlib():
+    try:
+        from pathlib import Path
+    except ImportError:
+        raise pytest.skip("pathlib not installed")
+    from tempfile import NamedTemporaryFile
+
+    tmpfile = NamedTemporaryFile(delete=False)
+    tmpfile.close()
+    path = Path(tmpfile.name)
+    cbook.to_filehandle(path)

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.testing.utils import (assert_array_equal, assert_approx_equal,
                                  assert_array_almost_equal)
 import pytest
+from matplotlib.testing import closed_tempfile
 
 import matplotlib.cbook as cbook
 import matplotlib.colors as mcolors
@@ -536,8 +537,6 @@ class TestFuncParser(object):
 
 
 def test_to_filehandle_accept_pep_519():
-    from tempfile import NamedTemporaryFile
-
     class FakeFSPathClass(object):
         def __init__(self, path):
             self._path = path
@@ -545,10 +544,9 @@ def test_to_filehandle_accept_pep_519():
         def __fspath__(self):
             return self._path
 
-    tmpfile = NamedTemporaryFile(delete=False)
-    tmpfile.close()
-    pep519_path = FakeFSPathClass(tmpfile.name)
-    cbook.to_filehandle(pep519_path)
+    with closed_tempfile() as tmpfile:
+        pep519_path = FakeFSPathClass(tmpfile)
+        cbook.to_filehandle(pep519_path)
 
 
 def test_to_filehandle_accept_pathlib():
@@ -556,9 +554,7 @@ def test_to_filehandle_accept_pathlib():
         from pathlib import Path
     except ImportError:
         raise pytest.skip("pathlib not installed")
-    from tempfile import NamedTemporaryFile
 
-    tmpfile = NamedTemporaryFile(delete=False)
-    tmpfile.close()
-    path = Path(tmpfile.name)
-    cbook.to_filehandle(path)
+    with closed_tempfile() as tmpfile:
+        path = Path(tmpfile)
+        cbook.to_filehandle(path)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from numpy.testing import assert_equal
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing import skip, closed_tempfile
 from matplotlib.axes import Axes
 from matplotlib.ticker import AutoMinorLocator, FixedFormatter
 import matplotlib.pyplot as plt
@@ -277,8 +278,6 @@ def test_autofmt_xdate(which):
 
 @pytest.mark.parametrize('ext', ['png', 'svg', 'pdf'])
 def test_savefig_accept_pep_519(ext):
-    from tempfile import NamedTemporaryFile
-
     class FakeFSPathClass(object):
         def __init__(self, path):
             self._path = path
@@ -288,11 +287,8 @@ def test_savefig_accept_pep_519(ext):
 
     fig, ax = plt.subplots()
     ax.plot([1, 2], [3, 4])
-
-    tmpfile = NamedTemporaryFile(suffix='.{}'.format(ext))
-    tmpfile.close()
-    pep519_path = FakeFSPathClass(tmpfile.name)
-    fig.savefig(pep519_path)
+    with closed_tempfile(suffix='.{}'.format(ext)) as fname:
+        fig.savefig(FakeFSPathClass(fname))
 
 
 @pytest.mark.parametrize('ext', ['png', 'svg', 'pdf'])
@@ -300,12 +296,9 @@ def test_savefig_accept_pathlib(ext):
     try:
         from pathlib import Path
     except ImportError:
-        raise pytest.skipd("pathlib not installed")
-    from tempfile import NamedTemporaryFile
+        skip("pathlib not installed")
 
     fig, ax = plt.subplots()
     ax.plot([1, 2], [3, 4])
-    tmpfile = NamedTemporaryFile(suffix='.{}'.format(ext))
-    tmpfile.close()
-    path = Path(tmpfile.name)
-    fig.savefig(path)
+    with closed_tempfile(suffix='.{}'.format(ext)) as fname:
+        fig.savefig(Path(fname))

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -273,3 +273,39 @@ def test_autofmt_xdate(which):
     if which in ('both', 'minor'):
         for label in fig.axes[0].get_xticklabels(True, 'minor'):
             assert int(label.get_rotation()) == angle
+
+
+@pytest.mark.parametrize('ext', ['png', 'svg', 'pdf'])
+def test_savefig_accept_pep_519(ext):
+    from tempfile import NamedTemporaryFile
+
+    class FakeFSPathClass(object):
+        def __init__(self, path):
+            self._path = path
+
+        def __fspath__(self):
+            return self._path
+
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [3, 4])
+
+    tmpfile = NamedTemporaryFile(suffix='.{}'.format(ext))
+    tmpfile.close()
+    pep519_path = FakeFSPathClass(tmpfile.name)
+    fig.savefig(pep519_path)
+
+
+@pytest.mark.parametrize('ext', ['png', 'svg', 'pdf'])
+def test_savefig_accept_pathlib(ext):
+    try:
+        from pathlib import Path
+    except ImportError:
+        raise pytest.skipd("pathlib not installed")
+    from tempfile import NamedTemporaryFile
+
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [3, 4])
+    tmpfile = NamedTemporaryFile(suffix='.{}'.format(ext))
+    tmpfile.close()
+    path = Path(tmpfile.name)
+    fig.savefig(path)

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -8,7 +8,7 @@ import tempfile
 import warnings
 
 import pytest
-
+from matplotlib.testing import closed_tempfile
 from matplotlib.font_manager import (
     findfont, FontProperties, fontManager, json_dump, json_load, get_font,
     get_fontconfig_fonts, is_opentype_cff_font, fontManager as fm)
@@ -41,15 +41,9 @@ def test_font_priority():
 def test_json_serialization():
     # on windows, we can't open a file twice, so save the name and unlink
     # manually...
-    try:
-        name = None
-        with tempfile.NamedTemporaryFile(delete=False) as temp:
-            name = temp.name
-        json_dump(fontManager, name)
-        copy = json_load(name)
-    finally:
-        if name and os.path.exists(name):
-            os.remove(name)
+    with closed_tempfile(".json") as temp:
+        json_dump(fontManager, temp)
+        copy = json_load(temp)
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', 'findfont: Font family.*not found')
         for prop in ({'family': 'STIXGeneral'},

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -783,3 +783,34 @@ def test_empty_imshow():
 def test_imshow_float128():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((3, 3), dtype=np.longdouble))
+
+
+def test_imsave_accept_pep_519():
+    from tempfile import NamedTemporaryFile
+
+    class FakeFSPathClass(object):
+        def __init__(self, path):
+            self._path = path
+
+        def __fspath__(self):
+            return self._path
+
+    a = np.array([[1, 2], [3, 4]])
+    tmpfile = NamedTemporaryFile(suffix='.pdf')
+    tmpfile.close()
+    pep519_path = FakeFSPathClass(tmpfile.name)
+    plt.imsave(pep519_path, a)
+
+
+def test_imsave_accept_pathlib():
+    try:
+        from pathlib import Path
+    except ImportError:
+        raise pytest.skip("pathlib not installed")
+    from tempfile import NamedTemporaryFile
+
+    a = np.array([[1, 2], [3, 4]])
+    tmpfile = NamedTemporaryFile(suffix='.pdf')
+    tmpfile.close()
+    path = Path(tmpfile.name)
+    plt.imsave(path, a)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_array_equal
 from matplotlib.testing.decorators import image_comparison
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
+from matplotlib.testing import closed_tempfile
 from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
 from matplotlib import rcParams, rc_context
 from matplotlib import patches
@@ -786,8 +787,6 @@ def test_imshow_float128():
 
 
 def test_imsave_accept_pep_519():
-    from tempfile import NamedTemporaryFile
-
     class FakeFSPathClass(object):
         def __init__(self, path):
             self._path = path
@@ -796,10 +795,9 @@ def test_imsave_accept_pep_519():
             return self._path
 
     a = np.array([[1, 2], [3, 4]])
-    tmpfile = NamedTemporaryFile(suffix='.pdf')
-    tmpfile.close()
-    pep519_path = FakeFSPathClass(tmpfile.name)
-    plt.imsave(pep519_path, a)
+    with closed_tempfile(suffix='.pdf') as fname:
+        pep519_path = FakeFSPathClass(fname)
+        plt.imsave(pep519_path, a)
 
 
 def test_imsave_accept_pathlib():
@@ -807,10 +805,8 @@ def test_imsave_accept_pathlib():
         from pathlib import Path
     except ImportError:
         raise pytest.skip("pathlib not installed")
-    from tempfile import NamedTemporaryFile
 
     a = np.array([[1, 2], [3, 4]])
-    tmpfile = NamedTemporaryFile(suffix='.pdf')
-    tmpfile.close()
-    path = Path(tmpfile.name)
-    plt.imsave(path, a)
+    with closed_tempfile(suffix='.pdf') as fname:
+        path = Path(fname)
+        plt.imsave(path, a)

--- a/lib/matplotlib/tests/test_testing.py
+++ b/lib/matplotlib/tests/test_testing.py
@@ -1,0 +1,21 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import os.path
+
+from matplotlib.testing import closed_tempfile
+
+
+def test_closed_tempfile():
+    with closed_tempfile(".txt") as fname:
+        assert os.path.exists(fname)
+        assert fname.endswith(".txt")
+        name = fname
+    assert os.path.exists(name)
+
+
+def test_closed_tempfile_text():
+    text = "This is a test"
+    with closed_tempfile(".txt", text=text) as f:
+        with open(f, "rt") as g:
+            assert text == g.read()


### PR DESCRIPTION
Thank you so much for your PR! To help us review, fill out the form to the best of your ability. Also, please make use of the development guide at http://matplotlib.org/devdocs/devel/index.html

<!--- Provide a general summary of your changes in the Title above, for example "Raises ValueError on Non-Numeric Input to set_xlim". Please avoid non-descriptive titles such as "Addresses issue #8576"-->
Replaces  #6788 to support the Path protocol (pep 519)

## PR Summary
<!--- Please provide at least 1-2 sentences describing the pull request in detail. Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## PR Checklist
- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

