### PR TITLE
Fix two cases of signed integer overflow.

### DIFF
--- a/extern/agg24-svn/include/agg_rasterizer_scanline_aa_nogamma.h
+++ b/extern/agg24-svn/include/agg_rasterizer_scanline_aa_nogamma.h
@@ -60,7 +60,7 @@ namespace agg
 
         int not_equal(int ex, int ey, const cell_aa&) const
         {
-            return (ex - x) | (ey - y);
+            return ex != x || ey != y;
         }
     };
 

--- a/extern/agg24-svn/include/agg_scanline_storage_aa.h
+++ b/extern/agg24-svn/include/agg_scanline_storage_aa.h
@@ -720,10 +720,10 @@ namespace agg
             m_ptr = m_data;
             if(m_ptr < m_end)
             {
-                m_min_x = read_int32() + m_dx; 
-                m_min_y = read_int32() + m_dy;
-                m_max_x = read_int32() + m_dx;
-                m_max_y = read_int32() + m_dy;
+                m_min_x = read_int32u() + m_dx;
+                m_min_y = read_int32u() + m_dy;
+                m_max_x = read_int32u() + m_dx;
+                m_max_y = read_int32u() + m_dy;
             }
             return m_ptr < m_end;
         }


### PR DESCRIPTION
## PR Summary

This tweaks two cases where there is potential for signed integer overflow:
* in `rewind_scanlines`, we switch to unsigned ints
* in `not_equal`, we switch for operations which cannot overflow.

These cases were caught by matplotlib-using tests being run under
[ASan](https://github.com/google/sanitizers) with a check for signed integer
overflow.

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant 
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [X] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [X] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

I did not see an easy way to add a test for this; I am happy to do so if someone has thoughts on a good place to include a test. (The "right" test to add would be a variant of the test suite running under ASan, but that seems a bit heavy for a small PR.)