### PR TITLE
Axes.__init__ speedup

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -610,11 +610,11 @@ class _AxesBase(martist.Artist):
     def _init_axis(self):
         "move this out of __init__ because non-separable axes don't use it"
         self.xaxis = maxis.XAxis(self)
-        self.spines['bottom'].register_axis(self.xaxis)
-        self.spines['top'].register_axis(self.xaxis)
+        self.spines['bottom'].register_axis(self.xaxis, _init=True)
+        self.spines['top'].register_axis(self.xaxis, _init=True)
         self.yaxis = maxis.YAxis(self)
-        self.spines['left'].register_axis(self.yaxis)
-        self.spines['right'].register_axis(self.yaxis)
+        self.spines['left'].register_axis(self.yaxis, _init=True)
+        self.spines['right'].register_axis(self.yaxis, _init=True)
         self._update_transScale()
 
     def set_figure(self, fig):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -479,6 +479,7 @@ class _AxesBase(martist.Artist):
         """ % {'scale': ' | '.join(
             [repr(x) for x in mscale.get_scale_names()])}
         martist.Artist.__init__(self)
+        self._in_init = True
         if isinstance(rect, mtransforms.Bbox):
             self._position = rect
         else:
@@ -575,6 +576,8 @@ class _AxesBase(martist.Artist):
             left=rcParams['ytick.left'] and rcParams['ytick.major.left'],
             right=rcParams['ytick.right'] and rcParams['ytick.major.right'],
             which='major')
+
+        self._in_init = False
 
     def __getstate__(self):
         # The renderer should be re-created by the figure, and then cached at
@@ -965,10 +968,13 @@ class _AxesBase(martist.Artist):
         xaxis_visible = self.xaxis.get_visible()
         yaxis_visible = self.yaxis.get_visible()
 
-        self.xaxis.cla()
-        self.yaxis.cla()
-        for name, spine in six.iteritems(self.spines):
-            spine.cla()
+        # Don't clear during __init__ because they're already been cleared by
+        # their own __init__.
+        if not self._in_init:
+            self.xaxis.cla()
+            self.yaxis.cla()
+            for name, spine in six.iteritems(self.spines):
+                spine.cla()
 
         self.ignore_existing_data_limits = True
         self.callbacks = cbook.CallbackRegistry()

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -245,8 +245,10 @@ class PolarAxes(Axes):
 If you need to interpolate data points, consider running
 cbook.simple_linear_interpolation on the data before passing to matplotlib.""")
         Axes.__init__(self, *args, **kwargs)
+        self._in_init = True
         self.set_aspect('equal', adjustable='box', anchor='C')
         self.cla()
+        self._in_init = False
     __init__.__doc__ = Axes.__init__.__doc__
 
     def cla(self):

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -151,7 +151,7 @@ class Spine(mpatches.Patch):
             self._position = ('outward', 0.0)  # in points
             self.set_position(self._position)
 
-    def register_axis(self, axis):
+    def register_axis(self, axis, _init=False):
         """register an axis
 
         An axis should be registered with its corresponding spine from
@@ -159,7 +159,9 @@ class Spine(mpatches.Patch):
         properties when needed.
         """
         self.axis = axis
-        if self.axis is not None:
+        if not _init and self.axis is not None:
+            # Clear the axis when added, but *not* if the caller says it was
+            # just created.
             self.axis.cla()
         self.stale = True
 


### PR DESCRIPTION
## PR Summary

As noted in #6664, `Axes.__init__` is fairly slow due to the eventual call to `Axis.reset_ticks`. @efiring suggested lazy instantiation and @Kojoley was implementing, but I'm unsure of the status. In the meantime though, we still speed things up by avoiding calling `cla` too many times.

Using the example from #6664 with `v2.0.x`:
```
$ python3 -m timeit \
  -s "from matplotlib.figure import Figure; from matplotlib.axes import Axes; fig = Figure()" \
  "Axes(fig, (0, 0, 1 ,1))"
10 loops, best of 3: 29.7 msec per loop
```
and `master` is already a bit faster:
```
$ python -m timeit \
  -s "from matplotlib.figure import Figure; from matplotlib.axes import Axes; fig = Figure()" \
  "Axes(fig, (0, 0, 1 ,1))"
100 loops, best of 3: 17.7 msec per loop
```

The trouble with `Axes.__init__` is that it does a bit too much clearing; `Axes.__init__` calls:
* `Axes._init_axis`
    * Creates `self.xaxis` and `self.yaxis`
        * `Axis.__init__` -> `Axis.cla`  (2 calls per `Axes`)
    * Registers each `Axis` with two spines via `Spine.register_axis`
        * `Axis.cla` is called on the registered `Axis`  (2 `Spine` * 2 `Axis` = 4 calls per `Axes`)
* `Axes.cla` - Necessary to finish initializing the `Axes` in a clean state, though it's generic for any caller.
    * `self.xaxis.cla()` / `self.yaxis.cla()`  (2 calls per `Axes`)
    * `self.spines[:].cla()` (2 spines per `Axis` = 4 calls per `Axes`)

That makes _12_ calls to `Axis.cla` for only _2_ `Axis` objects. Adding some hidden argument to skip these calls as in this PR would reduce those calls by 6, though the speedup is only approximately 4 times:

```
$ python -m timeit \
  -s "from matplotlib.figure import Figure; from matplotlib.axes import Axes; fig = Figure()" \
  "Axes(fig, (0, 0, 1 ,1))"
100 loops, best of 3: 4.45 msec per loop
```

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/whats_new.rst if major new feature
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way