### PR TITLE
Fix typos

### DIFF
--- a/extern/agg24-svn/include/platform/agg_platform_support.h
+++ b/extern/agg24-svn/include/platform/agg_platform_support.h
@@ -18,7 +18,7 @@
 // It's not a part of the AGG library, it's just a helper class to create 
 // interactive demo examples. Since the examples should not be too complex
 // this class is provided to support some very basic interactive graphical
-// funtionality, such as putting the rendered image to the window, simple 
+// functionality, such as putting the rendered image to the window, simple 
 // keyboard and mouse input, window resizing, setting the window title,
 // and catching the "idle" events.
 // 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4085,7 +4085,7 @@ class FancyArrowPatch(Patch):
             the mutation and the mutated box will be stretched by the inverse
             of it.
 
-        dpi_cor : scalar, optional (defualt: 1)
+        dpi_cor : scalar, optional (default: 1)
             dpi_cor is currently used for linewidth-related things and shrink
             factor. Mutation scale is affected by this.
 

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -90,8 +90,8 @@ class ConversionInterface(object):
     def convert(obj, unit, axis):
         """
         convert obj using unit for the specified axis.  If obj is a sequence,
-        return the converted sequence.  The ouput must be a sequence of scalars
-        that can be used by the numpy array layer
+        return the converted sequence.  The output must be a sequence of
+        scalars that can be used by the numpy array layer
         """
         return obj
 


### PR DESCRIPTION
This PR fixes some typos: `funtionality`, `defualt`, and `ouput`.