### PR TITLE
Document class methods

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -3,6 +3,8 @@
 ======================
 
 .. automodule:: matplotlib.animation
+   :no-members:
+   :no-undoc-members:
 
 .. contents:: Table of Contents
    :depth: 1
@@ -30,16 +32,10 @@ to.  If you do not hold a reference to the `Animation` object, it (and
 hence the timers), will be garbage collected which will stop the
 animation.
 
-To save an animation to disk use
+To save an animation to disk use `Animation.save` or `Animation.to_html5_video`
 
-.. autosummary::
-   :toctree: _as_gen
-   :nosignatures:
-
-   Animation.save
-   Animation.to_html5_video
-
-See :ref:`ani_writer_classes` below for details about what movie formats are supported.
+See :ref:`ani_writer_classes` below for details about what movie formats are
+supported.
 
 
 ``FuncAnimation``
@@ -205,18 +201,6 @@ from the same underlying `~matplotlib.figure.Figure` object.  The base
 class `MovieWriter` implements 3 methods and a context manager.  The
 only difference between the pipe-based and file-based writers is in the
 arguments to their respective ``setup`` methods.
-
-
-.. autosummary::
-   :toctree: _as_gen
-   :nosignatures:
-
-   MovieWriter.setup
-   FileMovieWriter.setup
-   MovieWriter.grab_frame
-   MovieWriter.finish
-   MovieWriter.saving
-
 
 The ``setup()`` method is used to prepare the writer (possibly opening
 a pipe), successive calls to ``grab_frame()`` capture a single frame

--- a/doc/api/artist_api.rst
+++ b/doc/api/artist_api.rst
@@ -11,12 +11,16 @@
 
 
 .. automodule:: matplotlib.artist
+   :no-members:
+   :no-undoc-members:
 
 
 ``Artist`` class
 ================
 
 .. autoclass:: Artist
+   :no-members:
+   :no-undoc-members:
 
 Interactive
 -----------

--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -4,6 +4,8 @@
 .. currentmodule:: matplotlib.axes
 
 .. autoclass:: Axes
+   :no-members:
+   :no-undoc-members:
 
 .. contents:: Table of Contents
    :depth: 2

--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -8,6 +8,8 @@
    :backlinks: entry
 
 .. automodule:: matplotlib.axis
+   :no-members:
+   :no-undoc-members:
 
 Inheritance
 ===========
@@ -20,9 +22,17 @@ Inheritance
 ================
 
 .. autoclass:: Axis
+   :no-members:
+   :no-undoc-members:
 .. autoclass:: XAxis
+   :no-members:
+   :no-undoc-members:
 .. autoclass:: YAxis
+   :no-members:
+   :no-undoc-members:
 .. autoclass:: Ticker
+   :no-members:
+   :no-undoc-members:
 
 
 .. autosummary::
@@ -235,8 +245,14 @@ not used together may de-couple your tick labels from your data.
 ================
 
 .. autoclass:: Tick
+   :no-members:
+   :no-undoc-members:
 .. autoclass:: XTick
+   :no-members:
+   :no-undoc-members:
 .. autoclass:: YTick
+   :no-members:
+   :no-undoc-members:
 
 
 .. autosummary::

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -89,6 +89,7 @@ if not has_dot:
 autosummary_generate = True
 
 autodoc_docstring_signature = True
+autodoc_default_flags = ['members', 'undoc-members']
 
 intersphinx_mapping = {
   'python': ('https://docs.python.org/', None),

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -901,6 +901,8 @@ class Figure(Artist):
 
         Examples
         --------
+        A simple example::
+
             rect = l,b,w,h
             fig.add_axes(rect)
             fig.add_axes(rect, frameon=False, facecolor='g')

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -344,8 +344,8 @@ def split_code_at_show(text):
 
 
 def remove_coding(text):
-    """
-    Remove the coding comment, which six.exec_ doesn't like.
+    r"""
+    Remove the coding comment, which six.exec\_ doesn't like.
     """
     sub_re = re.compile("^#\s*-\*-\s*coding:\s*.*-\*-$", flags=re.MULTILINE)
     return sub_re.sub("", text)


### PR DESCRIPTION
This is an attempt to fix #8701. Currently this throws a lot of warnings which need investigating, but building with `--allowsphinxwarnings` results in correctly documented class pages.