### PR TITLE
Let QPaintEvent tell us what region to repaint.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -241,6 +241,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         self._dpi_ratio_prev = None
 
         self._draw_pending = False
+        self._erase_before_paint = False
         self._is_drawing = False
         self._draw_rect_callback = lambda painter: None
 
@@ -494,6 +495,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             return
         with cbook._setattr_cm(self, _is_drawing=True):
             super().draw()
+        self._erase_before_paint = True
         self.update()
 
     def draw_idle(self):

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -15,11 +15,7 @@ from .qt_compat import QT_API
 
 class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
-    def __init__(self, figure):
-        super().__init__(figure=figure)
-        self._bbox_queue = []
-
-    def paintEvent(self, e):
+    def paintEvent(self, event):
         """Copy the image from the Agg canvas to the qt.drawable.
 
         In Qt, all drawing should be done inside of here when a widget is
@@ -37,29 +33,31 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
         painter = QtGui.QPainter(self)
 
-        if self._bbox_queue:
-            bbox_queue = self._bbox_queue
-        else:
+        if self._erase_before_paint:
             painter.eraseRect(self.rect())
-            bbox_queue = [
-                Bbox([[0, 0], [self.renderer.width, self.renderer.height]])]
-        self._bbox_queue = []
-        for bbox in bbox_queue:
-            l, b, r, t = map(int, bbox.extents)
-            w = r - l
-            h = t - b
-            reg = self.copy_from_bbox(bbox)
-            buf = reg.to_string_argb()
-            qimage = QtGui.QImage(buf, w, h, QtGui.QImage.Format_ARGB32)
-            # Adjust the buf reference count to work around a memory leak bug
-            # in QImage under PySide on Python 3.
-            if QT_API == 'PySide':
-                ctypes.c_long.from_address(id(buf)).value = 1
-            if hasattr(qimage, 'setDevicePixelRatio'):
-                # Not available on Qt4 or some older Qt5.
-                qimage.setDevicePixelRatio(self._dpi_ratio)
-            origin = QtCore.QPoint(l, self.renderer.height - t)
-            painter.drawImage(origin / self._dpi_ratio, qimage)
+            self._erase_before_paint = False
+
+        rect = event.rect()
+        left = rect.left()
+        top = rect.top()
+        width = rect.width()
+        height = rect.height()
+        # See documentation of QRect: bottom() and right() are off by 1, so use
+        # left() + width() and top() + height().
+        bbox = Bbox([[left, self.renderer.height - (top + height)],
+                     [left + width, self.renderer.height - top]])
+        reg = self.copy_from_bbox(bbox)
+        buf = reg.to_string_argb()
+        qimage = QtGui.QImage(buf, width, height, QtGui.QImage.Format_ARGB32)
+        if hasattr(qimage, 'setDevicePixelRatio'):
+            # Not available on Qt4 or some older Qt5.
+            qimage.setDevicePixelRatio(self._dpi_ratio)
+        origin = QtCore.QPoint(left, top)
+        painter.drawImage(origin / self._dpi_ratio, qimage)
+        # Adjust the buf reference count to work around a memory
+        # leak bug in QImage under PySide on Python 3.
+        if QT_API == 'PySide':
+            ctypes.c_long.from_address(id(buf)).value = 1
 
         self._draw_rect_callback(painter)
 
@@ -72,8 +70,6 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         # blit only the area defined by the bbox.
         if bbox is None and self.figure:
             bbox = self.figure.bbox
-
-        self._bbox_queue.append(bbox)
 
         # repaint uses logical pixels, not physical pixels like the renderer.
         l, b, w, h = [pt / self._dpi_ratio for pt in bbox.bounds]

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -37,6 +37,9 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
             # Not available on Qt4 or some older Qt5.
             qimage.setDevicePixelRatio(dpi_ratio)
         painter = QtGui.QPainter(self)
+        if self._erase_before_paint:
+            painter.eraseRect(self.rect())
+            self._erase_before_paint = False
         painter.drawImage(0, 0, qimage)
         self._draw_rect_callback(painter)
         painter.end()


### PR DESCRIPTION
(instead of just updating the blitboxes.)

Alternate approach for #8948.
attn @tacaswell 

As for the performance questions, my work on mpl_cairo suggests to me that a big cost actually comes from the fact that we are copying the whole buffer into a string (https://github.com/matplotlib/matplotlib/blob/master/src/_backend_agg_wrapper.cpp#L586 before my recent changes, https://github.com/matplotlib/matplotlib/blob/master/src/_backend_agg_wrapper.cpp#L79 now that we always rely on Regions).  Note that the old Py2 version used to create a buffer object, which would avoid the need for copying.
In mpl_cairo, I instead return a numpy array which is a view on the internal buffer (https://github.com/anntzer/mpl_cairo/blob/master/src/_mpl_cairo.cpp#L260) and pass the address of the pointer (which can be retrieve via numpy) into QImage (https://github.com/anntzer/mpl_cairo/blob/master/mpl_cairo/qt.py#L15).  (To be clear, I haven't tried with agg, but on mpl_cairo this is much faster than copying the string around.)
This approach also removes the need for a refcount hack on PySide, as there is no buffer object for PySide to hold on anymore.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
