### PR TITLE
ENH: add fill argument to AnchoredSizeBar

### DIFF
--- a/doc/users/whats_new/anchoredsizebar_fill_argument.rst
+++ b/doc/users/whats_new/anchoredsizebar_fill_argument.rst
@@ -1,0 +1,6 @@
+Add fill argument to `AnchoredSizeBar`
+--------------------------------------
+
+The mpl_toolkits class :class:`~mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`
+now has an additional ``fill`` argument, which makes the rectangle solid instead of just
+drawing the border of the rectangle. The default is False.

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -232,8 +232,8 @@ class AnchoredSizeBar(AnchoredOffsetbox):
     def __init__(self, transform, size, label, loc,
                  pad=0.1, borderpad=0.1, sep=2,
                  frameon=True, size_vertical=0, color='black',
-                 fill=False, label_top=False, fontproperties=None,
-                 **kwargs):
+                 label_top=False, fontproperties=None,
+                 fill=False, **kwargs):
         """
         Draw a horizontal scale bar with a center-aligned label underneath.
 
@@ -288,15 +288,15 @@ class AnchoredSizeBar(AnchoredOffsetbox):
             Color for the size bar and label.
             Defaults to black.
 
-        fill : bool, optional
-            Sizebar rectangle fill. Defaults to False.
-
         label_top : bool, optional
             If True, the label will be over the size bar.
             Defaults to False.
 
         fontproperties : `matplotlib.font_manager.FontProperties`, optional
             Font properties for the label text.
+
+        fill : bool, optional
+            Sizebar rectangle fill. Defaults to False.
 
         **kwargs :
             Keyworded arguments to pass to

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -232,7 +232,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
     def __init__(self, transform, size, label, loc,
                  pad=0.1, borderpad=0.1, sep=2,
                  frameon=True, size_vertical=0, color='black',
-                 label_top=False, fontproperties=None,
+                 fill=False, label_top=False, fontproperties=None,
                  **kwargs):
         """
         Draw a horizontal scale bar with a center-aligned label underneath.
@@ -288,6 +288,9 @@ class AnchoredSizeBar(AnchoredOffsetbox):
             Color for the size bar and label.
             Defaults to black.
 
+        fill : bool, optional
+            Sizebar rectangle fill. Defaults to False.
+
         label_top : bool, optional
             If True, the label will be over the size bar.
             Defaults to False.
@@ -336,7 +339,7 @@ fontproperties=fontprops)
         """
         self.size_bar = AuxTransformBox(transform)
         self.size_bar.add_artist(Rectangle((0, 0), size, size_vertical,
-                                           fill=False, facecolor=color,
+                                           fill=fill, facecolor=color,
                                            edgecolor=color))
 
         if fontproperties is None and 'prop' in kwargs:


### PR DESCRIPTION
## PR Summary

This pull request introduces a optional AnchoredSizeBar argument for filling the rectangle used in the sizebar.

Having the option to have a filled rectangle is useful when plotting scalebars for microscopy images, where this is the conventional way.

```Python
import matplotlib.pyplot as plt
from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar

fig, ax = plt.subplots(figsize=(3, 3))

bar0 = AnchoredSizeBar(ax.transData, 0.3, '0.3', loc=3, frameon=False, size_vertical=0.05)
ax.add_artist(bar0)
bar1 = AnchoredSizeBar(ax.transData, 0.3, '0.3', loc=4, frameon=False, fill=True, size_vertical=0.05)
ax.add_artist(bar1)
fig.savefig("sizebar_fill.png")
```
![sizebar_fill](https://user-images.githubusercontent.com/1690979/27738208-9f6c91ba-5da2-11e7-9d74-fb5e3c35e003.png)

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant