### PR TITLE
Add test to colorbar.py to see if ax is an object as returned by plt.subplots

### DIFF
--- a/doc/users/github_stats.rst
+++ b/doc/users/github_stats.rst
@@ -677,7 +677,7 @@ Pull Requests (1003):
 * :ghpull:`7548`: Clarify to_rgba docstring.
 * :ghpull:`7476`: Sticky margins
 * :ghpull:`7552`: Correctly extend a lognormed colorbar
-* :ghpull:`7499`: Improve the the marker table in markers_api documentation
+* :ghpull:`7499`: Improve the marker table in markers_api documentation
 * :ghpull:`7468`: TST: Enable pytest-xdist
 * :ghpull:`7530`: MAINT: TkAgg default backend depends on tkinter
 * :ghpull:`7531`: double tolerance for test_png.py/pngsuite on Windows

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -1488,7 +1488,7 @@ the `API changes <../../api/api_changes.html>`_.
            (instead of deprecated popen*) and distutils (for version
            checking) - DSD
 
-2008-11-30 Reimplementaion of the legend which supports baseline alignement,
+2008-11-30 Reimplementation of the legend which supports baseline alignement,
            multi-column, and expand mode. - JJL
 
 2008-12-01 Fixed histogram autoscaling bug when bins or range are given
@@ -5142,7 +5142,7 @@ the `API changes <../../api/api_changes.html>`_.
 
 2004-05-19 0.54 released
 
-2004-05-18 Added newline seperated text with rotations to text.Text
+2004-05-18 Added newline separated text with rotations to text.Text
            layout - JDH
 
 2004-05-16 Added fast pcolor using PolyCollections.  - JDH

--- a/doc/users/whats_new/CheckButtons_widget_get_status.rst
+++ b/doc/users/whats_new/CheckButtons_widget_get_status.rst
@@ -1,4 +1,4 @@
 CheckButtons widget get_status function
 ---------------------------------------
 
-A :func:`get_status` function has been added the the :class:`matplotlib.widgets.CheckButtons` class. This :func:`get_status` function allows user to query the status (True/False) of all of the buttons in the CheckButtons object. 
+A :func:`get_status` function has been added the :class:`matplotlib.widgets.CheckButtons` class. This :func:`get_status` function allows user to query the status (True/False) of all of the buttons in the CheckButtons object. 

--- a/examples/api/colorbar_basics.py
+++ b/examples/api/colorbar_basics.py
@@ -30,7 +30,7 @@ pos = ax1.imshow(Zpos, cmap='Blues', interpolation='none')
 # which axes object it should be near
 fig.colorbar(pos, ax=ax1)
 
-# repeat everything above for the the negative data
+# repeat everything above for the negative data
 neg = ax2.imshow(Zneg, cmap='Reds_r', interpolation='none')
 fig.colorbar(neg, ax=ax2)
 

--- a/examples/pylab_examples/demo_text_path.py
+++ b/examples/pylab_examples/demo_text_path.py
@@ -5,8 +5,6 @@ Demo Text Path
 
 """
 
-# -*- coding: utf-8 -*-
-
 import matplotlib.pyplot as plt
 from matplotlib.image import BboxImage
 import numpy as np

--- a/examples/statistics/hist.py
+++ b/examples/statistics/hist.py
@@ -46,7 +46,7 @@ axs[1].hist(y, bins=n_bins)
 # edit the histogram to our liking. Let's change the color of each bar
 # based on its y value.
 
-fig, axs = plt.subplots(1, 2, figsize=(10, 5), tight_layout=True)
+fig, axs = plt.subplots(1, 2, tight_layout=True)
 
 # N is the count in each bin, bins is the lower-limit of the bin
 N, bins, patches = axs[0].hist(x, bins=n_bins)
@@ -87,7 +87,7 @@ hist = ax.hist2d(x, y)
 # Customizing a 2D histogram is similar to the 1D case, you can control
 # visual components such as the bin size or color normalization.
 
-fig, axs = plt.subplots(1, 3, figsize=(15, 5), sharex=True, sharey=True,
+fig, axs = plt.subplots(3, 1, figsize=(5, 15), sharex=True, sharey=True,
                         tight_layout=True)
 
 # We can increase the number of bins on each axis

--- a/examples/text_labels_and_annotations/tex_demo.py
+++ b/examples/text_labels_and_annotations/tex_demo.py
@@ -11,7 +11,7 @@ properly installed on your system.  The first time you run a script
 you will see a lot of output from tex and associated tools.  The next
 time, the run may be silent, as a lot of the information is cached.
 
-Notice how the the label for the y axis is provided using unicode!
+Notice how the label for the y axis is provided using unicode!
 
 """
 from __future__ import unicode_literals

--- a/extern/libqhull/io.c
+++ b/extern/libqhull/io.c
@@ -3698,7 +3698,7 @@ coordT *qh_readpoints(int *numpoints, int *dimension, boolT *ismalloc) {
         strncat(qh rbox_command, s, sizeof(qh rbox_command)-1);
     }
     if (!s) {
-      qh_fprintf(qh ferr, 6074, "qhull input error: missing \"begin\" for cdd-formated input\n");
+      qh_fprintf(qh ferr, 6074, "qhull input error: missing \"begin\" for cdd-formatted input\n");
       qh_errexit(qh_ERRinput, NULL, NULL);
     }
   }

--- a/extern/ttconv/pprdrv_tt.cpp
+++ b/extern/ttconv/pprdrv_tt.cpp
@@ -1102,7 +1102,7 @@ void ttfont_trailer(TTStreamWriter& stream, struct TTFONT *font)
 
         stream.put_char('\n');
 
