### PR TITLE
TST: do not do import in finally block

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -49,7 +49,6 @@ def mpl_test_settings(request):
         yield
     finally:
         if backend is not None:
-            import matplotlib.pyplot as plt
             plt.switch_backend(prev_backend)
         _do_cleanup(original_units_registry,
                     original_settings)


### PR DESCRIPTION
This works around a cpython bug (https://bugs.python.org/issue31286) and should un-break our 3.7 tests on travis.