### PR TITLE
timedelta formatter

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -406,6 +406,38 @@ def num2date(x, tz=None):
         return _from_ordinalf_np_vectorized(x, tz).tolist()
 
 
+def _ordinalf_to_timedelta(x):
+    return datetime.timedelta(days=x)
+
+
+_ordinalf_to_timedelta_np_vectorized = np.vectorize(_ordinalf_to_timedelta)
+
+
+def num2timedelta(x):
+    """
+    Converts number of days to a :class:`timdelta` object.
+    If *x* is a sequence, a sequence of :class:`timedelta` objects will
+    be returned.
+
+    Parameters
+    ----------
+    x : float, sequence of floats
+        Number of days (fraction part represents hours, minutes, seconds)
+
+    Returns
+    -------
+    :class:`timedelta`
+
+    """
+    if not cbook.iterable(x):
+        return _ordinalf_to_timedelta(x)
+    else:
+        x = np.asarray(x)
+        if not x.size:
+            return x
+        return _ordinalf_to_timedelta_np_vectorized(x).tolist()
+
+
 def drange(dstart, dend, delta):
     """
     Return a date range as float Gregorian ordinals.  *dstart* and

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -137,7 +137,7 @@ import matplotlib.ticker as ticker
 
 
 __all__ = ('date2num', 'num2date', 'drange', 'epoch2num',
-           'num2epoch', 'mx2num', 'DateFormatter',
+           'num2epoch', 'mx2num', 'TimedeltaFormatter', 'DateFormatter',
            'IndexDateFormatter', 'AutoDateFormatter', 'DateLocator',
            'RRuleLocator', 'AutoDateLocator', 'YearLocator',
            'MonthLocator', 'WeekdayLocator',
@@ -619,15 +619,15 @@ class TimedeltaFormatter(ticker.Formatter):
         .. table:: Accepted format arguments
            :widths: auto
 
-           ========    =======
+           ========    ============
            Argument    Meaning
-           ========    =======
+           ========    ============
            {D}         Days
            {H}         Hours
            {M}         Minutes
            {S}         Seconds
            {f}         Microseconds
-           =========   =======
+           ========    ============
 
         Examples
         --------

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -466,3 +466,18 @@ def test_tz_utc():
 def test_num2timedelta(x, tdelta):
     dt = mdates.num2timedelta(x)
     assert dt == tdelta
+
+
+@pytest.mark.parametrize('dt, fmt, out',
+                         [(datetime.timedelta(days=8, hours=1, minutes=2,
+                                              seconds=3, microseconds=4),
+                           '{D}d {H:02}:{M:02}:{S:02}.{f:06}',
+                           '8d 01:02:03.000004'),
+                          (datetime.timedelta(seconds=1), '{f}', '1000000'),
+                          (datetime.timedelta(microseconds=1e5), '{S}', '0.1'),
+                          ])
+def test_TimedeltaFormatter(dt, fmt, out):
+    formatter = mdates.TimedeltaFormatter(fmt)
+    x = mdates.date2num(dt)
+    formatted = formatter(x)
+    assert formatted == out

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -457,3 +457,12 @@ def test_DayLocator():
 def test_tz_utc():
     dt = datetime.datetime(1970, 1, 1, tzinfo=mdates.UTC)
     dt.tzname()
+
+
+@pytest.mark.parametrize("x, tdelta",
+                         [(1, datetime.timedelta(days=1)),
+                          ([1, 1.5], [datetime.timedelta(days=1),
+                                      datetime.timedelta(days=1.5)])])
+def test_num2timedelta(x, tdelta):
+    dt = mdates.num2timedelta(x)
+    assert dt == tdelta


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

A new `TimedeltaFormatter`  class for formatting `timedelta` objects. Unlike `datetime` objects there's no `strftime` method, so I've had to roll my own version. The docstring examples and tests I've added should make it clear how it works.

This depends on PR #8730. See #8869 for tracker issue for plotting `timedelta` objects.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
