### PR TITLE
Backend class for better code reuse between backend modules

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -29,8 +29,8 @@ import numpy as np
 from collections import OrderedDict
 from math import radians, cos, sin
 from matplotlib import verbose, rcParams, __version__
-from matplotlib.backend_bases import (RendererBase, FigureManagerBase,
-                                      FigureCanvasBase)
+from matplotlib.backend_bases import (
+    _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
 from matplotlib.cbook import maxdict, restrict_dict
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, get_font
@@ -394,24 +394,6 @@ class RendererAgg(RendererBase):
                 gc, l + ox, height - b - h + oy, img)
 
 
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasAgg(figure)
-    manager = FigureManagerBase(canvas, num)
-    return manager
-
-
 class FigureCanvasAgg(FigureCanvasBase):
     """
     The canvas the figure renders into.  Calls the draw and print fig
@@ -606,4 +588,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         print_tiff = print_tif
 
 
-FigureCanvas = FigureCanvasAgg
+@_Backend.export
+class _BackendAgg(_Backend):
+    FigureCanvas = FigureCanvasAgg
+    FigureManager = FigureManagerBase

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -52,11 +52,12 @@ backend_version = cairo.version
 del _version_required
 
 from matplotlib.backend_bases import (
-    RendererBase, GraphicsContextBase, FigureManagerBase, FigureCanvasBase)
-from matplotlib.figure       import Figure
-from matplotlib.mathtext     import MathTextParser
-from matplotlib.path         import Path
-from matplotlib.transforms   import Bbox, Affine2D
+    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    RendererBase)
+from matplotlib.figure import Figure
+from matplotlib.mathtext import MathTextParser
+from matplotlib.path import Path
+from matplotlib.transforms import Bbox, Affine2D
 from matplotlib.font_manager import ttfFontProperty
 
 
@@ -452,24 +453,6 @@ class GraphicsContextCairo(GraphicsContextBase):
         self.ctx.set_line_width(self.renderer.points_to_pixels(w))
 
 
-def new_figure_manager(num, *args, **kwargs): # called by backends/__init__.py
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas  = FigureCanvasCairo(figure)
-    manager = FigureManagerBase(canvas, num)
-    return manager
-
-
 class FigureCanvasCairo(FigureCanvasBase):
     def print_png(self, fobj, *args, **kwargs):
         width, height = self.get_width_height()
@@ -555,4 +538,7 @@ class FigureCanvasCairo(FigureCanvasBase):
             fo.close()
 
 
-FigureCanvas = FigureCanvasCairo
+@_Backend.export
+class _BackendCairo(_Backend):
+    FigureCanvas = FigureCanvasCairo
+    FigureManager = FigureManagerBase

--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -24,7 +24,8 @@ import matplotlib
 from matplotlib import rcParams
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
-    RendererBase, GraphicsContextBase, FigureManagerBase, FigureCanvasBase)
+    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    RendererBase)
 from matplotlib.cbook import restrict_dict, warn_deprecated
 from matplotlib.figure import Figure
 from matplotlib.mathtext import MathTextParser
@@ -381,24 +382,6 @@ class GraphicsContextGDK(GraphicsContextBase):
             self.gdkGC.line_width = max(1, int(np.round(pixels)))
 
 
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas  = FigureCanvasGDK(figure)
-    manager = FigureManagerBase(canvas, num)
-    return manager
-
-
 class FigureCanvasGDK (FigureCanvasBase):
     def __init__(self, figure):
         FigureCanvasBase.__init__(self, figure)
@@ -452,3 +435,9 @@ class FigureCanvasGDK (FigureCanvasBase):
             options['quality'] = str(options['quality'])
 
         pixbuf.save(filename, format, options=options)
+
+
+@_Backend.export
+class _BackendGDK(_Backend):
+    FigureCanvas = FigureCanvasGDK
+    FigureManager = FigureManagerBase

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -28,10 +28,9 @@ except ImportError:
 import matplotlib
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
-    FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
     NavigationToolbar2, RendererBase, TimerBase, cursors)
-from matplotlib.backend_bases import (
-    ShowBase, ToolContainerBase, StatusbarBase)
+from matplotlib.backend_bases import ToolContainerBase, StatusbarBase
 from matplotlib.backend_managers import ToolManager
 from matplotlib.cbook import is_writable_file_like
 from matplotlib.figure import Figure
@@ -53,22 +52,6 @@ cursord = {
     cursors.POINTER       : Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR),
     cursors.SELECT_REGION : Gdk.Cursor.new(Gdk.CursorType.TCROSS),
     }
-
-def draw_if_interactive():
-    """
-    Is called after every pylab drawing command
-    """
-    if matplotlib.is_interactive():
-        figManager =  Gcf.get_active()
-        if figManager is not None:
-            figManager.canvas.draw_idle()
-
-class Show(ShowBase):
-    def mainloop(self):
-        if Gtk.main_level() == 0:
-            Gtk.main()
-
-show = Show()
 
 
 class TimerGTK3(TimerBase):
@@ -947,5 +930,18 @@ backend_tools.ToolSetCursor = SetCursorGTK3
 backend_tools.ToolRubberband = RubberbandGTK3
 
 Toolbar = ToolbarGTK3
-FigureCanvas = FigureCanvasGTK3
-FigureManager = FigureManagerGTK3
+
+
+@_Backend.export
+class _BackendGTK3(_Backend):
+    FigureCanvas = FigureCanvasGTK3
+    FigureManager = FigureManagerGTK3
+
+    @staticmethod
+    def trigger_manager_draw(manager):
+        manager.canvas.draw_idle()
+
+    @staticmethod
+    def mainloop():
+        if Gtk.main_level() == 0:
+            Gtk.main()

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -6,9 +6,9 @@ import six
 import numpy as np
 import warnings
 
-from . import backend_agg
-from . import backend_gtk3
+from . import backend_agg, backend_gtk3
 from .backend_cairo import cairo, HAS_CAIRO_CFFI
+from .backend_gtk3 import _BackendGTK3
 from matplotlib.figure import Figure
 from matplotlib import transforms
 
@@ -97,24 +97,7 @@ class FigureManagerGTK3Agg(backend_gtk3.FigureManagerGTK3):
     pass
 
 
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasGTK3Agg(figure)
-    manager = FigureManagerGTK3Agg(canvas, num)
-    return manager
-
-
-FigureCanvas = FigureCanvasGTK3Agg
-FigureManager = FigureManagerGTK3Agg
-show = backend_gtk3.show
+@_BackendGTK3.export
+class _BackendGTK3Cairo(_BackendGTK3):
+    FigureCanvas = FigureCanvasGTK3Agg
+    FigureManager = FigureManagerGTK3Agg

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -3,10 +3,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-from . import backend_gtk3
-from . import backend_cairo
+from . import backend_cairo, backend_gtk3
 from .backend_cairo import cairo, HAS_CAIRO_CFFI
+from .backend_gtk3 import _BackendGTK3
 from matplotlib.figure import Figure
+
 
 class RendererGTK3Cairo(backend_cairo.RendererCairo):
     def set_context(self, ctx):
@@ -22,16 +23,14 @@ class RendererGTK3Cairo(backend_cairo.RendererCairo):
 
 class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
                             backend_cairo.FigureCanvasCairo):
-    def __init__(self, figure):
-        backend_gtk3.FigureCanvasGTK3.__init__(self, figure)
 
     def _renderer_init(self):
         """use cairo renderer"""
         self._renderer = RendererGTK3Cairo(self.figure.dpi)
 
     def _render_figure(self, width, height):
-        self._renderer.set_width_height (width, height)
-        self.figure.draw (self._renderer)
+        self._renderer.set_width_height(width, height)
+        self.figure.draw(self._renderer)
 
     def on_draw_event(self, widget, ctx):
         """ GtkDrawable draw event, like expose_event in GTK 2.X
