### PR TITLE
Parameterize test_fill_between and test_fill_betweenx

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -847,40 +847,32 @@ def test_polycollection_joinstyle():
     ax.set_ybound(0, 3)
 
 
-def test_fill_between_2d_x_input():
-    x = np.zeros((2, 2))
-    y1 = 3
-    y2 = 3
-
+@pytest.mark.parametrize(
+    'x, y1, y2', [
+        (np.zeros((2, 2)), 3, 3),
+        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
+        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ]
+)
+def test_fill_between_input(x, y1, y2):
     fig = plt.figure()
     ax = fig.add_subplot(211)
     with pytest.raises(ValueError):
-        ax.plot(x, y1, x, y2, color='black')
         ax.fill_between(x, y1, y2)
 
 
-def test_fill_between_2d_y1_input():
-    x = np.arange(0.0, 2, 0.02)
-    y1 = np.zeros((2, 2))
-    y2 = 3
-
+@pytest.mark.parametrize(
+    'y, x1, x2', [
+        (np.zeros((2, 2)), 3, 3),
+        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
+        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ]
+)
+def test_fill_betweenx_input(y, x1, x2):
     fig = plt.figure()
     ax = fig.add_subplot(211)
     with pytest.raises(ValueError):
-        ax.plot(x, y1, x, y2, color='black')
-        ax.fill_between(x, y1, y2)
-
-
-def test_fill_between_2d_y2_input():
-    x = np.arange(0.0, 2, 0.02)
-    y1 = 3
-    y2 = np.zeros((2, 2))
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(x, y1, x, y2, color='black')
-        ax.fill_between(x, y1, y2)
+        ax.fill_betweenx(y, x1, x2)
 
 
 @image_comparison(baseline_images=['fill_between_interpolate'],
@@ -4993,42 +4985,6 @@ def test_tick_param_label_rotation():
         assert text.get_rotation() == 75
     for text in ax.get_yticklabels(which='both'):
         assert text.get_rotation() == 90
-
-
-def test_fill_betweenx_2d_y_input():
-    y = np.zeros((2, 2))
-    x1 = 3
-    x2 = 3
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(y, x1, y, x2, color='black')
-        ax.fill_betweenx(y, x1, x2)
-
-
-def test_fill_betweenx_2d_x1_input():
-    y = np.arange(0.0, 2, 0.02)
-    x1 = np.zeros((2, 2))
-    x2 = 3
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(y, x1, y, x2, color='black')
-        ax.fill_betweenx(y, x1, x2)
-
-
-def test_fill_betweenx_2d_x2_input():
-    y = np.arange(0.0, 2, 0.02)
-    x1 = 3
-    x2 = np.zeros((2, 2))
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(y, x1, y, x2, color='black')
-        ax.fill_betweenx(y, x1, x2)
 
 
 @pytest.mark.style('default')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -852,6 +852,10 @@ def test_polycollection_joinstyle():
         (np.zeros((2, 2)), 3, 3),
         (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
         (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ], ids=[
+        '2d_x_input',
+        '2d_y1_input',
+        '2d_y2_input'
     ]
 )
 def test_fill_between_input(x, y1, y2):
@@ -866,6 +870,10 @@ def test_fill_between_input(x, y1, y2):
         (np.zeros((2, 2)), 3, 3),
         (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
         (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ], ids=[
+        '2d_y_input',
+        '2d_x1_input',
+        '2d_x2_input'
     ]
 )
 def test_fill_betweenx_input(y, x1, x2):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->
Parametrize test_fill_between and test_fill_betweenx and drops plot call
fixes #8698 

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
