### PR TITLE
Fix pandas datetime test on pandas 0.20

### DIFF
--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -437,7 +437,7 @@ def test_date2num_dst_pandas():
     pd = pytest.importorskip('pandas')
 
     def tz_convert(*args):
-        return pd.DatetimeIndex.tz_convert(*args).astype(datetime.datetime)
+        return pd.DatetimeIndex.tz_convert(*args).astype(object)
 
     _test_date2num_dst(pd.date_range, tz_convert)
 


### PR DESCRIPTION
Fixes #8579 . I've checked the code in #3896, and it still works if all the `.astype(dt.datetime)` are replaced by `.astype(object)`.