### PR TITLE
Fix tests against pytest 3.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,7 +94,7 @@ install:
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   - if %PYTHON_VERSION% == 2.7 conda install -q backports.functools_lru_cache
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q pytest "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-warnings pytest-xdist
+  - pip install -q pytest "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Let the install prefer the static builds of the libs
   - set LIBRARY_LIB=%CONDA_PREFIX%\Library\lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ install:
     fi
 
     # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-    pip install $PRE pytest 'pytest-cov>=2.3.1' pytest-faulthandler pytest-rerunfailures pytest-timeout pytest-warnings pytest-xdist $INSTALL_PEP8
+    pip install $PRE pytest 'pytest-cov>=2.3.1' pytest-faulthandler pytest-rerunfailures pytest-timeout pytest-xdist $INSTALL_PEP8
 
     # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
     # availible in the Ubuntu version used by Travis but we can manually install the deb from a later

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -223,7 +223,11 @@ def _xfail_if_format_is_uncomparable(extension):
 
 
 def _mark_xfail_if_format_is_uncomparable(extension):
-    will_fail = extension not in comparable_formats()
+    if isinstance(extension, six.string_types):
+        will_fail = extension not in comparable_formats()
+    else:
+        # Extension might be a pytest marker instead of a plain string.
+        will_fail = extension.args[0] not in comparable_formats()
     if will_fail:
         fail_msg = 'Cannot compare %s files on this system' % extension
         import pytest


### PR DESCRIPTION
Builds are currently broken as the latest pytest 3.1.0 has just hit the builders. It seems there's a bug in the Marker comparison function which breaks test collection.

~~This is a bit of a hack until the upstream bug is fixed, though I'd be open to just not allowing 3.1.0 instead.~~ This is actually a bug but only surfaced due to another behavioural change in pytest.