### PR TITLE
Allow timedelta to be converted to a ordinalf

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -207,15 +207,18 @@ WEEKDAYS = (MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
 
 def _to_ordinalf(dt):
     """
-    Convert :mod:`datetime` or :mod:`date` to the Gregorian date as UTC float
-    days, preserving hours, minutes, seconds and microseconds.  Return value
-    is a :func:`float`.
+    Convert :mod:`datetime`, :mod:`date` or :mod:`timedelta` to the Gregorian
+    date as UTC float days, preserving hours, minutes, seconds and
+    microseconds. Return value is a :func:`float`.
     """
     # Convert to UTC
     tzi = getattr(dt, 'tzinfo', None)
     if tzi is not None:
         dt = dt.astimezone(UTC)
         tzi = UTC
+
+    if isinstance(dt, datetime.timedelta):
+        return dt.total_seconds() / SEC_PER_DAY
 
     base = float(dt.toordinal())
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -466,3 +466,10 @@ def test_tz_utc():
 def test_num2timedelta(x, tdelta):
     dt = mdates.num2timedelta(x)
     assert dt == tdelta
+
+
+def test_timedelta_ordinalf():
+    # Check that timedeltas can be converted to ordinalfs
+    dt = datetime.timedelta(seconds=60)
+    ordinalf = mdates._to_ordinalf(dt)
+    assert ordinalf == 1 / (24 * 60)


### PR DESCRIPTION
This allows `_to_ordinalf` to handle python `timedelta` objects. This is a first step in solving #4916, where the problem is that it is currently not possible to convert a width into a ordinal.

e.g. the following now works with this PR, whereas `delta` being a `timedelta` object was a problem before:

```python
import matplotlib.pyplot as plt
import matplotlib.patches as mpatch
from datetime import datetime, timedelta

start = datetime(2017, 1, 1, 0, 0, 0)
delta = timedelta(seconds=16)
patch = mpatch.Rectangle((start, 0),
                         delta, 1)
fig, ax = plt.subplots()
ax.add_patch(patch)
ax.set_xlim(start - delta, start + 2 * delta)
ax.set_ylim(-1, 2)
plt.show()
```