### PR TITLE
linking front thumbnails, updating screenshots + pyplot API page

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -55,18 +55,18 @@ function getSnippet(id, url) {
   interface toolkits.</p>
 
   <div class="responsive_screenshots">
-    <a a href="{{ pathto('users/screenshots') }}">
+    <a a href="{{ pathto('tutorials/01_introductory/sample_plots') }}">
       <div class="responsive_subfig">
-        <img align="middle", src="{{ pathto('_static/membrane_frontpage.png', 1) }}", border="0", alt="screenshots"/>
+        <img align="middle", src="{{ pathto('_images/sphx_glr_membrane_thumb.png', 1) }}", border="0", alt="screenshots"/>
       </div>
       <div class="responsive_subfig">
-        <img align="middle", src="{{ pathto('_static/histogram_frontpage.png', 1) }}", border="0", alt="screenshots"/>
+        <img align="middle", src="{{ pathto('_images/sphx_glr_histogram_thumb1.png', 1) }}", border="0", alt="screenshots"/>
       </div>
       <div class="responsive_subfig">
-        <img align="middle", src="{{ pathto('_static/contour_frontpage.png', 1) }}", border="0", alt="screenshots"/>
+        <img align="middle", src="{{ pathto('_images/sphx_glr_contour_thumb.png', 1) }}", border="0", alt="screenshots"/>
       </div>
       <div class="responsive_subfig">
-        <img align="middle", src="{{ pathto('_static/surface3d_frontpage.png', 1) }}", border="0", alt="screenshots"/>
+        <img align="middle", src="{{ pathto('_images/sphx_glr_3D_thumb.png', 1) }}", border="0", alt="screenshots"/>
       </div>
     </a>
   </div>
@@ -75,8 +75,8 @@ function getSnippet(id, url) {
   <p>Matplotlib tries to make easy things easy and hard things possible.
   You can generate plots, histograms, power spectra, bar charts,
   errorcharts, scatterplots, etc., with just a few lines of code.
-  For a example, see the <a href="{{ pathto('users/screenshots')
-  }}">screenshots</a> and <a href="{{ pathto('gallery/index') }}">thumbnail</a> gallery.</p>
+  For examples, see the <a href="{{ pathto('tutorials/01_introductory/sample_plots')
+  }}">sample plots</a> and <a href="{{ pathto('gallery/index') }}">thumbnail</a> gallery.</p>
 
 <p>For simple plotting the <tt>pyplot</tt> module provides a
   MATLAB-like interface, particularly when combined

--- a/doc/api/pyplot_summary.rst
+++ b/doc/api/pyplot_summary.rst
@@ -1,14 +1,24 @@
-Plotting commands summary
-=========================
+Below we describe several common approaches to plotting with Matplotlib.
+
+.. contents::
+
+The Pyplot API
+--------------
 
 The :mod:`matplotlib.pyplot` module contains functions that allow you to generate
 many kinds of plots quickly. For examples that showcase the use
 of the :mod:`matplotlib.pyplot` module, see the
 :ref:`sphx_glr_tutorials_01_introductory_pyplot.py`
-or the :ref:`pyplots_examples`.
+or the :ref:`pyplots_examples`. We also recommend that you look into
+the object-oriented approach to plotting, described below.
+
+.. currentmodule:: matplotlib.pyplot
+
+.. autofunction:: plotting
 
 The Object-Oriented API
 -----------------------
+
 Most of these functions also exist as methods in the
 :class:`matplotlib.axes.Axes` class. You can use them with the
 so-called "Object Oriented" approach to Matplotlib.
@@ -19,11 +29,13 @@ we recommend using the object-oriented approach for more control
 and customization of your plots. For some examples of the OO approach
 to Matplotlib, see the :ref:`api_examples` examples.
 
-The Pyplot API
---------------
+Colors in Matplotlib
+--------------------
 
-.. currentmodule:: matplotlib.pyplot
+There are many colormaps you can use to map data onto color values.
+Below we list several ways in which color can be utilized in Matplotlib.
 
-.. autofunction:: plotting
+For a more in-depth look at colormaps, see the
+:ref:`sphx_glr_tutorials_colors_colormaps.py` tutorial.
 
 .. autofunction:: colormaps

--- a/doc/api/pyplot_summary.rst
+++ b/doc/api/pyplot_summary.rst
@@ -1,6 +1,27 @@
 Plotting commands summary
 =========================
 
