### PR TITLE
[MRG+1] Use svg file for applicaiton icon on qt5

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -489,7 +489,7 @@ class FigureManagerQT(FigureManagerBase):
 
         self.window.setWindowTitle("Figure %d" % num)
         image = os.path.join(matplotlib.rcParams['datapath'],
-                             'images', 'matplotlib.png')
+                             'images', 'matplotlib.svg')
         self.window.setWindowIcon(QtGui.QIcon(image))
 
         # Give the keyboard focus to the figure instead of the


### PR DESCRIPTION
Currently QT5 uses a low resolution .png for the application icon; this uses the .svg instead which looks way better (top is svg, bottom is png):

![screenshot from 2017-05-26 12-38-41](https://cloud.githubusercontent.com/assets/6197628/26493330/bb81b04a-4210-11e7-8b6f-87d658f18b0b.png)