### PR TITLE
[MRG+1] Fix markup in plt.subplots docstring.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1125,9 +1125,8 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         :class:`~matplotlib.gridspec.GridSpec` constructor used to create the
         grid the subplots are placed on.
 
-    fig_kw : dict, optional
-        Dict with keywords passed to the :func:`figure` call.  Note that all
-        keywords not recognized above will be automatically included here.
+    **fig_kw :
+        All additional keyword arguments are passed to the :func:`figure` call.
 
     Returns
     -------


### PR DESCRIPTION
(does not apply to Figure.subplots, which does not take fig_kw).

closes #8078 
see http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html for markup (numpydoc itself does not have an example for that but I hope that it works too...)