### PR TITLE
Remove unused resolution kwarg to PolarAxes

### DIFF
--- a/doc/api/api_changes/2017-05-19-resolution_polar_axes.rst
+++ b/doc/api/api_changes/2017-05-19-resolution_polar_axes.rst
@@ -1,0 +1,6 @@
+Removed resolution kwarg from PolarAxes
+```````````````````````````````````````
+
+The kwarg `resolution` of `matplotlib.projections.polar.PolarAxes` has been
+removed. It has triggered a warning of being with no effect which acted as the
+deprecation warning as well.

--- a/doc/api/api_changes/2017-05-19-resolution_polar_axes.rst
+++ b/doc/api/api_changes/2017-05-19-resolution_polar_axes.rst
@@ -2,5 +2,5 @@ Removed resolution kwarg from PolarAxes
 ```````````````````````````````````````
 
 The kwarg `resolution` of `matplotlib.projections.polar.PolarAxes` has been
-removed. It has triggered a warning of being with no effect which acted as the
-deprecation warning as well.
+removed. It has triggered a deprecation warning of being with no effect
+beyond version `0.98.x`. 

--- a/lib/matplotlib/projections/__init__.py
+++ b/lib/matplotlib/projections/__init__.py
@@ -87,11 +87,6 @@ def process_projection_requirements(figure, *args, **kwargs):
                 projection)
         projection = 'polar'
 
-    # ensure that the resolution keyword is always put into the key
-    # for polar plots
-    if projection == 'polar':
-        kwargs.setdefault('resolution', 1)
-
     if isinstance(projection, six.string_types) or projection is None:
         projection_class = get_projection_class(projection)
     elif hasattr(projection, '_as_mpl_axes'):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -227,23 +227,11 @@ class PolarAxes(Axes):
     def __init__(self, *args, **kwargs):
         """
         Create a new Polar Axes for a polar plot.
-
-        The following optional kwargs are supported:
-
-          - *resolution*: The number of points of interpolation between
-            each pair of data points.  Set to 1 to disable
-            interpolation.
         """
-        self.resolution = kwargs.pop('resolution', 1)
         self._default_theta_offset = kwargs.pop('theta_offset', 0)
         self._default_theta_direction = kwargs.pop('theta_direction', 1)
         self._default_rlabel_position = kwargs.pop('rlabel_position', 22.5)
 
-        if self.resolution not in (None, 1):
-            warnings.warn(
-                """The resolution kwarg to Polar plots is now ignored.
-If you need to interpolate data points, consider running
-cbook.simple_linear_interpolation on the data before passing to matplotlib.""")
         Axes.__init__(self, *args, **kwargs)
         self.set_aspect('equal', adjustable='box', anchor='C')
         self.cla()


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
Remove unused resolution kwarg to PolarAxes
refs #8629 

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
