### PR TITLE
[MRG + 1] Cleanup examples and re-enable pep8

### DIFF
--- a/ci/travis/test_script.sh
+++ b/ci/travis/test_script.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -e
+set -ev
 
 # This script is meant to be called by the "script" step defined in
 # .travis.yml. See http://docs.travis-ci.com/ for more details.
@@ -26,9 +26,9 @@ if [[ $BUILD_DOCS == false ]]; then
 
   echo The following args are passed to pytest $PYTEST_ARGS $RUN_PEP8
   if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-    python tests.py $PYTEST_ARGS $RUN_PEP8
+    pytest $PYTEST_ARGS $RUN_PEP8
   else
-    gdb -return-child-result -batch -ex r -ex bt --args python $PYTHON_ARGS tests.py $PYTEST_ARGS $RUN_PEP8
+    gdb -return-child-result -batch -ex r -ex bt --args python $PYTHON_ARGS -m pytest $PYTEST_ARGS $RUN_PEP8
   fi
 else
   cd doc

--- a/examples/axes_grid1/demo_colorbar_of_inset_axes.py
+++ b/examples/axes_grid1/demo_colorbar_of_inset_axes.py
@@ -9,17 +9,17 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes, zoomed_inset_axes
 from mpl_toolkits.axes_grid1.colorbar import colorbar
 
+
 def get_demo_image():
     from matplotlib.cbook import get_sample_data
     import numpy as np
     f = get_sample_data("axes_grid/bivariate_normal.npy", asfileobj=False)
     z = np.load(f)
     # z is a numpy array of 15x15
-    return z, (-3,4,-4,3)
+    return z, (-3, 4, -4, 3)
 
 
-fig = plt.figure(1, [5,4])
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(figsize=[5, 4])
 
 Z, extent = get_demo_image()
 
@@ -28,7 +28,7 @@ ax.set(aspect=1,
        ylim=(-20, 5))
 
 
-axins = zoomed_inset_axes(ax, 2, loc=2) # zoom = 6
+axins = zoomed_inset_axes(ax, 2, loc=2)  # zoom = 6
 im = axins.imshow(Z, extent=extent, interpolation="nearest",
                   origin="lower")
 
@@ -38,17 +38,14 @@ plt.yticks(visible=False)
 
 # colorbar
 cax = inset_axes(axins,
-                 width="5%", # width = 10% of parent_bbox width
-                 height="100%", # height : 50%
+                 width="5%",  # width = 10% of parent_bbox width
+                 height="100%",  # height : 50%
                  loc=3,
                  bbox_to_anchor=(1.05, 0., 1, 1),
                  bbox_transform=axins.transAxes,
                  borderpad=0,
                  )
 
+colorbar(im, cax=cax)
 
-colorbar(im, cax=cax) #, ticks=[1,2,3])
-
-
-plt.draw()
 plt.show()

--- a/examples/axes_grid1/demo_colorbar_with_axes_divider.py
+++ b/examples/axes_grid1/demo_colorbar_with_axes_divider.py
@@ -14,14 +14,14 @@ fig = plt.figure(1, figsize=(6, 3))
 fig.subplots_adjust(wspace=0.5)
 
 ax1 = fig.add_subplot(121)
-im1 = ax1.imshow([[1,2],[3,4]])
+im1 = ax1.imshow([[1, 2], [3, 4]])
 
 ax1_divider = make_axes_locatable(ax1)
 cax1 = ax1_divider.append_axes("right", size="7%", pad="2%")
 cb1 = colorbar(im1, cax=cax1)
 
 ax2 = fig.add_subplot(122)
-im2 = ax2.imshow([[1,2],[3,4]])
+im2 = ax2.imshow([[1, 2], [3, 4]])
 
 ax2_divider = make_axes_locatable(ax2)
 cax2 = ax2_divider.append_axes("top", size="7%", pad="2%")

--- a/examples/axes_grid1/demo_fixed_size_axes.py
+++ b/examples/axes_grid1/demo_fixed_size_axes.py
@@ -8,8 +8,8 @@ import matplotlib.pyplot as plt
 
 from mpl_toolkits.axes_grid1 import Divider, LocatableAxes, Size
 
-def demo_fixed_size_axes():
 
+def demo_fixed_size_axes():
     fig1 = plt.figure(1, (6, 6))
 
     # The first items are for padding and the second items are for the axes.
@@ -25,19 +25,16 @@ def demo_fixed_size_axes():
 
     fig1.add_axes(ax)
 
-    ax.plot([1,2,3])
-
-
+    ax.plot([1, 2, 3])
 
 
 def demo_fixed_pad_axes():
-
     fig = plt.figure(2, (6, 6))
 
-    # The first & third items are for padding and the second items are for the axes.
-    # sizes are in inch.
-    h = [Size.Fixed(1.0), Size.Scaled(1.), Size.Fixed(.2),]
-    v = [Size.Fixed(0.7), Size.Scaled(1.), Size.Fixed(.5),]
+    # The first & third items are for padding and the second items are for the
+    # axes. Sizes are in inches.
+    h = [Size.Fixed(1.0), Size.Scaled(1.), Size.Fixed(.2)]
+    v = [Size.Fixed(0.7), Size.Scaled(1.), Size.Fixed(.5)]
 
     divider = Divider(fig, (0.0, 0.0, 1., 1.), h, v, aspect=False)
     # the width and height of the rectangle is ignored.
@@ -47,16 +44,11 @@ def demo_fixed_pad_axes():
 
     fig.add_axes(ax)
 
-    ax.plot([1,2,3])
-
-
-
-
+    ax.plot([1, 2, 3])
 
 
 if __name__ == "__main__":
     demo_fixed_size_axes()
     demo_fixed_pad_axes()
 
-    plt.draw()
     plt.show()

--- a/examples/axes_grid1/demo_new_colorbar.py
+++ b/examples/axes_grid1/demo_new_colorbar.py
@@ -5,21 +5,20 @@ Demo New Colorbar
 
 """
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.colorbar import colorbar
 
-plt.rcParams["text.usetex"]=False
 
-fig = plt.figure(1, figsize=(6, 3))
+plt.rcParams["text.usetex"] = False
 
-ax1 = fig.add_subplot(121)
-im1 = ax1.imshow([[1,2],[3,4]])
-cb1 = plt.colorbar(im1)
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(6, 3))
+
+im1 = ax1.imshow([[1, 2], [3, 4]])
+cb1 = fig.colorbar(im1, ax=ax1)
 cb1.ax.set_yticks([1, 3])
 ax1.set_title("Original MPL's colorbar w/\nset_yticks([1,3])", size=10)
 
-from mpl_toolkits.axes_grid1.colorbar import colorbar
-ax2 = fig.add_subplot(122)
-im2 = ax2.imshow([[1,2],[3,4]])
-cb2 = colorbar(im2)
+im2 = ax2.imshow([[1, 2], [3, 4]])
+cb2 = colorbar(im2, ax=ax2)
 cb2.ax.set_yticks([1, 3])
 ax2.set_title("AxesGrid's colorbar w/\nset_yticks([1,3])", size=10)
 

--- a/examples/axes_grid1/parasite_simple.py
+++ b/examples/axes_grid1/parasite_simple.py
@@ -27,4 +27,3 @@ par.yaxis.get_label().set_color(p2.get_color())
 leg.texts[1].set_color(p2.get_color())
 
 plt.show()
-

--- a/examples/axes_grid1/simple_axes_divider1.py
+++ b/examples/axes_grid1/simple_axes_divider1.py
@@ -30,6 +30,4 @@ ax2.set_axes_locator(divider.new_locator(nx=0, ny=2))
 ax3.set_axes_locator(divider.new_locator(nx=2, ny=2))
 ax4.set_axes_locator(divider.new_locator(nx=2, nx1=4, ny=0))
 
-
-plt.draw()
 plt.show()

--- a/examples/axes_grid1/simple_axes_divider2.py
+++ b/examples/axes_grid1/simple_axes_divider2.py
@@ -12,7 +12,7 @@ fig1 = plt.figure(1, (5.5, 4.))
 
 # the rect parameter will be ignore as we will set axes_locator
 rect = (0.1, 0.1, 0.8, 0.8)
-ax = [fig1.add_axes(rect, label="%d"%i) for i in range(4)]
+ax = [fig1.add_axes(rect, label="%d" % i) for i in range(4)]
 
 horiz = [Size.Scaled(1.5), Size.Fixed(.5), Size.Scaled(1.),
          Size.Scaled(.5)]
@@ -31,5 +31,4 @@ for ax1 in ax:
     plt.setp(ax1.get_xticklabels()+ax1.get_yticklabels(),
              visible=False)
 
-plt.draw()
 plt.show()

--- a/examples/axes_grid1/simple_axes_divider3.py
+++ b/examples/axes_grid1/simple_axes_divider3.py
@@ -13,7 +13,7 @@ fig1 = plt.figure(1, (5.5, 4))
 
 # the rect parameter will be ignore as we will set axes_locator
 rect = (0.1, 0.1, 0.8, 0.8)
-ax = [fig1.add_axes(rect, label="%d"%i) for i in range(4)]
+ax = [fig1.add_axes(rect, label="%d" % i) for i in range(4)]
 
 
 horiz = [Size.AxesX(ax[0]), Size.Fixed(.5), Size.AxesX(ax[1])]
@@ -40,5 +40,4 @@ for ax1 in ax:
     plt.setp(ax1.get_xticklabels()+ax1.get_yticklabels(),
              visible=False)
 
-plt.draw()
 plt.show()

--- a/examples/axes_grid1/simple_colorbar.py
+++ b/examples/axes_grid1/simple_colorbar.py
@@ -9,7 +9,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 
 ax = plt.subplot(111)
-im = ax.imshow(np.arange(100).reshape((10,10)))
+im = ax.imshow(np.arange(100).reshape((10, 10)))
 
 # create an axes on the right side of ax. The width of cax will be 5%
 # of ax and the padding between cax and ax will be fixed at 0.05 inch.
@@ -17,4 +17,3 @@ divider = make_axes_locatable(ax)
 cax = divider.append_axes("right", size="5%", pad=0.05)
 
 plt.colorbar(im, cax=cax)
-

--- a/examples/axes_grid1/simple_rgb.py
+++ b/examples/axes_grid1/simple_rgb.py
@@ -8,23 +8,25 @@ import matplotlib.pyplot as plt
 
 from mpl_toolkits.axes_grid1.axes_rgb import RGBAxes
 
+
 def get_demo_image():
     import numpy as np
     from matplotlib.cbook import get_sample_data
     f = get_sample_data("axes_grid/bivariate_normal.npy", asfileobj=False)
     z = np.load(f)
     # z is a numpy array of 15x15
-    return z, (-3,4,-4,3)
+    return z, (-3, 4, -4, 3)
+
 
 def get_rgb():
     Z, extent = get_demo_image()
 
-    Z[Z<0] = 0.
-    Z = Z/Z.max()
+    Z[Z < 0] = 0.
+    Z = Z / Z.max()
 
-    R = Z[:13,:13]
-    G = Z[2:,2:]
-    B = Z[:13,2:]
+    R = Z[:13, :13]
+    G = Z[2:, 2:]
+    B = Z[:13, 2:]
 
     return R, G, B
 
@@ -39,6 +41,4 @@ ax.imshow_rgb(r, g, b, **kwargs)
 ax.RGB.set_xlim(0., 9.5)
 ax.RGB.set_ylim(0.9, 10.6)
 
-
-plt.draw()
 plt.show()

--- a/examples/pylab_examples/ginput_manual_clabel_sgskip.py
+++ b/examples/pylab_examples/ginput_manual_clabel_sgskip.py
@@ -61,6 +61,7 @@ while not happy:
         for p in ph:
             p.remove()
 
+
 ##################################################
 # Now contour according to distance from triangle
 # corners - just an example

--- a/examples/user_interfaces/embedding_in_qt5_sgskip.py
+++ b/examples/user_interfaces/embedding_in_qt5_sgskip.py
@@ -14,8 +14,6 @@ modified with no restriction; raw copies as well as modified versions
 may be distributed without limitation.
 """
 
