### PR TITLE
Interpret data to normalize as ndarrays

### DIFF
--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -689,3 +689,22 @@ def test_tableau_order():
                   '#bcbd22', '#17becf']
 
     assert list(mcolors.TABLEAU_COLORS.values()) == dflt_cycle
+
+
+def test_ndarray_subclass_norm():
+    # Emulate an ndarray subclass that handles units
+    # which objects when adding or subtracting with other
+    # arrays. See #6622 and #8696
+    class MyArray(np.ndarray):
+        def __isub__(self, other):
+            raise RuntimeError
+
+        def __add__(self, other):
+            raise RuntimeError
+
+    data = np.arange(-10, 10, 1, dtype=float)
+
+    for norm in [mcolors.Normalize(), mcolors.LogNorm(),
+                 mcolors.SymLogNorm(3, vmax=5, linscale=1),
+                 mcolors.PowerNorm(1)]:
+        assert_array_equal(norm(data.view(MyArray)), norm(data))


### PR DESCRIPTION
This follows on from #6622. That PR fixed the case where we were calling imshow with linear normalization. This fixes the case when we call imshow with log, symlog, or power normalization. For example:

```python
import numpy as np

from matplotlib import pyplot as plt
from matplotlib.colors import LogNorm
from yt.units import km

plt.imshow(np.random.random((16, 16))*km, norm=LogNorm())
```

Currently this dies with a unit error in LogNorm. Analogous to the fix applied in #6622 the fix is to interpret data handed to us by a user as an ndarray.