### PR TITLE
Minor pytest parametrization

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -27,7 +27,26 @@ needs_tex = pytest.mark.xfail(
     reason="This test needs a TeX installation")
 
 
-def _test_savefig_to_stringio(format='ps', use_log=False):
+@pytest.mark.parametrize('format, use_log, rcParams', [
+    ('ps', False, {}),
+    needs_ghostscript(('ps', False, {'ps.usedistiller': 'ghostscript'})),
+    needs_tex(needs_ghostscript(('ps', False, {'text.latex.unicode': True,
+                                               'text.usetex': True}))),
+    ('eps', False, {}),
+    ('eps', True, {'ps.useafm': True}),
+    needs_tex(needs_ghostscript(('eps', False, {'text.latex.unicode': True,
+                                                'text.usetex': True}))),
+], ids=[
+    'ps',
+    'ps with distiller',
+    'ps with usetex',
+    'eps',
+    'eps afm',
+    'eps with usetex'
+])
+def test_savefig_to_stringio(format, use_log, rcParams):
+    matplotlib.rcParams.update(rcParams)
+
     fig, ax = plt.subplots()
     buffers = [
         six.moves.StringIO(),
@@ -58,41 +77,6 @@ def _test_savefig_to_stringio(format='ps', use_log=False):
     assert values[1] == values[2].replace(b'\r\n', b'\n')
     for buffer in buffers:
         buffer.close()
-
-
-def test_savefig_to_stringio():
-    _test_savefig_to_stringio()
-
-
-@needs_ghostscript
-def test_savefig_to_stringio_with_distiller():
-    matplotlib.rcParams['ps.usedistiller'] = 'ghostscript'
-    _test_savefig_to_stringio()
-
-
-@needs_tex
-@needs_ghostscript
-def test_savefig_to_stringio_with_usetex():
-    matplotlib.rcParams['text.latex.unicode'] = True
-    matplotlib.rcParams['text.usetex'] = True
-    _test_savefig_to_stringio()
-
-
-def test_savefig_to_stringio_eps():
-    _test_savefig_to_stringio(format='eps')
-
-
-def test_savefig_to_stringio_eps_afm():
-    matplotlib.rcParams['ps.useafm'] = True
-    _test_savefig_to_stringio(format='eps', use_log=True)
-
-
-@needs_tex
-@needs_ghostscript
-def test_savefig_to_stringio_with_usetex_eps():
-    matplotlib.rcParams['text.latex.unicode'] = True
-    matplotlib.rcParams['text.usetex'] = True
-    _test_savefig_to_stringio(format='eps')
 
 
 def test_composite_image():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -2,6 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+import pytest
+
 from matplotlib import rc_context
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
@@ -207,7 +209,9 @@ def test_colorbar_single_scatter():
     plt.colorbar(cs)
 
 
-def _test_remove_from_figure(use_gridspec):
+@pytest.mark.parametrize('use_gridspec', [False, True],
+                         ids=['no gridspec', 'with gridspec'])
+def test_remove_from_figure(use_gridspec):
     """
     Test `remove_from_figure` with the specified ``use_gridspec`` setting
     """
@@ -222,22 +226,6 @@ def _test_remove_from_figure(use_gridspec):
     fig.subplots_adjust()
     post_figbox = np.array(ax.figbox)
     assert (pre_figbox == post_figbox).all()
-
-
-def test_remove_from_figure_with_gridspec():
-    """
-    Make sure that `remove_from_figure` removes the colorbar and properly
-    restores the gridspec
-    """
-    _test_remove_from_figure(True)
-
-
-def test_remove_from_figure_no_gridspec():
-    """
-    Make sure that `remove_from_figure` removes a colorbar that was created
-    without modifying the gridspec
-    """
-    _test_remove_from_figure(False)
 
 
 def test_colorbarbase():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -9,7 +9,6 @@ from distutils.version import LooseVersion as V
 import numpy as np
 import pytest
 
-from numpy.testing import assert_equal
 from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
 
 from matplotlib import cycler
@@ -160,8 +159,8 @@ def test_PowerNorm():
     expected = [0, 0, 1/16, 1/4, 1]
     pnorm = mcolors.PowerNorm(2, vmin=0, vmax=8)
     assert_array_almost_equal(pnorm(a), expected)
-    assert_equal(pnorm(a[0]), expected[0])
-    assert_equal(pnorm(a[2]), expected[2])
+    assert pnorm(a[0]) == expected[0]
+    assert pnorm(a[2]) == expected[2]
     assert_array_almost_equal(a[1:], pnorm.inverse(pnorm(a))[1:])
 
     # Clip = True
@@ -169,16 +168,16 @@ def test_PowerNorm():
     expected = [0, 0, 0, 1, 1]
     pnorm = mcolors.PowerNorm(2, vmin=2, vmax=8, clip=True)
     assert_array_almost_equal(pnorm(a), expected)
-    assert_equal(pnorm(a[0]), expected[0])
-    assert_equal(pnorm(a[-1]), expected[-1])
+    assert pnorm(a[0]) == expected[0]
+    assert pnorm(a[-1]) == expected[-1]
 
     # Clip = True at call time
     a = np.array([-0.5, 0, 1, 8, 16], dtype=float)
     expected = [0, 0, 0, 1, 1]
     pnorm = mcolors.PowerNorm(2, vmin=2, vmax=8, clip=False)
     assert_array_almost_equal(pnorm(a, clip=True), expected)
-    assert_equal(pnorm(a[0], clip=True), expected[0])
-    assert_equal(pnorm(a[-1], clip=True), expected[-1])
+    assert pnorm(a[0], clip=True) == expected[0]
+    assert pnorm(a[-1], clip=True) == expected[-1]
 
 
 def test_Normalize():
@@ -652,14 +651,14 @@ def test_conversions():
         mcolors.to_rgba_array([".2", ".5", ".8"]),
         np.vstack([mcolors.to_rgba(c) for c in [".2", ".5", ".8"]]))
     # alpha is properly set.