@@ -47,24 +46,7 @@ class FigureManagerGTK3Cairo(backend_gtk3.FigureManagerGTK3):
     pass
 
 
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasGTK3Cairo(figure)
-    manager = FigureManagerGTK3Cairo(canvas, num)
-    return manager
-
-
-FigureCanvas = FigureCanvasGTK3Cairo
-FigureManager = FigureManagerGTK3Cairo
-show = backend_gtk3.show
+@_BackendGTK3.export
+class _BackendGTK3Cairo(_BackendGTK3):
+    FigureCanvas = FigureCanvasGTK3Cairo
+    FigureManager = FigureManagerGTK3Cairo

--- a/lib/matplotlib/backends/backend_gtkagg.py
+++ b/lib/matplotlib/backends/backend_gtkagg.py
@@ -11,10 +11,9 @@ import os
 import matplotlib
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg
-from matplotlib.backends.backend_gtk import gtk, FigureManagerGTK, FigureCanvasGTK,\
-     show, draw_if_interactive,\
-     error_msg_gtk, PIXELS_PER_INCH, backend_version, \
-     NavigationToolbar2GTK
+from matplotlib.backends.backend_gtk import (
+    gtk, _BackendGTK, FigureCanvasGTK, FigureManagerGTK, NavigationToolbar2GTK,
+    backend_version, error_msg_gtk, PIXELS_PER_INCH)
 from matplotlib.backends._gtkagg import agg_to_gtk_drawable
 
 