-        /* This proceedure is for compatiblity with */
+        /* This proceedure is for compatibility with */
         /* level 1 interpreters. */
         stream.putline("/BuildChar {");
         stream.putline(" 1 index /Encoding get exch get");

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1250,7 +1250,7 @@ class Animation(object):
   <source type="video/mp4" src="data:video/mp4;base64,{video}">
   Your browser does not support the video tag.
 </video>'''
-        # Cache the the rendering of the video as HTML
+        # Cache the rendering of the video as HTML
         if not hasattr(self, '_base64_video'):
             # First write the video to a tempfile. Set delete to False
             # so we can re-open to read binary data.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -806,7 +806,7 @@ class Artist(object):
 
     def set_agg_filter(self, filter_func):
         """
-        set agg_filter fuction.
+        set agg_filter function.
 
         """
         self._agg_filter = filter_func

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -84,25 +84,18 @@ class RendererAgg(RendererBase):
 
     lock = threading.RLock()
     def __init__(self, width, height, dpi):
-        if __debug__: verbose.report('RendererAgg.__init__', 'debug-annoying')
         RendererBase.__init__(self)
 
         self.dpi = dpi
         self.width = width
         self.height = height
-        if __debug__: verbose.report('RendererAgg.__init__ width=%s, height=%s'%(width, height), 'debug-annoying')
         self._renderer = _RendererAgg(int(width), int(height), dpi, debug=False)
         self._filter_renderers = []
-
-        if __debug__: verbose.report('RendererAgg.__init__ _RendererAgg done',
-                                     'debug-annoying')
 
         self._update_methods()
         self.mathtext_parser = MathTextParser('Agg')
 
         self.bbox = Bbox.from_bounds(0, 0, self.width, self.height)
-        if __debug__: verbose.report('RendererAgg.__init__ done',
-                                     'debug-annoying')
 
     def __getstate__(self):
         # We only want to preserve the init keywords of the Renderer.
@@ -178,8 +171,6 @@ class RendererAgg(RendererBase):
         """
         Draw the math text using matplotlib.mathtext
         """
-        if __debug__: verbose.report('RendererAgg.draw_mathtext',
-                                     'debug-annoying')
         ox, oy, width, height, descent, font_image, used_characters = \
             self.mathtext_parser.parse(s, self.dpi, prop)
 
@@ -193,8 +184,6 @@ class RendererAgg(RendererBase):
         """
         Render the text
         """
-        if __debug__: verbose.report('RendererAgg.draw_text', 'debug-annoying')
-
         if ismath:
             return self.draw_mathtext(gc, x, y, s, prop, angle)
 
@@ -279,9 +268,6 @@ class RendererAgg(RendererBase):
         """
         Get the font for text instance t, cacheing for efficiency
         """
-        if __debug__: verbose.report('RendererAgg._get_agg_font',
-                                     'debug-annoying')
-
         fname = findfont(prop)
         font = get_font(
             fname,
@@ -298,23 +284,15 @@ class RendererAgg(RendererBase):
         convert point measures to pixes using dpi and the pixels per
         inch of the display
         """
-        if __debug__: verbose.report('RendererAgg.points_to_pixels',
-                                     'debug-annoying')
         return points*self.dpi/72.0
 
     def tostring_rgb(self):
-        if __debug__: verbose.report('RendererAgg.tostring_rgb',
-                                     'debug-annoying')
         return self._renderer.tostring_rgb()
 
     def tostring_argb(self):
-        if __debug__: verbose.report('RendererAgg.tostring_argb',
-                                     'debug-annoying')
         return self._renderer.tostring_argb()
 
     def buffer_rgba(self):
-        if __debug__: verbose.report('RendererAgg.buffer_rgba',
-                                     'debug-annoying')
         return self._renderer.buffer_rgba()
 
     def clear(self):
@@ -423,10 +401,6 @@ def new_figure_manager(num, *args, **kwargs):
     """
     Create a new figure manager instance
     """
-    if __debug__: verbose.report('backend_agg.new_figure_manager',
-                                 'debug-annoying')
-
-
     FigureClass = kwargs.pop('FigureClass', Figure)
     thisFig = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, thisFig)
@@ -465,8 +439,6 @@ class FigureCanvasAgg(FigureCanvasBase):
         """
         Draw the figure using the renderer
         """
-        if __debug__: verbose.report('FigureCanvasAgg.draw', 'debug-annoying')
-
         self.renderer = self.get_renderer(cleared=True)
         # acquire a lock on the shared font cache
         RendererAgg.lock.acquire()
@@ -500,8 +472,6 @@ class FigureCanvasAgg(FigureCanvasBase):
         -------
         bytes
         '''
-        if __debug__: verbose.report('FigureCanvasAgg.tostring_rgb',
-                                     'debug-annoying')
         return self.renderer.tostring_rgb()
 
     def tostring_argb(self):
@@ -515,8 +485,6 @@ class FigureCanvasAgg(FigureCanvasBase):
         bytes
 
         '''
-        if __debug__: verbose.report('FigureCanvasAgg.tostring_argb',
-                                     'debug-annoying')
         return self.renderer.tostring_argb()
 
     def buffer_rgba(self):
@@ -529,8 +497,6 @@ class FigureCanvasAgg(FigureCanvasBase):
         -------
         bytes
         '''
-        if __debug__: verbose.report('FigureCanvasAgg.buffer_rgba',
-                                     'debug-annoying')
         return self.renderer.buffer_rgba()
 
     def print_raw(self, filename_or_obj, *args, **kwargs):

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -27,8 +27,6 @@ import os, sys, warnings, gzip
 
 import numpy as np
 
-def _fn_name(): return sys._getframe(1).f_code.co_name
-
 try:
     import cairocffi as cairo
 except ImportError:
