### PR TITLE
Don't revalidate original rcParams when exiting rc_context.

### DIFF
--- a/doc/api/matplotlib_configuration_api.rst
+++ b/doc/api/matplotlib_configuration_api.rst
@@ -12,21 +12,15 @@ The top level :mod:`matplotlib` module
 
     An instance of :class:`RcParams` for handling default matplotlib values.
 
+.. autofunction:: rc_context
+
 .. autofunction:: rc
 
-.. autofunction::rcdefaults
+.. autofunction:: rc_file
 
-.. autofunction::rc_file
+.. autofunction:: rcdefaults
 
-.. autofunction::rc_context
-
-.. autofunction:: matplotlib_fname
-
-.. autofunction::rc_file_defaults
-
-.. autofunction::interactive
-
-.. autofunction::is_interactive
+.. autofunction:: rc_file_defaults
 
 .. autoclass:: RcParams
 
@@ -34,4 +28,8 @@ The top level :mod:`matplotlib` module
 
 .. autofunction:: rc_params_from_file
 
-.. autoclass:: rc_context
+.. autofunction:: matplotlib_fname
+
+.. autofunction:: interactive
+
+.. autofunction:: is_interactive

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1223,7 +1223,8 @@ def rc_file(fname):
     rcParams.update(rc_params_from_file(fname))
 
 
-class rc_context(object):
+@contextlib.contextmanager
+def rc_context(rc=None, fname=None):
     """
     Return a context manager for managing rc settings.
 
@@ -1256,26 +1257,16 @@ class rc_context(object):
 
     """
 
-    def __init__(self, rc=None, fname=None):
-        self.rcdict = rc
-        self.fname = fname
-        self._rcparams = rcParams.copy()
-        try:
-            if self.fname:
-                rc_file(self.fname)
-            if self.rcdict:
-                rcParams.update(self.rcdict)
-        except:
-            # if anything goes wrong, revert rc parameters and re-raise
-            rcParams.clear()
-            rcParams.update(self._rcparams)
-            raise
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, tb):
-        rcParams.update(self._rcparams)
+    orig = rcParams.copy()
+    try:
+        if fname:
+            rc_file(fname)
+        if rc:
+            rcParams.update(rc)
+        yield
+    finally:
+        # No need to revalidate the original values.
+        dict.update(rcParams, orig)
 
 
 _use_error_msg = """

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -103,21 +103,22 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-import sys
-import distutils.version
-from itertools import chain
 
 from collections import MutableMapping
+import contextlib
+import distutils.version
+import distutils.sysconfig
+import functools
 import io
 import inspect
+import itertools
 import locale
 import os
 import re
+import sys
 import tempfile
 import warnings
-import contextlib
-import distutils.sysconfig
-import functools
+
 # cbook must import matplotlib only within function
 # definitions, so it is safe to import from it here.
 from . import cbook
@@ -798,9 +799,8 @@ _obsolete_set = {'text.dvipnghack', 'legend.isaxes'}
 # The following may use a value of None to suppress the warning.
 _deprecated_set = {'axes.hold'}  # do NOT include in _all_deprecated
 
-_all_deprecated = set(chain(_deprecated_ignore_map,
-                            _deprecated_map,
-                            _obsolete_set))
+_all_deprecated = set(itertools.chain(
+    _deprecated_ignore_map, _deprecated_map, _obsolete_set))
 
 
 class RcParams(MutableMapping, dict):


### PR DESCRIPTION
- Rewrite rc_context using contextmanager, which removes the need for
  saving state.

- When `__exit__`ing rc_context, skip rcParam validation, as the items
  have already been validated originally.

The rationale for not revalidating (beyond a minor gain in speed) is
that it may make sense to smuggle seemingly "invalid" values into the
rcParams (by calling `dict.__setitem__`), and we do not want them to
cause an error when exiting a rc_context (of course, they may or may not
cause an error at the backend level, but that is the responsibility of
whoever set this "invalid" value).

For example, the rcparam `lines.antialiased` is declared as a boolean,
but the mpl_cairo backend actually also recognizes any of cairo's
internal antialiasing enum values (NONE, FAST, GOOD, BEST, etc.).

    
(The rst docs needed to be slightly updated because .. autoclass::
rc_context won't work anymore, so I also took advantage of that to
reorder all the rc-related functions slightly more logically.)

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant 
- [X] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
