### PR TITLE
Allow users to control the fill for AnchoredSizeBar

### DIFF
--- a/doc/users/whats_new/anchoredsizebar_fill_bar_argument.rst
+++ b/doc/users/whats_new/anchoredsizebar_fill_bar_argument.rst
@@ -1,0 +1,13 @@
+Add fill_bar argument to ``AnchoredSizeBar``
+--------------------------------------------
+
+The mpl_toolkits class
+:class:`~mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar` now has an
+additional ``fill_bar`` argument, which makes the size bar a solid rectangle
+instead of just drawing the border of the rectangle. The default is ``None``,
+and whether or not the bar will be filled by default depends on the value of
+``size_vertical``. If ``size_vertical`` is nonzero, ``fill_bar`` will be set to
+``True``. If ``size_vertical`` is zero then ``fill_bar`` will be set to
+``False``. If you wish to override this default behavior, set ``fill_bar`` to
+``True`` or ``False`` to unconditionally always or never use a filled patch
+rectangle for the size bar.

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -232,7 +232,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
     def __init__(self, transform, size, label, loc,
                  pad=0.1, borderpad=0.1, sep=2,
                  frameon=True, size_vertical=0, color='black',
-                 label_top=False, fontproperties=None,
+                 label_top=False, fontproperties=None, fill_bar=False,
                  **kwargs):
         """
         Draw a horizontal scale bar with a center-aligned label underneath.
@@ -295,6 +295,11 @@ class AnchoredSizeBar(AnchoredOffsetbox):
         fontproperties : `matplotlib.font_manager.FontProperties`, optional
             Font properties for the label text.
 
+        fill_bar : bool, optional
+            If True and if size_vertical is nonzero, the size bar will
+            be filled in with the color specified by the size bar.
+            Defaults to False.
+
         **kwargs :
             Keyworded arguments to pass to
             :class:`matplotlib.offsetbox.AnchoredOffsetbox`.
@@ -336,7 +341,7 @@ fontproperties=fontprops)
         """
         self.size_bar = AuxTransformBox(transform)
         self.size_bar.add_artist(Rectangle((0, 0), size, size_vertical,
-                                           fill=False, facecolor=color,
+                                           fill=fill_bar, facecolor=color,
                                            edgecolor=color))
 
         if fontproperties is None and 'prop' in kwargs:

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -232,7 +232,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
     def __init__(self, transform, size, label, loc,
                  pad=0.1, borderpad=0.1, sep=2,
                  frameon=True, size_vertical=0, color='black',
-                 label_top=False, fontproperties=None, fill_bar=False,
+                 label_top=False, fontproperties=None, fill_bar=None,
                  **kwargs):
         """
         Draw a horizontal scale bar with a center-aligned label underneath.
@@ -298,7 +298,8 @@ class AnchoredSizeBar(AnchoredOffsetbox):
         fill_bar : bool, optional
             If True and if size_vertical is nonzero, the size bar will
             be filled in with the color specified by the size bar.
-            Defaults to False.
+            Defaults to True if `size_vertical` is greater than
+            zero and False otherwise.
 
         **kwargs :
             Keyworded arguments to pass to
@@ -339,6 +340,9 @@ sep=5, borderpad=0.5, frameon=False, \
 size_vertical=0.5, color='white', \
 fontproperties=fontprops)
         """
+        if fill_bar is None:
+            fill_bar = size_vertical > 0
+
         self.size_bar = AuxTransformBox(transform)
         self.size_bar.add_artist(Rectangle((0, 0), size, size_vertical,
                                            fill=fill_bar, facecolor=color,


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Currently it's only possible to control the `fill` property for the `Rectangle` patch created by the AnchoredSizeBar by doing something like:

```
bar = AnchoredSizeBar(...)
bar.size_bar._children[0].set_fill(True)
```

This is very non-obvious and as far as I can tell can only be accomplished by manipulating the private `_children` attribute.

### What this does

This PR adds a new keyword argument to the `AnchoredSizeBar` initializer that allows users to control the `fill` keyword argument passed to the `Rectangle` patch, making it possible to easily create filled size bars.