### PR TITLE
BUG: handle empty levels array in contour, closes #7486

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1132,14 +1132,10 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                 self.locator = ticker.LogLocator()
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
-        zmax = self.zmax
-        zmin = self.zmin
-        lev = self.locator.tick_values(zmin, zmax)
+
+        lev = self.locator.tick_values(self.zmin, self.zmax)
         self._auto = True
-        if self.filled:
-            return lev
-        # For line contours, drop levels outside the data range.
-        return lev[(lev > zmin) & (lev < zmax)]
+        return lev
 
     def _contour_level_args(self, z, args):
         """
@@ -1165,6 +1161,17 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                         "Last {0} arg must give levels; see help({0})"
                         .format(fn))
             self.levels = lev
+        else:
+            self.levels = np.asarray(self.levels).astype(np.float64)
+
+        if not self.filled:
+            inside = (self.levels > self.zmin) & (self.levels < self.zmax)
+            self.levels = self.levels[inside]
+            if len(self.levels) == 0:
+                self.levels = [self.zmin]
+                warnings.warn("No contour levels were found"
+                              " within the data range.")
+
         if self.filled and len(self.levels) < 2:
             raise ValueError("Filled contours require at least 2 levels.")
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -132,6 +132,28 @@ def test_contour_shape_invalid_2():
     excinfo.match(r'Input z must be a 2D array.')
 
 
+def test_contour_empty_levels():
+
+    x = np.arange(9)
+    z = np.random.random((9, 9))
+
+    fig, ax = plt.subplots()
+    with pytest.warns(UserWarning) as record:
+        ax.contour(x, x, z, levels=[])
+    assert len(record) == 1
+
+
+def test_contour_uniform_z():
+
+    x = np.arange(9)
+    z = np.ones((9, 9))
+
+    fig, ax = plt.subplots()
+    with pytest.warns(UserWarning) as record:
+        ax.contour(x, x, z)
+    assert len(record) == 1
+
+
 @image_comparison(baseline_images=['contour_manual_labels'])
 def test_contour_manual_labels():
 


### PR DESCRIPTION
This relates to line contours only, not to filled contours.

This handles the case where an empty array is provided as the
"levels" kwarg, or where for any reason there are no levels within
the data range.  An example is the case of uniform z. The
levels array is then set to the minimum value of z so that
the plotting can proceed, and a warning is generated.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
