### PR TITLE
Mathtext rendering

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -222,7 +222,7 @@ class RendererAgg(RendererBase):
         # texmanager more efficient.  It is not meant to be used
         # outside the backend
         """
-        if rcParams['text.usetex']:
+        if rcParams['text.usetex'] or ismath=='TeX' or ismath=='TeX!':
             # todo: handle props
             size = prop.get_size_in_points()
             texmanager = self.get_texmanager()

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2142,7 +2142,7 @@ class RendererPdf(RendererBase):
             return draw_text_woven(chunks)
 
     def get_text_width_height_descent(self, s, prop, ismath):
-        if rcParams['text.usetex']:
+        if rcParams['text.usetex'] or ismath=='TeX' or ismath=='TeX!':
             texmanager = self.get_texmanager()
             fontsize = prop.get_size_in_points()
             w, h, d = texmanager.get_text_width_height_descent(s, fontsize,

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -316,7 +316,7 @@ class RendererPS(RendererBase):
         with FontPropertry prop
 
         """
-        if rcParams['text.usetex']:
+        if rcParams['text.usetex'] or ismath=='TeX' or ismath=='TeX!':
             texmanager = self.get_texmanager()
             fontsize = prop.get_size_in_points()
             w, h, d = texmanager.get_text_width_height_descent(s, fontsize,


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

This picks up where #8318 left off and rebases. To quote that PR:

> I discovered that mathtext was being used for certain backends when I was using uselatex=True when adding text with ax.text(). The issue stems from when a text object is created the is_math_text method checks if the usetex=True was used when the text object was created but it returns the string 'TeX' assigned to the ismath variable which is supposed to tell the renderer down the line to treat the object as LaTeX. However, when checking what size to render the object the renderer only checks the rcParams['text.usetex'] instead of checking ismath=='TeX'. What is even more troublesome is that some functions for the renderer will set ismath='TeX!' instead of 'TeX' meaning that you have to check if ismath=='TeX' or ismath=='TeX!' to make sure that the renderer uses LaTeX.
> 
> This is more or less a bandaid to fix the problem because it doesn't make sense to have a line that checks two different types of strings. I fixed it for the two renderers I use most frequently although I am sure other renderers that are LaTeX capable are probably affected.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
