### PR TITLE
Made colorbar.py accept numpy array input, compatible with output fro…

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1118,7 +1118,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     pad = kw.pop('pad', loc_settings['pad'])
 
     # turn parents into a list if it is not already. We do this w/ np
-    # because `ax=plt.subplots(1,1)` is an ndarray and is natural to
+    # because `plt.subplots` can return an ndarray and is natural to
     # pass to `colorbar`.
     parents = np.atleast_1d(parents).ravel()
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1117,9 +1117,10 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     parent_anchor = kw.pop('panchor', loc_settings['panchor'])
     pad = kw.pop('pad', loc_settings['pad'])
 
-    # turn parents into a list if it is not already
-    if not isinstance(parents, (list, tuple)):
-        parents = [parents]
+    # turn parents into a list if it is not already. We do this w/ np
+    # because `ax=plt.subplots(1,1)` is an ndarray and is natural to
+    # pass to `colorbar`.
+    parents = np.atleast_1d(parents).ravel().tolist()
 
     fig = parents[0].get_figure()
     if not all(fig is ax.get_figure() for ax in parents):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1120,7 +1120,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     # turn parents into a list if it is not already. We do this w/ np
     # because `ax=plt.subplots(1,1)` is an ndarray and is natural to
     # pass to `colorbar`.
-    parents = np.atleast_1d(parents).ravel().tolist()
+    parents = np.atleast_1d(parents).ravel()
 
     fig = parents[0].get_figure()
     if not all(fig is ax.get_figure() for ax in parents):


### PR DESCRIPTION

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

This is a duplicate of #8733.  Appologies to @anntzer who reviewed the previous, and suggested the fix used here.

`fig.colorbar(pcm=pcm,ax=axs)` can take a list of axes objects as the argument to ax.  However, `axs=plt.subplots(2,1)` returns a numpy `object`.  This PR simply checks if `axs` is  an object and flattens and makes the object a list.  Now commands like:

```python
fig,axs = plt.subplots(2,2)
pcm = axs[0,0].pcolormesh(np.random.rand(30,30),vmin=-1.,vmax=1.)
fig.colorbar(pcm=pcm,ax=axs)
```
will take space away from all the subplots, and put a colorbar on the right of all four subplots. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->