### PR TITLE
Fix typos

### DIFF
--- a/doc/users/github_stats.rst
+++ b/doc/users/github_stats.rst
@@ -677,7 +677,7 @@ Pull Requests (1003):
 * :ghpull:`7548`: Clarify to_rgba docstring.
 * :ghpull:`7476`: Sticky margins
 * :ghpull:`7552`: Correctly extend a lognormed colorbar
-* :ghpull:`7499`: Improve the the marker table in markers_api documentation
+* :ghpull:`7499`: Improve the marker table in markers_api documentation
 * :ghpull:`7468`: TST: Enable pytest-xdist
 * :ghpull:`7530`: MAINT: TkAgg default backend depends on tkinter
 * :ghpull:`7531`: double tolerance for test_png.py/pngsuite on Windows

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -1488,7 +1488,7 @@ the `API changes <../../api/api_changes.html>`_.
            (instead of deprecated popen*) and distutils (for version
            checking) - DSD
 
-2008-11-30 Reimplementaion of the legend which supports baseline alignement,
+2008-11-30 Reimplementation of the legend which supports baseline alignement,
            multi-column, and expand mode. - JJL
 
 2008-12-01 Fixed histogram autoscaling bug when bins or range are given
@@ -5142,7 +5142,7 @@ the `API changes <../../api/api_changes.html>`_.
 
 2004-05-19 0.54 released
 
-2004-05-18 Added newline seperated text with rotations to text.Text
+2004-05-18 Added newline separated text with rotations to text.Text
            layout - JDH
 
 2004-05-16 Added fast pcolor using PolyCollections.  - JDH

--- a/doc/users/whats_new/CheckButtons_widget_get_status.rst
+++ b/doc/users/whats_new/CheckButtons_widget_get_status.rst
@@ -1,4 +1,4 @@
 CheckButtons widget get_status function
 ---------------------------------------
 
-A :func:`get_status` function has been added the the :class:`matplotlib.widgets.CheckButtons` class. This :func:`get_status` function allows user to query the status (True/False) of all of the buttons in the CheckButtons object. 
+A :func:`get_status` function has been added the :class:`matplotlib.widgets.CheckButtons` class. This :func:`get_status` function allows user to query the status (True/False) of all of the buttons in the CheckButtons object. 

--- a/examples/api/colorbar_basics.py
+++ b/examples/api/colorbar_basics.py
@@ -30,7 +30,7 @@ pos = ax1.imshow(Zpos, cmap='Blues', interpolation='none')
 # which axes object it should be near
 fig.colorbar(pos, ax=ax1)
 
-# repeat everything above for the the negative data
+# repeat everything above for the negative data
 neg = ax2.imshow(Zneg, cmap='Reds_r', interpolation='none')
 fig.colorbar(neg, ax=ax2)
 

--- a/examples/text_labels_and_annotations/tex_demo.py
+++ b/examples/text_labels_and_annotations/tex_demo.py
@@ -11,7 +11,7 @@ properly installed on your system.  The first time you run a script
 you will see a lot of output from tex and associated tools.  The next
 time, the run may be silent, as a lot of the information is cached.
 
-Notice how the the label for the y axis is provided using unicode!
+Notice how the label for the y axis is provided using unicode!
 
 """
 from __future__ import unicode_literals

--- a/extern/libqhull/io.c
+++ b/extern/libqhull/io.c
@@ -3698,7 +3698,7 @@ coordT *qh_readpoints(int *numpoints, int *dimension, boolT *ismalloc) {
         strncat(qh rbox_command, s, sizeof(qh rbox_command)-1);
     }
     if (!s) {
-      qh_fprintf(qh ferr, 6074, "qhull input error: missing \"begin\" for cdd-formated input\n");
+      qh_fprintf(qh ferr, 6074, "qhull input error: missing \"begin\" for cdd-formatted input\n");
       qh_errexit(qh_ERRinput, NULL, NULL);
     }
   }

--- a/extern/ttconv/pprdrv_tt.cpp
+++ b/extern/ttconv/pprdrv_tt.cpp
@@ -1102,7 +1102,7 @@ void ttfont_trailer(TTStreamWriter& stream, struct TTFONT *font)
 
         stream.put_char('\n');
 
-        /* This proceedure is for compatiblity with */
+        /* This proceedure is for compatibility with */
         /* level 1 interpreters. */
         stream.putline("/BuildChar {");
         stream.putline(" 1 index /Encoding get exch get");

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1250,7 +1250,7 @@ class Animation(object):
   <source type="video/mp4" src="data:video/mp4;base64,{video}">
   Your browser does not support the video tag.
 </video>'''
-        # Cache the the rendering of the video as HTML
+        # Cache the rendering of the video as HTML
         if not hasattr(self, '_base64_video'):
             # First write the video to a tempfile. Set delete to False
             # so we can re-open to read binary data.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -806,7 +806,7 @@ class Artist(object):
 
     def set_agg_filter(self, filter_func):
         """
-        set agg_filter fuction.
+        set agg_filter function.
 
         """
         self._agg_filter = filter_func

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1640,7 +1640,7 @@ class DraggableBase(object):
 
     *artist_picker* is a picker method that will be
      used. *finalize_offset* is called when the mouse is released. In
-     current implementaion of DraggableLegend and DraggableAnnotation,
+     current implementation of DraggableLegend and DraggableAnnotation,
      *update_offset* places the artists simply in display
      coordinates. And *finalize_offset* recalculate their position in
      the normalized axes coordinate and set a relavant attribute.

--- a/src/_path.h
+++ b/src/_path.h
@@ -1262,7 +1262,7 @@ struct _is_sorted
         size = PyArray_DIM(array, 0);
 
         // std::isnan is only in C++11, which we don't yet require,
-        // so we use the the "self == self" trick
+        // so we use the "self == self" trick
         for (i = 0; i < size; ++i) {
             last_value = *((T *)PyArray_GETPTR1(array, i));
             if (last_value == last_value) {


### PR DESCRIPTION
This PR fixes some typos: `the the`, `implementaion`, `seperated`, `formated`, `compatiblity`, `fuction`.