### PR TITLE
Update make.py clean for tutorials

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -161,7 +161,7 @@ def texinfo():
 def clean():
     """Remove generated files. """
     shutil.rmtree("build", ignore_errors=True)
-    shutil.rmtree("examples", ignore_errors=True)
+    shutil.rmtree("tutorials", ignore_errors=True)
     shutil.rmtree("api/_as_gen", ignore_errors=True)
     for pattern in ['_static/matplotlibrc',
                     '_templates/gallery.html',


### PR DESCRIPTION
Since tutorials were added, `doc/examples` no longer is generated, but `doc/tutorials` is. This updates `python make.py clean` to work with this change.