### PR TITLE
WebAgg backend: Fix unbound variable error in get_diff_image

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -236,8 +236,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 self._last_renderer, renderer)
             self._force_full = False
             self._png_is_old = False
-            self.buff = buff
-        return self.buff
+            return buff
 
     def get_renderer(self, cleared=None):
         # Mirrors super.get_renderer, but caches the old one
@@ -487,8 +486,9 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
     def refresh_all(self):
         if self.web_sockets:
             diff = self.canvas.get_diff_image()
-            for s in self.web_sockets:
-                s.send_binary(diff)
+            if diff is not None:
+                for s in self.web_sockets:
+                    s.send_binary(diff)
 
     @classmethod
     def get_javascript(cls, stream=None):

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -236,8 +236,8 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 self._last_renderer, renderer)
             self._force_full = False
             self._png_is_old = False
-
-        return buff
+            self.buff = buff
+        return self.buff
 
     def get_renderer(self, cleared=None):
         # Mirrors super.get_renderer, but caches the old one


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
`FigureCanvasWebAggCore.get_diff_image()` can crash with an UnboundLocalError on its return value `buff`. This is because `buff` is only created when `self._png_is_old == True`, but get_diff_image tries to return it in either case.

We presumably ran into this because tornado likes to call `FigureManagerWebAgg.refresh_all` multiple times in between calls to draw() in certain situations -- then, even if draw() did set the _png_is_old flag, refresh_all resets it through its call to get_diff_image, and so the next refresh will fail.

<strike>This change keeps the buffer around as an attribute of the Canvas, so get_diff_image can return it regardless of whether it has been refreshed.</strike>

This change lets get_diff_image return None when the png isn't outdated and adds a condition to `refresh_all` to only send diffs that are non-None.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

