### PR TITLE
Don't drop marker alpha in Qt figure options.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -117,8 +117,12 @@ def figure_edit(axes, parent=None):
         color = mcolors.to_hex(
             mcolors.to_rgba(line.get_color(), line.get_alpha()),
             keep_alpha=True)
-        ec = mcolors.to_hex(line.get_markeredgecolor(), keep_alpha=True)
-        fc = mcolors.to_hex(line.get_markerfacecolor(), keep_alpha=True)
+        ec = mcolors.to_hex(
+            mcolors.to_rgba(line.get_markeredgecolor(), line.get_alpha()),
+            keep_alpha=True)
+        fc = mcolors.to_hex(
+            mcolors.to_rgba(line.get_markerfacecolor(), line.get_alpha()),
+            keep_alpha=True)
         curvedata = [
             ('Label', label),
             sep,


### PR DESCRIPTION
Markers follow the artist alpha, if it is set (to check this, try

    l, = plot([1, 2], "o-", alpha=.5)
    l.set(markerfacecolor="#1f77b4ff")

and the marker will have alpha=.5 instead of 1); so also do so when
initializing the figure options dialog.

Otherwise, plotting `plot([1, 2], "o", alpha=.5)` and opening and
closing the figure options dialog will set the alpha of the markers to
fully opaque (essentially, we're just making markers pick their alpha
like the line itself does, on the line above).

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
