### PR TITLE
Clean up Line2D kwarg docstring bits

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -166,7 +166,7 @@ class Axes(_AxesBase):
         text : :class:`~matplotlib.text.Text`
             The matplotlib text instance representing the title
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : text properties
             Other keyword arguments are text properties, see
@@ -210,7 +210,7 @@ class Axes(_AxesBase):
         labelpad : scalar, optional, default: None
             spacing in points between the label and the x-axis
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : `~matplotlib.text.Text` properties
 
@@ -241,7 +241,7 @@ class Axes(_AxesBase):
         labelpad : scalar, optional, default: None
             spacing in points between the label and the x-axis
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : `~matplotlib.text.Text` properties
 
@@ -588,7 +588,7 @@ or tuple of floats
             Creates a `~matplotlib.text.TextWithDash` instance instead of a
             `~matplotlib.text.Text` instance.
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : `~matplotlib.text.Text` properties.
             Other miscellaneous text parameters.
@@ -677,7 +677,7 @@ or tuple of floats
         -------
         :class:`~matplotlib.lines.Line2D`
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
@@ -751,7 +751,7 @@ or tuple of floats
         -------
         :class:`~matplotlib.lines.Line2D`
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
@@ -945,7 +945,7 @@ or tuple of floats
         -------
         lines : `~matplotlib.collections.LineCollection`
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs :  `~matplotlib.collections.LineCollection` properties.
 
@@ -1023,7 +1023,7 @@ or tuple of floats
         -------
         lines : `~matplotlib.collections.LineCollection`
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : `~matplotlib.collections.LineCollection` properties.
 
@@ -1454,7 +1454,7 @@ or tuple of floats
         matplotlib.dates.num2date : how to convert num to dates
         matplotlib.dates.drange : how floating point dates
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -1559,7 +1559,7 @@ or tuple of floats
         `~matplotlib.pyplot.plot`
             Log-scaled plot on the *x* axis.
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -1612,7 +1612,7 @@ or tuple of floats
         `~matplotlib.lines.Line2D`
             Line instance of the plot.
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             This function supports all the keyword arguments of
@@ -1675,7 +1675,7 @@ or tuple of floats
             `plot`.
           - `b` is the x-axis.
 
-        Other parameters
+        Other Parameters
         ----------------
         linestyle : `~matplotlib.lines.Line2D` prop, optional, default: None
             Only used if usevlines is False.
@@ -1733,7 +1733,7 @@ or tuple of floats
             `plot`.
           - `b` is the x-axis (none, if plot is used).
 
-        Other parameters
+        Other Parameters
         ----------------
         linestyle : `~matplotlib.lines.Line2D` prop, optional, default: None
             Only used if usevlines is False.
@@ -1803,7 +1803,7 @@ or tuple of floats
         list
             List of lines that were added.
 
-        Other parameters
+        Other Parameters
         ----------------
         where : [ 'pre' | 'post' | 'mid'  ]
             If 'pre' (the default), the interval from
@@ -2186,7 +2186,7 @@ or tuple of floats
         -------
         `matplotlib.patches.Rectangle` instances.
 
-        Other parameters
+        Other Parameters
         ----------------
         color : scalar or array-like, optional
             the colors of the bars
@@ -3838,7 +3838,7 @@ or tuple of floats
         -------
         paths : `~matplotlib.collections.PathCollection`
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : `~matplotlib.collections.Collection` properties
 
@@ -4105,7 +4105,7 @@ or tuple of floats
 
             Order of scalars is (left, right, bottom, top).
 
-        Other parameters
+        Other Parameters
         ----------------
         cmap : object, optional, default is *None*
             a :class:`matplotlib.colors.Colormap` instance. If *None*,
@@ -5061,7 +5061,7 @@ or tuple of floats
         -------
         image : `~matplotlib.image.AxesImage`
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : `~matplotlib.artist.Artist` properties.
 
@@ -6359,7 +6359,7 @@ or tuple of floats
         -------
         The return value is ``(counts, xedges, yedges, Image)``.
 
-        Other parameters
+        Other Parameters
         ----------------
         cmap : {Colormap, string}, optional
             A :class:`matplotlib.colors.Colormap` instance.  If not set, use rc
@@ -6463,7 +6463,7 @@ or tuple of floats
             The line created by this function.
             Only returned if *return_line* is True.
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -6592,7 +6592,7 @@ or tuple of floats
             The line created by this function.
             Only returned if *return_line* is True.
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -6693,7 +6693,7 @@ or tuple of floats
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -6788,7 +6788,7 @@ or tuple of floats
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -6868,7 +6868,7 @@ or tuple of floats
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -6944,7 +6944,7 @@ or tuple of floats
 
         kwargs are applied to the lines.
 
-        Other parameters
+        Other Parameters
         ----------------
         **kwargs :
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
@@ -7261,7 +7261,7 @@ or tuple of floats
         -------
         image : `~matplotlib.image.AxesImage`
 