-
-
 from __future__ import unicode_literals
 import sys
 import os

--- a/examples/userdemo/anchored_box01.py
+++ b/examples/userdemo/anchored_box01.py
@@ -7,13 +7,11 @@ Anchored Box01
 import matplotlib.pyplot as plt
 from matplotlib.offsetbox import AnchoredText
 
-fig=plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+
+fig, ax = plt.subplots(figsize=(3, 3))
 
 at = AnchoredText("Figure 1a",
-                  prop=dict(size=15), frameon=True,
-                  loc=2, 
-                  )
+                  prop=dict(size=15), frameon=True, loc=2)
 at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
 ax.add_artist(at)
 

--- a/examples/userdemo/anchored_box02.py
+++ b/examples/userdemo/anchored_box02.py
@@ -8,9 +8,8 @@ from matplotlib.patches import Circle
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredDrawingArea
 
-fig=plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
 
+fig, ax = plt.subplots(figsize=(3, 3))
 
 ada = AnchoredDrawingArea(40, 20, 0, 0,
                           loc=1, pad=0., frameon=False)

--- a/examples/userdemo/anchored_box03.py
+++ b/examples/userdemo/anchored_box03.py
@@ -8,11 +8,11 @@ from matplotlib.patches import Ellipse
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredAuxTransformBox
 
-fig=plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+
+fig, ax = plt.subplots(figsize=(3, 3))
 
 box = AnchoredAuxTransformBox(ax.transData, loc=2)
-el = Ellipse((0,0), width=0.1, height=0.4, angle=30) # in data coordinates!
+el = Ellipse((0, 0), width=0.1, height=0.4, angle=30)  # in data coordinates!
 box.drawing_area.add_artist(el)
 
 ax.add_artist(box)

--- a/examples/userdemo/anchored_box04.py
+++ b/examples/userdemo/anchored_box04.py
@@ -6,21 +6,21 @@ Anchored Box04
 """
 from matplotlib.patches import Ellipse
 import matplotlib.pyplot as plt
-from matplotlib.offsetbox import AnchoredOffsetbox, TextArea, DrawingArea, HPacker
+from matplotlib.offsetbox import (AnchoredOffsetbox, DrawingArea, HPacker,
+                                  TextArea)
 
-fig=plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+
+fig, ax = plt.subplots(figsize=(3, 3))
 
 box1 = TextArea(" Test : ", textprops=dict(color="k"))
 
 box2 = DrawingArea(60, 20, 0, 0)
 el1 = Ellipse((10, 10), width=16, height=5, angle=30, fc="r")
-el2 = Ellipse((30, 10), width=16, height=5, angle=170, fc="g") 
-el3 = Ellipse((50, 10), width=16, height=5, angle=230, fc="b") 
+el2 = Ellipse((30, 10), width=16, height=5, angle=170, fc="g")
+el3 = Ellipse((50, 10), width=16, height=5, angle=230, fc="b")
 box2.add_artist(el1)
 box2.add_artist(el2)
 box2.add_artist(el3)
-
 
 box = HPacker(children=[box1, box2],
               align="center",
@@ -33,7 +33,6 @@ anchored_box = AnchoredOffsetbox(loc=3,
                                  bbox_transform=ax.transAxes,
                                  borderpad=0.,
                                  )
-
 
 ax.add_artist(anchored_box)
 

--- a/examples/userdemo/annotate_explain.py
+++ b/examples/userdemo/annotate_explain.py
@@ -7,16 +7,15 @@ Annotate Explain
 
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
+from mpl_toolkits.axes_grid1.axes_grid import AxesGrid
+from matplotlib.offsetbox import AnchoredText
 
 x1, y1 = 0.3, 0.3
 x2, y2 = 0.7, 0.7
 
-fig = plt.figure(1, figsize=(8,3))
+fig = plt.figure(1, figsize=(8, 3))
 fig.clf()
-from mpl_toolkits.axes_grid1.axes_grid import AxesGrid
-from matplotlib.offsetbox import AnchoredText
 
-#from matplotlib.font_manager import FontProperties
 
 def add_at(ax, t, loc=2):
     fp = dict(size=10)
@@ -36,7 +35,7 @@ ax.add_artist(el)
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="-", #linestyle="dashed",
+            arrowprops=dict(arrowstyle="-",
                             color="0.5",
                             patchB=None,
                             shrinkB=0,
@@ -53,7 +52,7 @@ ax.add_artist(el)
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="-", #linestyle="dashed",
+            arrowprops=dict(arrowstyle="-",
                             color="0.5",
                             patchB=el,
                             shrinkB=0,
@@ -71,7 +70,7 @@ ax.add_artist(el)
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="-", #linestyle="dashed",
+            arrowprops=dict(arrowstyle="-",
                             color="0.5",
                             patchB=el,
                             shrinkB=5,
@@ -89,7 +88,7 @@ ax.add_artist(el)
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="fancy", #linestyle="dashed",
+            arrowprops=dict(arrowstyle="fancy",
                             color="0.5",
                             patchB=el,
                             shrinkB=5,
@@ -105,5 +104,4 @@ grid[0].axis["bottom"].toggle(ticklabels=False)
 grid[0].axis["left"].toggle(ticklabels=False)
 fig.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=0.95)
 
-plt.draw()
 plt.show()

--- a/examples/userdemo/annotate_simple01.py
+++ b/examples/userdemo/annotate_simple01.py
@@ -6,15 +6,14 @@ Annotate Simple01
 """
 import matplotlib.pyplot as plt
 
-plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+
+fig, ax = plt.subplots(figsize=(3, 3))
 
 ax.annotate("",
             xy=(0.2, 0.2), xycoords='data',
             xytext=(0.8, 0.8), textcoords='data',
             arrowprops=dict(arrowstyle="->",
-                            connectionstyle="arc3"), 
+                            connectionstyle="arc3"),
             )
 
 plt.show()
-

--- a/examples/userdemo/annotate_simple02.py
+++ b/examples/userdemo/annotate_simple02.py
@@ -6,16 +6,15 @@ Annotate Simple02
 """
 import matplotlib.pyplot as plt
 
-plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+
+fig, ax = plt.subplots(figsize=(3, 3))
 
 ax.annotate("Test",
             xy=(0.2, 0.2), xycoords='data',
             xytext=(0.8, 0.8), textcoords='data',
             size=20, va="center", ha="center",
             arrowprops=dict(arrowstyle="simple",
-                            connectionstyle="arc3,rad=-0.2"), 
+                            connectionstyle="arc3,rad=-0.2"),
             )
 
 plt.show()
-

--- a/examples/userdemo/annotate_simple03.py
+++ b/examples/userdemo/annotate_simple03.py
@@ -6,8 +6,8 @@ Annotate Simple03
 """
 import matplotlib.pyplot as plt
 
-plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+
+fig, ax = plt.subplots(figsize=(3, 3))
 
 ann = ax.annotate("Test",
                   xy=(0.2, 0.2), xycoords='data',
@@ -16,8 +16,7 @@ ann = ax.annotate("Test",
                   bbox=dict(boxstyle="round4", fc="w"),
                   arrowprops=dict(arrowstyle="-|>",
                                   connectionstyle="arc3,rad=-0.2",
-                                  fc="w"), 
+                                  fc="w"),
                   )
 
 plt.show()
-

