### PR TITLE
Allow zero dash linewidth

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1032,7 +1032,7 @@ class GraphicsContextBase(object):
         """
         if dash_list is not None:
             dl = np.asarray(dash_list)
-            if np.any(dl <= 0.0):
+            if np.any(dl < 0.0):
                 raise ValueError("All values in the dash list must be positive")
         self._dashes = dash_offset, dash_list
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5113,3 +5113,8 @@ def test_twinx_knows_limits():
     ax2.plot([0, 0.5], [1, 2])
 
     assert((xtwin.viewLim.intervalx == ax2.viewLim.intervalx).all())
+
+
+def test_zero_linewidth():
+    # Check that setting a zero linewidth doesn't error
+    plt.plot([0, 1], [0, 1], ls='--', lw=0)


### PR DESCRIPTION
Allow `0` as a valid value for dash linewidths. Fixes #8821 .