### PR TITLE
Use Axes.tick_params/Axis.set_tick_params more

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -241,21 +241,34 @@ over so that the tick labels fit in the figure:
 
 .. _howto-ticks:
 
-Configure the tick linewidths
------------------------------
+Configure the tick widths
+-------------------------
 
-In Matplotlib, the ticks are *markers*.  All
-:class:`~matplotlib.lines.Line2D` objects support a line (solid,
-dashed, etc) and a marker (circle, square, tick).  The tick linewidth
-is controlled by the "markeredgewidth" property::
+Wherever possible, it is recommended to use the :meth:`~Axes.tick_params` or
+:meth:`~Axis.set_tick_params` methods to modify tick properties::
 
     import matplotlib.pyplot as plt
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+    fig, ax = plt.subplots()
+    ax.plot(range(10))
+
+    ax.tick_params(width=10)
+
+    plt.show()
+
+For more control of tick properties that are not provided by the above methods,
+it is important to know that in Matplotlib, the ticks are *markers*.  All
+:class:`~matplotlib.lines.Line2D` objects support a line (solid, dashed, etc)
+and a marker (circle, square, tick).  The tick width is controlled by the
+``"markeredgewidth"`` property, so the above effect can also be achieved by::
+
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
     ax.plot(range(10))
 
     for line in ax.get_xticklines() + ax.get_yticklines():
-        line.set_markersize(10)
+        line.set_markeredgewidth(10)
 
     plt.show()
 

--- a/examples/api/logos2.py
+++ b/examples/api/logos2.py
@@ -71,14 +71,10 @@ def add_polar_bar():
         bar.set_facecolor(cm.jet(r/10.))
         bar.set_alpha(0.6)
 
-    for label in ax.get_xticklabels() + ax.get_yticklabels():
-        label.set_visible(False)
+    ax.tick_params(labelbottom=False, labeltop=False,
+                   labelleft=False, labelright=False)
 
-    for line in ax.get_ygridlines() + ax.get_xgridlines():
-        line.set_lw(0.8)
-        line.set_alpha(0.9)
-        line.set_ls('-')
-        line.set_color('0.5')
+    ax.grid(lw=0.8, alpha=0.9, ls='-', color='0.5')
 
     ax.set_yticks(np.arange(1, 9, 2))
     ax.set_rmax(9)

--- a/examples/axes_grid1/demo_axes_divider.py
+++ b/examples/axes_grid1/demo_axes_divider.py
@@ -77,9 +77,7 @@ def demo_locatable_axes_easy(ax):
 
     plt.colorbar(im, cax=ax_cb)
     ax_cb.yaxis.tick_right()
-    for tl in ax_cb.get_yticklabels():
-        tl.set_visible(False)
-    ax_cb.yaxis.tick_right()
+    ax_cb.yaxis.set_tick_params(labelright=False)
 
 
 def demo_images_side_by_side(ax):
@@ -94,8 +92,7 @@ def demo_images_side_by_side(ax):
 
     ax.imshow(Z, extent=extent, interpolation="nearest")
     ax2.imshow(Z, extent=extent, interpolation="nearest")
-    for tl in ax2.get_yticklabels():
-        tl.set_visible(False)
+    ax2.yaxis.set_tick_params(labelleft=False)
 
 
 def demo():

--- a/examples/axes_grid1/scatter_hist.py
+++ b/examples/axes_grid1/scatter_hist.py
@@ -31,8 +31,8 @@ axHistx = divider.append_axes("top", 1.2, pad=0.1, sharex=axScatter)
 axHisty = divider.append_axes("right", 1.2, pad=0.1, sharey=axScatter)
 
 # make some labels invisible
-plt.setp(axHistx.get_xticklabels() + axHisty.get_yticklabels(),
-         visible=False)
+axHistx.xaxis.set_tick_params(labelbottom=False)
+axHisty.yaxis.set_tick_params(labelleft=False)
 
 # now determine nice limits by hand:
 binwidth = 0.25
@@ -47,14 +47,8 @@ axHisty.hist(y, bins=bins, orientation='horizontal')
 # thus there is no need to manually adjust the xlim and ylim of these
 # axis.
 
-#axHistx.axis["bottom"].major_ticklabels.set_visible(False)
-for tl in axHistx.get_xticklabels():
-    tl.set_visible(False)
 axHistx.set_yticks([0, 50, 100])
 
