### PR TITLE
Separating examples with multiple plots into separate blocks

### DIFF
--- a/examples/animation/basic_example.py
+++ b/examples/animation/basic_example.py
@@ -16,6 +16,7 @@ def update_line(num, data, line):
     line.set_data(data[..., :num])
     return line,
 
+###############################################################################
 fig1 = plt.figure()
 
 # Fixing random state for reproducibility
@@ -32,6 +33,7 @@ line_ani = animation.FuncAnimation(fig1, update_line, 25, fargs=(data, l),
 
 # To save the animation, use the command: line_ani.save('lines.mp4')
 
+###############################################################################
 fig2 = plt.figure()
 
 x = np.arange(-9, 10)

--- a/examples/animation/basic_example.py
+++ b/examples/animation/basic_example.py
@@ -17,6 +17,7 @@ def update_line(num, data, line):
     return line,
 
 ###############################################################################
+
 fig1 = plt.figure()
 
 # Fixing random state for reproducibility
@@ -34,6 +35,7 @@ line_ani = animation.FuncAnimation(fig1, update_line, 25, fargs=(data, l),
 # To save the animation, use the command: line_ani.save('lines.mp4')
 
 ###############################################################################
+
 fig2 = plt.figure()
 
 x = np.arange(-9, 10)

--- a/examples/api/filled_step.py
+++ b/examples/api/filled_step.py
@@ -191,7 +191,9 @@ np.random.seed(19680801)
 stack_data = np.random.randn(4, 12250)
 dict_data = OrderedDict(zip((c['label'] for c in label_cycle), stack_data))
 
-# work with plain arrays
+###############################################################################
+# Work with plain arrays
+
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 4.5), tight_layout=True)
 arts = stack_hist(ax1, stack_data, color_cycle + label_cycle + hatch_cycle,
                   hist_func=hist_func)
@@ -204,7 +206,8 @@ ax1.set_xlabel('x')
 ax2.set_xlabel('counts')
 ax2.set_ylabel('x')
 
-# work with labeled data
+###############################################################################
+# Work with labeled data
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 4.5),
                                tight_layout=True, sharey=True)

--- a/examples/api/sankey_basics.py
+++ b/examples/api/sankey_basics.py
@@ -13,6 +13,7 @@ from matplotlib.sankey import Sankey
 
 ###############################################################################
 # Example 1 -- Mostly defaults
+#
 # This demonstrates how to create a simple diagram by implicitly calling the
 # Sankey.add() method and by appending finish() to the call to the class.
 
@@ -23,24 +24,28 @@ plt.title("The default settings produce a diagram like this.")
 
 ###############################################################################
 # Notice:
-#   1. Axes weren't provided when Sankey() was instantiated, so they were
-#      created automatically.
-#   2. The scale argument wasn't necessary since the data was already
-#      normalized.
-#   3. By default, the lengths of the paths are justified.
+#
+# 1. Axes weren't provided when Sankey() was instantiated, so they were
+#    created automatically.
+# 2. The scale argument wasn't necessary since the data was already
+#    normalized.
+# 3. By default, the lengths of the paths are justified.
+
 
 ###############################################################################
 # Example 2
+#
 # This demonstrates:
-#   1. Setting one path longer than the others
-#   2. Placing a label in the middle of the diagram
-#   3. Using the scale argument to normalize the flows
-#   4. Implicitly passing keyword arguments to PathPatch()
-#   5. Changing the angle of the arrow heads
-#   6. Changing the offset between the tips of the paths and their labels
-#   7. Formatting the numbers in the path labels and the associated unit
-#   8. Changing the appearance of the patch and the labels after the figure is
-#      created
+#
+# 1. Setting one path longer than the others
+# 2. Placing a label in the middle of the diagram
+# 3. Using the scale argument to normalize the flows
+# 4. Implicitly passing keyword arguments to PathPatch()
+# 5. Changing the angle of the arrow heads
+# 6. Changing the offset between the tips of the paths and their labels
+# 7. Formatting the numbers in the path labels and the associated unit
+# 8. Changing the appearance of the patch and the labels after the figure is
+#    created
 
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1, xticks=[], yticks=[],
@@ -60,18 +65,22 @@ diagrams[0].text.set_fontweight('bold')
 
 ###############################################################################
 # Notice:
-#   1. Since the sum of the flows is nonzero, the width of the trunk isn't
-#      uniform.  If verbose.level is helpful (in matplotlibrc), a message is
-#      given in the terminal window.
-#   2. The second flow doesn't appear because its value is zero.  Again, if
-#      verbose.level is helpful, a message is given in the terminal window.
+#
+# 1. Since the sum of the flows is nonzero, the width of the trunk isn't
+#    uniform.  If verbose.level is helpful (in matplotlibrc), a message is
+#    given in the terminal window.
+# 2. The second flow doesn't appear because its value is zero.  Again, if
+#    verbose.level is helpful, a message is given in the terminal window.
+
 
 ###############################################################################
 # Example 3
+#
 # This demonstrates:
-#   1. Connecting two systems
-#   2. Turning off the labels of the quantities
-#   3. Adding a legend
+#
+# 1. Connecting two systems
+# 2. Turning off the labels of the quantities
+# 3. Adding a legend
 
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1, xticks=[], yticks=[], title="Two Systems")

--- a/examples/api/sankey_basics.py
+++ b/examples/api/sankey_basics.py
@@ -15,10 +15,12 @@ from matplotlib.sankey import Sankey
 # Example 1 -- Mostly defaults
 # This demonstrates how to create a simple diagram by implicitly calling the
 # Sankey.add() method and by appending finish() to the call to the class.
+
 Sankey(flows=[0.25, 0.15, 0.60, -0.20, -0.15, -0.05, -0.50, -0.10],
        labels=['', '', '', 'First', 'Second', 'Third', 'Fourth', 'Fifth'],
        orientations=[-1, 1, 0, 1, 1, 1, 0, -1]).finish()
 plt.title("The default settings produce a diagram like this.")
+
 ###############################################################################
 # Notice:
 #   1. Axes weren't provided when Sankey() was instantiated, so they were
@@ -39,6 +41,7 @@ plt.title("The default settings produce a diagram like this.")
 #   7. Formatting the numbers in the path labels and the associated unit
 #   8. Changing the appearance of the patch and the labels after the figure is
 #      created
+
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1, xticks=[], yticks=[],
                      title="Flow Diagram of a Widget")
@@ -54,6 +57,7 @@ sankey.add(flows=[25, 0, 60, -10, -20, -5, -15, -10, -40],
 diagrams = sankey.finish()
 diagrams[0].texts[-1].set_color('r')
 diagrams[0].text.set_fontweight('bold')
+
 ###############################################################################
 # Notice:
 #   1. Since the sum of the flows is nonzero, the width of the trunk isn't
@@ -68,6 +72,7 @@ diagrams[0].text.set_fontweight('bold')
 #   1. Connecting two systems
 #   2. Turning off the labels of the quantities
 #   3. Adding a legend
+
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1, xticks=[], yticks=[], title="Two Systems")
 flows = [0.25, 0.15, 0.60, -0.10, -0.05, -0.25, -0.15, -0.10, -0.35]
