### PR TITLE
[MRG+1] Fix AttributeError: 'QPixmap' object has no attribute 'setDevicePixelRatio'

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -588,7 +588,8 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         if is_pyqt5():
             name = name.replace('.png', '_large.png')
         pm = QtGui.QPixmap(os.path.join(self.basedir, name))
-        pm.setDevicePixelRatio(self.canvas._dpi_ratio)
+        if hasattr(pm, 'setDevicePixelRatio'):
+            pm.setDevicePixelRatio(self.canvas._dpi_ratio)
         return QtGui.QIcon(pm)
 
     def _init_toolbar(self):


### PR DESCRIPTION
Re #8440.
Using matplotlib-2.0.1 with PyQt4‑4.11.4, the example `embedding_in_qt4_wtoolbar.py` fails:
```
X:\Python36\lib\site-packages\matplotlib\backends\qt4_compat.py:10: MatplotlibDeprecationWarning: This module has been deprecated in 1.4 in favor of matplotlib.backends.qt_compat
This module will be removed in 1.5, please update your imports.
  warnings.warn(_warn_str, mplDeprecation)
Traceback (most recent call last):
  File "embedding_in_qt4_wtoolbar.py", line 74, in <module>
    main()
  File "embedding_in_qt4_wtoolbar.py", line 69, in main
    form = AppForm()
  File "embedding_in_qt4_wtoolbar.py", line 27, in __init__
    self.create_main_frame()
  File "embedding_in_qt4_wtoolbar.py", line 39, in create_main_frame
    self.mpl_toolbar = NavigationToolbar(self.canvas, self.main_frame)
  File "X:\Python36\lib\site-packages\matplotlib\backends\backend_qt5.py", line 585, in __init__
    NavigationToolbar2.__init__(self, canvas)
  File "X:\Python36\lib\site-packages\matplotlib\backend_bases.py", line 2760, in __init__
    self._init_toolbar()
  File "X:\Python36\lib\site-packages\matplotlib\backends\backend_qt5.py", line 601, in _init_toolbar
    a = self.addAction(self._icon(image_file + '.png'),
  File "X:\Python36\lib\site-packages\matplotlib\backends\backend_qt5.py", line 591, in _icon
    pm.setDevicePixelRatio(self.canvas._dpi_ratio)
AttributeError: 'QPixmap' object has no attribute 'setDevicePixelRatio'
```