### PR TITLE
Fix crash with Slider if value is out-of-bounds.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -335,6 +335,8 @@ class Slider(AxesWidget):
         self.valmin = valmin
         self.valmax = valmax
         valinit = self._value_in_bounds(valinit)
+        if valinit is None:
+            valinit = valmin
         self.val = valinit
         self.valinit = valinit
         self.poly = ax.axvspan(valmin, valinit, 0, 1, **kwargs)
@@ -407,8 +409,9 @@ class Slider(AxesWidget):
             self.drag_active = False
             event.canvas.release_mouse(self.ax)
             return
-        val = event.xdata
-        self.set_val(self._value_in_bounds(val))
+        val = self._value_in_bounds(event.xdata)
+        if val is not None:
+            self.set_val(val)
 
     def set_val(self, val):
         xy = self.poly.xy


### PR DESCRIPTION
Before #8134, the `return` in `_update` would mean that out-of-bounds updates would be ignored. But now that the `return` is in a helper function, out-of-bounds updates try to set the slider value to `None`, which crashes (in Qt at least). So try not to set the slider value to `None`.