### PR TITLE
Turn off increasing contour levels for contour (not contourf)

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1183,7 +1183,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         if self.filled and len(self.levels) < 2:
             raise ValueError("Filled contours require at least 2 levels.")
 
-        if len(self.levels) > 1 and np.min(np.diff(self.levels)) <= 0.0:
+        if (self.filled and np.min(np.diff(self.levels)) <= 0.0):
             if hasattr(self, '_corner_mask') and self._corner_mask == 'legacy':
                 warnings.warn("Contour levels are not increasing")
             else:
@@ -1674,7 +1674,8 @@ class QuadContourSet(ContourSet):
           contour(X,Y,Z,V)
 
         draw contour lines at the values specified in sequence *V*,
-        which must be in increasing order.
+        which must be in increasing order for
+        ``contourf``.
 
         ::
 
@@ -1744,8 +1745,9 @@ class QuadContourSet(ContourSet):
 
           *levels*: [level0, level1, ..., leveln]
             A list of floating point numbers indicating the level
-            curves to draw, in increasing order; e.g., to draw just
-            the zero contour pass ``levels=[0]``
+            curves to draw.  Must be in increasing order for
+            ``contourf``.  To draw just the
+            zero contour pass ``levels=[0]``
 
           *origin*: [ *None* | 'upper' | 'lower' | 'image' ]
             If *None*, the first value of *Z* will correspond to the


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

This is a redo of #9047 after feedback there.  Closes #9047 

It removes the check for increasing values of `levels` for calls to `contour`.


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Calls like `contour(Z, levels=[1., 0., -1.])` currently fail on a check for increasing values in `levels`.  This isn't needed for the contouring algorithm, so this PR removes that check for `contour`.  

Unlike the #9047 this change doesn't change the levels specified by the user.  

`contourf` still has the check for increasing levels.  

https://mail.python.org/pipermail/matplotlib-users/2017-August/000974.html

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->