### PR TITLE
[MRG+1] FIX markevery only accepts builtin integers, not numpy integers

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -144,7 +144,7 @@ def _mark_every_path(markevery, tpath, affine, ax_transform):
     elif isinstance(markevery, int):
         markevery = (0, markevery)
     # if just an numpy int, assume starting at 0 and make a tuple
-    elif isinstance(markevery, np.int64):
+    elif isinstance(markevery, (int, np.integer)):
         markevery = (0, markevery.item())
 
     if isinstance(markevery, tuple):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -143,6 +143,9 @@ def _mark_every_path(markevery, tpath, affine, ax_transform):
     # if just an int, assume starting at 0 and make a tuple
     elif isinstance(markevery, int):
         markevery = (0, markevery)
+    # if just an numpy int, assume starting at 0 and make a tuple
+    elif isinstance(markevery, np.int64):
+        markevery = (0, markevery.item())
 
     if isinstance(markevery, tuple):
         if len(markevery) != 2:

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -144,7 +144,7 @@ def _mark_every_path(markevery, tpath, affine, ax_transform):
     elif isinstance(markevery, int):
         markevery = (0, markevery)
     # if just an numpy int, assume starting at 0 and make a tuple
-    elif isinstance(markevery, (int, np.integer)):
+    elif isinstance(markevery, np.integer):
         markevery = (0, markevery.item())
 
     if isinstance(markevery, tuple):


### PR DESCRIPTION
This is the PR for #8057 
markevery now accepts numpy integers


