### PR TITLE
Fix typos

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -925,7 +925,7 @@ class Barbs(mcollections.PolyCollection):
         self.flip = kw.pop('flip_barb', False)
         transform = kw.pop('transform', ax.transData)
 
-        # Flagcolor and and barbcolor provide convenience parameters for
+        # Flagcolor and barbcolor provide convenience parameters for
         # setting the facecolor and edgecolor, respectively, of the barb
         # polygon.  We also work here to make the flag the same color as the
         # rest of the barb by default

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -410,7 +410,7 @@ def test_light_source_shading_default():
     ls = mcolors.LightSource(315, 45)
     rgb = ls.shade(z, cmap)
 
-    # Result stored transposed and rounded for for more compact display...
+    # Result stored transposed and rounded for more compact display...
     expect = np.array(
         [[[0.00, 0.45, 0.90, 0.90, 0.82, 0.62, 0.28, 0.00],
           [0.45, 0.94, 0.99, 1.00, 1.00, 0.96, 0.65, 0.17],
@@ -475,7 +475,7 @@ def test_light_source_masked_shading():
     ls = mcolors.LightSource(315, 45)
     rgb = ls.shade(z, cmap)
 
-    # Result stored transposed and rounded for for more compact display...
+    # Result stored transposed and rounded for more compact display...
     expect = np.array(
         [[[0.00, 0.46, 0.91, 0.91, 0.84, 0.64, 0.29, 0.00],
           [0.46, 0.96, 1.00, 1.00, 1.00, 0.97, 0.67, 0.18],

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -57,7 +57,7 @@ class TriInterpolator(object):
         self._unit_y = 1.0
 
         # Default triangle renumbering: None (= no renumbering)
-        # Renumbering may be used to avoid unecessary computations
+        # Renumbering may be used to avoid unnecessary computations
         # if complex calculations are done inside the Interpolator.
         # Please refer to :meth:`_interpolate_multikeys` for details.
         self._tri_renum = None

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -55,7 +55,7 @@
 # therefore they are installed unconditionally.
 #
 # You can uncomment any the following lines to change this
-# behavior. Acceptible values are:
+# behavior. Acceptable values are:
 #
 #     True: build the extension. Exits with a warning if the
 #           required dependencies are not available

--- a/src/_contour.cpp
+++ b/src/_contour.cpp
@@ -1213,7 +1213,7 @@ void QuadContourGenerator::init_cache_grid(const MaskArray& mask)
     long i, j, quad;
 
     if (mask.empty()) {
-        // No mask, easy to calculate quad existance and boundaries together.
+        // No mask, easy to calculate quad existence and boundaries together.
         quad = 0;
         for (j = 0; j < _ny; ++j) {
             for (i = 0; i < _nx; ++i, ++quad) {


### PR DESCRIPTION
This PR fixes some typos: `and and`, `for for`, `unecessary`, `Acceptible`, and `existance`.