### PR TITLE
TST: remove out-dated antialiased param

### DIFF
--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -129,8 +129,7 @@ def test_mixedsubplots():
     R = np.sqrt(X ** 2 + Y ** 2)
     Z = np.sin(R)
 
-    surf = ax.plot_surface(X, Y, Z, rcount=40, ccount=40,
-                           linewidth=0, antialiased=False)
+    surf = ax.plot_surface(X, Y, Z, rcount=40, ccount=40, linewidth=0)
 
     ax.set_zlim3d(-1, 1)
 


### PR DESCRIPTION

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
Per @WeatherGod 's [request](https://github.com/matplotlib/matplotlib/pull/8346#issuecomment-298111405)
Hopefully this makes the test less flaky. 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 



