### PR TITLE
Remove semicolon after PyObject_HEAD.

### DIFF
--- a/lib/matplotlib/tri/_tri_wrapper.cpp
+++ b/lib/matplotlib/tri/_tri_wrapper.cpp
@@ -7,7 +7,7 @@
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     Triangulation* ptr;
 } PyTriangulation;
 
@@ -216,7 +216,7 @@ static PyTypeObject* PyTriangulation_init_type(PyObject* m, PyTypeObject* type)
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     TriContourGenerator* ptr;
     PyTriangulation* py_triangulation;
 } PyTriContourGenerator;
@@ -351,7 +351,7 @@ static PyTypeObject* PyTriContourGenerator_init_type(PyObject* m, PyTypeObject* 
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     TrapezoidMapTriFinder* ptr;
     PyTriangulation* py_triangulation;
 } PyTrapezoidMapTriFinder;

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -4,7 +4,7 @@
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     RendererAgg *x;
     Py_ssize_t shape[3];
     Py_ssize_t strides[3];
@@ -13,7 +13,7 @@ typedef struct
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     BufferRegion *x;
     Py_ssize_t shape[3];
     Py_ssize_t strides[3];

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -6,7 +6,7 @@
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     QuadContourGenerator* ptr;
 } PyQuadContourGenerator;
 

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -26,7 +26,7 @@
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     Tcl_Interp *interp;
 } TkappObject;
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -26,7 +26,7 @@ static PyObject *convert_xys_to_array(std::vector<double> &xys)
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     FT2Image *x;
     Py_ssize_t shape[2];
     Py_ssize_t strides[2];
@@ -229,7 +229,7 @@ static PyTypeObject *PyFT2Image_init_type(PyObject *m, PyTypeObject *type)
 
 typedef struct
 {
-    PyObject_HEAD;
+    PyObject_HEAD
     size_t glyphInd;
     long width;
     long height;
@@ -323,7 +323,8 @@ static PyTypeObject *PyGlyph_init_type(PyObject *m, PyTypeObject *type)
 
 typedef struct
 {
-    PyObject_HEAD FT2Font *x;
+    PyObject_HEAD
+    FT2Font *x;
     PyObject *fname;
     PyObject *py_file;
     FILE *fp;


### PR DESCRIPTION
Just a cleanup.

See https://docs.python.org/3/extending/newtypes.html#the-basics:

> Note that there is no semicolon after the PyObject_HEAD macro; one is
included in the macro definition. Be wary of adding one by accident;
it’s easy to do from habit, and your compiler might not complain, but
someone else’s probably will!

Also move a FT2Font *x; declaration to its own line (that was the
original motivation).

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
