### PR TITLE
Cairo rendering for Qt5

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -9,6 +9,7 @@
 sphinx>=1.3,!=1.5.0,!=1.6.4
 colorspacious
 ipython
+ipywidgets
 mock
 numpydoc>=0.4
 pillow

--- a/doc/api/backend_agg_api.rst
+++ b/doc/api/backend_agg_api.rst
@@ -1,8 +1,8 @@
 
-:mod:`matplotlib.backends.backend_svg`
+:mod:`matplotlib.backends.backend_agg`
 ======================================
 
-.. automodule:: matplotlib.backends.backend_svg
+.. automodule:: matplotlib.backends.backend_agg
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/backend_cairo_api.rst
+++ b/doc/api/backend_cairo_api.rst
@@ -1,8 +1,8 @@
 
-:mod:`matplotlib.backends.backend_mixed`
+:mod:`matplotlib.backends.backend_cairo`
 ========================================
 
-.. automodule:: matplotlib.backends.backend_mixed
+.. automodule:: matplotlib.backends.backend_cairo
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/backend_gtk3agg_api.rst
+++ b/doc/api/backend_gtk3agg_api.rst
@@ -1,0 +1,11 @@
+
+:mod:`matplotlib.backends.backend_gtk3agg`
+==========================================
+
+**TODO** We'll add this later, importing the gtk3 backends requires an active
+X-session, which is not compatible with cron jobs.
+
+.. .. automodule:: matplotlib.backends.backend_gtk3agg
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:

--- a/doc/api/backend_gtk3cairo_api.rst
+++ b/doc/api/backend_gtk3cairo_api.rst
@@ -1,0 +1,11 @@
+
+:mod:`matplotlib.backends.backend_gtk3cairo`
+============================================
+
+**TODO** We'll add this later, importing the gtk3 backends requires an active
+X-session, which is not compatible with cron jobs.
+
+.. .. automodule:: matplotlib.backends.backend_gtk3cairo
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:

--- a/doc/api/backend_gtkcairo_api.rst
+++ b/doc/api/backend_gtkcairo_api.rst
@@ -1,0 +1,11 @@
+
+:mod:`matplotlib.backends.backend_gtkcairo`
+===========================================
+
+**TODO** We'll add this later, importing the gtk backends requires an active
+X-session, which is not compatible with cron jobs.
+
+.. .. automodule:: matplotlib.backends.backend_gtkcairo
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:

--- a/doc/api/backend_managers_api.rst
+++ b/doc/api/backend_managers_api.rst
@@ -1,6 +1,6 @@
 
 :mod:`matplotlib.backend_managers`
-===================================
+==================================
 
 .. automodule:: matplotlib.backend_managers
    :members:

--- a/doc/api/backend_nbagg_api.rst
+++ b/doc/api/backend_nbagg_api.rst
@@ -1,8 +1,8 @@
 
-:mod:`matplotlib.backends.backend_mixed`
+:mod:`matplotlib.backends.backend_nbagg`
 ========================================
 
-.. automodule:: matplotlib.backends.backend_mixed
+.. automodule:: matplotlib.backends.backend_nbagg
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/backend_pdf_api.rst
+++ b/doc/api/backend_pdf_api.rst
@@ -4,4 +4,5 @@
 
 .. automodule:: matplotlib.backends.backend_pdf
    :members:
+   :undoc-members:
    :show-inheritance:

--- a/doc/api/backend_pgf_api.rst
+++ b/doc/api/backend_pgf_api.rst
@@ -1,8 +1,8 @@
 
-:mod:`matplotlib.backends.backend_svg`
+:mod:`matplotlib.backends.backend_pgf`
 ======================================
 
-.. automodule:: matplotlib.backends.backend_svg
+.. automodule:: matplotlib.backends.backend_pgf
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/backend_ps_api.rst
+++ b/doc/api/backend_ps_api.rst
@@ -1,0 +1,8 @@
+
+:mod:`matplotlib.backends.backend_ps`
+=====================================
+
+.. automodule:: matplotlib.backends.backend_ps
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/backend_qt4agg_api.rst
+++ b/doc/api/backend_qt4agg_api.rst
@@ -6,4 +6,3 @@
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/doc/api/backend_qt4cairo_api.rst
+++ b/doc/api/backend_qt4cairo_api.rst
@@ -1,0 +1,8 @@
+
+:mod:`matplotlib.backends.backend_qt4cairo`
+===========================================
+
+.. automodule:: matplotlib.backends.backend_qt4cairo
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/backend_qt5agg_api.rst
+++ b/doc/api/backend_qt5agg_api.rst
@@ -6,4 +6,3 @@
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/doc/api/backend_qt5cairo_api.rst
+++ b/doc/api/backend_qt5cairo_api.rst
@@ -1,0 +1,8 @@
+
+:mod:`matplotlib.backends.backend_qt5cairo`
+===========================================
+
+.. automodule:: matplotlib.backends.backend_qt5cairo
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/backend_tkagg_api.rst
+++ b/doc/api/backend_tkagg_api.rst
@@ -1,8 +1,8 @@
 
-:mod:`matplotlib.backends.backend_mixed`
+:mod:`matplotlib.backends.backend_tkagg`
 ========================================
 
