### PR TITLE
Tick formatter does not support grouping with locale

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ omit = matplotlib/_version.py
 
 [report]
 exclude_lines =
+    pragma: no cover
     raise NotImplemented
     def __str__
     def __repr__

--- a/doc/api/next_api_changes/behavior/8987-Z.rst
+++ b/doc/api/next_api_changes/behavior/8987-Z.rst
@@ -1,0 +1,6 @@
+``ScalarFormatter`` *useLocale* option obeys grouping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the `~.ScalarFormatter` option *useLocale* is enabled (or
+:rc:`axes.formatter.use_locale` is *True*) and the configured locale uses
+grouping, a separator will be added as described in `locale.format_string`.

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,6 +1,7 @@
 from contextlib import nullcontext
-import re
 import itertools
+import locale
+import re
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
@@ -545,6 +546,21 @@ class TestScalarFormatter:
         with mpl.rc_context({'axes.formatter.useoffset': use_offset}):
             tmp_form = mticker.ScalarFormatter()
             assert use_offset == tmp_form.get_useOffset()
+
+    def test_use_locale(self):
+        conv = locale.localeconv()
+        sep = conv['thousands_sep']
+        if not sep or conv['grouping'][-1:] in ([], [locale.CHAR_MAX]):
+            pytest.skip('Locale does not apply grouping')  # pragma: no cover
+
+        with mpl.rc_context({'axes.formatter.use_locale': True}):
+            tmp_form = mticker.ScalarFormatter()
+            assert tmp_form.get_useLocale()
+
+            tmp_form.create_dummy_axis()
+            tmp_form.set_bounds(0, 10)
+            tmp_form.set_locs([1, 2, 3])
+            assert sep in tmp_form(1e9)
 
     @pytest.mark.parametrize(
         'sci_type, scilimits, lim, orderOfMag, fewticks', scilimits_data)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -612,7 +612,7 @@ class ScalarFormatter(Formatter):
         """
         Format *arg* with *fmt*, applying unicode minus and locale if desired.
         """
-        return self.fix_minus(locale.format_string(fmt, (arg,))
+        return self.fix_minus(locale.format_string(fmt, (arg,), True)
                               if self._useLocale else fmt % arg)
 
     def get_useMathText(self):


### PR DESCRIPTION
When formatting and setting useLocale to True, the numbers greater than 1000 are not grouped as specified by the locale. 1000 should be 1,000 in certain locales. By setting the last argument to locale.format_string the locale dependent grouping is honored.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