+The :mod:`matplotlib.pyplot` module contains functions that allow you to generate
+many kinds of plots quickly. For examples that showcase the use
+of the :mod:`matplotlib.pyplot` module, see the
+:ref:`sphx_glr_tutorials_01_introductory_pyplot.py`
+or the :ref:`pyplots_examples`.
+
+The Object-Oriented API
+-----------------------
+Most of these functions also exist as methods in the
+:class:`matplotlib.axes.Axes` class. You can use them with the
+so-called "Object Oriented" approach to Matplotlib.
+
+While it is easy to quickly generate plots with the
+:mod:`matplotlib.pyplot` module,
+we recommend using the object-oriented approach for more control
+and customization of your plots. For some examples of the OO approach
+to Matplotlib, see the :ref:`api_examples` examples.
+
+The Pyplot API
+--------------
+
 .. currentmodule:: matplotlib.pyplot
 
 .. autofunction:: plotting

--- a/doc/api/pyplot_summary.rst
+++ b/doc/api/pyplot_summary.rst
@@ -21,13 +21,15 @@ The Object-Oriented API
 
 Most of these functions also exist as methods in the
 :class:`matplotlib.axes.Axes` class. You can use them with the
-so-called "Object Oriented" approach to Matplotlib.
+"Object Oriented" approach to Matplotlib.
 
 While it is easy to quickly generate plots with the
 :mod:`matplotlib.pyplot` module,
 we recommend using the object-oriented approach for more control
-and customization of your plots. For some examples of the OO approach
-to Matplotlib, see the :ref:`api_examples` examples.
+and customization of your plots. See the methods in the
+:meth:`matplotlib.axes.Axes` class for many of the same plotting functions.
+For examples of the OO approach to Matplotlib, see the
+:ref:`API Examples<api_examples>`.
 
 Colors in Matplotlib
 --------------------

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -15,11 +15,11 @@ Overview
    :maxdepth: 2
 
    users/index.rst
-   api/index.rst
    faq/index.rst
    mpl_toolkits/index.rst
    resources/index.rst
    thirdpartypackages/index.rst
+   api/index.rst
    devel/index.rst
    glossary/index.rst
 

--- a/doc/make.py
+++ b/doc/make.py
@@ -52,45 +52,6 @@ def linkcheck():
         [sys.executable]
         + '-msphinx -b linkcheck -d build/doctrees . build/linkcheck'.split())
 
-
-# For generating PNGs of the top row of index.html:
-FRONTPAGE_PY_PATH = "../examples/frontpage/"  # python scripts location
-FRONTPAGE_PNG_PATH = "_static/"  # png files location
-# png files and corresponding generation scripts:
-FRONTPAGE_PNGS = {"surface3d_frontpage.png": "3D.py",
-                  "contour_frontpage.png":   "contour.py",
-                  "histogram_frontpage.png": "histogram.py",
-                  "membrane_frontpage.png":  "membrane.py"}
-
-
-def generate_frontpage_pngs(only_if_needed=True):
-    """Executes the scripts for PNG generation of the top row of index.html.
-
-    If `only_if_needed` is `True`, then the PNG file is only generated, if it
-    doesn't exist or if the python file is newer.
-
-    Note that the element `div.responsive_screenshots` in the file
-    `_static/mpl.css` has the height and cumulative width of the used PNG files
-    as attributes. This ensures that the magnification of those PNGs is <= 1.
-    """
-    for fn_png, fn_py in FRONTPAGE_PNGS.items():
-        pn_png = os.path.join(FRONTPAGE_PNG_PATH, fn_png)  # get full paths
-        pn_py = os.path.join(FRONTPAGE_PY_PATH, fn_py)
-
-        # Read file modification times:
-        mtime_py = os.path.getmtime(pn_py)
-        mtime_png = (os.path.getmtime(pn_png) if os.path.exists(pn_png) else
-                     mtime_py - 1)  # set older time, if file doesn't exist
-
-        if only_if_needed and mtime_py <= mtime_png:
-            continue  # do nothing if png is newer
-
-        # Execute python as subprocess (preferred over os.system()):
-        subprocess.check_call(
-            [sys.executable, pn_py])  # raises CalledProcessError()
-        os.rename(fn_png, pn_png)  # move file to _static/ directory
-
-
 DEPSY_PATH = "_static/depsy_badge.svg"
 DEPSY_URL = "http://depsy.org/api/package/pypi/matplotlib/badge.svg"
 DEPSY_DEFAULT = "_static/depsy_badge_default.svg"
