### PR TITLE
Drop python 3.3 from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,6 @@ classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
According to the docs python 3.3 isn't supported any more. Fixes #9085