### PR TITLE
Adds support for rgba and rgb images to pcolorfast

### DIFF
--- a/doc/api/api_changes/2019-02-11-PGE.rst
+++ b/doc/api/api_changes/2019-02-11-PGE.rst
@@ -1,0 +1,6 @@
+Added support for RGB(A) images in pcolorfast
+`````````````````````````````````````````````
+
+pcolorfast now accepts 3D images (RGB or RGBA) arrays if the X and Y
+specifications allow image or pcolorimage rendering; they remain unsupported by
+the more general quadmesh rendering

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6185,6 +6185,10 @@ optional.
             A 2D array or masked array. The values will be color-mapped.
             This argument can only be passed positionally.
 
+            C can in some cases be 3D with the last dimension as rgb(a).
+            This is available when C qualifies for image or pcolorimage type,
+            will throw a TypeError if C is 3D and quadmesh.
+
         X, Y : tuple or array-like, default: ``(0, N)``, ``(0, M)``
             *X* and *Y* are used to specify the coordinates of the
             quadrilaterals. There are different ways to do this:
@@ -6258,7 +6262,7 @@ optional.
                 "'norm' must be an instance of 'mcolors.Normalize'")
 
         C = args[-1]
-        nr, nc = np.shape(C)
+        nr, nc = np.shape(C)[:2]
         if len(args) == 1:
             style = "image"
             x = [0, nc]
@@ -6279,6 +6283,10 @@ optional.
                     else:
                         style = "pcolorimage"
             elif x.ndim == 2 and y.ndim == 2:
+                if C.ndim > 2:
+                    raise ValueError(
+                        'pcolorfast needs to use quadmesh, '
+                        'which is not supported when x and y are 2D and C 3D')
                 style = "quadmesh"
             else:
                 raise TypeError("arguments do not match valid signatures")

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5184,6 +5184,21 @@ def test_pcolorfast_colormapped(xy, cls):
     assert type(ax.pcolorfast(*xy, data)) == cls
 
 
+def test_pcolor_fast_RGB():
+
+    fig, ax = plt.subplots(1, 1)
+
+    np.random.seed(19680801)
+    C = np.random.rand(10, 10, 3)  # RGB image [0,1]
+    x = np.arange(11, dtype=np.float)
+    y = np.arange(11, dtype=np.float)
+
+    xv, yv = np.meshgrid(x, y)
+
+    with pytest.raises(ValueError):
+        ax.pcolorfast(xv, yv, C)
+
+
 def test_shared_scale():
     fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

This pull request fixes issue #1317, by making nr, and nc equal to the first and second element of C.shape.
Through this, pcolorfast now works on RGBA arrays, i.e.  NxMx3 or NxMx4.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/whats_new.rst if major new feature
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
