### PR TITLE
Pdf backend

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 """
 A PDF matplotlib backend
@@ -1625,6 +1625,8 @@ class RendererPdf(RendererBase):
         gc._fillcolor = fillcolor
 
         orig_alphas = getattr(gc, '_effective_alphas', (1.0, 1.0))
+		if gc.get_rgb() is None:
+            gc.set_foreground([0.0, 0.0, 0.0, 1.0])
 
         if gc._forced_alpha:
             gc._effective_alphas = (gc._alpha, gc._alpha)

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1625,7 +1625,7 @@ class RendererPdf(RendererBase):
         gc._fillcolor = fillcolor
 
         orig_alphas = getattr(gc, '_effective_alphas', (1.0, 1.0))
-		if gc.get_rgb() is None:
+        if gc.get_rgb() is None:
             gc.set_foreground([0.0, 0.0, 0.0, 1.0])
 
         if gc._forced_alpha:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
Small pull request to address #8142. The issue seems to propagate from a feature enhancement #5596 where `Line2D.get_markeredgecolor()` returns `None` due to the change-set. The fix simply check if `gc._rgb == None` in backendpdf (caused the said change-set), if so, set `gc._rgb` to be the value it would have taken if the change-set was not there (pre #5596 behavior). Hence, this can probably be viewed as an addition to #5596 where behaviour of backendpdf remains the same .
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