--- a/examples/userdemo/annotate_simple04.py
+++ b/examples/userdemo/annotate_simple04.py
@@ -6,8 +6,8 @@ Annotate Simple04
 """
 import matplotlib.pyplot as plt
 
-plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+
+fig, ax = plt.subplots(figsize=(3, 3))
 
 ann = ax.annotate("Test",
                   xy=(0.2, 0.2), xycoords='data',
@@ -17,7 +17,7 @@ ann = ax.annotate("Test",
                   arrowprops=dict(arrowstyle="-|>",
                                   connectionstyle="arc3,rad=0.2",
                                   relpos=(0., 0.),
-                                  fc="w"), 
+                                  fc="w"),
                   )
 
 ann = ax.annotate("Test",
@@ -28,8 +28,7 @@ ann = ax.annotate("Test",
                   arrowprops=dict(arrowstyle="-|>",
                                   connectionstyle="arc3,rad=-0.2",
                                   relpos=(1., 0.),
-                                  fc="w"), 
+                                  fc="w"),
                   )
 
 plt.show()
-

--- a/examples/userdemo/annotate_simple_coord01.py
+++ b/examples/userdemo/annotate_simple_coord01.py
@@ -7,15 +7,13 @@ Annotate Simple Coord01
 
 import matplotlib.pyplot as plt
 
-plt.figure(figsize=(3,2))
-ax=plt.subplot(111)
+fig, ax = plt.subplots(figsize=(3, 2))
 an1 = ax.annotate("Test 1", xy=(0.5, 0.5), xycoords="data",
                   va="center", ha="center",
                   bbox=dict(boxstyle="round", fc="w"))
 an2 = ax.annotate("Test 2", xy=(1, 0.5), xycoords=an1,
-                  xytext=(30,0), textcoords="offset points",
+                  xytext=(30, 0), textcoords="offset points",
                   va="center", ha="left",
                   bbox=dict(boxstyle="round", fc="w"),
                   arrowprops=dict(arrowstyle="->"))
 plt.show()
-

--- a/examples/userdemo/annotate_simple_coord02.py
+++ b/examples/userdemo/annotate_simple_coord02.py
@@ -7,16 +7,17 @@ Annotate Simple Coord02
 
 import matplotlib.pyplot as plt
 
-plt.figure(figsize=(3,2))
-ax=plt.axes([0.1, 0.1, 0.8, 0.7])
+
+fig, ax = plt.subplots(figsize=(3, 2))
 an1 = ax.annotate("Test 1", xy=(0.5, 0.5), xycoords="data",
                   va="center", ha="center",
                   bbox=dict(boxstyle="round", fc="w"))
 
 an2 = ax.annotate("Test 2", xy=(0.5, 1.), xycoords=an1,
-                  xytext=(0.5,1.1), textcoords=(an1, "axes fraction"),
+                  xytext=(0.5, 1.1), textcoords=(an1, "axes fraction"),
                   va="bottom", ha="center",
                   bbox=dict(boxstyle="round", fc="w"),
                   arrowprops=dict(arrowstyle="->"))
-plt.show()
 
+fig.subplots_adjust(top=0.83)
+plt.show()

--- a/examples/userdemo/annotate_simple_coord03.py
+++ b/examples/userdemo/annotate_simple_coord03.py
@@ -6,14 +6,14 @@ Annotate Simple Coord03
 """
 
 import matplotlib.pyplot as plt
+from matplotlib.text import OffsetFrom
 
-plt.figure(figsize=(3,2))
-ax=plt.axes([0.1, 0.1, 0.8, 0.7])
+
+fig, ax = plt.subplots(figsize=(3, 2))
 an1 = ax.annotate("Test 1", xy=(0.5, 0.5), xycoords="data",
                   va="center", ha="center",
                   bbox=dict(boxstyle="round", fc="w"))
 
-from matplotlib.text import OffsetFrom
 offset_from = OffsetFrom(an1, (0.5, 0))
 an2 = ax.annotate("Test 2", xy=(0.1, 0.1), xycoords="data",
                   xytext=(0, -10), textcoords=offset_from,
@@ -22,4 +22,3 @@ an2 = ax.annotate("Test 2", xy=(0.1, 0.1), xycoords="data",
                   bbox=dict(boxstyle="round", fc="w"),
                   arrowprops=dict(arrowstyle="->"))
 plt.show()
-

--- a/examples/userdemo/annotate_text_arrow.py
+++ b/examples/userdemo/annotate_text_arrow.py
@@ -8,10 +8,7 @@ Annotate Text Arrow
 import numpy.random
 import matplotlib.pyplot as plt
 
-fig = plt.figure(1, figsize=(5,5))
-fig.clf()
-
-ax = fig.add_subplot(111)
+fig, ax = plt.subplots(figsize=(5, 5))
 ax.set_aspect(1)
 
 x1 = -1 + numpy.random.randn(100)
@@ -29,7 +26,7 @@ ax.text(2, 2, "Sample B", ha="center", va="center", size=20,
         bbox=bbox_props)
 
 
-bbox_props = dict(boxstyle="rarrow", fc=(0.8,0.9,0.9), ec="b", lw=2)
+bbox_props = dict(boxstyle="rarrow", fc=(0.8, 0.9, 0.9), ec="b", lw=2)
 t = ax.text(0, 0, "Direction", ha="center", va="center", rotation=45,
             size=15,
             bbox=bbox_props)
@@ -40,5 +37,4 @@ bb.set_boxstyle("rarrow", pad=0.6)
 ax.set_xlim(-4, 4)
 ax.set_ylim(-4, 4)
 
-plt.draw()
 plt.show()

--- a/examples/userdemo/axis_direction_demo_step01.py
+++ b/examples/userdemo/axis_direction_demo_step01.py
@@ -7,6 +7,7 @@ Axis Direction Demo Step01
 import matplotlib.pyplot as plt
 import mpl_toolkits.axisartist as axisartist
 
+
 def setup_axes(fig, rect):
     ax = axisartist.Subplot(fig, rect)
     fig.add_axes(ax)
@@ -21,11 +22,11 @@ def setup_axes(fig, rect):
 
     return ax
 
-fig = plt.figure(figsize=(3,2.5))
+
+fig = plt.figure(figsize=(3, 2.5))
 fig.subplots_adjust(top=0.8)
 ax1 = setup_axes(fig, "111")
 
 ax1.axis["x"].set_axis_direction("left")
-
 
 plt.show()

--- a/examples/userdemo/axis_direction_demo_step02.py
+++ b/examples/userdemo/axis_direction_demo_step02.py
@@ -7,6 +7,7 @@ Axis Direction Demo Step02
 import matplotlib.pyplot as plt
 import mpl_toolkits.axisartist as axisartist
 
+
 def setup_axes(fig, rect):
     ax = axisartist.Subplot(fig, rect)
     fig.add_axes(ax)
@@ -23,7 +24,8 @@ def setup_axes(fig, rect):
 
     return ax
 
-fig = plt.figure(figsize=(6,2.5))
+
+fig = plt.figure(figsize=(6, 2.5))
 fig.subplots_adjust(bottom=0.2, top=0.8)
 
 ax1 = setup_axes(fig, "121")
@@ -37,6 +39,5 @@ ax2.axis["x"].set_ticklabel_direction("-")
 ax2.annotate("ticklabel direction=$-$", (0.5, 0), xycoords="axes fraction",
              xytext=(0, -10), textcoords="offset points",
              va="top", ha="center")
-
 
 plt.show()

--- a/examples/userdemo/axis_direction_demo_step03.py
+++ b/examples/userdemo/axis_direction_demo_step03.py
@@ -7,6 +7,7 @@ Axis Direction Demo Step03
 import matplotlib.pyplot as plt
 import mpl_toolkits.axisartist as axisartist
 
+
 def setup_axes(fig, rect):
     ax = axisartist.Subplot(fig, rect)
     fig.add_axes(ax)
@@ -23,7 +24,8 @@ def setup_axes(fig, rect):
 
     return ax
 
-fig = plt.figure(figsize=(6,2.5))
+
+fig = plt.figure(figsize=(6, 2.5))
 fig.subplots_adjust(bottom=0.2, top=0.8)
 
 ax1 = setup_axes(fig, "121")
@@ -41,6 +43,5 @@ ax2.axis["x"].set_axislabel_direction("-")
 ax2.annotate("label direction=$-$", (0.5, 0), xycoords="axes fraction",
              xytext=(0, -10), textcoords="offset points",
              va="top", ha="center")
-
 
 plt.show()

--- a/examples/userdemo/axis_direction_demo_step04.py
+++ b/examples/userdemo/axis_direction_demo_step04.py
@@ -7,6 +7,7 @@ Axis Direction Demo Step04
 import matplotlib.pyplot as plt
 import mpl_toolkits.axisartist as axisartist
 
+
 def setup_axes(fig, rect):
     ax = axisartist.Subplot(fig, rect)
     fig.add_axes(ax)
@@ -24,7 +25,8 @@ def setup_axes(fig, rect):
 
     return ax
 
-fig = plt.figure(figsize=(6,2.5))
+
+fig = plt.figure(figsize=(6, 2.5))
 fig.subplots_adjust(bottom=0.2, top=0.8)
 
 ax1 = setup_axes(fig, "121")
@@ -51,10 +53,8 @@ ax2.axis["x2"].label.set_text("rotation=10")
 ax2.axis["x2"].label.set_rotation(10)
 ax2.axis["x2"].toggle(ticklabels=False)
 
-
 ax2.annotate("label direction=$-$", (0.5, 0), xycoords="axes fraction",
              xytext=(0, -10), textcoords="offset points",
              va="top", ha="center")
-
 
 plt.show()

--- a/examples/userdemo/colormap_normalizations.py
+++ b/examples/userdemo/colormap_normalizations.py
@@ -33,7 +33,6 @@ fig.colorbar(pcm, ax=ax[0], extend='max')
 
 pcm = ax[1].pcolor(X, Y, Z1, cmap='PuBu_r')
 fig.colorbar(pcm, ax=ax[1], extend='max')
-fig.show()
 
 
 '''
@@ -51,7 +50,6 @@ fig.colorbar(pcm, ax=ax[0], extend='max')
 
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='PuBu_r')
 fig.colorbar(pcm, ax=ax[1], extend='max')
-fig.show()
 
 '''
 SymLogNorm: two humps, one negative and one positive, The positive
@@ -77,7 +75,6 @@ fig.colorbar(pcm, ax=ax[0], extend='both')
 
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[1], extend='both')
-fig.show()
 
 
 '''
@@ -114,7 +111,6 @@ fig.colorbar(pcm, ax=ax[0], extend='both')
 
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[1], extend='both')
-fig.show()
 
 '''
 BoundaryNorm: For this one you provide the boundaries for your colors,
@@ -140,5 +136,5 @@ fig.colorbar(pcm, ax=ax[1], extend='both', orientation='vertical')
 
 pcm = ax[2].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[2], extend='both', orientation='vertical')
-fig.show()
 
+plt.show()

