### PR TITLE
sort input files

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1341,7 +1341,7 @@ class Qhull(SetupPackage):
                                        default_libraries=['qhull'])
         else:
             ext.include_dirs.append('extern')
-            ext.sources.extend(glob.glob('extern/libqhull/*.c'))
+            ext.sources.extend(sorted(glob.glob('extern/libqhull/*.c')))
 
 
 class TTConv(SetupPackage):


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.