-.. automodule:: matplotlib.backends.backend_mixed
+.. automodule:: matplotlib.backends.backend_tkagg
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/backend_tools_api.rst
+++ b/doc/api/backend_tools_api.rst
@@ -1,6 +1,6 @@
 
 :mod:`matplotlib.backend_tools`
-================================
+===============================
 
 .. automodule:: matplotlib.backend_tools
    :members:

--- a/doc/api/backend_webagg_api.rst
+++ b/doc/api/backend_webagg_api.rst
@@ -1,0 +1,12 @@
+
+:mod:`matplotlib.backends.backend_webagg`
+=========================================
+
+.. note::
+   The WebAgg backend is not documented here, in order to avoid adding Tornado
+   to the doc build requirements.
+
+.. .. automodule:: matplotlib.backends.backend_webagg
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:

--- a/doc/api/index_backend_api.rst
+++ b/doc/api/index_backend_api.rst
@@ -8,12 +8,21 @@ backends
    backend_managers_api.rst
    backend_mixed_api.rst
    backend_tools_api.rst
+   backend_agg_api.rst
+   backend_cairo_api.rst
    backend_gtkagg_api.rst
-   backend_qt4agg_api.rst
-   backend_qt5agg_api.rst
-   backend_wxagg_api.rst
+   backend_gtkcairo_api.rst
+   backend_gtk3agg_api.rst
+   backend_gtk3cairo_api.rst
+   backend_nbagg_api.rst
    backend_pdf_api.rst
+   backend_pgf_api.rst
+   backend_ps_api.rst
+   backend_qt4agg_api.rst
+   backend_qt4cairo_api.rst
+   backend_qt5agg_api.rst
+   backend_qt5cairo_api.rst
    backend_svg_api.rst
-..   backend_webagg.rst
-   dviread.rst
-   type1font.rst
+   backend_tkagg_api.rst
+   backend_webagg_api.rst
+   backend_wxagg_api.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -335,17 +335,8 @@ texinfo_documents = [
 ]
 
 
-class MyWX(MagicMock):
-    class Panel(object):
-        pass
-
-    class ToolBar(object):
-        pass
-
-    class Frame(object):
-        pass
-
-    VERSION_STRING = '2.9'
+class MyCairo(MagicMock):
+    version_info = (1, 2, 0)
 
 
 class MyPyQt4(MagicMock):
@@ -450,14 +441,25 @@ class MySip(MagicMock):
         return 1
 
 
-mockwxversion = MagicMock()
-mockwx = MyWX()
-mocksip = MySip()
-mockpyqt4 = MyPyQt4()
-sys.modules['wxversion'] = mockwxversion
-sys.modules['wx'] = mockwx
-sys.modules['sip'] = mocksip
-sys.modules['PyQt4'] = mockpyqt4
+class MyWX(MagicMock):
+    class Panel(object):
+        pass
+
+    class ToolBar(object):
+        pass
+
+    class Frame(object):
+        pass
+
+    VERSION_STRING = '2.9'
+
+
+sys.modules['cairo'] = MyCairo()
+sys.modules['cairo'].__name__ = 'cairocffi'
+sys.modules['PyQt4'] = MyPyQt4()
+sys.modules['sip'] = MySip()
+sys.modules['wx'] = MyWX()
+sys.modules['wxversion'] = MagicMock()
 
 # numpydoc config
 

--- a/doc/users/whats_new/qtcairo.rst
+++ b/doc/users/whats_new/qtcairo.rst
@@ -1,0 +1,5 @@
+Cairo rendering for Qt canvases
+-------------------------------
+
+The new ``Qt4Cairo`` and ``Qt5Cairo`` backends allow Qt canvases to use Cairo
+rendering instead of Agg.

--- a/examples/showcase/mandelbrot.py
+++ b/examples/showcase/mandelbrot.py
@@ -67,10 +67,9 @@ if __name__ == '__main__':
 
     # Some advertisement for matplotlib
     year = time.strftime("%Y")
-    major, minor, micro = matplotlib.__version__.split('.', 2)
     text = ("The Mandelbrot fractal set\n"
-            "Rendered with matplotlib %s.%s, %s - http://matplotlib.org"
-            % (major, minor, year))
+            "Rendered with matplotlib %s, %s - http://matplotlib.org"
+            % (matplotlib.__version__, year))
     ax.text(xmin+.025, ymin+.025, text, color="white", fontsize=12, alpha=0.5)
 
     plt.show()

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -422,18 +422,18 @@ class FigureCanvasAgg(FigureCanvasBase):
         Draw the figure using the renderer
         """
         self.renderer = self.get_renderer(cleared=True)
-        # acquire a lock on the shared font cache
-        RendererAgg.lock.acquire()
-
         toolbar = self.toolbar
         try:
             if toolbar:
                 toolbar.set_cursor(cursors.WAIT)
-            self.figure.draw(self.renderer)
+            with RendererAgg.lock:
+                self.figure.draw(self.renderer)
+            # A GUI class may be need to update a window using this draw, so
+            # don't forget to call the superclass.
+            super(FigureCanvasAgg, self).draw()
         finally:
             if toolbar:
                 toolbar.set_cursor(toolbar._lastCursor)
-            RendererAgg.lock.release()
 
     def get_renderer(self, cleared=False):
         l, b, w, h = self.figure.bbox.bounds

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -1,21 +1,10 @@
 """
 A Cairo backend for matplotlib
-Author: Steve Chaplin
+==============================
+:Author: Steve Chaplin and others
 