--- a/examples/userdemo/colormap_normalizations_bounds.py
+++ b/examples/userdemo/colormap_normalizations_bounds.py
@@ -41,5 +41,5 @@ fig.colorbar(pcm, ax=ax[1], extend='both', orientation='vertical')
 
 pcm = ax[2].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[2], extend='both', orientation='vertical')
-fig.show()
 
+plt.show()

--- a/examples/userdemo/colormap_normalizations_custom.py
+++ b/examples/userdemo/colormap_normalizations_custom.py
@@ -46,5 +46,5 @@ fig.colorbar(pcm, ax=ax[0], extend='both')
 
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[1], extend='both')
-fig.show()
 
+plt.show()

--- a/examples/userdemo/colormap_normalizations_lognorm.py
+++ b/examples/userdemo/colormap_normalizations_lognorm.py
@@ -33,4 +33,5 @@ fig.colorbar(pcm, ax=ax[0], extend='max')
 
 pcm = ax[1].pcolor(X, Y, Z1, cmap='PuBu_r')
 fig.colorbar(pcm, ax=ax[1], extend='max')
-fig.show()
+
+plt.show()

--- a/examples/userdemo/colormap_normalizations_power.py
+++ b/examples/userdemo/colormap_normalizations_power.py
@@ -29,6 +29,5 @@ fig.colorbar(pcm, ax=ax[0], extend='max')
 
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='PuBu_r')
 fig.colorbar(pcm, ax=ax[1], extend='max')
-fig.show()
 
-
+plt.show()

--- a/examples/userdemo/colormap_normalizations_symlognorm.py
+++ b/examples/userdemo/colormap_normalizations_symlognorm.py
@@ -19,11 +19,12 @@ negative data separately.
 
 Note that colorbar labels do not come out looking very good.
 """
-N=100
+
+N = 100
 X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]
-Z1 = (bivariate_normal(X, Y, 1., 1., 1.0, 1.0))**2  \
-    - 0.4 * (bivariate_normal(X, Y, 1.0, 1.0, -1.0, 0.0))**2
-Z1 = Z1/0.03
+Z1 = (bivariate_normal(X, Y, 1., 1., 1.0, 1.0)**2 -
+      0.4 * bivariate_normal(X, Y, 1.0, 1.0, -1.0, 0.0)**2)
+Z1 = Z1 / 0.03
 
 fig, ax = plt.subplots(2, 1)
 
@@ -35,5 +36,5 @@ fig.colorbar(pcm, ax=ax[0], extend='both')
 
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[1], extend='both')
-fig.show()
 
+plt.show()

--- a/examples/userdemo/connect_simple01.py
+++ b/examples/userdemo/connect_simple01.py
@@ -7,23 +7,21 @@ Connect Simple01
 from matplotlib.patches import ConnectionPatch
 import matplotlib.pyplot as plt
 
-fig = plt.figure(1, figsize=(6,3))
-ax1 = plt.subplot(121)
-xyA=(0.2, 0.2)
-xyB=(0.8, 0.8)
-coordsA="data"
-coordsB="data"
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(6, 3))
+
+xyA = (0.2, 0.2)
+xyB = (0.8, 0.8)
+coordsA = "data"
+coordsB = "data"
 con = ConnectionPatch(xyA, xyB, coordsA, coordsB,
                       arrowstyle="-|>", shrinkA=5, shrinkB=5,
                       mutation_scale=20, fc="w")
 ax1.plot([xyA[0], xyB[0]], [xyA[1], xyB[1]], "o")
 ax1.add_artist(con)
 
-ax2 = plt.subplot(122)
-#xyA=(0.7, 0.7)
-xy=(0.3, 0.2)
-coordsA="data"
-coordsB="data"
+xy = (0.3, 0.2)
+coordsA = "data"
+coordsB = "data"
 con = ConnectionPatch(xyA=xy, xyB=xy, coordsA=coordsA, coordsB=coordsB,
                       axesA=ax2, axesB=ax1,
                       arrowstyle="->", shrinkB=5)
@@ -33,5 +31,5 @@ ax1.set_xlim(0, 1)
 ax1.set_ylim(0, 1)
 ax2.set_xlim(0, .5)
 ax2.set_ylim(0, .5)
-plt.draw()
+
 plt.show()

--- a/examples/userdemo/connectionstyle_demo.py
+++ b/examples/userdemo/connectionstyle_demo.py
@@ -7,13 +7,13 @@ Connectionstyle Demo
 
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-
-fig = plt.figure(1, figsize=(8,5))
-fig.clf()
 from mpl_toolkits.axes_grid1.axes_grid import AxesGrid
 from matplotlib.offsetbox import AnchoredText
 
-#from matplotlib.font_manager import FontProperties
+
+fig = plt.figure(1, figsize=(8, 5))
+fig.clf()
+
 
 def add_at(ax, t, loc=2):
     fp = dict(size=8)
@@ -26,13 +26,11 @@ grid = AxesGrid(fig, 111, (3, 5), label_mode="1", share_all=True)
 
 grid[0].set_autoscale_on(False)
 
-
 x1, y1 = 0.3, 0.3
 x2, y2 = 0.7, 0.7
 
 
 def demo_con_style(ax, connectionstyle, label=None):
-
     if label is None:
         label = connectionstyle
 
@@ -43,7 +41,7 @@ def demo_con_style(ax, connectionstyle, label=None):
     ax.annotate("",
                 xy=(x1, y1), xycoords='data',
                 xytext=(x2, y2), textcoords='data',
-                arrowprops=dict(arrowstyle="->", #linestyle="dashed",
+                arrowprops=dict(arrowstyle="->",
                                 color="0.5",
                                 shrinkA=5, shrinkB=5,
                                 patchA=None,
@@ -54,6 +52,7 @@ def demo_con_style(ax, connectionstyle, label=None):
 
     add_at(ax, label, loc=2)
 
+
 column = grid.axes_column[0]
 
 demo_con_style(column[0], "angle3,angleA=90,angleB=0",
@@ -61,15 +60,11 @@ demo_con_style(column[0], "angle3,angleA=90,angleB=0",
 demo_con_style(column[1], "angle3,angleA=0,angleB=90",
                label="angle3,\nangleA=0,\nangleB=90")
 
-
-
 column = grid.axes_column[1]
 
 demo_con_style(column[0], "arc3,rad=0.")
 demo_con_style(column[1], "arc3,rad=0.3")
 demo_con_style(column[2], "arc3,rad=-0.3")
-
-
 
 column = grid.axes_column[2]
 
@@ -80,7 +75,6 @@ demo_con_style(column[1], "angle,angleA=-90,angleB=180,rad=5",
 demo_con_style(column[2], "angle,angleA=-90,angleB=10,rad=5",
                label="angle,\nangleA=-90,\nangleB=10,\nrad=0")
 
-
 column = grid.axes_column[3]
 
 demo_con_style(column[0], "arc,angleA=-90,angleB=0,armA=30,armB=30,rad=0",
@@ -89,7 +83,6 @@ demo_con_style(column[1], "arc,angleA=-90,angleB=0,armA=30,armB=30,rad=5",
                label="arc,\nangleA=-90,\nangleB=0,\narmA=30,\narmB=30,\nrad=5")
 demo_con_style(column[2], "arc,angleA=-90,angleB=0,armA=0,armB=40,rad=0",
                label="arc,\nangleA=-90,\nangleB=0,\narmA=0,\narmB=40,\nrad=0")
-
 
 column = grid.axes_column[4]
 
@@ -100,16 +93,10 @@ demo_con_style(column[1], "bar,fraction=-0.3",
 demo_con_style(column[2], "bar,angle=180,fraction=-0.2",
                label="bar,\nangle=180,\nfraction=-0.2")
 
-
-#demo_con_style(column[1], "arc3,rad=0.3")
-#demo_con_style(column[2], "arc3,rad=-0.3")
-
-
 grid[0].set_xlim(0, 1)
 grid[0].set_ylim(0, 1)
 grid.axes_llc.axis["bottom"].toggle(ticklabels=False)
 grid.axes_llc.axis["left"].toggle(ticklabels=False)
 fig.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=0.95)
 
-plt.draw()
 plt.show()

--- a/examples/userdemo/custom_boxstyle01.py
+++ b/examples/userdemo/custom_boxstyle01.py
@@ -6,11 +6,12 @@ Custom Boxstyle01
 """
 from matplotlib.path import Path
 
+
 def custom_box_style(x0, y0, width, height, mutation_size, mutation_aspect=1):
     """
     Given the location and size of the box, return the path of
     the box around it.
-    
+
      - *x0*, *y0*, *width*, *height* : location and size of the box
      - *mutation_size* : a reference scale for the mutation.
      - *aspect_ratio* : aspect-ration for the mutation.
@@ -23,12 +24,12 @@ def custom_box_style(x0, y0, width, height, mutation_size, mutation_aspect=1):
     pad = mutation_size * mypad
 
     # width and height with padding added.
-    width, height = width + 2.*pad, \
-                    height + 2.*pad,
+    width = width + 2 * pad
+    height = height + 2 * pad
 
     # boundary of the padded box
-    x0, y0 = x0-pad, y0-pad,
-    x1, y1 = x0+width, y0 + height
+    x0, y0 = x0 - pad, y0 - pad
+    x1, y1 = x0 + width, y0 + height
 
     cp = [(x0, y0),
           (x1, y0), (x1, y1), (x0, y1),
@@ -47,7 +48,8 @@ def custom_box_style(x0, y0, width, height, mutation_size, mutation_aspect=1):
 
 import matplotlib.pyplot as plt
 
-plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+fig, ax = plt.subplots(figsize=(3, 3))
 ax.text(0.5, 0.5, "Test", size=30, va="center", ha="center",
         bbox=dict(boxstyle=custom_box_style, alpha=0.2))
+
+plt.show()

--- a/examples/userdemo/custom_boxstyle02.py
+++ b/examples/userdemo/custom_boxstyle02.py
@@ -8,9 +8,9 @@ from matplotlib.path import Path
 from matplotlib.patches import BoxStyle
 import matplotlib.pyplot as plt
 
+
 # we may derive from matplotlib.patches.BoxStyle._Base class.
 # You need to override transmute method in this case.
-
 class MyStyle(BoxStyle._Base):
     """
     A simple box.
