### PR TITLE
Using `canvas.draw_idle()` inside `plt.pause`

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -294,7 +294,7 @@ def pause(interval):
         if figManager is not None:
             canvas = figManager.canvas
             if canvas.figure.stale:
-                canvas.draw()
+                canvas.draw_idle()
             show(block=False)
             canvas.start_event_loop(interval)
             return


### PR DESCRIPTION
Instead of `canvas.draw()` we may use `canvas.draw_idle()` inside `plt.pause`. In general using `draw_idle()` has several advantages over `draw()`, so one might also use it here.


