### PR TITLE
ENH: add two new modes for 'adjustable' option

### DIFF
--- a/doc/users/whats_new/adjustable_xlim_ylim.rst
+++ b/doc/users/whats_new/adjustable_xlim_ylim.rst
@@ -1,0 +1,13 @@
+New ``'xlim'`` and ``'ylim'`` options for ``adjustable`` argument
+-----------------------------------------------------------------
+
+The ``adjustable`` argument to the :meth:`~matplotlib.axes.Axes.set_aspect`
+method (and the same argument which can be specified when initializing
+:meth:`~matplotlib.axes.Axes`) can take two new values: ``'xlim'`` and
+``'ylim'``. Previously, users could pass the ``'datalim'`` value to indicate
+that Matplotlib should adjust the limits as needed so as to be able to avoid
+modifying the position and aspect ratio of the axes, but it was impossible to
+know deterministically whether Matplotlib would modify the x or y limits. The
+new ``'xlim'`` and ``'ylim'`` options behave like ``'datalim'`` except that
+``'xlim'`` causes only the x limits to be adjusted, and ``'ylim'`` causes only
+the y limits to be adjusted.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -438,7 +438,7 @@ class _AxesBase(martist.Artist):
           ================   =========================================
           Keyword            Description
           ================   =========================================
-          *adjustable*       [ 'box' | 'datalim' | 'xlim' | 'ylim' |
+          *adjustable*       [ 'box' | 'datalim' | 'xlim' | 'ylim' | \
                                'box-forced' ]
           *alpha*            float: the alpha transparency (can be None)
           *anchor*           [ 'C', 'SW', 'S', 'SE', 'E', 'NE', 'N',

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5171,11 +5171,11 @@ def test_adjustable_limits():
     assert_allclose(ax.get_xlim(), [-1.75, 5.75])
     assert_allclose(ax.get_ylim(), [-0.5, 4.5])
 
-    # Because of the way Matplotlib computes the aspect internally, it turns out
-    # that in this scenario ylim is the adjustable, so even if we change ylim,
-    # xlim will stay the same and ylim will get adjusted. This could be improved
-    # in future by checking in set_xlim and set_ylim whether adjustable='datalim'
-    # and try and make sure this value is respected.
+    # Because of the way Matplotlib computes the aspect internally, it turns
+    # out that in this scenario ylim is the adjustable, so even if we change
+    # ylim, xlim will stay the same and ylim will get adjusted. This could be
+    # improved in future by checking in set_xlim and set_ylim whether
+    # adjustable='datalim' and try and make sure this value is respected.
     ax.set_ylim(4, 5)
     ax.apply_aspect()
     assert_allclose(ax.get_xlim(), [-1.75, 5.75])
@@ -5183,7 +5183,8 @@ def test_adjustable_limits():
 
     # Similarly, if xlim is changed, the values are not necessarily respected
     # and in fact ylim is the one that stays constant. This behavior is the
-    # reason for adding explicit adjustable='xlim' and adjustable='ylim' options.
+    # reason for adding explicit adjustable='xlim' and adjustable='ylim'
+    # options.
     ax.set_xlim(1, 4)
     ax.apply_aspect()
     assert_allclose(ax.get_xlim(), [-1.25, 6.25])
@@ -5214,7 +5215,8 @@ def test_adjustable_limits():
     assert_allclose(ax.get_xlim(), [1.5, 4.5])
     assert_allclose(ax.get_ylim(), [4, 6])
 
-    # Finally we test adjustable='ylim', which should behave similarly to 'xlim'
+    # Finally we test adjustable='ylim', which should behave similarly to
+    # 'xlim'
 
     fig = plt.figure(figsize=(6, 4))
     ax = fig.add_axes([0, 0, 1, 1], aspect='equal')


### PR DESCRIPTION
## PR Summary

This adds two new modes for the ``adjustable=`` option (in ``set_aspect`` and in the initializer for axes). The new modes are ``'xlim'`` and ``'ylim'`` - these behave like the 'datalim' option except that only the x or y limits are adjusted, in a deterministic way. The changes are backward-compatible. It looked like there were no (?) tests for ``adjustable='datalim'``, so I've covered that in the test I added.

**Question:** I need to add an entry to 'what's new', but it looks like ``doc/users/whats_new.rst`` refers to 2.0 not 2.1?

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] <s> Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way</s>

(I wasn't sure if I was supposed to tick the above, or the reviewers, maybe this could be made clearer?)

cc @tacaswell - as discussed on Gitter