### PR TITLE
Fix typos

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -320,9 +320,9 @@ class FigureCanvasTkAgg(FigureCanvasAgg):
         # backend_bases, the canvas needs to know _lastx and _lasty.
         # There are three ways to get this info the canvas:
         #
-        # 1) set it explicity
+        # 1) set it explicitly
         #
-        # 2) call enter/leave events explicity.  The downside of this
+        # 2) call enter/leave events explicitly.  The downside of this
         #    in the impl below is that enter could be repeatedly
         #    triggered if thes  mouse is over the axes and one is
         #    resizing with the keyboard.  This is not entirely bad,

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -45,7 +45,7 @@ Call signatures::
   quiver(X, Y, U, V, **kw)
   quiver(X, Y, U, V, C, **kw)
 
-*U* and *V* are the arrow data, *X* and *Y* set the locaiton of the
+*U* and *V* are the arrow data, *X* and *Y* set the location of the
 arrows, and *C* sets the color of the arrows. These arguments may be 1-D or
 2-D arrays or sequences.
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1481,7 +1481,7 @@ def test_contour_colorbar():
 @image_comparison(baseline_images=['hist2d', 'hist2d'])
 def test_hist2d():
     np.random.seed(0)
-    # make it not symetric in case we switch x and y axis
+    # make it not symmetric in case we switch x and y axis
     x = np.random.randn(100)*2+5
     y = np.random.randn(100)-2
     fig = plt.figure()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2267,7 +2267,7 @@ class Axes3D(Axes):
 
         Supported are:
             - PolyCollection
-            - LineColleciton
+            - LineCollection
             - PatchCollection
         '''
         zvals = np.atleast_1d(zs)


### PR DESCRIPTION
This PR fixes some typos: `explicity`, `locaiton`, `symetric`, and `Colleciton`.