### PR TITLE
Add one-line descriptions to 19 examples currently missing them

### DIFF
--- a/examples/animation/image_slices_viewer.py
+++ b/examples/animation/image_slices_viewer.py
@@ -3,6 +3,7 @@
 Image Slices Viewer
 ===================
 
+This example demonstrates how to scroll through 2D image slices of a 3D array.
 """
 from __future__ import print_function
 

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -3,6 +3,7 @@
 Contourf Demo
 =============
 
+Example use of the `contourf` function to create filled contour plots.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -3,7 +3,7 @@
 Contourf Demo
 =============
 
-Example use of the `contourf` function to create filled contour plots.
+How to use the ``contourf`` function to create filled contour plots.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/images_contours_and_fields/contourf_hatching.py
+++ b/examples/images_contours_and_fields/contourf_hatching.py
@@ -3,7 +3,7 @@
 Contourf Hatching
 =================
 
-Demo of filled contour plots with of hatched patterns.
+Demo filled contour plots with of hatched patterns.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,8 +29,6 @@ cs = plt.contourf(x, y, z, hatches=['-', '/', '\\', '//'],
                   extend='both', alpha=0.5
                   )
 plt.colorbar()
-
-###############################################################################
 
 # ---------------------------------------------
 # |                 Plot #2                   |

--- a/examples/images_contours_and_fields/contourf_hatching.py
+++ b/examples/images_contours_and_fields/contourf_hatching.py
@@ -3,6 +3,7 @@
 Contourf Hatching
 =================
 
+Demo of filled contour plots with of hatched patterns.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,6 +30,7 @@ cs = plt.contourf(x, y, z, hatches=['-', '/', '\\', '//'],
                   )
 plt.colorbar()
 
+###############################################################################
 
 # ---------------------------------------------
 # |                 Plot #2                   |

--- a/examples/images_contours_and_fields/contourf_hatching.py
+++ b/examples/images_contours_and_fields/contourf_hatching.py
@@ -3,7 +3,7 @@
 Contourf Hatching
 =================
 
-Demo filled contour plots with of hatched patterns.
+Demo filled contour plots with hatched patterns.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/agg_buffer_to_array.py
+++ b/examples/pylab_examples/agg_buffer_to_array.py
@@ -3,6 +3,7 @@
 Agg Buffer To Array
 ===================
 
+Convert a rendered figure to its image (NumPy array) representation.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/axes_demo.py
+++ b/examples/pylab_examples/axes_demo.py
@@ -3,6 +3,7 @@
 Axes Demo
 =========
 
+Example use of `plt.axes` to create inset axes within the main plot axes.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/axes_demo.py
+++ b/examples/pylab_examples/axes_demo.py
@@ -3,7 +3,7 @@
 Axes Demo
 =========
 
-Example use of `plt.axes` to create inset axes within the main plot axes.
+Example use of ``plt.axes`` to create inset axes within the main plot axes.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/axhspan_demo.py
+++ b/examples/pylab_examples/axhspan_demo.py
@@ -3,6 +3,7 @@
 Axhspan Demo
 ============
 
+The example shows how to create lines or rectangles that span the axes in either the horizontal or vertical direction.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/axhspan_demo.py
+++ b/examples/pylab_examples/axhspan_demo.py
@@ -3,7 +3,7 @@
 Axhspan Demo
 ============
 
-The example shows how to create lines or rectangles that span the axes in either the horizontal or vertical direction.
+Create lines or rectangles that span the axes in either the horizontal or vertical direction.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/axis_equal_demo.py
+++ b/examples/pylab_examples/axis_equal_demo.py
@@ -3,6 +3,7 @@
 Axis Equal Demo
 ===============
 
+This example how to set and adjust plots with equal axis ratios.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/axis_equal_demo.py
+++ b/examples/pylab_examples/axis_equal_demo.py
@@ -3,7 +3,7 @@
 Axis Equal Demo
 ===============
 
-This example how to set and adjust plots with equal axis ratios.
+How to set and adjust plots with equal axis ratios.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/figure_title.py
+++ b/examples/pylab_examples/figure_title.py
@@ -3,6 +3,7 @@
 Figure Title
 ============
 
+Example use of `title` and `suptitle` to create subplot titles and a centered figure title, respectively.
 """
 from matplotlib.font_manager import FontProperties
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/figure_title.py
+++ b/examples/pylab_examples/figure_title.py
@@ -3,7 +3,7 @@
 Figure Title
 ============
 
-Example use of `title` and `suptitle` to create subplot titles and a centered figure title, respectively.
+Create a figure with separate subplot titles and a centered figure title.
 """
 from matplotlib.font_manager import FontProperties
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/fill_betweenx_demo.py
+++ b/examples/pylab_examples/fill_betweenx_demo.py
@@ -3,6 +3,7 @@
 Fill Betweenx Demo
 ==================
 
+This example shows how to use `fill_betweenx` to color between two horizontal curves.
 """
 import matplotlib.mlab as mlab
 from matplotlib.pyplot import figure, show

--- a/examples/pylab_examples/fill_betweenx_demo.py
+++ b/examples/pylab_examples/fill_betweenx_demo.py
@@ -3,7 +3,7 @@
 Fill Betweenx Demo
 ==================
 
-This example shows how to use `fill_betweenx` to color between two horizontal curves.
+Using ``fill_betweenx`` to color between two horizontal curves.
 """
 import matplotlib.mlab as mlab
 from matplotlib.pyplot import figure, show

--- a/examples/pylab_examples/log_demo.py
+++ b/examples/pylab_examples/log_demo.py
@@ -3,6 +3,7 @@
 Log Demo
 ========
 
+Examples of plots with logarithmic axes.
 """
 
 import numpy as np

