### PR TITLE
Arrow patch docstring clean

### DIFF
--- a/examples/shapes_and_collections/artist_reference.py
+++ b/examples/shapes_and_collections/artist_reference.py
@@ -58,7 +58,8 @@ patches.append(ellipse)
 label(grid[4], "Ellipse")
 
 # add an arrow
-arrow = mpatches.Arrow(grid[5, 0] - 0.05, grid[5, 1] - 0.05, 0.1, 0.1, width=0.1)
+arrow = mpatches.Arrow(grid[5, 0] - 0.05, grid[5, 1] - 0.05, 0.1, 0.1,
+                       width=0.1)
 patches.append(arrow)
 label(grid[5], "Arrow")
 
@@ -67,14 +68,13 @@ Path = mpath.Path
 path_data = [
     (Path.MOVETO, [0.018, -0.11]),
     (Path.CURVE4, [-0.031, -0.051]),
-    (Path.CURVE4, [-0.115,  0.073]),
-    (Path.CURVE4, [-0.03 ,  0.073]),
-    (Path.LINETO, [-0.011,  0.039]),
-    (Path.CURVE4, [0.043,  0.121]),
+    (Path.CURVE4, [-0.115, 0.073]),
+    (Path.CURVE4, [-0.03, 0.073]),
+    (Path.LINETO, [-0.011, 0.039]),
+    (Path.CURVE4, [0.043, 0.121]),
     (Path.CURVE4, [0.075, -0.005]),
     (Path.CURVE4, [0.035, -0.027]),
-    (Path.CLOSEPOLY, [0.018, -0.11])
-    ]
+    (Path.CLOSEPOLY, [0.018, -0.11])]
 codes, verts = zip(*path_data)
 path = mpath.Path(verts + grid[6], codes)
 patch = mpatches.PathPatch(path)
@@ -99,8 +99,8 @@ collection.set_array(np.array(colors))
 ax.add_collection(collection)
 ax.add_line(line)
 
-plt.subplots_adjust(left=0, right=1, bottom=0, top=1)
 plt.axis('equal')
 plt.axis('off')
+plt.tight_layout()
 
 plt.show()

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1131,21 +1131,42 @@ class Arrow(Patch):
     def __str__(self):
         return "Arrow()"
 
-    _path = Path([
-            [0.0,  0.1], [0.0, -0.1],
-            [0.8, -0.1], [0.8, -0.3],
-            [1.0,  0.0], [0.8,  0.3],
-            [0.8,  0.1], [0.0,  0.1]],
-                  closed=True)
+    _path = Path([[0.0, 0.1], [0.0, -0.1],
+                  [0.8, -0.1], [0.8, -0.3],
+                  [1.0, 0.0], [0.8, 0.3],
+                  [0.8, 0.1], [0.0, 0.1]],
+                 closed=True)
 
     @docstring.dedent_interpd
     def __init__(self, x, y, dx, dy, width=1.0, **kwargs):
         """
-        Draws an arrow, starting at (*x*, *y*), direction and length
-        given by (*dx*, *dy*) the width of the arrow is scaled by *width*.
+        Draws an arrow from (*x*, *y*) to (*x* + *dx*, *y* + *dy*).
+        The width of the arrow is scaled by *width*.
 
-        Valid kwargs are:
-        %(Patch)s
+        Parameters
+        ----------
+        x : scalar
+            x coordinate of the arrow tail
+        y : scalar
+            y coordinate of the arrow tail
+        dx : scalar
+            Arrow length in the x direction
+        dy : scalar
+            Arrow length in the y direction
+        width : scalar, optional (default: 1)
+            Scale factor for the width of the arrow. With a default value of
+            1, the tail width is 0.2 and head width is 0.6.
+        **kwargs :
+            Keyword arguments control the :class:`~matplotlib.patches.Patch`
+            properties:
+
+            %(Patch)s
+
+        See Also
+        --------
+        :class:`FancyArrow` :
+            Patch that allows independent control of the head and tail
+            properties
         """
         Patch.__init__(self, **kwargs)
         L = np.hypot(dx, dy)


### PR DESCRIPTION
Make `mpatches.Arrow` into a numpydoc docstring, and make it clear the units and size that the patch is drawn in.

Also gives a minor clean to `artist_reference.py` to stop some text leaking off the bottom of the plot.