### PR TITLE
[MRG+1] Fix autoscaling with twinx and vspans: consider axis with one pair of finite limits ONLY

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2272,7 +2272,14 @@ class _AxesBase(martist.Artist):
             # ignore non-finite data limits if good limits exist
             finite_dl = [d for d in dl if np.isfinite(d).all()]
             if len(finite_dl):
+                # if finite limits exist for atleast one axis (and the other is infinite), restore the
+                # finite limits
+                x_finite = [d for d in dl if (np.isfinite(d.intervalx).all() and (d not in finite_dl))]
+                y_finite = [d for d in dl if (np.isfinite(d.intervaly).all() and (d not in finite_dl))]
+
                 dl = finite_dl
+                dl.extend(x_finite)
+                dl.extend(y_finite)
 
             bb = mtransforms.BboxBase.union(dl)
             x0, x1 = getattr(bb, interval)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5134,3 +5134,18 @@ def test_minorticks_on(xscale, yscale):
     ax.set_xscale(xscale)
     ax.set_yscale(yscale)
     ax.minorticks_on()
+
+
+def test_twinx_knows_limits():
+    fig, ax = plt.subplots()
+
+    ax.axvspan(1, 2)
+    xtwin = ax.twinx()
+    xtwin.plot([0, 0.5], [1, 2])
+    # control axis
+    fig2, ax2 = plt.subplots()
+
+    ax2.axvspan(1, 2)
+    ax2.plot([0, 0.5], [1, 2])
+
+    assert((xtwin.viewLim.intervalx == ax2.viewLim.intervalx).all())


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Fixes #6284. The problem was that autoscaling was ignoring all axis limits when any of them were infinite. However we should handle this on a case by case basis: If only the x-limits are infinite, we can still use the y-limits, and vice versa. This makes autoscaling work properly with vspans (which only have infinite y-limits).

In order to reproduce the issue (and verify it is fixed), try this:
```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
ax.axvspan(1,2)

bx = ax.twinx()
bx.plot([0,.5], [1,2])
plt.show()
```

If fixed, you should see that the vspan does not disappear.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- n/a New features are documented, with examples if plot related
- n/a Documentation is sphinx and numpydoc compliant
- n/a Added an entry to doc/users/whats_new.rst if major new feature
- n/a Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