@@ -121,7 +82,6 @@ def fetch_depsy_badge():
 def html(buildername='html'):
     """Build Sphinx 'html' target. """
     check_build()
-    generate_frontpage_pngs()
     fetch_depsy_badge()
 
     rc = '../lib/matplotlib/mpl-data/matplotlibrc'
@@ -213,10 +173,6 @@ def clean():
         for filename in glob.glob(pattern):
             if os.path.exists(filename):
                 os.remove(filename)
-        for fn in FRONTPAGE_PNGS.keys():  # remove generated PNGs
-            pn = os.path.join(FRONTPAGE_PNG_PATH, fn)
-            if os.path.exists(pn):
-                os.remove(os.path.join(pn))
 
 
 def build_all():

--- a/doc/users/examples_index.rst
+++ b/doc/users/examples_index.rst
@@ -1,7 +1,0 @@
-===================
- Selected Examples
-===================
-
-.. toctree::
-
-    screenshots.rst

--- a/doc/users/index.rst
+++ b/doc/users/index.rst
@@ -15,7 +15,6 @@ User's Guide
     intro.rst
     installing.rst
     interactive.rst
-    examples_index
     whats_new.rst
     github_stats.rst
     license.rst

--- a/examples/lines_bars_and_markers/categorical_variables.py
+++ b/examples/lines_bars_and_markers/categorical_variables.py
@@ -13,13 +13,27 @@ many plotting functions.
 """
 import matplotlib.pyplot as plt
 
-names = ['group_a', 'group_b', 'group_c']
-values = [1, 10, 100]
+data = {'apples': 10, 'oranges': 15, 'lemons': 5, 'limes': 20}
+names = list(data.keys())
+values = list(data.values())
 
-fig, axs = plt.subplots(1, 3, figsize=(9, 3))
+fig, axs = plt.subplots(1, 3, figsize=(9, 3), sharey=True)
 axs[0].bar(names, values)
 axs[1].scatter(names, values)
 axs[2].plot(names, values)
 fig.suptitle('Categorical Plotting')
+
+
+###############################################################################
+# This works on both axes:
+
+cat = ["bored", "happy", "bored", "bored", "happy", "bored"]
+dog = ["happy", "happy", "happy", "happy", "bored", "bored"]
+activity = ["combing", "drinking", "feeding", "napping", "playing", "washing"]
+
+fig, ax = plt.subplots()
+ax.plot(activity, dog, label="dog")
+ax.plot(activity, cat, label="cat")
+ax.legend()
 
 plt.show()

--- a/examples/lines_bars_and_markers/categorical_variables.py
+++ b/examples/lines_bars_and_markers/categorical_variables.py
@@ -6,10 +6,8 @@ Plotting categorical variables
 How to use categorical variables in matplotlib.
 
 Many times you want to create a plot that uses categorical variables
-in Matplotlib. For example, your data may naturally fall into
-several "bins" and you're interested in summarizing the data per
-bin. Matplotlib allows you to pass categorical variables directly to
-many plotting functions.
+in Matplotlib. Matplotlib allows you to pass categorical variables directly to
+many plotting functions, which we demonstrate below.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/lines_bars_and_markers/categorical_variables.py
+++ b/examples/lines_bars_and_markers/categorical_variables.py
@@ -1,0 +1,25 @@
+"""
+==============================
+Plotting categorical variables
+==============================
+
+How to use categorical variables in matplotlib.
+
+Many times you want to create a plot that uses categorical variables
+in Matplotlib. For example, your data may naturally fall into
+several "bins" and you're interested in summarizing the data per
+bin. Matplotlib allows you to pass categorical variables directly to
+many plotting functions.
+"""
+import matplotlib.pyplot as plt
+
+names = ['group_a', 'group_b', 'group_c']
+values = [1, 10, 100]
+
+fig, axs = plt.subplots(1, 3, figsize=(9, 3))
+axs[0].bar(names, values)
+axs[1].scatter(names, values)
+axs[2].plot(names, values)
+fig.suptitle('Categorical Plotting')
+
+plt.show()

--- a/examples/lines_bars_and_markers/categorical_variables.py
+++ b/examples/lines_bars_and_markers/categorical_variables.py
@@ -3,7 +3,7 @@
 Plotting categorical variables
 ==============================
 
-How to use categorical variables in matplotlib.
+How to use categorical variables in Matplotlib.
 
 Many times you want to create a plot that uses categorical variables
 in Matplotlib. Matplotlib allows you to pass categorical variables directly to

--- a/tutorials/01_introductory/pyplot.py
+++ b/tutorials/01_introductory/pyplot.py
@@ -124,7 +124,7 @@ plt.show()
 # Plotting with categorical variables
 # ===================================
 #
-# It is also possible to create a plot using categorical variables
+# It is also possible to create a plot using categorical variables.
 # Matplotlib allows you to pass categorical variables directly to
 # many plotting functions. For example:
 

--- a/tutorials/01_introductory/pyplot.py
+++ b/tutorials/01_introductory/pyplot.py
@@ -131,11 +131,15 @@ plt.show()
 names = ['group_a', 'group_b', 'group_c']
 values = [1, 10, 100]
 
-fig, axs = plt.subplots(1, 3, figsize=(9, 3))
-axs[0].bar(names, values)
-axs[1].scatter(names, values)
-axs[2].plot(names, values)
-fig.suptitle('Categorical Plotting')
+plt.figure(1, figsize=(9, 3))
+
+plt.subplot(131)
+plt.bar(names, values)
+plt.subplot(132)
+plt.scatter(names, values)
+plt.subplot(133)
+plt.plot(names, values)
+plt.suptitle('Categorical Plotting')
 plt.show()
 
 ###############################################################################

--- a/tutorials/01_introductory/pyplot.py
+++ b/tutorials/01_introductory/pyplot.py
@@ -119,6 +119,26 @@ plt.ylabel('entry b')
 plt.show()
 
 ###############################################################################
+# .. _plotting-with-categorical-vars:
+#
+# Plotting with categorical variables
+# ===================================
+#
+# It is also possible to create a plot using categorical variables
+# Matplotlib allows you to pass categorical variables directly to
+# many plotting functions. For example:
+
+names = ['group_a', 'group_b', 'group_c']
+values = [1, 10, 100]
+
+fig, axs = plt.subplots(1, 3, figsize=(9, 3))
+axs[0].bar(names, values)
+axs[1].scatter(names, values)
+axs[2].plot(names, values)
+fig.suptitle('Categorical Plotting')
+plt.show()
+
+###############################################################################
 # .. _controlling-line-properties:
 #
 # Controlling line properties

--- a/tutorials/01_introductory/sample_plots.py
+++ b/tutorials/01_introductory/sample_plots.py
@@ -386,6 +386,7 @@ matplotlib supports plotting in the style of `xkcd
 import matplotlib.pyplot as plt
 import numpy as np
 
+np.random.seed(19680801)
 data = np.random.randn(2, 100)
 
 fig, axs = plt.subplots(2, 2, figsize=(5, 5))

--- a/tutorials/01_introductory/sample_plots.py
+++ b/tutorials/01_introductory/sample_plots.py
@@ -1,19 +1,20 @@
-.. _matplotlibscreenshots:
-
-**********************
-Screenshots
-**********************
+"""
+==========================
+Sample plots in Matplotlib
+==========================
 
 Here you'll find a host of example plots with the code that
 generated them.