-Cairo is a vector graphics library with cross-device output support.
-Features of Cairo:
- * anti-aliasing
- * alpha channel
- * saves image files as PNG, PostScript, PDF
-
-http://cairographics.org
-Requires (in order, all available from Cairo website):
-    cairo, pycairo
-
-Naming Conventions
-  * classes MixedUpperCase
-  * varables lowerUpper
-  * functions underscore_separated
+This backend depends on `cairo <http://cairographics.org>`_, and either on
+cairocffi, or (Python 2 only) on pycairo.
 """
 
 from __future__ import (absolute_import, division, print_function,

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -106,7 +106,10 @@ class RendererCairo(RendererBase):
 
     def set_ctx_from_surface(self, surface):
         self.gc.ctx = cairo.Context(surface)
-        self.set_width_height(surface.get_width(), surface.get_height())
+        # Although it may appear natural to automatically call
+        # `self.set_width_height(surface.get_width(), surface.get_height())`
+        # here (instead of having the caller do so separately), this would fail
+        # for PDF/PS/SVG surfaces, which have no way to report their extents.
 
     def set_width_height(self, width, height):
         self.width  = width
@@ -441,9 +444,9 @@ class FigureCanvasCairo(FigureCanvasBase):
         width, height = self.get_width_height()
 
         renderer = RendererCairo(self.figure.dpi)
-        renderer.set_width_height(width, height)
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         renderer.set_ctx_from_surface(surface)
+        renderer.set_width_height(width, height)
 
         self.figure.draw(renderer)
         surface.write_to_png(fobj)
@@ -500,6 +503,7 @@ class FigureCanvasCairo(FigureCanvasBase):
         # surface.set_dpi() can be used
         renderer = RendererCairo(self.figure.dpi)
         renderer.set_ctx_from_surface(surface)
+        renderer.set_width_height(width_in_points, height_in_points)
         ctx = renderer.gc.ctx
 
         if orientation == 'landscape':

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -19,8 +19,7 @@ import warnings
 import numpy as np
 
 # In order to make it possible to pick the binding, use whichever has already
-# been imported, if any.  (The intermediate call to iter is just to placate
-# Python2.)
+# been imported, if any.
 cairo = next(
     (mod for mod in (
         sys.modules.get(name) for name in ["cairocffi", "cairo"]) if mod),

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -102,14 +102,11 @@ class RendererCairo(RendererBase):
 
     def set_ctx_from_surface(self, surface):
         self.gc.ctx = cairo.Context(surface)
+        self.set_width_height(surface.get_width(), surface.get_height())
 
     def set_width_height(self, width, height):
         self.width  = width
         self.height = height
-        self.matrix_flipy = cairo.Matrix(yy=-1, y0=self.height)
-        # use matrix_flipy for ALL rendering?
-        # - problem with text? - will need to switch matrix_flipy off, or do a
-        # font transform?
 
     def _fill_and_stroke(self, ctx, fill_c, alpha, alpha_overrides):
         if fill_c is not None:
@@ -302,11 +299,6 @@ class RendererCairo(RendererBase):
             ctx.fill_preserve()
 
         ctx.restore()
-
-    def flipy(self):
-        return True
-        #return False # tried - all draw objects ok except text (and images?)
-        # which comes out mirrored!
 
     def get_canvas_width_height(self):
         return self.width, self.height
@@ -503,7 +495,6 @@ class FigureCanvasCairo(FigureCanvasBase):
 
         # surface.set_dpi() can be used
         renderer = RendererCairo(self.figure.dpi)
-        renderer.set_width_height(width_in_points, height_in_points)
         renderer.set_ctx_from_surface(surface)
         ctx = renderer.gc.ctx
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -275,11 +275,8 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         pass
 
     def draw(self):
-        if self.get_visible() and self.get_mapped():
+        if self.is_drawable():
             self.queue_draw()
-            # do a synchronous draw (its less efficient than an async draw,
-            # but is required if/when animation is used)
-            self.get_property("window").process_updates (False)
 
     def draw_idle(self):
         if self._idle_draw_id != 0:

--- a/lib/matplotlib/backends/backend_qt4cairo.py
+++ b/lib/matplotlib/backends/backend_qt4cairo.py
@@ -1,0 +1,6 @@
+from .backend_qt5cairo import _BackendQT5Cairo
+
+
+@_BackendQT5Cairo.export
+class _BackendQT4Cairo(_BackendQT5Cairo):
+    pass

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -78,15 +78,15 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
             reg = self.copy_from_bbox(bbox)
             buf = reg.to_string_argb()
             qimage = QtGui.QImage(buf, w, h, QtGui.QImage.Format_ARGB32)
+            # Adjust the buf reference count to work around a memory leak bug
+            # in QImage under PySide on Python 3.
+            if QT_API == 'PySide' and six.PY3:
+                ctypes.c_long.from_address(id(buf)).value = 1
             if hasattr(qimage, 'setDevicePixelRatio'):
                 # Not available on Qt4 or some older Qt5.
                 qimage.setDevicePixelRatio(self._dpi_ratio)
             origin = QtCore.QPoint(l, self.renderer.height - t)
             painter.drawImage(origin / self._dpi_ratio, qimage)
-            # Adjust the buf reference count to work around a memory
-            # leak bug in QImage under PySide on Python 3.
-            if QT_API == 'PySide' and six.PY3:
-                ctypes.c_long.from_address(id(buf)).value = 1
 
         self._draw_rect_callback(painter)
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -35,30 +35,13 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         In Qt, all drawing should be done inside of here when a widget is
         shown onscreen.
         """
