### PR TITLE
Gridspec add tight_rect 

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -43,9 +43,12 @@ class GridSpecBase(object):
         """
         #self.figure = figure
         self._nrows , self._ncols = nrows, ncols
-
         self.set_height_ratios(height_ratios)
         self.set_width_ratios(width_ratios)
+        # setting this to None because there is no reason to let
+        # the tight rectangle be set at instantiation.
+        self.set_tight_rect(None)
+
 
     def get_geometry(self):
         'get the geometry of the grid, e.g., 2,3'
@@ -133,8 +136,18 @@ class GridSpecBase(object):
         figLefts = [left + cellWs[2*colNum] for colNum in range(ncols)]
         figRights = [left + cellWs[2*colNum+1] for colNum in range(ncols)]
 
-
         return figBottoms, figTops, figLefts, figRights
+
+    def get_tight_rect(self):
+        'get the rectangle for use with gridspec.tight_layout'
+        return self._tight_rect
+
+    def set_tight_rect(self, tight_rect):
+        'set a rectangle for use with gridspec.tight_layout'
+        if tight_rect is not None and len(tight_rect) != 4:
+            raise ValueError('Expected keyword rect to be a list or tuple'
+                'with four elements')
+        self._tight_rect =  tight_rect
 
     def __getitem__(self, key):
         """
@@ -306,6 +319,9 @@ class GridSpec(GridSpecBase):
 
         if renderer is None:
             renderer = get_renderer(fig)
+
+        if rect is None:
+            rect = self.get_tight_rect()
 
         kwargs = get_tight_layout_figure(fig, fig.axes, subplotspec_list,
                                          renderer,


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

This adds `set_tight_rect` and `get_tight_rect` to `gridspec.GridspecBase` , and checks the value of this when `gridspec.tight_layout()` is called.  If the `rect` keyword of `tight_layout` is `None`, then `tight_rect` will be used instead.  


### Example

```python
import matplotlib.pyplot as plt
import matplotlib.gridspec as gridspec

gs = gridspec.GridSpec(3,3)
fig = plt.figure()
for g in gs:
     fig.add_subplot(g)
# we would usually do:
# gs.tight_layout(fig, rect=[0, 0, 0.7, 1.])
gs.set_tight_rect([0, 0, 0.7, 1.])
gs.tight_layout(fig)
# if instead we called:
# gs.tight_layout(fig,rect = [0.2, 0.14, 0.5, 0.5]) 
# this wouldl override the value of tight_rect.
```

### Rationale

The user wouldn't necessarily want to use this function (though they could).  Its for other functions to offer rectangle suggestions to `gridspec.tight_layout()` without the user having to do it manually.  i.e if we create a colorbar that is for more than one axes at `x = 0.85`, then `fig.colorbar` may want to call `gs.set_tight_rect([0, 0, 0.8, 1.])` to constrain `tight_layout` from drawing over the colorbar.  

Note the user can still override the suggestion.  

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->