### PR TITLE
Convert get_ticklabels/add_axes/add_subplot to numpydoc

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3011,9 +3011,9 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        minor : bool
+        minor : bool, optional
            If True return the minor ticklabels,
-           else return the major ticklabels
+           else return the major ticklabels.
 
         which : None, ('minor', 'major', 'both')
            Overrides `minor`.
@@ -3037,6 +3037,19 @@ class _AxesBase(martist.Artist):
         ----------
         labels : list of str
             list of string labels
+
+        fontdict : dict, optional
+            A dictionary controlling the appearance of the ticklabels,
+            the default `fontdict` is:
+
+               {'fontsize': rcParams['axes.titlesize'],
+                'fontweight' : rcParams['axes.titleweight'],
+                'verticalalignment': 'baseline',
+                'horizontalalignment': loc}
+
+        minor : bool, optional
+            If True select the minor ticklabels,
+            else select the minor ticklabels
 
         Returns
         -------
@@ -3334,6 +3347,19 @@ class _AxesBase(martist.Artist):
         ----------
         labels : list of str
             list of string labels
+
+        fontdict : dict, optional
+            A dictionary controlling the appearance of the ticklabels,
+            the default `fontdict` is::
+
+               {'fontsize': rcParams['axes.titlesize'],
+                'fontweight' : rcParams['axes.titleweight'],
+                'verticalalignment': 'baseline',
+                'horizontalalignment': loc}
+
+        minor : bool, optional
+            If True select the minor ticklabels,
+            else select the minor ticklabels
 
         Returns
         -------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -872,8 +872,8 @@ class Figure(Artist):
             A 4-length sequence of [left, bottom, width, height] quantities.
 
         projection :
-            [‘aitoff’ | ‘hammer’ | ‘lambert’ | ‘mollweide’ | \
-‘polar’ | ‘rectilinear’], optional
+            ['aitoff' | 'hammer' | 'lambert' | 'mollweide' | \
+'polar' | 'rectilinear'], optional
             The projection type of the axes.
 
         polar : boolean, optional
@@ -972,8 +972,8 @@ class Figure(Artist):
             integers are I, J, and K, the subplot is the Ith plot on a
             grid with J rows and K columns.
 
-        projection : [‘aitoff’ | ‘hammer’ | ‘lambert’ | \
-‘mollweide’, ‘polar’ | ‘rectilinear’], optional
+        projection : ['aitoff' | 'hammer' | 'lambert' | \
+'mollweide', 'polar' | 'rectilinear'], optional
             The projection type of the axes.
 
         polar : boolean, optional

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -860,20 +860,35 @@ class Figure(Artist):
         key = fixlist(args), fixitems(six.iteritems(kwargs))
         return key
 
-    @docstring.dedent_interpd
     def add_axes(self, *args, **kwargs):
         """
         Add an axes at position *rect* [*left*, *bottom*, *width*,
         *height*] where all quantities are in fractions of figure
-        width and height.  kwargs are legal
-        :class:`~matplotlib.axes.Axes` kwargs plus *projection* which
-        sets the projection type of the axes.  (For backward
-        compatibility, ``polar=True`` may also be provided, which is
-        equivalent to ``projection='polar'``).  Valid values for
-        *projection* are: %(projection_names)s.  Some of these
-        projections support  additional kwargs, which may be provided
-        to :meth:`add_axes`. Typical usage::
+        width and height.
 
+        Parameters
+        ----------
+        rect : sequence of float
+            A 4-length sequence of [left, bottom, width, height] quantities.
+
+        projection :
+            [‘aitoff’ | ‘hammer’ | ‘lambert’ | ‘mollweide’ | \
+‘polar’ | ‘rectilinear’], optional
+            The projection type of the axes.
+
+        polar : boolean, optional
+            If True, equivalent to projection='polar'.
+
+        This method also takes the keyword arguments for
+        :class:`~matplotlib.axes.Axes`.
+
+        Returns
+        ------
+        axes : Axes
+            The added axes.
+
+        Examples
+        --------
             rect = l,b,w,h
             fig.add_axes(rect)
             fig.add_axes(rect, frameon=False, facecolor='g')
@@ -903,10 +918,6 @@ class Figure(Artist):
 
         In all cases, the :class:`~matplotlib.axes.Axes` instance
         will be returned.
-
-        In addition to *projection*, the following kwargs are supported:
-
-        %(Axes)s
         """
         if not len(args):
             return
@@ -949,11 +960,41 @@ class Figure(Artist):
         a.stale_callback = _stale_figure_callback
         return a
 
-    @docstring.dedent_interpd
     def add_subplot(self, *args, **kwargs):
         """
-        Add a subplot.  Examples::
+        Add a subplot.
 
+        Parameters
+        ----------
+        *args
+            Either a 3-digit integer or three separate integers
+            describing the position of the subplot. If the three
+            integers are I, J, and K, the subplot is the Ith plot on a
+            grid with J rows and K columns.
+
+        projection : [‘aitoff’ | ‘hammer’ | ‘lambert’ | \
+‘mollweide’, ‘polar’ | ‘rectilinear’], optional
+            The projection type of the axes.
+
+        polar : boolean, optional
+            If True, equivalent to projection='polar'.
+
+        This method also takes the keyword arguments for
+        :class:`~matplotlib.axes.Axes`.
+
+        Returns
+        -------
+        axes : Axes
+            The axes of the subplot.
+
+        Notes
+        -----
+        If the figure already has a subplot with key (*args*,
+        *kwargs*) then it will simply make that subplot current and
+        return it.
+
+        Examples
+        --------
             fig.add_subplot(111)
 
             # equivalent but more general
@@ -968,27 +1009,9 @@ class Figure(Artist):
             # add Subplot instance sub
             fig.add_subplot(sub)
 
-        *kwargs* are legal :class:`~matplotlib.axes.Axes` kwargs plus
-        *projection*, which chooses a projection type for the axes.
-        (For backward compatibility, *polar=True* may also be
-        provided, which is equivalent to *projection='polar'*). Valid
-        values for *projection* are: %(projection_names)s.  Some of
-        these projections
-        support additional *kwargs*, which may be provided to
-        :meth:`add_axes`.
-
-        The :class:`~matplotlib.axes.Axes` instance will be returned.
-
-        If the figure already has a subplot with key (*args*,
-        *kwargs*) then it will simply make that subplot current and
-        return it.
-
-        .. seealso:: :meth:`~matplotlib.pyplot.subplot` for an
-           explanation of the args.
-
-        The following kwargs are supported:
-
-        %(Axes)s
+        See Also
+        --------
+        matplotlib.pyplot.subplot : for an explanation of the args.
         """
         if not len(args):
             return


### PR DESCRIPTION

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->

Converts some functions mentioned in #7205 to `numpydoc` syntax.