### PR TITLE
STY: fix whitespace in svg_tooltip.py example

### DIFF
--- a/examples/user_interfaces/svg_tooltip.py
+++ b/examples/user_interfaces/svg_tooltip.py
@@ -39,10 +39,12 @@ labels = ['This is a blue rectangle.', 'This is a green rectangle']
 
 for i, (item, label) in enumerate(zip(shapes, labels)):
     patch = ax.add_patch(item)
-    annotate = ax.annotate(labels[i], xy=item.get_xy(), xytext=(0, 0), 
-                           textcoords='offset points', color='w', ha='center', 
-                           fontsize=8, bbox=dict(boxstyle='round, pad=.5', fc=(.1, .1, .1, .92), 
-                                                 ec=(1., 1., 1.), lw=1, zorder=1))
+    annotate = ax.annotate(labels[i], xy=item.get_xy(), xytext=(0, 0),
+                           textcoords='offset points', color='w', ha='center',
+                           fontsize=8, bbox=dict(boxstyle='round, pad=.5',
+                                                 fc=(.1, .1, .1, .92),
+                                                 ec=(1., 1., 1.), lw=1,
+                                                 zorder=1))
 
     ax.add_patch(patch)
     patch.set_gid('mypatch_{:03d}'.format(i))


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form to the best of your ability. Please make use of the development guide at http://matplotlib.org/devdocs/devel/index.html-->

<!--- Provide a general summary of your changes in the title above, for example "Raises ValueError on Non-Numeric Input to set_xlim". Please avoid non-descriptive titles such as "Addresses issue #8576"-->

## PR Summary
<!--- Please provide at least 1-2 sentences describing the pull request in detail. Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes pep8 tests on 2.0.x introduced via backport of #8324 
## PR Checklist
- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in. Please let us know 
if the reviews are unclear or the recommended next step seems overly demanding , or if you would like help in addressing a reviewer's comments. And please ping us if you've been waiting too long to hear back on your PR-->