@@ -34,26 +33,6 @@ class FigureManagerGTKAgg(FigureManagerGTK):
         else:
             toolbar = None
         return toolbar
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    if DEBUG: print('backend_gtkagg.new_figure_manager')
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasGTKAgg(figure)
-    figuremanager = FigureManagerGTKAgg(canvas, num)
-    if DEBUG: print('backend_gtkagg.new_figure_manager done')
-    return figuremanager
 
 
 class FigureCanvasGTKAgg(FigureCanvasGTK, FigureCanvasAgg):
@@ -115,14 +94,7 @@ class FigureCanvasGTKAgg(FigureCanvasGTK, FigureCanvasAgg):
         return agg.print_png(filename, *args, **kwargs)
 
 
-"""\
-Traceback (most recent call last):
-  File "/home/titan/johnh/local/lib/python2.3/site-packages/matplotlib/backends/backend_gtk.py", line 304, in expose_event
-    self._render_figure(self._pixmap, w, h)
-  File "/home/titan/johnh/local/lib/python2.3/site-packages/matplotlib/backends/backend_gtkagg.py", line 77, in _render_figure
-    pixbuf = gtk.gdk.pixbuf_new_from_data(
-ValueError: data length (3156672) is less then required by the other parameters (3160608)
-"""
-
-FigureCanvas = FigureCanvasGTKAgg
-FigureManager = FigureManagerGTKAgg
+@_BackendGTK.export
+class _BackendGTKAgg(_BackendGTK):
+    FigureCanvas = FigureCanvasGTKAgg
+    FigureManager = FigureManagerGTKAgg

--- a/lib/matplotlib/backends/backend_gtkcairo.py
+++ b/lib/matplotlib/backends/backend_gtkcairo.py
@@ -11,28 +11,13 @@ import gtk
 if gtk.pygtk_version < (2, 7, 0):
     import cairo.gtk
 
+from matplotlib import cbook
 from matplotlib.backends import backend_cairo
 from matplotlib.backends.backend_gtk import *
+from matplotlib.backends.backend_gtk import _BackendGTK
 
 backend_version = ('PyGTK(%d.%d.%d) ' % gtk.pygtk_version
                    + 'Pycairo(%s)' % backend_cairo.backend_version)
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasGTKCairo(figure)
-    return FigureManagerGTK(canvas, num)
 
 
 class RendererGTKCairo (backend_cairo.RendererCairo):
@@ -53,6 +38,8 @@ class FigureCanvasGTKCairo(backend_cairo.FigureCanvasCairo, FigureCanvasGTK):
         self._renderer = RendererGTKCairo(self.figure.dpi)
 
 
+# This class has been unused for a while at least.
+@cbook.deprecated("2.1")
 class FigureManagerGTKCairo(FigureManagerGTK):
     def _get_toolbar(self, canvas):
         # must be inited after the window, drawingArea and figure
@@ -64,10 +51,14 @@ class FigureManagerGTKCairo(FigureManagerGTK):
         return toolbar
 
 
+# This class has been unused for a while at least.
+@cbook.deprecated("2.1")
 class NavigationToolbar2Cairo(NavigationToolbar2GTK):
     def _get_canvas(self, fig):
         return FigureCanvasGTKCairo(fig)
 
 