-        # if there is a pending draw, run it now as we need the updated render
-        # to paint the widget
-        if self._agg_draw_pending:
-            self.__draw_idle_agg()
-        # As described in __init__ above, we need to be careful in cases with
-        # mixed resolution displays if dpi_ratio is changing between painting
-        # events.
-        if self._dpi_ratio != self._dpi_ratio_prev:
-            # We need to update the figure DPI
-            self._update_figure_dpi()
-            self._dpi_ratio_prev = self._dpi_ratio
-            # The easiest way to resize the canvas is to emit a resizeEvent
-            # since we implement all the logic for resizing the canvas for
-            # that event.
-            event = QtGui.QResizeEvent(self.size(), self.size())
-            # We use self.resizeEvent here instead of QApplication.postEvent
-            # since the latter doesn't guarantee that the event will be emitted
-            # straight away, and this causes visual delays in the changes.
-            self.resizeEvent(event)
-            # resizeEvent triggers a paintEvent itself, so we exit this one.
+        if self._update_dpi():
+            # The dpi update triggered its own paintEvent.
             return
+        self._draw_idle()  # Only does something if a draw is pending.
 
-        # if the canvas does not have a renderer, then give up and wait for
-        # FigureCanvasAgg.draw(self) to be called
+        # If the canvas does not have a renderer, then give up and wait for
+        # FigureCanvasAgg.draw(self) to be called.
         if not hasattr(self, 'renderer'):
             return
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import ctypes
-import traceback
 
 from matplotlib import cbook
 from matplotlib.transforms import Bbox
@@ -19,32 +18,11 @@ from .backend_qt5 import (
 from .qt_compat import QT_API
 
 
-class FigureCanvasQTAggBase(FigureCanvasAgg):
-    """
-    The canvas the figure renders into.  Calls the draw and print fig
-    methods, creates the renderers, etc...
-
-    Attributes
-    ----------
-    figure : `matplotlib.figure.Figure`
-        A high-level Figure instance
-
-    """
+class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
     def __init__(self, figure):
-        super(FigureCanvasQTAggBase, self).__init__(figure=figure)
-        self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
-        self._agg_draw_pending = False
-        self._agg_is_drawing = False
+        super(FigureCanvasQTAgg, self).__init__(figure=figure)
         self._bbox_queue = []
-        self._drawRect = None
-
-    def drawRectangle(self, rect):
-        if rect is not None:
-            self._drawRect = [pt / self._dpi_ratio for pt in rect]
-        else:
-            self._drawRect = None
-        self.update()
 
     @property
     @cbook.deprecated("2.1")
@@ -110,13 +88,7 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
             if QT_API == 'PySide' and six.PY3:
                 ctypes.c_long.from_address(id(buf)).value = 1
 
-        # draw the zoom rectangle to the QPainter
-        if self._drawRect is not None:
-            pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio,
-                             QtCore.Qt.DotLine)
-            painter.setPen(pen)
-            x, y, w, h = self._drawRect
-            painter.drawRect(x, y, w, h)
+        self._draw_rect_callback(painter)
 
         painter.end()
 
@@ -130,41 +102,10 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
 
         self._agg_is_drawing = True
         try:
-            super(FigureCanvasQTAggBase, self).draw()
+            super(FigureCanvasQTAgg, self).draw()
         finally:
             self._agg_is_drawing = False
         self.update()
