### PR TITLE
Changed dev docs to use https://github.com instead of git@github.com

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -67,9 +67,11 @@ We use `Git <https://git-scm.com/>`_ for version control and
 You can check out the latest sources with the command (see
 :ref:`set-up-fork` for more details)::
 
-    git clone git@github.com:matplotlib/matplotlib.git
+    git clone https://github.com:matplotlib/matplotlib.git
 
-and navigate to the :file:`matplotlib` directory.
+and navigate to the :file:`matplotlib` directory. If you have the proper privileges, 
+you can use ``git@`` instead of  ``https://``, which works through the ssh protocol 
+and might be easier to use if you are using 2-factor authentication.
 
 To make sure the tests run locally you must build against the correct version
 of freetype.  To configure the build system to fetch and build it either export
@@ -156,7 +158,7 @@ then submit a "pull request" (PR):
 
  3. Clone this copy to your local disk::
 
-        $ git clone git@github.com:YourLogin/matplotlib.git
+        $ git clone https://github.com:YourLogin/matplotlib.git
 
  4. Create a branch to hold your changes::
 

--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -208,10 +208,10 @@ collaborator:
 
 Now all those people can do::
 
-    git clone git@githhub.com:your-user-name/matplotlib.git
+    git clone https://gith hub.com:your-user-name/matplotlib.git
 
-Remember that links starting with ``git@`` use the ssh protocol and are
-read-write; links starting with ``git://`` are read-only.
+Remember that links starting with ``https`` or ``git@`` are read-write, and that 
+``git@`` uses the ssh protocol; links starting with ``git://`` are read-only.
 
 Your collaborators can then commit directly into that repo with the
 usual::

--- a/doc/devel/gitwash/set_up_fork.rst
+++ b/doc/devel/gitwash/set_up_fork.rst
@@ -13,7 +13,7 @@ Overview
 
 ::
 
-   git clone git@github.com:your-user-name/matplotlib.git
+   git clone https://github.com:your-user-name/matplotlib.git
    cd matplotlib
    git remote add upstream git://github.com/matplotlib/matplotlib.git
 
@@ -24,7 +24,7 @@ Clone your fork
 ---------------
 
 #. Clone your fork to the local computer with ``git clone
-   git@github.com:your-user-name/matplotlib.git``
+   https://github.com:your-user-name/matplotlib.git``
 #. Investigate.  Change directory to your new repo: ``cd matplotlib``. Then
    ``git branch -a`` to show you all branches.  You'll get something
    like:
@@ -55,7 +55,7 @@ Linking your repository to the upstream repo
 ``upstream`` here is just the arbitrary name we're using to refer to the
 main `Matplotlib`_ repository at `Matplotlib github`_.
 
-Note that we've used ``git://`` for the URL rather than ``git@``.  The
+Note that we've used ``git://`` for the URL rather than ``https://`` or ``git@``.  The
 ``git://`` URL is read only.  This means we that we can't accidentally
 (or deliberately) write to the upstream repo, and we are only going to
 use it to merge into our own code.
@@ -67,7 +67,7 @@ Just for your own satisfaction, show yourself that you now have a new
 
    upstream	git://github.com/matplotlib/matplotlib.git (fetch)
    upstream	git://github.com/matplotlib/matplotlib.git (push)
-   origin	git@github.com:your-user-name/matplotlib.git (fetch)
-   origin	git@github.com:your-user-name/matplotlib.git (push)
+   origin	https://github.com:your-user-name/matplotlib.git (fetch)
+   origin	https://github.com:your-user-name/matplotlib.git (push)
 
 .. include:: links.inc


### PR DESCRIPTION

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
The guide for new contributers says to use `git@github.com/matplotlib/matplotlib.git` to clone or interact with the project, but this only works for those with the proper privileges. These changes updates the docs so it tells users to use https:// (which should work for anybody)

This issue was on these pages:
http://matplotlib.org/devdocs/devel/contributing.html#contributing
http://matplotlib.org/devdocs/devel/gitwash/set_up_fork.html#set-up-fork
http://matplotlib.org/devdocs/devel/gitwash/development_workflow.html

<!--If it fixes an open issue, please link to the issue here.-->

