### PR TITLE
BLD: bump minimum dateutil to 2.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -178,7 +178,7 @@ Matplotlib requires a large number of dependencies:
   * `Python <https://www.python.org/downloads/>`_ (>= 2.7 or >= 3.4)
   * `NumPy <http://www.numpy.org>`_ (>= |minimum_numpy_version|)
   * `setuptools <https://setuptools.readthedocs.io/en/latest/>`__
-  * dateutil (>= 1.1)
+  * `dateutil <https://pypi.python.org/pypi/python-dateutil>`_ (>= 2.0)
   * `pyparsing <https://pyparsing.wikispaces.com/>`__
   * `libpng <http://www.libpng.org>`__ (>= 1.2)
   * `pytz <http://pytz.sourceforge.net/>`__
@@ -189,6 +189,7 @@ Matplotlib requires a large number of dependencies:
     (for Python 2.7 only)
   * `subprocess32 <https://pypi.python.org/pypi/subprocess32/>`_ (for Python
     2.7 only, on Linux and macOS only)
+
 
 Optionally, you can also install a number of packages to enable better user
 interface toolkits. See :ref:`what-is-a-backend` for more details on the

--- a/setupext.py
+++ b/setupext.py
@@ -1507,7 +1507,7 @@ class Cycler(SetupPackage):
 class Dateutil(SetupPackage):
     name = "dateutil"
 
-    def __init__(self, version=None):
+    def __init__(self, version='>=2.0'):
         self.version = version
 
     def check(self):


### PR DESCRIPTION
 - we had it documented as >= 1.1
 - we had not specified it in setup.py
 - the minimum version available on pypi is 1.5
 - 2.0 is the first version that support python3
 - 2.0 is > 5 years old
 - debian versions
    - wheezy (oldoldstable) has 1.5
    - jessie (oldstable) as 2.2

Suggested by @pganssle 

He suggested just documenting >=2, but leaving setup.py unpinned.  Opted to be a bit stronger about it so we can have the same minimum version on both python2 and python3