### PR TITLE
fix leaked exception in RRuleLocator.tick_values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .pydevproject
 *.swp
 .idea
+.vscode/
 
 # Compiled source #
 ###################

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -845,7 +845,7 @@ class RRuleLocator(DateLocator):
 
         try:
             stop = vmax + delta
-        except ValueError:
+        except (ValueError, OverflowError):
             # The magic number!
             stop = _from_ordinalf(3652059.9999999)
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -840,7 +840,7 @@ class RRuleLocator(DateLocator):
         # We need to cap at the endpoints of valid datetime
         try:
             start = vmin - delta
-        except ValueError:
+        except (ValueError, OverflowError):
             start = _from_ordinalf(1.0)
 
         try:

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -130,8 +130,8 @@ def test_RRuleLocator():
 
 def test_RRuleLocator_dayrange():
     loc = mdates.DayLocator()
-    x1 = datetime.datetime(year=1, month=1, day=1)
-    y1 = datetime.datetime(year=1, month=1, day=16)
+    x1 = datetime.datetime(year=1, month=1, day=1, tzinfo=pytz.UTC)
+    y1 = datetime.datetime(year=1, month=1, day=16, tzinfo=pytz.UTC)
     loc.tick_values(x1, y1)
     # On success, no overflow error shall be thrown
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -128,6 +128,23 @@ def test_RRuleLocator():
     fig.autofmt_xdate()
 
 
+def test_RRuleLocator_dayrange():
+    ret = 0
+
+    try:
+        loc = mdates.DayLocator()
+        x1 = datetime.datetime(year=1, month=1, day=1)
+        y1 = datetime.datetime(year=1, month=1, day=16)
+        loc.tick_values(x1, y1)
+    except OverflowError:
+       # On success, no overflow error shall be thrown
+       ret = 1
+    except:
+        pass
+    
+    assert ret == 0
+
+
 @image_comparison(baseline_images=['DateFormatter_fractionalSeconds'],
                   extensions=['png'])
 def test_DateFormatter():

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -129,20 +129,11 @@ def test_RRuleLocator():
 
 
 def test_RRuleLocator_dayrange():
-    ret = 0
-
-    try:
-        loc = mdates.DayLocator()
-        x1 = datetime.datetime(year=1, month=1, day=1)
-        y1 = datetime.datetime(year=1, month=1, day=16)
-        loc.tick_values(x1, y1)
-    except OverflowError:
-       # On success, no overflow error shall be thrown
-       ret = 1
-    except:
-        pass
-    
-    assert ret == 0
+    loc = mdates.DayLocator()
+    x1 = datetime.datetime(year=1, month=1, day=1)
+    y1 = datetime.datetime(year=1, month=1, day=16)
+    loc.tick_values(x1, y1)
+    # On success, no overflow error shall be thrown
 
 
 @image_comparison(baseline_images=['DateFormatter_fractionalSeconds'],


### PR DESCRIPTION
The ```tick_values``` method of ```RRuleLocator``` in ```matlotlib.dates``` module uses ```dateutil``` module to calculate the datetime padding in an axis and in case the padding go out of leftist bound it will be set to ```num2date(1.0)```. However, in the case when the calculation of datetime goes out of bound, not only the ```ValueError``` will be thrown, but also ```OverflowError``` will. Not catching ```OverflowError``` would cause this exception to propagate through the call stack and ultimately prevent the main program from executing. This patch is intended to fix the bug, and a case that would cause this bug is added in test_dates.py in ```test_RRuleLocator_dayrange``` function.