### PR TITLE
Remove 'Demo of' from stats example titles

### DIFF
--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -1,7 +1,7 @@
 """
-=========================================
-Demo of artist customization in box plots
-=========================================
+=================================
+Artist customization in box plots
+=================================
 
 This example demonstrates how to use the various kwargs
 to fully customize box plots. The first figure demonstrates

--- a/examples/statistics/bxp.py
+++ b/examples/statistics/bxp.py
@@ -1,7 +1,7 @@
 """
-===================================
-Demo of the boxplot drawer function
-===================================
+=======================
+Boxplot drawer function
+=======================
 
 This example demonstrates how to pass pre-computed box plot
 statistics to the box plot drawer. The first figure demonstrates

--- a/examples/statistics/customized_violin.py
+++ b/examples/statistics/customized_violin.py
@@ -1,7 +1,7 @@
 """
-=================================
-Demo of violin plot customization
-=================================
+=========================
+Violin plot customization
+=========================
 
 This example demonstrates how to fully customize violin plots.
 The first plot shows the default style by providing only

--- a/examples/statistics/errorbar.py
+++ b/examples/statistics/errorbar.py
@@ -1,7 +1,7 @@
 """
-=============================
-Demo of the errorbar function
-=============================
+=================
+Errorbar function
+=================
 
 This exhibits the most basic use of the error bar method.
 In this case, constant values are provided for the error

--- a/examples/statistics/errorbar_features.py
+++ b/examples/statistics/errorbar_features.py
@@ -1,7 +1,7 @@
 """
-===================================================
-Demo of the different ways of specifying error bars
-===================================================
+=======================================
+Different ways of specifying error bars
+=======================================
 
 Errors can be specified as a constant value (as shown in
 `errorbar_demo.py`). However, this example demonstrates

--- a/examples/statistics/errorbar_limits.py
+++ b/examples/statistics/errorbar_limits.py
@@ -1,7 +1,7 @@
 """
-===========================================================
-Demo of how to include upper and lower limits in error bars
-===========================================================
+==============================================
+Including upper and lower limits in error bars
+==============================================
 
 In matplotlib, errors bars can have "limits". Applying limits to the
 error bars essentially makes the error unidirectional. Because of that,

--- a/examples/statistics/errorbars_and_boxes.py
+++ b/examples/statistics/errorbars_and_boxes.py
@@ -1,7 +1,7 @@
 """
-============================================================
-Demo on creating boxes from error bars using PatchCollection
-============================================================
+====================================================
+Creating boxes from error bars using PatchCollection
+====================================================
 
 In this example, we snazz up a pretty standard error bar plot by adding
 a rectangle patch defined by the limits of the bars in both the x- and

--- a/examples/statistics/histogram_cumulative.py
+++ b/examples/statistics/histogram_cumulative.py
@@ -1,7 +1,7 @@
 """
-==========================================================
-Demo of using histograms to plot a cumulative distribution
-==========================================================
+==================================================
+Using histograms to plot a cumulative distribution
+==================================================
 
 This shows how to plot a cumulative, normalized histogram as a
 step function in order to visualize the empirical cumulative

--- a/examples/statistics/multiple_histograms_side_by_side.py
+++ b/examples/statistics/multiple_histograms_side_by_side.py
@@ -1,7 +1,7 @@
 """
-=======================================================
-Demo of how to produce multiple histograms side by side
-=======================================================
+==========================================
+Producing multiple histograms side by side
+==========================================
 
 This example plots horizontal histograms of different samples along
 a categorical x-axis. Additionally, the histograms are plotted to

--- a/examples/statistics/violinplot.py
+++ b/examples/statistics/violinplot.py
@@ -1,7 +1,7 @@
 """
-==================================
-Demo of the basics of violin plots
-==================================
+==================
+Violin plot basics
+==================
 
 Violin plots are similar to histograms and box plots in that they show
 an abstract representation of the probability distribution of the


### PR DESCRIPTION
Looking through the examples today for something, and I think it's a bit annoying that lots of the titles start with "Demo of..." (http://matplotlib.org/devdocs/gallery/index.html#statistics).

I've renamed some of the titles to get rid of this and make them easier to read.