-FigureCanvas = FigureCanvasGTKCairo
-FigureManager = FigureManagerGTKCairo
+@_BackendGTK.export
+class _BackendGTKCairo(_BackendGTK):
+    FigureCanvas = FigureCanvasGTKCairo
+    FigureManager = FigureManagerGTK

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -6,9 +6,9 @@ import six
 import os
 
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase, \
-    NavigationToolbar2, TimerBase
-from matplotlib.backend_bases import ShowBase
+from matplotlib.backend_bases import (
+    _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
+    TimerBase)
 
 from matplotlib.figure import Figure
 from matplotlib import rcParams
@@ -21,49 +21,12 @@ from matplotlib.backends import _macosx
 from .backend_agg import RendererAgg, FigureCanvasAgg
 
 
-class Show(ShowBase):
-    def mainloop(self):
-        _macosx.show()
-show = Show()
-
-
 ########################################################################
 #
 # The following functions and classes are for pylab and implement
 # window/figure managers, etc...
 #
 ########################################################################
-
-def draw_if_interactive():
-    """
-    For performance reasons, we don't want to redraw the figure after
-    each draw command. Instead, we mark the figure as invalid, so that
-    it will be redrawn as soon as the event loop resumes via PyOS_InputHook.
-    This function should be called after each draw event, even if
-    matplotlib is not running interactively.
-    """
-    if matplotlib.is_interactive():
-        figManager =  Gcf.get_active()
-        if figManager is not None:
-            figManager.canvas.invalidate()
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    figure = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, figure)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasMac(figure)
-    manager = FigureManagerMac(canvas, num)
-    return manager
 
 
 class TimerMac(_macosx.Timer, TimerBase):
@@ -248,5 +211,19 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
 #
 ########################################################################
 
-FigureCanvas = FigureCanvasMac
-FigureManager = FigureManagerMac
+@_Backend.export
+class _BackendMac(_Backend):
+    FigureCanvas = FigureCanvasMac
+    FigureManager = FigureManagerMac
+
+    def trigger_manager_draw(manager):
+        # For performance reasons, we don't want to redraw the figure after
+        # each draw command. Instead, we mark the figure as invalid, so that it
+        # will be redrawn as soon as the event loop resumes via PyOS_InputHook.
+        # This function should be called after each draw event, even if
+        # matplotlib is not running interactively.
+        manager.canvas.invalidate()
+
+    @staticmethod
+    def mainloop():
+        _macosx.show()

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -31,8 +31,9 @@ from math import ceil, cos, floor, pi, sin
 import matplotlib
 from matplotlib import __version__, rcParams
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.backend_bases import (RendererBase, GraphicsContextBase,
-                                      FigureManagerBase, FigureCanvasBase)
+from matplotlib.backend_bases import (
+    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.cbook import (Bunch, get_realpath_and_stat,
                               is_writable_file_like, maxdict)
@@ -2425,28 +2426,6 @@ class GraphicsContextPdf(GraphicsContextBase):
 ########################################################################
 
 
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    # if a main-level app must be created, this is the usual place to
-    # do it -- see backend_wx, backend_wxagg and backend_tkagg for
-    # examples.  Not all GUIs require explicit instantiation of a
-    # main-level app (egg backend_gtk, backend_gtkagg) for pylab
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasPdf(figure)
-    manager = FigureManagerPdf(canvas, num)
-    return manager
-
-
 class PdfPages(object):
     """
     A multi-page PDF file.
@@ -2624,5 +2603,7 @@ class FigureManagerPdf(FigureManagerBase):
     pass
 
 
-FigureCanvas = FigureCanvasPdf
-FigureManager = FigureManagerPdf
+@_Backend.export
+class _BackendPdf(_Backend):
+    FigureCanvas = FigureCanvasPdf
+    FigureManager = FigureManagerPdf

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -18,8 +18,9 @@ import warnings
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib.backend_bases import RendererBase, GraphicsContextBase,\
-    FigureManagerBase, FigureCanvasBase
+from matplotlib.backend_bases import (
+    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.figure import Figure
 from matplotlib.text import Text
@@ -743,32 +744,6 @@ class GraphicsContextPgf(GraphicsContextBase):
 ########################################################################
 
 
-def draw_if_interactive():
-    pass
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    # if a main-level app must be created, this is the usual place to
-    # do it -- see backend_wx, backend_wxagg and backend_tkagg for
-    # examples.  Not all GUIs require explicit instantiation of a
-    # main-level app (egg backend_gtk, backend_gtkagg) for pylab
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasPgf(figure)
-    manager = FigureManagerPgf(canvas, num)
-    return manager
-
-
 class TmpDirCleaner(object):
     remaining_tmpdirs = set()
 
@@ -976,8 +951,10 @@ class FigureManagerPgf(FigureManagerBase):
         FigureManagerBase.__init__(self, *args)
 
 
-FigureCanvas = FigureCanvasPgf
-FigureManager = FigureManagerPgf
+@_Backend.export
+class _BackendPgf(_Backend):
+    FigureCanvas = FigureCanvasPgf
+    FigureManager = FigureManagerPgf
 
 
 def _cleanup_all():

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -14,8 +14,9 @@ import io
 from tempfile import mkstemp
 from matplotlib import verbose, __version__, rcParams, checkdep_ghostscript
 from matplotlib.afm import AFM
-from matplotlib.backend_bases import (RendererBase, GraphicsContextBase,
-                                      FigureManagerBase, FigureCanvasBase)
+from matplotlib.backend_bases import (
+    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    RendererBase)
 
 from matplotlib.cbook import (get_realpath_and_stat, is_writable_file_like,
                               maxdict, file_requires_unicode)
@@ -889,21 +890,6 @@ class GraphicsContextPS(GraphicsContextBase):
     def shouldstroke(self):
         return (self.get_linewidth() > 0.0 and
                 (len(self.get_rgb()) <= 3 or self.get_rgb()[3] != 0.0))
-
-
-def new_figure_manager(num, *args, **kwargs):
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasPS(figure)
-    manager = FigureManagerPS(canvas, num)
-    return manager
 
 
 class FigureCanvasPS(FigureCanvasBase):
@@ -1785,5 +1771,8 @@ psDefs = [
     } bind def""",
 ]
 
