### PR TITLE
Discourage omitting backend in matplotlibrc

### DIFF
--- a/doc/users/customizing.rst
+++ b/doc/users/customizing.rst
@@ -156,6 +156,9 @@ locations, in the following order:
    your customizations to be saved, please move this file to your
    user-specific matplotlib directory.
 
+Once a :file:`matplotlibrc` file has been found, it will *not* search any of
+the other paths.
+
 To display where the currently active :file:`matplotlibrc` file was
 loaded from, one can do the following::
 
@@ -164,6 +167,12 @@ loaded from, one can do the following::
   '/home/foo/.config/matplotlib/matplotlibrc'
 
 See below for a sample :ref:`matplotlibrc file<matplotlibrc-sample>`.
+Although all parameters are optional, you should almost always set the
+`backend` or else matplotlib will choose `Agg`, a *non-interactive* backend.
+This can lead to unexpected behavior, since if you do not have a
+:file:`matplotlibrc` file, it would normally fall back to
+:file:`{INSTALL}/matplotlib/mpl-data/matplotlibrc`, which is often set to an
+interactive backend by the package maintainer.
 
 .. _matplotlibrc-sample:
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -35,6 +35,9 @@
 # You can also deploy your own backend outside of matplotlib by
 # referring to the module name (which must be in the PYTHONPATH) as
 # 'module://my_backend'.
+#
+# If you omit this parameter, it will always default to "Agg", which is a
+# non-interactive backend.
 backend      : $TEMPLATE_BACKEND
 
 # If you are using the Qt4Agg backend, you can choose here


### PR DESCRIPTION
## PR Summary

Remind users who want to customize their `matplotlibrc` to set the backend, or else unexpected behavior can occur as matplotlib defaults to a non-interactive backend.

## PR Checklist

- (n/a) Has Pytest style unit tests
- (n/a) Code is PEP 8 compliant 
- (n/a) New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- (n/a) Added an entry to doc/users/whats_new.rst if major new feature
- (n/a) Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way