### PR TITLE
Add pandas to python 3.6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
     - python: 3.5
       env: BUILD_DOCS=true
     - python: 3.6
-      env: DELETE_FONT_CACHE=1 INSTALL_PEP8=pytest-pep8 RUN_PEP8=--pep8
+      env: DELETE_FONT_CACHE=1 INSTALL_PEP8=pytest-pep8 RUN_PEP8=--pep8 PANDAS=pandas
     - python: "nightly"
       env: PRE=--pre
     - os: osx


### PR DESCRIPTION
I don't see any reason why we shouldn't do pandas tests on the python 3.6 build, especially now we have a nice tutorial about plotting with pandas data!