### PR TITLE
Add basic testing of interactive backends.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ addons:
       - graphviz
       - libgeos-dev
       - otf-freefont
-#     - fonts-humor-sans
-#    sources:
-#      - debian-sid
 
 env:
   global:
@@ -95,7 +92,7 @@ before_install:
     else
       brew update
       brew tap homebrew/gui
-      brew install python libpng  ffmpeg imagemagick mplayer ccache
+      brew install python libpng ffmpeg imagemagick mplayer ccache
       # We could install ghostscript and inkscape here to test svg and pdf
       # but this makes the test time really long.
       # brew install ghostscript inkscape
@@ -110,23 +107,44 @@ install:
     ccache -s
     git describe
     # Upgrade pip and setuptools and wheel to get as clean an install as possible
-    pip install --upgrade pip
-    pip install --upgrade wheel
-    pip install --upgrade setuptools
+    pip install --upgrade pip setuptools wheel
   - |
     # Install dependencies from pypi
-    pip install $PRE python-dateutil $NUMPY pyparsing!=2.1.6 $PANDAS cycler codecov coverage $MOCK $NOSE sphinx pillow
+    pip install $PRE \
+        $MOCK \
+        $NOSE \
+        $NUMPY \
+        $PANDAS \
+        codecov \
+        coverage \
+        cycler \
+        pillow \
+        pyparsing!=2.1.6 \
+        python-dateutil \
+        sphinx
+    # GUI toolkits are pip-installable only for some versions of Python so don't
+    # fail if we can't install them.
+    pip install pyqt5 || true
+    python -c 'import PyQt5.QtCore' || true
     if [[ $BUILD_DOCS == true ]]; then
       pip install $PRE -r doc-requirements.txt
     fi
 
     # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-    pip install $PRE pytest 'pytest-cov>=2.3.1' pytest-faulthandler pytest-rerunfailures pytest-timeout pytest-xdist $INSTALL_PEP8
+    pip install $PRE \
+        pytest \
+        pytest-cov>=2.3.1 \
+        pytest-faulthandler \
+        pytest-rerunfailures \
+        pytest-timeout \
+        pytest-xdist \
+        $INSTALL_PEP8
 
-    # We manually install humor sans using the package from Ubuntu 14.10. Unfortunatly humor sans is not
-    # availible in the Ubuntu version used by Travis but we can manually install the deb from a later
-    # version since is it basically just a .ttf file
-    # The current Travis Ubuntu image is to old to search .local/share/fonts so we store fonts in .fonts
+    # We manually install humor sans using the package from Ubuntu 14.10.
+    # Unfortunatly humor sans is not availible in the Ubuntu version used by
+    # Travis but we can manually install the deb from a later version since is
+    # it basically just a .ttf file.  The current Travis Ubuntu image is to old
+    # to search .local/share/fonts so we store fonts in .fonts
     if [[ $BUILD_DOCS == true ]]; then
       wget https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O Felipa-Regular.ttf
       wget http://mirrors.kernel.org/ubuntu/pool/universe/f/fonts-humor-sans/fonts-humor-sans_1.0-1_all.deb
@@ -143,6 +161,13 @@ install:
   - |
     # Install matplotlib
     pip install -ve .
+
+before_script:
+  - |
+    if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
+      export DISPLAY=:99.0
+      sh -e /etc/init.d/xvfb start
+    fi
 
 script: ci/travis/test_script.sh
 

--- a/ci/travis/test_script.sh
+++ b/ci/travis/test_script.sh
@@ -11,9 +11,6 @@ set -ev
 # Travis VM to run out of memory (since so many copies of inkscape and
 # ghostscript are running at the same time).
 
-echo Testing import of tkagg backend
-MPLBACKEND="tkagg" python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())'
-
 if [[ $BUILD_DOCS == false ]]; then
   if [[ $DELETE_FONT_CACHE == 1 ]]; then
     rm -rf ~/.cache/matplotlib

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -15,8 +15,8 @@ except ImportError:
 
 with matplotlib.rc_context(rc={'backend': 'Qt4Agg'}):
     qt_compat = pytest.importorskip('matplotlib.backends.qt_compat')
