### PR TITLE
Add entry for .notdef to CharStrings for type 42 fonts in eps files. …

### DIFF
--- a/extern/ttconv/pprdrv_tt.cpp
+++ b/extern/ttconv/pprdrv_tt.cpp
@@ -1055,7 +1055,9 @@ void ttfont_CharStrings(TTStreamWriter& stream, struct TTFONT *font, std::vector
     post_format = getFixed( font->post_table );
 
     /* Emmit the start of the PostScript code to define the dictionary. */
-    stream.printf("/CharStrings %d dict dup begin\n", glyph_ids.size());
+    stream.printf("/CharStrings %d dict dup begin\n", glyph_ids.size()+1);
+    /* Section 5.8.2 table 5.7 of the PS Language Ref says a CharStrings dictionary must contain an entry for .notdef */
+    stream.printf("/.notdef 0 def\n");
 
     /* Emmit one key-value pair for each glyph. */
     for (std::vector<int>::const_iterator i = glyph_ids.begin();


### PR DESCRIPTION
… See issue #9044

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
According to the Postscript Language Ref CharStrings dictionaries for Type 42 fonts "must have an entry whose key is .notdef".   The lack of this entry caused several macOS apps to fail to open eps files created with ps.fonttype = 42.  This PR modifies ppdrvr_tt.cpp to add an entry for .notdef to the CharStrings dict.

<!--If it fixes an open issue, please link to the issue here.-->
https://github.com/matplotlib/matplotlib/issues/9044

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->