### PR TITLE
Stop using np.{builtin}, and fix bugs due to the previous confusion

### DIFF
--- a/examples/event_handling/viewlims.py
+++ b/examples/event_handling/viewlims.py
@@ -36,8 +36,8 @@ class MandelbrotDisplay(object):
         self.y = np.linspace(ystart, yend, self.height).reshape(-1, 1)
         c = self.x + 1.0j * self.y
         threshold_time = np.zeros((self.height, self.width))
-        z = np.zeros(threshold_time.shape, dtype=np.complex)
-        mask = np.ones(threshold_time.shape, dtype=np.bool)
+        z = np.zeros(threshold_time.shape, dtype=complex)
+        mask = np.ones(threshold_time.shape, dtype=bool)
         for i in range(self.niter):
             z[mask] = z[mask]**self.power + c[mask]
             mask = (np.abs(z) < self.radius)

--- a/examples/images_contours_and_fields/contour_corner_mask.py
+++ b/examples/images_contours_and_fields/contour_corner_mask.py
@@ -14,7 +14,7 @@ x, y = np.meshgrid(np.arange(7), np.arange(10))
 z = np.sin(0.5 * x) * np.cos(0.52 * y)
 
 # Mask various z values.
-mask = np.zeros_like(z, dtype=np.bool)
+mask = np.zeros_like(z, dtype=bool)
 mask[2, 3:5] = True
 mask[3:5, 4] = True
 mask[7, 2] = True

--- a/examples/images_contours_and_fields/tricontour_smooth_delaunay.py
+++ b/examples/images_contours_and_fields/tricontour_smooth_delaunay.py
@@ -75,7 +75,7 @@ tri = Triangulation(x_test, y_test)
 ntri = tri.triangles.shape[0]
 
 # Some invalid data are masked out
-mask_init = np.zeros(ntri, dtype=np.bool)
+mask_init = np.zeros(ntri, dtype=bool)
 masked_tri = random_gen.randint(0, ntri, int(ntri * init_mask_frac))
 mask_init[masked_tri] = True
 tri.set_mask(mask_init)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4769,9 +4769,9 @@ or tuple of floats
             y2 = np.ones_like(x) * y2
 
         if where is None:
-            where = np.ones(len(x), np.bool)
+            where = np.ones(len(x), bool)
         else:
-            where = np.asarray(where, np.bool)
+            where = np.asarray(where, bool)
 
         if not (x.shape == y1.shape == y2.shape == where.shape):
             raise ValueError("Argument dimensions are incompatible")
@@ -4930,9 +4930,9 @@ or tuple of floats
             x2 = np.ones_like(y) * x2
 
         if where is None:
-            where = np.ones(len(y), np.bool)
+            where = np.ones(len(y), bool)
         else:
-            where = np.asarray(where, np.bool)
+            where = np.asarray(where, bool)
 
         if not (y.shape == x1.shape == x2.shape == where.shape):
             raise ValueError("Argument dimensions are incompatible")
@@ -4954,7 +4954,7 @@ or tuple of floats
                 continue
 
             N = len(yslice)
-            Y = np.zeros((2 * N + 2, 2), np.float)
+            Y = np.zeros((2 * N + 2, 2), float)
             if interpolate:
                 def get_interp_point(ind):
                     im1 = max(ind - 1, 0)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1443,7 +1443,7 @@ def hsv_to_rgb(hsv):
     g = np.empty_like(h)
     b = np.empty_like(h)
 
-    i = (h * 6.0).astype(np.int)
+    i = (h * 6.0).astype(int)
     f = (h * 6.0) - i
     p = v * (1.0 - s)
     q = v * (1.0 - s * f)

--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -58,13 +58,13 @@ stock_dt_ohlc = np.dtype([
     (str('year'), np.int16),
     (str('month'), np.int8),
     (str('day'), np.int8),
-    (str('d'), np.float),     # mpl datenum
-    (str('open'), np.float),
-    (str('high'), np.float),
-    (str('low'), np.float),
-    (str('close'), np.float),
-    (str('volume'), np.float),
-    (str('aclose'), np.float)])
+    (str('d'), float),     # mpl datenum
+    (str('open'), float),
+    (str('high'), float),
+    (str('low'), float),
+    (str('close'), float),
+    (str('volume'), float),
+    (str('aclose'), float)])
 
 
 stock_dt_ochl = np.dtype(
@@ -72,13 +72,13 @@ stock_dt_ochl = np.dtype(
      (str('year'), np.int16),
      (str('month'), np.int8),
      (str('day'), np.int8),
-     (str('d'), np.float),     # mpl datenum
-     (str('open'), np.float),
-     (str('close'), np.float),
-     (str('high'), np.float),
-     (str('low'), np.float),
-     (str('volume'), np.float),
-     (str('aclose'), np.float)])
+     (str('d'), float),     # mpl datenum
+     (str('open'), float),
+     (str('close'), float),
+     (str('high'), float),
+     (str('low'), float),
+     (str('volume'), float),
+     (str('aclose'), float)])
 
 
 def parse_yahoo_historical_ochl(fh, adjusted=True, asobject=False):

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3136,17 +3136,17 @@ def rec2txt(r, header=None, padding=3, precision=3, fields=None):
     def get_justify(colname, column, precision):
         ntype = column.dtype
 