--- a/examples/pylab_examples/plotfile_demo.py
+++ b/examples/pylab_examples/plotfile_demo.py
@@ -3,7 +3,7 @@
 Plotfile Demo
 =============
 
-Example use of `plotfile` to plot data directly from a file.
+Example use of ``plotfile`` to plot data directly from a file.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/plotfile_demo.py
+++ b/examples/pylab_examples/plotfile_demo.py
@@ -3,6 +3,7 @@
 Plotfile Demo
 =============
 
+Example use of `plotfile` to plot data directly from a file.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/polar_legend.py
+++ b/examples/pylab_examples/polar_legend.py
@@ -3,6 +3,7 @@
 Polar Legend
 ============
 
+Demo of a legend on a polar-axis plot.
 """
 import numpy as np
 from matplotlib.pyplot import figure, show, rc

--- a/examples/pylab_examples/simple_plot.py
+++ b/examples/pylab_examples/simple_plot.py
@@ -3,6 +3,7 @@
 Simple Plot
 ===========
 
+Simple example of a simple plot.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/simple_plot.py
+++ b/examples/pylab_examples/simple_plot.py
@@ -3,7 +3,7 @@
 Simple Plot
 ===========
 
-Simple example of a simple plot.
+Create a simple plot.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/specgram_demo.py
+++ b/examples/pylab_examples/specgram_demo.py
@@ -3,6 +3,7 @@
 Specgram Demo
 =============
 
+Demo of a spectrogram plot.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/specgram_demo.py
+++ b/examples/pylab_examples/specgram_demo.py
@@ -1,7 +1,7 @@
 """
-=============
-Specgram Demo
-=============
+================
+Spectrogram Demo
+================
 
 Demo of a spectrogram plot.
 """

--- a/examples/pylab_examples/spine_placement_demo.py
+++ b/examples/pylab_examples/spine_placement_demo.py
@@ -3,6 +3,7 @@
 Spine Placement Demo
 ====================
 
+This example demos how to adjust the location and appearance of axis spines.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/spine_placement_demo.py
+++ b/examples/pylab_examples/spine_placement_demo.py
@@ -3,7 +3,7 @@
 Spine Placement Demo
 ====================
 
-This example demos how to adjust the location and appearance of axis spines.
+Adjusting the location and appearance of axis spines.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/pylab_examples/stem_plot.py
+++ b/examples/pylab_examples/stem_plot.py
@@ -3,6 +3,7 @@
 Stem Plot
 =========
 
+Example stem plot.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/step_demo.py
+++ b/examples/pylab_examples/step_demo.py
@@ -3,6 +3,7 @@
 Step Demo
 =========
 
+Example step plots.
 """
 import numpy as np
 from numpy import ma

--- a/examples/pylab_examples/symlog_demo.py
+++ b/examples/pylab_examples/symlog_demo.py
@@ -3,6 +3,7 @@
 Symlog Demo
 ===========
 
+Example use of symlog (symmetrical log) axis scaling.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/symlog_demo.py
+++ b/examples/pylab_examples/symlog_demo.py
@@ -3,7 +3,7 @@
 Symlog Demo
 ===========
 
-Example use of symlog (symmetrical log) axis scaling.
+Example use of symlog (symmetric log) axis scaling.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/xcorr_acorr_demo.py
+++ b/examples/pylab_examples/xcorr_acorr_demo.py
@@ -1,7 +1,7 @@
 """
-============================
-Cross-/Auto-correlation Demo
-============================
+================================
+Cross- and Auto-Correlation Demo
+================================
 
 Example use of cross-correlation (``xcorr``) and auto-correlation (``acorr``) plots.
 """

--- a/examples/pylab_examples/xcorr_acorr_demo.py
+++ b/examples/pylab_examples/xcorr_acorr_demo.py
@@ -1,7 +1,7 @@
 """
-======================
-Cross-correlation Demo
-======================
+============================
+Cross-/Auto-correlation Demo
+============================
 
 Example use of cross-correlation (``xcorr``) and auto-correlation (``acorr``) plots.
 """

--- a/examples/pylab_examples/xcorr_demo.py
+++ b/examples/pylab_examples/xcorr_demo.py
@@ -1,7 +1,7 @@
 """
-==========
+======================
 Cross-correlation Demo
-==========
+======================
 
 Example use of cross-correlation (``xcorr``) and auto-correlation (``acorr``) plots.
 """

--- a/examples/pylab_examples/xcorr_demo.py
+++ b/examples/pylab_examples/xcorr_demo.py
@@ -1,9 +1,9 @@
 """
 ==========
-Xcorr Demo
+Cross-correlation Demo
 ==========
 
-Example use of cross-correlation (`xcorr`) and auto-correlation (`acorr`) plots.
+Example use of cross-correlation (``xcorr``) and auto-correlation (``acorr``) plots.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pylab_examples/xcorr_demo.py
+++ b/examples/pylab_examples/xcorr_demo.py
@@ -3,6 +3,7 @@
 Xcorr Demo
 ==========
 
+Example use of cross-correlation (`xcorr`) and auto-correlation (`acorr`) plots.
 """
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
## PR Summary

I've added one-line descriptions to 19 examples that currently do not have them.

This partially addresses one of the issues mentioned in #8885 ("Ensure that all examples / tutorials have a title and a one-line description underneath").

@choldgraf @NelleV 
