### PR TITLE
adding webagg.address parameter to rcParams

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -229,7 +229,7 @@ class WebAggApplication(tornado.web.Application):
             template_path=core.FigureManagerWebAgg.get_static_file_path())
 
     @classmethod
-    def initialize(cls, url_prefix='', port=None):
+    def initialize(cls, url_prefix='', port=None, address=None):
         if cls.initialized:
             return
 
@@ -253,10 +253,15 @@ class WebAggApplication(tornado.web.Application):
                 yield port + random.randint(-2 * n, 2 * n)
 
         success = None
+
+        if address is None:
+            cls.address = rcParams['webagg.address']
+        else:
+            cls.address = address
         cls.port = rcParams['webagg.port']
         for port in random_ports(cls.port, rcParams['webagg.port_retries']):
             try:
-                app.listen(port)
+                app.listen(port, cls.address)
             except socket.error as e:
                 if e.errno != errno.EADDRINUSE:
                     raise

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -892,7 +892,8 @@ def validate_webagg_address(s):
             socket.inet_aton(s)
         except socket.error as e:
             raise ValueError("'webagg.address' is not a valid IP address")
-    return s
+        return s
+    raise ValueError("'webagg.address' is not a valid IP address")
 
 # A validator dedicated to the named line styles, based on the items in
 # ls_mapper, and a list of possible strings read from Line2D.set_linestyle

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -885,6 +885,15 @@ def validate_animation_writer_path(p):
         modules["matplotlib.animation"].writers.set_dirty()
     return p
 
+def validate_webagg_address(s):
+    if s is not None:
+        import socket
+        try:
+            socket.inet_aton(s)
+        except socket.error as e:
+            raise ValueError("'webagg.address' is not a valid IP address")
+    return s
+
 # A validator dedicated to the named line styles, based on the items in
 # ls_mapper, and a list of possible strings read from Line2D.set_linestyle
 _validate_named_linestyle = ValidateInStrings('linestyle',
@@ -943,6 +952,7 @@ defaultParams = {
     'backend.qt4':       ['PyQt4', validate_qt4],
     'backend.qt5':       ['PyQt5', validate_qt5],
     'webagg.port':       [8988, validate_int],
+    'webagg.address':    ['127.0.0.1', validate_webagg_address],
     'webagg.open_in_browser': [True, validate_bool],
     'webagg.port_retries': [50, validate_int],
     'nbagg.transparent':       [True, validate_bool],

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -37,7 +37,7 @@ STYLE_FILE_PATTERN = re.compile(r'([\S]+).%s$' % STYLE_EXTENSION)
 
 # A list of rcParams that should not be applied from styles
 STYLE_BLACKLIST = {
-    'interactive', 'backend', 'backend.qt4', 'webagg.port',
+    'interactive', 'backend', 'backend.qt4', 'webagg.port', 'webagg.address',
     'webagg.port_retries', 'webagg.open_in_browser', 'backend_fallback',
     'toolbar', 'timezone', 'datapath', 'figure.max_open_warning',
     'savefig.directory', 'tk.window_focus', 'docstring.hardcopy'}

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -53,6 +53,9 @@ backend      : $TEMPLATE_BACKEND
 # The port to use for the web server in the WebAgg backend.
 # webagg.port : 8888
 
+# The address on which the WebAgg web server should be reachable
+# webagg.address : 127.0.0.1
+
 # If webagg.port is unavailable, a number of other random ports will
 # be tried until one that is available is found.
 # webagg.port_retries : 50


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

WebAgg is by default accessible to anyone on the network, so to provide better control over the access to it, it is needed to add the address parameter

<!--If it fixes an open issue, please link to the issue here.-->
