### PR TITLE
Fixed bug caused by wrong scoping

### DIFF
--- a/lib/matplotlib/backends/web_backend/mpl.js
+++ b/lib/matplotlib/backends/web_backend/mpl.js
@@ -77,7 +77,7 @@ mpl.figure = function(figure_id, websocket, ondownload, parent_element) {
         };
 
     this.imageObj.onunload = function() {
-        this.ws.close();
+        fig.ws.close();
     }
 
     this.ws.onmessage = this._make_on_message_function(this);


### PR DESCRIPTION
Fixed a bug related to potentially wrong variable scope where the inner `this` of a function is used instead of the `this` of the outer scope.

rebase of #8724 