### PR TITLE
Allow divmod to be overridden by numpy

### DIFF
--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -20,7 +20,8 @@ def test_override_builtins():
         '__spec__',
         'any',
         'all',
-        'sum'
+        'sum',
+        'divmod'
     }
 
     # We could use six.moves.builtins here, but that seems


### PR DESCRIPTION
Fixes #8732 - numpy 1.13 now has `np.divmod` that can override python's native `divmod` function.