### PR TITLE
FIX: gtk blitting

### DIFF
--- a/src/_gtkagg.cpp
+++ b/src/_gtkagg.cpp
@@ -71,8 +71,8 @@ static PyObject *Py_agg_to_gtk_drawable(PyObject *self, PyObject *args, PyObject
         destwidth = (int)(rect.x2 - rect.x1);
         destheight = (int)(rect.y2 - rect.y1);
         deststride = destwidth * 4;
-        destbuffer.reserve(destheight * deststride);
-        destbufferptr = &destbuffer[0];
+        destbuffer.resize(destheight * deststride, 0);
+        destbufferptr = &destbuffer.front();
 
         agg::rendering_buffer destrbuf;
         destrbuf.attach(destbufferptr, destwidth, destheight, deststride);


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

 - Resize (rather than reserve) stl vector which will serve as our
   buffer.
 - use `front` rather than `[0]` to get the first element
   to get the pointer

closes #8684

attn @jrgirvan Can you verify that this still fixes it for you?


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->


<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
