### PR TITLE
FIX: shim Qt4 and Qt5 together better

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -28,22 +28,14 @@ DEBUG = False
 
 class FigureCanvasQT(FigureCanvasQT5):
 
-    def __init__(self, figure):
-        if DEBUG:
-            print('FigureCanvasQt qt4: ', figure)
-        _create_qApp()
-
+    def _fake_super_fcq(self, figure):
         # Note different super-calling style to backend_qt5
         QtWidgets.QWidget.__init__(self)
-        FigureCanvasBase.__init__(self, figure)
-        self.figure = figure
-        self.setMouseTracking(True)
-        self._idle = True
-        w, h = self.get_width_height()
-        self.resize(w, h)
-
-        # Key auto-repeat enabled by default
-        self._keyautorepeat = True
+        # Do not call this here (even though it looks like we should!)
+        # because it will be called in the Agg backend and we want to 'break'
+        # the MI diamond.  With PyQt5 (which in cooperative) this is handled by
+        # super
+        # FigureCanvasBase.__init__(self, figure)
 
     def wheelEvent(self, event):
         x = event.x()

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -12,6 +12,11 @@ from .backend_qt4 import (
 from .backend_qt5agg import FigureCanvasQTAggBase
 
 
+class FigureCanvasQTAggBase(FigureCanvasQTAggBase):
+    def _fake_super_fcqab(self, figure):
+        FigureCanvasAgg.__init__(self, figure)
+
+
 class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
     """
     The canvas the figure renders into.  Calls the draw and print fig
@@ -23,6 +28,9 @@ class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
         A high-level Figure instance
 
     """
+    def __init__(self, figure):
+        FigureCanvasQT.__init__(self, figure)
+        FigureCanvasQTAggBase.__init__(self, figure)
 
 
 @_BackendQT4.export

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -172,6 +172,8 @@ class TimerQT(TimerBase):
         self._timer.stop()
 
 
+# FigureCanvasBase is not cooperative so it most go last here
+# or the super-chain will be truncated early.
 class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
     # map Qt button codes to MouseEvent's ones:
@@ -190,12 +192,10 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         _create_qApp()
         figure._original_dpi = figure.dpi
 
-        # NB: Using super for this call to avoid a TypeError:
-        # __init__() takes exactly 2 arguments (1 given) on QWidget
-        # PyQt5
-        # The need for this change is documented here
+        # PyQt5 does cooperative MI so we can just use `super`, PyQt4
+        # and PySide do not so we have to fake it.
         # http://pyqt.sourceforge.net/Docs/PyQt5/pyqt4_differences.html#cooperative-multi-inheritance
-        super(FigureCanvasQT, self).__init__(figure=figure)
+        self._fake_super_fcq(figure)
         self.figure = figure
         self._update_figure_dpi()
 
@@ -205,6 +205,9 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
         # Key auto-repeat enabled by default
         self._keyautorepeat = True
+
+    def _fake_super_fcq(self, figure):
+        super(FigureCanvasQT, self).__init__(figure=figure)
 
     @property
     def _dpi_ratio(self):

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -32,7 +32,7 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
     """
 
     def __init__(self, figure):
-        super(FigureCanvasQTAggBase, self).__init__(figure=figure)
+        self._fake_super_fcqab(figure)
         self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent)
         self._agg_draw_pending = False
         self._bbox_queue = []
@@ -46,6 +46,9 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         # dpi_ratio value here and in paintEvent we resize the canvas if
         # needed.
         self._dpi_ratio_prev = None
+
+    def _fake_super_fcqab(self, figure):
+        super(FigureCanvasQTAggBase, self).__init__(figure=figure)
 
     def drawRectangle(self, rect):
         if rect is not None:


### PR DESCRIPTION
in two places `super` needs to be used in the Qt5 case and
frustrated in the Qt4 case.  These are handled by the two
`_fake_super_*` methods.  The must be just private as we need to
override in sub-classes.

Closes #9040
