### PR TITLE
Add a banner indicating docs are unreleased.

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -710,6 +710,30 @@ figcaption {
   text-align: center;
 }
 
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.5em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}
+
 /* Fork me on GitHub "button" */
 #forkongithub a{
   background:#FF7F0E;

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -162,6 +162,14 @@ parents[-1].link|e }}" />
 
 {% block relbar1 %}
 
+{%- if '+' in release %}
+<div id="unreleased-message">
+    You are reading documentation for the unreleased version of Matplotlib.
+    <a href="https://matplotlib.org/search.html?q={{ title | striptags | urlencode }}&amp;check_keywords=yes&amp;area=default">
+        Try searching for the released version of this page instead?
+    </a>
+</div>
+{%- endif %}
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px; position: relative;">
 {%- if builder in ('htmlhelp', 'devhelp', 'latex') %}
 <a href="{{ pathto('index') }}"><img src="{{pathto("_static/logo2.png", 1) }}" width="540px" border="0" alt="matplotlib"/></a>


### PR DESCRIPTION
We've been getting quite a lot of tickets asking about features that don't yet exist in the released versions, so add a banner indicating that the page is for the unreleased version. I chose to use tab10:red + bolding, which I hope is flashy enough to catch people's attention.

Also, point to a search for the same page in the latest released version. Unfortunately, there's no easy way to point to the exact same page, especially with all the moved examples lately.

cc @doraf