-FigureCanvas = FigureCanvasPS
-FigureManager = FigureManagerPS
+
+@_Backend.export
+class _BackendPS(_Backend):
+    FigureCanvas = FigureCanvasPS
+    FigureManager = FigureManagerPS

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -8,48 +8,22 @@ import re
 import signal
 import sys
 
-import matplotlib
-
-from matplotlib.backend_bases import FigureManagerBase
-from matplotlib.backend_bases import FigureCanvasBase
-from matplotlib.backend_bases import NavigationToolbar2
-
-from matplotlib.backend_bases import cursors
-from matplotlib.backend_bases import TimerBase
-from matplotlib.backend_bases import ShowBase
-
 from matplotlib._pylab_helpers import Gcf
+from matplotlib.backend_bases import (
+    FigureCanvasBase, FigureManagerBase, NavigationToolbar2, TimerBase,
+    cursors)
 from matplotlib.figure import Figure
-
 from matplotlib.widgets import SubplotTool
 
 from .qt_compat import QtCore, QtWidgets, _getSaveFileName, __version__
 
 from .backend_qt5 import (
     backend_version, SPECIAL_KEYS, SUPER, ALT, CTRL, SHIFT, MODIFIER_KEYS,
-    cursord, draw_if_interactive, _create_qApp, show, TimerQT, MainWindow,
-    FigureManagerQT, NavigationToolbar2QT, SubplotToolQt, error_msg_qt,
-    exception_handler)
+    cursord, _create_qApp, _BackendQT5, TimerQT, MainWindow, FigureManagerQT,
+    NavigationToolbar2QT, SubplotToolQt, error_msg_qt, exception_handler)
 from .backend_qt5 import FigureCanvasQT as FigureCanvasQT5
 
 DEBUG = False
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    thisFig = Figure(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasQT(figure)
-    manager = FigureManagerQT(canvas, num)
-    return manager
 
 
 class FigureCanvasQT(FigureCanvasQT5):
@@ -84,5 +58,6 @@ class FigureCanvasQT(FigureCanvasQT5):
                       'steps = %i ' % (event.delta(), steps))
 
 
