### PR TITLE
Add test for _num_to_string method used in __call__ of  LogFormatter

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -467,6 +467,10 @@ class TestLogFormatter(object):
         (100000, 1000000.0, '1e5'),
     ]
 
+    call_data = [
+            1, 10, 100, 1000
+    ]
+
     @pytest.mark.parametrize('value, domain, expected', pprint_data)
     def test_pprint(self, value, domain, expected):
         fmt = mticker.LogFormatter()
@@ -521,11 +525,12 @@ class TestLogFormatter(object):
         ax.set_xlim(0.5, 0.9)
         self._sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
 
-    def test_LogFormatter_call(self):
+    @pytest.mark.parametrize('val', call_data)
+    def test_LogFormatter_call(self, val):
         # test _num_to_string method used in __call__
         temp_lf = mticker.LogFormatter()
         temp_lf.axis = FakeAxis()
-        assert str(temp_lf(10)) is not None
+        assert str(temp_lf(val)) is not None
 
 
 class TestFormatStrFormatter(object):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -530,7 +530,7 @@ class TestLogFormatter(object):
         # test _num_to_string method used in __call__
         temp_lf = mticker.LogFormatter()
         temp_lf.axis = FakeAxis()
-        assert str(temp_lf(val)) is not None
+        assert temp_lf(val) == str(val)
 
 
 class TestFormatStrFormatter(object):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -521,14 +521,12 @@ class TestLogFormatter(object):
         ax.set_xlim(0.5, 0.9)
         self._sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
 
-    def test_LogFormatter_call(self):
+    @pytest.mark.parametrize(('val', [1, 10, 100, 1000]), 
+    def test_LogFormatter_call(self, val):
         # test _num_to_string method used in __call__
-        call_data = [ 1, 10, 100, 1000 ]   
         temp_lf = mticker.LogFormatter()
         temp_lf.axis = FakeAxis()
-
-        for val in call_data:
-            assert temp_lf(val) == str(val)
+        assert temp_lf(val) == str(val)
 
 
 class TestFormatStrFormatter(object):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -521,7 +521,7 @@ class TestLogFormatter(object):
         ax.set_xlim(0.5, 0.9)
         self._sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
 
-    @pytest.mark.parametrize('val', [1, 10, 100, 1000]), 
+    @pytest.mark.parametrize('val', [1, 10, 100, 1000])
     def test_LogFormatter_call(self, val):
         # test _num_to_string method used in __call__
         temp_lf = mticker.LogFormatter()

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -467,6 +467,10 @@ class TestLogFormatter(object):
         (100000, 1000000.0, '1e5'),
     ]
 
+    call_data = [
+            1, 5, 10, 50, 100, 10000
+    ]
+
     @pytest.mark.parametrize('value, domain, expected', pprint_data)
     def test_pprint(self, value, domain, expected):
         fmt = mticker.LogFormatter()
@@ -520,6 +524,15 @@ class TestLogFormatter(object):
         # axis range at 0 to 0.4 decades, label all
         ax.set_xlim(0.5, 0.9)
         self._sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
+
+    @pytest.mark.parametrize('val', call_data)
+    def test_LogFormatter_call(self, val):
+        # test _num_to_string method used in __call__
+        fig, ax = plt.subplots()
+        lf = matplotlib.ticker.LogFormatter()
+        ax.xaxis.set_major_formatter(lf)
+
+        assert str(lf(val)) is not None
 
 
 class TestFormatStrFormatter(object):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -521,7 +521,7 @@ class TestLogFormatter(object):
         ax.set_xlim(0.5, 0.9)
         self._sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
 
-    @pytest.mark.parametrize(('val', [1, 10, 100, 1000]), 
+    @pytest.mark.parametrize('val', [1, 10, 100, 1000]), 
     def test_LogFormatter_call(self, val):
         # test _num_to_string method used in __call__
         temp_lf = mticker.LogFormatter()

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -467,10 +467,6 @@ class TestLogFormatter(object):
         (100000, 1000000.0, '1e5'),
     ]
 
-    call_data = [
-            1, 10, 100, 1000
-    ]
-
     @pytest.mark.parametrize('value, domain, expected', pprint_data)
     def test_pprint(self, value, domain, expected):
         fmt = mticker.LogFormatter()
@@ -525,12 +521,14 @@ class TestLogFormatter(object):
         ax.set_xlim(0.5, 0.9)
         self._sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
 
-    @pytest.mark.parametrize('val', call_data)
-    def test_LogFormatter_call(self, val):
+    def test_LogFormatter_call(self):
         # test _num_to_string method used in __call__
+        call_data = [ 1, 10, 100, 1000 ]   
         temp_lf = mticker.LogFormatter()
         temp_lf.axis = FakeAxis()
-        assert temp_lf(val) == str(val)
+
+        for val in call_data:
+            assert temp_lf(val) == str(val)
 
 
 class TestFormatStrFormatter(object):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -467,10 +467,6 @@ class TestLogFormatter(object):
         (100000, 1000000.0, '1e5'),
     ]
 
-    call_data = [
-            1, 5, 10, 50, 100, 10000
-    ]
-
     @pytest.mark.parametrize('value, domain, expected', pprint_data)
     def test_pprint(self, value, domain, expected):
         fmt = mticker.LogFormatter()
@@ -525,14 +521,11 @@ class TestLogFormatter(object):
         ax.set_xlim(0.5, 0.9)
         self._sub_labels(ax.xaxis, subs=np.arange(2, 10, dtype=int))
 
-    @pytest.mark.parametrize('val', call_data)
-    def test_LogFormatter_call(self, val):
+    def test_LogFormatter_call(self):
         # test _num_to_string method used in __call__
-        fig, ax = plt.subplots()
-        lf = matplotlib.ticker.LogFormatter()
-        ax.xaxis.set_major_formatter(lf)
-
-        assert str(lf(val)) is not None
+        temp_lf = mticker.LogFormatter()
+        temp_lf.axis = FakeAxis()
+        assert str(temp_lf(10)) is not None
 
 
 class TestFormatStrFormatter(object):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
Closes #8597

Write tests for LogFormatter to explicitly test the return value of  `__call__ `.

<!--If it fixes an open issue, please link to the issue here.--> 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
