### PR TITLE
[MAINT] savefig only takes one args

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1709,7 +1709,7 @@ class Figure(Artist):
         'whenever the axes state change, ``func(self)`` will be called'
         self._axobservers.append(func)
 
-    def savefig(self, *args, **kwargs):
+    def savefig(self, fname, **kwargs):
         """
         Save the current figure.
 
@@ -1787,7 +1787,6 @@ class Figure(Artist):
             tight bbox is calculated.
 
         """
-
         kwargs.setdefault('dpi', rcParams['savefig.dpi'])
         frameon = kwargs.pop('frameon', rcParams['savefig.frameon'])
         transparent = kwargs.pop('transparent',
@@ -1811,7 +1810,7 @@ class Figure(Artist):
             original_frameon = self.get_frameon()
             self.set_frameon(frameon)
 
-        self.canvas.print_figure(*args, **kwargs)
+        self.canvas.print_figure(fname, **kwargs)
 
         if frameon:
             self.set_frameon(original_frameon)


### PR DESCRIPTION
Making this explicit improves error message when user provides
two args to the function.

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 