### PR TITLE
FIX: logscale + subplots share axes

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1173,14 +1173,16 @@ class Figure(Artist):
         if sharex in ["col", "all"]:
             # turn off all but the bottom row
             for ax in axarr[:-1, :].flat:
-                for label in ax.get_xticklabels():
-                    label.set_visible(False)
+                ax.xaxis.set_tick_params(which='both',
+                                         label1On=False, label2On=False)
                 ax.xaxis.offsetText.set_visible(False)
         if sharey in ["row", "all"]:
             # turn off all but the first column
             for ax in axarr[:, 1:].flat:
-                for label in ax.get_yticklabels():
+                for label in ax.get_yticklabels(which='both'):
                     label.set_visible(False)
+                ax.yaxis.set_tick_params(which='both',
+                                         label1On=False, label2On=False)
                 ax.yaxis.offsetText.set_visible(False)
 
         if squeeze:

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -298,3 +298,24 @@ def test_invalid_figure_size():
 
     with pytest.raises(ValueError):
         fig.add_axes((.1, .1, .5, np.nan))
+
+
+def test_subplots_shareax_loglabels():
+    fig, ax_arr = plt.subplots(2, 2, sharex=True, sharey=True, squeeze=False)
+    for ax in ax_arr.flatten():
+        ax.plot([10, 20, 30], [10, 20, 30])
+
+    ax.set_yscale("log")
+    ax.set_xscale("log")
+
+    for ax in ax_arr[0, :]:
+        assert 0 == len(ax.xaxis.get_ticklabels(which='both'))
+
+    for ax in ax_arr[1, :]:
+        assert 0 < len(ax.xaxis.get_ticklabels(which='both'))
+
+    for ax in ax_arr[:, 1]:
+        assert 0 == len(ax.yaxis.get_ticklabels(which='both'))
+
+    for ax in ax_arr[:, 0]:
+        assert 0 < len(ax.yaxis.get_ticklabels(which='both'))


### PR DESCRIPTION
Use `set_tick_params` to hide tick labels in not-edge plots instead
of setting the visibility on the tick label objects.

This catches both major and minor tick-labels and is more robust to
changes in the ticklabel generation.

closes #8903

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