@@ -57,9 +55,6 @@ from matplotlib.mathtext     import MathTextParser
 from matplotlib.path         import Path
 from matplotlib.transforms   import Bbox, Affine2D
 from matplotlib.font_manager import ttfFontProperty
-
-_debug = False
-#_debug = True
 
 # Image::color_conv(format) for draw_image()
 if sys.byteorder == 'little':
@@ -114,7 +109,6 @@ class RendererCairo(RendererBase):
     def __init__(self, dpi):
         """
         """
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
         self.dpi = dpi
         self.gc = GraphicsContextCairo (renderer=self)
         self.text_ctx = cairo.Context (
@@ -227,8 +221,6 @@ class RendererCairo(RendererBase):
 
     def draw_image(self, gc, x, y, im):
         # bbox - not currently used
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
-
         if sys.byteorder == 'little':
             im = im[:, :, (2, 1, 0, 3)]
         else:
@@ -266,8 +258,6 @@ class RendererCairo(RendererBase):
     def draw_text(self, gc, x, y, s, prop, angle, ismath=False, mtext=None):
         # Note: x,y are device/display coords, not user-coords, unlike other
         # draw_* methods
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
-
         if ismath:
             self._draw_mathtext(gc, x, y, s, prop, angle)
 
@@ -297,8 +287,6 @@ class RendererCairo(RendererBase):
             ctx.restore()
 
     def _draw_mathtext(self, gc, x, y, s, prop, angle):
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
-
         ctx = gc.ctx
         width, height, descent, glyphs, rects = self.mathtext_parser.parse(
             s, self.dpi, prop)
@@ -335,19 +323,16 @@ class RendererCairo(RendererBase):
 
 
     def flipy(self):
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
         return True
         #return False # tried - all draw objects ok except text (and images?)
         # which comes out mirrored!
 
 
     def get_canvas_width_height(self):
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
         return self.width, self.height
 
 
     def get_text_width_height_descent(self, s, prop, ismath):
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
         if ismath:
             width, height, descent, fonts, used_characters = self.mathtext_parser.parse(
                s, self.dpi, prop)
@@ -376,7 +361,6 @@ class RendererCairo(RendererBase):
 
 
     def new_gc(self):
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
         self.gc.ctx.save()
         self.gc._alpha = 1.0
         self.gc._forced_alpha = False # if True, _alpha overrides A from RGBA
@@ -384,7 +368,6 @@ class RendererCairo(RendererBase):
 
 
     def points_to_pixels(self, points):
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
         return points/72.0 * self.dpi
 
 
@@ -488,7 +471,6 @@ def new_figure_manager(num, *args, **kwargs): # called by backends/__init__.py
     """
     Create a new figure manager instance
     """
-    if _debug: print('%s()' % (_fn_name()))
     FigureClass = kwargs.pop('FigureClass', Figure)
     thisFig = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, thisFig)

--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -7,7 +7,6 @@ import math
 import os
 import sys
 import warnings
-def fn_name(): return sys._getframe(1).f_code.co_name
 
 import gobject
 import gtk; gdk = gtk.gdk
@@ -24,8 +23,8 @@ import numpy as np
 import matplotlib
 from matplotlib import rcParams
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
-     FigureManagerBase, FigureCanvasBase
+from matplotlib.backend_bases import (
+    RendererBase, GraphicsContextBase, FigureManagerBase, FigureCanvasBase)
 from matplotlib.cbook import restrict_dict, warn_deprecated
 from matplotlib.figure import Figure
 from matplotlib.mathtext import MathTextParser
@@ -33,7 +32,6 @@ from matplotlib.transforms import Affine2D
 from matplotlib.backends._backend_gdk import pixbuf_get_pixels_array
 
 backend_version = "%d.%d.%d" % gtk.pygtk_version
-_debug = False
 
 # Image formats that this backend supports - for FileChooser and print_figure()
 IMAGE_FORMAT = sorted(['bmp', 'eps', 'jpg', 'png', 'ps', 'svg']) # 'raw', 'rgb'

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import os, sys, warnings
-def fn_name(): return sys._getframe(1).f_code.co_name
 
 if six.PY3:
     warnings.warn(
@@ -43,9 +42,6 @@ from matplotlib import (
     cbook, colors as mcolors, lines, markers, rcParams, verbose)
 
 backend_version = "%d.%d.%d" % gtk.pygtk_version
-
-_debug = False
-#_debug = True
 
 # the true dots per inch on the screen; should be display dependent
 # see http://groups.google.com/groups?q=screen+dpi+x11&hl=en&lr=&ie=UTF-8&oe=UTF-8&safe=off&selm=7077.26e81ad5%40swift.cs.tcd.ie&rnum=5 for some info about screen dpi
@@ -225,7 +221,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
                             "See Matplotlib usage FAQ for"
                             " more info on backends.",
                             alternative="GTKAgg")
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         FigureCanvasBase.__init__(self, figure)
         gtk.DrawingArea.__init__(self)
 
@@ -261,7 +256,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
             gobject.source_remove(self._idle_draw_id)
 
     def scroll_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         x = event.x
         # flipy so y=0 is bottom of canvas
         y = self.allocation.height - event.y
@@ -273,7 +267,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         return False  # finish event propagation?
 
     def button_press_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         x = event.x
         # flipy so y=0 is bottom of canvas
         y = self.allocation.height - event.y
@@ -297,7 +290,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         return False  # finish event propagation?
 
     def button_release_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         x = event.x
         # flipy so y=0 is bottom of canvas
         y = self.allocation.height - event.y
@@ -305,21 +297,16 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         return False  # finish event propagation?
 
     def key_press_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         key = self._get_key(event)
-        if _debug: print("hit", key)
         FigureCanvasBase.key_press_event(self, key, guiEvent=event)
         return True  # stop event propagation
 
     def key_release_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         key = self._get_key(event)
