### PR TITLE
Faster path drawing for the cairo backend (cairocffi only)

### DIFF
--- a/doc/api/backend_cairo_api.rst
+++ b/doc/api/backend_cairo_api.rst
@@ -2,12 +2,7 @@
 :mod:`matplotlib.backends.backend_cairo`
 ========================================
 
-.. Building the docs requires either adding pycairo/cairocffi as docs build
-   dependency, or bumping the minimal numpy version to one that supports
-   MagicMocks (which does define `__index__`) as indices (recent numpys do, but
-   1.7.1 doesn't).
-
-.. .. automodule:: matplotlib.backends.backend_cairo
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
+.. automodule:: matplotlib.backends.backend_cairo
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/backend_cairo_api.rst
+++ b/doc/api/backend_cairo_api.rst
@@ -2,7 +2,12 @@
 :mod:`matplotlib.backends.backend_cairo`
 ========================================
 
-.. automodule:: matplotlib.backends.backend_cairo
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. Building the docs requires either adding pycairo/cairocffi as docs build
+   dependency, or bumping the minimal numpy version to one that supports
+   MagicMocks (which does define `__index__`) as indices (recent numpys do, but
+   1.7.1 doesn't).
+
+.. .. automodule:: matplotlib.backends.backend_cairo
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -307,6 +307,8 @@ class RendererCairo(RendererBase):
             # We actually need to call the setters to reset the internal state.
             vars(gc).update(gc_vars)
             for k, v in gc_vars.items():
+                if k == "_linestyle":  # Deprecated, no effect.
+                    continue
                 try:
                     getattr(gc, "set" + k)(v)
                 except (AttributeError, TypeError) as e:

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -299,7 +299,6 @@ class RendererCairo(RendererBase):
             ctx.move_to(ox, oy)
 
             fontProp = ttfFontProperty(font)
-            ctx.save()
             ctx.select_font_face(fontProp.name,
                                  self.fontangles[fontProp.style],
                                  self.fontweights[fontProp.weight])
@@ -309,7 +308,6 @@ class RendererCairo(RendererBase):
             if not six.PY3 and isinstance(s, six.text_type):
                 s = s.encode("utf-8")
             ctx.show_text(s)
-            ctx.restore()
 
         for ox, oy, w, h in rects:
             ctx.new_path()

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -233,12 +233,12 @@ class RendererCairo(RendererBase):
             # on ctypes to get a pointer to the numpy array. This works
             # correctly on a numpy array in python3 but not 2.7. We replicate
             # the array.array functionality here to get cross version support.
-            imbuffer = ArrayWrapper(im.flatten())
+            imbuffer = ArrayWrapper(im.ravel())
         else:
-            # pycairo uses PyObject_AsWriteBuffer to get a pointer to the
+            # py2cairo uses PyObject_AsWriteBuffer to get a pointer to the
             # numpy array; this works correctly on a regular numpy array but
-            # not on a py2 memoryview.
-            imbuffer = im.flatten()
+            # not on a memory view.
+            imbuffer = im.ravel()
         surface = cairo.ImageSurface.create_for_data(
             imbuffer, cairo.FORMAT_ARGB32,
             im.shape[1], im.shape[0], im.shape[1]*4)


### PR DESCRIPTION
When using cairocffi only:

Accelerate Path drawing by directly constructing a cairo_path_t using numpy operations rather than repeatedly calling the cairo API to add one point at a time.
Accelerate PathCollection drawing by concatenating Paths that have the same drawing parameters (color, etc., i.e. GraphicsContext attributes).
Minor additional performance improvements (remove an unneeded ndarray copy and an unneeded context save/restore pair).

Overall, this brings the performance of examples/mplot3d/wire3d_animation.py (used as a microbenchmark) from ~8.3fps to ~11.6fps on the same computer (just optimizing Paths instead of PathCollections gives ~10.5fps), using the gtk3cairo backend.  As a comparison point, the gtk3agg backend renders ~16.2fps for that example.

From profiling, I believe that further improvements (on that same microbenchmark) could be achieved by improving the text drawing (currently, we use the "toy" API, which is unfortunately the only one exposed by cairocffi so far; additionally, I am not certain whether ft2font exposes pointers to the underlying freetype structures).

Or (for other performance tests) draw_markers could probably also benefit from a similar approach as this PR.