### PR TITLE
More robust check for numpoints in legend_handler.

### DIFF
--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -149,15 +149,14 @@ class HandlerNpoints(HandlerBase):
         numpoints = self.get_numpoints(legend)
 
         if numpoints > 1:
-            # we put some pad here to compensate the size of the
-            # marker
+            # we put some pad here to compensate the size of the marker
             pad = self._marker_pad * fontsize
             xdata = np.linspace(-xdescent + pad,
                                 -xdescent + width - pad,
                                 numpoints)
             xdata_marker = xdata
-        elif numpoints == 1:
-            xdata = np.linspace(-xdescent, -xdescent+width, 2)
+        else:
+            xdata = np.linspace(-xdescent, -xdescent + width, 2)
             xdata_marker = [-xdescent + 0.5 * width]
 
         return xdata, xdata_marker


### PR DESCRIPTION
Alternate for #8478 (see https://github.com/matplotlib/matplotlib/pull/8478#issuecomment-294053238) and #6949.  Fixes https://github.com/matplotlib/matplotlib/issues/6921: ""Error: local variable 'xdata' referenced before assignment" in legend_handler.py"

Feel free to push / force-push to the branch.