### PR TITLE
Let dpi be set when saving JPEG using Agg backend

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -568,9 +568,13 @@ class FigureCanvasAgg(FigureCanvasBase):
             background = Image.new('RGB', size, color)
             background.paste(image, image)
             options = {k: kwargs[k]
-                       for k in ['quality', 'optimize', 'progressive']
+                       for k in ['quality', 'optimize', 'progressive', 'dpi']
                        if k in kwargs}
             options.setdefault('quality', rcParams['savefig.jpeg_quality'])
+            if 'dpi' in options:
+                # Set the same dpi in both x and y directions
+                options['dpi'] = (options['dpi'], options['dpi'])
+
             return background.save(filename_or_obj, format='jpeg', **options)
         print_jpeg = print_jpg
 

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -7,6 +7,7 @@ from distutils.version import LooseVersion
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pytest
+from PIL import Image
 
 from matplotlib.image import imread
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
@@ -234,3 +235,12 @@ def test_chunksize():
     rcParams['agg.path.chunksize'] = 105
     ax.plot(x, np.sin(x))
     fig.canvas.draw()
+
+
+@pytest.mark.backend('Agg')
+def test_jpeg_dpi():
+    # Check that dpi is set correctly in jpg files
+    plt.plot([0, 1, 2], [0, 1, 0])
+    plt.savefig('test.jpg', dpi=200)
+    im = Image.open("test.jpg")
+    assert im.info['dpi'] == (200, 200)

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -7,7 +7,6 @@ from distutils.version import LooseVersion
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pytest
-from PIL import Image
 
 from matplotlib.image import imread
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
@@ -239,6 +238,10 @@ def test_chunksize():
 
 @pytest.mark.backend('Agg')
 def test_jpeg_dpi():
+    try:
+        from PIL import Image
+    except Exception:
+        pytest.skip("Could not import PIL")
     # Check that dpi is set correctly in jpg files
     plt.plot([0, 1, 2], [0, 1, 0])
     plt.savefig('test.jpg', dpi=200)


### PR DESCRIPTION
Partially fixes (for the Agg backend) #9035. Not sure if there's a test I can put in, but I have checked that preview on macOS reports the correct dpi when I manually change the dpi.