### PR TITLE
Remove codecov coverage targets.

### DIFF
--- a/ci/codecov.yml
+++ b/ci/codecov.yml
@@ -10,19 +10,21 @@ coverage:
   status:
     patch:
       default:
-        target: '80'
+        target: 50%
         if_no_uploads: error
         if_not_found: success
         if_ci_failed: failure
     project:
       default: false
       library:
-        target: auto
+        target: 50%
         if_no_uploads: error
         if_not_found: success
         if_ci_failed: failure
         paths: '!lib/.*/tests/.*'
-
       tests:
-        target: 97.9%
+        target: auto
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
         paths: 'lib/.*/tests/.*'


### PR DESCRIPTION
As mentioned in the conversation starting at

https://gitter.im/matplotlib/matplotlib?at=58eed50a69a692963ea5e238

codecov seems to be failing PR builds on the basis of incorrectly
computed coverage deltas.  This PR sets the required coverage values to
zero, so that the coverage is still computed but does not affect build
anymore.

<!--Thank you so much for your PR! To help us review, fill out the form to the best of your ability. Please make use of the development guide at http://matplotlib.org/devdocs/devel/index.html-->

<!--- Provide a general summary of your changes in the title above, for example "Raises ValueError on Non-Numeric Input to set_xlim". Please avoid non-descriptive titles such as "Addresses issue #8576"-->

## PR Summary
<!--- Please provide at least 1-2 sentences describing the pull request in detail. Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## PR Checklist
- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in. Please let us know 
if the reviews are unclear or the recommended next step seems overly demanding , or if you would like help in addressing a reviewer's comments. And please ping us if you've been waiting too long to hear back on your PR-->
