### PR TITLE
adding missing numpy import in backend-tools

### DIFF
--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -19,6 +19,7 @@ from weakref import WeakKeyDictionary
 import six
 import time
 import warnings
+import numpy as np
 
 
 class Cursors(object):


### PR DESCRIPTION
Since bad265755784a5e6c142d233c9ff67ec1708d620 when zooming the following error appears

```
Traceback (most recent call last):
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/backends/backend_gtk3.py", line 243, in motion_notify_event
    FigureCanvasBase.motion_notify_event(self, x, y, guiEvent=event)
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 1987, in motion_notify_event
    self.callbacks.process(s, event)
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/cbook/__init__.py", line 365, in process
    proxy(*args, **kwargs)
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/cbook/__init__.py", line 227, in __call__
    return mtd(*args, **kwargs)
  File "/home/fariza/workspace/matplotlib/lib/matplotlib/backend_tools.py", line 899, in _mouse_move
    (x1, y1), (x2, y2) = np.clip(
NameError: name 'np' is not defined
```

It is a simple forgotten import