-#axHisty.axis["left"].major_ticklabels.set_visible(False)
-for tl in axHisty.get_yticklabels():
-    tl.set_visible(False)
 axHisty.set_xticks([0, 50, 100])
 
 plt.draw()

--- a/examples/axes_grid1/simple_axes_divider2.py
+++ b/examples/axes_grid1/simple_axes_divider2.py
@@ -28,7 +28,6 @@ ax[2].set_axes_locator(divider.new_locator(nx=2, ny=2))
 ax[3].set_axes_locator(divider.new_locator(nx=2, nx1=4, ny=0))
 
 for ax1 in ax:
-    plt.setp(ax1.get_xticklabels()+ax1.get_yticklabels(),
-             visible=False)
+    ax1.tick_params(labelbottom=False, labelleft=False)
 
 plt.show()

--- a/examples/axes_grid1/simple_axes_divider3.py
+++ b/examples/axes_grid1/simple_axes_divider3.py
@@ -37,7 +37,6 @@ ax[2].set_ylim(0, 2)
 divider.set_aspect(1.)
 
 for ax1 in ax:
-    plt.setp(ax1.get_xticklabels()+ax1.get_yticklabels(),
-             visible=False)
+    ax1.tick_params(labelbottom=False, labelleft=False)
 
 plt.show()

--- a/examples/misc/patheffect_demo.py
+++ b/examples/misc/patheffect_demo.py
@@ -22,12 +22,9 @@ if 1:
         PathEffects.Stroke(linewidth=5, foreground="w"),
         PathEffects.Normal()])
 
-    ax1.grid(True, linestyle="-")
-
     pe = [PathEffects.withStroke(linewidth=3,
                                  foreground="w")]
-    for l in ax1.get_xgridlines() + ax1.get_ygridlines():
-        l.set_path_effects(pe)
+    ax1.grid(True, linestyle="-", path_effects=pe)
 
     ax2 = plt.subplot(132)
     arr = np.arange(25).reshape((5, 5))

--- a/examples/misc/pythonic_matplotlib.py
+++ b/examples/misc/pythonic_matplotlib.py
@@ -70,8 +70,7 @@ ax1.set_ylim((-2, 2))
 ax1.set_ylabel('1 Hz')
 ax1.set_title('A sine wave or two')
 
-for label in ax1.get_xticklabels():
-    label.set_color('r')
+ax1.xaxis.set_tick_params(labelcolor='r')
 
 
 ax2 = fig.add_subplot(212)

--- a/examples/subplots_axes_and_figures/axes_props.py
+++ b/examples/subplots_axes_and_figures/axes_props.py
@@ -11,22 +11,11 @@ import numpy as np
 
 t = np.arange(0.0, 2.0, 0.01)
 s = np.sin(2 * np.pi * t)
+
 fig, ax = plt.subplots()
 ax.plot(t, s)
-ax.grid(True)
 
-ticklines = ax.get_xticklines() + ax.get_yticklines()
-gridlines = ax.get_xgridlines() + ax.get_ygridlines()
-ticklabels = ax.get_xticklabels() + ax.get_yticklabels()
-
-for line in ticklines:
-    line.set_linewidth(3)
-
-for line in gridlines:
-    line.set_linestyle('-.')
-
-for label in ticklabels:
-    label.set_color('r')
-    label.set_fontsize('medium')
+ax.grid(True, linestyle='-.')
+ax.tick_params(labelcolor='r', labelsize='medium', width=3)
 
 plt.show()

--- a/examples/ticks_and_spines/centered_ticklabels.py
+++ b/examples/ticks_and_spines/centered_ticklabels.py
@@ -7,9 +7,7 @@ sometimes it is nice to have ticklabels centered.  Matplotlib currently
 associates a label with a tick, and the label can be aligned
 'center', 'left', or 'right' using the horizontal alignment property::
 
-
-    for label in ax.xaxis.get_xticklabels():
-        label.set_horizontalalignment('right')
+    ax.xaxis.set_tick_params(horizontalalignment='right')
 
 but this doesn't help center the label between ticks.  One solution
 is to "fake it".  Use the minor ticks to place a tick centered

--- a/examples/ticks_and_spines/date_demo_rrule.py
+++ b/examples/ticks_and_spines/date_demo_rrule.py
@@ -34,7 +34,6 @@ fig, ax = plt.subplots()
 plt.plot_date(dates, s)
 ax.xaxis.set_major_locator(loc)
 ax.xaxis.set_major_formatter(formatter)