-        if _debug: print("release", key)
         FigureCanvasBase.key_release_event(self, key, guiEvent=event)
         return True  # stop event propagation
 
     def motion_notify_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         if event.is_hint:
             x, y, state = event.window.get_pointer()
         else:
@@ -355,7 +342,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         return key
 
     def configure_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
         if widget.window is None:
             return
         w, h = event.width, event.height
@@ -408,8 +394,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         Make sure _._pixmap is at least width, height,
         create new pixmap if necessary
         """
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
-
         create_pixmap = False
         if width > self._pixmap_width:
             # increase the pixmap in 10%+ (rather than 1 pixel) steps
@@ -438,8 +422,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
     def expose_event(self, widget, event):
         """Expose_event for all GTK backends. Should not be overridden.
         """
-        if _debug: print('FigureCanvasGTK.%s' % fn_name())
-
         if GTK_WIDGET_DRAWABLE(self):
             if self._need_redraw:
                 x, y, w, h = self.allocation
@@ -556,7 +538,6 @@ class FigureManagerGTK(FigureManagerBase):
 
     """
     def __init__(self, canvas, num):
-        if _debug: print('FigureManagerGTK.%s' % fn_name())
         FigureManagerBase.__init__(self, canvas, num)
 
         self.window = gtk.Window()
@@ -610,7 +591,6 @@ class FigureManagerGTK(FigureManagerBase):
         self.canvas.grab_focus()
 
     def destroy(self, *args):
-        if _debug: print('FigureManagerGTK.%s' % fn_name())
         if hasattr(self, 'toolbar') and self.toolbar is not None:
             self.toolbar.destroy()
         if hasattr(self, 'vbox'):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import os, sys
-def fn_name(): return sys._getframe(1).f_code.co_name
 
 try:
     import gi
@@ -28,23 +27,21 @@ except ImportError:
 
 import matplotlib
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.backend_bases import RendererBase, GraphicsContextBase, \
-     FigureManagerBase, FigureCanvasBase, NavigationToolbar2, cursors, TimerBase
-from matplotlib.backend_bases import (ShowBase, ToolContainerBase,
-                                      StatusbarBase)
+from matplotlib.backend_bases import (
+    FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    NavigationToolbar2, RendererBase, TimerBase, cursors)
+from matplotlib.backend_bases import (
+    ShowBase, ToolContainerBase, StatusbarBase)
 from matplotlib.backend_managers import ToolManager
-from matplotlib import backend_tools
-
 from matplotlib.cbook import is_writable_file_like
 from matplotlib.figure import Figure
 from matplotlib.widgets import SubplotTool
 
-from matplotlib import cbook, colors as mcolors, lines, verbose, rcParams
+from matplotlib import (
+    backend_tools, cbook, colors as mcolors, lines, verbose, rcParams)
 
-backend_version = "%s.%s.%s" % (Gtk.get_major_version(), Gtk.get_micro_version(), Gtk.get_minor_version())
-
-_debug = False
-#_debug = True
+backend_version = "%s.%s.%s" % (
+    Gtk.get_major_version(), Gtk.get_micro_version(), Gtk.get_minor_version())
 
 # the true dots per inch on the screen; should be display dependent
 # see http://groups.google.com/groups?q=screen+dpi+x11&hl=en&lr=&ie=UTF-8&oe=UTF-8&safe=off&selm=7077.26e81ad5%40swift.cs.tcd.ie&rnum=5 for some info about screen dpi
@@ -119,7 +116,7 @@ class TimerGTK3(TimerBase):
             self._timer = None
             return False
 
-class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
+class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
     keyvald = {65507 : 'control',
                65505 : 'shift',
                65513 : 'alt',
@@ -185,7 +182,6 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
                   Gdk.EventMask.SCROLL_MASK)
 
     def __init__(self, figure):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         FigureCanvasBase.__init__(self, figure)
         GObject.GObject.__init__(self)
 
@@ -219,7 +215,6 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
             GLib.source_remove(self._idle_draw_id)
 
     def scroll_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         x = event.x
         # flipy so y=0 is bottom of canvas
         y = self.get_allocation().height - event.y
@@ -231,7 +226,6 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         return False  # finish event propagation?
 
     def button_press_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         x = event.x
         # flipy so y=0 is bottom of canvas
         y = self.get_allocation().height - event.y
@@ -239,7 +233,6 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         return False  # finish event propagation?
 
     def button_release_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         x = event.x
         # flipy so y=0 is bottom of canvas
         y = self.get_allocation().height - event.y
@@ -247,21 +240,16 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         return False  # finish event propagation?
 
     def key_press_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         key = self._get_key(event)
-        if _debug: print("hit", key)
         FigureCanvasBase.key_press_event(self, key, guiEvent=event)
         return True  # stop event propagation
 
     def key_release_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         key = self._get_key(event)
-        if _debug: print("release", key)
         FigureCanvasBase.key_release_event(self, key, guiEvent=event)
         return True  # stop event propagation
 
     def motion_notify_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         if event.is_hint:
             t, x, y, state = event.window.get_pointer()
         else:
@@ -279,9 +267,6 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         FigureCanvasBase.enter_notify_event(self, event)
 
     def size_allocate(self, widget, allocation):
-        if _debug:
-            print("FigureCanvasGTK3.%s" % fn_name())
-            print("size_allocate (%d x %d)" % (allocation.width, allocation.height))
         dpival = self.figure.dpi
         winch = allocation.width / dpival
         hinch = allocation.height / dpival
@@ -309,7 +294,6 @@ class FigureCanvasGTK3 (Gtk.DrawingArea, FigureCanvasBase):
         return key
 
     def configure_event(self, widget, event):
-        if _debug: print('FigureCanvasGTK3.%s' % fn_name())
         if widget.get_property("window") is None:
             return
         w, h = event.width, event.height
