### PR TITLE
Fix invalid NumPyDoc headings.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1157,8 +1157,8 @@ or tuple of floats
         array-like is given, it must have the same length as *positions*, and
         each value will be applied to the corresponding row of the array.
 
-        Example
-        -------
+        Examples
+        --------
 
         .. plot:: mpl_examples/pylab_examples/eventplot_demo.py
         """

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1300,8 +1300,8 @@ class EventCollection(LineCollection):
             :class:`~matplotlib.collections.LineCollection` for a list of
             the valid properties.
 
-        Example
-        -------
+        Examples
+        --------
 
         .. plot:: mpl_examples/pylab_examples/eventcollection_demo.py
         """

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -398,8 +398,8 @@ def compare_images(expected, actual, tol, in_decorator=False):
         If called from image_comparison decorator, this should be
         True. (default=False)
 
-    Example
-    -------
+    Examples
+    --------
     img1 = "./baseline/plot.png"
     img2 = "./output/plot.png"
     compare_images( img1, img2, 0.001 ):


### PR DESCRIPTION
These cause small warnings during the doc build.