### PR TITLE
Fix `text.set(bbox=None)`.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -239,10 +239,12 @@ class Text(Artist):
         """
         Update properties from a dictionary.
         """
-        bbox = kwargs.pop('bbox', None)
+        # Update bbox last, as it depends on font properties.
+        sentinel = object()  # bbox can be None, so use another sentinel.
+        bbox = kwargs.pop("bbox", sentinel)
         super(Text, self).update(kwargs)
-        if bbox:
-            self.set_bbox(bbox)  # depends on font properties
+        if bbox is not sentinel:
+            self.set_bbox(bbox)
 
     def __getstate__(self):
         d = super(Text, self).__getstate__()


### PR DESCRIPTION
So far, in

    from pylab import *
    t = plt.text(.5, .5, "foo")
    t.set(bbox=dict(facecolor='red', alpha=0.5))
    # Other stuff, e.g. animation.
    t.set(bbox=None)
    plt.show()

The line `t.set(bbox=None)` has no effect and leaves the previous bbox
(even though `t.set_bbox(None)` would correctly remove it).  Fix by not
dropping the `{"bbox": None}` entry from the kwargs.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/whats_new.rst if major new feature
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
