### PR TITLE
Fixed Issue #8576 'markevery' support in prop_cycle

### DIFF
--- a/doc/users/whats_new/prop_cycle_markevery_support.rst
+++ b/doc/users/whats_new/prop_cycle_markevery_support.rst
@@ -1,0 +1,8 @@
+Implementation of axes.prop_cycle support for the markevery property
+--------------------------------------------------------------------
+
+The ``rcParams`` attribute of a matplotlib session or script now supports assignments
+of the attribute `axes.prop_cycle` composed from cyclers including the `markevery` property.
+The full API of the `~matplotlib.lines.set_markevery` method is enabled 
+via the new `validate_markevery` method of rcsetup.py. A demonstration is available at 
+`~matplotlib/examples/lines_bars_and_markers/markevery_propcycles_demo.py`

--- a/examples/lines_bars_and_markers/markevery_propcycles_demo.py
+++ b/examples/lines_bars_and_markers/markevery_propcycles_demo.py
@@ -1,0 +1,67 @@
+"""
+===============================================================
+Implementation of prop_cycle support for the markevery property
+===============================================================
+
+An example demonstrating the fix to issue #8576, enabling full utilization of
+the markevery property in axes.prop_cycle assignments. Uses the same list
+of cases from the examples/pylab_examples/markevery_demo.py, implemented
+as an rcParams assignment as a composite cycler after addition with a colormap.
+
+Renders an ascending series of Weierstrass functions from a 2D Numpy array
+"""
+
+
+from __future__ import division
+import numpy as np
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from cycler import cycler
+
+# define a list of markevery cases to plot
+cases = [None,
+         8,
+         (30, 8),
+         [16, 24, 30], [0, -1],
+         slice(100, 200, 3),
+         0.1, 0.3, 1.5,
+         (0.0, 0.1), (0.45, 0.1)]
+        
+markevery_cycler = cycler(markevery=cases) 
+
+#compose cyclic color scheme along with markevery cycler
+phases = np.linspace(0, 1, len(cases))
+colorlist = [ plt.cm.jet(phase) for phase in phases]
+color_cycler = cycler(color=colorlist)
+
+composite_cycler = markevery_cycler + color_cycler
+mpl.rcParams['axes.prop_cycle']=composite_cycler
+
+
+# define the data for cartesian plots
+numExamples =2*len(cases)+1
+
+numSamples =201
+
+x = np.linspace(-np.pi/2, np.pi/2, numSamples)
+yarray = np.zeros((numExamples, numSamples))
+yarray[0] = np.sum(np.power(0.5,n)*np.cos(np.pi*x*np.power(8,n)) for \
+n in np.arange(0,100,1))
+
+for i in range(1, numExamples):
+    yarray[i]=yarray[i-1]+1
+
+# plot each markevery case for linear x and y scales
+fig = plt.figure()
+ax = fig.add_subplot(111) 
+for i, y in enumerate(yarray):
+    ax.plot(x, y, 'o', markersize=1.5, ls='-', linewidth=0.4)
+lgd = plt.legend(title='markevery values', handles=[mpl.patches.Patch(color=colorlist[i], label=str(cases[i])) \
+for i in range(len(cases)) ], bbox_to_anchor=(1.0,1.02),loc=2)
+
+plt.title("Weierstrass functions with 'markevery' prop_cycles enabled")
+#plt.savefig('markevery_composite', bbox_extra_artists=(lgd,), bbox_inches='tight', format="png")
+#plt.savefig('markevery_composite', bbox_extra_artists=(lgd,), bbox_inches='tight', format="pdf")
+#plt.savefig('markevery_composite', bbox_extra_artists=(lgd,), bbox_inches='tight', format="svg")
+plt.show()

--- a/examples/pylab_examples/markevery_demo.py
+++ b/examples/pylab_examples/markevery_demo.py
@@ -38,7 +38,7 @@ cases = [None,
 figsize = (10, 8)
 cols = 3
 gs = gridspec.GridSpec(len(cases) // cols + 1, cols)
-
+gs.update(hspace=0.4)
 # define the data for cartesian plots
 delta = 0.11
 x = np.linspace(0, 10 - 2 * delta, 200) + delta

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -26,6 +26,7 @@ from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_bool,
                                 validate_nseq_int,
                                 validate_nseq_float,
+                                validate_markevery,
                                 validate_cycler,
                                 validate_hatch,
                                 validate_hist_bins,
@@ -260,6 +261,13 @@ def generate_validator_testcases(valid):
                   for _ in ('aardvark', ('a', 1),
                             (1, 2, 3)
                             ))
+        },
+        {'validator': validate_markevery,
+         'success': ((1,1), (0.2, 0.2),((0.1,0.2),(0.1,0.2)),
+                     ([1,2,3], [1,2,3]), (None, None)),
+         'fail': (((1,2,3), ValueError),
+                  ((1.5,1), ValueError),
+                  ('zyzzyx', ValueError), ([1.4, 2.2], ValueError))
         },
         {'validator': validate_cycler,
          'success': (('cycler("color", "rgb")',


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
New validate_markevery method written to support full lines.set_markevery API for 'axes.prop_cycle' assignment through rcParams. Includes an example utilizing the 'cases' list from the markevery example at https://matplotlib.org/examples/pylab_examples/markevery_demo.html, implemented as a cycler.cycler alongside a matched list of samples from the jet colormap, to display a collection of (finite approximations to) Weierstrass functions.
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