@@ -20,7 +20,7 @@ class MyStyle(BoxStyle._Base):
         """
         The arguments need to be floating numbers and need to have
         default values.
-        
+
          *pad*
             amount of padding
         """
@@ -70,8 +70,7 @@ class MyStyle(BoxStyle._Base):
 # register the custom style
 BoxStyle._style_list["angled"] = MyStyle
 
-plt.figure(1, figsize=(3,3))
-ax = plt.subplot(111)
+fig, ax = plt.subplots(figsize=(3, 3))
 ax.text(0.5, 0.5, "Test", size=30, va="center", ha="center", rotation=30,
         bbox=dict(boxstyle="angled,pad=0.5", alpha=0.2))
 

--- a/examples/userdemo/demo_axis_direction.py
+++ b/examples/userdemo/demo_axis_direction.py
@@ -5,16 +5,17 @@ Demo Axis Direction
 
 """
 
-
 import numpy as np
-import  mpl_toolkits.axisartist.angle_helper as angle_helper
-import  mpl_toolkits.axisartist.grid_finder as grid_finder
+import matplotlib.pyplot as plt
+import mpl_toolkits.axisartist.angle_helper as angle_helper
+import mpl_toolkits.axisartist.grid_finder as grid_finder
 from matplotlib.projections import PolarAxes
 from matplotlib.transforms import Affine2D
 
 import mpl_toolkits.axisartist as axisartist
 
-from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
+from mpl_toolkits.axisartist.grid_helper_curvelinear import \
+    GridHelperCurveLinear
 
 
 def setup_axes(fig, rect):
@@ -26,10 +27,10 @@ def setup_axes(fig, rect):
     tr = Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform()
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20, 20,
-                                                     lon_cycle = 360,
-                                                     lat_cycle = None,
-                                                     lon_minmax = None,
-                                                     lat_minmax = (0, np.inf),
+                                                     lon_cycle=360,
+                                                     lat_cycle=None,
+                                                     lon_minmax=None,
+                                                     lat_minmax=(0, np.inf),
                                                      )
 
     grid_locator1 = angle_helper.LocatorDMS(12)
@@ -44,7 +45,6 @@ def setup_axes(fig, rect):
                                         tick_formatter1=tick_formatter1
                                         )
 
-
     ax1 = axisartist.Subplot(fig, rect, grid_helper=grid_helper)
     ax1.axis[:].toggle(ticklabels=False)
 
@@ -53,8 +53,6 @@ def setup_axes(fig, rect):
     ax1.set_aspect(1.)
     ax1.set_xlim(-5, 12)
     ax1.set_ylim(-5, 10)
-
-    #ax1.grid(True)
 
     return ax1
 
@@ -75,8 +73,7 @@ def add_floating_axis2(ax1):
     return axis
 
 
-import matplotlib.pyplot as plt
-fig = plt.figure(1, figsize=(8, 4.))
+fig = plt.figure(1, figsize=(8, 4))
 fig.clf()
 fig.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.99,
                     wspace=0.01, hspace=0.01)
@@ -97,8 +94,4 @@ for i, d in enumerate(["bottom", "left", "top", "right"]):
                  xycoords="axes fraction", textcoords="offset points",
                  va="top", ha="left")
 
-
-
 plt.show()
-
-

--- a/examples/userdemo/demo_gridspec01.py
+++ b/examples/userdemo/demo_gridspec01.py
@@ -6,6 +6,7 @@ Demo Gridspec01
 """
 import matplotlib.pyplot as plt
 
+
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
@@ -13,14 +14,14 @@ def make_ticklabels_invisible(fig):
             tl.set_visible(False)
 
 
-plt.figure(0)
-ax1 = plt.subplot2grid((3,3), (0,0), colspan=3)
-ax2 = plt.subplot2grid((3,3), (1,0), colspan=2)
-ax3 = plt.subplot2grid((3,3), (1, 2), rowspan=2)
-ax4 = plt.subplot2grid((3,3), (2, 0))
-ax5 = plt.subplot2grid((3,3), (2, 1))
+fig = plt.figure(0)
+ax1 = plt.subplot2grid((3, 3), (0, 0), colspan=3)
+ax2 = plt.subplot2grid((3, 3), (1, 0), colspan=2)
+ax3 = plt.subplot2grid((3, 3), (1, 2), rowspan=2)
+ax4 = plt.subplot2grid((3, 3), (2, 0))
+ax5 = plt.subplot2grid((3, 3), (2, 1))
 
-plt.suptitle("subplot2grid")
-make_ticklabels_invisible(plt.gcf())
+fig.suptitle("subplot2grid")
+make_ticklabels_invisible(fig)
+
 plt.show()
-

--- a/examples/userdemo/demo_gridspec02.py
+++ b/examples/userdemo/demo_gridspec02.py
@@ -15,18 +15,17 @@ def make_ticklabels_invisible(fig):
             tl.set_visible(False)
 
 
-plt.figure()
+fig = plt.figure()
 
 gs = GridSpec(3, 3)
 ax1 = plt.subplot(gs[0, :])
-# identical to ax1 = plt.subplot(gs.new_subplotspec((0,0), colspan=3))
-ax2 = plt.subplot(gs[1,:-1])
+# identical to ax1 = plt.subplot(gs.new_subplotspec((0, 0), colspan=3))
+ax2 = plt.subplot(gs[1, :-1])
 ax3 = plt.subplot(gs[1:, -1])
-ax4 = plt.subplot(gs[-1,0])
-ax5 = plt.subplot(gs[-1,-2])
+ax4 = plt.subplot(gs[-1, 0])
+ax5 = plt.subplot(gs[-1, -2])
 
-plt.suptitle("GridSpec")
-make_ticklabels_invisible(plt.gcf())
+fig.suptitle("GridSpec")
+make_ticklabels_invisible(fig)
 
 plt.show()
-

--- a/examples/userdemo/demo_gridspec03.py
+++ b/examples/userdemo/demo_gridspec03.py
@@ -15,12 +15,11 @@ def make_ticklabels_invisible(fig):
             tl.set_visible(False)
 
 
-
 # demo 3 : gridspec with subplotpars set.
 
-f = plt.figure()
+fig = plt.figure()
 
-plt.suptitle("GridSpec w/ different subplotpars")
+fig.suptitle("GridSpec w/ different subplotpars")
 
 gs1 = GridSpec(3, 3)
 gs1.update(left=0.05, right=0.48, wspace=0.05)
@@ -34,7 +33,6 @@ ax4 = plt.subplot(gs2[:, :-1])
 ax5 = plt.subplot(gs2[:-1, -1])
 ax6 = plt.subplot(gs2[-1, -1])
 
-make_ticklabels_invisible(plt.gcf())
+make_ticklabels_invisible(fig)
 
 plt.show()
-

--- a/examples/userdemo/demo_gridspec04.py
+++ b/examples/userdemo/demo_gridspec04.py
@@ -7,12 +7,12 @@ Demo Gridspec04
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 
+
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
         for tl in ax.get_xticklabels() + ax.get_yticklabels():
             tl.set_visible(False)
-
 
 
 # gridspec inside gridspec
@@ -41,7 +41,6 @@ ax6 = plt.Subplot(f, gs01[-1, -1])
 f.add_subplot(ax6)
 
 plt.suptitle("GridSpec Inside GridSpec")
-make_ticklabels_invisible(plt.gcf())
+make_ticklabels_invisible(f)
 
 plt.show()
-

--- a/examples/userdemo/demo_gridspec05.py
+++ b/examples/userdemo/demo_gridspec05.py
@@ -7,6 +7,7 @@ Demo Gridspec05
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 
+
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
@@ -14,13 +15,10 @@ def make_ticklabels_invisible(fig):
             tl.set_visible(False)
 
 
-
 f = plt.figure()
 
 gs = gridspec.GridSpec(2, 2,
-                       width_ratios=[1,2],
-                       height_ratios=[4,1]
-                       )
+                       width_ratios=[1, 2], height_ratios=[4, 1])
 
 ax1 = plt.subplot(gs[0])
 ax2 = plt.subplot(gs[1])
@@ -29,4 +27,3 @@ ax4 = plt.subplot(gs[3])
 
 make_ticklabels_invisible(f)
 plt.show()
-

--- a/examples/userdemo/demo_gridspec06.py
+++ b/examples/userdemo/demo_gridspec06.py
@@ -9,8 +9,11 @@ import matplotlib.gridspec as gridspec
 import numpy as np
 from itertools import product
 
-def squiggle_xy(a, b, c, d, i=np.arange(0.0, 2*np.pi, 0.05)):
+
+def squiggle_xy(a, b, c, d):
+    i = np.arange(0.0, 2*np.pi, 0.05)
     return np.sin(i*a)*np.cos(i*b), np.sin(i*c)*np.cos(i*d)
+
 
 fig = plt.figure(figsize=(8, 8))
 
@@ -20,7 +23,8 @@ outer_grid = gridspec.GridSpec(4, 4, wspace=0.0, hspace=0.0)
 for i in range(16):
     inner_grid = gridspec.GridSpecFromSubplotSpec(3, 3,
             subplot_spec=outer_grid[i], wspace=0.0, hspace=0.0)
-    a, b = int(i/4)+1,i%4+1
+    a = i // 4 + 1
+    b = i % 4 + 1
     for j, (c, d) in enumerate(product(range(1, 4), repeat=2)):
         ax = plt.Subplot(fig, inner_grid[j])
         ax.plot(*squiggle_xy(a, b, c, d))

--- a/examples/userdemo/demo_parasite_axes_sgskip.py
+++ b/examples/userdemo/demo_parasite_axes_sgskip.py
@@ -33,7 +33,6 @@ if __name__ == "__main__":
                                        axes=par2,
                                        offset=offset)
 
-
     fig.add_axes(host)
 
     host.set_xlim(0, 2)
@@ -56,5 +55,4 @@ if __name__ == "__main__":
     par1.axis["right"].label.set_color(p2.get_color())
     par2.axis["right2"].label.set_color(p3.get_color())
 
-    plt.draw()
     plt.show()

