### PR TITLE
Prefer to the GraphicsContext public API when possible.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1120,9 +1120,10 @@ class GraphicsContextBase(object):
         """
         Returns a Path for the current hatch.
         """
-        if self._hatch is None:
+        hatch = self.get_hatch()
+        if hatch is None:
             return None
-        return Path.hatch(self._hatch, density)
+        return Path.hatch(hatch, density)
 
     def get_hatch_color(self):
         """
@@ -1178,16 +1179,15 @@ class GraphicsContextBase(object):
 
         length : float, optional
              The length of the wiggle along the line, in pixels
-             (default 128.0)
+             (default 128)
 
         randomness : float, optional
             The scale factor by which the length is shrunken or
-            expanded (default 16.0)
+            expanded (default 16)
         """
-        if scale is None:
-            self._sketch = None
-        else:
-            self._sketch = (scale, length or 128.0, randomness or 16.0)
+        self._sketch = (
+            None if scale is None
+            else (scale, length or 128., randomness or 16.))
 
 
 class TimerBase(object):

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -386,6 +386,8 @@ class PathPatchEffect(AbstractPathEffect):
         affine = self._offset_transform(renderer, affine)
         self.patch._path = tpath
         self.patch.set_transform(affine)
-        self.patch.set_clip_box(gc._cliprect)
-        self.patch.set_clip_path(gc._clippath)
+        self.patch.set_clip_box(gc.get_clip_rectangle())
+        clip_path = gc.get_clip_path()
+        if clip_path:
+            self.patch.set_clip_path(*clip_path)
         self.patch.draw(renderer)


### PR DESCRIPTION
This allows independent backends to just implement the corresponding
methods, rather than also having to provide the private attributes.

Also simplify the signature/implementation of set_sketch_params.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