+
+.. _matplotlibscreenshots:
 
 Simple Plot
 ===========
 
 Here's a very basic :func:`~matplotlib.pyplot.plot` with text labels:
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_simple_plot_001.png
-   :target: ../gallery/pylab_examples/simple_plot.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_simple_plot_001.png
+   :target: ../../gallery/pylab_examples/simple_plot.html
    :align: center
    :scale: 50
 
@@ -27,8 +28,8 @@ Subplot demo
 Multiple axes (i.e. subplots) are created with the
 :func:`~matplotlib.pyplot.subplot` command:
 
-.. figure:: ../gallery/subplots_axes_and_figures/images/sphx_glr_subplot_001.png
-   :target: ../gallery/subplots_axes_and_figures/subplot.html
+.. figure:: ../../gallery/subplots_axes_and_figures/images/sphx_glr_subplot_001.png
+   :target: ../../gallery/subplots_axes_and_figures/subplot.html
    :align: center
    :scale: 50
 
@@ -42,8 +43,8 @@ Histograms
 The :func:`~matplotlib.pyplot.hist` command automatically generates
 histograms and returns the bin counts or probabilities:
 
-.. figure:: ../gallery/statistics/images/sphx_glr_histogram_features_001.png
-   :target: ../gallery/statistics/histogram_features.html
+.. figure:: ../../gallery/statistics/images/sphx_glr_histogram_features_001.png
+   :target: ../../gallery/statistics/histogram_features.html
    :align: center
    :scale: 50
 
