### PR TITLE
CI: increase the allowed number of failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - INSTALL_PEP8=
     - RUN_PEP8=
     - NOSE=
-    - PYTEST_ARGS="-rawR --maxfail=1 --timeout=300 --durations=25 --cov-report= --cov=lib -n $NPROC"
+    - PYTEST_ARGS="-rawR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n $NPROC"
     - PYTHON_ARGS=
     - DELETE_FONT_CACHE=
 


### PR DESCRIPTION
This is low enough in the case of catastrophic failures it will still
bail early, but high enough that we will see all of the failures due
to a change / be resilient to the few remaining transient failures.

