### PR TITLE
Add tight_layout to some examples

### DIFF
--- a/examples/images_contours_and_fields/contour_image.py
+++ b/examples/images_contours_and_fields/contour_image.py
@@ -103,4 +103,5 @@ plt.setp(plt.gca(), ylim=ylim[::-1])
 plt.title("Origin from rc, reversed y-axis")
 plt.colorbar(im)
 
+plt.tight_layout()
 plt.show()

--- a/examples/images_contours_and_fields/pcolor_demo.py
+++ b/examples/images_contours_and_fields/pcolor_demo.py
@@ -78,8 +78,7 @@ c = ax.pcolorfast(x, y, z, cmap='RdBu', vmin=z_min, vmax=z_max)
 ax.set_title('pcolorfast')
 fig.colorbar(c, ax=ax)
 
-fig.subplots_adjust(wspace=0.5, hspace=0.5)
-
+fig.tight_layout()
 plt.show()
 
 

--- a/examples/scales/log_demo.py
+++ b/examples/scales/log_demo.py
@@ -15,10 +15,6 @@ t = np.arange(0.01, 20.0, 0.01)
 # Create figure
 fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
 
-# Note hspace is the amount of height reserved for white space between subplots
-# expressed as a fraction of the average axis height
-fig.subplots_adjust(hspace=0.5)
-
 # log y axis
 ax1.semilogy(t, np.exp(-t / 5.0))
 ax1.set(title='semilogy')
@@ -46,4 +42,5 @@ ax4.errorbar(x, y, xerr=0.1 * x, yerr=5.0 + 0.75 * y)
 # ylim must be set after errorbar to allow errorbar to autoscale limits
 ax4.set_ylim(ymin=0.1)
 
+fig.tight_layout()
 plt.show()


### PR DESCRIPTION
A replacement of #4937 - it was much easier to manually do the changes than trying to do a horrible rebase. Lots of the files originally modified have since had `tight_layout` added, so there were only a few left to do. Thanks to @sargas for the original PR!