@@ -58,8 +59,8 @@ Path demo
 You can add arbitrary paths in matplotlib using the
 :mod:`matplotlib.path` module:
 
-.. figure:: ../gallery/shapes_and_collections/images/sphx_glr_path_patch_001.png
-   :target: ../gallery/shapes_and_collections/path_patch.html
+.. figure:: ../../gallery/shapes_and_collections/images/sphx_glr_path_patch_001.png
+   :target: ../../gallery/shapes_and_collections/path_patch.html
    :align: center
    :scale: 50
 
@@ -74,8 +75,8 @@ The mplot3d toolkit (see :ref:`toolkit_mplot3d-tutorial` and
 :ref:`mplot3d-examples-index`) has support for simple 3d graphs
 including surface, wireframe, scatter, and bar charts.
 
-.. figure:: ../gallery/mplot3d/images/sphx_glr_surface3d_001.png
-   :target: ../gallery/mplot3d/surface3d.html
+.. figure:: ../../gallery/mplot3d/images/sphx_glr_surface3d_001.png
+   :target: ../../gallery/mplot3d/surface3d.html
    :align: center
    :scale: 50
 
@@ -96,8 +97,8 @@ a vector field. In addition to simply plotting the streamlines, it allows you
 to map the colors and/or line widths of streamlines to a separate parameter,
 such as the speed or local intensity of the vector field.
 
-.. figure:: ../gallery/images_contours_and_fields/images/sphx_glr_plot_streamplot_001.png
-   :target: ../gallery/images_contours_and_fields/plot_streamplot.html
+.. figure:: ../../gallery/images_contours_and_fields/images/sphx_glr_plot_streamplot_001.png
+   :target: ../../gallery/images_contours_and_fields/plot_streamplot.html
    :align: center
    :scale: 50
 
@@ -118,8 +119,8 @@ Michael Droettboom built on work by Charlie Moad to provide an extremely
 accurate  8-spline approximation to elliptical arcs (see
 :class:`~matplotlib.patches.Arc`), which are insensitive to zoom level.
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_ellipse_demo_001.png
-   :target: ../gallery/pylab_examples/ellipse_demo.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_ellipse_demo_001.png
+   :target: ../../gallery/pylab_examples/ellipse_demo.html
    :align: center
    :scale: 50
 
@@ -133,17 +134,17 @@ Bar charts
 Bar charts are simple to create using the :func:`~matplotlib.pyplot.bar`
 command, which includes customizations such as error bars:
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_barchart_demo_001.png
-   :target: ../gallery/pylab_examples/barchart_demo.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_barchart_demo_001.png
+   :target: ../../gallery/pylab_examples/barchart_demo.html
    :align: center
    :scale: 50
 
    Barchart Demo
 
 It's also simple to create stacked bars
-(`bar_stacked.py <../gallery/pylab_examples/bar_stacked.html>`_),
+(`bar_stacked.py <../../gallery/pylab_examples/bar_stacked.html>`_),
 or horizontal bar charts
-(`barh.py <../gallery/lines_bars_and_markers/barh.html>`_).
+(`barh.py <../../gallery/lines_bars_and_markers/barh.html>`_).
 
 .. _screenshots_pie_demo:
 
@@ -157,8 +158,8 @@ exploding one or more wedges from the center of the pie, and a shadow effect.
 Take a close look at the attached code, which generates this figure in just
 a few lines of code.
 
-.. figure:: ../gallery/pie_and_polar_charts/images/sphx_glr_pie_features_001.png
-   :target: ../gallery/pie_and_polar_charts/pie_features.html
+.. figure:: ../../gallery/pie_and_polar_charts/images/sphx_glr_pie_features_001.png
+   :target: ../../gallery/pie_and_polar_charts/pie_features.html
    :align: center
    :scale: 50
 
@@ -172,8 +173,8 @@ Table demo
 The :func:`~matplotlib.pyplot.table` command adds a text table
 to an axes.
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_table_demo_001.png
-   :target: ../gallery/pylab_examples/table_demo.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_table_demo_001.png
+   :target: ../../gallery/pylab_examples/table_demo.html
    :align: center
    :scale: 50
 
