### PR TITLE
Simpler PySide QImage refcount/memleak fix

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -107,9 +107,6 @@ class FigureCanvasQTAggBase(object):
                 stringBuffer = self.renderer._renderer.tostring_bgra()
             else:
                 stringBuffer = self.renderer._renderer.tostring_argb()
-
-            refcnt = sys.getrefcount(stringBuffer)
-
             qImage = QtGui.QImage(
                 _make_non_owning_array(stringBuffer),
                 self.renderer.width, self.renderer.height,
@@ -134,8 +131,6 @@ class FigureCanvasQTAggBase(object):
                 p.drawRect(x, y, w, h)
             p.end()
 
-            assert refcnt == sys.getrefcount(stringBuffer)
-
         else:
             p = QtGui.QPainter(self)
 
@@ -153,7 +148,6 @@ class FigureCanvasQTAggBase(object):
                 if hasattr(qImage, 'setDevicePixelRatio'):
                     # Not available on Qt4 or some older Qt5.
                     qImage.setDevicePixelRatio(self._dpi_ratio)
-                assert ctypes.c_long.from_address(id(stringBuffer)).value == 1
                 origin = QtCore.QPoint(l, self.renderer.height - t)
                 pixmap = QtGui.QPixmap.fromImage(qImage)
                 p.drawPixmap(origin / self._dpi_ratio, pixmap)

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -98,6 +98,8 @@ class FigureCanvasQTAggBase(object):
             print('FigureCanvasQtAgg.paintEvent: ', self,
                   self.get_width_height())
 
+        p = QtGui.QPainter(self)
+
         if len(self.blitbox) == 0:
             # matplotlib is in rgba byte order.  QImage wants to put the bytes
             # into argb format and is in a 4 byte unsigned int.  Little endian
@@ -115,31 +117,17 @@ class FigureCanvasQTAggBase(object):
                 # Not available on Qt4 or some older Qt5.
                 qImage.setDevicePixelRatio(self._dpi_ratio)
             # get the rectangle for the image
-            rect = qImage.rect()
-            p = QtGui.QPainter(self)
             # reset the image area of the canvas to be the back-ground color
-            p.eraseRect(rect)
+            p.eraseRect(qImage.rect())
             # draw the rendered image on to the canvas
             p.drawPixmap(QtCore.QPoint(0, 0), QtGui.QPixmap.fromImage(qImage))
 
-            # draw the zoom rectangle to the QPainter
-            if self._drawRect is not None:
-                pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio,
-                                 QtCore.Qt.DotLine)
-                p.setPen(pen)
-                x, y, w, h = self._drawRect
-                p.drawRect(x, y, w, h)
-            p.end()
-
         else:
-            p = QtGui.QPainter(self)
-
             while len(self.blitbox):
                 bbox = self.blitbox.pop()
-                l, b, r, t = bbox.extents
-                w = int(r) - int(l)
-                h = int(t) - int(b)
-                t = int(b) + h
+                l, b, r, t = map(int, bbox.extents)
+                w = r - l
+                h = t - b
                 reg = self.copy_from_bbox(bbox)
                 stringBuffer = reg.to_string_argb()
                 qImage = QtGui.QImage(
@@ -152,15 +140,15 @@ class FigureCanvasQTAggBase(object):
                 pixmap = QtGui.QPixmap.fromImage(qImage)
                 p.drawPixmap(origin / self._dpi_ratio, pixmap)
 
-            # draw the zoom rectangle to the QPainter
-            if self._drawRect is not None:
-                pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio,
-                                 QtCore.Qt.DotLine)
-                p.setPen(pen)
-                x, y, w, h = self._drawRect
-                p.drawRect(x, y, w, h)
+        # draw the zoom rectangle to the QPainter
+        if self._drawRect is not None:
+            pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio,
+                                QtCore.Qt.DotLine)
+            p.setPen(pen)
+            x, y, w, h = self._drawRect
+            p.drawRect(x, y, w, h)
 
-            p.end()
+        p.end()
 
     def draw(self):
         """


### PR DESCRIPTION
Instead of manipulating refcounts, hide the image buffer behind a numpy array that does not own the data; this prevents QImage from setting a positive refcount on the Python buffer that actually is in charge of
deallocating the data upon GC.

The first commit includes asserts that check that the fix actually works (compare with the version before the PR).  Replacing the body of `_make_non_owning_array` by `return buf` make the asserts fail.

The second commit removes the asserts.