### PR TITLE
Cooperative __init__ for Qt4 canvas.

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -28,23 +28,6 @@ DEBUG = False
 
 class FigureCanvasQT(FigureCanvasQT5):
 
-    def __init__(self, figure):
-        if DEBUG:
-            print('FigureCanvasQt qt4: ', figure)
-        _create_qApp()
-
-        # Note different super-calling style to backend_qt5
-        QtWidgets.QWidget.__init__(self)
-        FigureCanvasBase.__init__(self, figure)
-        self.figure = figure
-        self.setMouseTracking(True)
-        self._idle = True
-        w, h = self.get_width_height()
-        self.resize(w, h)
-
-        # Key auto-repeat enabled by default
-        self._keyautorepeat = True
-
     def wheelEvent(self, event):
         x = event.x()
         # flipy so y=0 is bottom of canvas


### PR DESCRIPTION
Alternate for #9048 (basically pulling out the relevant parts of #8771, but using a local monkey-patch approach.
I personally find this approach clearer in intent ("PyQt4 does not support multiple inheritance so let's just locally patch it so that it does") than #9048.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
