### PR TITLE
Clarify docstring for SymmetricLogScale linthresh keyword arg

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -358,8 +358,9 @@ class SymmetricalLogScale(ScaleBase):
            The base of the logarithm
 
         *linthreshx*/*linthreshy*:
-          The range (-*x*, *x*) within which the plot is linear (to
-          avoid having the plot go to infinity around zero).
+          A single float which defines the range (-*x*, *x*), within
+          which the plot is linear. This avoids having the plot go to
+          infinity around zero.
 
         *subsx*/*subsy*:
            Where to place the subticks between each major tick.


### PR DESCRIPTION
The linthreshx/y keyword argument for the SymmetricalLogScale class
could have been misunderstood as accepting a tuple. Added some words
to make sure this is completely obvious when reading the documentation.