### PR TITLE
FIX: if bins input to hist is str, treat like no bins

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6612,7 +6612,9 @@ optional.
             bin_range = self.convert_xunits(bin_range)
 
         # Check whether bins or range are given explicitly.
-        binsgiven = np.iterable(bins) or bin_range is not None
+        binsgiven = ((np.iterable(bins) and
+                      not isinstance(bins, str)) or
+                     bin_range is not None)
 
         # We need to do to 'weights' what was done to 'x'
         if weights is not None:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6352,3 +6352,17 @@ def test_hist_auto_bins():
     _, bins, _ = plt.hist([[1, 2, 3], [3, 4, 5, 6]], bins='auto')
     assert bins[0] <= 1
     assert bins[-1] >= 6
+
+
+def test_hist_nan_data():
+    fig, (ax1, ax2) = plt.subplots(2)
+
+    data = [1, 2, 3]
+    nan_data = data + [np.nan]
+
+    bins, edges, _ = ax1.hist(data)
+    with np.errstate(invalid='ignore'):
+        nanbins, nanedges, _ = ax2.hist(nan_data)
+
+    assert np.allclose(bins, nanbins)
+    assert np.allclose(edges, nanedges)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6346,3 +6346,9 @@ def test_datetime_masked():
     ax.plot(x, m)
     # these are the default viewlim
     assert ax.get_xlim() == (730120.0, 733773.0)
+
+
+def test_hist_auto_bins():
+    _, bins, _ = plt.hist([[1, 2, 3], [3, 4, 5, 6]], bins='auto')
+    assert bins[0] <= 1
+    assert bins[-1] >= 6


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
This change causes the range of all data sets to be computed and
passed to numpy (which in turn uses the total range to compute the
'best' bins).

The existing code 'latches' the bins from the first data set to use
for the rest so this is can still lead to poor binning (if the data
sets are widely different).

closes #8636

This still needs some tests and possibly a more through thinking of how to deal with the 'string' bins and multiple data sets.

Computing the histogram once with all of the data and the using those bins may be a better option (but involves computing the histograms twice).


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
