### PR TITLE
Don't call draw() twice when Qt canvas first appears.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -14,7 +14,7 @@ from matplotlib.transforms import Bbox
 
 from .backend_agg import FigureCanvasAgg
 from .backend_qt5 import (
-    QtCore, QtGui, _BackendQT5, FigureCanvasQT, FigureManagerQT,
+    QtCore, QtGui, QtWidgets, _BackendQT5, FigureCanvasQT, FigureManagerQT,
     NavigationToolbar2QT, backend_version)
 from .qt_compat import QT_API
 
@@ -38,15 +38,6 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         self._bbox_queue = []
         self._drawRect = None
 
-        # In cases with mixed resolution displays, we need to be careful if the
-        # dpi_ratio changes - in this case we need to resize the canvas
-        # accordingly. We could watch for screenChanged events from Qt, but
-        # the issue is that we can't guarantee this will be emitted *before*
-        # the first paintEvent for the canvas, so instead we keep track of the
-        # dpi_ratio value here and in paintEvent we resize the canvas if
-        # needed.
-        self._dpi_ratio_prev = None
-
     def drawRectangle(self, rect):
         if rect is not None:
             self._drawRect = [pt / self._dpi_ratio for pt in rect]
@@ -66,18 +57,13 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         shown onscreen.
         """
 
-        # if the canvas does not have a renderer, then give up and wait for
-        # FigureCanvasAgg.draw(self) to be called
-        if not hasattr(self, 'renderer'):
-            return
-
         # As described in __init__ above, we need to be careful in cases with
         # mixed resolution displays if dpi_ratio is changing between painting
         # events.
-        if (self._dpi_ratio_prev is None or
-            self._dpi_ratio != self._dpi_ratio_prev):
+        if self._dpi_ratio != self._dpi_ratio_prev:
             # We need to update the figure DPI
             self._update_figure_dpi()
+            self._dpi_ratio_prev = self._dpi_ratio
             # The easiest way to resize the canvas is to emit a resizeEvent
             # since we implement all the logic for resizing the canvas for
             # that event.
@@ -86,7 +72,14 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
             # since the latter doesn't guarantee that the event will be emitted
             # straight away, and this causes visual delays in the changes.
             self.resizeEvent(event)
-            self._dpi_ratio_prev = self._dpi_ratio
+            QtWidgets.QApplication.instance().processEvents()
+            # resizeEvent triggers a paintEvent itself, so we exit this one.
+            return
+
+        # if the canvas does not have a renderer, then give up and wait for
+        # FigureCanvasAgg.draw(self) to be called
+        if not hasattr(self, 'renderer'):
+            return
 
         painter = QtGui.QPainter(self)
 


### PR DESCRIPTION
Right now the resizeEvent triggered from within the paintEvent will
itself trigger a second paintEvent.  Adding a print to draw() shows that
this patch ensures that draw() only gets called once the first time the
canvas appears.

See http://doc.qt.io/qt-5/qwidget.html#resizeEvent http://doc.qt.io/qt-4.8/qwidget.html#resizeEvent for relevant docs.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
