### PR TITLE
[MRG+1] added basic_units download link to units examples

### DIFF
--- a/examples/units/README.txt
+++ b/examples/units/README.txt
@@ -1,5 +1,7 @@
 .. _units_examples:
 
+.. _units-examples-index:
+
 Units in Matplotlib
 ===================
 

--- a/examples/units/annotate_with_units.py
+++ b/examples/units/annotate_with_units.py
@@ -6,7 +6,11 @@ Annotation with units
 The example illustrates how to create text and arrow
 annotations using a centimeter-scale plot.
 
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
 """
+
 import matplotlib.pyplot as plt
 from basic_units import cm
 

--- a/examples/units/artist_tests.py
+++ b/examples/units/artist_tests.py
@@ -9,6 +9,10 @@ The axis handles unit conversions and the artists keep a pointer to their axis
 parent. You must initialize the artists with the axis instance if you want to
 use them with unit data, or else they will not know how to convert the units
 to scalars.
+
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
 """
 import random
 import matplotlib.lines as lines

--- a/examples/units/bar_demo2.py
+++ b/examples/units/bar_demo2.py
@@ -9,6 +9,9 @@ set the x and y units to override the defaults (ax2, ax3, ax4) and how one can
 set the xlimits using scalars (ax3, current units assumed) or units
 (conversions applied to get the numbers to current units).
 
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
 """
 import numpy as np
 from basic_units import cm, inch

--- a/examples/units/bar_unit_demo.py
+++ b/examples/units/bar_unit_demo.py
@@ -3,9 +3,12 @@
 Group barchart with units
 =========================
 
-This is the same example as
-<a href='http://matplotlib.org/examples/api/barchart_demo.html'>
-the barchart demo</a> in centimeters.
+This is the same example as :doc:`the barchart demo<../api/barchart>`
+the barchart demo in centimeters.
+
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
 """
 
 import numpy as np

--- a/examples/units/bar_unit_demo.py
+++ b/examples/units/bar_unit_demo.py
@@ -4,7 +4,7 @@ Group barchart with units
 =========================
 
 This is the same example as :doc:`the barchart demo<../api/barchart>`
-the barchart demo in centimeters.
+in centimeters.
 
 .. only:: builder_html
 

--- a/examples/units/ellipse_with_units.py
+++ b/examples/units/ellipse_with_units.py
@@ -4,6 +4,10 @@ Ellipse With Units
 ==================
 
 Compare the ellipse generated with arcs versus a polygonal approximation
+
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
 """
 from basic_units import cm
 import numpy as np
@@ -12,7 +16,6 @@ import matplotlib.pyplot as plt
 
 
 xcenter, ycenter = 0.38*cm, 0.52*cm
-#xcenter, ycenter = 0., 0.
 width, height = 1e-1*cm, 3e-1*cm
 angle = -30
 
@@ -33,7 +36,8 @@ y += ycenter
 
 fig = plt.figure()
 ax = fig.add_subplot(211, aspect='auto')
-ax.fill(x, y, alpha=0.2, facecolor='yellow', edgecolor='yellow', linewidth=1, zorder=1)
+ax.fill(x, y, alpha=0.2, facecolor='yellow',
+        edgecolor='yellow', linewidth=1, zorder=1)
 
 e1 = patches.Ellipse((xcenter, ycenter), width, height,
                      angle=angle, linewidth=2, fill=False, zorder=2)
@@ -47,13 +51,12 @@ e2 = patches.Ellipse((xcenter, ycenter), width, height,
 
 
 ax.add_patch(e2)
-
-#fig.savefig('ellipse_compare.png')
 fig.savefig('ellipse_compare')
 
 fig = plt.figure()
 ax = fig.add_subplot(211, aspect='auto')
-ax.fill(x, y, alpha=0.2, facecolor='yellow', edgecolor='yellow', linewidth=1, zorder=1)
+ax.fill(x, y, alpha=0.2, facecolor='yellow',
+        edgecolor='yellow', linewidth=1, zorder=1)
 
 e1 = patches.Arc((xcenter, ycenter), width, height,
                  angle=angle, linewidth=2, fill=False, zorder=2)
@@ -67,8 +70,6 @@ e2 = patches.Arc((xcenter, ycenter), width, height,
 
 
 ax.add_patch(e2)
-
-#fig.savefig('arc_compare.png')
 fig.savefig('arc_compare')
 
 plt.show()

--- a/examples/units/radian_demo.py
+++ b/examples/units/radian_demo.py
@@ -3,10 +3,11 @@
 Radian ticks
 ============
 
-Plot with radians from the basic_units mockup example package.
+Plot using radian units.
 
-This example shows how the unit class can determine the tick locating,
-formatting and axis labeling.
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
 """
 import numpy as np
 from basic_units import radians, degrees, cos

--- a/examples/units/units_sample.py
+++ b/examples/units/units_sample.py
@@ -8,6 +8,10 @@ inches and centimeters using the `xunits` and `yunits` parameters for the
 `plot` function. Note that conversions are applied to get numbers to correct
 units.
 
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
+
 """
 from basic_units import cm, inch
 import matplotlib.pyplot as plt

--- a/examples/units/units_scatter.py
+++ b/examples/units/units_scatter.py
@@ -3,12 +3,12 @@
 Unit handling
 =============
 
-basic_units is a mockup of a true units package used for testing
-purposed, which illustrates the basic interface that a units package
-must provide to matplotlib.
-
 The example below shows support for unit conversions over masked
 arrays.
+
+.. only:: builder_html
+
+   This example requires :download:`basic_units.py <basic_units.py>`
 """
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## PR Summary

Added download link for [basic_units.py](http://matplotlib.org/devdocs/gallery/units/basic_units.html#sphx-glr-gallery-units-basic-units-py) to all [units examples](http://matplotlib.org/devdocs/gallery/index.html#units-in-matplotlib) that require it. Also fixed cross-reference in [bar-unit-demo](http://matplotlib.org/devdocs/gallery/units/bar_unit_demo.html#sphx-glr-gallery-units-bar-unit-demo-py) - which tangentially I think should be deprecated since it seems clunky relative to the [other bar example](http://matplotlib.org/devdocs/gallery/units/bar_demo2.html#sphx-glr-gallery-units-bar-demo2-py). 
Here's a screenshot:
![screen shot 2017-05-01 at 2 02 50 am](https://cloud.githubusercontent.com/assets/1300499/25573330/7355c9bc-2e12-11e7-99db-d77506c05127.png)



<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist
- [x] Code is PEP 8 compliant 
- [x] Documentation is sphinx and numpydoc compliant