-    assert_equal(mcolors.to_rgba((1, 1, 1), .5), (1, 1, 1, .5))
-    assert_equal(mcolors.to_rgba(".1", .5), (.1, .1, .1, .5))
+    assert mcolors.to_rgba((1, 1, 1), .5) == (1, 1, 1, .5)
+    assert mcolors.to_rgba(".1", .5) == (.1, .1, .1, .5)
     # builtin round differs between py2 and py3.
-    assert_equal(mcolors.to_hex((.7, .7, .7)), "#b2b2b2")
+    assert mcolors.to_hex((.7, .7, .7)) == "#b2b2b2"
     # hex roundtrip.
     hex_color = "#1234abcd"
-    assert_equal(mcolors.to_hex(mcolors.to_rgba(hex_color), keep_alpha=True),
-                 hex_color)
+    assert mcolors.to_hex(mcolors.to_rgba(hex_color), keep_alpha=True) == \
+        hex_color
 
 
 def test_grey_gray():

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import warnings
 
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_almost_equal
 import pytest
 
 from matplotlib.testing.compare import compare_images
@@ -41,7 +41,7 @@ def image_comparison_expect_rms(im1, im2, tol, expect_rms):
     results = compare_images(im1, im2, tol=tol, in_decorator=True)
 
     if expect_rms is None:
-        assert_equal(None, results)
+        assert results is None
     else:
         assert results is not None
         assert_almost_equal(expect_rms, results['rms'], decimal=4)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -17,8 +17,6 @@ try:
 except ImportError:
     import mock
 
-from numpy.testing import assert_equal
-
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
@@ -184,7 +182,7 @@ def test_date_formatter_strftime():
                 minute=dt.minute,
                 second=dt.second,
                 microsecond=dt.microsecond))
-        assert_equal(formatter.strftime(dt), formatted_date_str)
+        assert formatter.strftime(dt) == formatted_date_str
 
         try:
             # Test strftime("%x") with the current locale.
@@ -192,8 +190,8 @@ def test_date_formatter_strftime():
             locale_formatter = mdates.DateFormatter("%x")
             locale_d_fmt = locale.nl_langinfo(locale.D_FMT)
             expanded_formatter = mdates.DateFormatter(locale_d_fmt)
-            assert_equal(locale_formatter.strftime(dt),
-                         expanded_formatter.strftime(dt))
+            assert locale_formatter.strftime(dt) == \
+                expanded_formatter.strftime(dt)
         except (ImportError, AttributeError):
             pass
 
@@ -211,8 +209,7 @@ def test_date_formatter_callable():
 
     formatter = mdates.AutoDateFormatter(locator)
     formatter.scaled[-10] = callable_formatting_function
