### PR TITLE
Fix docstring of set_clip_path.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -668,18 +668,16 @@ class Artist(object):
         """
         Set the artist's clip path, which may be:
 
-          * a :class:`~matplotlib.patches.Patch` (or subclass) instance
+        - a :class:`~matplotlib.patches.Patch` (or subclass) instance; or
+        - a :class:`~matplotlib.path.Path` instance, in which case a
+          :class:`~matplotlib.transforms.Transform` instance, which will be
+          applied to the path before using it for clipping, must be provided;
+          or
+        - ``None``, to remove a previously set clipping path.
 
-          * a :class:`~matplotlib.path.Path` instance, in which case
-             an optional :class:`~matplotlib.transforms.Transform`
-             instance may be provided, which will be applied to the
-             path before using it for clipping.
-
-          * *None*, to remove the clipping path
-
-        For efficiency, if the path happens to be an axis-aligned
-        rectangle, this method will set the clipping box to the
-        corresponding rectangle and set the clipping path to *None*.
+        For efficiency, if the path happens to be an axis-aligned rectangle,
+        this method will set the clipping box to the corresponding rectangle
+        and set the clipping path to ``None``.
 
         ACCEPTS: [ (:class:`~matplotlib.path.Path`,
         :class:`~matplotlib.transforms.Transform`) |
@@ -714,10 +712,11 @@ class Artist(object):
             success = True
 
         if not success:
-            print(type(path), type(transform))
-            raise TypeError("Invalid arguments to set_clip_path")
-        # this may result in the callbacks being hit twice, but grantees they
-        # will be hit at least once
+            raise TypeError(
+                "Invalid arguments to set_clip_path, of type {} and {}"
+                .format(type(path).__name__, type(transform).__name__))
+        # This may result in the callbacks being hit twice, but guarantees they
+        # will be hit at least once.
         self.pchanged()
         self.stale = True
 


### PR DESCRIPTION
Most importantly, document that transform *must* be set if path is a
Path instance.

Also fix some rst markup and improve the exception message.

xref https://github.com/matplotlib/matplotlib/issues/8974#issuecomment-319621106

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
