### PR TITLE
Workaround for islice int error in animation.py

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1565,7 +1565,7 @@ class FuncAnimation(TimedAnimation):
         # itertools.islice can return an error when passed a numpy int instead
         # of a native python int. This is a known issue:
         # http://bugs.python.org/issue30537
-        # As a workaround, enforce conversion of save_count to native python int.
+        # As a workaround, enforce conversion of save_count to native python int
         if self.save_count is None:
             self.save_count = 100
         else:

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1585,6 +1585,10 @@ class FuncAnimation(TimedAnimation):
         # Generate an iterator for the sequence of saved data. If there are
         # no saved frames, generate a new frame sequence and take the first
         # save_count entries in it.
+        # itertools.islice can return an error when passed a numpy int instead
+        # of a native python int. This is a known issue:http://bugs.python.org/issue30537
+        # As a workaround, enforce conversion to native python int
+        self.save_count = int(self.save_count)
         if self._save_seq:
             # While iterating we are going to update _save_seq
             # so make a copy to safely iterate over

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1562,13 +1562,14 @@ class FuncAnimation(TimedAnimation):
             self.save_count = frames
 
         # If we're passed in and using the default, set it to 100.
-        if self.save_count is None:
-            self.save_count = 100
         # itertools.islice can return an error when passed a numpy int instead
         # of a native python int. This is a known issue:
         # http://bugs.python.org/issue30537
         # As a workaround, enforce conversion to native python int.
-        self.save_count = int(self.save_count)
+        if self.save_count is None:
+            self.save_count = 100
+        else:
+            self.save_count = int(self.save_count)
 
         self._init_func = init_func
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1565,7 +1565,7 @@ class FuncAnimation(TimedAnimation):
         # itertools.islice can return an error when passed a numpy int instead
         # of a native python int. This is a known issue:
         # http://bugs.python.org/issue30537
-        # As a workaround, enforce conversion of save_count to native python int
+        # As a workaround, convert save_count to native python int
         if self.save_count is None:
             self.save_count = 100
         else:

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1568,7 +1568,7 @@ class FuncAnimation(TimedAnimation):
         # of a native python int. This is a known issue:
         # http://bugs.python.org/issue30537
         # As a workaround, enforce conversion to native python int.
-        self.save_count = int(save_count)
+        self.save_count = int(self.save_count)
 
         self._init_func = init_func
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1543,7 +1543,6 @@ class FuncAnimation(TimedAnimation):
         # Amount of framedata to keep around for saving movies. This is only
         # used if we don't know how many frames there will be: in the case
         # of no generator or in the case of a callable.
-        self.save_count = save_count
 
         # Set up a function that creates a new iterable when needed. If nothing
         # is passed in for frames, just use itertools.count, which will just
@@ -1565,6 +1564,11 @@ class FuncAnimation(TimedAnimation):
         # If we're passed in and using the default, set it to 100.
         if self.save_count is None:
             self.save_count = 100
+        # itertools.islice can return an error when passed a numpy int instead
+        # of a native python int. This is a known issue:
+        # http://bugs.python.org/issue30537
+        # As a workaround, enforce conversion to native python int.
+        self.save_count = int(save_count)
 
         self._init_func = init_func
 
@@ -1585,10 +1589,6 @@ class FuncAnimation(TimedAnimation):
         # Generate an iterator for the sequence of saved data. If there are
         # no saved frames, generate a new frame sequence and take the first
         # save_count entries in it.
-        # itertools.islice can return an error when passed a numpy int instead
-        # of a native python int. This is a known issue:http://bugs.python.org/issue30537
-        # As a workaround, enforce conversion to native python int
-        self.save_count = int(self.save_count)
         if self._save_seq:
             # While iterating we are going to update _save_seq
             # so make a copy to safely iterate over

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1543,7 +1543,7 @@ class FuncAnimation(TimedAnimation):
         # Amount of framedata to keep around for saving movies. This is only
         # used if we don't know how many frames there will be: in the case
         # of no generator or in the case of a callable.
-
+        self.save_count = save_count
         # Set up a function that creates a new iterable when needed. If nothing
         # is passed in for frames, just use itertools.count, which will just
         # keep counting from 0. A callable passed in for frames is assumed to
@@ -1561,11 +1561,11 @@ class FuncAnimation(TimedAnimation):
             self._iter_gen = lambda: iter(xrange(frames))
             self.save_count = frames
 
-        # If we're passed in and using the default, set it to 100.
+        # If we're passed in and using the default, set save_count to 100.
         # itertools.islice can return an error when passed a numpy int instead
         # of a native python int. This is a known issue:
         # http://bugs.python.org/issue30537
-        # As a workaround, enforce conversion to native python int.
+        # As a workaround, enforce conversion of save_count to native python int.
         if self.save_count is None:
             self.save_count = 100
         else:


### PR DESCRIPTION
itertools.islice may raise an error when passed a numpy int instead of a native python int.
This is a known issue:http://bugs.python.org/issue30537

As a workaround, enforce conversion of self.save_count to native python int in new_saved_frame_seq():
        self.save_count = int(self.save_count)