--- a/examples/userdemo/demo_ticklabel_alignment.py
+++ b/examples/userdemo/demo_ticklabel_alignment.py
@@ -11,7 +11,6 @@ import mpl_toolkits.axisartist as axisartist
 
 
 def setup_axes(fig, rect):
-    
     ax = axisartist.Subplot(fig, rect)
     fig.add_subplot(ax)
 
@@ -22,10 +21,9 @@ def setup_axes(fig, rect):
 
     return ax
 
+
 fig = plt.figure(1, figsize=(3, 5))
 fig.subplots_adjust(left=0.5, hspace=0.7)
-
-
 
 ax = setup_axes(fig, 311)
 ax.set_ylabel("ha=right")
@@ -42,3 +40,5 @@ ax.axis["left"].major_ticklabels.set_ha("left")
 ax.axis["bottom"].major_ticklabels.set_va("bottom")
 ax.set_ylabel("ha=left")
 ax.set_xlabel("va=bottom")
+
+plt.show()

--- a/examples/userdemo/demo_ticklabel_direction.py
+++ b/examples/userdemo/demo_ticklabel_direction.py
@@ -10,39 +10,28 @@ import mpl_toolkits.axisartist.axislines as axislines
 
 
 def setup_axes(fig, rect):
-    
     ax = axislines.Subplot(fig, rect)
     fig.add_subplot(ax)
 
     ax.set_yticks([0.2, 0.8])
-    #ax.set_yticklabels(["short", "loooong"])
     ax.set_xticks([0.2, 0.8])
-    #ax.set_xticklabels([r"$\frac{1}{2}\pi$", r"$\pi$"])
 
     return ax
+
 
 fig = plt.figure(1, figsize=(6, 3))
 fig.subplots_adjust(bottom=0.2)
 
-
-
 ax = setup_axes(fig, 131)
-for axis in ax.axis.values(): axis.major_ticks.set_tick_out(True)
-#or you can simply do "ax.axis[:].major_ticks.set_tick_out(True)"
-
-
-
+for axis in ax.axis.values():
+    axis.major_ticks.set_tick_out(True)
+# or you can simply do "ax.axis[:].major_ticks.set_tick_out(True)"
 
 ax = setup_axes(fig, 132)
 ax.axis["left"].set_axis_direction("right")
 ax.axis["bottom"].set_axis_direction("top")
 ax.axis["right"].set_axis_direction("left")
 ax.axis["top"].set_axis_direction("bottom")
-
-#ax.axis["left"].major_ticklabels.set_pad(0)
-#ax.axis["bottom"].major_ticklabels.set_pad(10)
-
-
 
 ax = setup_axes(fig, 133)
 ax.axis["left"].set_axis_direction("right")

--- a/examples/userdemo/pgf_fonts_sgskip.py
+++ b/examples/userdemo/pgf_fonts_sgskip.py
@@ -10,13 +10,13 @@ import matplotlib as mpl
 mpl.use("pgf")
 pgf_with_rc_fonts = {
     "font.family": "serif",
-    "font.serif": [],                   # use latex default serif font
-    "font.sans-serif": ["DejaVu Sans"], # use a specific sans-serif font
+    "font.serif": [],                    # use latex default serif font
+    "font.sans-serif": ["DejaVu Sans"],  # use a specific sans-serif font
 }
 mpl.rcParams.update(pgf_with_rc_fonts)
 
 import matplotlib.pyplot as plt
-plt.figure(figsize=(4.5,2.5))
+plt.figure(figsize=(4.5, 2.5))
 plt.plot(range(5))
 plt.text(0.5, 3., "serif")
 plt.text(0.5, 2., "monospace", family="monospace")

--- a/examples/userdemo/pgf_preamble_sgskip.py
+++ b/examples/userdemo/pgf_preamble_sgskip.py
@@ -13,21 +13,21 @@ import six
 import matplotlib as mpl
 mpl.use("pgf")
 pgf_with_custom_preamble = {
-    "font.family": "serif", # use serif/main font for text elements
-    "text.usetex": True,    # use inline math for ticks
-    "pgf.rcfonts": False,   # don't setup fonts from rc parameters
+    "font.family": "serif",  # use serif/main font for text elements
+    "text.usetex": True,     # use inline math for ticks
+    "pgf.rcfonts": False,    # don't setup fonts from rc parameters
     "pgf.preamble": [
-         "\\usepackage{units}",         # load additional packages
+         "\\usepackage{units}",          # load additional packages
          "\\usepackage{metalogo}",
-         "\\usepackage{unicode-math}",  # unicode math setup
+         "\\usepackage{unicode-math}",   # unicode math setup
          r"\setmathfont{xits-math.otf}",
-         r"\setmainfont{DejaVu Serif}", # serif font via preamble
+         r"\setmainfont{DejaVu Serif}",  # serif font via preamble
          ]
 }
 mpl.rcParams.update(pgf_with_custom_preamble)
 
 import matplotlib.pyplot as plt
-plt.figure(figsize=(4.5,2.5))
+plt.figure(figsize=(4.5, 2.5))
 plt.plot(range(5))
 plt.xlabel("unicode text: я, ψ, €, ü, \\unitfrac[10]{°}{µm}")
 plt.ylabel("\\XeLaTeX")

--- a/examples/userdemo/pgf_texsystem_sgskip.py
+++ b/examples/userdemo/pgf_texsystem_sgskip.py
@@ -19,7 +19,7 @@ pgf_with_pdflatex = {
 mpl.rcParams.update(pgf_with_pdflatex)
 
 import matplotlib.pyplot as plt
-plt.figure(figsize=(4.5,2.5))
+plt.figure(figsize=(4.5, 2.5))
 plt.plot(range(5))
 plt.text(0.5, 3., "serif", family="serif")
 plt.text(0.5, 2., "monospace", family="monospace")

--- a/examples/userdemo/simple_annotate01.py
+++ b/examples/userdemo/simple_annotate01.py
@@ -18,6 +18,7 @@ from matplotlib.offsetbox import AnchoredText
 
 from matplotlib.font_manager import FontProperties
 
+
 def add_at(ax, t, loc=2):
     fp = dict(size=10)
     _at = AnchoredText(t, loc=loc, prop=fp)
@@ -38,13 +39,13 @@ ax.annotate("",
 
 add_at(ax, "A $->$ B", loc=2)
 
+
 ax = grid[1]
 ax.plot([x1, x2], [y1, y2], "o")
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="->",
-                            connectionstyle="arc3,rad=0.3"))
+            arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.3"))
 
 add_at(ax, "connectionstyle=arc3", loc=2)
 
@@ -54,10 +55,8 @@ ax.plot([x1, x2], [y1, y2], "o")
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="->",
-                            connectionstyle="arc3,rad=0.3",
-                            shrinkB=5,
-                            )
+            arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.3",
+                            shrinkB=5)
             )
 
 add_at(ax, "shrinkB=5", loc=2)
@@ -70,9 +69,7 @@ ax.add_artist(el)
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="->",
-                            connectionstyle="arc3,rad=0.2",
-                            )
+            arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.2")
             )
 
 
@@ -83,15 +80,11 @@ ax.add_artist(el)
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="->",
-                            connectionstyle="arc3,rad=0.2",
-                            patchB=el,
-                            )
+            arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.2",
+                            patchB=el)
             )
 
-
 add_at(ax, "patchB", loc=2)
-
 
 
 ax = grid[5]
@@ -100,14 +93,9 @@ ax.annotate("Test",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
             ha="center", va="center",
-            bbox=dict(boxstyle="round",
-                      fc="w",
-                      ),
-            arrowprops=dict(arrowstyle="->",
-                            #connectionstyle="arc3,rad=0.2",
-                            )
+            bbox=dict(boxstyle="round", fc="w"),
+            arrowprops=dict(arrowstyle="->")
             )
-
 
 add_at(ax, "annotate", loc=2)
 
@@ -118,21 +106,10 @@ ax.annotate("Test",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
             ha="center", va="center",
-            bbox=dict(boxstyle="round",
-                      fc="w",
-                      ),
-            arrowprops=dict(arrowstyle="->",
-                            #connectionstyle="arc3,rad=0.2",
-                            relpos=(0., 0.)
-                            )
+            bbox=dict(boxstyle="round", fc="w", ),
+            arrowprops=dict(arrowstyle="->", relpos=(0., 0.))
             )
-
 
 add_at(ax, "relpos=(0,0)", loc=2)
 
-
-
-#ax.set_xlim(0, 1)
-#ax.set_ylim(0, 1)
-plt.draw()
 plt.show()

--- a/examples/userdemo/simple_axis_direction01.py
+++ b/examples/userdemo/simple_axis_direction01.py
@@ -7,7 +7,7 @@ Simple Axis Direction01
 import matplotlib.pyplot as plt
 import mpl_toolkits.axisartist as axisartist
 
-fig = plt.figure(figsize=(4,2.5))
+fig = plt.figure(figsize=(4, 2.5))
 ax1 = fig.add_subplot(axisartist.Subplot(fig, "111"))
 fig.subplots_adjust(right=0.8)
 

--- a/examples/userdemo/simple_axis_direction03.py
+++ b/examples/userdemo/simple_axis_direction03.py
@@ -8,6 +8,7 @@ Simple Axis Direction03
 import matplotlib.pyplot as plt
 import mpl_toolkits.axisartist as axisartist
 
+
 def setup_axes(fig, rect):
     ax = axisartist.Subplot(fig, rect)
     fig.add_subplot(ax)
@@ -16,7 +17,8 @@ def setup_axes(fig, rect):
     ax.set_xticks([0.2, 0.8])
 
     return ax
-    
+
+
 fig = plt.figure(1, figsize=(5, 2))
 fig.subplots_adjust(wspace=0.4, bottom=0.3)
 
@@ -33,5 +35,3 @@ ax2.set_ylabel("Y-label")
 ax2.axis[:].major_ticks.set_tick_out(True)
 
 plt.show()
-
-