@@ -79,6 +84,7 @@ sankey.add(flows=[-0.25, 0.15, 0.1], label='two',
 diagrams = sankey.finish()
 diagrams[-1].patch.set_hatch('/')
 plt.legend(loc='best')
+
 ###############################################################################
 # Notice that only one connection is specified, but the systems form a
 # circuit since: (1) the lengths of the paths are justified and (2) the

--- a/examples/api/sankey_basics.py
+++ b/examples/api/sankey_basics.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 from matplotlib.sankey import Sankey
 
 
+###############################################################################
 # Example 1 -- Mostly defaults
 # This demonstrates how to create a simple diagram by implicitly calling the
 # Sankey.add() method and by appending finish() to the call to the class.
@@ -18,6 +19,7 @@ Sankey(flows=[0.25, 0.15, 0.60, -0.20, -0.15, -0.05, -0.50, -0.10],
        labels=['', '', '', 'First', 'Second', 'Third', 'Fourth', 'Fifth'],
        orientations=[-1, 1, 0, 1, 1, 1, 0, -1]).finish()
 plt.title("The default settings produce a diagram like this.")
+###############################################################################
 # Notice:
 #   1. Axes weren't provided when Sankey() was instantiated, so they were
 #      created automatically.
@@ -25,6 +27,7 @@ plt.title("The default settings produce a diagram like this.")
 #      normalized.
 #   3. By default, the lengths of the paths are justified.
 
+###############################################################################
 # Example 2
 # This demonstrates:
 #   1. Setting one path longer than the others
@@ -51,6 +54,7 @@ sankey.add(flows=[25, 0, 60, -10, -20, -5, -15, -10, -40],
 diagrams = sankey.finish()
 diagrams[0].texts[-1].set_color('r')
 diagrams[0].text.set_fontweight('bold')
+###############################################################################
 # Notice:
 #   1. Since the sum of the flows is nonzero, the width of the trunk isn't
 #      uniform.  If verbose.level is helpful (in matplotlibrc), a message is
@@ -58,6 +62,7 @@ diagrams[0].text.set_fontweight('bold')
 #   2. The second flow doesn't appear because its value is zero.  Again, if
 #      verbose.level is helpful, a message is given in the terminal window.
 
+###############################################################################
 # Example 3
 # This demonstrates:
 #   1. Connecting two systems
@@ -74,6 +79,7 @@ sankey.add(flows=[-0.25, 0.15, 0.1], label='two',
 diagrams = sankey.finish()
 diagrams[-1].patch.set_hatch('/')
 plt.legend(loc='best')
+###############################################################################
 # Notice that only one connection is specified, but the systems form a
 # circuit since: (1) the lengths of the paths are justified and (2) the
 # orientation and ordering of the flows is mirrored.

--- a/examples/event_handling/figure_axes_enter_leave.py
+++ b/examples/event_handling/figure_axes_enter_leave.py
@@ -33,6 +33,8 @@ def leave_figure(event):
     event.canvas.figure.patch.set_facecolor('grey')
     event.canvas.draw()
 
+###############################################################################
+
 fig1, (ax, ax2) = plt.subplots(2, 1)
 fig1.suptitle('mouse hover over figure or axes to trigger events')
 
@@ -40,6 +42,8 @@ fig1.canvas.mpl_connect('figure_enter_event', enter_figure)
 fig1.canvas.mpl_connect('figure_leave_event', leave_figure)
 fig1.canvas.mpl_connect('axes_enter_event', enter_axes)
 fig1.canvas.mpl_connect('axes_leave_event', leave_axes)
+
+###############################################################################
 
 fig2, (ax, ax2) = plt.subplots(2, 1)
 fig2.suptitle('mouse hover over figure or axes to trigger events')

--- a/examples/images_contours_and_fields/contour_demo.py
+++ b/examples/images_contours_and_fields/contour_demo.py
@@ -26,7 +26,7 @@ Z2 = mlab.bivariate_normal(X, Y, 1.5, 0.5, 1, 1)
 # difference of Gaussians
 Z = 10.0 * (Z2 - Z1)
 
-
+###############################################################################
 # Create a simple contour plot with labels using default colors.  The
 # inline argument to clabel will control whether the labels are draw
 # over the line segments of the contour, removing the lines beneath
@@ -37,6 +37,7 @@ plt.clabel(CS, inline=1, fontsize=10)
 plt.title('Simplest default with labels')
 
 
+###############################################################################
 # contour labels can be placed manually by providing list of positions
 # (in data coordinate). See ginput_manual_clabel.py for interactive
 # placement.
@@ -47,6 +48,7 @@ plt.clabel(CS, inline=1, fontsize=10, manual=manual_locations)
 plt.title('labels at selected locations')
 
 
+###############################################################################
 # You can force all the contours to be the same color.
 plt.figure()
 CS = plt.contour(X, Y, Z, 6,
@@ -55,6 +57,7 @@ CS = plt.contour(X, Y, Z, 6,
 plt.clabel(CS, fontsize=9, inline=1)
 plt.title('Single color - negative contours dashed')
 
+###############################################################################
 # You can set negative contours to be solid instead of dashed:
 matplotlib.rcParams['contour.negative_linestyle'] = 'solid'
 plt.figure()
@@ -65,6 +68,7 @@ plt.clabel(CS, fontsize=9, inline=1)
 plt.title('Single color - negative contours solid')
 
 
+###############################################################################
 # And you can manually specify the colors of the contour
 plt.figure()
 CS = plt.contour(X, Y, Z, 6,
@@ -75,6 +79,7 @@ plt.clabel(CS, fontsize=9, inline=1)
 plt.title('Crazy lines')
 
 
+###############################################################################
 # Or you can use a colormap to specify the colors; the default
 # colormap will be used for the contour lines
 plt.figure()

--- a/examples/images_contours_and_fields/contour_demo.py
+++ b/examples/images_contours_and_fields/contour_demo.py
@@ -31,6 +31,7 @@ Z = 10.0 * (Z2 - Z1)
 # inline argument to clabel will control whether the labels are draw
 # over the line segments of the contour, removing the lines beneath
 # the label
+
 plt.figure()
 CS = plt.contour(X, Y, Z)
 plt.clabel(CS, inline=1, fontsize=10)
@@ -41,6 +42,7 @@ plt.title('Simplest default with labels')
 # contour labels can be placed manually by providing list of positions
 # (in data coordinate). See ginput_manual_clabel.py for interactive
 # placement.
+
 plt.figure()
 CS = plt.contour(X, Y, Z)
 manual_locations = [(-1, -1.4), (-0.62, -0.7), (-2, 0.5), (1.7, 1.2), (2.0, 1.4), (2.4, 1.7)]
@@ -50,6 +52,7 @@ plt.title('labels at selected locations')
 
 ###############################################################################
 # You can force all the contours to be the same color.
+
 plt.figure()
 CS = plt.contour(X, Y, Z, 6,
                  colors='k',  # negative contours will be dashed by default
@@ -59,6 +62,7 @@ plt.title('Single color - negative contours dashed')
 
 ###############################################################################
 # You can set negative contours to be solid instead of dashed:
+
 matplotlib.rcParams['contour.negative_linestyle'] = 'solid'
 plt.figure()
 CS = plt.contour(X, Y, Z, 6,
@@ -70,6 +74,7 @@ plt.title('Single color - negative contours solid')
 
 ###############################################################################
 # And you can manually specify the colors of the contour
+
 plt.figure()
 CS = plt.contour(X, Y, Z, 6,
                  linewidths=np.arange(.5, 4, .5),
@@ -82,6 +87,7 @@ plt.title('Crazy lines')
 ###############################################################################
 # Or you can use a colormap to specify the colors; the default
 # colormap will be used for the contour lines
+
 plt.figure()
 im = plt.imshow(Z, interpolation='bilinear', origin='lower',
                 cmap=cm.gray, extent=(-3, 3, -2, 2))

--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -18,7 +18,7 @@ import matplotlib.pyplot as plt
 matplotlib.rcParams['xtick.direction'] = 'out'
 matplotlib.rcParams['ytick.direction'] = 'out'
 
-##################################################
+###############################################################################
 # Define our surface
 delta = 0.025
 x = np.arange(-3.0, 3.0, delta)
@@ -29,7 +29,7 @@ Z2 = mlab.bivariate_normal(X, Y, 1.5, 0.5, 1, 1)
 # difference of Gaussians
 Z = 10.0 * (Z2 - Z1)
 
-##################################################
+###############################################################################
 # Make contour labels using creative float classes
 # Follows suggestion of Manuel Metz
 plt.figure()
@@ -59,7 +59,7 @@ else:
     fmt = '%r %%'
 plt.clabel(CS, CS.levels, inline=True, fmt=fmt, fontsize=10)
 
-##################################################
+###############################################################################
 # Label contours with arbitrary strings using a
 # dictionary
 plt.figure()
@@ -75,6 +75,7 @@ for l, s in zip(CS.levels, strs):
 # Label every other level using strings
 plt.clabel(CS, CS.levels[::2], inline=True, fmt=fmt, fontsize=10)
 
+###############################################################################
 # Use a Formatter
 
 plt.figure()

--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -20,6 +20,7 @@ matplotlib.rcParams['ytick.direction'] = 'out'
 
 ###############################################################################
 # Define our surface
+
 delta = 0.025
 x = np.arange(-3.0, 3.0, delta)
 y = np.arange(-2.0, 2.0, delta)
@@ -32,6 +33,7 @@ Z = 10.0 * (Z2 - Z1)
 ###############################################################################
 # Make contour labels using creative float classes
 # Follows suggestion of Manuel Metz
+
 plt.figure()
 
 # Basic contour plot
@@ -60,8 +62,8 @@ else:
 plt.clabel(CS, CS.levels, inline=True, fmt=fmt, fontsize=10)
 
 ###############################################################################
-# Label contours with arbitrary strings using a
-# dictionary
+# Label contours with arbitrary strings using a dictionary
+
 plt.figure()
 
 # Basic contour plot

--- a/examples/images_contours_and_fields/contourf_hatching.py
+++ b/examples/images_contours_and_fields/contourf_hatching.py
@@ -18,10 +18,8 @@ z = np.cos(x) + np.sin(y)
 x, y = x.flatten(), y.flatten()
 
 ###############################################################################
-# ---------------------------------------------
-# |                 Plot #1                   |
-# ---------------------------------------------
-# the simplest hatched plot with a colorbar
+# Plot 1: the simplest hatched plot with a colorbar
+
 fig = plt.figure()
 cs = plt.contourf(x, y, z, hatches=['-', '/', '\\', '//'],
                   cmap=plt.get_cmap('gray'),
@@ -30,10 +28,8 @@ cs = plt.contourf(x, y, z, hatches=['-', '/', '\\', '//'],
 plt.colorbar()
 
 ###############################################################################
-# ---------------------------------------------
-# |                 Plot #2                   |
-# ---------------------------------------------
-# a plot of hatches without color with a legend
+# Plot 2: a plot of hatches without color with a legend
+
 plt.figure()
 n_levels = 6
 plt.contour(x, y, z, n_levels, colors='black', linestyles='-')

--- a/examples/images_contours_and_fields/contourf_hatching.py
+++ b/examples/images_contours_and_fields/contourf_hatching.py
@@ -8,7 +8,6 @@ Demo filled contour plots with hatched patterns.
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 # invent some numbers, turning the x and y arrays into simple
 # 2d arrays, which make combining them together easier.
 x = np.linspace(-3, 5, 150).reshape(1, -1)
@@ -18,7 +17,7 @@ z = np.cos(x) + np.sin(y)
 # we no longer need x and y to be 2 dimensional, so flatten them.
 x, y = x.flatten(), y.flatten()
 
-
+###############################################################################
 # ---------------------------------------------
 # |                 Plot #1                   |
 # ---------------------------------------------
@@ -30,6 +29,7 @@ cs = plt.contourf(x, y, z, hatches=['-', '/', '\\', '//'],
                   )
 plt.colorbar()
 
+###############################################################################
 # ---------------------------------------------
 # |                 Plot #2                   |
 # ---------------------------------------------

--- a/examples/images_contours_and_fields/quiver_demo.py
+++ b/examples/images_contours_and_fields/quiver_demo.py
@@ -17,6 +17,7 @@ U = np.cos(X)
 V = np.sin(Y)
 
 ###############################################################################
+
 plt.figure()
 plt.title('Arrows scale with plot width, not view')
 Q = plt.quiver(X, Y, U, V, units='width')
@@ -24,6 +25,7 @@ qk = plt.quiverkey(Q, 0.9, 0.9, 2, r'$2 \frac{m}{s}$', labelpos='E',
                    coordinates='figure')
 
 ###############################################################################
+
 plt.figure()
 plt.title("pivot='mid'; every third arrow; units='inches'")
 Q = plt.quiver(X[::3, ::3], Y[::3, ::3], U[::3, ::3], V[::3, ::3],
@@ -33,6 +35,7 @@ qk = plt.quiverkey(Q, 0.9, 0.9, 1, r'$1 \frac{m}{s}$', labelpos='E',
 plt.scatter(X[::3, ::3], Y[::3, ::3], color='r', s=5)
 
 ###############################################################################
+
 plt.figure()
 plt.title("pivot='tip'; scales with x view")
 M = np.hypot(U, V)

--- a/examples/images_contours_and_fields/quiver_demo.py
+++ b/examples/images_contours_and_fields/quiver_demo.py
@@ -16,12 +16,14 @@ X, Y = np.meshgrid(np.arange(0, 2 * np.pi, .2), np.arange(0, 2 * np.pi, .2))
 U = np.cos(X)
 V = np.sin(Y)
 
+###############################################################################
 plt.figure()
 plt.title('Arrows scale with plot width, not view')
 Q = plt.quiver(X, Y, U, V, units='width')
 qk = plt.quiverkey(Q, 0.9, 0.9, 2, r'$2 \frac{m}{s}$', labelpos='E',
                    coordinates='figure')
 
+###############################################################################
 plt.figure()
 plt.title("pivot='mid'; every third arrow; units='inches'")
 Q = plt.quiver(X[::3, ::3], Y[::3, ::3], U[::3, ::3], V[::3, ::3],
@@ -30,6 +32,7 @@ qk = plt.quiverkey(Q, 0.9, 0.9, 1, r'$1 \frac{m}{s}$', labelpos='E',
                    coordinates='figure')
 plt.scatter(X[::3, ::3], Y[::3, ::3], color='r', s=5)
 
+###############################################################################
 plt.figure()
 plt.title("pivot='tip'; scales with x view")
 M = np.hypot(U, V)

--- a/examples/images_contours_and_fields/tricontour_demo.py
+++ b/examples/images_contours_and_fields/tricontour_demo.py
@@ -39,6 +39,7 @@ triang.set_mask(mask)
 
 ###############################################################################
 # pcolor plot.
+
 plt.figure()
 plt.gca().set_aspect('equal')
 plt.tricontourf(triang, z)
@@ -101,6 +102,7 @@ triangles = np.asarray([
 # arrays to tripcolor directly.  It would be better to use a Triangulation
 # object if the same triangulation was to be used more than once to save
 # duplicated calculations.
+
 plt.figure()
 plt.gca().set_aspect('equal')
 plt.tricontourf(x, y, triangles, z)

--- a/examples/images_contours_and_fields/tricontour_demo.py
+++ b/examples/images_contours_and_fields/tricontour_demo.py
@@ -10,6 +10,7 @@ import matplotlib.tri as tri
 import numpy as np
 import math
 
+###############################################################################
 # Creating a Triangulation without specifying the triangles results in the
 # Delaunay triangulation of the points.
 
@@ -36,6 +37,7 @@ ymid = y[triang.triangles].mean(axis=1)
 mask = np.where(xmid * xmid + ymid * ymid < min_radius * min_radius, 1, 0)
 triang.set_mask(mask)
 
+###############################################################################
 # pcolor plot.
 plt.figure()
 plt.gca().set_aspect('equal')
@@ -44,6 +46,7 @@ plt.colorbar()
 plt.tricontour(triang, z, colors='k')
 plt.title('Contour plot of Delaunay triangulation')
 
+###############################################################################
 # You can specify your own triangulation rather than perform a Delaunay
 # triangulation of the points, where each triangle is given by the indices of
 # the three points that make up the triangle, ordered in either a clockwise or
@@ -93,6 +96,7 @@ triangles = np.asarray([
     [42, 41, 40], [72, 33, 31], [32, 31, 33], [39, 38, 72], [33, 72, 38],
     [33, 38, 34], [37, 35, 38], [34, 38, 35], [35, 37, 36]])
 
+###############################################################################
 # Rather than create a Triangulation object, can simply pass x, y and triangles
 # arrays to tripcolor directly.  It would be better to use a Triangulation
 # object if the same triangulation was to be used more than once to save

--- a/examples/images_contours_and_fields/tripcolor_demo.py
+++ b/examples/images_contours_and_fields/tripcolor_demo.py
@@ -39,6 +39,7 @@ triang.set_mask(mask)
 
 ###############################################################################
 # tripcolor plot.
+
 plt.figure()
 plt.gca().set_aspect('equal')
 plt.tripcolor(triang, z, shading='flat')
@@ -47,6 +48,7 @@ plt.title('tripcolor of Delaunay triangulation, flat shading')
 
 ###############################################################################
 # Illustrate Gouraud shading.
+
 plt.figure()
 plt.gca().set_aspect('equal')
 plt.tripcolor(triang, z, shading='gouraud')
@@ -114,6 +116,7 @@ zfaces = np.exp(-0.01 * ((xmid - x0) * (xmid - x0) +
 # duplicated calculations.
 # Can specify one color value per face rather than one per point by using the
 # facecolors kwarg.
+
 plt.figure()
 plt.gca().set_aspect('equal')
 plt.tripcolor(x, y, triangles, facecolors=zfaces, edgecolors='k')

--- a/examples/images_contours_and_fields/tripcolor_demo.py
+++ b/examples/images_contours_and_fields/tripcolor_demo.py
@@ -10,6 +10,7 @@ import matplotlib.tri as tri
 import numpy as np
 import math
 
+###############################################################################
 # Creating a Triangulation without specifying the triangles results in the
 # Delaunay triangulation of the points.
 
@@ -36,6 +37,7 @@ ymid = y[triang.triangles].mean(axis=1)
 mask = np.where(xmid * xmid + ymid * ymid < min_radius * min_radius, 1, 0)
 triang.set_mask(mask)
 
+###############################################################################
 # tripcolor plot.
 plt.figure()
 plt.gca().set_aspect('equal')
@@ -43,6 +45,7 @@ plt.tripcolor(triang, z, shading='flat')
 plt.colorbar()
 plt.title('tripcolor of Delaunay triangulation, flat shading')
 
+###############################################################################
 # Illustrate Gouraud shading.
 plt.figure()
 plt.gca().set_aspect('equal')
@@ -51,6 +54,7 @@ plt.colorbar()
 plt.title('tripcolor of Delaunay triangulation, gouraud shading')
 
 
+###############################################################################
 # You can specify your own triangulation rather than perform a Delaunay
 # triangulation of the points, where each triangle is given by the indices of
 # the three points that make up the triangle, ordered in either a clockwise or
@@ -103,6 +107,7 @@ y0 = 52
 zfaces = np.exp(-0.01 * ((xmid - x0) * (xmid - x0) +
                          (ymid - y0) * (ymid - y0)))
 
+###############################################################################
 # Rather than create a Triangulation object, can simply pass x, y and triangles
 # arrays to tripcolor directly.  It would be better to use a Triangulation
 # object if the same triangulation was to be used more than once to save

--- a/examples/images_contours_and_fields/triplot_demo.py
+++ b/examples/images_contours_and_fields/triplot_demo.py
@@ -10,6 +10,7 @@ import matplotlib.tri as tri
 import numpy as np
 import math
 
+###############################################################################
 # Creating a Triangulation without specifying the triangles results in the
 # Delaunay triangulation of the points.
 
@@ -35,6 +36,7 @@ ymid = y[triang.triangles].mean(axis=1)
 mask = np.where(xmid * xmid + ymid * ymid < min_radius * min_radius, 1, 0)
 triang.set_mask(mask)
 
+###############################################################################
 # Plot the triangulation.
 plt.figure()
 plt.gca().set_aspect('equal')
@@ -42,6 +44,7 @@ plt.triplot(triang, 'bo-', lw=1)
 plt.title('triplot of Delaunay triangulation')
 
 
+###############################################################################
 # You can specify your own triangulation rather than perform a Delaunay
 # triangulation of the points, where each triangle is given by the indices of
 # the three points that make up the triangle, ordered in either a clockwise or
@@ -88,6 +91,7 @@ triangles = np.asarray([
     [42, 41, 40], [72, 33, 31], [32, 31, 33], [39, 38, 72], [33, 72, 38],
     [33, 38, 34], [37, 35, 38], [34, 38, 35], [35, 37, 36]])
 
+###############################################################################
 # Rather than create a Triangulation object, can simply pass x, y and triangles
 # arrays to triplot directly.  It would be better to use a Triangulation object
 # if the same triangulation was to be used more than once to save duplicated

--- a/examples/images_contours_and_fields/triplot_demo.py
+++ b/examples/images_contours_and_fields/triplot_demo.py
@@ -38,6 +38,7 @@ triang.set_mask(mask)
 
 ###############################################################################
 # Plot the triangulation.
+
 plt.figure()
 plt.gca().set_aspect('equal')
 plt.triplot(triang, 'bo-', lw=1)
@@ -96,6 +97,7 @@ triangles = np.asarray([
 # arrays to triplot directly.  It would be better to use a Triangulation object
 # if the same triangulation was to be used more than once to save duplicated
 # calculations.
+
 plt.figure()
 plt.gca().set_aspect('equal')
 plt.triplot(x, y, triangles, 'go-', lw=1.0)

--- a/examples/lines_bars_and_markers/fill.py
+++ b/examples/lines_bars_and_markers/fill.py
@@ -3,19 +3,16 @@
 Fill plot demo
 ==============
 
-First example showcases the most basic fill plot a user can do with matplotlib.
-
-Second example shows a few optional features:
-
-    * Multiple curves with a single command.
-    * Setting the fill color.
-    * Setting the opacity (alpha value).
+Demo fill plot.
 """
 import numpy as np
 import matplotlib.pyplot as plt
 
 x = np.linspace(0, 1, 500)
 y = np.sin(4 * np.pi * x) * np.exp(-5 * x)
+
+###############################################################################
+# First, the most basic fill plot a user can make with matplotlib:
 
 fig, ax = plt.subplots()
 
@@ -25,6 +22,13 @@ ax.grid(True, zorder=5)
 x = np.linspace(0, 2 * np.pi, 500)
 y1 = np.sin(x)
 y2 = np.sin(3 * x)
+
+###############################################################################
+# Next, a few more optional features:
+#
+# * Multiple curves with a single command.
+# * Setting the fill color.
+# * Setting the opacity (alpha value).
 
 fig, ax = plt.subplots()
 ax.fill(x, y1, 'b', x, y2, 'r', alpha=0.3)

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -30,9 +30,8 @@ def split_list(a_list):
     i_half = len(a_list) // 2
     return (a_list[:i_half], a_list[i_half:])
 
-
+###############################################################################
 # Plot all un-filled markers
-# --------------------------
 
 fig, axes = plt.subplots(ncols=2)
 
@@ -53,8 +52,8 @@ for ax, markers in zip(axes, split_list(unfilled_markers)):
 fig.suptitle('un-filled markers', fontsize=14)
 
 
+###############################################################################
 # Plot all filled markers.
-# ------------------------
 
 fig, axes = plt.subplots(ncols=2)
 for ax, markers in zip(axes, split_list(Line2D.filled_markers)):

--- a/examples/misc/contour_manual.py
+++ b/examples/misc/contour_manual.py
@@ -9,17 +9,21 @@ import matplotlib.pyplot as plt
 from matplotlib.contour import ContourSet
 import matplotlib.cm as cm
 
+
+###############################################################################
 # Contour lines for each level are a list/tuple of polygons.
 lines0 = [[[0, 0], [0, 4]]]
 lines1 = [[[2, 0], [1, 2], [1, 3]]]
 lines2 = [[[3, 0], [3, 2]], [[3, 3], [3, 4]]]  # Note two lines.
 
+###############################################################################
 # Filled contours between two levels are also a list/tuple of polygons.
 # Points can be ordered clockwise or anticlockwise.
 filled01 = [[[0, 0], [0, 4], [1, 3], [1, 2], [2, 0]]]
 filled12 = [[[2, 0], [3, 0], [3, 2], [1, 3], [1, 2]],   # Note two polygons.
             [[1, 4], [3, 4], [3, 3]]]
 
+###############################################################################
 
 plt.figure()
 
@@ -35,7 +39,7 @@ cbar.add_lines(lines)
 plt.axis([-0.5, 3.5, -0.5, 4.5])
 plt.title('User-specified contours')
 
-
+###############################################################################
 # Multiple filled contour lines can be specified in a single list of polygon
 # vertices along with a list of vertex kinds (code types) as described in the
 # Path class.  This is particularly useful for polygons with holes.

--- a/examples/pylab_examples/colorbar_tick_labelling_demo.py
+++ b/examples/pylab_examples/colorbar_tick_labelling_demo.py
@@ -13,7 +13,9 @@ import numpy as np
 from matplotlib import cm
 from numpy.random import randn
 
+###############################################################################
 # Make plot with vertical (default) colorbar
+
 fig, ax = plt.subplots()
 
 data = np.clip(randn(250, 250), -1, 1)
@@ -25,7 +27,9 @@ ax.set_title('Gaussian noise with vertical colorbar')
 cbar = fig.colorbar(cax, ticks=[-1, 0, 1])
 cbar.ax.set_yticklabels(['< -1', '0', '> 1'])  # vertically oriented colorbar
 
+###############################################################################
 # Make plot with horizontal colorbar
+
 fig, ax = plt.subplots()
 
 data = np.clip(randn(250, 250), -1, 1)

--- a/examples/pylab_examples/custom_cmap.py
+++ b/examples/pylab_examples/custom_cmap.py
@@ -77,6 +77,7 @@ X, Y = np.meshgrid(x, y)
 Z = np.cos(X) * np.sin(Y) * 10
 
 
+###############################################################################
 # --- Colormaps from a list ---
 
 colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]  # R -> G -> B
@@ -94,6 +95,7 @@ for n_bin, ax in zip(n_bins, axs.ravel()):
     fig.colorbar(im, ax=ax)
 
 
+###############################################################################
 # --- Custom colormaps ---
 
 cdict1 = {'red':   ((0.0, 0.0, 0.0),
@@ -149,12 +151,14 @@ cdict4['alpha'] = ((0.0, 1.0, 1.0),
                    (1.0, 1.0, 1.0))
 
 
+###############################################################################
 # Now we will use this example to illustrate 3 ways of
 # handling custom colormaps.
 # First, the most direct and explicit:
 
 blue_red1 = LinearSegmentedColormap('BlueRed1', cdict1)
 
+###############################################################################
 # Second, create the map explicitly and register it.
 # Like the first method, this method works with any kind
 # of Colormap, not just
@@ -163,12 +167,14 @@ blue_red1 = LinearSegmentedColormap('BlueRed1', cdict1)
 blue_red2 = LinearSegmentedColormap('BlueRed2', cdict2)
 plt.register_cmap(cmap=blue_red2)
 
+###############################################################################
 # Third, for LinearSegmentedColormap only,
 # leave everything to register_cmap:
 
 plt.register_cmap(name='BlueRed3', data=cdict3)  # optional lut kwarg
 plt.register_cmap(name='BlueRedAlpha', data=cdict4)
 
+###############################################################################
 # Make the figure:
 
 fig, axs = plt.subplots(2, 2, figsize=(6, 9))

--- a/examples/pylab_examples/demo_tight_layout.py
+++ b/examples/pylab_examples/demo_tight_layout.py
@@ -20,9 +20,13 @@ def example_plot(ax):
     ax.set_title('Title', fontsize=next(fontsizes))
 
 
+###############################################################################
+
 fig, ax = plt.subplots()
 example_plot(ax)
 plt.tight_layout()
+
+###############################################################################
 
 fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(nrows=2, ncols=2)
 example_plot(ax1)
@@ -31,15 +35,21 @@ example_plot(ax3)
 example_plot(ax4)
 plt.tight_layout()
 
+###############################################################################
+
 fig, (ax1, ax2) = plt.subplots(nrows=2, ncols=1)
 example_plot(ax1)
 example_plot(ax2)
 plt.tight_layout()
 
+###############################################################################
+
 fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2)
 example_plot(ax1)
 example_plot(ax2)
 plt.tight_layout()
+
+###############################################################################
 
 fig, axes = plt.subplots(nrows=3, ncols=3)
 for row in axes:
@@ -47,6 +57,7 @@ for row in axes:
         example_plot(ax)
 plt.tight_layout()
 
+###############################################################################
 
 fig = plt.figure()
 
@@ -60,6 +71,7 @@ example_plot(ax3)
 
 plt.tight_layout()
 
+###############################################################################
 
 fig = plt.figure()
 
@@ -77,6 +89,7 @@ plt.tight_layout()
 
 plt.show()
 
+###############################################################################
 
 fig = plt.figure()
 

--- a/examples/pylab_examples/errorbar_limits.py
+++ b/examples/pylab_examples/errorbar_limits.py
@@ -9,6 +9,8 @@ Illustration of upper and lower limit symbols on errorbars
 import numpy as np
 import matplotlib.pyplot as plt
 
+###############################################################################
+
 fig = plt.figure(0)
 x = np.arange(10.0)
 y = np.sin(np.arange(10.0)/20.0*np.pi)
@@ -24,6 +26,8 @@ lowerlimits = np.array([0, 1]*5)
 plt.errorbar(x, y, yerr=0.1, uplims=upperlimits, lolims=lowerlimits)
 
 plt.xlim(-1, 10)
+
+###############################################################################
 
 fig = plt.figure(1)
 x = np.arange(10.0)/10.0

--- a/examples/pylab_examples/fill_between_demo.py
+++ b/examples/pylab_examples/fill_between_demo.py
@@ -14,6 +14,8 @@ x = np.arange(0.0, 2, 0.01)
 y1 = np.sin(2*np.pi*x)
 y2 = 1.2*np.sin(4*np.pi*x)
 
+###############################################################################
+
 fig, (ax1, ax2, ax3) = plt.subplots(3, 1, sharex=True)
 
 ax1.fill_between(x, 0, y1)
@@ -26,10 +28,12 @@ ax3.fill_between(x, y1, y2)
 ax3.set_ylabel('between y1 and y2')
 ax3.set_xlabel('x')
 
-# now fill between y1 and y2 where a logical condition is met.  Note
+###############################################################################
+# Now fill between y1 and y2 where a logical condition is met.  Note
 # this is different than calling
-#   fill_between(x[where], y1[where],y2[where]
+#   ``fill_between(x[where], y1[where],y2[where] ...)``
 # because of edge effects over multiple contiguous regions.
+
 fig, (ax, ax1) = plt.subplots(2, 1, sharex=True)
 ax.plot(x, y1, x, y2, color='black')
 ax.fill_between(x, y1, y2, where=y2 >= y1, facecolor='green', interpolate=True)
@@ -43,12 +47,15 @@ ax1.fill_between(x, y1, y2, where=y2 >= y1, facecolor='green', interpolate=True)
 ax1.fill_between(x, y1, y2, where=y2 <= y1, facecolor='red', interpolate=True)
 ax1.set_title('Now regions with y2>1 are masked')
 
+###############################################################################
 # This example illustrates a problem; because of the data
 # gridding, there are undesired unfilled triangles at the crossover
 # points.  A brute-force solution would be to interpolate all
 # arrays to a very fine grid before plotting.
 
-# show how to use transforms to create axes spans where a certain condition is satisfied
+###############################################################################
+# Use transforms to create axes spans where a certain condition is satisfied:
+
 fig, ax = plt.subplots()
 y = np.sin(4*np.pi*x)
 ax.plot(x, y, color='black')

--- a/examples/pylab_examples/fill_between_demo.py
+++ b/examples/pylab_examples/fill_between_demo.py
@@ -3,7 +3,7 @@
 Filling the area between lines
 ==============================
 
-This example shows how to use `fill_between` to color between lines based on
+This example shows how to use ``fill_between`` to color between lines based on
 user-defined logic.
 """
 
@@ -31,7 +31,7 @@ ax3.set_xlabel('x')
 ###############################################################################
 # Now fill between y1 and y2 where a logical condition is met.  Note
 # this is different than calling
-#   ``fill_between(x[where], y1[where],y2[where] ...)``
+# ``fill_between(x[where], y1[where], y2[where] ...)``
 # because of edge effects over multiple contiguous regions.
 
 fig, (ax, ax1) = plt.subplots(2, 1, sharex=True)
@@ -53,6 +53,7 @@ ax1.set_title('Now regions with y2>1 are masked')
 # points.  A brute-force solution would be to interpolate all
 # arrays to a very fine grid before plotting.
 
+
 ###############################################################################
 # Use transforms to create axes spans where a certain condition is satisfied:
 
@@ -60,7 +61,7 @@ fig, ax = plt.subplots()
 y = np.sin(4*np.pi*x)
 ax.plot(x, y, color='black')
 
-# use the data coordinates for the x-axis and the axes coordinates for the y-axis
+# use data coordinates for the x-axis and the axes coordinates for the y-axis
 import matplotlib.transforms as mtransforms
 trans = mtransforms.blended_transform_factory(ax.transData, ax.transAxes)
 theta = 0.9

--- a/examples/pylab_examples/geo_demo.py
+++ b/examples/pylab_examples/geo_demo.py
@@ -11,20 +11,28 @@ supports `Basemaps Toolkit <https://matplotlib.org/basemap>`_ and
 
 import matplotlib.pyplot as plt
 
+###############################################################################
+
 plt.figure()
 plt.subplot(111, projection="aitoff")
 plt.title("Aitoff")
 plt.grid(True)
+
+###############################################################################
 
 plt.figure()
 plt.subplot(111, projection="hammer")
 plt.title("Hammer")
 plt.grid(True)
 
+###############################################################################
+
 plt.figure()
 plt.subplot(111, projection="lambert")
 plt.title("Lambert")
 plt.grid(True)
+
+###############################################################################
 
 plt.figure()
 plt.subplot(111, projection="mollweide")

--- a/examples/pylab_examples/hyperlinks_sgskip.py
+++ b/examples/pylab_examples/hyperlinks_sgskip.py
@@ -15,10 +15,14 @@ import matplotlib.cm as cm
 import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
 
+###############################################################################
+
 f = plt.figure()
 s = plt.scatter([1, 2, 3], [4, 5, 6])
 s.set_urls(['http://www.bbc.co.uk/news', 'http://www.google.com', None])
 f.canvas.print_figure('scatter.svg')
+
+###############################################################################
 
 f = plt.figure()
 delta = 0.025

--- a/examples/pylab_examples/markevery_demo.py
+++ b/examples/pylab_examples/markevery_demo.py
@@ -46,6 +46,7 @@ y = np.sin(x) + 1.0 + delta
 
 ###############################################################################
 # Plot each markevery case for linear x and y scales
+
 fig1 = plt.figure(num=1, figsize=figsize)
 ax = []
 for i, case in enumerate(cases):
@@ -58,6 +59,7 @@ for i, case in enumerate(cases):
 
 ###############################################################################
 # Plot each markevery case for log x and y scales
+
 fig2 = plt.figure(num=2, figsize=figsize)
 axlog = []
 for i, case in enumerate(cases):
@@ -75,6 +77,7 @@ fig2.tight_layout()
 # note the behaviour when zoomed in.  When a start marker offset is specified
 # it is always interpreted with respect to the first data point which might be
 # different to the first visible data point.
+
 fig3 = plt.figure(num=3, figsize=figsize)
 axzoom = []
 for i, case in enumerate(cases):
@@ -93,6 +96,7 @@ theta = 2 * np.pi * r
 
 ###############################################################################
 # Plot each markevery case for polar plots
+
 fig4 = plt.figure(num=4, figsize=figsize)
 axpolar = []
 for i, case in enumerate(cases):

--- a/examples/pylab_examples/markevery_demo.py
+++ b/examples/pylab_examples/markevery_demo.py
@@ -44,7 +44,8 @@ delta = 0.11
 x = np.linspace(0, 10 - 2 * delta, 200) + delta
 y = np.sin(x) + 1.0 + delta
 
-# plot each markevery case for linear x and y scales
+###############################################################################
+# Plot each markevery case for linear x and y scales
 fig1 = plt.figure(num=1, figsize=figsize)
 ax = []
 for i, case in enumerate(cases):
@@ -55,7 +56,8 @@ for i, case in enumerate(cases):
     ax[-1].plot(x, y, 'o', ls='-', ms=4, markevery=case)
 #fig1.tight_layout()
 
-# plot each markevery case for log x and y scales
+###############################################################################
+# Plot each markevery case for log x and y scales
 fig2 = plt.figure(num=2, figsize=figsize)
 axlog = []
 for i, case in enumerate(cases):
@@ -68,7 +70,8 @@ for i, case in enumerate(cases):
     axlog[-1].plot(x, y, 'o', ls='-', ms=4, markevery=case)
 fig2.tight_layout()
 
-# plot each markevery case for linear x and y scales but zoomed in
+###############################################################################
+# Plot each markevery case for linear x and y scales but zoomed in
 # note the behaviour when zoomed in.  When a start marker offset is specified
 # it is always interpreted with respect to the first data point which might be
 # different to the first visible data point.
@@ -88,7 +91,8 @@ fig3.tight_layout()
 r = np.linspace(0, 3.0, 200)
 theta = 2 * np.pi * r
 
-# plot each markevery case for polar plots
+###############################################################################
+# Plot each markevery case for polar plots
 fig4 = plt.figure(num=4, figsize=figsize)
 axpolar = []
 for i, case in enumerate(cases):

--- a/examples/pylab_examples/multiple_figs_demo.py
+++ b/examples/pylab_examples/multiple_figs_demo.py
@@ -12,16 +12,21 @@ t = np.arange(0.0, 2.0, 0.01)
 s1 = np.sin(2*np.pi*t)
 s2 = np.sin(4*np.pi*t)
 
+###############################################################################
+# Create figure 1
 plt.figure(1)
 plt.subplot(211)
 plt.plot(t, s1)
 plt.subplot(212)
 plt.plot(t, 2*s1)
 
+###############################################################################
+# Create figure 2
 plt.figure(2)
 plt.plot(t, s2)
 
-# now switch back to figure 1 and make some changes
+###############################################################################
+# Now switch back to figure 1 and make some changes
 plt.figure(1)
 plt.subplot(211)
 plt.plot(t, s2, 's')

--- a/examples/pylab_examples/multiple_figs_demo.py
+++ b/examples/pylab_examples/multiple_figs_demo.py
@@ -14,6 +14,7 @@ s2 = np.sin(4*np.pi*t)
 
 ###############################################################################
 # Create figure 1
+
 plt.figure(1)
 plt.subplot(211)
 plt.plot(t, s1)
@@ -22,11 +23,13 @@ plt.plot(t, 2*s1)
 
 ###############################################################################
 # Create figure 2
+
 plt.figure(2)
 plt.plot(t, s2)
 
 ###############################################################################
 # Now switch back to figure 1 and make some changes
+
 plt.figure(1)
 plt.subplot(211)
 plt.plot(t, s2, 's')

--- a/examples/pylab_examples/spine_placement_demo.py
+++ b/examples/pylab_examples/spine_placement_demo.py
@@ -66,6 +66,7 @@ ax.yaxis.set_ticks_position('left')
 ###############################################################################
 # Define a method that adjusts the location of the axis spines
 
+
 def adjust_spines(ax, spines):
     for loc, spine in ax.spines.items():
         if loc in spines:

--- a/examples/pylab_examples/spine_placement_demo.py
+++ b/examples/pylab_examples/spine_placement_demo.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 
 
 ###############################################################################
+
 fig = plt.figure()
 x = np.linspace(-np.pi, np.pi, 100)
 y = 2*np.sin(x)

--- a/examples/pylab_examples/spine_placement_demo.py
+++ b/examples/pylab_examples/spine_placement_demo.py
@@ -9,6 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
+###############################################################################
 fig = plt.figure()
 x = np.linspace(-np.pi, np.pi, 100)
 y = 2*np.sin(x)
@@ -60,8 +61,9 @@ ax.spines['left'].set_smart_bounds(True)
 ax.spines['bottom'].set_smart_bounds(True)
 ax.xaxis.set_ticks_position('bottom')
 ax.yaxis.set_ticks_position('left')
-# ----------------------------------------------------
 
+###############################################################################
+# Define a method that adjusts the location of the axis spines
 
 def adjust_spines(ax, spines):
     for loc, spine in ax.spines.items():
@@ -83,6 +85,9 @@ def adjust_spines(ax, spines):
     else:
         # no xaxis ticks
         ax.xaxis.set_ticks([])
+
+###############################################################################
+# Create another figure using our new ``adjust_spines`` method
 
 fig = plt.figure()
 

--- a/examples/pylab_examples/zorder_demo.py
+++ b/examples/pylab_examples/zorder_demo.py
@@ -36,6 +36,7 @@ np.random.seed(19680801)
 x = np.random.random(20)
 y = np.random.random(20)
 
+###############################################################################
 # Lines on top of scatter
 plt.figure()
 plt.subplot(211)
@@ -49,6 +50,7 @@ plt.plot(x, y, 'r', zorder=1, lw=3)
 plt.scatter(x, y, s=120, zorder=2)
 plt.title('Dots on top of lines')
 
+###############################################################################
 # A new figure, with individually ordered items
 x = np.linspace(0, 2*np.pi, 100)
 plt.figure()

--- a/examples/pylab_examples/zorder_demo.py
+++ b/examples/pylab_examples/zorder_demo.py
@@ -38,6 +38,7 @@ y = np.random.random(20)
 
 ###############################################################################
 # Lines on top of scatter
+
 plt.figure()
 plt.subplot(211)
 plt.plot(x, y, 'r', lw=3)
@@ -52,6 +53,7 @@ plt.title('Dots on top of lines')
 
 ###############################################################################
 # A new figure, with individually ordered items
+
 x = np.linspace(0, 2*np.pi, 100)
 plt.figure()
 plt.plot(x, np.sin(x), linewidth=10, color='black', label='zorder=10', zorder=10)  # on top

--- a/examples/pyplots/boxplot_demo.py
+++ b/examples/pyplots/boxplot_demo.py
@@ -19,33 +19,47 @@ flier_high = np.random.rand(10) * 100 + 100
 flier_low = np.random.rand(10) * -100
 data = np.concatenate((spread, center, flier_high, flier_low), 0)
 
+###############################################################################
+
 fig1, ax1 = plt.subplots()
 ax1.set_title('Basic Plot')
 ax1.boxplot(data)
 
+###############################################################################
+
 fig2, ax2 = plt.subplots()
 ax2.set_title('Notched boxes')
 ax2.boxplot(data, notch=True)
+
+###############################################################################
 
 green_diamond = dict(markerfacecolor='g', marker='D')
 fig3, ax3 = plt.subplots()
 ax3.set_title('Changed Outlier Symbols')
 ax3.boxplot(data, flierprops=green_diamond)
 
+###############################################################################
+
 fig4, ax4 = plt.subplots()
 ax4.set_title('Hide Outlier Points')
 ax4.boxplot(data, showfliers=False)
+
+###############################################################################
 
 red_square = dict(markerfacecolor='r', marker='s')
 fig5, ax5 = plt.subplots()
 ax5.set_title('Horizontal Boxes')
 ax5.boxplot(data, vert=False, flierprops=red_square)
 
+###############################################################################
+
 fig6, ax6 = plt.subplots()
 ax6.set_title('Shorter Whisker Length')
 ax6.boxplot(data, flierprops=red_square, vert=False, whis=0.75)
 
-# fake up some more data
+###############################################################################
+# Fake up some more data
+
 spread = np.random.rand(50) * 100
 center = np.ones(25) * 40
 flier_high = np.random.rand(10) * 100 + 100
@@ -54,10 +68,12 @@ d2 = np.concatenate((spread, center, flier_high, flier_low), 0)
 data.shape = (-1, 1)
 d2.shape = (-1, 1)
 
+###############################################################################
 # Making a 2-D array only works if all the columns are the
 # same length.  If they are not, then use a list instead.
 # This is actually more efficient because boxplot converts
 # a 2-D array into a list of vectors internally anyway.
+
 data = [data, d2, d2[::2,0]]
 fig7, ax7 = plt.subplots()
 ax7.set_title('Multiple Samples with Different sizes')

--- a/examples/pyplots/fig_axes_customize_simple.py
+++ b/examples/pyplots/fig_axes_customize_simple.py
@@ -7,7 +7,8 @@ Fig Axes Customize Simple
 import numpy as np
 import matplotlib.pyplot as plt
 
-# plt.figure creates a matplotlib.figure.Figure instance
+###############################################################################
+# ``plt.figure`` creates a ```matplotlib.figure.Figure`` instance
 fig = plt.figure()
 rect = fig.patch # a rectangle instance
 rect.set_facecolor('lightgoldenrodyellow')

--- a/examples/pyplots/fig_axes_customize_simple.py
+++ b/examples/pyplots/fig_axes_customize_simple.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 
 ###############################################################################
 # ``plt.figure`` creates a ```matplotlib.figure.Figure`` instance
+
 fig = plt.figure()
 rect = fig.patch # a rectangle instance
 rect.set_facecolor('lightgoldenrodyellow')

--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -27,6 +27,7 @@ fs = 10  # fontsize
 
 ###############################################################################
 # Demonstrate how to toggle the display of different elements:
+
 fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
 axes[0, 0].boxplot(data, labels=labels)
 axes[0, 0].set_title('Default', fontsize=fs)
@@ -57,6 +58,7 @@ plt.show()
 
 ###############################################################################
 # Demonstrate how to customize the display different elements:
+
 boxprops = dict(linestyle='--', linewidth=3, color='darkgoldenrod')
 flierprops = dict(marker='o', markerfacecolor='green', markersize=12,
                   linestyle='none')

--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -25,7 +25,8 @@ data = np.random.lognormal(size=(37, 4), mean=1.5, sigma=1.75)
 labels = list('ABCD')
 fs = 10  # fontsize
 
-# demonstrate how to toggle the display of different elements:
+###############################################################################
+# Demonstrate how to toggle the display of different elements:
 fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
 axes[0, 0].boxplot(data, labels=labels)
 axes[0, 0].set_title('Default', fontsize=fs)
@@ -54,7 +55,8 @@ fig.subplots_adjust(hspace=0.4)
 plt.show()
 
 
-# demonstrate how to customize the display different elements:
+###############################################################################
+# Demonstrate how to customize the display different elements:
 boxprops = dict(linestyle='--', linewidth=3, color='darkgoldenrod')
 flierprops = dict(marker='o', markerfacecolor='green', markersize=12,
                   linestyle='none')

--- a/examples/statistics/bxp.py
+++ b/examples/statistics/bxp.py
@@ -30,6 +30,7 @@ stats = cbook.boxplot_stats(data, labels=labels, bootstrap=10000)
 # After we've computed the stats, we can go through and change anything.
 # Just to prove it, I'll set the median of each set to the median of all
 # the data, and double the means
+
 for n in range(len(stats)):
     stats[n]['med'] = np.median(data)
     stats[n]['mean'] *= 2
@@ -40,6 +41,7 @@ fs = 10  # fontsize
 
 ###############################################################################
 # Demonstrate how to toggle the display of different elements:
+
 fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
 axes[0, 0].bxp(stats)
 axes[0, 0].set_title('Default', fontsize=fs)
@@ -69,6 +71,7 @@ plt.show()
 
 ###############################################################################
 # Demonstrate how to customize the display different elements:
+
 boxprops = dict(linestyle='--', linewidth=3, color='darkgoldenrod')
 flierprops = dict(marker='o', markerfacecolor='green', markersize=12,
                   linestyle='none')

--- a/examples/statistics/bxp.py
+++ b/examples/statistics/bxp.py
@@ -25,6 +25,8 @@ labels = list('ABCD')
 
 # compute the boxplot stats
 stats = cbook.boxplot_stats(data, labels=labels, bootstrap=10000)
+
+###############################################################################
 # After we've computed the stats, we can go through and change anything.
 # Just to prove it, I'll set the median of each set to the median of all
 # the data, and double the means
@@ -36,7 +38,8 @@ print(list(stats[0]))
 
 fs = 10  # fontsize
 
-# demonstrate how to toggle the display of different elements:
+###############################################################################
+# Demonstrate how to toggle the display of different elements:
 fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
 axes[0, 0].bxp(stats)
 axes[0, 0].set_title('Default', fontsize=fs)
@@ -64,7 +67,8 @@ for ax in axes.flatten():
 fig.subplots_adjust(hspace=0.4)
 plt.show()
 
-# demonstrate how to customize the display different elements:
+###############################################################################
+# Demonstrate how to customize the display different elements:
 boxprops = dict(linestyle='--', linewidth=3, color='darkgoldenrod')
 flierprops = dict(marker='o', markerfacecolor='green', markersize=12,
                   linestyle='none')

--- a/examples/subplots_axes_and_figures/subplots_demo.py
+++ b/examples/subplots_axes_and_figures/subplots_demo.py
@@ -20,24 +20,32 @@ y = np.sin(x ** 2)
 
 plt.close('all')
 
+###############################################################################
 # Just a figure and one subplot
+
 f, ax = plt.subplots()
 ax.plot(x, y)
 ax.set_title('Simple plot')
 
+###############################################################################
 # Two subplots, the axes array is 1-d
+
 f, axarr = plt.subplots(2, sharex=True)
 f.suptitle('Sharing X axis')
 axarr[0].plot(x, y)
 axarr[1].scatter(x, y)
 
+###############################################################################
 # Two subplots, unpack the axes array immediately
+
 f, (ax1, ax2) = plt.subplots(1, 2, sharey=True)
 f.suptitle('Sharing Y axis')
 ax1.plot(x, y)
 ax2.scatter(x, y)
 
+###############################################################################
 # Three subplots sharing both x/y axes
+
 f, axarr = plt.subplots(3, sharex=True, sharey=True)
 f.suptitle('Sharing both axes')
 axarr[0].plot(x, y)
@@ -49,7 +57,9 @@ f.subplots_adjust(hspace=0)
 for ax in axarr:
     ax.label_outer()
 
-# row and column sharing
+###############################################################################
+# Row and column sharing
+
 f, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, sharex='col', sharey='row')
 f.suptitle('Sharing x per column, y per row')
 ax1.plot(x, y)
@@ -57,7 +67,9 @@ ax2.scatter(x, y)
 ax3.scatter(x, 2 * y ** 2 - 1, color='r')
 ax4.plot(x, 2 * y ** 2 - 1, color='r')
 
+###############################################################################
 # Four axes, returned as a 2-d array
+
 f, axarr = plt.subplots(2, 2)
 axarr[0, 0].plot(x, y)
 axarr[0, 0].set_title('Axis [0,0]')
@@ -73,7 +85,9 @@ for ax in axarr.flat:
 for ax in axarr.flat:
     ax.label_outer()
 
+###############################################################################
 # Four polar axes
+
 f, axarr = plt.subplots(2, 2, subplot_kw=dict(projection='polar'))
 axarr[0, 0].plot(x, y)
 axarr[0, 0].set_title('Axis [0,0]')

--- a/examples/text_labels_and_annotations/accented_text.py
+++ b/examples/text_labels_and_annotations/accented_text.py
@@ -16,7 +16,9 @@ e.g., to make an overbar you do \bar{o} or to make an o umlaut you do
 from __future__ import unicode_literals
 import matplotlib.pyplot as plt
 
+###############################################################################
 # Mathtext demo
+
 fig, ax = plt.subplots()
 ax.plot(range(10))
 ax.set_title(r'$\ddot{o}\acute{e}\grave{e}\hat{O}'
@@ -27,7 +29,9 @@ ax.set_xlabel(r"""$\"o\ddot o \'e\`e\~n\.x\^y$""", fontsize=20)
 ax.text(4, 0.5, r"$F=m\ddot{x}$")
 fig.tight_layout()
 
+###############################################################################
 # Unicode demo
+
 fig, ax = plt.subplots()
 ax.set_title("GISCARD CHAHUTÉ À L'ASSEMBLÉE")
 ax.set_xlabel("LE COUP DE DÉ DE DE GAULLE")

--- a/examples/text_labels_and_annotations/accented_text.py
+++ b/examples/text_labels_and_annotations/accented_text.py
@@ -16,9 +16,7 @@ e.g., to make an overbar you do \bar{o} or to make an o umlaut you do
 from __future__ import unicode_literals
 import matplotlib.pyplot as plt
 
-###############################################################################
 # Mathtext demo
-
 fig, ax = plt.subplots()
 ax.plot(range(10))
 ax.set_title(r'$\ddot{o}\acute{e}\grave{e}\hat{O}'
@@ -29,9 +27,7 @@ ax.set_xlabel(r"""$\"o\ddot o \'e\`e\~n\.x\^y$""", fontsize=20)
 ax.text(4, 0.5, r"$F=m\ddot{x}$")
 fig.tight_layout()
 
-###############################################################################
 # Unicode demo
-
 fig, ax = plt.subplots()
 ax.set_title("GISCARD CHAHUTÉ À L'ASSEMBLÉE")
 ax.set_xlabel("LE COUP DE DÉ DE DE GAULLE")

--- a/examples/ticks_and_spines/scalarformatter.py
+++ b/examples/ticks_and_spines/scalarformatter.py
@@ -15,7 +15,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.ticker import ScalarFormatter
 
+###############################################################################
 # Example 1
+
 x = np.arange(0, 1, .01)
 fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, figsize=(6, 6))
 fig.text(0.5, 0.975, 'The new formatter, default settings',
@@ -40,7 +42,9 @@ ax4.yaxis.set_major_formatter(ScalarFormatter())
 
 fig.subplots_adjust(wspace=0.7, hspace=0.6)
 
+###############################################################################
 # Example 2
+
 x = np.arange(0, 1, .01)
 fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, figsize=(6, 6))
 fig.text(0.5, 0.975, 'The new formatter, no numerical offset',
@@ -65,7 +69,9 @@ ax4.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
 
 fig.subplots_adjust(wspace=0.7, hspace=0.6)
 
+###############################################################################
 # Example 3
+
 x = np.arange(0, 1, .01)
 fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, figsize=(6, 6))
 fig.text(0.5, 0.975, 'The new formatter, with mathtext',

--- a/examples/units/ellipse_with_units.py
+++ b/examples/units/ellipse_with_units.py
@@ -34,6 +34,8 @@ x, y = np.dot(R, np.array([x, y]))
 x += xcenter
 y += ycenter
 
+###############################################################################
+
 fig = plt.figure()
 ax = fig.add_subplot(211, aspect='auto')
 ax.fill(x, y, alpha=0.2, facecolor='yellow',
@@ -52,6 +54,8 @@ e2 = patches.Ellipse((xcenter, ycenter), width, height,
 
 ax.add_patch(e2)
 fig.savefig('ellipse_compare')
+
+###############################################################################
 
 fig = plt.figure()
 ax = fig.add_subplot(211, aspect='auto')

--- a/examples/userdemo/colormap_normalizations.py
+++ b/examples/userdemo/colormap_normalizations.py
@@ -57,7 +57,7 @@ fig.colorbar(pcm, ax=ax[1], extend='max')
 # with 5-times the amplitude. Linearly, you cannot see detail in the
 # negative hump.  Here we logarithmically scale the positive and
 # negative data separately.
-# 
+#
 # Note that colorbar labels do not come out looking very good.
 
 X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]

--- a/examples/userdemo/colormap_normalizations.py
+++ b/examples/userdemo/colormap_normalizations.py
@@ -11,16 +11,17 @@ import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 from matplotlib.mlab import bivariate_normal
 
-'''
-Lognorm: Instead of pcolor log10(Z1) you can have colorbars that have
-the exponential labels using a norm.
-'''
+###############################################################################
+# Lognorm: Instead of pcolor log10(Z1) you can have colorbars that have
+# the exponential labels using a norm.
+
 N = 100
 X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]
 
 # A low hump with a spike coming out of the top right.  Needs to have
 # z/colour axis on a log scale so we see both hump and spike.  linear
 # scale only shows the spike.
+
 Z1 = bivariate_normal(X, Y, 0.1, 0.2, 1.0, 1.0) +  \
     0.1 * bivariate_normal(X, Y, 1.0, 1.0, 0.0, 0.0)
 
@@ -35,10 +36,10 @@ pcm = ax[1].pcolor(X, Y, Z1, cmap='PuBu_r')
 fig.colorbar(pcm, ax=ax[1], extend='max')
 
 
-'''
-PowerNorm: Here a power-law trend in X partially obscures a rectified
-sine wave in Y. We can remove the power law using a PowerNorm.
-'''
+###############################################################################
+# PowerNorm: Here a power-law trend in X partially obscures a rectified
+# sine wave in Y. We can remove the power law using a PowerNorm.
+
 X, Y = np.mgrid[0:3:complex(0, N), 0:2:complex(0, N)]
 Z1 = (1 + np.sin(Y * 10.)) * X**(2.)
 
@@ -51,14 +52,13 @@ fig.colorbar(pcm, ax=ax[0], extend='max')
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='PuBu_r')
 fig.colorbar(pcm, ax=ax[1], extend='max')
 
-'''
-SymLogNorm: two humps, one negative and one positive, The positive
-with 5-times the amplitude. Linearly, you cannot see detail in the
-negative hump.  Here we logarithmically scale the positive and
-negative data separately.
-
-Note that colorbar labels do not come out looking very good.
-'''
+###############################################################################
+# SymLogNorm: two humps, one negative and one positive, The positive
+# with 5-times the amplitude. Linearly, you cannot see detail in the
+# negative hump.  Here we logarithmically scale the positive and
+# negative data separately.
+# 
+# Note that colorbar labels do not come out looking very good.
 
 X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]
 Z1 = (bivariate_normal(X, Y, 1., 1., 1.0, 1.0))**2  \
@@ -77,11 +77,11 @@ pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[1], extend='both')
 
 
-'''
-Custom Norm: An example with a customized normalization.  This one
-uses the example above, and normalizes the negative data differently
-from the positive.
-'''
+###############################################################################
+# Custom Norm: An example with a customized normalization.  This one
+# uses the example above, and normalizes the negative data differently
+# from the positive.
+
 X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]
 Z1 = (bivariate_normal(X, Y, 1., 1., 1.0, 1.0))**2  \
     - 0.4 * (bivariate_normal(X, Y, 1.0, 1.0, -1.0, 0.0))**2
@@ -112,11 +112,10 @@ fig.colorbar(pcm, ax=ax[0], extend='both')
 pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
 fig.colorbar(pcm, ax=ax[1], extend='both')
 
-'''
-BoundaryNorm: For this one you provide the boundaries for your colors,
-and the Norm puts the first color in between the first pair, the
-second color between the second pair, etc.
-'''
+###############################################################################
+# BoundaryNorm: For this one you provide the boundaries for your colors,
+# and the Norm puts the first color in between the first pair, the
+# second color between the second pair, etc.
 
 fig, ax = plt.subplots(3, 1, figsize=(8, 8))
 ax = ax.flatten()


### PR DESCRIPTION
## PR Summary

Added `#####...` separators to 34 examples which draw multiple plots (i.e. multiple calls to `plt.figure()`, `plt.show()`, and/or `plt.subplots()`).

This addresses one of the issues mentioned in #8885:
> Find examples w/ multiple plots generated and add sphinx-gallery `##########` blocks + rST so that it's more narrative

@choldgraf @NelleV 
