### PR TITLE
Backend pdf

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2628,4 +2628,3 @@ class FigureManagerPdf(FigureManagerBase):
 
 FigureCanvas = FigureCanvasPdf
 FigureManager = FigureManagerPdf
-

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1626,6 +1626,13 @@ class RendererPdf(RendererBase):
 
         orig_alphas = getattr(gc, '_effective_alphas', (1.0, 1.0))
 
+        if gc._rgb is None:
+            if gc.get_linewidth() != 0:
+                warnings.warn('if rgb is None, ' +
+                              'linewidth should also be 0')
+            # doesn't matter what color here
+            gc._rgb = [1, 0, 0, 1]
+
         if gc._forced_alpha:
             gc._effective_alphas = (gc._alpha, gc._alpha)
         elif fillcolor is None or len(fillcolor) < 4:
@@ -2621,3 +2628,4 @@ class FigureManagerPdf(FigureManagerBase):
 
 FigureCanvas = FigureCanvasPdf
 FigureManager = FigureManagerPdf
+

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -492,4 +492,3 @@ def save_diff_image(expected, actual, output):
     save_image_np[:, :, 3] = 255
 
     _png.write_png(save_image_np, output)
-

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -355,8 +355,8 @@ def crop_to_same(actual_path, actual_image, expected_path, expected_image):
     # clip the images to the same size -- this is useful only when
     # comparing eps to pdf
     if actual_path[-7:-4] == 'eps' and expected_path[-7:-4] == 'pdf':
-        aw, ah = actual_image.shape
-        ew, eh = expected_image.shape
+        aw, ah, ad = actual_image.shape
+        ew, eh, ed = expected_image.shape
         actual_image = actual_image[int(aw / 2 - ew / 2):int(
             aw / 2 + ew / 2), int(ah / 2 - eh / 2):int(ah / 2 + eh / 2)]
     return actual_image, expected_image
@@ -492,3 +492,4 @@ def save_diff_image(expected, actual, output):
     save_image_np[:, :, 3] = 255
 
     _png.write_png(save_image_np, output)
+

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -223,7 +223,12 @@ def _xfail_if_format_is_uncomparable(extension):
 
 
 def _mark_xfail_if_format_is_uncomparable(extension):
-    will_fail = extension not in comparable_formats()
+    will_fail = True
+    for compare_type in comparable_formats():
+        if (isinstance(extension, type(compare_type)) and\
+           extension == compare_type):
+            will_fail = False
+            break
     if will_fail:
         fail_msg = 'Cannot compare %s files on this system' % extension
         import pytest
@@ -569,3 +574,4 @@ def skip_if_command_unavailable(cmd):
         return pytest.mark.skip(reason='missing command: %s' % cmd[0])
 
     return lambda f: f
+

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -225,7 +225,7 @@ def _xfail_if_format_is_uncomparable(extension):
 def _mark_xfail_if_format_is_uncomparable(extension):
     will_fail = True
     for compare_type in comparable_formats():
-        if (isinstance(extension, type(compare_type)) and\
+        if (isinstance(extension, type(compare_type)) and
            extension == compare_type):
             will_fail = False
             break

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -574,4 +574,3 @@ def skip_if_command_unavailable(cmd):
         return pytest.mark.skip(reason='missing command: %s' % cmd[0])
 
     return lambda f: f
-

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -19,7 +19,9 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 from matplotlib.testing.decorators import image_comparison
 from matplotlib import dviread
+from matplotlib.testing.compare import compare_images
 
+import matplotlib as mpl
 
 needs_tex = pytest.mark.xfail(
     not checkdep_tex(),
@@ -191,3 +193,23 @@ def test_missing_psfont(monkeypatch):
     ax.text(0.5, 0.5, 'hello')
     with tempfile.TemporaryFile() as tmpfile, pytest.raises(ValueError):
         fig.savefig(tmpfile, format='pdf')
+
+
+def test_pdf_savefig_when_color_is_none():
+    backup_params = mpl.rcParams.copy()
+    mpl.rcParams.update(mpl.rcParamsDefault)
+    plt.subplot()
+    plt.axis('off')
+    plt.plot(np.sin(np.linspace(-5, 5, 100)), 'v', c='none')
+    try:
+        plt.savefig("figure.pdf", format='pdf')
+    except Exception:
+        pytest.fail("Failed to save pdf")
+    plt.savefig("figure.eps", format='eps')
+    result = compare_images('figure.pdf', 'figure.eps', 0)
+    assert result is None
+    from os import remove
+    remove('figure.eps')
+    remove('figure.pdf')
+    mpl.rcParams.update(backup_params)
+

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -212,4 +212,3 @@ def test_pdf_savefig_when_color_is_none():
     remove('figure.eps')
     remove('figure.pdf')
     mpl.rcParams.update(backup_params)
-


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
The second pull request to address #8142  to address @tacaswell 's comment in #8644. Added a test case to compare generated figures using pdf backend with eps backend (the later does not have this bug). Added some small fix to testing facility in the process. Note that while implementing the test, I believe that along the way, someone tried to make automated comparison between pdf and eps images, but this engine does not really work on general images. I use this engine since the expected images are supposed to be blank, which is the only case where this engine really works (comparing blank to non-blank images)
<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
