### PR TITLE
Only install doc requirements if building docs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ install:
     pip install --upgrade setuptools
   - |
     # Install dependencies from pypi
-    pip install $PRE python-dateutil $NUMPY pyparsing!=2.1.6 $PANDAS cycler codecov coverage $MOCK $NOSE
+    pip install $PRE python-dateutil $NUMPY pyparsing!=2.1.6 $PANDAS cycler codecov coverage $MOCK $NOSE sphinx
     if [[ $BUILD_DOCS == true ]]; then
       pip install $PRE -r doc-requirements.txt
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ install:
     pip install --upgrade setuptools
   - |
     # Install dependencies from pypi
-    pip install $PRE python-dateutil $NUMPY pyparsing!=2.1.6 $PANDAS cycler codecov coverage $MOCK $NOSE sphinx
+    pip install $PRE python-dateutil $NUMPY pyparsing!=2.1.6 $PANDAS cycler codecov coverage $MOCK $NOSE sphinx pillow
     if [[ $BUILD_DOCS == true ]]; then
       pip install $PRE -r doc-requirements.txt
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,9 @@ install:
   - |
     # Install dependencies from pypi
     pip install $PRE python-dateutil $NUMPY pyparsing!=2.1.6 $PANDAS cycler codecov coverage $MOCK $NOSE
-    pip install $PRE -r doc-requirements.txt
+    if [[ $BUILD_DOCS == true ]]; then
+      pip install $PRE -r doc-requirements.txt
+    fi
 
     # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
     pip install $PRE pytest 'pytest-cov>=2.3.1' pytest-faulthandler pytest-rerunfailures pytest-timeout pytest-warnings pytest-xdist $INSTALL_PEP8


### PR DESCRIPTION
Was having a look through `.travis.yml` and noticed that the doc requirements get installed all the time. This PR only installs the requirements if the docs are being built. The extra sphinx dependency is needed for tests in `lib/matplotlib/sphinxext` which are run during normal testing. 