-
-    def draw_idle(self):
-        """Queue redraw of the Agg buffer and request Qt paintEvent.
-        """
-        # The Agg draw needs to be handled by the same thread matplotlib
-        # modifies the scene graph from. Post Agg draw request to the
-        # current event loop in order to ensure thread affinity and to
-        # accumulate multiple draw requests from event handling.
-        # TODO: queued signal connection might be safer than singleShot
-        if not (self._agg_draw_pending or self._agg_is_drawing):
-            self._agg_draw_pending = True
-            QtCore.QTimer.singleShot(0, self.__draw_idle_agg)
-
-    def __draw_idle_agg(self, *args):
-        # if nothing to do, bail
-        if not self._agg_draw_pending:
-            return
-        # we have now tried this function at least once, do not run
-        # again until re-armed.  Doing this here rather than after
-        # protects against recursive calls triggered through self.draw
-        # The recursive call is via `repaintEvent`
-        self._agg_draw_pending = False
-        # if negative size, bail
-        if self.height() < 0 or self.width() < 0:
-            return
-        try:
-            # actually do the drawing
-            self.draw()
-        except Exception:
-            # Uncaught exceptions are fatal for PyQt5, so catch them instead.
-            traceback.print_exc()
 
     def blit(self, bbox=None):
         """Blit the region in bbox.
@@ -182,23 +123,8 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         self.repaint(l, self.renderer.height / self._dpi_ratio - t, w, h)
 
     def print_figure(self, *args, **kwargs):
-        super(FigureCanvasQTAggBase, self).print_figure(*args, **kwargs)
+        super(FigureCanvasQTAgg, self).print_figure(*args, **kwargs)
         self.draw()
-
-
-class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
-    """
-    The canvas the figure renders into.  Calls the draw and print fig
-    methods, creates the renderers, etc.
-
-    Modified to import from Qt5 backend for new-style mouse events.
-
-    Attributes
-    ----------
-    figure : `matplotlib.figure.Figure`
-        A high-level Figure instance
-
-    """
 
 
 @_BackendQT5.export

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -1,19 +1,18 @@
-from . import backend_cairo  # Keep the RendererCairo class swappable.
+from .backend_cairo import cairo, FigureCanvasCairo, RendererCairo
 from .backend_qt5 import QtCore, QtGui, _BackendQT5, FigureCanvasQT
 from .qt_compat import QT_API
 
 
-class FigureCanvasQTCairo(FigureCanvasQT):
+class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
     def __init__(self, figure):
         super(FigureCanvasQTCairo, self).__init__(figure=figure)
-        self._renderer = backend_cairo.RendererCairo(self.figure.dpi)
+        self._renderer = RendererCairo(self.figure.dpi)
 
     def paintEvent(self, event):
         self._update_dpi()
         width = self.width()
         height = self.height()
-        surface = backend_cairo.cairo.ImageSurface(
-            backend_cairo.cairo.FORMAT_ARGB32, width, height)
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_ctx_from_surface(surface)
         self._renderer.set_width_height(width, height)
         self.figure.draw(self._renderer)

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -1,0 +1,29 @@
+from . import backend_cairo  # Keep the RendererCairo class swappable.
+from .backend_qt5 import QtCore, QtGui, _BackendQT5, FigureCanvasQT
+
+
+class FigureCanvasQTCairo(FigureCanvasQT):
+    def __init__(self, figure):
+        super(FigureCanvasQTCairo, self).__init__(figure=figure)
+        self._renderer = backend_cairo.RendererCairo(self.figure.dpi)
+
+    def paintEvent(self, event):
+        width = self.width()
+        height = self.height()
+        surface = backend_cairo.cairo.ImageSurface(
+            backend_cairo.cairo.FORMAT_ARGB32, width, height)
+        self._renderer.set_ctx_from_surface(surface)
+        # This should be really done by set_ctx_from_surface...
+        self._renderer.set_width_height(width, height)
+        self.figure.draw(self._renderer)
+        qimage = QtGui.QImage(surface.get_data(), width, height,
+                              QtGui.QImage.Format_ARGB32_Premultiplied)
+        painter = QtGui.QPainter(self)
+        painter.drawImage(0, 0, qimage)
+        self._draw_rect_callback(painter)
+        painter.end()
+
+
+@_BackendQT5.export
+class _BackendQT5Cairo(_BackendQT5):
+    FigureCanvas = FigureCanvasQTCairo

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -1,5 +1,6 @@
 from . import backend_cairo  # Keep the RendererCairo class swappable.
 from .backend_qt5 import QtCore, QtGui, _BackendQT5, FigureCanvasQT
+from .qt_compat import QT_API
 
 
 class FigureCanvasQTCairo(FigureCanvasQT):
@@ -13,11 +14,14 @@ class FigureCanvasQTCairo(FigureCanvasQT):
         surface = backend_cairo.cairo.ImageSurface(
             backend_cairo.cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_ctx_from_surface(surface)
-        # This should be really done by set_ctx_from_surface...
-        self._renderer.set_width_height(width, height)
         self.figure.draw(self._renderer)
-        qimage = QtGui.QImage(surface.get_data(), width, height,
+        buf = surface.get_data()
+        qimage = QtGui.QImage(buf, width, height,
                               QtGui.QImage.Format_ARGB32_Premultiplied)
+        # Adjust the buf reference count to work around a memory leak bug in
+        # QImage under PySide on Python 3.
+        if QT_API == 'PySide' and six.PY3:
+            ctypes.c_long.from_address(id(buf)).value = 1
         painter = QtGui.QPainter(self)
         painter.drawImage(0, 0, qimage)
         self._draw_rect_callback(painter)

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -15,6 +15,7 @@ class FigureCanvasQTCairo(FigureCanvasQT):
         surface = backend_cairo.cairo.ImageSurface(
             backend_cairo.cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_ctx_from_surface(surface)
+        self._renderer.set_width_height(width, height)
         self.figure.draw(self._renderer)
         buf = surface.get_data()
         qimage = QtGui.QImage(buf, width, height,

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -9,6 +9,7 @@ class FigureCanvasQTCairo(FigureCanvasQT):
         self._renderer = backend_cairo.RendererCairo(self.figure.dpi)
 
     def paintEvent(self, event):
+        self._update_dpi()
         width = self.width()
         height = self.height()
         surface = backend_cairo.cairo.ImageSurface(

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -10,8 +10,9 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
 
     def paintEvent(self, event):
         self._update_dpi()
-        width = self.width()
-        height = self.height()
+        dpi_ratio = self._dpi_ratio
+        width = dpi_ratio * self.width()
+        height = dpi_ratio * self.height()
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_ctx_from_surface(surface)
         self._renderer.set_width_height(width, height)
@@ -23,6 +24,9 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
         # QImage under PySide on Python 3.
         if QT_API == 'PySide' and six.PY3:
             ctypes.c_long.from_address(id(buf)).value = 1
+        if hasattr(qimage, 'setDevicePixelRatio'):
+            # Not available on Qt4 or some older Qt5.
+            qimage.setDevicePixelRatio(dpi_ratio)
         painter = QtGui.QPainter(self)
         painter.drawImage(0, 0, qimage)
         self._draw_rect_callback(painter)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -39,7 +39,7 @@ from cycler import Cycler, cycler as ccycler
 # change for later versions.
 
 interactive_bk = ['GTK', 'GTKAgg', 'GTKCairo', 'MacOSX',
-                  'Qt4Agg', 'Qt5Agg', 'TkAgg', 'WX', 'WXAgg',
+                  'Qt4Agg', 'Qt5Agg', 'Qt5Cairo', 'TkAgg', 'WX', 'WXAgg',
                   'GTK3Cairo', 'GTK3Agg', 'WebAgg', 'nbAgg']
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -29,20 +29,17 @@ from matplotlib.cbook import mplDeprecation, deprecated, ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
 from matplotlib.colors import is_color_like
 
-
 # Don't let the original cycler collide with our validating cycler
 from cycler import Cycler, cycler as ccycler
 
-# interactive_bk = ['gtk', 'gtkagg', 'gtkcairo', 'qt4agg',
-#                  'tkagg', 'wx', 'wxagg', 'webagg']
-# The capitalized forms are needed for ipython at present; this may
-# change for later versions.
 
-interactive_bk = ['GTK', 'GTKAgg', 'GTKCairo', 'MacOSX',
-                  'Qt4Agg', 'Qt5Agg', 'Qt5Cairo', 'TkAgg', 'WX', 'WXAgg',
-                  'GTK3Cairo', 'GTK3Agg', 'WebAgg', 'nbAgg']
-
-
+interactive_bk = ['GTK', 'GTKAgg', 'GTKCairo', 'GTK3Agg', 'GTK3Cairo',
+                  'MacOSX',
+                  'nbAgg',
+                  'Qt4Agg', 'Qt4Cairo', 'Qt5Agg', 'Qt5Cairo',
+                  'TkAgg',
+                  'WebAgg',
+                  'WX', 'WXAgg']
 non_interactive_bk = ['agg', 'cairo', 'gdk',
                       'pdf', 'pgf', 'ps', 'svg', 'template']
 all_backends = interactive_bk + non_interactive_bk

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -21,6 +21,7 @@ def _get_testable_interactive_backends():
     for deps, backend in [(["cairocffi", "pgi"], "gtk3agg"),
                           (["cairocffi", "pgi"], "gtk3cairo"),
                           (["PyQt5"], "qt5agg"),
+                          (["cairocffi", "PyQt5"], "qt5cairo"),
                           (["tkinter"], "tkagg"),
                           (["wx"], "wxagg")]:
         reason = None

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -432,15 +432,15 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #           ``%matplotlib notebook``.
 # WebAgg    On ``show()`` will start a tornado server with an interactive
 #           figure.
-# Qt5Cairo  Cairo rendering in a :term:`Qt5` canvas (requires PyQt5_ and
-#           cairocffi_).
+# Qt5Cairo  Cairo rendering in a :term:`Qt5` canvas (requires PyQt5_, and
+#           pycairo_ or cairocffi_).
 # GTK3Cairo Cairo rendering to a :term:`GTK` 3.x canvas (requires PyGObject_,
 #           and pycairo_ or cairocffi_).
 # Qt4Agg    Agg rendering to a :term:`Qt4` canvas (requires PyQt4_ or
 #           ``pyside``).  This backend can be activated in IPython with
 #           ``%matplotlib qt4``.
-# Qt4Cairo  Cairo rendering in a :term:`Qt5` canvas (requires PyQt5_ and
-#           cairocffi_).
+# Qt4Cairo  Cairo rendering in a :term:`Qt4` canvas (requires PyQt4_, and
+#           pycairo_ or cairocffi_).
 # GTKAgg    Agg rendering to a :term:`GTK` 2.x canvas (requires PyGTK_, and
 #           pycairo_ or cairocffi_; Python2 only).  This backend can be
 #           activated in IPython with ``%matplotlib gtk``.
@@ -448,7 +448,7 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #           and pycairo_ or cairocffi_; Python2 only).
 # WXAgg     Agg rendering to a :term:`wxWidgets` canvas (requires wxPython_;
 #           v4.0 (in beta) is required for Python3). This backend can be
-#           activated in IPython with ``%matplotlib wx``.
+#           activated in IPython with ``%matplotlib wx``.#
 # ========= ================================================================
 #
 # .. _`Anti-Grain Geometry`: http://antigrain.com/

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -322,12 +322,17 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #        backend : WXAgg   # use wxpython with antigrain (agg) rendering
 #
 # #. Setting the :envvar:`MPLBACKEND` environment
-#    variable, either for your current shell or for a single script::
+#    variable, either for your current shell or for a single script.  On Unix::
 #
-#         > export MPLBACKEND="module://my_backend"
+#         > export MPLBACKEND=module://my_backend
 #         > python simple_plot.py
 #
 #         > MPLBACKEND="module://my_backend" python simple_plot.py
+#
+#    On Windows, only the former is possible::
+#
+#         > set MPLBACKEND=module://my_backend
+#         > python simple_plot.py
 #
 #    Setting this environment variable will override the ``backend`` parameter
 #    in *any* ``matplotlibrc``, even if there is a ``matplotlibrc`` in your
@@ -360,19 +365,18 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # methods given above.
 #
 # If, however, you want to write graphical user interfaces, or a web
-# application server (:ref:`howto-webapp`), or need a better
-# understanding of what is going on, read on. To make things a little
-# more customizable for graphical user interfaces, matplotlib separates
-# the concept of the renderer (the thing that actually does the drawing)
-# from the canvas (the place where the drawing goes).  The canonical
-# renderer for user interfaces is ``Agg`` which uses the `Anti-Grain
-# Geometry`_ C++ library to make a raster (pixel) image of the figure.
-# All of the user interfaces except ``macosx`` can be used with
-# agg rendering, e.g.,
-# ``WXAgg``, ``GTKAgg``, ``QT4Agg``, ``QT5Agg``, ``TkAgg``.  In
-# addition, some of the user interfaces support other rendering engines.
-# For example, with GTK, you can also select GDK rendering (backend
-# ``GTK`` deprecated in 2.0) or Cairo rendering (backend ``GTKCairo``).
+# application server (:ref:`howto-webapp`), or need a better understanding of
+# what is going on, read on.  To make things a little more customizable for
+# graphical user interfaces, matplotlib separates the concept of the renderer
+# (the thing that actually does the drawing) from the canvas (the place where
+# the drawing goes).  The canonical renderer for user interfaces is ``Agg``
+# which uses the `Anti-Grain Geometry`_ C++ library to make a raster (pixel)
+# image of the figure.  All of the user interfaces except ``macosx`` can
+# be used with Agg rendering, e.g., ``GTKAgg``, ``GTK3Agg``, ``Qt4Agg``,
+# ``Qt5Agg``, ``TkAgg``, ``WxAgg``.  In addition, some of the user interfaces
+# support other rendering engines.  For example, with GTK, GTK3, and QT5,
+# you can also select Cairo rendering (backends ``GTKCairo``, ``GTK3Cairo``,
+# ``Qt5Cairo``).
 #
 # For the rendering engines, one can also distinguish between `vector
 # <https://en.wikipedia.org/wiki/Vector_graphics>`_ or `raster
@@ -397,11 +401,10 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #                                `Portable Document Format`_
 # SVG             :term:`svg`    :term:`vector graphics` --
 #                                `Scalable Vector Graphics`_
-# :term:`Cairo`   :term:`png`    :term:`vector graphics` --
-#                 :term:`ps`     `Cairo graphics`_
-#                 :term:`pdf`
+# :term:`Cairo`   :term:`png`    :term:`raster graphics` and
+#                 :term:`ps`     :term:`vector graphics` -- using the
+#                 :term:`pdf`    `Cairo graphics`_ library
 #                 :term:`svg`
-#                 ...
 # =============   ============   ================================================
 #
 # And here are the user interfaces and renderer combinations supported;
@@ -409,53 +412,50 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # and of using appropriate renderers from the table above to write to
 # a file:
 #
-# ============   ================================================================
-# Backend        Description
-# ============   ================================================================
-# Qt5Agg         Agg rendering in a :term:`Qt5` canvas (requires PyQt5_).  This
-#                backend can be activated in IPython with ``%matplotlib qt5``.
-# ipympl         Agg rendering embedded in a Jupyter widget.  (requires ipympl)
-#                This can be enabled in a Jupyter notebook with
-#                ``%matplotlib ipympl``
-# GTK3Agg        Agg rendering to a :term:`GTK` 3.x canvas (requires PyGObject_
-#                and pycairo_ or cairocffi_)
-#                This backend can be activated in IPython with
-#                ``%matplotlib gtk3``.
-# macosx         Agg rendering into a Cocoa canvas in OSX.
-#                This backend can be activated in IPython with
-#                ``%matplotlib osx``.
-# TkAgg          Agg rendering to a :term:`Tk` canvas (requires TkInter_).
-#                This backend can be activated in IPython with
-#                ``%matplotlib tk``.
-# nbAgg          Embed an interactive figure in a Jupyter classic notebook.  This
-#                backend can be enabled in Jupyter notebooks via
-#                ``%matplotlib notebook``.
-# WebAgg         On ``show()`` will start a tornado server with an interactive
-#                figure.
-# GTK3Cairo      Cairo rendering to a :term:`GTK` 3.x canvas (requires PyGObject_
-#                and pycairo_ or cairocffi_)
-# Qt4Agg         Agg rendering to a :term:`Qt4` canvas (requires PyQt4_
-#                or ``pyside``).
-#                This backend can be activated in IPython with
-#                ``%matplotlib qt4``.
-# GTKAgg         Agg rendering to a :term:`GTK` 2.x canvas (requires PyGTK_ and
-#                pycairo_ or cairocffi_; Python2 only)
-#                This backend can be activated in IPython with
-#                ``%matplotlib gtk``.
-# GTKCairo       Cairo rendering to a :term:`GTK` 2.x canvas (requires PyGTK_
-#                and pycairo_ or cairocffi_; Python2 only)
-# WXAgg          Agg rendering to a :term:`wxWidgets` canvas
-#                (requires wxPython_.  v4.0 (in beta) is
-#                required for python3).
-#                This backend can be activated in IPython with
-#                ``%matplotlib wx``.
-# ============   ================================================================
+# ========= ================================================================
+# Backend   Description
+# ========= ================================================================
+# Qt5Agg    Agg rendering in a :term:`Qt5` canvas (requires PyQt5_).  This
+#           backend can be activated in IPython with ``%matplotlib qt5``.
+# ipympl    Agg rendering embedded in a Jupyter widget.  (requires ipympl).
+#           This backend can be enabled in a Jupyter notebook with
+#           ``%matplotlib ipympl``.
+# GTK3Agg   Agg rendering to a :term:`GTK` 3.x canvas (requires PyGObject_,
+#           and pycairo_ or cairocffi_).  This backend can be activated in
+#           IPython with ``%matplotlib gtk3``.
+# macosx    Agg rendering into a Cocoa canvas in OSX.  This backend can be
+#           activated in IPython with ``%matplotlib osx``.
+# TkAgg     Agg rendering to a :term:`Tk` canvas (requires TkInter_). This
+#           backend can be activated in IPython with ``%matplotlib tk``.
+# nbAgg     Embed an interactive figure in a Jupyter classic notebook.  This
+#           backend can be enabled in Jupyter notebooks via
+#           ``%matplotlib notebook``.
+# WebAgg    On ``show()`` will start a tornado server with an interactive
+#           figure.
+# Qt5Cairo  Cairo rendering in a :term:`Qt5` canvas (requires PyQt5_ and
+#           cairocffi_).
+# GTK3Cairo Cairo rendering to a :term:`GTK` 3.x canvas (requires PyGObject_,
+#           and pycairo_ or cairocffi_).
+# Qt4Agg    Agg rendering to a :term:`Qt4` canvas (requires PyQt4_ or
+#           ``pyside``).  This backend can be activated in IPython with
+#           ``%matplotlib qt4``.
+# Qt4Cairo  Cairo rendering in a :term:`Qt5` canvas (requires PyQt5_ and
+#           cairocffi_).
+# GTKAgg    Agg rendering to a :term:`GTK` 2.x canvas (requires PyGTK_, and
+#           pycairo_ or cairocffi_; Python2 only).  This backend can be
+#           activated in IPython with ``%matplotlib gtk``.
+# GTKCairo  Cairo rendering to a :term:`GTK` 2.x canvas (requires PyGTK_,
+#           and pycairo_ or cairocffi_; Python2 only).
+# WXAgg     Agg rendering to a :term:`wxWidgets` canvas (requires wxPython_;
+#           v4.0 (in beta) is required for Python3). This backend can be
+#           activated in IPython with ``%matplotlib wx``.
+# ========= ================================================================
 #
 # .. _`Anti-Grain Geometry`: http://antigrain.com/
 # .. _Postscript: https://en.wikipedia.org/wiki/PostScript
 # .. _`Portable Document Format`: https://en.wikipedia.org/wiki/Portable_Document_Format
 # .. _`Scalable Vector Graphics`: https://en.wikipedia.org/wiki/Scalable_Vector_Graphics
-# .. _`Cairo graphics`: https://en.wikipedia.org/wiki/Cairo_(graphics)
+# .. _`Cairo graphics`: https://wwW.cairographics.org
 # .. _`Gimp Drawing Kit`: https://en.wikipedia.org/wiki/GDK
 # .. _PyGTK: http://www.pygtk.org
 # .. _PyGObject: https://wiki.gnome.org/action/show/Projects/PyGObject
@@ -489,11 +489,8 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # GTK and Cairo
 # -------------
 #
-# Both `GTK2` and `GTK3` have implicit dependencies on PyCairo regardless of the
-# specific Matplotlib backend used. Unfortunatly the latest release of PyCairo
-# for Python3 does not implement the Python wrappers needed for the `GTK3Agg`
-# backend. `Cairocffi` can be used as a replacement which implements the correct
-# wrapper.
+# Both `GTK2` and `GTK3` depend on a Cairo wrapper (PyCairo or cairocffi) even
+# if the Agg renderer is used.  On Python3, only cairocffi is supported.
 #
 # How do I select PyQt4 or PySide?
 # --------------------------------


### PR DESCRIPTION
This PR implements a cairo based renderer for Qt canvas, under the name "Qt4Cairo"/"Qt5Cairo".  Test e.g. by setting the MPLBACKEND environment variable to `qt4cairo`/`qt5cairo`.

> The quoted text below is no longer relevant (the corresponding PRs have been merged).

> The first three commits include a number of cleanups to specific backends code, some of them related to the issue at hand and some of them not so much.  They are also the object of a separate PR (#8772), that may be merged first (and independently) to simplify review.

> The fourth commit ("backend class to factor out common code") implements a class-based approach to define the various functions needed by a backend module, in order to remove large chunks of copy-pasted code.  It does not modify the public API though.  Likewise, it is the object of a separate PR (#8773) that may be merged second to simplify review.

The following commits implement the Qt5Cairo backend, then the Qt4Cairo backend, and redistributes relevant code chunks between the various `backend_qt*` modules in order to maximize code reuse, and then update the docs.  I would suggest restricting comments for this PR to the diff of these last commits.

> As a side effect of the refactoring of the Qt canvas classes, this also closes #8618 (PySide2 support).

Note that because of the way the cairo backend is currently written, all the drawing occurs during the Qt draw event, instead of being buffered before it as in Agg.  The third party mplcairo backend works around this limitation, but this PR is still useful to cleanly separate the windowing and rendering parts of the code.

## PR Checklist

- [X] Has Pytest style unit tests
    -> see test_backends_interactive.py
- [X] Code is PEP 8 compliant
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [X] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way