### PR TITLE
Allow ScaledTranslation to work with Bboxes.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -467,7 +467,7 @@ class PolarAxes(Axes):
         value : number
             The angular position of the radius labels in degrees.
         """
-        self._r_label_position._t = (value, 0.0)
+        self._r_label_position._xt = value
         self._r_label_position.invalidate()
 
     def set_yscale(self, *args, **kwargs):

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -634,3 +634,29 @@ def test_lockable_bbox(locked_element):
     assert getattr(locked, 'locked_' + locked_element) == 3
     for elem in other_elements:
         assert getattr(locked, elem) == getattr(orig, elem)
+
+
+class TestScaledTranslation(object):
+    def test_basic(self):
+        st = mtransforms.ScaledTranslation(0.5, 0.5, 3)
+        assert np.allclose(st.transform_point((0, 1)), [1.5, 2.5])
+
+    def test_with_transform(self):
+        trans = mtransforms.Affine2D()
+        st = mtransforms.ScaledTranslation(0.5, 0.5, trans)
+        assert np.allclose(st.transform_point((0, 1)), [0.5, 1.5])
+
+        # Changes to the transform should propagate.
+        trans.scale(3)
+        assert np.allclose(st.transform_point((0, 1)), [1.5, 2.5])
+
+    def test_with_bbox(self):
+        bbox = mtransforms.Bbox([[0, 0], [1, 1]])
+        st = mtransforms.ScaledTranslation((bbox, 'x0'), (bbox, 'y0'), 3)
+        assert np.allclose(st.transform_point((0, 1)), [0, 1])
+
+        # Changes to the bbox should propagate.
+        bbox.x0 = 2
+        assert np.allclose(st.transform_point((0, 1)), [6, 1])
+        bbox.y0 = 3
+        assert np.allclose(st.transform_point((0, 1)), [6, 10])


### PR DESCRIPTION
## PR Summary

This is a change pulled out of #4699 for easier review, used [here](https://github.com/matplotlib/matplotlib/pull/4699/files#diff-ad040ae4f095420eea5cee0b19e0a415R475), plus some new tests. It allows `ScaledTranslation` to pull the translation out of a `Bbox` instead of being hard-coded. Using the transform invalidation mechanism, it can remain up-to-date with whatever's in the `Bbox`.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/whats_new.rst if major new feature
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way