### PR TITLE
FIX: fail early for non-finite figure sizes

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -79,8 +79,8 @@ class _ColorMapping(dict):
         super(_ColorMapping, self).__setitem__(key, value)
         self.cache.clear()
 
-    def __delitem__(self, key, value):
-        super(_ColorMapping, self).__delitem__(key, value)
+    def __delitem__(self, key):
+        super(_ColorMapping, self).__delitem__(key)
         self.cache.clear()
 
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -324,7 +324,11 @@ class Figure(Artist):
         if frameon is None:
             frameon = rcParams['figure.frameon']
 
+        if not np.isfinite(figsize).all():
+            raise ValueError('figure size must be finite not '
+                             '{}'.format(figsize))
         self.bbox_inches = Bbox.from_bounds(0, 0, *figsize)
+
         self.dpi_scale_trans = Affine2D().scale(dpi, dpi)
         # do not use property as it will trigger
         self._dpi = dpi
@@ -710,7 +714,9 @@ class Figure(Artist):
         # argument, so unpack them
         if h is None:
             w, h = w
-
+        if not all(np.isfinite(_) for _ in (w, h)):
+            raise ValueError('figure size must be finite not '
+                             '({}, {})'.format(w, h))
         dpival = self.dpi
         self.bbox_inches.p1 = w, h
 
@@ -920,6 +926,9 @@ class Figure(Artist):
                 raise ValueError(msg)
         else:
             rect = args[0]
+            if not np.isfinite(rect).all():
+                raise ValueError('all entries in rect must be finite '
+                                 'not {}'.format(rect))
             projection_class, kwargs, key = process_projection_requirements(
                 self, *args, **kwargs)
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -286,3 +286,15 @@ def test_change_dpi():
     fig.canvas.draw()
     assert fig.canvas.renderer.height == 200
     assert fig.canvas.renderer.width == 200
+
+
+def test_invalid_figure_size():
+    with pytest.raises(ValueError):
+        plt.figure(figsize=(1, np.nan))
+
+    fig = plt.figure()
+    with pytest.raises(ValueError):
+        fig.set_size_inches(1, np.nan)
+
+    with pytest.raises(ValueError):
+        fig.add_axes((.1, .1, .5, np.nan))


### PR DESCRIPTION
Closes #8640

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

If passed non-finite values to figure size or add_axes, raise immediately rather than at draw time. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
