### PR TITLE
Add pandas package to appveyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -89,7 +89,7 @@ install:
   - conda create -q -n test-environment python=%PYTHON_VERSION%
     pip setuptools numpy python-dateutil freetype=2.6 msinttypes "tk=8.5"
     pyparsing pytz tornado "libpng>=1.6.21,<1.7" "zlib=1.2" "cycler>=0.10"
-    mock sphinx
+    mock sphinx pandas
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   - if %PYTHON_VERSION% == 2.7 conda install -q backports.functools_lru_cache


### PR DESCRIPTION
## PR Summary

I appended pandas to the list of packages that are installed into the conda environment that's used for testing on Appveyor. 

This lets all tests that depend on pandas run (currently 7). Two of the Travis CI jobs already include pandas and I think that there's no reason not to run these tests on Appveyor as well. Please tell me if there are any.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