-        Other parameters
+        Other Parameters
         ----------------
         kwargs : `~matplotlib.axes.Axes.imshow` arguments
             Sets `origin` to 'upper', 'interpolation' to 'nearest' and

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -677,6 +677,14 @@ or tuple of floats
         -------
         :class:`~matplotlib.lines.Line2D`
 
+        Other parameters
+        ----------------
+        **kwargs :
+            Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
+            with the exception of 'transform':
+
+            %(Line2D)s
+
         Notes
         -----
         kwargs are passed to :class:`~matplotlib.lines.Line2D` and can be used
@@ -697,11 +705,6 @@ or tuple of floats
           the xrange::
 
             >>> axhline(y=.5, xmin=0.25, xmax=0.75)
-
-        Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
-        with the exception of 'transform':
-
-        %(Line2D)s
 
         See also
         --------
@@ -748,6 +751,13 @@ or tuple of floats
         -------
         :class:`~matplotlib.lines.Line2D`
 
+        Other parameters
+        ----------------
+        **kwargs :
+            Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
+            with the exception of 'transform':
+
+            %(Line2D)s
 
         Examples
         --------
@@ -763,11 +773,6 @@ or tuple of floats
           the yrange::
 
             >>> axvline(x=.5, ymin=0.25, ymax=0.75)
-
-        Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
-        with the exception of 'transform':
-
-        %(Line2D)s
 
         See also
         --------
@@ -1449,11 +1454,13 @@ or tuple of floats
         matplotlib.dates.num2date : how to convert num to dates
         matplotlib.dates.drange : how floating point dates
 
-
-        Other Parameters
+        Other parameters
         ----------------
-        kwargs : :class:`matplotlib.lines.Line2D`
-        properties : %(Line2D)s
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
+
+            %(Line2D)s
 
         """
 
@@ -1552,22 +1559,19 @@ or tuple of floats
         `~matplotlib.pyplot.plot`
             Log-scaled plot on the *x* axis.
 
-        Other Parameters
+        Other parameters
         ----------------
-        :class:`~matplotlib.lines.Line2D` properties:
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
 
-        %(Line2D)s
-
-        See Also
-        --------
-        loglog : For example code and figure.
+            %(Line2D)s
 
         Notes
         -----
         This function supports all the keyword arguments of
         :func:`~matplotlib.pyplot.plot` and
         :meth:`matplotlib.axes.Axes.set_xscale`.
-
         """
         if not self._hold:
             self.cla()
@@ -1608,18 +1612,17 @@ or tuple of floats
         `~matplotlib.lines.Line2D`
             Line instance of the plot.
 
-        Other Parameters
+        Other parameters
         ----------------
-        kwargs : `~matplotlib.lines.Line2D` properties,
-        `~matplotlib.pylab.plot` and
-        `matplotlib.axes.Axes.set_yscale` arguments.
+        **kwargs :
+            This function supports all the keyword arguments of
+            :func:`~matplotlib.pyplot.plot` and
+            :meth:`matplotlib.axes.Axes.set_xscale`.
 
-        %(Line2D)s
+            Keyword arguments also control the
+            :class:`~matplotlib.lines.Line2D` properties:
 