@@ -395,7 +379,6 @@ class FigureManagerGTK3(FigureManagerBase):
 
     """
     def __init__(self, canvas, num):
-        if _debug: print('FigureManagerGTK3.%s' % fn_name())
         FigureManagerBase.__init__(self, canvas, num)
 
         self.window = Gtk.Window()
@@ -468,16 +451,15 @@ class FigureManagerGTK3(FigureManagerBase):
         self.canvas.grab_focus()
 
     def destroy(self, *args):
-        if _debug: print('FigureManagerGTK3.%s' % fn_name())
         self.vbox.destroy()
         self.window.destroy()
         self.canvas.destroy()
         if self.toolbar:
             self.toolbar.destroy()
 
-        if Gcf.get_num_fig_managers()==0 and \
-               not matplotlib.is_interactive() and \
-               Gtk.main_level() >= 1:
+        if (Gcf.get_num_fig_managers() == 0 and
+                not matplotlib.is_interactive() and
+                Gtk.main_level() >= 1):
             Gtk.main_quit()
 
     def show(self):
@@ -497,7 +479,7 @@ class FigureManagerGTK3(FigureManagerBase):
         # must be inited after the window, drawingArea and figure
         # attrs are set
         if rcParams['toolbar'] == 'toolbar2':
-            toolbar = NavigationToolbar2GTK3 (self.canvas, self.window)
+            toolbar = NavigationToolbar2GTK3(self.canvas, self.window)
         elif rcParams['toolbar'] == 'toolmanager':
             toolbar = ToolbarGTK3(self.toolmanager)
         else:
@@ -941,7 +923,8 @@ if sys.platform == 'win32':
     icon_filename = 'matplotlib.png'
 else:
     icon_filename = 'matplotlib.svg'
-window_icon = os.path.join(matplotlib.rcParams['datapath'], 'images', icon_filename)
+window_icon = os.path.join(
+    matplotlib.rcParams['datapath'], 'images', icon_filename)
 
 
 def error_msg_gtk(msg, parent=None):
@@ -951,7 +934,7 @@ def error_msg_gtk(msg, parent=None):
             parent = None
 
     if not isinstance(msg, six.string_types):
-        msg = ','.join(map(str,msg))
+        msg = ','.join(map(str, msg))
 
     dialog = Gtk.MessageDialog(
         parent         = parent,

--- a/lib/matplotlib/backends/backend_gtkcairo.py
+++ b/lib/matplotlib/backends/backend_gtkcairo.py
@@ -8,25 +8,20 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import gtk
-if gtk.pygtk_version < (2,7,0):
+if gtk.pygtk_version < (2, 7, 0):
     import cairo.gtk
 
 from matplotlib.backends import backend_cairo
 from matplotlib.backends.backend_gtk import *
 
-backend_version = 'PyGTK(%d.%d.%d) ' % gtk.pygtk_version + \
-                  'Pycairo(%s)' % backend_cairo.backend_version
-
-
-_debug = False
-#_debug = True
+backend_version = ('PyGTK(%d.%d.%d) ' % gtk.pygtk_version
+                   + 'Pycairo(%s)' % backend_cairo.backend_version)
 
 
 def new_figure_manager(num, *args, **kwargs):
     """
     Create a new figure manager instance
     """
-    if _debug: print('backend_gtkcairo.%s()' % fn_name())
     FigureClass = kwargs.pop('FigureClass', Figure)
     thisFig = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, thisFig)
@@ -55,8 +50,7 @@ class FigureCanvasGTKCairo(backend_cairo.FigureCanvasCairo, FigureCanvasGTK):
 
     def _renderer_init(self):
         """Override to use cairo (rather than GDK) renderer"""
-        if _debug: print('%s.%s()' % (self.__class__.__name__, _fn_name()))
-        self._renderer = RendererGTKCairo (self.figure.dpi)
+        self._renderer = RendererGTKCairo(self.figure.dpi)
 
 
 class FigureManagerGTKCairo(FigureManagerGTK):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -9,7 +9,6 @@ import six
 from six.moves import StringIO
 
 import glob, os, shutil, sys, time, datetime
-def _fn_name(): return sys._getframe(1).f_code.co_name
 import io
 
 from tempfile import mkstemp

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -25,12 +25,11 @@ from matplotlib.widgets import SubplotTool
 
 from .qt_compat import QtCore, QtWidgets, _getSaveFileName, __version__
 
-from .backend_qt5 import (backend_version, SPECIAL_KEYS, SUPER, ALT, CTRL,
-                        SHIFT, MODIFIER_KEYS, fn_name, cursord,
-                        draw_if_interactive, _create_qApp, show, TimerQT,
-                        MainWindow, FigureManagerQT, NavigationToolbar2QT,
-                        SubplotToolQt, error_msg_qt, exception_handler)
-
+from .backend_qt5 import (
+    backend_version, SPECIAL_KEYS, SUPER, ALT, CTRL, SHIFT, MODIFIER_KEYS,
+    cursord, draw_if_interactive, _create_qApp, show, TimerQT, MainWindow,
+    FigureManagerQT, NavigationToolbar2QT, SubplotToolQt, error_msg_qt,
+    exception_handler)
 from .backend_qt5 import FigureCanvasQT as FigureCanvasQT5
 
 DEBUG = False

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -90,11 +90,6 @@ if sys.platform == 'darwin':
                         QtCore.Qt.Key_Meta)
 
 
-def fn_name():
-    return sys._getframe(1).f_code.co_name
-
-DEBUG = False
-
 cursord = {
     cursors.MOVE: QtCore.Qt.SizeAllCursor,
     cursors.HAND: QtCore.Qt.PointingHandCursor,
@@ -123,8 +118,6 @@ def _create_qApp():
     global qApp
 
     if qApp is None:
-        if DEBUG:
-            print("Starting up QApplication")
         app = QtWidgets.QApplication.instance()
         if app is None:
             # check for DISPLAY env variable on X11 build of Qt
@@ -233,8 +226,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
                }
 
     def __init__(self, figure):
-        if DEBUG:
-            print('FigureCanvasQt qt5: ', figure)
         _create_qApp()
 
         # NB: Using super for this call to avoid a TypeError:
@@ -292,8 +283,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         if button is not None:
             FigureCanvasBase.button_press_event(self, x, y, button,
                                                 guiEvent=event)
-        if DEBUG:
-            print('button pressed:', event.button())
 
     def mouseDoubleClickEvent(self, event):
         x, y = self.mouseEventCoords(event.pos())
@@ -302,13 +291,10 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             FigureCanvasBase.button_press_event(self, x, y,
                                                 button, dblclick=True,
                                                 guiEvent=event)
-        if DEBUG:
-            print('button doubleclicked:', event.button())
 
     def mouseMoveEvent(self, event):
         x, y = self.mouseEventCoords(event)
         FigureCanvasBase.motion_notify_event(self, x, y, guiEvent=event)
-        # if DEBUG: print('mouse move')
 
     def mouseReleaseEvent(self, event):
         x, y = self.mouseEventCoords(event)
@@ -316,8 +302,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         if button is not None:
             FigureCanvasBase.button_release_event(self, x, y, button,
                                                   guiEvent=event)
-        if DEBUG:
-            print('button released')
 
     def wheelEvent(self, event):
         x, y = self.mouseEventCoords(event)
@@ -326,28 +310,18 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             steps = event.angleDelta().y() / 120
         else:
             steps = event.pixelDelta().y()
-
-        if steps != 0:
+        if steps:
             FigureCanvasBase.scroll_event(self, x, y, steps, guiEvent=event)
-            if DEBUG:
-                print('scroll event: delta = %i, '
-                      'steps = %i ' % (event.delta(), steps))
 
     def keyPressEvent(self, event):
         key = self._get_key(event)
-        if key is None:
-            return
-        FigureCanvasBase.key_press_event(self, key, guiEvent=event)
-        if DEBUG:
-            print('key press', key)
+        if key is not None:
+            FigureCanvasBase.key_press_event(self, key, guiEvent=event)
 
     def keyReleaseEvent(self, event):
         key = self._get_key(event)
-        if key is None:
-            return
-        FigureCanvasBase.key_release_event(self, key, guiEvent=event)
-        if DEBUG:
-            print('key release', key)
+        if key is not None:
+            FigureCanvasBase.key_release_event(self, key, guiEvent=event)
 
     @property
     def keyAutoRepeat(self):
@@ -363,9 +337,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     def resizeEvent(self, event):
         w = event.size().width() * self._dpi_ratio
         h = event.size().height() * self._dpi_ratio
-        if DEBUG:
-            print('resize (%d x %d)' % (w, h))
-            print("FigureCanvasQt.resizeEvent(%d, %d)" % (w, h))
         dpival = self.figure.dpi
         winch = w / dpival
         hinch = h / dpival
@@ -478,8 +449,6 @@ class FigureManagerQT(FigureManagerBase):
     """
 
     def __init__(self, canvas, num):
