### PR TITLE
Don't require sphinx-gallery<1.6

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -6,7 +6,7 @@
 # Install the documentation requirements with:
 #     pip install -r doc-requirements.txt
 #
-sphinx>=1.3,!=1.5.0,<1.6
+sphinx>=1.3,!=1.5.0
 colorspacious
 ipython
 mock

--- a/doc/devel/MEP/MEP12.rst
+++ b/doc/devel/MEP/MEP12.rst
@@ -195,7 +195,3 @@ navigate the gallery. Thus, tags are complementary to this reorganization.
 .. _PEP8: https://www.python.org/dev/peps/pep-0008/
 
 .. [1] https://github.com/matplotlib/matplotlib/pull/714
-.. [2] https://github.com/matplotlib/matplotlib/issues/524
-.. [3] http://matplotlib.1069221.n5.nabble.com/Matplotlib-gallery-td762.html#a33379091
-.. [4] http://www.labri.fr/perso/nrougier/teaching/matplotlib/
-.. [5] http://www.labri.fr/perso/nrougier/coding/gallery/

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -388,8 +388,6 @@ for cmap_category, cmap_list in cmaps.items():
 # .. [list-colormaps] https://gist.github.com/endolith/2719900#id7
 # .. [mycarta-banding] https://mycarta.wordpress.com/2012/10/14/the-rainbow-is-deadlong-live-the-rainbow-part-4-cie-lab-heated-body/
 # .. [mycarta-jet] https://mycarta.wordpress.com/2012/10/06/the-rainbow-is-deadlong-live-the-rainbow-part-3/
-# .. [mycarta-lablinear] https://mycarta.wordpress.com/2012/12/06/the-rainbow-is-deadlong-live-the-rainbow-part-5-cie-lab-linear-l-rainbow/
-# .. [mycarta-cubelaw] https://mycarta.wordpress.com/2013/02/21/perceptual-rainbow-palette-the-method/
 # .. [bw] http://www.tannerhelland.com/3643/grayscale-image-algorithm-vb6/
 # .. [colorblindness] http://www.color-blindness.com/
 # .. [vischeck] http://www.vischeck.com/vischeck/


### PR DESCRIPTION
Reverts matplotlib/matplotlib#8634. Needed to remove a couple of un-used references for the doc build to pass too.