### PR TITLE
Fix a bug with the Qt5 backend with mixed resolution displays

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -674,7 +674,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
         fname, filter = _getSaveFileName(self.parent,
                                          "Choose a filename to save to",
-                                 start, filters, selectedFilter)
+                                         start, filters, selectedFilter)
         if fname:
             if startpath == '':
                 # explicitly missing key or empty str signals to use cwd

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -194,9 +194,8 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
         super(FigureCanvasQTAgg, self).__init__(figure=figure)
         # We don't want to scale up the figure DPI more than once.
         # Note, we don't handle a signal for changing DPI yet.
-        if not hasattr(self.figure, '_original_dpi'):
-            self.figure._original_dpi = self.figure.dpi
-        self.figure.dpi = self._dpi_ratio * self.figure._original_dpi
+        self.figure._original_dpi = self.figure.dpi
+        self._update_figure_dpi()
 
     def _update_figure_dpi(self):
         dpi = self._dpi_ratio * self.figure._original_dpi

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -66,6 +66,11 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         shown onscreen.
         """
 
+        # if the canvas does not have a renderer, then give up and wait for
+        # FigureCanvasAgg.draw(self) to be called
+        if not hasattr(self, 'renderer'):
+            return
+
         # As described in __init__ above, we need to be careful in cases with
         # mixed resolution displays if dpi_ratio is changing between painting
         # events.
@@ -82,11 +87,6 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
             # straight away, and this causes visual delays in the changes.
             self.resizeEvent(event)
             self._dpi_ratio_prev = self._dpi_ratio
-
-        # if the canvas does not have a renderer, then give up and wait for
-        # FigureCanvasAgg.draw(self) to be called
-        if not hasattr(self, 'renderer'):
-            return
 
         painter = QtGui.QPainter(self)
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -43,7 +43,8 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         # accordingly. We could watch for screenChanged events from Qt, but
         # the issue is that we can't guarantee this will be emitted *before*
         # the first paintEvent for the canvas, so instead we keep track of the
-        # dpi_ratio value here and in paintEvent we resize the canvas if needed.
+        # dpi_ratio value here and in paintEvent we resize the canvas if
+        # needed.
         self._dpi_ratio_prev = None
 
     def drawRectangle(self, rect):
@@ -68,9 +69,10 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         # As described in __init__ above, we need to be careful in cases with
         # mixed resolution displays if dpi_ratio is changing between painting
         # events.
-        if self._dpi_ratio_prev is None:
-            self._dpi_ratio_prev = self._dpi_ratio
-        elif self._dpi_ratio != self._dpi_ratio_prev:
+        if (self._dpi_ratio_prev is None or
+            self._dpi_ratio != self._dpi_ratio_prev):
+            # We need to update the figure DPI
+            self._update_figure_dpi()
             # The easiest way to resize the canvas is to emit a resizeEvent
             # since we implement all the logic for resizing the canvas for
             # that event.
@@ -195,6 +197,10 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
         if not hasattr(self.figure, '_original_dpi'):
             self.figure._original_dpi = self.figure.dpi
         self.figure.dpi = self._dpi_ratio * self.figure._original_dpi
+
+    def _update_figure_dpi(self):
+        dpi = self._dpi_ratio * self.figure._original_dpi
+        self.figure._set_dpi(dpi, forward=False)
 
 
 @_BackendQT5.export

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -418,11 +418,16 @@ class Figure(Artist):
     def _get_dpi(self):
         return self._dpi
 
-    def _set_dpi(self, dpi):
+    def _set_dpi(self, dpi, forward=True):
+        """
+        The forward kwarg is passed on to set_size_inches
+        """
         self._dpi = dpi
         self.dpi_scale_trans.clear().scale(dpi, dpi)
-        self.set_size_inches(*self.get_size_inches())
+        w, h = self.get_size_inches()
+        self.set_size_inches(w, h, forward=forward)
         self.callbacks.process('dpi_changed', self)
+
     dpi = property(_get_dpi, _set_dpi)
 
     def get_tight_layout(self):


### PR DESCRIPTION
When mixed-resolution displays are present, the _dpi_ratio attribute on the canvas may change between paintEvents, which means that we need to change the size of the canvas. However, the underlying canvas is only resized if a resizeEvent is emitted, so we check whether _dpi_ratio has changed between paintEvents, and if so we emit a fake resizeEvent for the widget.

Fixes https://github.com/matplotlib/matplotlib/issues/8061

Note that while this fixes the issue described in #8061 which was that one could end up with weird visual issues such as:

![screenshot](https://cloud.githubusercontent.com/assets/314716/22837602/3cc5cba0-efb9-11e6-9f62-65d6c66bf92c.png)

the plot for the lower DPI display still has too large fonts/linewidths, but I think that is a separate bug, which I'll try and fix in another PR.

cc @tacaswell @efiring 