-        if DEBUG:
-            print('FigureManagerQT.%s' % fn_name())
         FigureManagerBase.__init__(self, canvas, num)
         self.canvas = canvas
         self.window = MainWindow()
@@ -578,11 +547,8 @@ class FigureManagerQT(FigureManagerBase):
             return
         self.window._destroying = True
         self.window.destroyed.connect(self._widgetclosed)
-
         if self.toolbar:
             self.toolbar.destroy()
-        if DEBUG:
-            print("destroy figure manager")
         self.window.close()
 
     def get_window_title(self):
@@ -712,8 +678,6 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             self.locLabel.setText(s)
 
     def set_cursor(self, cursor):
-        if DEBUG:
-            print('Set cursor', cursor)
         self.canvas.setCursor(cursord[cursor])
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
@@ -724,7 +688,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         w = abs(x1 - x0)
         h = abs(y1 - y0)
 
-        rect = [int(val)for val in (min(x0, x1), min(y0, y1), w, h)]
+        rect = [int(val) for val in (min(x0, x1), min(y0, y1), w, h)]
         self.canvas.drawRectangle(rect)
 
     def remove_rubberband(self):

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -719,7 +719,6 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
         self.canvas = canvas
         self.window = window
         self._idle = True
-        #Tk.Frame.__init__(self, master=self.canvas._tkcanvas)
         NavigationToolbar2.__init__(self, canvas)
 
     def destroy(self, *args):
@@ -731,11 +730,10 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         height = self.canvas.figure.bbox.height
-        y0 =  height-y0
-        y1 =  height-y1
-        try: self.lastrect
-        except AttributeError: pass
-        else: self.canvas._tkcanvas.delete(self.lastrect)
+        y0 = height - y0
+        y1 = height - y1
+        if hasattr(self, "lastrect"):
+            self.canvas._tkcanvas.delete(self.lastrect)
         self.lastrect = self.canvas._tkcanvas.create_rectangle(x0, y0, x1, y1)
 
         #self.canvas.draw()
@@ -751,7 +749,8 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
         self.window.configure(cursor=cursord[cursor])
 
     def _Button(self, text, file, command, extension='.gif'):
-        img_file = os.path.join(rcParams['datapath'], 'images', file + extension)
+        img_file = os.path.join(
+            rcParams['datapath'], 'images', file + extension)
         im = Tk.PhotoImage(master=self, file=img_file)
         b = Tk.Button(
             master=self, text=text, padx=2, pady=2, image=im, command=command)