-labels = ax.get_xticklabels()
-plt.setp(labels, rotation=30, fontsize=10)
+ax.xaxis.set_tick_params(rotation=30, labelsize=10)
 
 plt.show()

--- a/examples/userdemo/demo_gridspec01.py
+++ b/examples/userdemo/demo_gridspec01.py
@@ -10,8 +10,7 @@ import matplotlib.pyplot as plt
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
-        for tl in ax.get_xticklabels() + ax.get_yticklabels():
-            tl.set_visible(False)
+        ax.tick_params(labelbottom=False, labelleft=False)
 
 
 fig = plt.figure(0)

--- a/examples/userdemo/demo_gridspec02.py
+++ b/examples/userdemo/demo_gridspec02.py
@@ -11,8 +11,7 @@ from matplotlib.gridspec import GridSpec
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
-        for tl in ax.get_xticklabels() + ax.get_yticklabels():
-            tl.set_visible(False)
+        ax.tick_params(labelbottom=False, labelleft=False)
 
 
 fig = plt.figure()

--- a/examples/userdemo/demo_gridspec03.py
+++ b/examples/userdemo/demo_gridspec03.py
@@ -11,8 +11,7 @@ from matplotlib.gridspec import GridSpec
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
-        for tl in ax.get_xticklabels() + ax.get_yticklabels():
-            tl.set_visible(False)
+        ax.tick_params(labelbottom=False, labelleft=False)
 
 
 # demo 3 : gridspec with subplotpars set.

--- a/examples/userdemo/demo_gridspec04.py
+++ b/examples/userdemo/demo_gridspec04.py
@@ -11,8 +11,7 @@ import matplotlib.gridspec as gridspec
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
-        for tl in ax.get_xticklabels() + ax.get_yticklabels():
-            tl.set_visible(False)
+        ax.tick_params(labelbottom=False, labelleft=False)
 
 
 # gridspec inside gridspec

--- a/examples/userdemo/demo_gridspec05.py
+++ b/examples/userdemo/demo_gridspec05.py
@@ -11,8 +11,7 @@ import matplotlib.gridspec as gridspec
 def make_ticklabels_invisible(fig):
     for i, ax in enumerate(fig.axes):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
-        for tl in ax.get_xticklabels() + ax.get_yticklabels():
-            tl.set_visible(False)
+        ax.tick_params(labelbottom=False, labelleft=False)
 
 
 f = plt.figure()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1173,14 +1173,12 @@ class Figure(Artist):
         if sharex in ["col", "all"]:
             # turn off all but the bottom row
             for ax in axarr[:-1, :].flat:
-                for label in ax.get_xticklabels():
-                    label.set_visible(False)
+                ax.xaxis.set_tick_params(labelbottom=False)
                 ax.xaxis.offsetText.set_visible(False)
         if sharey in ["row", "all"]:
             # turn off all but the first column
             for ax in axarr[:, 1:].flat:
-                for label in ax.get_yticklabels():
-                    label.set_visible(False)
+                ax.yaxis.set_tick_params(labelleft=False)
                 ax.yaxis.offsetText.set_visible(False)
 
         if squeeze:

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1173,12 +1173,14 @@ class Figure(Artist):
         if sharex in ["col", "all"]:
             # turn off all but the bottom row
             for ax in axarr[:-1, :].flat:
-                ax.xaxis.set_tick_params(labelbottom=False)
+                ax.xaxis.set_tick_params(which='both',
+                                         labelbottom=False, labeltop=False)
                 ax.xaxis.offsetText.set_visible(False)
         if sharey in ["row", "all"]:
             # turn off all but the first column
             for ax in axarr[:, 1:].flat:
-                ax.yaxis.set_tick_params(labelleft=False)
+                ax.yaxis.set_tick_params(which='both',
+                                         labelleft=False, labelright=False)
                 ax.yaxis.offsetText.set_visible(False)
 
         if squeeze:

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -50,15 +50,14 @@ def _colorbar_extension_shape(spacing):
         boundaries = values = norm.boundaries
         # Create a subplot.
         cax = fig.add_subplot(4, 1, i + 1)
-        # Turn off text and ticks.
-        for item in cax.get_xticklabels() + cax.get_yticklabels() +\
-                cax.get_xticklines() + cax.get_yticklines():
-            item.set_visible(False)
         # Generate the colorbar.
         cb = ColorbarBase(cax, cmap=cmap, norm=norm,
                 boundaries=boundaries, values=values,
                 extend=extension_type, extendrect=True,
                 orientation='horizontal', spacing=spacing)
