### PR TITLE
Micro-optimization of to_rgba_array.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -212,13 +212,6 @@ def to_rgba_array(c, alpha=None):
     If `alpha` is not `None`, it forces the alpha value.  If `c` is "none"
     (case-insensitive) or an empty list, an empty array is returned.
     """
-    # Single value?
-    if isinstance(c, six.string_types) and c.lower() == "none":
-        return np.zeros((0, 4), float)
-    try:
-        return np.array([to_rgba(c, alpha)], float)
-    except (ValueError, TypeError):
-        pass
     # Special-case inputs that are already arrays, for performance.  (If the
     # array has the wrong kind or shape, raise the error during one-at-a-time
     # conversion.)
@@ -234,6 +227,16 @@ def to_rgba_array(c, alpha=None):
         if np.any((result < 0) | (result > 1)):
             raise ValueError("RGBA values should be within 0-1 range")
         return result
+    # Handle single values.
+    # Note that this occurs *after* handling inputs that are already arrays, as
+    # `to_rgba(c, alpha)` (below) is expensive for such inputs, due to the need
+    # to format the array in the ValueError message(!).
+    if isinstance(c, six.string_types) and c.lower() == "none":
+        return np.zeros((0, 4), float)
+    try:
+        return np.array([to_rgba(c, alpha)], float)
+    except (ValueError, TypeError):
+        pass
     # Convert one at a time.
     result = np.empty((len(c), 4), float)
     for i, cc in enumerate(c):


### PR DESCRIPTION
Avoid having to compute a repr of the entire array whenever calling
to_rgba_array with an array input (that repr would be generated when the
call to to_rgba fails and needs to generate an error message; instead,
first check whether the input is already an array).  See comments for
detail.

Slightly improves the performance of wire3d_animation on mpl_cairo.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
