### PR TITLE
Cleanup to image.py.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -206,15 +206,14 @@ optional Matplotlib backends and the capabilities they provide.
 For better support of animation output format and image file formats, LaTeX,
 etc., you can install the following:
 
-  * `ffmpeg <https://www.ffmpeg.org/>`__/`avconv
-    <https://libav.org/avconv.html>`__ or `mencoder
-    <https://mplayerhq.hu/design7/news.html>`__ (for saving movies);
-  * `ImageMagick <https://www.imagemagick.org/script/index.php>`__ (for saving
-    animated gifs);
-  * `Pillow <https://python-pillow.org/>`__ (for a larger selection of image
-    file formats: JPEG, BMP, and TIFF image files);
-  * `LaTeX <https://miktex.org/>`_ and `GhostScript <https://ghostscript.com/download/>`_
-    (for rendering text with LaTeX);
+  * `ffmpeg <https://www.ffmpeg.org/>`_/`avconv
+    <https://libav.org/avconv.html>`_: for saving movies;
+  * `ImageMagick <https://www.imagemagick.org/script/index.php>`_: for saving
+    animated gifs;
+  * `Pillow <https://python-pillow.org/>`_ (>=2.0): for a larger selection of
+    image file formats: JPEG, BMP, and TIFF image files;
+  * `LaTeX <https://miktex.org/>`_ and `GhostScript
+    <https://ghostscript.com/download/>`_ (for rendering text with LaTeX).
 
 .. note::
 


### PR DESCRIPTION
Various cleanups.

PIL.Image.Image.tobytes has existed since Pillow 2.0, which was released
in March 2013, and is also the first version to support Python 3.

One may want to add a check for the Pillow version, although it is
superfluous on Py3.

(While updating the docs on the required version of Pillow, also remove
mencoder from the dependencies doc, as its support is deprecated
anyways.)

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ N/A ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant 
- [ N/A ] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [ N/A ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ N/A ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