-FigureCanvas = FigureCanvasQT
-FigureManager = FigureManagerQT
+@_BackendQT5.export
+class _BackendQT4(_BackendQT5):
+    FigureCanvas = FigureCanvasQT

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -6,31 +6,10 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-import matplotlib
-from matplotlib.figure import Figure
-
 from .backend_agg import FigureCanvasAgg
 from .backend_qt4 import (
-    QtCore, FigureCanvasQT, FigureManagerQT, NavigationToolbar2QT,
-    backend_version, draw_if_interactive, show)
+    QtCore, _BackendQT4, FigureCanvasQT, FigureManagerQT, NavigationToolbar2QT)
 from .backend_qt5agg import FigureCanvasQTAggBase
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasQTAgg(figure)
-    return FigureManagerQT(canvas, num)
 
 
 class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
@@ -46,5 +25,6 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
     """
 
 
-FigureCanvas = FigureCanvasQTAgg
-FigureManager = FigureManagerQT
+@_BackendQT4.export
+class _BackendQT4Agg(_BackendQT4):
+    FigureCanvas = FigureCanvasQTAgg

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -10,31 +10,13 @@ import ctypes
 import traceback
 
 from matplotlib import cbook
-from matplotlib.figure import Figure
 from matplotlib.transforms import Bbox
 
 from .backend_agg import FigureCanvasAgg
 from .backend_qt5 import (
-    QtCore, QtGui, FigureCanvasQT, FigureManagerQT, NavigationToolbar2QT,
-    backend_version, draw_if_interactive, show)
+    QtCore, QtGui, _BackendQT5, FigureCanvasQT, FigureManagerQT,
+    NavigationToolbar2QT, backend_version)
 from .qt_compat import QT_API
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasQTAgg(figure)
-    return FigureManagerQT(canvas, num)
 
 
 class FigureCanvasQTAggBase(FigureCanvasAgg):
@@ -190,5 +172,6 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
         self.figure.dpi = self._dpi_ratio * self.figure._original_dpi
 
 
-FigureCanvas = FigureCanvasQTAgg
-FigureManager = FigureManagerQT
+@_BackendQT5.export
+class _BackendQT5Agg(_BackendQT5):
+    FigureCanvas = FigureCanvasQTAgg

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -15,8 +15,9 @@ from hashlib import md5
 import uuid
 
 from matplotlib import verbose, __version__, rcParams
-from matplotlib.backend_bases import RendererBase, GraphicsContextBase,\
-     FigureManagerBase, FigureCanvasBase
+from matplotlib.backend_bases import (
+     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+    RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.cbook import is_writable_file_like, maxdict
 from matplotlib.colors import rgb2hex
@@ -1254,21 +1255,6 @@ class FigureManagerSVG(FigureManagerBase):
     pass
 
 
-def new_figure_manager(num, *args, **kwargs):
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas  = FigureCanvasSVG(figure)
-    manager = FigureManagerSVG(canvas, num)
-    return manager
-
-
 svgProlog = """\
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
@@ -1277,5 +1263,7 @@ svgProlog = """\
 """
 
 
-FigureCanvas = FigureCanvasSVG
-FigureManager = FigureManagerSVG
+@_Backend.export
+class _BackendSVG(_Backend):
+    FigureCanvas = FigureCanvasSVG
+    FigureManager = FigureManagerSVG

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -176,7 +176,8 @@ def draw_if_interactive():
     For GUI backends - this should be overridden if drawing should be done in
     interactive python mode
     """
-    pass
+    # May be implemented via the `_draw_if_interactive_template` helper.
+
 
 def show():
     """
@@ -195,11 +196,12 @@ def new_figure_manager(num, *args, **kwargs):
     """
     Create a new figure manager instance
     """
-    # if a main-level app must be created, this (and
-    # new_figure_manager_given_figure) is the usual place to
-    # do it -- see backend_wx, backend_wxagg and backend_tkagg for
-    # examples.  Not all GUIs require explicit instantiation of a
-    # main-level app (egg backend_gtk, backend_gtkagg) for pylab
+    # May be implemented via the `_new_figure_manager_template` helper.
+    # If a main-level app must be created, this (and
+    # new_figure_manager_given_figure) is the usual place to do it -- see
+    # backend_wx, backend_wxagg and backend_tkagg for examples.  Not all GUIs
+    # require explicit instantiation of a main-level app (egg backend_gtk,
+    # backend_gtkagg) for pylab.
     FigureClass = kwargs.pop('FigureClass', Figure)
     thisFig = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, thisFig)
