### PR TITLE
Fix typos

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -88,8 +88,9 @@ class UnitData(object):
     def __init__(self, data):
         """Create mapping between unique categorical values
         and numerical identifier
-        Paramters
-        ---------
+
+        Parameters
+        ----------
         data: iterable
             sequence of values
         """

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -948,7 +948,7 @@ class Legend(Artist):
         draggable is on.
 
         The update parameter control which parameter of the legend changes
-        when dragged. If update is "loc", the *loc* paramter of the legend
+        when dragged. If update is "loc", the *loc* parameter of the legend
         is changed. If "bbox", the *bbox_to_anchor* parameter is changed.
         """
         is_draggable = self._draggable is not None

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3751,7 +3751,7 @@ def inside_poly(points, verts):
     # Make a closed polygon path
     poly = Path(verts)
 
-    # Check to see which points are contained withing the Path
+    # Check to see which points are contained within the Path
     return [idx for idx, p in enumerate(points) if poly.contains_point(p)]
 
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -109,7 +109,7 @@ def test_alpha_rcparam():
     ax.plot(range(10), lw=5)
     with mpl.rc_context(rc={'legend.framealpha': .75}):
         leg = plt.legend(['Longlabel that will go away'], loc=10)
-        # this alpha is going to be over-ridden by the rcparam whith
+        # this alpha is going to be over-ridden by the rcparam with
         # sets the alpha of the patch to be non-None which causes the alpha
         # value of the face color to be discarded.  This behavior may not be
         # ideal, but it is what it is and we should keep track of it changing


### PR DESCRIPTION
This PR fixes some typos: `Paramter`, `paramter`, `withing`, and `whith`.