@@ -761,10 +760,11 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
 
     def _Spacer(self):
         # Buttons are 30px high, so make this 26px tall with padding to center it
-        s = Tk.Frame(master=self, height=26, relief=Tk.RIDGE, pady=2, bg="DarkGray")
+        s = Tk.Frame(
+            master=self, height=26, relief=Tk.RIDGE, pady=2, bg="DarkGray")
         s.pack(side=Tk.LEFT, padx=5)
         return s
-        
+
     def _init_toolbar(self):
         xmin, xmax = self.canvas.figure.bbox.intervalx
         height, width = 50, xmax-xmin
@@ -776,11 +776,11 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
 
         for text, tooltip_text, image_file, callback in self.toolitems:
             if text is None:
-                # Add a spacer -- we don't need to use the return value for anything
+                # Add a spacer; return value is unused.
                 self._Spacer()
             else:
                 button = self._Button(text=text, file=image_file,
-                                   command=getattr(self, callback))
+                                      command=getattr(self, callback))
                 if tooltip_text is not None:
                     ToolTip.createToolTip(button, tooltip_text)
 
@@ -788,7 +788,6 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
         self._message_label = Tk.Label(master=self, textvariable=self.message)
         self._message_label.pack(side=Tk.RIGHT)
         self.pack(side=Tk.BOTTOM, fill=Tk.X)
-
 
     def configure_subplots(self):
         toolfig = Figure(figsize=(6,3))
@@ -846,17 +845,11 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
 
     def set_active(self, ind):
         self._ind = ind
-        self._active = [ self._axes[i] for i in self._ind ]
+        self._active = [self._axes[i] for i in self._ind]
 
     def update(self):
         _focus = windowing.FocusManager()
         self._axes = self.canvas.figure.axes
-        naxes = len(self._axes)
-        #if not hasattr(self, "omenu"):
-        #    self.set_active(range(naxes))
-        #    self.omenu = AxisMenu(master=self, naxes=naxes)
-        #else:
-        #    self.omenu.adjust(naxes)
         NavigationToolbar2.update(self)
 
 
@@ -900,8 +893,7 @@ class ToolTip(object):
         except Tk.TclError:
             pass
         label = Tk.Label(tw, text=self.text, justify=Tk.LEFT,
-                      background="#ffffe0", relief=Tk.SOLID, borderwidth=1,
-                      )
+                         background="#ffffe0", relief=Tk.SOLID, borderwidth=1)
         label.pack(ipadx=1)
 
     def hidetip(self):
@@ -919,20 +911,13 @@ class RubberbandTk(backend_tools.RubberbandBase):
         height = self.figure.canvas.figure.bbox.height
         y0 = height - y0
         y1 = height - y1
-        try:
-            self.lastrect
-        except AttributeError:
-            pass
-        else:
+        if hasattr(self, "lastrect"):
             self.figure.canvas._tkcanvas.delete(self.lastrect)
-        self.lastrect = self.figure.canvas._tkcanvas.create_rectangle(x0, y0, x1, y1)
+        self.lastrect = self.figure.canvas._tkcanvas.create_rectangle(
+            x0, y0, x1, y1)
 
     def remove_rubberband(self):
-        try:
-            self.lastrect
-        except AttributeError:
-            pass
-        else:
+        if hasattr(self, "lastrect"):
             self.figure.canvas._tkcanvas.delete(self.lastrect)
             del self.lastrect
 
@@ -954,8 +939,8 @@ class ToolbarTk(ToolContainerBase, Tk.Frame):
         self.pack(side=Tk.TOP, fill=Tk.X)
         self._groups = {}
 
-    def add_toolitem(self, name, group, position, image_file, description,
-                     toggle):
+    def add_toolitem(
+            self, name, group, position, image_file, description, toggle):
         frame = self._get_groupframe(group)
         button = self._Button(name, image_file, toggle, frame)
         if description is not None:

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1118,7 +1118,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     pad = kw.pop('pad', loc_settings['pad'])
 
     # turn parents into a list if it is not already
-    if isinstance(parents,object):
+    if isinstance(parents, object):
         parents = parents.flatten().tolist()
     if not isinstance(parents, (list, tuple)):
         parents = [parents]

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1119,7 +1119,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
 
     # turn parents into a list if it is not already. We do this w/ np
     # because `ax=plt.subplots(1,1)` is an ndarray and is natural to
-    # pass to `colorbar`
+    # pass to `colorbar`. 
     parents = np.atleast_1d(parents).ravel().tolist()
 
     fig = parents[0].get_figure()

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1117,11 +1117,10 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     parent_anchor = kw.pop('panchor', loc_settings['panchor'])
     pad = kw.pop('pad', loc_settings['pad'])
 
-    # turn parents into a list if it is not already
-    if isinstance(parents, np.ndarray):
-        parents = parents.flatten().tolist()
-    if not isinstance(parents, (list, tuple)):
-        parents = [parents]
+    # turn parents into a list if it is not already. We do this w/ np
+    # because `ax=plt.subplots(1,1)` is an ndarray and is natural to
+    # pass to `colorbar`
+    parents = np.atleast_1d(parents).ravel().tolist()
 
     fig = parents[0].get_figure()
     if not all(fig is ax.get_figure() for ax in parents):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1118,6 +1118,8 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     pad = kw.pop('pad', loc_settings['pad'])
 
     # turn parents into a list if it is not already
+    if isinstance(parents,object):
+        parents = parents.flatten().tolist()
     if not isinstance(parents, (list, tuple)):
         parents = [parents]
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1118,7 +1118,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     pad = kw.pop('pad', loc_settings['pad'])
 
     # turn parents into a list if it is not already
