### PR TITLE
Fix 'animation' unable to detect AVConv.

### DIFF
--- a/doc/users/whats_new/fix_avconv.rst
+++ b/doc/users/whats_new/fix_avconv.rst
@@ -1,0 +1,3 @@
+AVConv writer is back
+---------------------
+Correct a bug that prevented detection of AVconv for matplotlib.animation.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -616,7 +616,7 @@ class FFMpegBase(object):
     def _handle_subprocess(cls, process):
         _, err = process.communicate()
         # Ubuntu 12.04 ships a broken ffmpeg binary which we shouldn't use
-        if 'Libav' in err.decode():
+        if 'Libav' in err.decode() and 'AVConv' not in cls.__name__:
             return False
         return True
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -616,7 +616,8 @@ class FFMpegBase(object):
     def _handle_subprocess(cls, process):
         _, err = process.communicate()
         # Ubuntu 12.04 ships a broken ffmpeg binary which we shouldn't use
-        if 'Libav' in err.decode() and 'AVConv' not in cls.__name__:
+        # NOTE : when removed, remove the same method in AVConvBase.
+        if 'Libav' in err.decode():
             return False
         return True
 
@@ -673,6 +674,11 @@ class AVConvBase(FFMpegBase):
 
     exec_key = 'animation.avconv_path'
     args_key = 'animation.avconv_args'
+
+    # NOTE : should be removed when the same method is removed in FFMpegBase.
+    @classmethod
+    def _handle_subprocess(cls, process):
+        return MovieWriter._handle_subprocess(process)
 
 
 # Combine AVConv options with pipe-based writing


### PR DESCRIPTION
Hi,

The commit 926a59fdb9cfbad05c9f2008ed8e828b5faa3a03 introduced a major bug : animation became unable to load Avconv.
Basically the issue came from the fact that this commit was unaware that AVConvBase inherit from FFMpegBase.

This pull request fix it (it was easy).

I haven't seen any open issue concerning it.

Maybe it could be useful to have a test to check that it doesn't happen again.
But I'm not sure if it's really relevant since the same would happen for someone that didn't install Avconv.

Best,
Élie
