### PR TITLE
adding backreferences_dir param

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -113,6 +113,7 @@ sphinx_gallery_conf = {
     'reference_url': {'matplotlib': None,
                       'numpy': 'http://docs.scipy.org/doc/numpy/reference',
                       'scipy': 'http://docs.scipy.org/doc/scipy/reference'},
+    'backreferences_dir': False,
 }
 
 plot_gallery = True


### PR DESCRIPTION
quick fix to keep sphinx gallery from erroring. I'll add a proper backreferences dir in another PR