### PR TITLE
Sorted and uniqued the contour levels before check

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1183,11 +1183,9 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         if self.filled and len(self.levels) < 2:
             raise ValueError("Filled contours require at least 2 levels.")
 
-        if len(self.levels) > 1 and np.min(np.diff(self.levels)) <= 0.0:
-            if hasattr(self, '_corner_mask') and self._corner_mask == 'legacy':
-                warnings.warn("Contour levels are not increasing")
-            else:
-                raise ValueError("Contour levels must be increasing")
+        # Sort the contour levels.
+        if len(self.levels) > 1:
+            self.levels = list(sorted(set(self.levels)))
 
     @property
     def vmin(self):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Enforces uniqueness and sorts contour levels. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Previously

```
fig, ax = plt.subplots()
ax.contour(X, [-0.6, 0.3, 0.0, 0.6, -0.3, 0.6])
```

would fail because it was not in ascending order and `0.6` was repeated.   Now it does not fail.  

https://mail.python.org/pipermail/matplotlib-users/2017-August/000974.html

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->