### PR TITLE
BUGS: in colorbar: divide-by-zero, and undesired masked array

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -801,6 +801,7 @@ class ColorbarBase(cm.ScalarMappable):
             y = y / (self._boundaries[-1] - self._boundaries[0])
         else:
             y = self.norm(self._boundaries.copy())
+            y = np.ma.filled(y, np.nan)
         if self.extend == 'min':
             # Exclude leftmost interval of y.
             clen = y[-1] - y[1]
@@ -811,21 +812,22 @@ class ColorbarBase(cm.ScalarMappable):
             clen = y[-2] - y[0]
             automin = (y[1] - y[0]) / clen
             automax = (y[-2] - y[-3]) / clen
-        else:
+        elif self.extend == 'both':
             # Exclude leftmost and rightmost intervals in y.
             clen = y[-2] - y[1]
             automin = (y[2] - y[1]) / clen
             automax = (y[-2] - y[-3]) / clen
-        extendlength = self._get_extension_lengths(self.extendfrac,
-                                                   automin, automax,
-                                                   default=0.05)
+        if self.extend in ('both', 'min', 'max'):
+            extendlength = self._get_extension_lengths(self.extendfrac,
+                                                       automin, automax,
+                                                       default=0.05)
         if self.extend in ('both', 'min'):
             y[0] = 0. - extendlength[0]
         if self.extend in ('both', 'max'):
             y[-1] = 1. + extendlength[1]
         yi = y[self._inside]
         norm = colors.Normalize(yi[0], yi[-1])
-        y[self._inside] = norm(yi)
+        y[self._inside] = np.ma.filled(norm(yi), np.nan)
         return y
 
     def _mesh(self):


### PR DESCRIPTION
Closes #8534 (divide-by-zero warning).
Also fixes a bug that became evident with #8801, which causes
pcolormesh to fail if X or Y is a masked array.  Although masked
arrays are not supported by pcolormesh, previously it would ignore
the mask.  Locators always return masked arrays, so the present
commit explicitly converts to an ndarray the Locator output used
by proportional colorbars.
