### PR TITLE
moved cla shared axes code to a dedicated function

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1072,6 +1072,8 @@ class _AxesBase(martist.Artist):
         self.xaxis.set_clip_path(self.patch)
         self.yaxis.set_clip_path(self.patch)
 
+        self._shared_x_axes.clean()
+        self._shared_y_axes.clean()
         if self._sharex:
             self.xaxis.set_visible(xaxis_visible)
             self.patch.set_visible(patch_visible)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -973,28 +973,9 @@ class _AxesBase(martist.Artist):
         self.ignore_existing_data_limits = True
         self.callbacks = cbook.CallbackRegistry()
 
+        # clear the shared axes
         if self._sharex is not None:
-            # major and minor are class instances with
-            # locator and formatter attributes
-            self.xaxis.major = self._sharex.xaxis.major
-            self.xaxis.minor = self._sharex.xaxis.minor
-            x0, x1 = self._sharex.get_xlim()
-            self.set_xlim(x0, x1, emit=False, auto=None)
-
-            # Save the current formatter/locator so we don't lose it
-            majf = self._sharex.xaxis.get_major_formatter()
-            minf = self._sharex.xaxis.get_minor_formatter()
-            majl = self._sharex.xaxis.get_major_locator()
-            minl = self._sharex.xaxis.get_minor_locator()
-
-            # This overwrites the current formatter/locator
-            self.xaxis._set_scale(self._sharex.xaxis.get_scale())
-
-            # Reset the formatter/locator
-            self.xaxis.set_major_formatter(majf)
-            self.xaxis.set_minor_formatter(minf)
-            self.xaxis.set_major_locator(majl)
-            self.xaxis.set_minor_locator(minl)
+            self._cla_shared("x")
         else:
             self.xaxis._set_scale('linear')
             try:
@@ -1003,25 +984,7 @@ class _AxesBase(martist.Artist):
                 pass
 
         if self._sharey is not None:
-            self.yaxis.major = self._sharey.yaxis.major
-            self.yaxis.minor = self._sharey.yaxis.minor
-            y0, y1 = self._sharey.get_ylim()
-            self.set_ylim(y0, y1, emit=False, auto=None)
-
-            # Save the current formatter/locator so we don't lose it
-            majf = self._sharey.yaxis.get_major_formatter()
-            minf = self._sharey.yaxis.get_minor_formatter()
-            majl = self._sharey.yaxis.get_major_locator()
-            minl = self._sharey.yaxis.get_minor_locator()
-
-            # This overwrites the current formatter/locator
-            self.yaxis._set_scale(self._sharey.yaxis.get_scale())
-
-            # Reset the formatter/locator
-            self.yaxis.set_major_formatter(majf)
-            self.yaxis.set_minor_formatter(minf)
-            self.yaxis.set_major_locator(majl)
-            self.yaxis.set_minor_locator(minl)
+            self._cla_shared("y")
         else:
             self.yaxis._set_scale('linear')
             try:
@@ -1109,8 +1072,6 @@ class _AxesBase(martist.Artist):
         self.xaxis.set_clip_path(self.patch)
         self.yaxis.set_clip_path(self.patch)
 
-        self._shared_x_axes.clean()
-        self._shared_y_axes.clean()
         if self._sharex:
             self.xaxis.set_visible(xaxis_visible)
             self.patch.set_visible(patch_visible)
@@ -1120,6 +1081,48 @@ class _AxesBase(martist.Artist):
             self.patch.set_visible(patch_visible)
 
         self.stale = True
+
+    def _cla_shared(self, axistype):
+        ''' clear the shared axes, for the given axis type.
+            Note : if cla is overrided, this method must
+            not be used.
+        '''
+        # major and minor are class instances with
+        # locator and formatter attributes
+        if not isinstance(axistype, str):
+            raise ValueError("Axis type is not a string (x or y for example)")
+        # ex : "self.xaxis"
+        axis = getattr(self, axistype + "axis")
+        # ex : self._sharex
+        share = getattr(self, "_share" + axistype)
+        # ex : self._sharex.xaxis
+        shareaxis = getattr(share, axistype+"axis")
+        # ex : self._sharex.get_xlim
+        limget = getattr(share, "get_"+axistype+"lim")
+        # ex : self.set_xlim
+        limset = getattr(self, "set_"+axistype+"lim")
+
+        # major and minor are class instances with
+        # locator and formatter attributes
+        axis.major = shareaxis.major
+        axis.minor = shareaxis.minor
+        x0, x1 = limget()
+        limset(x0, x1, emit=False, auto=None)
+
+        # Save the current formatter/locator so we don't lose it
+        majf = shareaxis.get_major_formatter()
+        minf = shareaxis.get_minor_formatter()
+        majl = shareaxis.get_major_locator()
+        minl = shareaxis.get_minor_locator()
+
+        # This overwrites the current formatter/locator
+        axis._set_scale(shareaxis.get_scale())
+
+        # Reset the formatter/locator
+        axis.set_major_formatter(majf)
+        axis.set_minor_formatter(minf)
+        axis.set_major_locator(majl)
+        axis.set_minor_locator(minl)
 
     @cbook.deprecated("2.1", alternative="Axes.patch")
     def axesPatch(self):


### PR DESCRIPTION
## PR Summary
Response to the end of #8455 with discussion with @WeatherGod 

The goal of this PR is to clean up the code in `Axes.cla()`, which has grown to be large. We probably want something clean over something quick here. This is meant to be a very simple aesthetic change, nothing more (no logic changes). 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

## PR Details
This is also just a suggestion, and there likely may be a better way. I am opening it so it does not get lost. I am open to suggestions, and if you have something nicer, feel free to create a new PR (but please reference this one so we don't get lost).

However, I believe it does bring some points of discussion that I think may be necessary to address, such as:
- I think I may be breaking convention (from what I see in code) by having the function take a string and use it to call class methods, but so far it seems to be a cleaner and still readable to me.
- If `cla` is overridden, then `_cla_shared` needs to be also removed from the class (i.e. for polar axes). Right now this would have to be manually done. I am wondering if there exist decorators implemented that take care of these? For example:
```python
def MyNewClass(OldClass):
    @cla.override
    def cla(self):
        #....
```
where `@cla.override` would contain the necessary bookeeping to remove `_cla_shared` when `cla` is overridden. I will try to search more when I have time but if someone has insight I'm interested to know (and thanks for saving me time :-) ). @QuLogic might have some idea and some input with his experience with polaraxes.
- Will need to wait for Travis. My local tests on `test/test_axes.py` contain a long list of failures (which seem to be the same with and without this change).

thanks!