### PR TITLE
Add tests for the external process calls

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -208,3 +208,15 @@ def test_pdf_savefig_when_color_is_none(tmpdir):
     fig.savefig(str(expected_image), format='eps')
     result = compare_images(str(actual_image), str(expected_image), 0)
     assert result is None
+
+
+def test_failing_latex(tmpdir):
+    """Test failing latex subprocess call"""
+    path = tmpdir.join("tmpoutput.pdf")
+
+    rcParams['text.usetex'] = True
+
+    # This failes with "Double subscript"
+    plt.xlabel("$%f_2_2$" % np.random.random())
+    with pytest.raises(RuntimeError) as excinfo:
+        plt.savefig(path)

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -12,7 +12,7 @@ import six
 
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib import patheffects
+from matplotlib import patheffects, rcParams
 from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 
@@ -174,3 +174,16 @@ def test_determinism_all():
 def test_determinism_all_tex():
     """Test for reproducible PS/tex output"""
     _determinism_check(format="ps", usetex=True)
+
+
+@needs_usetex
+def test_failing_latex(tmpdir):
+    """Test failing latex subprocess call"""
+    path = tmpdir.join("tmpoutput.ps")
+
+    rcParams['text.usetex'] = True
+
+    # This failes with "Double subscript"
+    plt.xlabel("$%f_2_2$" % np.random.random())
+    with pytest.raises(RuntimeError) as excinfo:
+        plt.savefig(path)


### PR DESCRIPTION
This PR tries to add tests for #7572 and tests mainly the dvi and latex backend.

I could not find a way to test e.g. the png backend as this requires a working dvi in the first place, but would then fail in the `dvipng` step.