### PR TITLE
Allow tuples of 4 floats as color rcparams.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -385,8 +385,8 @@ def validate_color(s):
         # get rid of grouping symbols
         stmp = ''.join([c for c in s if c.isdigit() or c == '.' or c == ','])
         vals = stmp.split(',')
-        if len(vals) != 3:
-            msg = '\nColor tuples must be length 3'
+        if len(vals) not in [3, 4]:
+            msg = '\nColor tuples must be of length 3 or 4'
         else:
             try:
                 colorarg = [float(val) for val in vals]

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -23,6 +23,7 @@ import numpy as np
 from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_stringlist,
                                 validate_colorlist,
+                                validate_color,
                                 validate_bool,
                                 validate_nseq_int,
                                 validate_nseq_float,
@@ -322,6 +323,27 @@ def generate_validator_testcases(valid):
                          np.array([[1, 0, 0], [0, 1, 0]])),
                     ),
          'fail': (('fish', ValueError),
+                 ),
+        },
+        {'validator': validate_color,
+         'success': (('None', 'none'),
+                     ('none', 'none'),
+                     ('AABBCC', '#AABBCC'),  # RGB hex code
+                     ('AABBCC00', '#AABBCC00'),  # RGBA hex code
+                     ('tab:blue', 'tab:blue'),  # named color
+                     ('C0', 'C0'),  # color from cycle
+                     ('(0, 1, 0)', [0.0, 1.0, 0.0]),  # RGB tuple
+                     ((0, 1, 0), (0, 1, 0)),  # non-string version
+                     ('(0, 1, 0, 1)', [0.0, 1.0, 0.0, 1.0]),  # RGBA tuple
+                     ((0, 1, 0, 1), (0, 1, 0, 1)),  # non-string version
+                     ('(0, 1, "0.5")', [0.0, 1.0, 0.5]),  # unusual but valid
+                     
+                    ),
+         'fail': (('tab:veryblue', ValueError),  # invalid name
+                  ('C123', ValueError),  # invalid RGB(A) code and cycle index
+                  ('(0, 1)', ValueError),  # tuple with length < 3
+                  ('(0, 1, 0, 1, 0)', ValueError),  # tuple with length > 4
+                  ('(0, 1, none)', ValueError),  # cannot cast none to float
                  ),
         },
         {'validator': validate_hist_bins,

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -337,7 +337,7 @@ def generate_validator_testcases(valid):
                      ('(0, 1, 0, 1)', [0.0, 1.0, 0.0, 1.0]),  # RGBA tuple
                      ((0, 1, 0, 1), (0, 1, 0, 1)),  # non-string version
                      ('(0, 1, "0.5")', [0.0, 1.0, 0.5]),  # unusual but valid
-                     
+
                     ),
          'fail': (('tab:veryblue', ValueError),  # invalid name
                   ('C123', ValueError),  # invalid RGB(A) code and cycle index


### PR DESCRIPTION
Fixes https://github.com/matplotlib/matplotlib/issues/9030#issuecomment-322412192.
(Although I *still* think (as argued in many other places) that the proper solution is to use Python files, or at least a full Python expression evaluator, as rcfile.)

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
