### PR TITLE
fixing scatter doc

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3762,9 +3762,9 @@ or tuple of floats
                 verts=None, edgecolors=None,
                 **kwargs):
         """
-        Make a scatter plot of `x` vs `y`
+        Make a scatter plot of `x` vs `y`.
 
-        Marker size is scaled by `s` and marker color is mapped to `c`
+        Marker size is scaled by `s` and marker color is mapped to `c`.
 
         Parameters
         ----------


### PR DESCRIPTION
sorry for the barrage of PRs today, but I just noticed that the docstring of `ax.scatter` was getting rendered improperly in the `pyplot` page because it doesn't have a period at the end of the first sentence.