### PR TITLE
Allow timedelta to be converted to an ordinalf

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -271,6 +271,17 @@ def _dt64_to_ordinalf(d):
     return dt
 
 
+def _tdelta_to_ordinalf(tdelta):
+    """
+    Convert :mod:`timedelta` to total days. Return value is a :func:`float`
+    """
+    return tdelta.total_seconds() / SEC_PER_DAY
+
+
+# a version of _tdelta_to_ordinalf that can operate on numpy arrays
+_tdelta_to_ordinalf_np_vectorized = np.vectorize(_tdelta_to_ordinalf)
+
+
 def _from_ordinalf(x, tz=None):
     """
     Convert Gregorian float of the date, preserving hours, minutes,

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -641,3 +641,10 @@ def test_tz_utc():
 def test_num2timedelta(x, tdelta):
     dt = mdates.num2timedelta(x)
     assert dt == tdelta
+
+
+def test_timedelta_ordinalf():
+    # Check that timedeltas can be converted to ordinalfs
+    dt = datetime.timedelta(seconds=60)
+    ordinalf = mdates._tdelta_to_ordinalf(dt)
+    assert ordinalf == 1 / (24 * 60)


### PR DESCRIPTION
Replaces #8730 and is a part of fixing #8869