### PR TITLE
Ci appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,9 +68,7 @@ install:
   # for obvci_appveyor_python_build_env.cmd
   - conda install -c pelson/channel/development --yes --quiet obvious-ci
   # for msinttypes and newer stuff
-  # conda-forge may serve outdated versions of certain packages (e.g. conda
-  # itself), so append it to the end of the list.
-  - conda config --append channels conda-forge
+  - conda config --prepend channels conda-forge
   - conda config --set show_channel_urls yes
   - conda config --set always_yes true
   # For building conda packages

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,6 @@ environment:
       CONDA_PY: "35"
       CONDA_NPY: "110"
       PYTHON_VERSION: "3.5"
-      TEST_ALL: "no"
       CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
       TEST_ALL: "yes"
     #    - TARGET_ARCH: "x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,15 +36,15 @@ environment:
       PYTHON_VERSION: "3.5"
       TEST_ALL: "no"
       CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
-    - TARGET_ARCH: "x64"
-      CONDA_PY: "36"
-      PYTHON_VERSION: "3.6"
-      # this variable influence pdf/svg and most importantly the latex related tests
-      # which triples the runtime of the tests (7-8min vs 30min).
-      # pick the one which seems to make the most problems and run it last, so that
-      # the rest of the tests can give feedback earlier
       TEST_ALL: "yes"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    #    - TARGET_ARCH: "x64"
+    #      CONDA_PY: "36"
+    #      PYTHON_VERSION: "3.6"
+    #      # this variable influence pdf/svg and most importantly the latex related tests
+    #      # which triples the runtime of the tests (7-8min vs 30min).
+    #      # pick the one which seems to make the most problems and run it last, so that
+    #      # the rest of the tests can give feedback earlier
+    #      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ environment:
     - TARGET_ARCH: "x64"
       CONDA_PY: "36"
       PYTHON_VERSION: "3.6"
-      CONDA_NPY: "110"
+      CONDA_NPY: "111"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
       TEST_ALL: "no"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,6 +39,7 @@ environment:
     - TARGET_ARCH: "x64"
       CONDA_PY: "36"
       PYTHON_VERSION: "3.6"
+      CONDA_NPY: "112"
       # this variable influence pdf/svg and most importantly the latex related tests
       # which triples the runtime of the tests (7-8min vs 30min).
       # pick the one which seems to make the most problems and run it last, so that

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,15 +35,16 @@ environment:
       CONDA_NPY: "110"
       PYTHON_VERSION: "3.5"
       CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
-      TEST_ALL: "yes"
-    #    - TARGET_ARCH: "x64"
-    #      CONDA_PY: "36"
-    #      PYTHON_VERSION: "3.6"
-    #      # this variable influence pdf/svg and most importantly the latex related tests
-    #      # which triples the runtime of the tests (7-8min vs 30min).
-    #      # pick the one which seems to make the most problems and run it last, so that
-    #      # the rest of the tests can give feedback earlier
-    #      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+      TEST_ALL: "no"
+    - TARGET_ARCH: "x64"
+      CONDA_PY: "36"
+      PYTHON_VERSION: "3.6"
+      # this variable influence pdf/svg and most importantly the latex related tests
+      # which triples the runtime of the tests (7-8min vs 30min).
+      # pick the one which seems to make the most problems and run it last, so that
+      # the rest of the tests can give feedback earlier
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+      TEST_ALL: "no"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,11 +39,7 @@ environment:
     - TARGET_ARCH: "x64"
       CONDA_PY: "36"
       PYTHON_VERSION: "3.6"
-      CONDA_NPY: "112"
-      # this variable influence pdf/svg and most importantly the latex related tests
-      # which triples the runtime of the tests (7-8min vs 30min).
-      # pick the one which seems to make the most problems and run it last, so that
-      # the rest of the tests can give feedback earlier
+      CONDA_NPY: "110"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
       TEST_ALL: "no"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,16 +36,15 @@ environment:
       PYTHON_VERSION: "3.5"
       TEST_ALL: "no"
       CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
-    - TARGET_ARCH: "x86"
-      CONDA_PY: "27"
-      CONDA_NPY: "18"
-      PYTHON_VERSION: "2.7"
+    - TARGET_ARCH: "x64"
+      CONDA_PY: "36"
+      PYTHON_VERSION: "3.6"
       # this variable influence pdf/svg and most importantly the latex related tests
       # which triples the runtime of the tests (7-8min vs 30min).
       # pick the one which seems to make the most problems and run it last, so that
       # the rest of the tests can give feedback earlier
       TEST_ALL: "yes"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,12 +24,12 @@ environment:
     # theoretically the CONDA_INSTALL_LOCN could be only two: one for 32bit,
     # one for 64bit because we construct envs anyway. But using one for the
     # right python version is hopefully making it fast due to package caching.
-    - TARGET_ARCH: "x64"
-      CONDA_PY: "27"
-      CONDA_NPY: "18"
-      PYTHON_VERSION: "2.7"
-      TEST_ALL: "no"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+    #    - TARGET_ARCH: "x64"
+    #      CONDA_PY: "27"
+    #      CONDA_NPY: "18"
+    #      PYTHON_VERSION: "2.7"
+    #      TEST_ALL: "no"
+    #      CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
     - TARGET_ARCH: "x64"
       CONDA_PY: "35"
       CONDA_NPY: "110"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
   - set PYTHONUNBUFFERED=1
   # for obvci_appveyor_python_build_env.cmd
-  - conda install -c pelson/channel/development --yes --quiet obvious-ci
+  - conda install -c conda-forge --yes --quiet obvious-ci
   # for msinttypes and newer stuff
   - conda config --prepend channels conda-forge
   - conda config --set show_channel_urls yes


### PR DESCRIPTION
hack for #8849 by just skipping python 2.7

If this passes I plan to merge myself and leave #8849 open to go back and fix 2.7 when the upstream conda-build bug is fixed.