### PR TITLE
check the type of the output animation filename

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -336,6 +336,15 @@ class MovieWriter(AbstractMovieWriter):
         self.dpi = dpi
         self._w, self._h = self._adjust_frame_size()
 
+        if not isinstance(self.outfile, basestring):
+            msg = (
+                'output file must be a string like object.\n The provided'
+                'output file value is "{}" that is of type {}'.format(
+                    self.outfile, type(self.outfile)
+                )
+            )
+            raise ValueError(msg)
+
         # Run here so that grab_frame() can write the data to a pipe. This
         # eliminates the need for temp files.
         self._run()

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -336,7 +336,7 @@ class MovieWriter(AbstractMovieWriter):
         self.dpi = dpi
         self._w, self._h = self._adjust_frame_size()
 
-        if not isinstance(self.outfile, basestring):
+        if not isinstance(self.outfile, six.string_types):
             msg = (
                 'output file must be a string like object.\n The provided'
                 'output file value is "{}" that is of type {}'.format(


### PR DESCRIPTION
Currently it is difficult to determine the error when the animation movie
filename is something other than a string. Even with the debug output of
matplotlib, it is not easy to determin the reason why the subprocess call
fails.

I added a check that explicitly checks the type of the output file variable.
