### PR TITLE
Use savefig instead of print_figure

### DIFF
--- a/examples/api/agg_oo_sgskip.py
+++ b/examples/api/agg_oo_sgskip.py
@@ -3,18 +3,21 @@
 The object-oriented interface
 =============================
 
-A pure OO (look Ma, no pylab!) example using the agg backend
-
+A pure OO (look Ma, no pyplot!) example using the agg backend.
 """
+
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 fig = Figure()
-canvas = FigureCanvas(fig)
+# A canvas must be manually attached to the figure (pyplot would automatically
+# do it).  This is done by instanciating the canvas with the figure as
+# argument.
+FigureCanvas(fig)
 ax = fig.add_subplot(111)
 ax.plot([1, 2, 3])
 ax.set_title('hi mom')
 ax.grid(True)
 ax.set_xlabel('time')
 ax.set_ylabel('volts')
-canvas.print_figure('test')
+fig.savefig('test')

--- a/examples/misc/hyperlinks_sgskip.py
+++ b/examples/misc/hyperlinks_sgskip.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 f = plt.figure()
 s = plt.scatter([1, 2, 3], [4, 5, 6])
 s.set_urls(['http://www.bbc.co.uk/news', 'http://www.google.com', None])
-f.canvas.print_figure('scatter.svg')
+f.savefig('scatter.svg')
 
 ###############################################################################
 
@@ -36,4 +36,4 @@ im = plt.imshow(Z, interpolation='bilinear', cmap=cm.gray,
                 origin='lower', extent=[-3, 3, -3, 3])
 
 im.set_url('http://www.google.com')
-f.canvas.print_figure('image.svg')
+f.savefig('image.svg')

--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -153,7 +153,7 @@ class MyApplication(tornado.web.Application):
             self.set_header('Content-Type', mimetypes.get(fmt, 'binary'))
 
             buff = io.BytesIO()
-            manager.canvas.print_figure(buff, format=fmt)
+            manager.canvas.figure.savefig(buff, format=fmt)
             self.write(buff.getvalue())
 
     class WebSocket(tornado.websocket.WebSocketHandler):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2303,7 +2303,7 @@ class FigureCanvasBase(object):
         default_filetype = self.get_default_filetype()
         default_filename = default_basename + '.' + default_filetype
 
-        save_dir = os.path.expanduser(rcParams.get('savefig.directory', ''))
+        save_dir = os.path.expanduser(rcParams['savefig.directory'])
 
         # ensure non-existing filename in save dir
         i = 1

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -726,7 +726,7 @@ class NavigationToolbar2GTK(NavigationToolbar2, gtk.Toolbar):
                 # save dir for next time
                 rcParams['savefig.directory'] = os.path.dirname(six.text_type(fname))
             try:
-                self.canvas.print_figure(fname, format=format)
+                self.canvas.figure.savefig(fname, format=format)
             except Exception as e:
                 error_msg_gtk(str(e), parent=self)
 

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -707,7 +707,7 @@ class NavigationToolbar2GTK(NavigationToolbar2, gtk.Toolbar):
         fc = FileChooserDialog(
             title='Save the figure',
             parent=self.win,
-            path=os.path.expanduser(rcParams.get('savefig.directory', '')),
+            path=os.path.expanduser(rcParams['savefig.directory']),
             filetypes=self.canvas.get_supported_filetypes(),
             default_filetype=self.canvas.get_default_filetype())
         fc.set_current_name(self.canvas.get_default_filename())
@@ -718,13 +718,10 @@ class NavigationToolbar2GTK(NavigationToolbar2, gtk.Toolbar):
         fname, format = chooser.get_filename_from_user()
         chooser.destroy()
         if fname:
-            startpath = os.path.expanduser(rcParams.get('savefig.directory', ''))
-            if startpath == '':
-                # explicitly missing key or empty str signals to use cwd
-                rcParams['savefig.directory'] = startpath
-            else:
-                # save dir for next time
-                rcParams['savefig.directory'] = os.path.dirname(six.text_type(fname))
+            # Save dir for next time, unless empty str (i.e., use cwd).
+            if startpath != "":
+                rcParams['savefig.directory'] = (
+                    os.path.dirname(six.text_type(fname)))
             try:
                 self.canvas.figure.savefig(fname, format=format)
             except Exception as e:

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -561,7 +561,7 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         fc = FileChooserDialog(
             title='Save the figure',
             parent=self.win,
-            path=os.path.expanduser(rcParams.get('savefig.directory', '')),
+            path=os.path.expanduser(rcParams['savefig.directory']),
             filetypes=self.canvas.get_supported_filetypes(),
             default_filetype=self.canvas.get_default_filetype())
         fc.set_current_name(self.canvas.get_default_filename())
@@ -572,13 +572,11 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         fname, format = chooser.get_filename_from_user()
         chooser.destroy()
         if fname:
-            startpath = os.path.expanduser(rcParams.get('savefig.directory', ''))
-            if startpath == '':
-                # explicitly missing key or empty str signals to use cwd
-                rcParams['savefig.directory'] = startpath
-            else:
-                # save dir for next time
-                rcParams['savefig.directory'] = os.path.dirname(six.text_type(fname))
+            startpath = os.path.expanduser(rcParams['savefig.directory'])
+            # Save dir for next time, unless empty str (i.e., use cwd).
+            if startpath != "":
+                rcParams['savefig.directory'] = (
+                    os.path.dirname(six.text_type(fname)))
             try:
                 self.canvas.figure.savefig(fname, format=format)
             except Exception as e:
@@ -814,7 +812,7 @@ class SaveFigureGTK3(backend_tools.SaveFigureBase):
         fc = FileChooserDialog(
             title='Save the figure',
             parent=self.figure.canvas.manager.window,
-            path=os.path.expanduser(rcParams.get('savefig.directory', '')),
+            path=os.path.expanduser(rcParams['savefig.directory']),
             filetypes=self.figure.canvas.get_supported_filetypes(),
             default_filetype=self.figure.canvas.get_default_filetype())
         fc.set_current_name(self.figure.canvas.get_default_filename())
@@ -825,8 +823,7 @@ class SaveFigureGTK3(backend_tools.SaveFigureBase):
         fname, format_ = chooser.get_filename_from_user()
         chooser.destroy()
         if fname:
-            startpath = os.path.expanduser(
-                rcParams.get('savefig.directory', ''))
+            startpath = os.path.expanduser(rcParams['savefig.directory'])
             if startpath == '':
                 # explicitly missing key or empty str signals to use cwd
                 rcParams['savefig.directory'] = startpath

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -580,7 +580,7 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
                 # save dir for next time
                 rcParams['savefig.directory'] = os.path.dirname(six.text_type(fname))
             try:
-                self.canvas.print_figure(fname, format=format)
+                self.canvas.figure.savefig(fname, format=format)
             except Exception as e:
                 error_msg_gtk(str(e), parent=self)
 

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -192,7 +192,7 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
                                             self.canvas.get_default_filename())
         if filename is None: # Cancel
             return
-        self.canvas.print_figure(filename)
+        self.canvas.figure.savefig(filename)
 
     def prepare_configure_subplots(self):
         toolfig = Figure(figsize=(6,3))

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -725,8 +725,8 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         sorted_filetypes = sorted(six.iteritems(filetypes))
         default_filetype = self.canvas.get_default_filetype()
 
-        startpath = matplotlib.rcParams.get('savefig.directory', '')
-        startpath = os.path.expanduser(startpath)
+        startpath = os.path.expanduser(
+            matplotlib.rcParams['savefig.directory'])
         start = os.path.join(startpath, self.canvas.get_default_filename())
         filters = []
         selectedFilter = None
@@ -742,13 +742,10 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                                          "Choose a filename to save to",
                                          start, filters, selectedFilter)
         if fname:
-            if startpath == '':
-                # explicitly missing key or empty str signals to use cwd
-                matplotlib.rcParams['savefig.directory'] = startpath
-            else:
-                # save dir for next time
-                savefig_dir = os.path.dirname(six.text_type(fname))
-                matplotlib.rcParams['savefig.directory'] = savefig_dir
+            # Save dir for next time, unless empty str (i.e., use cwd).
+            if startpath != "":
+                matplotlib.rcParams['savefig.directory'] = (
+                    os.path.dirname(six.text_type(fname)))
             try:
                 self.canvas.figure.savefig(six.text_type(fname))
             except Exception as e:

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -750,7 +750,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                 savefig_dir = os.path.dirname(six.text_type(fname))
                 matplotlib.rcParams['savefig.directory'] = savefig_dir
             try:
-                self.canvas.print_figure(six.text_type(fname))
+                self.canvas.figure.savefig(six.text_type(fname))
             except Exception as e:
                 QtWidgets.QMessageBox.critical(
                     self, "Error saving file", six.text_type(e),

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -768,8 +768,7 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
         # work - JDH!
         #defaultextension = self.canvas.get_default_filetype()
         defaultextension = ''
-        initialdir = rcParams.get('savefig.directory', '')
-        initialdir = os.path.expanduser(initialdir)
+        initialdir = os.path.expanduser(rcParams['savefig.directory'])
         initialfile = self.canvas.get_default_filename()
         fname = tkinter_tkfiledialog.asksaveasfilename(
             master=self.window,
@@ -780,20 +779,17 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
             initialfile=initialfile,
             )
 
-        if fname == "" or fname == ():
+        if fname in ["", ()]:
             return
-        else:
-            if initialdir == '':
-                # explicitly missing key or empty str signals to use cwd
-                rcParams['savefig.directory'] = initialdir
-            else:
-                # save dir for next time
-                rcParams['savefig.directory'] = os.path.dirname(six.text_type(fname))
-            try:
-                # This method will handle the delegation to the correct type
-                self.canvas.figure.savefig(fname)
-            except Exception as e:
-                tkinter_messagebox.showerror("Error saving file", str(e))
+        # Save dir for next time, unless empty str (i.e., use cwd).
+        if initialdir != "":
+            rcParams['savefig.directory'] = (
+                os.path.dirname(six.text_type(fname)))
+        try:
+            # This method will handle the delegation to the correct type
+            self.canvas.figure.savefig(fname)
+        except Exception as e:
+            tkinter_messagebox.showerror("Error saving file", str(e))
 
     def set_active(self, ind):
         self._ind = ind
@@ -984,8 +980,7 @@ class SaveFigureTk(backend_tools.SaveFigureBase):
         # work - JDH!
         # defaultextension = self.figure.canvas.get_default_filetype()
         defaultextension = ''
-        initialdir = rcParams.get('savefig.directory', '')
-        initialdir = os.path.expanduser(initialdir)
+        initialdir = os.path.expanduser(rcParams['savefig.directory'])
         initialfile = self.figure.canvas.get_default_filename()
         fname = tkinter_tkfiledialog.asksaveasfilename(
             master=self.figure.canvas.manager.window,

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -791,7 +791,7 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
                 rcParams['savefig.directory'] = os.path.dirname(six.text_type(fname))
             try:
                 # This method will handle the delegation to the correct type
-                self.canvas.print_figure(fname)
+                self.canvas.figure.savefig(fname)
             except Exception as e:
                 tkinter_messagebox.showerror("Error saving file", str(e))
 
@@ -1008,7 +1008,7 @@ class SaveFigureTk(backend_tools.SaveFigureBase):
                     six.text_type(fname))
             try:
                 # This method will handle the delegation to the correct type
-                self.figure.canvas.print_figure(fname)
+                self.figure.savefig(fname)
             except Exception as e:
                 tkinter_messagebox.showerror("Error saving file", str(e))
 

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -151,7 +151,7 @@ class WebAggApplication(tornado.web.Application):
             self.set_header('Content-Type', mimetypes.get(fmt, 'binary'))
 
             buff = six.BytesIO()
-            manager.canvas.print_figure(buff, format=fmt)
+            manager.canvas.figure.savefig(buff, format=fmt)
             self.write(buff.getvalue())
 
     class WebSocket(tornado.websocket.WebSocketHandler):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1587,7 +1587,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                     (ext, format, ext), stacklevel=0)
                 format = ext
             try:
-                self.canvas.print_figure(
+                self.canvas.figure.savefig(
                     os.path.join(dirname, filename), format=format)
             except Exception as e:
                 error_msg_wx(str(e))


### PR DESCRIPTION
As explained in the discussion of https://github.com/matplotlib/matplotlib/issues/9080, savefig and print_figure should ultimately be equivalent, but right now savefig handles transparency better, so use it instead of print_figure.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