-        See also
-        --------
-        :meth:`loglog`: For example code and figure.
-
+            %(Line2D)s
         """
         if not self._hold:
             self.cla()
@@ -2733,7 +2736,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : All other keyword arguments are passed on to the plot
+        **kwargs : All other keyword arguments are passed on to the plot
             command for the markers. For example, this code makes big red
             squares with thick green edges::
 
@@ -2745,7 +2748,7 @@ or tuple of floats
             property names, markerfacecolor, markeredgecolor, markersize
             and markeredgewidth.
 
-            valid kwargs for the marker properties are
+            Valid kwargs for the marker properties are
 
             %(Line2D)s
 
@@ -6447,12 +6450,6 @@ or tuple of floats
             Whether to include the line object plotted in the returned values.
             Default is False.
 
-        **kwargs :
-            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
-            properties:
-
-        %(Line2D)s
-
         Returns
         -------
         Pxx : 1-D array
@@ -6465,6 +6462,14 @@ or tuple of floats
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function.
             Only returned if *return_line* is True.
+
+        Other parameters
+        ----------------
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
+
+            %(Line2D)s
 
         Notes
         -----
@@ -6574,12 +6579,6 @@ or tuple of floats
             Whether to include the line object plotted in the returned values.
             Default is False.
 
-        **kwargs :
-            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
-            properties:
-
-        %(Line2D)s
-
         Returns
         -------
         Pxy : 1-D array
@@ -6592,6 +6591,14 @@ or tuple of floats
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function.
             Only returned if *return_line* is True.
+
+        Other parameters
+        ----------------
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
+
+            %(Line2D)s
 
         Notes
         -----
@@ -6675,12 +6682,6 @@ or tuple of floats
             when a signal is acquired and then filtered and downsampled to
             baseband.
 
-        **kwargs :
-            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
-            properties:
-
-        %(Line2D)s
-
         Returns
         -------
         spectrum : 1-D array
@@ -6691,6 +6692,14 @@ or tuple of floats
 
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function
+
+        Other parameters
+        ----------------
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
+
+            %(Line2D)s
 
         See Also
         --------
@@ -6768,12 +6777,6 @@ or tuple of floats
             when a signal is acquired and then filtered and downsampled to
             baseband.
 
-        **kwargs :
-            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
-            properties:
-
-        %(Line2D)s
-
         Returns
         -------
         spectrum : 1-D array
@@ -6784,6 +6787,14 @@ or tuple of floats
 
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function
+
+        Other parameters
+        ----------------
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
+
+            %(Line2D)s
 
         See Also
         --------
@@ -6846,12 +6857,6 @@ or tuple of floats
             when a signal is acquired and then filtered and downsampled to
             baseband.
 
-        **kwargs :
-            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
-            properties:
-
-        %(Line2D)s
-
         Returns
         -------
         spectrum : 1-D array
@@ -6862,6 +6867,14 @@ or tuple of floats
 
         line : a :class:`~matplotlib.lines.Line2D` instance
             The line created by this function
+
+        Other parameters
+        ----------------
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
+
+            %(Line2D)s
 
         See Also
         --------
@@ -6923,11 +6936,6 @@ or tuple of floats
             when a signal is acquired and then filtered and downsampled to
             baseband.
 
-        **kwargs :
-            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
-            properties of the coherence plot:
-
-        %(Line2D)s
 
         Returns
         -------
@@ -6935,6 +6943,14 @@ or tuple of floats
         frequencies of the coherence vector.
 
         kwargs are applied to the lines.
+
+        Other parameters
+        ----------------
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.lines.Line2D`
+            properties:
+
+            %(Line2D)s
 
         References
         ----------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -168,7 +168,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        kwargs : text properties
+        **kwargs : `~matplotlib.text.Text` properties
             Other keyword arguments are text properties, see
             :class:`~matplotlib.text.Text` for a list of valid text
             properties.
@@ -212,7 +212,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.text.Text` properties
+        **kwargs : `~matplotlib.text.Text` properties
 
         See also
         --------
@@ -243,7 +243,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.text.Text` properties
+        **kwargs : `~matplotlib.text.Text` properties
 
         See also
         --------
@@ -590,7 +590,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.text.Text` properties.
+        **kwargs : `~matplotlib.text.Text` properties.
             Other miscellaneous text parameters.
 
         Examples
@@ -829,7 +829,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.patches.Polygon` properties.
+        **kwargs : `~matplotlib.patches.Polygon` properties.
 
         %(Polygon)s
 
@@ -947,7 +947,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs :  `~matplotlib.collections.LineCollection` properties.
+        **kwargs :  `~matplotlib.collections.LineCollection` properties.
 
         See also
         --------
@@ -1025,7 +1025,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.collections.LineCollection` properties.
+        **kwargs : `~matplotlib.collections.LineCollection` properties.
 
         See also
         --------
@@ -2736,7 +2736,8 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        **kwargs : All other keyword arguments are passed on to the plot
+        **kwargs :
+            All other keyword arguments are passed on to the plot
             command for the markers. For example, this code makes big red
             squares with thick green edges::
 
@@ -3840,7 +3841,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.collections.Collection` properties
+        **kwargs : `~matplotlib.collections.Collection` properties
 
         See Also
         --------
@@ -4617,7 +4618,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : :class:`~matplotlib.patches.Polygon` properties
+        **kwargs : :class:`~matplotlib.patches.Polygon` properties
 
         Notes
         -----
@@ -5063,7 +5064,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.artist.Artist` properties.
+        **kwargs : `~matplotlib.artist.Artist` properties.
 
         See also
         --------
@@ -5998,7 +5999,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.patches.Patch` properties
+        **kwargs : `~matplotlib.patches.Patch` properties
 
         See also
         --------
@@ -7263,7 +7264,7 @@ or tuple of floats
 
         Other Parameters
         ----------------
-        kwargs : `~matplotlib.axes.Axes.imshow` arguments
+        **kwargs : `~matplotlib.axes.Axes.imshow` arguments
             Sets `origin` to 'upper', 'interpolation' to 'nearest' and
             'aspect' to equal.
 


### PR DESCRIPTION
This PR makes the location of all the %(Line2D)s parts of the docstrings in `_axes.py` consistent. I have put them in the `Other parameters` section, because that seemed the most sensible.

Inspired by the currently horrible `semilog{x,y}` docstrings, which this fixes (http://matplotlib.org/devdocs/api/_as_gen/matplotlib.axes.Axes.semilogy.html?highlight=semilogy#matplotlib.axes.Axes.semilogy)