### PR TITLE
Let dpi be set when saving jpeg using WX backend

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -16,6 +16,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import six
 from six.moves import xrange
 
 import sys
@@ -903,6 +904,8 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
                                       rcParams['savefig.jpeg_quality'])
             image = self.bitmap.ConvertToImage()
             image.SetOption(wx.IMAGE_OPTION_QUALITY, str(jpeg_quality))
+            image.SetOption(wx.IMAGE_OPTION_RESOLUTIONUNIT, 'inches')
+            image.SetOption(wx.IMAGE_OPTION_RESOLUTION, str(kwargs['dpi']))
 
         # Now that we have rendered into the bitmap, save it
         # to the appropriate file type and clean up


### PR DESCRIPTION
Partially fixes (for the wx backend) #9035. Not sure if there's a test I can put in, but I have checked that preview on macOS reports the correct dpi when I manually change the dpi.

(sorry for the separate PRs)