### PR TITLE
Fix typos

### DIFF
--- a/examples/user_interfaces/interactive_sgskip.py
+++ b/examples/user_interfaces/interactive_sgskip.py
@@ -84,7 +84,7 @@ class Completer(object):
         Assuming the text is of the form NAME.NAME....[NAME], and is
         evaluatable in the globals of __main__, it will be evaluated
         and its attributes (as revealed by dir()) are used as possible
-        completions.  (For class instances, class members are are also
+        completions.  (For class instances, class members are also
         considered.)
 
         WARNING: this can still invoke arbitrary C code, if an object

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2315,7 +2315,7 @@ or tuple of floats
 
         A stem plot plots vertical lines (using *linefmt*) at each *x*
         location from the baseline to *y*, and places a marker there
-        using *markerfmt*.  A horizontal line at 0 is is plotted using
+        using *markerfmt*.  A horizontal line at 0 is plotted using
         *basefmt*.
 
         If no *x* values are provided, the default is (0, 1, ..., len(y) - 1)

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -452,7 +452,7 @@ class ContourLabeler(object):
 
             # Round to integer values but keep as float
             # To allow check against nan below
-            # Ignore nans here to avoid throwing an error on on Appveyor build
+            # Ignore nans here to avoid throwing an error on Appveyor build
             # (can possibly be removed when build uses numpy 1.13)
             with np.errstate(invalid='ignore'):
                 I = [np.floor(I[0]), np.ceil(I[1])]

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -378,7 +378,7 @@ def test_rasterize_dpi():
     # It plots a rasterized line and a normal image with implot. So it will catch
     # when images end up in the wrong place in case of non-standard dpi setting.
     # Instead of high-res rasterization i use low-res.  Therefore the fact that the
-    # resolution is non-standard is is easily checked by image_comparison.
+    # resolution is non-standard is easily checked by image_comparison.
     import numpy as np
     import matplotlib.pyplot as plt
 

--- a/tutorials/01_introductory/usage.py
+++ b/tutorials/01_introductory/usage.py
@@ -424,7 +424,7 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #                and pycairo_ or cairocffi_; Python2 only)
 # GTK3Cairo      Cairo rendering to a :term:`GTK` 3.x canvas (requires PyGObject_
 #                and pycairo_ or cairocffi_)
-# WXAgg          Agg rendering to to a :term:`wxWidgets` canvas
+# WXAgg          Agg rendering to a :term:`wxWidgets` canvas
 #                (requires wxPython_)
 # WX             Native :term:`wxWidgets` drawing to a :term:`wxWidgets` Canvas
 #                (not recommended and deprecated in 2.0) (requires wxPython_)

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -98,7 +98,7 @@ which removes some postscript operators used by LaTeX that are illegal in an
 eps file. This step produces results which may be unacceptable to some users,
 because the text is coarsely rasterized and converted to bitmaps, which are not
 scalable like standard postscript, and the text is not searchable. One
-workaround is to to set ``ps.distiller.res`` to a higher value (perhaps 6000)
+workaround is to set ``ps.distiller.res`` to a higher value (perhaps 6000)
 in your rc settings, which will produce larger files but may look better and
 scale reasonably. A better workaround, which requires Poppler_ or Xpdf_, can be
 activated by changing the ``ps.usedistiller`` rc setting to ``xpdf``. This


### PR DESCRIPTION
This PR fixes some typos: `are are`, `is is`, `on on`, and `to to`.