### PR TITLE
ENH: add style aliases for 'default' and 'classic'

### DIFF
--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -89,12 +89,18 @@ def use(style):
 
 
     """
+    style_alias = {'mpl20': 'default',
+                   'mpl15': 'classic'}
     if isinstance(style, six.string_types) or hasattr(style, 'keys'):
         # If name is a single str or dict, make it a single element list.
         styles = [style]
     else:
         styles = style
 
+    styles = (style_alias.get(s, s)
+              if isinstance(s, six.string_types)
+              else s
+              for s in styles)
     for style in styles:
         if not isinstance(style, six.string_types):
             _apply_style(style)

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -143,3 +143,18 @@ def test_context_with_badparam():
             with x:
                 pass
         assert mpl.rcParams[PARAM] == other_value
+
+
+@pytest.mark.parametrize('equiv_styles',
+                         [('mpl20', 'default'),
+                          ('mpl15', 'classic')],
+                         ids=['mpl20', 'mpl15'])
+def test_alias(equiv_styles):
+    rc_dicts = []
+    for sty in equiv_styles:
+        with style.context(sty):
+            rc_dicts.append(dict(mpl.rcParams))
+
+    rc_base = rc_dicts[0]
+    for nm, rc in zip(equiv_styles[1:], rc_dicts[1:]):
+        assert rc_base == rc


### PR DESCRIPTION
mpl20 <-> default
mpl15 <-> classic

When we change the style again, lock down the mpl20 style as a
file, but until then using as an alias for defaults is ok

closes #8934

If people are happy with this approach, it still needs a whats_new