### PR TITLE
Remove superfluous list calls from around map

### DIFF
--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -43,7 +43,7 @@ class SubplotBase(object):
             else:
                 try:
                     s = str(int(args[0]))
-                    rows, cols, num = list(map(int, s))
+                    rows, cols, num = map(int, s)
                 except ValueError:
                     raise ValueError(
                         'Single argument to subplot must be a 3-digit '

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2236,8 +2236,8 @@ def binary_repr(number, max_length=1025):
     """
 
 #   assert number < 2L << max_length
-    shifts = list(map(operator.rshift, max_length * [number],
-                  range(max_length - 1, -1, -1)))
+    shifts = map(operator.rshift, max_length * [number],
+                 range(max_length - 1, -1, -1))
     digits = list(map(operator.mod, shifts, max_length * [2]))
     if not digits.count(1):
         return 0

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1376,7 +1376,7 @@ class YAArrow(Patch):
         line and intersects (*x2*, *y2*) and the distance from (*x2*,
         *y2*) of the returned points is *k*.
         """
-        x1, y1, x2, y2, k = list(map(float, (x1, y1, x2, y2, k)))
+        x1, y1, x2, y2, k = map(float, (x1, y1, x2, y2, k))
 
         if y2 - y1 == 0:
             return x2, y2 + k, x2, y2 - k

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -385,7 +385,7 @@ class SubplotDivider(Divider):
             else:
                 try:
                     s = str(int(args[0]))
-                    rows, cols, num = list(map(int, s))
+                    rows, cols, num = map(int, s)
                 except ValueError:
                     raise ValueError(
                         'Single argument to subplot must be a 3-digit integer')

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -470,7 +470,7 @@ class Axes3D(Axes):
                                          scalez=scalez)
 
     def auto_scale_xyz(self, X, Y, Z=None, had_data=None):
-        x, y, z = list(map(np.asarray, (X, Y, Z)))
+        x, y, z = map(np.asarray, (X, Y, Z))
         try:
             x, y = x.flatten(), y.flatten()
             if Z is not None:


### PR DESCRIPTION
In python 2 `map` already returns a list, and as far as I know (and as checked for 3.5) in python 3 any iterable can be unpacked on assignment.

- The first commit removes `list()` calls from unpacking assignments of the form `x,y = list(map(fun,seq))`.
- The second commit removes an unrelated instance of `list(map())` where the resulting object is directly consumed by another `map` call on the next line. Considering how this change is qualitatively different from the other, more trivial ones, I separated this change for ease of cherry-picking if necessary.