-        if np.issubdtype(ntype, str) or np.issubdtype(ntype, bytes):
+        if np.issubdtype(ntype, np.character):
             fixed_width = int(ntype.str[2:])
             length = max(len(colname), fixed_width)
             return 0, length+padding, "%s"  # left justify
 
-        if np.issubdtype(ntype, int):
+        if np.issubdtype(ntype, np.integer):
             length = max(len(colname),
                          np.max(list(map(len, list(map(str, column))))))
             return 1, length+padding, "%d"  # right justify
 
-        if np.issubdtype(ntype, float):
+        if np.issubdtype(ntype, np.floating):
             fmt = "%." + str(precision) + "f"
             length = max(
                 len(colname),

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3141,12 +3141,12 @@ def rec2txt(r, header=None, padding=3, precision=3, fields=None):
             length = max(len(colname), fixed_width)
             return 0, length+padding, "%s"  # left justify
 
-        if np.issubdtype(ntype, np.int):
+        if np.issubdtype(ntype, int):
             length = max(len(colname),
                          np.max(list(map(len, list(map(str, column))))))
             return 1, length+padding, "%d"  # right justify
 
-        if np.issubdtype(ntype, np.float):
+        if np.issubdtype(ntype, float):
             fmt = "%." + str(precision) + "f"
             length = max(
                 len(colname),

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -982,12 +982,12 @@ class Barbs(mcollections.PolyCollection):
         # If rounding, round to the nearest multiple of half, the smallest
         # increment
         if rounding:
-            mag = half * (mag / half + 0.5).astype(np.int)
+            mag = half * (mag / half + 0.5).astype(int)
 
-        num_flags = np.floor(mag / flag).astype(np.int)
+        num_flags = np.floor(mag / flag).astype(int)
         mag = np.mod(mag, flag)
 
-        num_barb = np.floor(mag / full).astype(np.int)
+        num_barb = np.floor(mag / full).astype(int)
         mag = np.mod(mag, full)
 
         half_flag = mag >= half

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -599,14 +599,14 @@ def interpgrid(a, xi, yi):
 
     Ny, Nx = np.shape(a)
     if isinstance(xi, np.ndarray):
-        x = xi.astype(np.int)
-        y = yi.astype(np.int)
+        x = xi.astype(int)
+        y = yi.astype(int)
         # Check that xn, yn don't exceed max index
         xn = np.clip(x + 1, 0, Nx - 1)
         yn = np.clip(y + 1, 0, Ny - 1)
     else:
-        x = np.int(xi)
-        y = np.int(yi)
+        x = int(xi)
+        y = int(yi)
         # conditional is faster than clipping for integers
         if x == (Nx - 2):
             xn = x

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -705,7 +705,7 @@ def test_mask_image():
 
     ax1.imshow(A, interpolation='nearest')
 
-    A = np.zeros((5, 5), dtype=np.bool)
+    A = np.zeros((5, 5), dtype=bool)
     A[1:2, 1:2] = True
     A = np.ma.masked_array(np.ones((5, 5), dtype=np.uint16), A)
 

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -847,7 +847,7 @@ def test_tritools():
     x = np.array([0., 1., 0.5, 0., 2.])
     y = np.array([0., 0., 0.5*np.sqrt(3.), -1., 1.])
     triangles = np.array([[0, 1, 2], [0, 1, 3], [1, 2, 4]], dtype=np.int32)
-    mask = np.array([False, False, True], dtype=np.bool)
+    mask = np.array([False, False, True], dtype=bool)
     triang = mtri.Triangulation(x, y, triangles, mask=mask)
     analyser = mtri.TriAnalyzer(triang)
     assert_array_almost_equal(analyser.scale_factors,
@@ -881,7 +881,7 @@ def test_tritools():
     triang = mtri.Triangulation(x, y, triangles=meshgrid_triangles(n+1))
     analyser = mtri.TriAnalyzer(triang)
     mask_flat = analyser.get_flat_tri_mask(0.2)
-    verif_mask = np.zeros(162, dtype=np.bool)
+    verif_mask = np.zeros(162, dtype=bool)
     corners_index = [0, 1, 2, 3, 14, 15, 16, 17, 18, 19, 34, 35, 126, 127,
                      142, 143, 144, 145, 146, 147, 158, 159, 160, 161]
     verif_mask[corners_index] = True
@@ -889,7 +889,7 @@ def test_tritools():
 
     # Now including a hole (masked triangle) at the center. The center also
     # shall be eliminated by get_flat_tri_mask.
-    mask = np.zeros(162, dtype=np.bool)
+    mask = np.zeros(162, dtype=bool)
     mask[80] = True
     triang.set_mask(mask)
     mask_flat = analyser.get_flat_tri_mask(0.2)
@@ -906,7 +906,7 @@ def test_trirefine():
     x, y = np.meshgrid(x, x)
     x = x.ravel()
     y = y.ravel()
-    mask = np.zeros(2*n**2, dtype=np.bool)
+    mask = np.zeros(2*n**2, dtype=bool)
     mask[n**2:] = True
     triang = mtri.Triangulation(x, y, triangles=meshgrid_triangles(n+1),
                                 mask=mask)
@@ -1032,7 +1032,7 @@ def test_trianalyzer_mismatched_indices():
     x = np.array([0., 1., 0.5, 0., 2.])
     y = np.array([0., 0., 0.5*np.sqrt(3.), -1., 1.])
     triangles = np.array([[0, 1, 2], [0, 1, 3], [1, 2, 4]], dtype=np.int32)
-    mask = np.array([False, False, True], dtype=np.bool)
+    mask = np.array([False, False, True], dtype=bool)
     triang = mtri.Triangulation(x, y, triangles, mask=mask)
     analyser = mtri.TriAnalyzer(triang)
     # numpy >= 1.10 raises a VisibleDeprecationWarning in the following line

--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -66,7 +66,7 @@ class Triangulation(object):
                 raise ValueError('triangles min element is out of bounds')
 
         if mask is not None:
-            self.mask = np.asarray(mask, dtype=np.bool)
+            self.mask = np.asarray(mask, dtype=bool)
             if self.mask.shape != (self.triangles.shape[0],):
                 raise ValueError('mask array must have same length as '
                                  'triangles array')
@@ -200,7 +200,7 @@ class Triangulation(object):
         if mask is None:
             self.mask = None
         else:
-            self.mask = np.asarray(mask, dtype=np.bool)
+            self.mask = np.asarray(mask, dtype=bool)
             if self.mask.shape != (self.triangles.shape[0],):
                 raise ValueError('mask array must have same length as '
                                  'triangles array')

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -177,7 +177,7 @@ class TriAnalyzer(object):
 
         current_mask = self._triangulation.mask
         if current_mask is None:
-            current_mask = np.zeros(ntri, dtype=np.bool)
+            current_mask = np.zeros(ntri, dtype=bool)
         valid_neighbors = np.copy(self._triangulation.neighbors)
         renum_neighbors = np.arange(ntri, dtype=np.int32)
         nadd = -1

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -343,8 +343,8 @@ def test_poly3dcollection_closed():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
 
-    poly1 = np.array([[0, 0, 1], [0, 1, 1], [0, 0, 0]], np.float)
-    poly2 = np.array([[0, 1, 1], [1, 1, 1], [1, 1, 0]], np.float)
+    poly1 = np.array([[0, 0, 1], [0, 1, 1], [0, 0, 0]], float)
+    poly2 = np.array([[0, 1, 1], [1, 1, 1], [1, 1, 0]], float)
     c1 = art3d.Poly3DCollection([poly1], linewidths=3, edgecolor='k',
                                 facecolor=(0.5, 0.5, 1, 0.5), closed=True)
     c2 = art3d.Poly3DCollection([poly2], linewidths=3, edgecolor='k',


### PR DESCRIPTION
For `x` in `{int, bool, str, float, complex, object}`, `np.{x}` and `builtins.{x}` are one and the same:

```
>>> np.float is float
True
>>> np.bool is bool
True
# etc
```

Using the `np.{x}` version is deceptive as it suggests that there is a difference, when there is not. This change doesn't affect any external behaviour.

Similar to numpy/numpy#9517