### PR TITLE
Ignore non-finite vertices when running count_contains

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -645,14 +645,16 @@ class BboxBase(TransformNode):
     def count_contains(self, vertices):
         """
         Count the number of vertices contained in the :class:`Bbox`.
+        Any vertices with a non-finite x or y value are ignored.
 
         *vertices* is a Nx2 Numpy array.
         """
         if len(vertices) == 0:
             return 0
         vertices = np.asarray(vertices)
-        return (
-            ((self.min < vertices) & (vertices < self.max)).all(axis=1).sum())
+        with np.errstate(invalid='ignore'):
+            return (((self.min < vertices) &
+                     (vertices < self.max)).all(axis=1).sum())
 
     def count_overlaps(self, bboxes):
         """


### PR DESCRIPTION
When deciding whether vertices are in a given bounding box, ignore non-finite vertices (ie. `np.nan` values). The avoids a spurious warning being raised. Fixes #8611.