### PR TITLE
DOC: use start_event_loop rather than plt.pause in example

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -50,12 +50,13 @@ The inner workings of `FuncAnimation` is more-or-less::
   for d in frames:
      artists = func(d, *fargs)
      fig.canvas.draw_idle()
-     plt.pause(interval)
+     fig.canvas.start_event_loop(interval)
 
 
 with details to handle 'blitting' (to dramatically improve the live
-performance), to be non-blocking, handle repeats, multiple animated
-axes, and easily save the animation to a movie file.
+performance), to be non-blocking, not repeatedly start/stop the GUI
+event loop, handle repeats, multiple animated axes, and easily save
+the animation to a movie file.
 
 'Blitting' is a `old technique
 <https://en.wikipedia.org/wiki/Bit_blit>`__ in computer graphics.  The
@@ -86,7 +87,7 @@ time.  When using blitting (by passing ``blit=True``) the core loop of
    for f in frames:
        artists = func(f, *fargs)
        update_blit(artists)
-       plt.pause(interval)
+       fig.canvas.start_event_loop(interval)
 
 This is of course leaving out many details (such as updating the
 background when the figure is resized or fully re-drawn).  However,


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Discussion at https://github.com/matplotlib/matplotlib/issues/596, https://stackoverflow.com/questions/44278369/how-to-keep-matplotlib-python-window-in-background , and https://stackoverflow.com/questions/45729092/make-interactive-matplotlib-window-not-pop-to-front-on-each-update-windows-7/45734500#45734500 pointed out that `plt.pause` has other side effects like raising the GUI windows.  Just spinning the event loop is closer to what actually happens.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