-from matplotlib.backends.backend_qt4 import (MODIFIER_KEYS,
-                                             SUPER, ALT, CTRL, SHIFT)  # noqa
+from matplotlib.backends.backend_qt4 import (
+    MODIFIER_KEYS, SUPER, ALT, CTRL, SHIFT)  # noqa
 
 QtCore = qt_compat.QtCore
 _, ControlModifier, ControlKey = MODIFIER_KEYS[CTRL]
@@ -47,7 +47,7 @@ def test_fig_close():
 
     # assert that we have removed the reference to the FigureManager
     # that got added by plt.figure()
-    assert(init_figs == Gcf.figs)
+    assert init_figs == Gcf.figs
 
 
 @pytest.mark.parametrize(

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -16,8 +16,8 @@ except ImportError:
 with matplotlib.rc_context(rc={'backend': 'Qt5Agg'}):
     qt_compat = pytest.importorskip('matplotlib.backends.qt_compat',
                                     minversion='5')
-from matplotlib.backends.backend_qt5 import (MODIFIER_KEYS,
-                                             SUPER, ALT, CTRL, SHIFT)  # noqa
+from matplotlib.backends.backend_qt5 import (
+    MODIFIER_KEYS, SUPER, ALT, CTRL, SHIFT)  # noqa
 
 QtCore = qt_compat.QtCore
 _, ControlModifier, ControlKey = MODIFIER_KEYS[CTRL]
@@ -40,7 +40,7 @@ def test_fig_close():
 
     # assert that we have removed the reference to the FigureManager
     # that got added by plt.figure()
-    assert(init_figs == Gcf.figs)
+    assert init_figs == Gcf.figs
 
 
 @pytest.mark.parametrize(

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -1,0 +1,53 @@
+import importlib
+import os
+import sys
+
+from matplotlib.compat.subprocess import Popen
+import pytest
+
+
+# Minimal smoke-testing of the backends for which the dependencies are
+# PyPI-installable on Travis.  They are not available for all tested Python
+# versions so we don't fail on missing backends.
+#
+# Once the Travis build environment switches to Ubuntu 14.04, we should be able
+# to add wxagg (which has wheels for 14.04 but not for 12.04).
+#
+# We also don't test on Py2 because its subprocess module doesn't support
+# timeouts, and it would require a separate code path to check for module
+# existence without actually trying to import the module (which may install
+# an undesirable input hook).
+
+
+def _get_available_backends():
+    if sys.version_info < (3,):
+        return []
+    else:
+        return [
+            pytest.mark.skipif(
+                importlib.util.find_spec(module_name) is None,
+                reason="Could not import {!r}".format(module_name))(backend)
+            for module_name, backend in [
+                ("PyQt5", "qt5agg"),
+                ("tkinter", "tkagg")]]
+
+
+_test_script = """\
+import sys
+from matplotlib import pyplot as plt
+
+fig = plt.figure()
+fig.canvas.mpl_connect("draw_event", lambda event: sys.exit())
+plt.show()
+"""
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ,
+                    reason="The DISPLAY environment variable is not set.")
+@pytest.mark.parametrize("backend", _get_available_backends())
+def test_backend(backend):
+    environ = os.environ.copy()
+    environ["MPLBACKEND"] = backend
+    proc = Popen([sys.executable, "-c", _test_script], env=environ)
+    # Empirically, 1s is not enough on Travis.
+    assert proc.wait(timeout=5) == 0


### PR DESCRIPTION
Just checking that we can open a window and trigger an exit upon draw_event.  The idea is to prevent issues such as https://github.com/matplotlib/matplotlib/issues/8563 (except that it wouldn't have prevented that specific issue as PyQt4 is not pip-installable... I haven't tried apt-installing GUI toolkits as that would only work for some specific python versions anyways).