-    if isinstance(parents, object):
+    if isinstance(parents, np.ndarray):
         parents = parents.flatten().tolist()
     if not isinstance(parents, (list, tuple)):
         parents = [parents]

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1119,7 +1119,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
 
     # turn parents into a list if it is not already. We do this w/ np
     # because `ax=plt.subplots(1,1)` is an ndarray and is natural to
-    # pass to `colorbar`. 
+    # pass to `colorbar`.
     parents = np.atleast_1d(parents).ravel().tolist()
 
     fig = parents[0].get_figure()

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1640,7 +1640,7 @@ class DraggableBase(object):
 
     *artist_picker* is a picker method that will be
      used. *finalize_offset* is called when the mouse is released. In
-     current implementaion of DraggableLegend and DraggableAnnotation,
+     current implementation of DraggableLegend and DraggableAnnotation,
      *update_offset* places the artists simply in display
      coordinates. And *finalize_offset* recalculate their position in
      the normalized axes coordinate and set a relavant attribute.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3995,6 +3995,10 @@ docstring.interpd.update(
 class FancyArrowPatch(Patch):
     """
     A fancy arrow patch. It draws an arrow using the :class:`ArrowStyle`.
+
+    The head and tail positions are fixed at the specified start and end points
+    of the arrow, but the size and shape (in display coordinates) of the arrow
+    does not change when the axis is moved or zoomed.
     """
     _edge_default = True
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -847,40 +847,40 @@ def test_polycollection_joinstyle():
     ax.set_ybound(0, 3)
 
 
-def test_fill_between_2d_x_input():
-    x = np.zeros((2, 2))
-    y1 = 3
-    y2 = 3
-
+@pytest.mark.parametrize(
+    'x, y1, y2', [
+        (np.zeros((2, 2)), 3, 3),
+        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
+        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ], ids=[
+        '2d_x_input',
+        '2d_y1_input',
+        '2d_y2_input'
+    ]
+)
+def test_fill_between_input(x, y1, y2):
     fig = plt.figure()
     ax = fig.add_subplot(211)
     with pytest.raises(ValueError):
-        ax.plot(x, y1, x, y2, color='black')
         ax.fill_between(x, y1, y2)
 
 
-def test_fill_between_2d_y1_input():
-    x = np.arange(0.0, 2, 0.02)
-    y1 = np.zeros((2, 2))
-    y2 = 3
-
+@pytest.mark.parametrize(
+    'y, x1, x2', [
+        (np.zeros((2, 2)), 3, 3),
+        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
+        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ], ids=[
+        '2d_y_input',
+        '2d_x1_input',
+        '2d_x2_input'
+    ]
+)
+def test_fill_betweenx_input(y, x1, x2):
     fig = plt.figure()
     ax = fig.add_subplot(211)
     with pytest.raises(ValueError):
-        ax.plot(x, y1, x, y2, color='black')
-        ax.fill_between(x, y1, y2)
-
-
-def test_fill_between_2d_y2_input():
-    x = np.arange(0.0, 2, 0.02)
-    y1 = 3
-    y2 = np.zeros((2, 2))
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(x, y1, x, y2, color='black')
-        ax.fill_between(x, y1, y2)
+        ax.fill_betweenx(y, x1, x2)
 
 
 @image_comparison(baseline_images=['fill_between_interpolate'],
@@ -4993,42 +4993,6 @@ def test_tick_param_label_rotation():
         assert text.get_rotation() == 75
     for text in ax.get_yticklabels(which='both'):
         assert text.get_rotation() == 90
-
-
-def test_fill_betweenx_2d_y_input():
-    y = np.zeros((2, 2))
-    x1 = 3
-    x2 = 3
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(y, x1, y, x2, color='black')
-        ax.fill_betweenx(y, x1, x2)
-
-
-def test_fill_betweenx_2d_x1_input():
-    y = np.arange(0.0, 2, 0.02)
-    x1 = np.zeros((2, 2))
-    x2 = 3
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(y, x1, y, x2, color='black')
-        ax.fill_betweenx(y, x1, x2)
-
-
-def test_fill_betweenx_2d_x2_input():
-    y = np.arange(0.0, 2, 0.02)
-    x1 = 3
-    x2 = np.zeros((2, 2))
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211)
-    with pytest.raises(ValueError):
-        ax.plot(y, x1, y, x2, color='black')
-        ax.fill_betweenx(y, x1, x2)
 
 
 @pytest.mark.style('default')

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -20,7 +20,8 @@ def test_override_builtins():
         '__spec__',
         'any',
         'all',
-        'sum'
+        'sum',
+        'divmod'
     }
 
     # We could use six.moves.builtins here, but that seems

--- a/src/_path.h
+++ b/src/_path.h
@@ -1262,7 +1262,7 @@ struct _is_sorted
         size = PyArray_DIM(array, 0);
 
         // std::isnan is only in C++11, which we don't yet require,
-        // so we use the the "self == self" trick
+        // so we use the "self == self" trick
         for (i = 0; i < size; ++i) {
             last_value = *((T *)PyArray_GETPTR1(array, i));
             if (last_value == last_value) {


### PR DESCRIPTION
…n and turn into a list.  This makes colorbar compaticble with the output of plt.subplots (for instance)

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

`fig.colorbar(pcm=pcm,ax=axs)` can take a list of axes objects as the argument to ax.  However, `axs=plt.subplots(2,1)` returns a numpy `object`.  This PR simply checks if `axs` is  an object and flattens and makes the object a list.  Now commands like:

```python
fig,axs = plt.subplots(2,2)
pcm = axs[0,0].pcolormesh(np.random.rand(30,30),vmin=-1.,vmax=1.)
fig.colorbar(pcm=pcm,ax=axs)
```
will take space away from all the subplots, and put a colorbar on the right of all four subplots. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->