--- a/examples/userdemo/simple_axis_pad.py
+++ b/examples/userdemo/simple_axis_pad.py
@@ -5,16 +5,17 @@ Simple Axis Pad
 
 """
 
-
 import numpy as np
-import  mpl_toolkits.axisartist.angle_helper as angle_helper
-import  mpl_toolkits.axisartist.grid_finder as grid_finder
+import matplotlib.pyplot as plt
+import mpl_toolkits.axisartist.angle_helper as angle_helper
+import mpl_toolkits.axisartist.grid_finder as grid_finder
 from matplotlib.projections import PolarAxes
 from matplotlib.transforms import Affine2D
 
 import mpl_toolkits.axisartist as axisartist
 
-from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
+from mpl_toolkits.axisartist.grid_helper_curvelinear import \
+    GridHelperCurveLinear
 
 
 def setup_axes(fig, rect):
@@ -26,10 +27,10 @@ def setup_axes(fig, rect):
     tr = Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform()
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20, 20,
-                                                     lon_cycle = 360,
-                                                     lat_cycle = None,
-                                                     lon_minmax = None,
-                                                     lat_minmax = (0, np.inf),
+                                                     lon_cycle=360,
+                                                     lat_cycle=None,
+                                                     lon_minmax=None,
+                                                     lat_minmax=(0, np.inf),
                                                      )
 
     grid_locator1 = angle_helper.LocatorDMS(12)
@@ -44,9 +45,7 @@ def setup_axes(fig, rect):
                                         tick_formatter1=tick_formatter1
                                         )
 
-
     ax1 = axisartist.Subplot(fig, rect, grid_helper=grid_helper)
-    #ax1.axis[:].toggle(all=False)
     ax1.axis[:].set_visible(False)
 
     fig.add_subplot(ax1)
@@ -54,8 +53,6 @@ def setup_axes(fig, rect):
     ax1.set_aspect(1.)
     ax1.set_xlim(-5, 12)
     ax1.set_ylim(-5, 10)
-
-    #ax1.grid(True)
 
     return ax1
 
@@ -76,7 +73,6 @@ def add_floating_axis2(ax1):
     return axis
 
 
-import matplotlib.pyplot as plt
 fig = plt.figure(1, figsize=(9, 3.))
 fig.clf()
 fig.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.99,
@@ -86,10 +82,11 @@ fig.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.99,
 def ann(ax1, d):
     if plt.rcParams["text.usetex"]:
         d = d.replace("_", r"\_")
-                    
+
     ax1.annotate(d, (0.5, 1), (5, -5),
                  xycoords="axes fraction", textcoords="offset points",
                  va="top", ha="center")
+
 
 ax1 = setup_axes(fig, rect=141)
 axis = add_floating_axis1(ax1)
@@ -110,9 +107,4 @@ axis = add_floating_axis1(ax1)
 axis.major_ticks.set_tick_out(True)
 ann(ax1, "ticks.set_tick_out(True)")
 
-
-#ax1.axis["bottom"].toggle(all=True)
-
 plt.show()
-
-

--- a/examples/userdemo/simple_axisartist1.py
+++ b/examples/userdemo/simple_axisartist1.py
@@ -25,4 +25,3 @@ ax.axis["y=0"].label.set_text("y = 0")
 ax.set_ylim(-2, 4)
 
 plt.show()
-

--- a/examples/userdemo/simple_axisline.py
+++ b/examples/userdemo/simple_axisline.py
@@ -39,6 +39,5 @@ if 1:
                                      axes=ax)
     ax.axis["right2"].label.set_text("Label Y2")
 
-    ax.plot([-2,3,2])
-    plt.draw()
+    ax.plot([-2, 3, 2])
     plt.show()

--- a/examples/userdemo/simple_axisline2.py
+++ b/examples/userdemo/simple_axisline2.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axisartist.axislines import SubplotZero
 import numpy as np
 
-fig = plt.figure(1, (4,3))
+fig = plt.figure(1, (4, 3))
 
 # a subplot with two additional axis, "xzero" and "yzero". "xzero" is
 # y=0 line, and "yzero" is x=0 line.

--- a/examples/userdemo/simple_axisline3.py
+++ b/examples/userdemo/simple_axisline3.py
@@ -7,7 +7,7 @@ Simple Axisline3
 import matplotlib.pyplot as plt
 from mpl_toolkits.axisartist.axislines import Subplot
 
-fig = plt.figure(1, (3,3))
+fig = plt.figure(1, (3, 3))
 
 ax = Subplot(fig, 111)
 fig.add_subplot(ax)

--- a/examples/userdemo/simple_legend01.py
+++ b/examples/userdemo/simple_legend01.py
@@ -8,16 +8,16 @@ import matplotlib.pyplot as plt
 
 
 plt.subplot(211)
-plt.plot([1,2,3], label="test1")
-plt.plot([3,2,1], label="test2")
+plt.plot([1, 2, 3], label="test1")
+plt.plot([3, 2, 1], label="test2")
 # Place a legend above this subplot, expanding itself to
 # fully use the given bounding box.
 plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3,
            ncol=2, mode="expand", borderaxespad=0.)
 
 plt.subplot(223)
-plt.plot([1,2,3], label="test1")
-plt.plot([3,2,1], label="test2")
+plt.plot([1, 2, 3], label="test1")
+plt.plot([3, 2, 1], label="test2")
 # Place a legend to the right of this smaller subplot.
 plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
 

--- a/examples/userdemo/simple_legend02.py
+++ b/examples/userdemo/simple_legend02.py
@@ -6,16 +6,18 @@ Simple Legend02
 """
 import matplotlib.pyplot as plt
 
-line1, = plt.plot([1,2,3], label="Line 1", linestyle='--')
-line2, = plt.plot([3,2,1], label="Line 2", linewidth=4)
+fig, ax = plt.subplots()
+
+line1, = ax.plot([1, 2, 3], label="Line 1", linestyle='--')
+line2, = ax.plot([3, 2, 1], label="Line 2", linewidth=4)
 
 # Create a legend for the first line.
-first_legend = plt.legend(handles=[line1], loc=1)
+first_legend = ax.legend(handles=[line1], loc=1)
 
 # Add the legend manually to the current Axes.
-ax = plt.gca().add_artist(first_legend)
+ax.add_artist(first_legend)
 
 # Create another legend for the second line.
-plt.legend(handles=[line2], loc=4)
+ax.legend(handles=[line2], loc=4)
 
 plt.show()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -500,8 +500,8 @@ or tuple of floats
         Notes
         -----
 
-        Not all kinds of artist are supported by the legend command.
-        See :ref:`sphx_glr_tutorials_02_intermediate_legend_guide.py` for details.
+        Not all kinds of artist are supported by the legend command. See
+        :ref:`sphx_glr_tutorials_02_intermediate_legend_guide.py` for details.
 
         Examples
         --------

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1857,7 +1857,8 @@ class _AxesBase(martist.Artist):
             p.set_clip_path(self.patch)
         self._update_patch_limits(p)
         if self.name != 'rectilinear':
-            p.get_path()._interpolation_steps = max(p.get_path()._interpolation_steps, 100)
+            path = p.get_path()
+            path._interpolation_steps = max(path._interpolation_steps, 100)
         self.patches.append(p)
         p._remove_method = lambda h: self.patches.remove(h)
         return p

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1411,8 +1411,8 @@ class Figure(Artist):
 
         Notes
         -----
