### PR TITLE
Fix flaky text tests

### DIFF
--- a/doc/api/api_changes/2017-06-03-ES_unique_renderer.rst
+++ b/doc/api/api_changes/2017-06-03-ES_unique_renderer.rst
@@ -1,0 +1,11 @@
+Unique identifier added to `RendererBase` classes
+`````````````````````````````````````````````````
+
+Since ``id()`` is not guaranteed to be unique between objects that exist at
+different times, a new private property ``_uid`` has been added to
+`RendererBase` which is used along with the renderer's ``id()`` to cache
+certain expensive operations.
+
+If a custom renderer does not subclass `RendererBase` or `MixedModeRenderer`,
+it is not required to implement this ``_uid`` property, but this may produce
+incorrect behavior when the renderers' ``id()`` clashes.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -100,6 +100,11 @@ _default_backends = {
 }
 
 
+# Used to ensure that caching based on renderer id() is unique without being as
+# expensive as a real UUID.
+_unique_renderer_id = 0
+
+
 def register_backend(format, backend, description=None):
     """
     Register a backend for saving to a given file format.
@@ -212,9 +217,24 @@ class RendererBase(object):
 
     """
     def __init__(self):
+        self._id = None
         self._texmanager = None
 
         self._text2path = textpath.TextToPath()
+
+    @property
+    def _uid(self):
+        """
+        A lightweight id for unique-ification purposes.
+
+        Along with id(self), this combination should be unique enough to use as
+        part of a caching key.
+        """
+        if self._id is None:
+            global _unique_renderer_id
+            _unique_renderer_id += 1
+            self._id = _unique_renderer_id
+        return self._id
 
     def open_group(self, s, gid=None):
         """

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -49,6 +49,7 @@ class MixedModeRenderer(object):
         if raster_renderer_class is None:
             raster_renderer_class = RendererAgg
 
+        self._id = None
         self._raster_renderer_class = raster_renderer_class
         self._width = width
         self._height = height
@@ -79,6 +80,18 @@ class MixedModeRenderer(object):
         draw_gouraud_triangles option_scale_image
         _text2path _get_text_path_transform height width
         """.split()
+
+    @property
+    def _uid(self):
+        """
+        See matplotlib.backend_bases.RendererBase._uid.
+        """
+        if self._id is None:
+            from matplotlib import backend_bases
+            backend_bases._unique_renderer_id
+            backend_bases._unique_renderer_id += 1
+            self._id = backend_bases._unique_renderer_id
+        return self._id
 
     def _set_current_renderer(self, renderer):
         self._renderer = renderer

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import six
 
+import matplotlib.backend_bases
 from matplotlib.backends.backend_agg import RendererAgg
 from matplotlib.tight_bbox import process_figure_for_rasterizing
 
@@ -49,7 +50,9 @@ class MixedModeRenderer(object):
         if raster_renderer_class is None:
             raster_renderer_class = RendererAgg
 
-        self._id = None
+        # See matplotlib.backend_bases.RendererBase._uid.
+        self._uid = next(matplotlib.backend_bases._unique_renderer_id)
+
         self._raster_renderer_class = raster_renderer_class
         self._width = width
         self._height = height
@@ -80,18 +83,6 @@ class MixedModeRenderer(object):
         draw_gouraud_triangles option_scale_image
         _text2path _get_text_path_transform height width
         """.split()
-
-    @property
-    def _uid(self):
-        """
-        See matplotlib.backend_bases.RendererBase._uid.
-        """
-        if self._id is None:
-            from matplotlib import backend_bases
-            backend_bases._unique_renderer_id
-            backend_bases._unique_renderer_id += 1
-            self._id = backend_bases._unique_renderer_id
-        return self._id
 
     def _set_current_renderer(self, renderer):
         self._renderer = renderer

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -178,6 +178,8 @@ def test_grayscale_alpha():
     ax.set_yticks([])
 
 
+# This tests tends to hit a TeX cache lock on AppVeyor.
+@pytest.mark.flaky(reruns=3)
 @needs_tex
 def test_missing_psfont(monkeypatch):
     """An error is raised if a TeX font lacks a Type-1 equivalent"""

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -27,6 +27,8 @@ needs_tex = pytest.mark.xfail(
     reason="This test needs a TeX installation")
 
 
+# This tests tends to hit a TeX cache lock on AppVeyor.
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('format, use_log, rcParams', [
     ('ps', False, {}),
     needs_ghostscript(('ps', False, {'ps.usedistiller': 'ghostscript'})),

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -167,9 +167,6 @@ def baseline_images(request, fontset, index):
     return ['%s_%s_%02d' % (request.param, fontset, index)]
 
 
-# See #7911 for why these tests are flaky and #7107 for why they are not so
-# easy to fix.
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('index, test', enumerate(math_tests),
                          ids=[str(index) for index in range(len(math_tests))])
 @pytest.mark.parametrize('fontset',
@@ -184,9 +181,6 @@ def test_mathtext_rendering(baseline_images, fontset, index, test):
              horizontalalignment='center', verticalalignment='center')
 
 
-# See #7911 for why these tests are flaky and #7107 for why they are not so
-# easy to fix.
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('index, test', enumerate(font_tests),
                          ids=[str(index) for index in range(len(font_tests))])
 @pytest.mark.parametrize('fontset',

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -58,7 +58,7 @@ def test_tight_layout3():
 
 
 @image_comparison(baseline_images=['tight_layout4'],
-                  freetype_version=('2.4.5', '2.4.9'))
+                  freetype_version=('2.5.5', '2.6.1'))
 def test_tight_layout4():
     'Test tight_layout for subplot2grid'
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -907,11 +907,12 @@ class Text(Artist):
         need to know if the text has changed.
         """
         x, y = self.get_unitless_position()
+        renderer = renderer or self._renderer
         return (x, y, self.get_text(), self._color,
                 self._verticalalignment, self._horizontalalignment,
                 hash(self._fontproperties),
                 self._rotation, self._rotation_mode,
-                self.figure.dpi, id(renderer or self._renderer),
+                self.figure.dpi, id(renderer), getattr(renderer, '_uid', 0),
                 self._linespacing
                 )
 


### PR DESCRIPTION
As noted in #7911, the mathtext tests sometimes fail if the `id` of the renderer is the same between tests. Since it's difficult to add the mathtext fontset to the key, I fixed/hacked it into working by adding a cache-busting "unique" value to each renderer, which is just a globally-incremented number. I thought of using a UUID or random number, but that seemed too expensive since we don't need to worry about threading locks on globals (AFAIK).

I ran the test from #7911, but using the repeat plugin to run everything 100 times over (so 50000 tests total.) So I'm not 100% certain, but I believe this fixes #7911.

Additionally, we've lately been seeing several failures of `test_savefig_to_stringio` on AppVeyor. This doesn't usually fail locally, but seems to be a timeout on the TeX cache. I've added some retries on these tests to hopefully reduce the problem.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way