### PR TITLE
Fix typos

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2479,7 +2479,7 @@ def key_press_handler(event, canvas, toolbar=None):
         except AttributeError:
             pass
 
-    # quit the figure (defaut key 'ctrl+w')
+    # quit the figure (default key 'ctrl+w')
     if event.key in quit_keys:
         Gcf.destroy_fig(canvas.figure)
 

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -173,7 +173,7 @@ class GraphicsContextTemplate(GraphicsContextBase):
 def draw_if_interactive():
     """
     For image backends - is not required
-    For GUI backends - this should be overriden if drawing should be done in
+    For GUI backends - this should be overridden if drawing should be done in
     interactive python mode
     """
     pass

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1181,7 +1181,7 @@ def _create_wx_app():
 
 def draw_if_interactive():
     """
-    This should be overriden in a windowing environment if drawing
+    This should be overridden in a windowing environment if drawing
     should be done in interactive python mode
     """
     DEBUG_MSG("draw_if_interactive()", 1, None)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1848,7 +1848,7 @@ class Figure(Artist):
         coordinates of each click in a list.
 
         The buttons used for the various actions (adding points, removing
-        points, terminating the inputs) can be overriden via the
+        points, terminating the inputs) can be overridden via the
         arguments *mouse_add*, *mouse_pop* and *mouse_stop*, that give
         the associated mouse button: 1 for left, 2 for middle, 3 for
         right.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1972,7 +1972,7 @@ class BoxStyle(_Style):
         def transmute(self, x0, y0, width, height, mutation_size):
             """
             The transmute method is a very core of the
-            :class:`BboxTransmuter` class and must be overriden in the
+            :class:`BboxTransmuter` class and must be overridden in the
             subclasses. It receives the location and size of the
             rectangle, and the mutation_size, with which the amount of
             padding and etc. will be scaled. It returns a
@@ -3210,7 +3210,7 @@ class ArrowStyle(_Style):
         def transmute(self, path, mutation_size, linewidth):
             """
             The transmute method is the very core of the ArrowStyle
-            class and must be overriden in the subclasses. It receives
+            class and must be overridden in the subclasses. It receives
             the path object along which the arrow will be drawn, and
             the mutation_size, with which the arrow head etc.
             will be scaled. The linewidth may be used to adjust

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -133,7 +133,7 @@ def test_customcell():
 def test_auto_column():
     fig = plt.figure()
 
-    #iteratble list input
+    # iterable list input
     ax1 = fig.add_subplot(4, 1, 1)
     ax1.axis('off')
     tb1 = ax1.table(cellText=[['Fit Text', 2],
@@ -145,7 +145,7 @@ def test_auto_column():
     tb1.set_fontsize(12)
     tb1.auto_set_column_width([-1, 0, 1])
 
-    #iteratble tuple input
+    # iterable tuple input
     ax2 = fig.add_subplot(4, 1, 2)
     ax2.axis('off')
     tb2 = ax2.table(cellText=[['Fit Text', 2],

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -81,7 +81,7 @@ class Widget(object):
         """
         return self._active
 
-    # set_active is overriden by SelectorWidgets.
+    # set_active is overridden by SelectorWidgets.
     active = property(get_active, lambda self, active: self.set_active(active),
                       doc="Is the widget active?")
 


### PR DESCRIPTION
This PR fixes some typos: `defaut`, `overriden`, and `iteratble`.