### PR TITLE
docstring for key_press_handler_id

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2685,12 +2685,7 @@ class FigureManagerBase(object):
         canvas.manager = self  # store a pointer to parent
         self.num = num
 
-        if rcParams['toolbar'] != 'toolmanager':
-            self.key_press_handler_id = self.canvas.mpl_connect(
-                                                'key_press_event',
-                                                self.key_press)
-        else:
-            self.key_press_handler_id = None
+        self.key_press_handler_id = None
         """
         The returned id from connecting the default key handler via
         :meth:`FigureCanvasBase.mpl_connect`.
@@ -2701,6 +2696,10 @@ class FigureManagerBase(object):
             canvas.mpl_disconnect(manager.key_press_handler_id)
 
         """
+        if rcParams['toolbar'] != 'toolmanager':
+            self.key_press_handler_id = self.canvas.mpl_connect(
+                'key_press_event',
+                self.key_press)
 
     def show(self):
         """


### PR DESCRIPTION

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
The docstring for `FigureManager.key_press_handler_id` was not being processed by sphinx.

The change just declares the variable with it's default value to make it visible to sphinx

This fixes #9020 
