### PR TITLE
make sure marker colors also accept np.array, fixes #8750

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1160,7 +1160,8 @@ class Line2D(Artist):
         """
         if ec is None:
             ec = 'auto'
-        if self._markeredgecolor is None or self._markeredgecolor != ec:
+        if self._markeredgecolor is None or \
+           np.any(self._markeredgecolor != ec):
             self.stale = True
         self._markeredgecolor = ec
 
@@ -1184,7 +1185,7 @@ class Line2D(Artist):
         """
         if fc is None:
             fc = 'auto'
-        if self._markerfacecolor != fc:
+        if np.any(self._markerfacecolor != fc):
             self.stale = True
         self._markerfacecolor = fc
 
@@ -1196,7 +1197,7 @@ class Line2D(Artist):
         """
         if fc is None:
             fc = 'auto'
-        if self._markerfacecoloralt != fc:
+        if np.any(self._markerfacecoloralt != fc):
             self.stale = True
         self._markerfacecoloralt = fc
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -143,7 +143,8 @@ def test_set_line_coll_dash_image():
 @image_comparison(baseline_images=['marker_fill_styles'], remove_text=True,
                   extensions=['png'])
 def test_marker_fill_styles():
-    colors = itertools.cycle(['b', 'g', 'r', 'c', 'm', 'y', 'k'])
+    colors = itertools.cycle([[0, 0, 1], 'g', '#ff0000', 'c', 'm', 'y',
+                              np.array([0, 0, 0])])
     altcolor = 'lightgreen'
 
     y = np.array([1, 1])


### PR DESCRIPTION
## PR Summary

Setting markerface/edgecolor with an np.array leads to a ValueError with numpy-1.13. See #8750 As suggested in the issue thread I replaced the comparison with np.array_equal(). I modified the unit test for marker styles to test a range of color specifications.

## PR Checklist

- [ x] Has Pytest style unit tests
- [ x] Code is PEP 8 compliant 
- [ N/A] New features are documented, with examples if plot related
- [ N/A] Documentation is sphinx and numpydoc compliant
- [ N/A] Added an entry to doc/users/whats_new.rst if major new feature
- [ N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

First PR to matplotlib. Hope this is fine.