-        Not all kinds of artist are supported by the legend command.
-        See :ref:`sphx_glr_tutorials_02_intermediate_legend_guide.py` for details.
+        Not all kinds of artist are supported by the legend command. See
+        :ref:`sphx_glr_tutorials_02_intermediate_legend_guide.py` for details.
         """
 
         # If no arguments given, collect up all the artists on the figure

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -7,7 +7,8 @@ drawing legends associated with axes and/or figures.
     It is unlikely that you would ever create a Legend instance manually.
     Most users would normally create a legend via the
     :meth:`~matplotlib.axes.Axes.legend` function. For more details on legends
-    there is also a :ref:`legend guide <sphx_glr_tutorials_02_intermediate_legend_guide.py>`.
+    there is also a :ref:`legend guide
+    <sphx_glr_tutorials_02_intermediate_legend_guide.py>`.
 
 The Legend class can be considered as a container of legend handles
 and legend texts. Creation of corresponding legend handles from the
@@ -16,9 +17,9 @@ specified by the handler map, which defines the mapping between the
 plot elements and the legend handlers to be used (the default legend
 handlers are defined in the :mod:`~matplotlib.legend_handler` module).
 Note that not all kinds of artist are supported by the legend yet by default
-but it is possible to extend the legend handler's capabilities to
-support arbitrary objects. See the :ref:`legend guide <sphx_glr_tutorials_02_intermediate_legend_guide.py>`
-for more information.
+but it is possible to extend the legend handler's capabilities to support
+arbitrary objects. See the :ref:`legend guide
+<sphx_glr_tutorials_02_intermediate_legend_guide.py>` for more information.
 
 """
 from __future__ import (absolute_import, division, print_function,

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -163,8 +163,8 @@ following methods::
   ax.yaxis.set_major_formatter( ymajorFormatter )
   ax.yaxis.set_minor_formatter( yminorFormatter )
 
-See :ref:`sphx_glr_gallery_pylab_examples_major_minor_demo1.py` for an example of setting
-major and minor ticks. See the :mod:`matplotlib.dates` module for
+See :ref:`sphx_glr_gallery_pylab_examples_major_minor_demo1.py` for an example
+of setting major and minor ticks. See the :mod:`matplotlib.dates` module for
 more information and examples of using date locators and formatters.
 """
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -109,6 +109,7 @@ pep8ignore =
     mpl_toolkits/gtktools.py E221 E222 E225 E228 E231 E251 E261 E301 E302 E303 E401 E501 E701
 
     doc/* ALL
+    tutorials/* E402 E501
 
     *examples/* E116 E501 E402
     *examples/pylab_examples/table_demo.py E201

--- a/tutorials/02_intermediate/artists.py
+++ b/tutorials/02_intermediate/artists.py
@@ -668,7 +668,7 @@ plt.show()
 # gridline         Line2D instance
 # label1           Text instance
 # label2           Text instance
-# gridOn           boolean which determines whether to draw the gridline 
+# gridOn           boolean which determines whether to draw the gridline
 # tick1On          boolean which determines whether to draw the 1st tickline
 # tick2On          boolean which determines whether to draw the 2nd tickline
 # label1On         boolean which determines whether to draw the 1st tick label

--- a/tutorials/02_intermediate/legend_guide.py
+++ b/tutorials/02_intermediate/legend_guide.py
@@ -236,8 +236,10 @@ l = plt.legend([(p1, p2)], ['Two keys'], numpoints=1,
 
 import matplotlib.patches as mpatches
 
+
 class AnyObject(object):
     pass
+
 
 class AnyObjectHandler(object):
     def legend_artist(self, legend, orig_handle, fontsize, handlebox):
@@ -248,6 +250,7 @@ class AnyObjectHandler(object):
                                    transform=handlebox.get_transform())
         handlebox.add_artist(patch)
         return patch
+
 
 plt.legend([AnyObject()], ['My first handler'],
            handler_map={AnyObject: AnyObjectHandler()})
@@ -266,6 +269,7 @@ plt.legend([AnyObject()], ['My first handler'],
 # rectangular ones:
 
 from matplotlib.legend_handler import HandlerPatch
+
 
 class HandlerEllipse(HandlerPatch):
     def create_artists(self, legend, orig_handle,

--- a/tutorials/03_advanced/path_tutorial.py
+++ b/tutorials/03_advanced/path_tutorial.py
@@ -19,19 +19,20 @@ from matplotlib.path import Path
 import matplotlib.patches as patches
 
 verts = [
-   (0., 0.), # left, bottom
-   (0., 1.), # left, top
-   (1., 1.), # right, top
-   (1., 0.), # right, bottom
-   (0., 0.), # ignored
-   ]
+   (0., 0.),  # left, bottom
+   (0., 1.),  # left, top
+   (1., 1.),  # right, top
+   (1., 0.),  # right, bottom
+   (0., 0.),  # ignored
+]
 
-codes = [Path.MOVETO,
-         Path.LINETO,
-         Path.LINETO,
-         Path.LINETO,
-         Path.CLOSEPOLY,
-         ]
+codes = [
+    Path.MOVETO,
+    Path.LINETO,
+    Path.LINETO,
+    Path.LINETO,
+    Path.CLOSEPOLY,
+]
 
 path = Path(verts, codes)
 
@@ -75,17 +76,18 @@ plt.show()
 # point
 
 verts = [
-   (0., 0.),  # P0
-   (0.2, 1.), # P1
-   (1., 0.8), # P2
-   (0.8, 0.), # P3
-   ]
+   (0., 0.),   # P0
+   (0.2, 1.),  # P1
+   (1., 0.8),  # P2
+   (0.8, 0.),  # P3
+]
 
-codes = [Path.MOVETO,
-         Path.CURVE4,
-         Path.CURVE4,
-         Path.CURVE4,
-         ]
+codes = [
+    Path.MOVETO,
+    Path.CURVE4,
+    Path.CURVE4,
+    Path.CURVE4,
+]
 
 path = Path(verts, codes)
 

--- a/tutorials/03_advanced/transforms_tutorial.py
+++ b/tutorials/03_advanced/transforms_tutorial.py
@@ -24,11 +24,11 @@ description of that system. In the `Transformation Object` column,
 Coordinate  Transformation Object  Description
 ==========  =====================  ====================================================================================
 `data`      ``ax.transData``       The userland data coordinate system, controlled by the xlim and ylim
-`axes`      ``ax.transAxes``       The coordinate system of the :class:`~matplotlib.axes.Axes`; (0,0) is
-                                   bottom left of the axes, and (1,1) is top right of the axes.
-`figure`    ``fig.transFigure``    The coordinate system of the :class:`~matplotlib.figure.Figure`; (0,0)
-                                   is bottom left of the figure, and (1,1) is top right of the figure.
-`display`   `None`                 This is the pixel coordinate system of the display; (0,0) is the bottom
+`axes`      ``ax.transAxes``       The coordinate system of the :class:`~matplotlib.axes.Axes`; (0, 0) is
+                                   bottom left of the axes, and (1, 1) is top right of the axes.
+`figure`    ``fig.transFigure``    The coordinate system of the :class:`~matplotlib.figure.Figure`; (0, 0)
+                                   is bottom left of the figure, and (1, 1) is top right of the figure.
+`display`   `None`                 This is the pixel coordinate system of the display; (0, 0) is the bottom
                                    left of the display, and (width, height) is the top right of the display in pixels.
                                    Alternatively, the identity transform
                                    (:class:`matplotlib.transforms.IdentityTransform()`) may be used instead of None.
@@ -87,7 +87,7 @@ plt.show()
 #     In [15]: ax.transData.transform((5, 0))
 #     Out[15]: array([ 335.175,  247.   ])
 #
-#     In [16]: ax.transData.transform([(5, 0), (1,2)])
+#     In [16]: ax.transData.transform([(5, 0), (1, 2)])
 #     Out[16]:
 #     array([[ 335.175,  247.   ],
 #            [ 132.435,  642.2  ]])
@@ -170,13 +170,13 @@ plt.show()
 #     In [54]: ax.transData.transform((5, 0))
 #     Out[54]: array([ 335.175,  247.   ])
 #
-#     In [55]: ax.set_ylim(-1,2)
+#     In [55]: ax.set_ylim(-1, 2)
 #     Out[55]: (-1, 2)
 #
 #     In [56]: ax.transData.transform((5, 0))
 #     Out[56]: array([ 335.175     ,  181.13333333])
 #
-#     In [57]: ax.set_xlim(10,20)
+#     In [57]: ax.set_xlim(10, 20)
 #     Out[57]: (10, 20)
 #
 #     In [58]: ax.transData.transform((5, 0))
@@ -189,7 +189,7 @@ plt.show()
 # ================
 #
 # After the `data` coordinate system, `axes` is probably the second most
-# useful coordinate system.  Here the point (0,0) is the bottom left of
+# useful coordinate system.  Here the point (0, 0) is the bottom left of
 # your axes or subplot, (0.5, 0.5) is the center, and (1.0, 1.0) is the
 # top right.  You can also refer to points outside the range, so (-0.1,
 # 1.1) is to the left and above your axes.  This coordinate system is
@@ -272,7 +272,7 @@ trans = transforms.blended_transform_factory(
 # highlight the 1..2 stddev region with a span.
 # We want x to be in data coordinates and y to
 # span from 0..1 in axes coords
-rect = patches.Rectangle((1,0), width=1, height=1,
+rect = patches.Rectangle((1, 0), width=1, height=1,
                          transform=trans, color='yellow',
                          alpha=0.5)
 
@@ -389,7 +389,7 @@ plt.show()
 #   self.transData = self.transScale + (self.transLimits + self.transAxes)
 #
 # We've been introduced to the ``transAxes`` instance above in
-# :ref:`axes-coords`, which maps the (0,0), (1,1) corners of the
+# :ref:`axes-coords`, which maps the (0, 0), (1, 1) corners of the
 # axes or subplot bounding box to `display` space, so let's look at
 # these other two pieces.
 #
@@ -405,19 +405,19 @@ plt.show()
 #     In [81]: ax.set_xlim(0, 10)
 #     Out[81]: (0, 10)
 #
-#     In [82]: ax.set_ylim(-1,1)
+#     In [82]: ax.set_ylim(-1, 1)
 #     Out[82]: (-1, 1)
 #
-#     In [84]: ax.transLimits.transform((0,-1))
+#     In [84]: ax.transLimits.transform((0, -1))
 #     Out[84]: array([ 0.,  0.])
 #
-#     In [85]: ax.transLimits.transform((10,-1))
+#     In [85]: ax.transLimits.transform((10, -1))
 #     Out[85]: array([ 1.,  0.])
 #
-#     In [86]: ax.transLimits.transform((10,1))
+#     In [86]: ax.transLimits.transform((10, 1))
 #     Out[86]: array([ 1.,  1.])
 #
-#     In [87]: ax.transLimits.transform((5,0))
+#     In [87]: ax.transLimits.transform((5, 0))
 #     Out[87]: array([ 0.5,  0.5])
 #
 # and we can use this same inverted transformation to go from the unit

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -27,7 +27,7 @@ steps in the color space. Researchers have found that the human brain
 perceives changes in the lightness parameter as changes in the data
 much better than, for example, changes in hue. Therefore, colormaps
 which have monotonically increasing lightness through the colormap
-will be better interpreted by the viewer. A wonderful example of 
+will be better interpreted by the viewer. A wonderful example of
 perceptually uniform colormaps is [colorcet]_.
 
 Color can be represented in 3D space in various ways. One way to represent color
@@ -340,11 +340,11 @@ def plot_color_gradients(cmap_category, cmap_list):
     for ax, name in zip(axes, cmap_list):
 
         # Get RGB values for colormap.
-        rgb = cm.get_cmap(plt.get_cmap(name))(x)[np.newaxis,:,:3]
+        rgb = cm.get_cmap(plt.get_cmap(name))(x)[np.newaxis, :, :3]
 
         # Get colormap in CAM02-UCS colorspace. We want the lightness.
         lab = cspace_converter("sRGB1", "CAM02-UCS")(rgb)
-        L = lab[0,:,0]
+        L = lab[0, :, 0]
         L = np.float32(np.vstack((L, L, L)))
 
         ax[0].imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -7,7 +7,7 @@ Introduction to plotting and working with text in Matplotlib.
 Matplotlib has extensive text support, including support for
 mathematical expressions, truetype support for raster and
 vector outputs, newline separated text with arbitrary
-rotations, and unicode support. 
+rotations, and unicode support.
 
 Because it embeds fonts directly in output documents, e.g., for postscript
 or PDF, what you see on the screen is what you get in the hardcopy.


### PR DESCRIPTION
## PR Summary


PEP8 has not been running for a while, so fix the examples and do a bit of minor cleanup. Most of the PEP8 stuff is just deleting or adding blank lines. For the cleanup, I tried to use `plt.subplots` a bit more often in the examples that were updated.

The reason why so many examples are suddenly failing is that a whole directory was moved out of `docs` to `examples` and docs are pep8-exempt.

For the `tutorials` directory, I've allowed `E402` and `E501`; these are already exempted for the `examples` directory and there are already very many long lines, so "fixing" this would cause a lot of churn and in some cases (tables, URLs, mostly) appear rather ugly.

Fixes #8498.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/whats_new.rst if major new feature
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way