### PR TITLE
Update front page so there's only one gallery

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -75,9 +75,8 @@ function getSnippet(id, url) {
   <p>Matplotlib tries to make easy things easy and hard things possible.
   You can generate plots, histograms, power spectra, bar charts,
   errorcharts, scatterplots, etc., with just a few lines of code.
-  For a sampling, see the <a href="{{ pathto('users/screenshots')
-  }}">screenshots</a>, <a href="{{ pathto('gallery/index') }}">thumbnail</a> gallery,  and
-    <a href="{{ pathto('examples/index') }}">examples</a> directory</p>
+  For a example, see the <a href="{{ pathto('users/screenshots')
+  }}">screenshots</a> and <a href="{{ pathto('gallery/index') }}">thumbnail</a> gallery.</p>
 
 <p>For simple plotting the <tt>pyplot</tt> module provides a
   MATLAB-like interface, particularly when combined
@@ -100,7 +99,7 @@ function getSnippet(id, url) {
   </script>
 
   <p>Trying to learn how to do a particular kind of plot?  Check out
-  the <a href="{{ pathto('gallery/index') }}">gallery</a>, <a href="{{ pathto('examples/index') }}">examples</a>,
+  the <a href="{{ pathto('gallery/index') }}">examples gallery</a>
   or the <a href="{{ pathto('api/pyplot_summary') }}">list of plotting
   commands</a>.</p>
 

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -38,8 +38,7 @@ endif %}>
         {%- endfor %}
 
         <li><a href="{{ pathto('index') }}">home</a>|&nbsp;</li>
-        <li><a href="{{ pathto('examples/index') }}">examples</a>|&nbsp;</li>
-        <li><a href="{{ pathto('gallery/index') }}">gallery</a>|&nbsp;</li>
+        <li><a href="{{ pathto('gallery/index') }}">examples</a>|&nbsp;</li>
         <li><a href="{{ pathto('api/pyplot_summary') }}">pyplot</a>|&nbsp;</li>
         <li><a href="{{ pathto('contents') }}">docs</a> &raquo;</li>
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,7 +108,12 @@ autodoc_docstring_signature = True
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',
     'filename_pattern': '^((?!sgskip).)*$',
-    'gallery_dirs': 'gallery'}
+    'gallery_dirs': 'gallery',
+    'doc_module': ('matplotlib',),
+    'reference_url': {'matplotlib': None,
+                      'numpy': 'http://docs.scipy.org/doc/numpy/reference',
+                      'scipy': 'http://docs.scipy.org/doc/scipy/reference'},
+}
 
 plot_gallery = True
 


### PR DESCRIPTION
## PR Summary

Updates the front page by replacing `gallery` and `examples` with a single link called `examples`. Also removes references to the old examples page on the front page.

The reason for this is because now the sphinx gallery build is basically duplicating everything that's in the examples page. So I think the current "examples" page is just the gallery minus any images. Better to simplify things with one link.

(I deleted the checklist since it's N/A in this case)