### PR TITLE
Fixes zoom rubberband display on macOS w/ wxagg and multiple subplots

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1619,7 +1619,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                         event.inaxes.bbox)
                     self.zoomStartX = event.xdata
                     self.zoomStartY = event.ydata
-                    self.zoomAxes = event.inaxes
+                    self._zoomAxes = event.inaxes
 
     def release(self, event):
         if self._active == 'ZOOM':
@@ -1633,6 +1633,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                 if self.prevZoomRect:
                     self.prevZoomRect.pop(0).remove()
                     self.prevZoomRect = None
+                    self._zoomAxes = None
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         if self.retinaFix:  # On Macs, use the following code
@@ -1645,10 +1646,10 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             Y0, Y1 = self.zoomStartY, event.ydata
             lineX = (X0, X0, X1, X1, X0)
             lineY = (Y0, Y1, Y1, Y0, Y0)
-            self.prevZoomRect = self.zoomAxes.plot(
+            self.prevZoomRect = self._zoomAxes.plot(
                 lineX, lineY, '-', color=rubberBandColor)
-            self.zoomAxes.draw_artist(self.prevZoomRect[0])
-            self.canvas.blit(self.zoomAxes.bbox)
+            self._zoomAxes.draw_artist(self.prevZoomRect[0])
+            self.canvas.blit(self._zoomAxes.bbox)
             return
 
         # Use an Overlay to draw a rubberband-like bounding box.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1614,10 +1614,12 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             if not self.retinaFix:
                 self.wxoverlay = wx.Overlay()
             else:
-                self.savedRetinaImage = self.canvas.copy_from_bbox(
-                    self.canvas.figure.gca().bbox)
-                self.zoomStartX = event.xdata
-                self.zoomStartY = event.ydata
+                if event.inaxes is not None:
+                    self.savedRetinaImage = self.canvas.copy_from_bbox(
+                        event.inaxes.bbox)
+                    self.zoomStartX = event.xdata
+                    self.zoomStartY = event.ydata
+                    self.zoomAxes = event.inaxes
 
     def release(self, event):
         if self._active == 'ZOOM':
@@ -1643,10 +1645,10 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             Y0, Y1 = self.zoomStartY, event.ydata
             lineX = (X0, X0, X1, X1, X0)
             lineY = (Y0, Y1, Y1, Y0, Y0)
-            self.prevZoomRect = self.canvas.figure.gca().plot(
+            self.prevZoomRect = self.zoomAxes.plot(
                 lineX, lineY, '-', color=rubberBandColor)
-            self.canvas.figure.gca().draw_artist(self.prevZoomRect[0])
-            self.canvas.blit(self.canvas.figure.gca().bbox)
+            self.zoomAxes.draw_artist(self.prevZoomRect[0])
+            self.canvas.blit(self.zoomAxes.bbox)
             return
 
         # Use an Overlay to draw a rubberband-like bounding box.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1619,7 +1619,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                         event.inaxes.bbox)
                     self.zoomStartX = event.xdata
                     self.zoomStartY = event.ydata
-                    self._zoomAxes = event.inaxes
+                    self.zoomAxes = event.inaxes
 
     def release(self, event):
         if self._active == 'ZOOM':
@@ -1633,7 +1633,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                 if self.prevZoomRect:
                     self.prevZoomRect.pop(0).remove()
                     self.prevZoomRect = None
-                    self._zoomAxes = None
+                    self.zoomAxes = None
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         if self.retinaFix:  # On Macs, use the following code
@@ -1646,10 +1646,10 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             Y0, Y1 = self.zoomStartY, event.ydata
             lineX = (X0, X0, X1, X1, X0)
             lineY = (Y0, Y1, Y1, Y0, Y0)
-            self.prevZoomRect = self._zoomAxes.plot(
+            self.prevZoomRect = self.zoomAxes.plot(
                 lineX, lineY, '-', color=rubberBandColor)
-            self._zoomAxes.draw_artist(self.prevZoomRect[0])
-            self.canvas.blit(self._zoomAxes.bbox)
+            self.zoomAxes.draw_artist(self.prevZoomRect[0])
+            self.canvas.blit(self.zoomAxes.bbox)
             return
 
         # Use an Overlay to draw a rubberband-like bounding box.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1633,6 +1633,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                 if self.prevZoomRect:
                     self.prevZoomRect.pop(0).remove()
                     self.prevZoomRect = None
+                if self.zoomAxes:
                     self.zoomAxes = None
 
     def draw_rubberband(self, event, x0, y0, x1, y1):


### PR DESCRIPTION
## PR Summary
This fixes an issue where the zoom box (rubberband) was not displaying correctly when using the wxagg backend on macOS/OS X and a figure had multiple subplots.
It is a fix for the following issue:
#9004 

## PR Checklist
- [X] Code is PEP 8 compliant 