### PR TITLE
document axhline from hlines docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -705,7 +705,8 @@ or tuple of floats
 
         See also
         --------
-        axhspan : for example plot and source code
+        hline : add horizontal lines in data coordinates
+        axhspan : add a horizontal span (rectangle) across the axis
         """
 
         if "transform" in kwargs:
@@ -771,7 +772,8 @@ or tuple of floats
 
         See also
         --------
-        axhspan : for example plot and source code
+        vline : add vertical lines in data coordinates
+        axvspan : add a vertical span (rectangle) across the axis
         """
 
         if "transform" in kwargs:
@@ -830,8 +832,7 @@ or tuple of floats
 
         See Also
         --------
-        axvspan : Add a vertical span (rectangle) across the axes.
-
+        axvspan : add a vertical span across the axes
         """
         trans = self.get_yaxis_transform(which='grid')
 
@@ -888,7 +889,7 @@ or tuple of floats
 
         See Also
         --------
-        axhspan
+        axhspan : add a horizontal span across the axes
 
         Examples
         --------
@@ -947,7 +948,7 @@ or tuple of floats
         See also
         --------
         vlines : vertical lines
-
+        axhline: horizontal line across the axes
         """
 
         # We do the conversion first since not all unitized data is uniform
@@ -1025,7 +1026,7 @@ or tuple of floats
         See also
         --------
         hlines : horizontal lines
-
+        axvline: vertical line across the axes
         """
 
         self._process_unit_info(xdata=x, ydata=[ymin, ymax], kwargs=kwargs)


### PR DESCRIPTION
I propose these small additions in the docstrings ("see also" sections) of the axhlines, axhspan and hlines family of axes methods to increase the discoverability of axhline (and same for axvline of course). Indeed, it's been years I've been working around `ax.hlines` to get lines which spans the entire axis... only to discover today `ax.axhline` out of pure chance, by reading the [Transformations Tutorial](https://matplotlib.org/users/transforms_tutorial.html).

In the end I tried to write a coherent and useful set of cross references between the six methods ( axhlines, axhspan and hlines, and vertical counterparts). I've favored compactness over exhaustivity.