### PR TITLE
Clarify that Path.contains_x implicitly closes the Path.

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -482,13 +482,12 @@ class Path(object):
 
     def contains_point(self, point, transform=None, radius=0.0):
         """
-        Returns *True* if the path contains the given point.
+        Returns whether the (closed) path contains the given point.
 
-        If *transform* is not *None*, the path will be transformed
-        before performing the test.
+        If *transform* is not ``None``, the path will be transformed before
+        performing the test.
 
-        *radius* allows the path to be made slightly larger or
-        smaller.
+        *radius* allows the path to be made slightly larger or smaller.
         """
         if transform is not None:
             transform = transform.frozen()
@@ -503,14 +502,13 @@ class Path(object):
 
     def contains_points(self, points, transform=None, radius=0.0):
         """
-        Returns a bool array which is *True* if the path contains the
-        corresponding point.
+        Returns a bool array which is ``True`` if the (closed) path contains
+        the corresponding point.
 
-        If *transform* is not *None*, the path will be transformed
-        before performing the test.
+        If *transform* is not ``None``, the path will be transformed before
+        performing the test.
 
-        *radius* allows the path to be made slightly larger or
-        smaller.
+        *radius* allows the path to be made slightly larger or smaller.
         """
         if transform is not None:
             transform = transform.frozen()
@@ -519,10 +517,10 @@ class Path(object):
 
     def contains_path(self, path, transform=None):
         """
-        Returns *True* if this path completely contains the given path.
+        Returns whether this (closed) path completely contains the given path.
 
-        If *transform* is not *None*, the path will be transformed
-        before performing the test.
+        If *transform* is not ``None``, the path will be transformed before
+        performing the test.
         """
         if transform is not None:
             transform = transform.frozen()


### PR DESCRIPTION
Also minor rewordings, markup fixes.

Closes #8038.