### PR TITLE
[MRG+1] Remove useless, confusing check in hist().

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6174,9 +6174,6 @@ or tuple of floats
             if len(color) != nx:
                 raise ValueError("color kwarg must have one color per dataset")
 
-        # Save the datalimits for the same reason:
-        _saved_bounds = self.dataLim.bounds
-
         # If bins are not specified either explicitly or via range,
         # we need to figure out the range required for all datasets,
         # and supply that to np.histogram.


### PR DESCRIPTION
_saved_bounds is not used anywhere.  It was introduced in c8af84ae9b6c3e7e78ef1f16a762999dad77be12 and even then was only used for numpy<=1.2.

Closes https://github.com/matplotlib/matplotlib/issues/7754.

<!--Thank you so much for your PR! To help us review, fill out the form to the best of your ability. Please make use of the development guide at http://matplotlib.org/devdocs/devel/index.html-->

<!--- Provide a general summary of your changes in the title above, for example "Raises ValueError on Non-Numeric Input to set_xlim". Please avoid non-descriptive titles such as "Addresses issue #8576"-->

## PR Summary
<!--- Please provide at least 1-2 sentences describing the pull request in detail. Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## PR Checklist
- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in. Please let us know 
if the reviews are unclear or the recommended next step seems overly demanding , or if you would like help in addressing a reviewer's comments. And please ping us if you've been waiting too long to hear back on your PR-->
