### PR TITLE
Catch exception for PyPy

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -174,8 +174,8 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             def finalize(wrapper, new_doc):
                 try:
                     obj.__doc__ = new_doc
-                except AttributeError:
-                    pass  # cls.__doc__ is not writeable on Py2.
+                except (AttributeError, TypeError):
+                    pass  # cls.__doc__ is not writeable on Py2. TypeError occurs on PyPy
                 obj.__init__ = wrapper
                 return obj
         else:

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -176,7 +176,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                     obj.__doc__ = new_doc
                 except (AttributeError, TypeError):
                     pass  # cls.__doc__ is not writeable on Py2. 
-				          #TypeError occurs on PyPy
+                          #TypeError occurs on PyPy
                 obj.__init__ = wrapper
                 return obj
         else:

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -175,8 +175,9 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                 try:
                     obj.__doc__ = new_doc
                 except (AttributeError, TypeError):
-                    pass  # cls.__doc__ is not writeable on Py2. 
-                          #TypeError occurs on PyPy
+                    # cls.__doc__ is not writeable on Py2.
+                    # TypeError occurs on PyPy
+                    pass
                 obj.__init__ = wrapper
                 return obj
         else:

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -175,7 +175,8 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                 try:
                     obj.__doc__ = new_doc
                 except (AttributeError, TypeError):
-                    pass  # cls.__doc__ is not writeable on Py2. TypeError occurs on PyPy
+                    pass  # cls.__doc__ is not writeable on Py2. 
+				          #TypeError occurs on PyPy
                 obj.__init__ = wrapper
                 return obj
         else:


### PR DESCRIPTION
## PR Summary

Catch additional exception, specific for PyPy (equivalent of Python 2.7). 
Because in python 2.7 `obj.__doc__` is read only, PyPy will throw an TypeError exception(somehow equivalent to AttributeError from CPython)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
