### PR TITLE
Fix exception in plt.tight_layout()

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1973,6 +1973,8 @@ class Figure(Artist):
                                          renderer,
                                          pad=pad, h_pad=h_pad, w_pad=w_pad,
                                          rect=rect)
+        if kwargs is None:
+            return
 
         self.subplots_adjust(**kwargs)
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1973,8 +1973,6 @@ class Figure(Artist):
                                          renderer,
                                          pad=pad, h_pad=h_pad, w_pad=w_pad,
                                          rect=rect)
-        if kwargs is None:
-            return
 
         self.subplots_adjust(**kwargs)
 

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -264,3 +264,11 @@ def test_tight_layout_offsetboxes():
                 child.set_visible(False)
 
     plt.tight_layout()
+
+def test_empty_layout():
+    """Tests that tight layout doesn't cause an error when there are
+    no axes.
+    """
+
+    fig = plt.gcf()
+    fig.tight_layout()

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -265,6 +265,7 @@ def test_tight_layout_offsetboxes():
 
     plt.tight_layout()
 
+
 def test_empty_layout():
     """Tests that tight layout doesn't cause an error when there are
     no axes.

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -320,7 +320,7 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
         subplots.append(ax)
 
     if (len(nrows_list) == 0) or (len(ncols_list) == 0):
-        return
+        return {}
 
     max_nrows = max(nrows_list)
     max_ncols = max(ncols_list)

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -319,6 +319,9 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
 
         subplots.append(ax)
 
+    if (len(nrows_list) == 0) or (len(ncols_list) == 0):
+        return
+
     max_nrows = max(nrows_list)
     max_ncols = max(ncols_list)
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
This PR addresses issue #8578 (Exception in plt.tight_layout()) and stops tight_layout from raising an exception when there are no axes in a figure.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/whats_new.rst if major new feature
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
