### PR TITLE
Revert "Require sphinx < 1.6"

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -6,7 +6,7 @@
 # Install the documentation requirements with:
 #     pip install -r doc-requirements.txt
 #
-sphinx>=1.3,!=1.5.0,<1.6
+sphinx>=1.3,!=1.5.0
 colorspacious
 ipython
 mock


### PR DESCRIPTION
Reverts matplotlib/matplotlib#8634 - now https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is fixed sphinx 1.6.1 should work again.