### PR TITLE
Undocument shading kwarg to pcolor.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5268,16 +5268,6 @@ or tuple of floats
             ``vmin`` or ``vmax`` passed in here override any pre-existing
             values supplied in the ``norm`` instance.
 
-        shading : {'flat', 'faceted'}, optional, default: 'flat'
-            This kwarg is deprecated; please use ``edgecolors`` instead -
-
-            * ``shading='flat'``: ``edgecolors='none'``
-            * ``shading='faceted'``: ``edgecolors='k'``
-
-            If 'faceted', a black grid is drawn around each rectangle; if
-            'flat', edges are not drawn. Default is 'flat', contrary to
-            MATLAB.
-
         edgecolors : {None, 'none', color, color sequence}
             If None, the rc setting is used by default.
             If 'none', edges will not be visible.


### PR DESCRIPTION
The kwarg doesn't even work anymore (`pcolor(np.random.rand(3, 3), shading="flat")` throws an exception).  It has also been marked as deprecated in the docstring since at least 2008.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