-    assert_equal(formatter([datetime.datetime(2014, 12, 25)]),
-                 ['25-12//2014'])
+    assert formatter([datetime.datetime(2014, 12, 25)]) == ['25-12//2014']
 
 
 def test_drange():
@@ -225,12 +222,12 @@ def test_drange():
     delta = datetime.timedelta(hours=1)
     # We expect 24 values in drange(start, end, delta), because drange returns
     # dates from an half open interval [start, end)
-    assert_equal(24, len(mdates.drange(start, end, delta)))
+    assert len(mdates.drange(start, end, delta)) == 24
 
     # if end is a little bit later, we expect the range to contain one element
     # more
     end = end + datetime.timedelta(microseconds=1)
-    assert_equal(25, len(mdates.drange(start, end, delta)))
+    assert len(mdates.drange(start, end, delta)) == 25
 
     # reset end
     end = datetime.datetime(2011, 1, 2, tzinfo=mdates.UTC)
@@ -239,8 +236,8 @@ def test_drange():
     # 4 hours = 1/6 day, this is an "dangerous" float
     delta = datetime.timedelta(hours=4)
     daterange = mdates.drange(start, end, delta)
-    assert_equal(6, len(daterange))
-    assert_equal(mdates.num2date(daterange[-1]), end - delta)
+    assert len(daterange) == 6
+    assert mdates.num2date(daterange[-1]) == (end - delta)
 
 
 def test_empty_date_with_year_formatter():
@@ -331,8 +328,7 @@ def test_auto_date_locator():
     for t_delta, expected in results:
         d2 = d1 + t_delta
         locator = _create_auto_date_locator(d1, d2)
