### PR TITLE
[DOC] replaced np.random with concrete data in stackplot_demo

### DIFF
--- a/examples/lines_bars_and_markers/stackplot_demo.py
+++ b/examples/lines_bars_and_markers/stackplot_demo.py
@@ -19,7 +19,7 @@ y3 = [1, 3, 5, 7, 9]
 
 y = np.vstack([y1, y2, y3])
 
-labels = ["fib", "evens", "odds"]
+labels = ["Fibonacci ", "Evens", "Odds"]
 
 fig, ax = plt.subplots()
 ax.stackplot(x, y1, y2, y3, labels=labels)

--- a/examples/lines_bars_and_markers/stackplot_demo.py
+++ b/examples/lines_bars_and_markers/stackplot_demo.py
@@ -12,29 +12,26 @@ show some examples to accomplish this with Matplotlib.
 import numpy as np
 import matplotlib.pyplot as plt
 
-# Fixing random state for reproducibility
-np.random.seed(19680801)
+x = [1, 2, 3, 4, 5]
+y1 = [1, 1, 2, 3, 5]
+y2 = [0, 4, 2, 6, 8]
+y3 = [1, 3, 5, 7, 9]
 
+y = np.vstack([y1, y2, y3])
 
-def fnx():
-    return np.random.randint(5, 50, 10)
+labels = ["fib", "evens", "odds"]
 
-
-y = np.row_stack((fnx(), fnx(), fnx()))
-x = np.arange(10)
-
-y1, y2, y3 = fnx(), fnx(), fnx()
+fig, ax = plt.subplots()
+ax.stackplot(x, y1, y2, y3, labels=labels)
+ax.legend(loc=2)
+plt.show()
 
 fig, ax = plt.subplots()
 ax.stackplot(x, y)
 plt.show()
 
-fig, ax = plt.subplots()
-ax.stackplot(x, y1, y2, y3)
-plt.show()
-
 ###############################################################################
-# Here we'll show a slightly more complex example.
+# Here we show an example of making a streamgraph using stackplot
 
 
 def layers(n, m):


### PR DESCRIPTION
Per the discussion on gitter, I explicitly define the data in the [stackplot_demo](http://matplotlib.org/examples/pylab_examples/stackplot_demo.html) example. This replaces data generated by np.random. So I changed:
```python
def fnx():
    return np.random.randint(5, 50, 10)

y = np.row_stack((fnx(), fnx(), fnx()))
x = np.arange(10)

y1, y2, y3 = fnx(), fnx(), fnx()
```
to 
```python
x = [1, 2, 3, 4, 5]
y1 = [1, 1, 2, 3, 5]
y2 = [0, 4, 2, 6, 8]
y3 = [1, 3, 5, 7, 9]

y = np.vstack([y1, y2, y3])

labels = ["fib", "evens", "odds"]
```
The reasoning behind this change is that I feel that the random data obscured what the function was doing. I also added labels 'cause I feel it adds clarity. 
- [x] Code is PEP 8 compliant 
- [x] Documentation is sphinx and numpydoc compliant