### PR TITLE
Fix typos

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1641,7 +1641,7 @@ class Axis(artist.Artist):
         """
         raise NotImplementedError('Derived must override')
 
-    def _update_offset_text_postion(self, bboxes, bboxes2):
+    def _update_offset_text_position(self, bboxes, bboxes2):
         """
         Update the label position based on the sequence of bounding
         boxes of all the ticklabels

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -75,7 +75,7 @@ Here are all the date tickers:
 
     * :class:`HourLocator`: locate hours
 
-    * :class:`DayLocator`: locate specifed days of the month
+    * :class:`DayLocator`: locate specified days of the month
 
     * :class:`WeekdayLocator`: Locate days of the week, e.g., MO, TU
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -948,7 +948,7 @@ class Legend(Artist):
         draggable is on.
 
         The update parameter control which parameter of the legend changes
-        when dragged. If update is "loc", the *loc* paramter of the legend
+        when dragged. If update is "loc", the *loc* parameter of the legend
         is changed. If "bbox", the *bbox_to_anchor* parameter is changed.
         """
         is_draggable = self._draggable is not None


### PR DESCRIPTION
This PR fixes some typos: `postion`, `specifed`, and `paramter`.