@@ -192,8 +193,8 @@ in Google's stock price, with marker sizes reflecting the
 trading volume and colors varying with time. Here, the
 alpha attribute is used to make semitransparent circle markers.
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_scatter_demo2_001.png
-   :target: ../gallery/pylab_examples/scatter_demo2.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_scatter_demo2_001.png
+   :target: ../../gallery/pylab_examples/scatter_demo2.html
    :align: center
    :scale: 50
 
@@ -208,10 +209,10 @@ Slider demo
 Matplotlib has basic GUI widgets that are independent of the graphical
 user interface you are using, allowing you to write cross GUI figures
 and widgets.  See :mod:`matplotlib.widgets` and the
-`widget examples <../gallery/index.html>`_.
+`widget examples <../../gallery/index.html>`_.
 
-.. figure:: ../gallery/widgets/images/sphx_glr_slider_demo_001.png
-   :target: ../gallery/widgets/slider_demo.html
+.. figure:: ../../gallery/widgets/images/sphx_glr_slider_demo_001.png
+   :target: ../../gallery/widgets/slider_demo.html
    :align: center
    :scale: 50
 
@@ -226,8 +227,8 @@ Fill demo
 The :func:`~matplotlib.pyplot.fill` command lets you
 plot filled curves and polygons:
 
-.. figure:: ../gallery/lines_bars_and_markers/images/sphx_glr_fill_001.png
-   :target: ../gallery/lines_bars_and_markers/fill.html
+.. figure:: ../../gallery/lines_bars_and_markers/images/sphx_glr_fill_001.png
+   :target: ../../gallery/lines_bars_and_markers/fill.html
    :align: center
    :scale: 50
 
@@ -243,8 +244,8 @@ Date demo
 You can plot date data with major and minor ticks and custom tick formatters
 for both.
 
-.. figure:: ../gallery/api/images/sphx_glr_date_001.png
-   :target: ../gallery/api/date.html
+.. figure:: ../../gallery/api/images/sphx_glr_date_001.png
+   :target: ../../gallery/api/date.html
    :align: center
    :scale: 50
 
@@ -263,8 +264,8 @@ The :func:`~matplotlib.pyplot.semilogx`,
 :func:`~matplotlib.pyplot.loglog` functions simplify the creation of
 logarithmic plots.
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_log_demo_001.png
-   :target: ../gallery/pylab_examples/log_demo.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_log_demo_001.png
+   :target: ../../gallery/pylab_examples/log_demo.html
    :align: center
    :scale: 50
 
@@ -280,8 +281,8 @@ Polar plots
 
 The :func:`~matplotlib.pyplot.polar` command generates polar plots.
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_polar_demo_001.png
-   :target: ../gallery/pylab_examples/polar_demo.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_polar_demo_001.png
+   :target: ../../gallery/pylab_examples/polar_demo.html
    :align: center
    :scale: 50
 
@@ -297,8 +298,8 @@ The :func:`~matplotlib.pyplot.legend` command automatically
 generates figure legends, with MATLAB-compatible legend placement
 commands.
 
-.. figure:: ../gallery/api/images/sphx_glr_legend_001.png
-   :target: ../gallery/api/legend.html
+.. figure:: ../../gallery/api/images/sphx_glr_legend_001.png
+   :target: ../../gallery/api/legend.html
    :align: center
    :scale: 50
 
@@ -317,8 +318,8 @@ expressions using `FreeType <https://www.freetype.org/>`_
 and the DejaVu, BaKoMa computer modern, or `STIX <http://www.stixfonts.org>`_
 fonts.  See the :mod:`matplotlib.mathtext` module for additional details.
 
-.. figure:: ../gallery/pylab_examples/images/sphx_glr_mathtext_examples_001.png
-   :target: ../gallery/pylab_examples/mathtext_examples.html
+.. figure:: ../../gallery/pylab_examples/images/sphx_glr_mathtext_examples_001.png
+   :target: ../../gallery/pylab_examples/mathtext_examples.html
    :align: center
    :scale: 50
 
@@ -338,8 +339,8 @@ Although matplotlib's internal math rendering engine is quite
 powerful, sometimes you need TeX. Matplotlib supports external TeX
 rendering of strings with the *usetex* option.
 
