### PR TITLE
Deprecate more of cbook.

### DIFF
--- a/doc/api/api_changes/2017-05-22-cbook-deprecations.rst
+++ b/doc/api/api_changes/2017-05-22-cbook-deprecations.rst
@@ -1,0 +1,11 @@
+cbook deprecations
+``````````````````
+
+Many unused or near-unused cbook functions and classes have been deprecated:
+``converter``, ``tostr``, ``todatetime``, ``todate``, ``tofloat``, ``toint``,
+``unique``, ``is_string_like``, ``is_sequence_of_strings``, ``is_scalar``,
+``Sorter``, ``Xlator``, ``soundex``, ``Null``, ``dict_delall``, ``RingBuffer``,
+``get_split_ind``, ``wrap``, ``get_recursive_filelist``, ``pieces``,
+``exception_to_str``, ``allequal``, ``alltrue``, ``onetrue``, ``allpairs``,
+``finddir``, ``reverse_dict``, ``restrict_dict``, ``issubclass_safe``,
+``recursive_remove``, ``unmasked_index_ranges``.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -31,7 +31,7 @@ from math import radians, cos, sin
 from matplotlib import verbose, rcParams, __version__
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
-from matplotlib.cbook import maxdict, restrict_dict
+from matplotlib.cbook import maxdict
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, get_font
 from matplotlib.ft2font import (LOAD_FORCE_AUTOHINT, LOAD_NO_HINTING,
@@ -567,12 +567,10 @@ class FigureCanvasAgg(FigureCanvasBase):
             color = tuple([int(x * 255.0) for x in rgba[:3]])
             background = Image.new('RGB', size, color)
             background.paste(image, image)
-            options = restrict_dict(kwargs, ['quality', 'optimize',
-                                             'progressive'])
-
-            if 'quality' not in options:
-                options['quality'] = rcParams['savefig.jpeg_quality']
-
+            options = {k: kwargs[k]
+                       for k in ['quality', 'optimize', 'progressive']
+                       if k in kwargs}
+            options.setdefault('quality', rcParams['savefig.jpeg_quality'])
             return background.save(filename_or_obj, format='jpeg', **options)
         print_jpeg = print_jpg
 

--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -26,7 +26,7 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
     RendererBase)
-from matplotlib.cbook import restrict_dict, warn_deprecated
+from matplotlib.cbook import warn_deprecated
 from matplotlib.figure import Figure
 from matplotlib.mathtext import MathTextParser
 from matplotlib.transforms import Affine2D
@@ -428,10 +428,9 @@ class FigureCanvasGDK (FigureCanvasBase):
 
         # set the default quality, if we are writing a JPEG.
         # http://www.pygtk.org/docs/pygtk/class-gdkpixbuf.html#method-gdkpixbuf--save
-        options = restrict_dict(kwargs, ['quality'])
-        if format in ['jpg','jpeg']:
-            if 'quality' not in options:
-                options['quality'] = rcParams['savefig.jpeg_quality']
+        options = {k: kwargs[k] for k in ['quality'] if k in kwargs}
+        if format in ['jpg', 'jpeg']:
+            options.setdefault('quality', rcParams['savefig.jpeg_quality'])
             options['quality'] = str(options['quality'])
 
         pixbuf.save(filename, format, options=options)

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -429,11 +429,9 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
 
         # set the default quality, if we are writing a JPEG.
         # http://www.pygtk.org/docs/pygtk/class-gdkpixbuf.html#method-gdkpixbuf--save
-        options = cbook.restrict_dict(kwargs, ['quality'])
-        if format in ['jpg','jpeg']:
-            if 'quality' not in options:
-                options['quality'] = rcParams['savefig.jpeg_quality']
-
+        options = {k: kwargs[k] for k in ['quality'] if k in kwargs}
+        if format in ['jpg', 'jpeg']:
+            options.setdefault('quality', rcParams['savefig.jpeg_quality'])
             options['quality'] = str(options['quality'])
 
         if isinstance(filename, six.string_types):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -889,6 +889,7 @@ class RingBuffer(object):
         return self.data[i % len(self.data)]
 
 
+@deprecated('2.1')
 def get_split_ind(seq, N):
     """
     *seq* is a list of words.  Return the index into seq such that::
@@ -1005,6 +1006,7 @@ def listFiles(root, patterns='*', recurse=1, return_folders=0):
     return results
 
 
+@deprecated('2.1')
 def get_recursive_filelist(args):
     """
     Recurse all the files and dirs in *args* ignoring symbolic links
@@ -1236,6 +1238,7 @@ def reverse_dict(d):
     return {v: k for k, v in six.iteritems(d)}
 
 
+@deprecated('2.1')
 def restrict_dict(d, keys):
     """
     Return a dictionary that contains those keys that appear in both


### PR DESCRIPTION
restrict_dict can easily be inlined as a comprehension and is more
legible that way.

get_split_ind is unused other than as a helper for the deprecated
cbook.wrap.

get_recursive_filelist is unused and can trivially be implemented using
os.walk.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