-        assert_equal(list(map(str, mdates.num2date(locator()))),
-                     expected)
+        assert list(map(str, mdates.num2date(locator()))) == expected
 
 
 @image_comparison(baseline_images=['date_inverted_limit'],
@@ -368,7 +364,7 @@ def _test_date2num_dst(date_range, tz_convert):
     expected_ordinalf = [735322.0 + (i * interval_days) for i in range(N)]
     actual_ordinalf = list(mdates.date2num(dt_bxl))
 
-    assert_equal(actual_ordinalf, expected_ordinalf)
+    assert actual_ordinalf == expected_ordinalf
 
 
 def test_date2num_dst():

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from numpy.testing import assert_equal
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison
 from matplotlib.axes import Axes
@@ -24,14 +23,14 @@ def test_figure_label():
     plt.figure(0)
     plt.figure(1)
     plt.figure(3)
-    assert_equal(plt.get_fignums(), [0, 1, 3, 4, 5])
-    assert_equal(plt.get_figlabels(), ['', 'today', '', 'tomorrow', ''])
+    assert plt.get_fignums() == [0, 1, 3, 4, 5]
+    assert plt.get_figlabels() == ['', 'today', '', 'tomorrow', '']
     plt.close(10)
     plt.close()
     plt.close(5)
     plt.close('tomorrow')
-    assert_equal(plt.get_fignums(), [0, 1])
-    assert_equal(plt.get_figlabels(), ['', 'today'])
+    assert plt.get_fignums() == [0, 1]
+    assert plt.get_figlabels() == ['', 'today']
 
 
 def test_fignum_exists():
@@ -40,31 +39,33 @@ def test_fignum_exists():
     plt.figure(2)
     plt.figure('three')
     plt.figure()
-    assert_equal(plt.fignum_exists('one'), True)
-    assert_equal(plt.fignum_exists(2), True)
-    assert_equal(plt.fignum_exists('three'), True)
-    assert_equal(plt.fignum_exists(4), True)
+    assert plt.fignum_exists('one')
+    assert plt.fignum_exists(2)
+    assert plt.fignum_exists('three')
+    assert plt.fignum_exists(4)
     plt.close('one')
     plt.close(4)
-    assert_equal(plt.fignum_exists('one'), False)
-    assert_equal(plt.fignum_exists(4), False)
+    assert not plt.fignum_exists('one')
+    assert not plt.fignum_exists(4)
 
 
 def test_clf_keyword():
     # test if existing figure is cleared with figure() and subplots()
+    text1 = 'A fancy plot'
+    text2 = 'Really fancy!'
+
     fig0 = plt.figure(num=1)
-    fig0.suptitle("A fancy plot")
-    assert_equal([t.get_text() for t in fig0.texts], ["A fancy plot"])
+    fig0.suptitle(text1)
+    assert [t.get_text() for t in fig0.texts] == [text1]
 
     fig1 = plt.figure(num=1, clear=False)
-    fig1.text(0.5, 0.5, "Really fancy!")
+    fig1.text(0.5, 0.5, text2)
     assert fig0 is fig1
-    assert_equal([t.get_text() for t in fig1.texts],
-                 ["A fancy plot", 'Really fancy!'])
+    assert [t.get_text() for t in fig1.texts] == [text1, text2]
 
     fig2, ax2 = plt.subplots(2, 1, num=1, clear=True)
     assert fig0 is fig2
-    assert_equal([t.get_text() for t in fig2.texts], [])
+    assert [t.get_text() for t in fig2.texts] == []
 
 
 @image_comparison(baseline_images=['figure_today'])
@@ -116,7 +117,7 @@ def test_gca():
         assert fig.gca(polar=True) is not ax3
         assert len(w) == 1
     assert fig.gca(polar=True) is not ax2
-    assert_equal(fig.gca().get_geometry(), (1, 1, 1))
+    assert fig.gca().get_geometry() == (1, 1, 1)
 
     fig.sca(ax1)
     assert fig.gca(projection='rectilinear') is ax1
@@ -135,8 +136,8 @@ def test_suptitle_fontproperties():
     fig, ax = plt.subplots()
     fps = FontProperties(size='large', weight='bold')
     txt = fig.suptitle('fontprops title', fontproperties=fps)
-    assert_equal(txt.get_fontsize(), fps.get_size_in_points())
-    assert_equal(txt.get_weight(), fps.get_weight())
+    assert txt.get_fontsize() == fps.get_size_in_points()
+    assert txt.get_weight() == fps.get_weight()
 
 
 @image_comparison(baseline_images=['alpha_background'],
@@ -202,21 +203,21 @@ def test_set_fig_size():
 
     # check figwidth
     fig.set_figwidth(5)
-    assert_equal(fig.get_figwidth(), 5)
+    assert fig.get_figwidth() == 5
 
     # check figheight
     fig.set_figheight(1)
-    assert_equal(fig.get_figheight(), 1)
+    assert fig.get_figheight() == 1
 
     # check using set_size_inches
     fig.set_size_inches(2, 4)
-    assert_equal(fig.get_figwidth(), 2)
-    assert_equal(fig.get_figheight(), 4)
+    assert fig.get_figwidth() == 2
+    assert fig.get_figheight() == 4
 
     # check using tuple to first argument
     fig.set_size_inches((1, 3))
-    assert_equal(fig.get_figwidth(), 1)
-    assert_equal(fig.get_figheight(), 3)
+    assert fig.get_figwidth() == 1
+    assert fig.get_figheight() == 3
 
 
 def test_axes_remove():
@@ -225,7 +226,7 @@ def test_axes_remove():
     for ax in axes.ravel()[:-1]:
         assert ax in fig.axes
     assert axes[-1, -1] not in fig.axes
-    assert_equal(len(fig.axes), 3)
+    assert len(fig.axes) == 3
 
 
 def test_figaspect():

--- a/lib/matplotlib/tests/test_gridspec.py
+++ b/lib/matplotlib/tests/test_gridspec.py
@@ -1,12 +1,11 @@
 import matplotlib.gridspec as gridspec
-from numpy.testing import assert_equal
 import pytest
 
 
 def test_equal():
     gs = gridspec.GridSpec(2, 1)
-    assert_equal(gs[0, 0], gs[0, 0])
-    assert_equal(gs[:, 0], gs[:, 0])
+    assert gs[0, 0] == gs[0, 0]
+    assert gs[:, 0] == gs[:, 0]
 
 
 def test_width_ratios():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -6,7 +6,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-from numpy.testing import assert_equal
 import numpy as np
 
 from matplotlib.testing.decorators import image_comparison
@@ -177,7 +176,7 @@ def test_legend_remove():
     lines = ax.plot(range(10))
     leg = fig.legend(lines, "test")
     leg.remove()
-    assert_equal(fig.legends, [])
+    assert fig.legends == []
     leg = ax.legend("test")
     leg.remove()
     assert ax.get_legend() is None


### PR DESCRIPTION
A few more small bits of parametrization and the removal of `assert_equal` calls which are much simpler as plain `assert`.