+        # Turn off text and ticks.
+        cax.tick_params(left=False, labelleft=False,
+                        bottom=False, labelbottom=False)
     # Return the figure to the caller.
     return fig
 
@@ -82,15 +81,14 @@ def _colorbar_extension_length(spacing):
         for j, extendfrac in enumerate((None, 'auto', 0.1)):
             # Create a subplot.
             cax = fig.add_subplot(12, 1, i*3 + j + 1)
-            # Turn off text and ticks.
-            for item in cax.get_xticklabels() + cax.get_yticklabels() +\
-                    cax.get_xticklines() + cax.get_yticklines():
-                item.set_visible(False)
             # Generate the colorbar.
             ColorbarBase(cax, cmap=cmap, norm=norm,
                          boundaries=boundaries, values=values,
                          extend=extension_type, extendfrac=extendfrac,
                          orientation='horizontal', spacing=spacing)
+            # Turn off text and ticks.
+            cax.tick_params(left=False, labelleft=False,
+                            bottom=False, labelbottom=False)
     # Return the figure to the caller.
     return fig
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -287,8 +287,7 @@ def test_cmap_and_norm_from_levels_and_colors():
     plt.colorbar(m)
 
     # Hide the axes labels (but not the colorbar ones, as they are useful)
-    for lab in ax.get_xticklabels() + ax.get_yticklabels():
-        lab.set_visible(False)
+    ax.tick_params(labelleft=False, labelbottom=False)
 
 
 def test_cmap_and_norm_from_levels_and_colors2():

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -298,3 +298,24 @@ def test_invalid_figure_size():
 
     with pytest.raises(ValueError):
         fig.add_axes((.1, .1, .5, np.nan))
+
+
+def test_subplots_shareax_loglabels():
+    fig, ax_arr = plt.subplots(2, 2, sharex=True, sharey=True, squeeze=False)
+    for ax in ax_arr.flatten():
+        ax.plot([10, 20, 30], [10, 20, 30])
+
+    ax.set_yscale("log")
+    ax.set_xscale("log")
+
+    for ax in ax_arr[0, :]:
+        assert 0 == len(ax.xaxis.get_ticklabels(which='both'))
+
+    for ax in ax_arr[1, :]:
+        assert 0 < len(ax.xaxis.get_ticklabels(which='both'))
+
+    for ax in ax_arr[:, 1]:
+        assert 0 == len(ax.yaxis.get_ticklabels(which='both'))
+
+    for ax in ax_arr[:, 0]:
+        assert 0 < len(ax.yaxis.get_ticklabels(which='both'))

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -23,11 +23,8 @@ def test_patheffect1():
                                                           foreground="w"),
                                       path_effects.Normal()])
 
-    ax1.grid(True, linestyle="-")
-
     pe = [path_effects.withStroke(linewidth=3, foreground="w")]
-    for l in ax1.get_xgridlines() + ax1.get_ygridlines():
-        l.set_path_effects(pe)
+    ax1.grid(True, linestyle="-", path_effects=pe)
 
 
 @image_comparison(baseline_images=['patheffect2'], remove_text=True)

--- a/tools/make_icons.py
+++ b/tools/make_icons.py
@@ -79,11 +79,9 @@ def make_matplotlib_icon():
     for r, bar in zip(radii, bars):
         bar.set_facecolor(cm.jet(r/10.))
 
-    for label in ax.get_xticklabels() + ax.get_yticklabels():
-        label.set_visible(False)
-
-    for line in ax.get_ygridlines() + ax.get_xgridlines():
-        line.set_lw(0.0)
+    ax.tick_params(labelleft=False, labelright=False,
+                   labelbottom=False, labeltop=False)
+    ax.grid(lw=0.0)
 
     ax.set_yticks(np.arange(1, 9, 2))
     ax.set_rmax(9)


### PR DESCRIPTION
## PR Summary

This PR replaces a lot of manual loops over ticks/tick labels with calls to `Axes.tick_params`/`Axis.set_tick_params`. These methods work on all ticks at the same time and using them will allow for some optimization in a later PR.

Ping @choldgraf since most of these are examples and to make sure I didn't botch anything there.

## PR Checklist

- [x] Has Pytest style unit tests (existing ones, anyway)
- [x] Code is PEP 8 compliant 
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/whats_new.rst if major new feature
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way