### PR TITLE
Fix stopping of Tk timers from with timer callback.

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -94,8 +94,10 @@ class TimerTk(TimerBase):
         TimerBase._on_timer(self)
 
         # Tk after() is only a single shot, so we need to add code here to
-        # reset the timer if we're not operating in single shot mode.
-        if not self._single and len(self.callbacks) > 0:
+        # reset the timer if we're not operating in single shot mode.  However,
+        # if _timer is None, this means that _timer_stop has been called; so
+        # don't recreate the timer in that case.
+        if not self._single and self._timer:
             self._timer = self.parent.after(self._interval, self._on_timer)
         else:
             self._timer = None


### PR DESCRIPTION
Fixes #5163.

(Also don't stop the timer if callbacks is empty, as someone could add more callbacks to the list later.)