### PR TITLE
FIX: the new _AxesStack with np.array as input

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -319,3 +319,11 @@ def test_subplots_shareax_loglabels():
 
     for ax in ax_arr[:, 0]:
         assert 0 < len(ax.yaxis.get_ticklabels(which='both'))
+
+
+def test_axes_add_np_behavior():
+    ax1 = plt.axes(plt.axes(np.array([.1, .1, .8, .8])))
+    ax2 = plt.axes(plt.axes(np.array([.1, .1, .8, .8])))
+    # in the future this test will need to be changed to not assert
+    # that the axes are equal, but still check that this does not blowup.
+    assert ax1 is ax2

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -322,8 +322,8 @@ def test_subplots_shareax_loglabels():
 
 
 def test_axes_add_np_behavior():
-    ax1 = plt.axes(plt.axes(np.array([.1, .1, .8, .8])))
-    ax2 = plt.axes(plt.axes(np.array([.1, .1, .8, .8])))
+    ax1 = plt.axes(np.array([.1, .1, .8, .8]))
+    ax2 = plt.axes(np.array([.1, .1, .8, .8]))
     # in the future this test will need to be changed to not assert
     # that the axes are equal, but still check that this does not blowup.
     assert ax1 is ax2


### PR DESCRIPTION

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
This adds a layer checking in the case where a numpy array is
passed as a value (either in args or kwargs).

fixes a bug that was in #7377 that I missed when I merged it.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
