### PR TITLE
shims for categorical support for numpy < 1.8

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -17,7 +17,7 @@ import collections
 
 
 def shim_array(data):
-    if LooseVersion(np.__version__) <= LooseVersion('1.8.0'):
+    if LooseVersion(np.__version__) < LooseVersion('1.8.0'):
         if (isinstance(data, six.string_types) or
                 not isinstance(data, collections.Iterable)):
             data = [data]

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -16,8 +16,11 @@ from distutils.version import LooseVersion
 import collections
 
 
-def shim_array(data):
-    if LooseVersion(np.__version__) < LooseVersion('1.8.0'):
+if LooseVersion(np.__version__) >= LooseVersion('1.8.0'):
+    def shim_array(data):
+        return np.array(data, dtype=np.unicode)
+else:
+    def shim_array(data):
         if (isinstance(data, six.string_types) or
                 not isinstance(data, collections.Iterable)):
             data = [data]
@@ -28,8 +31,7 @@ def shim_array(data):
             # render under numpy1.6 anyway
             data = [d.encode('utf-8', 'ignore').decode('utf-8')
                     for d in data]
-
-    return np.array(data, dtype=np.unicode)
+        return np.array(data, dtype=np.unicode)
 
 
 class StrCategoryConverter(units.ConversionInterface):

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -4,14 +4,32 @@ catch all for categorical functions
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
 import six
 
 import numpy as np
 
-import matplotlib.cbook as cbook
 import matplotlib.units as units
 import matplotlib.ticker as ticker
+
+# np 1.6/1.7 support
+from distutils.version import LooseVersion
+import collections
+
+
+def shim_array(data):
+    if LooseVersion(np.__version__) <= LooseVersion('1.8.0'):
+        if (isinstance(data, six.string_types) or
+                not isinstance(data, collections.Iterable)):
+            data = [data]
+        try:
+            data = [str(d) for d in data]
+        except UnicodeEncodeError:
+            # this yields gibberish but unicode text doesn't
+            # render under numpy1.6 anyway
+            data = [d.encode('utf-8', 'ignore').decode('utf-8')
+                    for d in data]
+
+    return np.array(data, dtype=np.unicode)
 
 
 class StrCategoryConverter(units.ConversionInterface):
@@ -25,7 +43,8 @@ class StrCategoryConverter(units.ConversionInterface):
         if isinstance(value, six.string_types):
             return vmap[value]
 
-        vals = np.array(value, dtype=np.unicode)
+        vals = shim_array(value)
+
         for lab, loc in vmap.items():
             vals[vals == lab] = loc
 
@@ -81,8 +100,7 @@ class UnitData(object):
         self._set_seq_locs(new_data, value)
 
     def _set_seq_locs(self, data, value):
-        strdata = np.array(data, dtype=np.unicode)
-        # np.unique makes dateframes work
+        strdata = shim_array(data)
         new_s = [d for d in np.unique(strdata) if d not in self.seq]
         for ns in new_s:
             self.seq.append(ns)

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -3,8 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from distutils.version import LooseVersion
-
 import pytest
 import numpy as np
 
@@ -12,11 +10,6 @@ import matplotlib.pyplot as plt
 import matplotlib.category as cat
 
 import unittest
-
-
-needs_new_numpy = pytest.mark.xfail(
-    LooseVersion(np.__version__) < LooseVersion('1.8.0'),
-    reason='NumPy < 1.8.0 is broken.')
 
 
 class TestUnitData(object):
@@ -28,14 +21,12 @@ class TestUnitData(object):
 
     ids = ["single", "unicode", "mixed"]
 
-    @needs_new_numpy
     @pytest.mark.parametrize("data, seq, locs", testdata, ids=ids)
     def test_unit(self, data, seq, locs):
         act = cat.UnitData(data)
         assert act.seq == seq
         assert act.locs == locs
 
-    @needs_new_numpy
     def test_update_map(self):
         data = ['a', 'd']
         oseq = ['a', 'd']
@@ -87,7 +78,6 @@ class TestStrCategoryConverter(object):
     def mock_axis(self, request):
         self.cc = cat.StrCategoryConverter()
 
-    @needs_new_numpy
     @pytest.mark.parametrize("data, unitmap, exp", testdata, ids=ids)
     def test_convert(self, data, unitmap, exp):
         MUD = MockUnitData(unitmap)


### PR DESCRIPTION
Matplotlib doesn't render unicode strings with numpy below 1.7 and numpy below 1.8 is buggy with mixed type arrays, truncating strings to the size of the smallest string in the mixed type array. This PR introduces a shim that converts mixed type elements to strings before converting the input into an array, and it has a shim that decodes and encodes unicode, essentially forcing it into utf endpoint ASCII gibberish. 

This PR closes #7988

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
