### PR TITLE
Backends cleanup

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -694,17 +694,17 @@ class RendererBase(object):
 
     def get_text_width_height_descent(self, s, prop, ismath):
         """
-        get the width and height, and the offset from the bottom to the
-        baseline (descent), in display coords of the string s with
-        :class:`~matplotlib.font_manager.FontProperties` prop
+        Get the width, height, and descent (offset from the bottom
+        to the baseline), in display coords, of the string *s* with
+        :class:`~matplotlib.font_manager.FontProperties` *prop*
         """
         if ismath == 'TeX':
             # todo: handle props
             size = prop.get_size_in_points()
             texmanager = self._text2path.get_texmanager()
             fontsize = prop.get_size_in_points()
-            w, h, d = texmanager.get_text_width_height_descent(s, fontsize,
-                                                               renderer=self)
+            w, h, d = texmanager.get_text_width_height_descent(
+                s, fontsize, renderer=self)
             return w, h, d
 
         dpi = self.points_to_pixels(72)
@@ -2151,7 +2151,6 @@ class FigureCanvasBase(object):
                 # the backend to support file-like object, i'm going
                 # to leave it as it is. However, a better solution
                 # than stringIO seems to be needed. -JJL
-                #result = getattr(self, method_name)
                 result = print_method(
                     io.BytesIO(),
                     dpi=dpi,
@@ -2203,7 +2202,6 @@ class FigureCanvasBase(object):
             _bbox_inches_restore = None
 
         try:
-            #result = getattr(self, method_name)(
             result = print_method(
                 filename,
                 dpi=dpi,

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -212,20 +212,17 @@ class RendererAgg(RendererBase):
 
     def get_text_width_height_descent(self, s, prop, ismath):
         """
-        get the width and height in display coords of the string s
-        with FontPropertry prop
-
-        # passing rgb is a little hack to make caching in the
-        # texmanager more efficient.  It is not meant to be used
-        # outside the backend
+        Get the width, height, and descent (offset from the bottom
+        to the baseline), in display coords, of the string *s* with
+        :class:`~matplotlib.font_manager.FontProperties` *prop*
         """
         if rcParams['text.usetex']:
             # todo: handle props
             size = prop.get_size_in_points()
             texmanager = self.get_texmanager()
             fontsize = prop.get_size_in_points()
-            w, h, d = texmanager.get_text_width_height_descent(s, fontsize,
-                                                               renderer=self)
+            w, h, d = texmanager.get_text_width_height_descent(
+                s, fontsize, renderer=self)
             return w, h, d
 
         if ismath:

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -549,18 +549,6 @@ class FigureCanvasCairo(FigureCanvasBase):
 
         self.figure.draw(renderer)
 
-        show_fig_border = False  # for testing figure orientation and scaling
-        if show_fig_border:
-            ctx.new_path()
-            ctx.rectangle(0, 0, width_in_points, height_in_points)
-            ctx.set_line_width(4.0)
-            ctx.set_source_rgb(1,0,0)
-            ctx.stroke()
-            ctx.move_to(30,30)
-            ctx.select_font_face('sans-serif')
-            ctx.set_font_size(20)
-            ctx.show_text('Origin corner')
-
         ctx.show_page()
         surface.finish()
         if fmt == 'svgz':

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -116,6 +116,7 @@ class TimerGTK3(TimerBase):
             self._timer = None
             return False
 
+
 class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
     keyvald = {65507 : 'control',
                65505 : 'shift',

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -186,7 +186,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         GObject.GObject.__init__(self)
 
         self._idle_draw_id  = 0
-        self._need_redraw   = True
         self._lastCursor    = None
 
         self.connect('scroll_event',         self.scroll_event)
@@ -299,12 +298,9 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         w, h = event.width, event.height
         if w < 3 or h < 3:
             return # empty fig
-
         # resize the figure (in inches)
         dpi = self.figure.dpi
         self.figure.set_size_inches(w/dpi, h/dpi, forward=False)
-        self._need_redraw = True
-
         return False  # finish event propagation?
 
     def on_draw_event(self, widget, ctx):
@@ -312,7 +308,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         pass
 
     def draw(self):
-        self._need_redraw = True
         if self.get_visible() and self.get_mapped():
             self.queue_draw()
             # do a synchronous draw (its less efficient than an async draw,

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import numpy as np
-import sys
 import warnings
 
 from . import backend_agg

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -38,11 +38,8 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         w, h = allocation.width, allocation.height
 
         if not len(self._bbox_queue):
-            if self._need_redraw:
-                self._render_figure(w, h)
-                bbox_queue = [transforms.Bbox([[0, 0], [w, h]])]
-            else:
-                return
+            self._render_figure(w, h)
+            bbox_queue = [transforms.Bbox([[0, 0], [w, h]])]
         else:
             bbox_queue = self._bbox_queue
 

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -36,15 +36,10 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
     def on_draw_event(self, widget, ctx):
         """ GtkDrawable draw event, like expose_event in GTK 2.X
         """
-        # the _need_redraw flag doesnt work. it sometimes prevents
-        # the rendering and leaving the canvas blank
-        #if self._need_redraw:
         self._renderer.set_context(ctx)
         allocation = self.get_allocation()
         x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
         self._render_figure(w, h)
-        #self._need_redraw = False
-
         return False  # finish event propagation?
 
 

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -6,41 +6,20 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-import os  # not used
-import sys
-import ctypes
-import warnings
-
 import matplotlib
 from matplotlib.figure import Figure
 
-
-from .backend_qt5agg import FigureCanvasQTAggBase
-
 from .backend_agg import FigureCanvasAgg
-from .backend_qt4 import QtCore
-from .backend_qt4 import FigureManagerQT
-from .backend_qt4 import FigureCanvasQT
-from .backend_qt4 import NavigationToolbar2QT
-##### not used
-from .backend_qt4 import show
-from .backend_qt4 import draw_if_interactive
-from .backend_qt4 import backend_version
-######
-
-DEBUG = False
-
-_decref = ctypes.pythonapi.Py_DecRef
-_decref.argtypes = [ctypes.py_object]
-_decref.restype = None
+from .backend_qt4 import (
+    QtCore, FigureCanvasQT, FigureManagerQT, NavigationToolbar2QT,
+    backend_version, draw_if_interactive, show)
+from .backend_qt5agg import FigureCanvasQTAggBase
 
 
 def new_figure_manager(num, *args, **kwargs):
     """
     Create a new figure manager instance
     """
-    if DEBUG:
-        print('backend_qt4agg.new_figure_manager')
     FigureClass = kwargs.pop('FigureClass', Figure)
     thisFig = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, thisFig)

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -15,7 +15,7 @@ import matplotlib
 from matplotlib.figure import Figure
 
 
-from .backend_qt5agg import FigureCanvasQTAggBase as _FigureCanvasQTAggBase
+from .backend_qt5agg import FigureCanvasQTAggBase
 
 from .backend_agg import FigureCanvasAgg
 from .backend_qt4 import QtCore
@@ -54,13 +54,7 @@ def new_figure_manager_given_figure(num, figure):
     return FigureManagerQT(canvas, num)
 
 
-class FigureCanvasQTAggBase(_FigureCanvasQTAggBase):
-    def __init__(self, figure):
-        self._agg_draw_pending = False
-
-
-class FigureCanvasQTAgg(FigureCanvasQTAggBase,
-                        FigureCanvasQT, FigureCanvasAgg):
+class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
     """
     The canvas the figure renders into.  Calls the draw and print fig
     methods, creates the renderers, etc...
@@ -71,16 +65,6 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase,
         A high-level Figure instance
 
     """
-
-    def __init__(self, figure):
-        if DEBUG:
-            print('FigureCanvasQtAgg: ', figure)
-        FigureCanvasQT.__init__(self, figure)
-        FigureCanvasQTAggBase.__init__(self, figure)
-        FigureCanvasAgg.__init__(self, figure)
-        self._drawRect = None
-        self.blitbox = []
-        self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
 
 
 FigureCanvas = FigureCanvasQTAgg

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -522,6 +522,7 @@ class FigureCanvasTkAgg(FigureCanvasAgg):
         FigureCanvasBase.stop_event_loop_default(self)
     stop_event_loop.__doc__=FigureCanvasBase.stop_event_loop_default.__doc__
 
+
 class FigureManagerTkAgg(FigureManagerBase):
     """
     Attributes


### PR DESCRIPTION
This is the first part of #8771, split out for simpler review.

1. general cleanup to the backends code
2. unification of blitting and nonblitting code paths in Qt5Agg's paintEvent, similarly to how it is implemented by Gtk3Cairo: a default repaint is simply equivalent to a blitting of the whole canvas.
3. removal of the unused Gtk3 _needs_redraw attribute (documented as "doesnt work").