### PR TITLE
BUG: Correct invocation of `expand_dims`

### DIFF
--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -898,7 +898,7 @@ class _ReducedHCT_Element():
         pts = self.gauss_pts
         for igauss in range(self.n_gauss):
             alpha = np.tile(pts[igauss, :], n).reshape(n, 3)
-            alpha = np.expand_dims(alpha, 3)
+            alpha = np.expand_dims(alpha, 2)
             weight = weights[igauss]
             d2Skdksi2 = self.get_d2Sidksij2(alpha, ecc)
             d2Skdx2 = _prod_vectorized(d2Skdksi2, H_rot)


### PR DESCRIPTION
`alpha` is 2d, yet here it was requested to insert a fourth (not third) dimension.

This rightly produces an error [in numpy 1.13.0rc1](https://github.com/numpy/numpy/pull/8584/files#diff-ba13cf8822527da9907ca1822369030dR290), although the final release might soften this to a deprecation warning to prevent breaking old version of matplotlib