-.. figure:: ../gallery/pyplots/images/sphx_glr_tex_demo_001.png
-   :target: ../gallery/pyplots/tex_demo.html
+.. figure:: ../../gallery/pyplots/images/sphx_glr_tex_demo_001.png
+   :target: ../../gallery/pyplots/tex_demo.html
    :align: center
    :scale: 50
 
@@ -354,7 +355,7 @@ You can embed matplotlib into pygtk, wx, Tk, or Qt applications.
 Here is a screenshot of an EEG viewer called `pbrain
 <https://github.com/nipy/pbrain>`__.
 
-.. image:: ../_static/eeg_small.png
+.. image:: ../../_static/eeg_small.png
 
 The lower axes uses :func:`~matplotlib.pyplot.specgram`
 to plot the spectrogram of one of the EEG channels.
@@ -373,30 +374,24 @@ XKCD-style sketch plots
 matplotlib supports plotting in the style of `xkcd
 <http://www.xkcd.com/>`.
 
-.. figure:: ../gallery/showcase/images/sphx_glr_xkcd_001.png
-   :target: ../gallery/showcase/xkcd.html
+.. figure:: ../../gallery/showcase/images/sphx_glr_xkcd_001.png
+   :target: ../../gallery/showcase/xkcd.html
    :align: center
    :scale: 50
 
    Xkcd
