### PR TITLE
axisbelow should just set zorder.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2632,12 +2632,12 @@ class _AxesBase(martist.Artist):
         """
         Set the zorder for the axes ticks and gridlines.
 
-        ``True`` corresponds to a zorder of 0.5, ``False`` to a zorder of 2.5,
-        and ``"line"`` to a zorder of 1.5.
-
         Parameters
         ----------
         b : bool or 'line'
+            ``True`` corresponds to a zorder of 0.5, ``False`` to a zorder of
+            2.5, and ``"line"`` to a zorder of 1.5.
+
         """
         self._axisbelow = axisbelow = validate_axisbelow(b)
         if axisbelow is True:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -477,7 +477,6 @@ class _AxesBase(martist.Artist):
         if self._position.width < 0 or self._position.height < 0:
             raise ValueError('Width and height specified must be non-negative')
         self._originalPosition = self._position.frozen()
-        # self.set_axes(self)
         self.axes = self
         self._aspect = 'auto'
         self._adjustable = 'box'
@@ -501,7 +500,7 @@ class _AxesBase(martist.Artist):
             facecolor = rcParams['axes.facecolor']
         self._facecolor = facecolor
         self._frameon = frameon
-        self._axisbelow = rcParams['axes.axisbelow']
+        self.set_axisbelow(rcParams['axes.axisbelow'])
 
         self._rasterization_zorder = None
         self._connected = {}  # a dict from events to (id, func)
@@ -2537,18 +2536,7 @@ class _AxesBase(martist.Artist):
 
         self._update_title_position(renderer)
 
-        if self.axison and not inframe:
-            if self._axisbelow is True:
-                self.xaxis.set_zorder(0.5)
-                self.yaxis.set_zorder(0.5)
-            elif self._axisbelow is False:
-                self.xaxis.set_zorder(2.5)
-                self.yaxis.set_zorder(2.5)
-            else:
-                # 'line': above patches, below lines
-                self.xaxis.set_zorder(1.5)
-                self.yaxis.set_zorder(1.5)
-        else:
+        if not self.axison or inframe:
             for _axis in self._get_axis_list():
                 artists.remove(_axis)
 
@@ -2620,9 +2608,7 @@ class _AxesBase(martist.Artist):
     # Axes rectangle characteristics
 
     def get_frame_on(self):
-        """
-        Get whether the axes rectangle patch is drawn.
-        """
+        """Get whether the axes rectangle patch is drawn."""
         return self._frameon
 
     def set_frame_on(self, b):
@@ -2644,13 +2630,26 @@ class _AxesBase(martist.Artist):
 
     def set_axisbelow(self, b):
         """
-        Set whether axis ticks and gridlines are above or below most artists.
+        Set the zorder for the axes ticks and gridlines.
+
+        ``True`` corresponds to a zorder of 0.5, ``False`` to a zorder of 2.5,
+        and ``"line"`` to a zorder of 1.5.
 
         Parameters
         ----------
         b : bool or 'line'
         """
-        self._axisbelow = validate_axisbelow(b)
+        self._axisbelow = axisbelow = validate_axisbelow(b)
+        if axisbelow is True:
+            zorder = 0.5
+        elif axisbelow is False:
+            zorder = 2.5
+        elif axisbelow == "line":
+            zorder = 1.5
+        else:
+            raise ValueError("Unexpected axisbelow value")
+        for axis in self._get_axis_list():
+            axis.set_zorder(zorder)
         self.stale = True
 
     @docstring.dedent_interpd
@@ -2678,6 +2677,8 @@ class _AxesBase(martist.Artist):
 
         %(Line2D)s
 
+        Note that the grid will be drawn according to the axes' zorder and not
+        its own.
         """
         if len(kwargs):
             b = True

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -786,7 +786,6 @@ def test_imshow_masked_interpolation():
     N = 20
     n = colors.Normalize(vmin=0, vmax=N*N-1)
 
-    # data = np.random.random((N, N))*N*N
     data = np.arange(N*N, dtype='float').reshape(N, N)
 
     data[5, 5] = -1

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -272,28 +272,28 @@ class Axes3D(Axes):
         renderer.eye = self.eye
         renderer.get_axis_position = self.get_axis_position
 
-        # Calculate projection of collections and zorder them
+        # Calculate projection of collections and patches and zorder them.
+        # Make sure they are drawn above the grids.
+        zorder_offset = max(axis.get_zorder()
+                            for axis in self._get_axis_list()) + 1
         for i, col in enumerate(
                 sorted(self.collections,
                        key=lambda col: col.do_3d_projection(renderer),
                        reverse=True)):
-            col.zorder = i
-
-        # Calculate projection of patches and zorder them
+            col.zorder = zorder_offset + i
         for i, patch in enumerate(
                 sorted(self.patches,
                        key=lambda patch: patch.do_3d_projection(renderer),
                        reverse=True)):
-            patch.zorder = i
+            patch.zorder = zorder_offset + i
 
         if self._axis3don:
-            axes = (self.xaxis, self.yaxis, self.zaxis)
             # Draw panes first
-            for ax in axes:
-                ax.draw_pane(renderer)
+            for axis in self._get_axis_list():
+                axis.draw_pane(renderer)
             # Then axes
-            for ax in axes:
-                ax.draw(renderer)
+            for axis in self._get_axis_list():
+                axis.draw(renderer)
 
         # Then rest
         super().draw(renderer)
@@ -1281,33 +1281,6 @@ class Axes3D(Axes):
         b : bool
         """
         self._frameon = bool(b)
-        self.stale = True
-
-    def get_axisbelow(self):
-        """
-        Get whether axis below is true or not.
-
-        For axes3d objects, this will always be *True*
-
-        .. versionadded :: 1.1.0
-            This function was added for completeness.
-        """
-        return True
-
-    def set_axisbelow(self, b):
-        """
-        Set whether axis ticks and gridlines are above or below most artists.
-
-        For axes3d objects, this will ignore any settings and just use *True*
-
-        .. versionadded :: 1.1.0
-            This function was added for completeness.
-
-        Parameters
-        ----------
-        b : bool
-        """
-        self._axisbelow = True
         self.stale = True
 
     def grid(self, b=True, **kwargs):


### PR DESCRIPTION
See discussion starting at https://gitter.im/matplotlib/matplotlib?at=59a0b3b9bc46472974c206bf.

Please vote as to whether we should just deprecate the old axisbelow functions in favor of just using zorder everywhere (I think we should).

xref #5045 #6287

attn @afvincent 

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