@@ -209,6 +211,7 @@ def new_figure_manager_given_figure(num, figure):
     """
     Create a new figure manager instance for the given figure.
     """
+    # May be implemented via the `_new_figure_manager_template` helper.
     canvas = FigureCanvasTemplate(figure)
     manager = FigureManagerTemplate(canvas, num)
     return manager
@@ -257,6 +260,7 @@ class FigureCanvasTemplate(FigureCanvasBase):
 
     def get_default_filetype(self):
         return 'foo'
+
 
 class FigureManagerTemplate(FigureManagerBase):
     """

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -26,27 +26,10 @@ import tornado
 import datetime
 
 from matplotlib.backends import backend_agg
+from matplotlib.backend_bases import _Backend
 from matplotlib.figure import Figure
 from matplotlib import backend_bases
 from matplotlib import _png
-
-
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    canvas = FigureCanvasWebAggCore(figure)
-    manager = FigureManagerWebAgg(canvas, num)
-    return manager
 
 
 # http://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes
@@ -566,3 +549,9 @@ class TimerTornado(backend_bases.TimerBase):
         if self._timer is not None:
             self._timer_stop()
             self._timer_start()
+
+
+@_Backend.export
+class _BackendWebAggCoreAgg(_Backend):
+    FigureCanvas = FigureCanvasWebAggCore
+    FigureManager = FigureManagerWebAgg

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -10,13 +10,10 @@ from .backend_agg import FigureCanvasAgg
 
 from . import wx_compat as wxc
 from . import backend_wx
-from .backend_wx import (FigureManagerWx, FigureCanvasWx,
+from .backend_wx import (_BackendWx, FigureManagerWx, FigureCanvasWx,
     FigureFrameWx, DEBUG_MSG, NavigationToolbar2Wx, Toolbar)
 
 import wx
-
-
-show = backend_wx.Show()
 
 
 class FigureFrameWxAgg(FigureFrameWx):
@@ -101,36 +98,8 @@ class NavigationToolbar2WxAgg(NavigationToolbar2Wx):
         return FigureCanvasWxAgg(frame, -1, fig)
 
 
-def new_figure_manager(num, *args, **kwargs):
-    """
-    Create a new figure manager instance
-    """
-    # in order to expose the Figure constructor to the pylab
-    # interface we need to create the figure here
-    DEBUG_MSG("new_figure_manager()", 3, None)
-    backend_wx._create_wx_app()
-
-    FigureClass = kwargs.pop('FigureClass', Figure)
-    fig = FigureClass(*args, **kwargs)
-
-    return new_figure_manager_given_figure(num, fig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """
-    Create a new figure manager instance for the given figure.
-    """
-    frame = FigureFrameWxAgg(num, figure)
-    figmgr = frame.get_figure_manager()
-    if matplotlib.is_interactive():
-        figmgr.frame.Show()
-        figure.canvas.draw_idle()
-    return figmgr
-
-
-#
 # agg/wxPython image conversion functions (wxPython >= 2.8)
-#
+
 
 def _convert_agg_to_wx_image(agg, bbox):
     """
@@ -193,5 +162,8 @@ def _WX28_clipped_agg_as_bitmap(agg, bbox):
 
     return destBmp
 
-FigureCanvas = FigureCanvasWxAgg
-FigureManager = FigureManagerWx
+
+@_BackendWx.export
+class _BackendWxAgg(_BackendWx):
+    FigureCanvas = FigureCanvasWxAgg
+    _frame_class = FigureFrameWxAgg


### PR DESCRIPTION
This is the second part of #8771, split out for simpler review (note that it also includes the first part, which is the object of #8772; thus, I would suggest specifically looking at the diff of the *last* commit).

Currently, backend modules need to define a number of classes (`FigureCanvas`, `FigureManager`) and functions (`new_figure_manager`, `new_figure_manager_given_figure`, `show`, `draw_if_interactive`) with specified names, which leads to some serious copy-pasting between the modules, as well as seemingly unused imports (see e.g. "not used" comment in backend_qt5agg.py).  Instead, use a class-based approach: the `_Backend` class can be subclassed to define these functions (and provides some templates for them); then a special decorator re-exports the attributes and methods of the `_Backend` class to the backend-defining module.