### PR TITLE
Fix typos

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6255,7 +6255,7 @@ or tuple of floats
             # stepfill is closed, step is not
             split = -1 if fill else 2 * len(bins)
             # add patches in reverse order so that when stacking,
-            # items lower in the stack are plottted on top of
+            # items lower in the stack are plotted on top of
             # items higher in the stack
             for x, y, c in reversed(list(zip(xvals, yvals, color))):
                 patches.append(self.fill(

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1997,7 +1997,7 @@ class FigureCanvasBase(object):
 
     def draw_idle(self, *args, **kwargs):
         """
-        :meth:`draw` only if idle; defaults to draw but backends can overrride
+        :meth:`draw` only if idle; defaults to draw but backends can override
         """
         if not self._is_idle_drawing:
             with self._idle_draw_cntx():
@@ -2636,7 +2636,7 @@ class FigureManagerBase(object):
             self.key_press_handler_id = None
         """
         The returned id from connecting the default key handler via
-        :meth:`FigureCanvasBase.mpl_connnect`.
+        :meth:`FigureCanvasBase.mpl_connect`.
 
         To disable default key press handling::
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -2689,7 +2689,7 @@ class Parser(object):
         raise ParseFatalException(s, loc, "Unknown symbol: %s" % c)
 
     _char_over_chars = {
-        # The first 2 entires in the tuple are (font, char, sizescale) for
+        # The first 2 entries in the tuple are (font, char, sizescale) for
         # the two symbols under and over.  The third element is the space
         # (in multiples of underline height)
         r'AA': (('it', 'A', 1.0), (None, '\\circ', 0.5), 0.0),


### PR DESCRIPTION
This PR fixes some typos: `redunant`, `flippped`, `plottted`, `overrride`, `connnect`, and `entires `.