### PR TITLE
Minor fix to pong_gtk demo example.

### DIFF
--- a/examples/event_handling/pong_gtk_sgskip.py
+++ b/examples/event_handling/pong_gtk_sgskip.py
@@ -23,7 +23,6 @@ canvas = ax.figure.canvas
 
 
 def start_anim(event):
-    # gobject.idle_add(animation.draw,animation)
     gobject.timeout_add(10, animation.draw, animation)
     canvas.mpl_disconnect(start_anim.cid)
 
@@ -34,4 +33,4 @@ start_anim.cid = canvas.mpl_connect('draw_event', start_anim)
 tstart = time.time()
 plt.grid()  # to ensure proper background restore
 plt.show()
-print('FPS: %f' % animation.cnt/(time.time() - tstart))
+print('FPS: {}'.format(animation.cnt / (time.time() - tstart)))


### PR DESCRIPTION
Formatting call was incorrect (would be interpreted as `("%f" % x) / y`
instead of `"%f" % (x / y)` and cause an exception to be thrown at exit).

Remove commented code using idle_event, which is not used by mpl
anymore.

(There are many other things that could be fixed about this example (e.g. the fact that "l" is used both to move a bar and to switch between log and linear scale...) but I don't plan to cover them in this PR.)