+"""
 
+# An extra set of sample plots for the thumbnail image.
+import matplotlib.pyplot as plt
+import numpy as np
 
+data = np.random.randn(2, 100)
 
+fig, axs = plt.subplots(2, 2, figsize=(5, 5))
+axs[0, 0].hist(data[0])
+axs[1, 0].scatter(data[0], data[1])
+axs[0, 1].plot(data[0], data[1])
+axs[1, 1].hist2d(data[0], data[1])
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+plt.show()

--- a/tutorials/01_introductory/sample_plots.py
+++ b/tutorials/01_introductory/sample_plots.py
@@ -8,10 +8,11 @@ generated them.
 
 .. _matplotlibscreenshots:
 
-Simple Plot
-===========
+Line Plot
+=========
 
-Here's a very basic :func:`~matplotlib.pyplot.plot` with text labels:
+Here's now to create a line plot with  text labels using
+:func:`~matplotlib.pyplot.plot`.
 
 .. figure:: ../../gallery/pylab_examples/images/sphx_glr_simple_plot_001.png
    :target: ../../gallery/pylab_examples/simple_plot.html
@@ -56,7 +57,7 @@ histograms and returns the bin counts or probabilities:
 Path demo
 =========
 
-You can add arbitrary paths in matplotlib using the
+You can add other paths in matplotlib using the
 :mod:`matplotlib.path` module:
 
 .. figure:: ../../gallery/shapes_and_collections/images/sphx_glr_path_patch_001.png
@@ -131,8 +132,8 @@ accurate  8-spline approximation to elliptical arcs (see
 Bar charts
 ==========
 
-Bar charts are simple to create using the :func:`~matplotlib.pyplot.bar`
-command, which includes customizations such as error bars:
+Use the :func:`~matplotlib.pyplot.bar` command to make bar charts, which
+includes customizations such as error bars:
 
 .. figure:: ../../gallery/pylab_examples/images/sphx_glr_barchart_demo_001.png
    :target: ../../gallery/pylab_examples/barchart_demo.html
@@ -141,7 +142,7 @@ command, which includes customizations such as error bars:
 
    Barchart Demo
 
-It's also simple to create stacked bars
+You can also create stacked bars
 (`bar_stacked.py <../../gallery/pylab_examples/bar_stacked.html>`_),
 or horizontal bar charts
 (`barh.py <../../gallery/lines_bars_and_markers/barh.html>`_).
@@ -152,7 +153,7 @@ or horizontal bar charts
 Pie charts
 ==========
 
-The :func:`~matplotlib.pyplot.pie` command allows you to easily create pie
+The :func:`~matplotlib.pyplot.pie` command allows you to create pie
 charts.  Optional features include auto-labeling the percentage of area,
 exploding one or more wedges from the center of the pie, and a shadow effect.
 Take a close look at the attached code, which generates this figure in just

--- a/tutorials/01_introductory/sample_plots.py
+++ b/tutorials/01_introductory/sample_plots.py
@@ -11,7 +11,7 @@ generated them.
 Line Plot
 =========
 
-Here's now to create a line plot with  text labels using
+Here's how to create a line plot with  text labels using
 :func:`~matplotlib.pyplot.plot`.
 
 .. figure:: ../../gallery/pylab_examples/images/sphx_glr_simple_plot_001.png
@@ -57,7 +57,7 @@ histograms and returns the bin counts or probabilities:
 Path demo
 =========
 
-You can add other paths in matplotlib using the
+You can add arbitrary paths in Matplotlib using the
 :mod:`matplotlib.path` module:
 
 .. figure:: ../../gallery/shapes_and_collections/images/sphx_glr_path_patch_001.png
@@ -84,7 +84,7 @@ including surface, wireframe, scatter, and bar charts.
    Surface3d
 
 Thanks to John Porter, Jonathon Taylor, Reinier Heeres, and Ben Root for
-the `mplot3d` toolkit. This toolkit is included with all standard matplotlib
+the `mplot3d` toolkit. This toolkit is included with all standard Matplotlib
 installs.
 
 .. _screenshots_ellipse_demo:
@@ -115,7 +115,7 @@ Ellipses
 
 In support of the
 `Phoenix <http://www.jpl.nasa.gov/news/phoenix/main.php>`_ mission to
-Mars (which used matplotlib to display ground tracking of spacecraft),
+Mars (which used Matplotlib to display ground tracking of spacecraft),
 Michael Droettboom built on work by Charlie Moad to provide an extremely
 accurate  8-spline approximation to elliptical arcs (see
 :class:`~matplotlib.patches.Arc`), which are insensitive to zoom level.
@@ -242,8 +242,8 @@ Thanks to Andrew Straw for adding this function.
 Date demo
 =========
 
-You can plot date data with major and minor ticks and custom tick formatters
-for both.
+You can plot timeseries data with major and minor ticks and custom
+tick formatters for both.
 
 .. figure:: ../../gallery/api/images/sphx_glr_date_001.png
    :target: ../../gallery/api/date.html
@@ -313,7 +313,7 @@ Thanks to Charles Twardy for input on the legend command.
 Mathtext_examples
 =================
 
-Below is a sampling of the many TeX expressions now supported by matplotlib's
+Below is a sampling of the many TeX expressions now supported by Matplotlib's
 internal mathtext engine.  The mathtext module provides TeX style mathematical
 expressions using `FreeType <https://www.freetype.org/>`_
 and the DejaVu, BaKoMa computer modern, or `STIX <http://www.stixfonts.org>`_
@@ -336,7 +336,7 @@ the tutorial at :ref:`sphx_glr_tutorials_text_mathtext.py`.
 Native TeX rendering
 ====================
 
-Although matplotlib's internal math rendering engine is quite
+Although Matplotlib's internal math rendering engine is quite
 powerful, sometimes you need TeX. Matplotlib supports external TeX
 rendering of strings with the *usetex* option.
 
@@ -352,7 +352,7 @@ rendering of strings with the *usetex* option.
 EEG demo
 =========
 
-You can embed matplotlib into pygtk, wx, Tk, or Qt applications.
+You can embed Matplotlib into pygtk, wx, Tk, or Qt applications.
 Here is a screenshot of an EEG viewer called `pbrain
 <https://github.com/nipy/pbrain>`__.
 
@@ -361,7 +361,7 @@ Here is a screenshot of an EEG viewer called `pbrain
 The lower axes uses :func:`~matplotlib.pyplot.specgram`
 to plot the spectrogram of one of the EEG channels.
 
-For examples of how to embed matplotlib in different toolkits, see:
+For examples of how to embed Matplotlib in different toolkits, see:
 
    * :ref:`sphx_glr_gallery_user_interfaces_embedding_in_gtk2_sgskip.py`
    * :ref:`sphx_glr_gallery_user_interfaces_embedding_in_wx2_sgskip.py`
@@ -372,7 +372,7 @@ For examples of how to embed matplotlib in different toolkits, see:
 XKCD-style sketch plots
 =======================
 
-matplotlib supports plotting in the style of `xkcd
+Matplotlib supports plotting in the style of `xkcd
 <http://www.xkcd.com/>`.
 
 .. figure:: ../../gallery/showcase/images/sphx_glr_xkcd_001.png


### PR DESCRIPTION
This links the frontpage thumbnails to the sphinx gallery versions so that we don't have to create them manually. Also moves `screenshots.rst` to a tutorial so continue the consolidation.