### PR TITLE
Use left/right top/bottom instead of width/height in Rectangle

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -687,10 +687,7 @@ class Rectangle(Patch):
                  makes it very important to call the accessor method and
                  not directly access the transformation member variable.
         """
-        x0 = self.convert_xunits(self._x0)
-        y0 = self.convert_yunits(self._y0)
-        x1 = self.convert_xunits(self._x1)
-        y1 = self.convert_yunits(self._y1)
+        x0, y0, x1, y1 = self._convert_units()
         bbox = transforms.Bbox.from_extents(x0, y0, x1, y1)
         rot_trans = transforms.Affine2D()
         rot_trans.rotate_deg_around(x0, y0, self.angle)
@@ -702,6 +699,16 @@ class Rectangle(Patch):
 
     def _update_y1(self):
         self._y1 = self._y0 + self._height
+
+    def _convert_units(self):
+        '''
+        Convert bounds of the rectangle
+        '''
+        x0 = self.convert_xunits(self._x0)
+        y0 = self.convert_yunits(self._y0)
+        x1 = self.convert_xunits(self._x1)
+        y1 = self.convert_yunits(self._y1)
+        return x0, y0, x1, y1
 
     def get_patch_transform(self):
         self._update_patch_transform()
@@ -720,7 +727,7 @@ class Rectangle(Patch):
         return self._x0, self._y0
 
     def get_width(self):
-        "Return the width of the  rectangle"
+        "Return the width of the rectangle"
         return self._width
 
     def get_height(self):
@@ -797,6 +804,7 @@ class Rectangle(Patch):
         self.stale = True
 
     def get_bbox(self):
+        x0, y0, x1, y1 = self._convert_units()
         return transforms.Bbox.from_extents(self._x0, self._y0,
                                             self._x1, self._y1)
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -650,12 +650,21 @@ class Rectangle(Patch):
     @docstring.dedent_interpd
     def __init__(self, xy, width, height, angle=0.0, **kwargs):
         """
+        Parameters
+        ----------
+        xy: length-2 tuple
+            The bottom and left rectangle coordinates
+        width:
+            Rectangle width
+        height:
+            Rectangle height
+        angle: float, optional
+          rotation in degrees anti-clockwise about *xy* (default is 0.0)
+        fill: bool, optional
+            Whether to fill the rectangle (default is ``True``)
 
-        *angle*
-          rotation in degrees (anti-clockwise)
-
-        *fill* is a boolean indicating whether to fill the rectangle
-
+        Notes
+        -----
         Valid kwargs are:
         %(Patch)s
         """
@@ -735,21 +744,13 @@ class Rectangle(Patch):
         return self._height
 
     def set_x(self, x):
-        """
-        Set the left coord of the rectangle
-
-        ACCEPTS: float
-        """
+        "Set the left coord of the rectangle"
         self._x0 = x
         self._update_x1()
         self.stale = True
 
     def set_y(self, y):
-        """
-        Set the bottom coord of the rectangle
-
-        ACCEPTS: float
-        """
+        "Set the bottom coord of the rectangle"
         self._y0 = y
         self._update_y1()
         self.stale = True
@@ -766,21 +767,13 @@ class Rectangle(Patch):
         self.stale = True
 
     def set_width(self, w):
-        """
-        Set the width rectangle
-
-        ACCEPTS: float
-        """
+        "Set the width of the rectangle"
         self._width = w
         self._update_x1()
         self.stale = True
 
     def set_height(self, h):
-        """
-        Set the width rectangle
-
-        ACCEPTS: float
-        """
+        "Set the height of the rectangle"
         self._height = h
         self._update_y1()
         self.stale = True

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -374,3 +374,16 @@ def test_datetime_rectangle():
 
     fig, ax = plt.subplots()
     ax.add_patch(patch)
+
+
+def test_datetime_datetime_fails():
+    from datetime import datetime
+
+    start = datetime(2017, 1, 1, 0, 0, 0)
+    dt_delta = datetime(1970, 1, 5)    # Will be 5 days if units are done wrong
+
+    with pytest.raises(TypeError):
+        mpatches.Rectangle((start, 0), dt_delta, 1)
+
+    with pytest.raises(TypeError):
+        mpatches.Rectangle((0, start), 1, dt_delta)

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -362,3 +362,15 @@ def test_connection_patch():
                                    axesA=ax2, axesB=ax1,
                                    arrowstyle="->")
     ax2.add_artist(con)
+
+
+def test_datetime_rectangle():
+    # Check that creating a rectangle with timedeltas doesn't fail
+    from datetime import datetime, timedelta
+
+    start = datetime(2017, 1, 1, 0, 0, 0)
+    delta = timedelta(seconds=16)
+    patch = mpatches.Rectangle((start, 0), delta, 1)
+
+    fig, ax = plt.subplots()
+    ax.add_patch(patch)


### PR DESCRIPTION
This changes the transform in `Rectangle` to use `transforms.Bbox.from_extents` instead of `transforms.Bbox.from_bounds`. This allows for rectangles whose "width" may be a different type to the actual coordinates (eg. `datetime` for coords and `timedelta` for width/height).

The api is maintained as before, all that has changed is stuff under the hood.

Fixes #4916, thanks to @pganssle for the idea.
