### PR TITLE
Improve font weight guessing

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -408,6 +408,7 @@ def ttfFontProperty(font):
     *font* is a :class:`FT2Font` instance.
     """
     name = font.family_name
+    style_name = font.style_name.lower().strip()
 
     #  Styles are: italic, oblique, and normal (default)
 
@@ -443,10 +444,14 @@ def ttfFontProperty(font):
 
     weight = next((w for w in weight_dict if sfnt4.find(w) >= 0), None)
     if not weight:
-        if font.style_flags & ft2font.BOLD:
-            weight = 700
-        else:
+        weight = next((w for w in weight_dict if style_name.find(w) >= 0), None)
+        if weight:
+            pass
+        elif style_name in ["italic", "oblique", "condensed"]:
             weight = 400
+        else:
+            # give up rather than risk making mistakes (reason: #8550)
+            raise KeyError("unknown weight: {!r}".format(font.family_name))
 
     #  Stretch can be absolute and relative
     #  Absolute stretches are: ultra-condensed, extra-condensed, condensed,

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -93,26 +93,26 @@ stretch_dict = {
     'ultra-expanded'  : 900}
 
 weight_dict = {
-    'hair'       : 100,
-    'thin'       : 100,
-    'extralight' : 200,
-    'ultralight' : 200,
-    'light'      : 300,
+    'hair'       :  50,
+    'thin'       :  50,
+    'extralight' : 100,
+    'ultralight' : 100,
+    'light'      : 200,
     'normal'     : 400,
     'regular'    : 400,
     'book'       : 400,
     'plain'      : 400,
-    'roman'      : 400,
     'medium'     : 500,
+    'roman'      : 500,
     'semibold'   : 600,
     'demibold'   : 600,
     'demi'       : 600,
     'bold'       : 700,
+    'heavy'      : 800,
     'extrabold'  : 800,
     'extra bold' : 800,
     'ultrabold'  : 800,
-    'black'      : 900,
-    'heavy'      : 900}
+    'black'      : 900}
 
 font_family_aliases = {
     'serif',

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -93,20 +93,26 @@ stretch_dict = {
     'ultra-expanded'  : 900}
 
 weight_dict = {
-    'ultralight' : 100,
-    'light'      : 200,
+    'hair'       : 100,
+    'thin'       : 100,
+    'extralight' : 200,
+    'ultralight' : 200,
+    'light'      : 300,
     'normal'     : 400,
     'regular'    : 400,
     'book'       : 400,
+    'plain'      : 400,
+    'roman'      : 400,
     'medium'     : 500,
-    'roman'      : 500,
     'semibold'   : 600,
     'demibold'   : 600,
     'demi'       : 600,
     'bold'       : 700,
-    'heavy'      : 800,
+    'extrabold'  : 800,
     'extra bold' : 800,
-    'black'      : 900}
+    'ultrabold'  : 800,
+    'black'      : 900,
+    'heavy'      : 900}
 
 font_family_aliases = {
     'serif',


### PR DESCRIPTION
## PR Summary

Bandaid-ish fix for #8550.  Would like some feedback on whether these are good/bad ideas.

1. Add more font weights ~~and change some existing ones to better fit [Mozzila's developer wiki](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight?v=example#Common_weight_name_mapping)~~: 

    - Added:

       - thin (~~100~~ 50)
       - extralight (~~200~~ 100)
       - plain (400)
       - extrabold and ultrabold (800)

    - ~~Changed:~~

       - ~~ultralight from 100 to 200~~
       - ~~light from 200 to 300~~
       - ~~roman from 500 to 400~~
       - ~~heavy from 800 to 900~~

2. Improve the font-weight guessing logic.  In particular, rather than trusting `style_flags` (which is very limited and inexpressive), the code now inspects `style_name` for keywords.  Some limited testing this on the fonts of my system indicates that most sensible cases are covered.  Otherwise, just bail with `KeyError` so that the font won’t get registered (mitigates #8550).

    The few fonts where the new logic fails have really exotic subfamilies like “Retina” or “Four Italic”, which don’t really map well to the existing font system anyway so I don’t think it’s much of a loss.  We could still check for `style_flags & BOLD`, but testing revealed only one font where this mattered (`Latin Modern Sans Quotation`, which is actually *not* bold despite the bold flag being set!).

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- (n/a) Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way