### PR TITLE
Fix typos

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -2902,7 +2902,7 @@ Changes for 0.50
       canvas.show()
       vbox.pack_start(canvas)
 
-    If you use the NavigationToolbar, this in now intialized with a
+    If you use the NavigationToolbar, this in now initialized with a
     FigureCanvas, not a Figure.  The examples embedding_in_gtk.py,
     embedding_in_gtk2.py, and mpl_with_glade.py all reflect the new
     API so use these as a guide.

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -596,7 +596,7 @@ the `API changes <../../api/api_changes.html>`_.
 2010-06-30 Added autoscale convenience method and corresponding
            pyplot function for simplified control of autoscaling;
            and changed axis, set_xlim, and set_ylim so that by
-           default, they turn off the autoscaling on the relevent
+           default, they turn off the autoscaling on the relevant
            axis or axes.  Therefore one can call set_xlim before
            plotting a line, for example, and the limits will be
            retained. - EF

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -39,7 +39,7 @@ def allow_rasterization(draw):
     """
     Decorator for Artist.draw method. Provides routines
     that run before and after the draw call. The before and after functions
-    are useful for changing artist-dependant renderer attributes or making
+    are useful for changing artist-dependent renderer attributes or making
     other setup function calls, such as starting and flushing a mixed-mode
     renderer.
     """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4038,7 +4038,7 @@ or tuple of floats
 
         Make a hexagonal binning plot of *x* versus *y*, where *x*,
         *y* are 1-D sequences of the same length, *N*. If *C* is *None*
-        (the default), this is a histogram of the number of occurences
+        (the default), this is a histogram of the number of occurrences
         of the observations at (x[i],y[i]).
 
         If *C* is specified, it specifies values at the coordinate

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3827,7 +3827,7 @@ class _AxesBase(martist.Artist):
 
     def contains(self, mouseevent):
         """
-        Test whether the mouse event occured in the axes.
+        Test whether the mouse event occurred in the axes.
 
         Returns *True* / *False*, {}
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1702,7 +1702,7 @@ class XAxis(Axis):
     axis_name = 'x'
 
     def contains(self, mouseevent):
-        """Test whether the mouse event occured in the x axis.
+        """Test whether the mouse event occurred in the x axis.
         """
         if callable(self._contains):
             return self._contains(self, mouseevent)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -382,7 +382,7 @@ class RendererBase(object):
                                    all_transforms):
         """
         This is a helper method (along with :meth:`_iter_collection`) to make
-        it easier to write a space-efficent :meth:`draw_path_collection`
+        it easier to write a space-efficient :meth:`draw_path_collection`
         implementation in a backend.
 
         This method yields all of the base path/transform
@@ -433,7 +433,7 @@ class RendererBase(object):
         """
         This is a helper method (along with
         :meth:`_iter_collection_raw_paths`) to make it easier to write
-        a space-efficent :meth:`draw_path_collection` implementation in a
+        a space-efficient :meth:`draw_path_collection` implementation in a
         backend.
 
         This method yields all of the path, offset and graphics

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -79,7 +79,7 @@ class RendererAgg(RendererBase):
     # FigureCanvas acquire a lock on the fontd at the start of the
     # draw, and release it when it is done.  This allows multiple
     # renderers to share the cached fonts, but only one figure can
-    # draw at at time and so the font cache is used by only one
+    # draw at time and so the font cache is used by only one
     # renderer at a time
 
     lock = threading.RLock()

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -548,7 +548,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def contains(self, mouseevent):
         """
-        Test whether the mouse event occured within the image.
+        Test whether the mouse event occurred within the image.
         """
         if callable(self._contains):
             return self._contains(self, mouseevent)
@@ -1195,7 +1195,7 @@ class BboxImage(_ImageBase):
             raise ValueError("unknown type of bbox")
 
     def contains(self, mouseevent):
-        """Test whether the mouse event occured within the image."""
+        """Test whether the mouse event occurred within the image."""
         if callable(self._contains):
             return self._contains(self, mouseevent)
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2312,7 +2312,7 @@ def plotfile(fname, cols=(0,), plotfuncs=None,
              comments='#', skiprows=0, checkrows=5, delimiter=',',
              names=None, subplots=True, newfig=True, **kwargs):
     """
-    Plot the data in in a file.
+    Plot the data in a file.
 
     *cols* is a sequence of column identifiers to plot.  An identifier
     is either an int or a string.  If it is an int, it indicates the

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -85,7 +85,7 @@
 #
 # The Agg, Ps, Pdf and SVG backends do not require external
 # dependencies. Do not choose GTK, GTKAgg, GTKCairo, MacOSX, or TkAgg
-# if you have disabled the relevent extension modules.  Agg will be used
+# if you have disabled the relevant extension modules.  Agg will be used
 # by default.
 #
 #backend = Agg


### PR DESCRIPTION
This PR fixes some typos: `intialized`, `relevent`, `dependant`, `occurences`, `occured`, `efficent`, `at at`, and `in in`.