### PR TITLE
Minor cleanups of the qt4 embedding examples.

### DIFF
--- a/examples/user_interfaces/embedding_in_qt4_sgskip.py
+++ b/examples/user_interfaces/embedding_in_qt4_sgskip.py
@@ -14,22 +14,20 @@ may be distributed without limitation.
 """
 
 from __future__ import unicode_literals
-import sys
 import os
 import random
-from matplotlib.backends import qt_compat
-use_pyside = qt_compat.QT_API == qt_compat.QT_API_PYSIDE
-if use_pyside:
-    from PySide import QtGui, QtCore
-else:
-    from PyQt4 import QtGui, QtCore
+import sys
 
 from numpy import arange, sin, pi
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+
+import matplotlib
+matplotlib.use("Qt4Agg")
+from matplotlib.backends.backend_qt4agg import (
+    FigureCanvasQTAgg as FigureCanvas)
+from matplotlib.backends.qt_compat import QtCore, QtGui
 from matplotlib.figure import Figure
 
 progname = os.path.basename(sys.argv[0])
-progversion = "0.1"
 
 
 class MyMplCanvas(FigureCanvas):

--- a/examples/user_interfaces/embedding_in_qt4_wtoolbar_sgskip.py
+++ b/examples/user_interfaces/embedding_in_qt4_wtoolbar_sgskip.py
@@ -9,46 +9,38 @@ from __future__ import print_function
 import sys
 
 import numpy as np
+
 import matplotlib
 matplotlib.use("Qt4Agg")
-from matplotlib.figure import Figure
 from matplotlib.backend_bases import key_press_handler
 from matplotlib.backends.backend_qt4agg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar)
-from matplotlib.backends import qt_compat
-use_pyside = qt_compat.QT_API == qt_compat.QT_API_PYSIDE
-
-if use_pyside:
-    from PySide.QtCore import *
-    from PySide.QtGui import *
-else:
-    from PyQt4.QtCore import *
-    from PyQt4.QtGui import *
+from matplotlib.backends.qt_compat import QtCore, QtGui
+from matplotlib.figure import Figure
 
 
-class AppForm(QMainWindow):
+class AppForm(QtGui.QMainWindow):
     def __init__(self, parent=None):
-        QMainWindow.__init__(self, parent)
-        #self.x, self.y = self.get_data()
+        QtGui.QMainWindow.__init__(self, parent)
         self.data = self.get_data2()
         self.create_main_frame()
         self.on_draw()
 
     def create_main_frame(self):
-        self.main_frame = QWidget()
+        self.main_frame = QtGui.QWidget()
 
         self.fig = Figure((5.0, 4.0), dpi=100)
         self.canvas = FigureCanvas(self.fig)
         self.canvas.setParent(self.main_frame)
-        self.canvas.setFocusPolicy(Qt.StrongFocus)
+        self.canvas.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.canvas.setFocus()
 
         self.mpl_toolbar = NavigationToolbar(self.canvas, self.main_frame)
 
         self.canvas.mpl_connect('key_press_event', self.on_key_press)
 
-        vbox = QVBoxLayout()
+        vbox = QtGui.QVBoxLayout()
         vbox.addWidget(self.canvas)  # the matplotlib canvas
         vbox.addWidget(self.mpl_toolbar)
         self.main_frame.setLayout(vbox)
@@ -60,9 +52,7 @@ class AppForm(QMainWindow):
     def on_draw(self):
         self.fig.clear()
         self.axes = self.fig.add_subplot(111)
-        #self.axes.plot(self.x, self.y, 'ro')
         self.axes.imshow(self.data, interpolation='nearest')
-        #self.axes.plot([1,2,3])
         self.canvas.draw()
 
     def on_key_press(self, event):
@@ -73,7 +63,7 @@ class AppForm(QMainWindow):
 
 
 def main():
-    app = QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     form = AppForm()
     form.show()
     app.exec_()


### PR DESCRIPTION
`embedding_in_qt4_sgskip.py` would not run if the backend is set to
qt5agg in the rcfile, so we explicitly set it to qt4agg.  Importing
QtCore, QtGui from qt_compat is simpler than explicitly checking for
PySide.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
