### PR TITLE
Make sure circular contours don't throw a warning

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -453,7 +453,10 @@ class ContourLabeler(object):
 
             # Round to integer values but keep as float
             # To allow check against nan below
-            I = [np.floor(I[0]), np.ceil(I[1])]
+            # Ignore nans here to avoid throwing an error on on Appveyor build
+            # (can possibly be removed when build uses numpy 1.13)
+            with np.errstate(invalid='ignore'):
+                I = [np.floor(I[0]), np.ceil(I[1])]
 
             # Actually break contours
             if closed:

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -335,6 +335,7 @@ class ContourLabeler(object):
         part of the contour).
         """
 
+        # Number of contour points
         nsize = len(linecontour)
         if labelwidth > 1:
             xsize = int(np.ceil(nsize / labelwidth))
@@ -354,7 +355,10 @@ class ContourLabeler(object):
         xlast = XX[:, -1].reshape(xsize, 1)
         s = (yfirst - YY) * (xlast - xfirst) - (xfirst - XX) * (ylast - yfirst)
         L = np.sqrt((xlast - xfirst) ** 2 + (ylast - yfirst) ** 2).ravel()
-        dist = np.add.reduce(([(abs(s)[i] / L[i]) for i in range(xsize)]), -1)
+        # Ignore warning that divide by zero throws, as this is a valid option
+        with np.errstate(divide='ignore', invalid='ignore'):
+            dist = np.add.reduce(([(abs(s)[i] / L[i]) for i in range(xsize)]),
+                                 -1)
         x, y, ind = self.get_label_coords(dist, XX, YY, ysize, labelwidth)
 
         # There must be a more efficient way...

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -357,7 +357,7 @@ class ContourLabeler(object):
         L = np.sqrt((xlast - xfirst) ** 2 + (ylast - yfirst) ** 2).ravel()
         # Ignore warning that divide by zero throws, as this is a valid option
         with np.errstate(divide='ignore', invalid='ignore'):
-            dist = np.add.reduce(([(abs(s)[i] / L[i]) for i in range(xsize)]),
+            dist = np.add.reduce([(abs(s)[i] / L[i]) for i in range(xsize)],
                                  -1)
         x, y, ind = self.get_label_coords(dist, XX, YY, ysize, labelwidth)
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -340,3 +340,15 @@ def test_internal_cpp_api():
     with pytest.raises(ValueError) as excinfo:
         qcg.create_filled_contour(1, 0)
     excinfo.match(r'filled contour levels must be increasing')
+
+
+def test_circular_contour_warning():
+    # Check that almost circular contours don't throw a warning
+    with pytest.warns(None) as record:
+        x, y = np.meshgrid(np.linspace(-2, 2, 4), np.linspace(-2, 2, 4))
+        r = np.sqrt(x ** 2 + y ** 2)
+
+        plt.figure()
+        cs = plt.contour(x, y, r)
+        plt.clabel(cs)
+    assert len(record) == 0


### PR DESCRIPTION
Fixes #8529. This feels very hacky though - is there a better way to make division by zero return np.inf and not raise a warning?