### PR TITLE
Cleanups

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -569,7 +569,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             # The image is "pasted" onto a white background image to safely
             # handle any transparency
             image = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
-            rgba = mcolors.to_rgba(rcParams.get('savefig.facecolor', 'white'))
+            rgba = mcolors.to_rgba(rcParams['savefig.facecolor'])
             color = tuple([int(x * 255.0) for x in rgba[:3]])
             background = Image.new('RGB', size, color)
             background.paste(image, image)

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -56,7 +56,7 @@ else:
 def get_texcommand():
     """Get chosen TeX system from rc."""
     texsystem_options = ["xelatex", "lualatex", "pdflatex"]
-    texsystem = rcParams.get("pgf.texsystem", "xelatex")
+    texsystem = rcParams["pgf.texsystem"]
     return texsystem if texsystem in texsystem_options else "xelatex"
 
 
@@ -68,7 +68,7 @@ def get_fontspec():
     if texcommand != "pdflatex":
         latex_fontspec.append("\\usepackage{fontspec}")
 
-    if texcommand != "pdflatex" and rcParams.get("pgf.rcfonts", True):
+    if texcommand != "pdflatex" and rcParams["pgf.rcfonts"]:
         # try to find fonts from rc parameters
         families = ["serif", "sans-serif", "monospace"]
         fontspecs = [r"\setmainfont{%s}", r"\setsansfont{%s}",
@@ -86,10 +86,7 @@ def get_fontspec():
 
 def get_preamble():
     """Get LaTeX preamble from rc."""
-    latex_preamble = rcParams.get("pgf.preamble", "")
-    if type(latex_preamble) == list:
-        latex_preamble = "\n".join(latex_preamble)
-    return latex_preamble
+    return "\n".join(rcParams["pgf.preamble"])
 
 ###############################################################################
 
@@ -223,13 +220,14 @@ class LatexManagerFactory(object):
         latex_header = LatexManager._build_latex_header()
         prev = LatexManagerFactory.previous_instance
 
-        # check if the previous instance of LatexManager can be reused
-        if prev and prev.latex_header == latex_header and prev.texcommand == texcommand:
-            if rcParams.get("pgf.debug", False):
+        # Check if the previous instance of LatexManager can be reused.
+        if (prev and prev.latex_header == latex_header
+                and prev.texcommand == texcommand):
+            if rcParams["pgf.debug"]:
                 print("reusing LatexManager")
             return prev
         else:
-            if rcParams.get("pgf.debug", False):
+            if rcParams["pgf.debug"]:
                 print("creating LatexManager")
             new_inst = LatexManager()
             LatexManagerFactory.previous_instance = new_inst
@@ -289,7 +287,7 @@ class LatexManager(object):
         # store references for __del__
         self._os_path = os.path
         self._shutil = shutil
-        self._debug = rcParams.get("pgf.debug", False)
+        self._debug = rcParams["pgf.debug"]
 
         # create a tmp directory for running latex, remember to cleanup
         self.tmpdir = tempfile.mkdtemp(prefix="mpl_pgf_lm_")

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -10,8 +10,7 @@ import six
 import math
 import copy
 
-from matplotlib import lines as mlines, axis as maxis, \
-        patches as mpatches
+from matplotlib import lines as mlines, axis as maxis, patches as mpatches
 from matplotlib import rcParams
 from . import art3d
 from . import proj3d
@@ -40,8 +39,8 @@ def move_from_center(coord, centers, deltas, axmask=(True, True, True)):
 def tick_update_position(tick, tickxs, tickys, labelpos):
     '''Update tick line and label position and style.'''
 
-    for (label, on) in ((tick.label1, tick.label1On), \
-            (tick.label2, tick.label2On)):
+    for (label, on) in [(tick.label1, tick.label1On),
+                        (tick.label2, tick.label2On)]:
         if on:
             label.set_position(labelpos)
 
@@ -81,68 +80,57 @@ class Axis(maxis.XAxis):
         # Do not depend on this existing in future releases!
         self._axinfo = self._AXINFO[adir].copy()
         if rcParams['_internal.classic_mode']:
-            self._axinfo.update({'label':
-                                    {'va': 'center',
-                                     'ha': 'center'},
-                                 'tick':
-                                    {'inward_factor': 0.2,
-                                     'outward_factor': 0.1,
-                                     'linewidth': rcParams['lines.linewidth'],
-                                     'color': 'k'},
-                                 'axisline':
-                                    {'linewidth': 0.75,
-                                     'color': (0, 0, 0, 1)},
-                                 'grid' :
-                                    {'color': (0.9, 0.9, 0.9, 1),
-                                     'linewidth': 1.0,
-                                     'linestyle': '-'},
-                                })
+            self._axinfo.update(
+                {'label': {'va': 'center',
+                           'ha': 'center'},
+                 'tick': {'inward_factor': 0.2,
+                          'outward_factor': 0.1,
+                          'linewidth': rcParams['lines.linewidth'],
+                          'color': 'k'},
+                 'axisline': {'linewidth': 0.75,
+                              'color': (0, 0, 0, 1)},
+                 'grid': {'color': (0.9, 0.9, 0.9, 1),
+                          'linewidth': 1.0,
+                          'linestyle': '-'},
+                 })
         else:
-            self._axinfo.update({'label' :
-                                    {'va': 'center',
-                                     'ha': 'center'},
-                                 'tick' :
-                                    {'inward_factor': 0.2,
-                                     'outward_factor': 0.1,
-                                     'linewidth': rcParams.get(
-                                        adir + 'tick.major.width',
-                                        rcParams['xtick.major.width']),
-                                     'color': rcParams.get(
-                                        adir + 'tick.color',
-                                        rcParams['xtick.color'])},
-                                 'axisline':
-                                    {'linewidth': rcParams['axes.linewidth'],
-                                     'color': rcParams['axes.edgecolor']},
-                                 'grid' :
-                                    {'color': rcParams['grid.color'],
-                                     'linewidth': rcParams['grid.linewidth'],
-                                     'linestyle': rcParams['grid.linestyle']},
-                                })
-
+            self._axinfo.update(
+                {'label': {'va': 'center',
+                           'ha': 'center'},
+                 'tick': {'inward_factor': 0.2,
+                          'outward_factor': 0.1,
+                          'linewidth': rcParams.get(
+                              adir + 'tick.major.width',
+                              rcParams['xtick.major.width']),
+                          'color': rcParams.get(
+                              adir + 'tick.color',
+                              rcParams['xtick.color'])},
+                 'axisline': {'linewidth': rcParams['axes.linewidth'],
+                              'color': rcParams['axes.edgecolor']},
+                 'grid': {'color': rcParams['grid.color'],
+                          'linewidth': rcParams['grid.linewidth'],
+                          'linestyle': rcParams['grid.linestyle']},
+                 })
 
         maxis.XAxis.__init__(self, axes, *args, **kwargs)
-
         self.set_rotate_label(kwargs.get('rotate_label', None))
 
-
     def init3d(self):
-        self.line = mlines.Line2D(xdata=(0, 0), ydata=(0, 0),
-                            linewidth=self._axinfo['axisline']['linewidth'],
-                            color=self._axinfo['axisline']['color'],
-                            antialiased=True,
-                           )
+        self.line = mlines.Line2D(
+            xdata=(0, 0), ydata=(0, 0),
+            linewidth=self._axinfo['axisline']['linewidth'],
+            color=self._axinfo['axisline']['color'],
+            antialiased=True)
 
         # Store dummy data in Polygon object
-        self.pane = mpatches.Polygon(np.array([[0,0], [0,1], [1,0], [0,0]]),
-                                    closed=False,
-                                    alpha=0.8,
-                                    facecolor=(1,1,1,0),
-                                    edgecolor=(1,1,1,0))
+        self.pane = mpatches.Polygon(
+            np.array([[0, 0], [0, 1], [1, 0], [0, 0]]),
+            closed=False, alpha=0.8, facecolor='k', edgecolor='k')
         self.set_pane_color(self._axinfo['color'])
 
         self.axes._set_artist_props(self.line)
         self.axes._set_artist_props(self.pane)
-        self.gridlines = art3d.Line3DCollection([], )
+        self.gridlines = art3d.Line3DCollection([])
         self.axes._set_artist_props(self.gridlines)
         self.axes._set_artist_props(self.label)
         self.axes._set_artist_props(self.offsetText)
@@ -153,7 +141,8 @@ class Axis(maxis.XAxis):
     def get_tick_positions(self):
         majorLocs = self.major.locator()
         self.major.formatter.set_locs(majorLocs)
-        majorLabels = [self.major.formatter(val, i) for i, val in enumerate(majorLocs)]
+        majorLabels = [self.major.formatter(val, i)
+                       for i, val in enumerate(majorLocs)]
         return majorLabels, majorLocs
 
     def get_major_ticks(self, numticks=None):
@@ -173,7 +162,7 @@ class Axis(maxis.XAxis):
         self.stale = True
 
     def set_pane_color(self, color):
-        '''Set pane color to a RGBA tuple'''
+        '''Set pane color to a RGBA tuple.'''
         self._axinfo['color'] = color
         self.pane.set_edgecolor(color)
         self.pane.set_facecolor(color)
@@ -211,8 +200,8 @@ class Axis(maxis.XAxis):
 
         vals = mins[0], maxs[0], mins[1], maxs[1], mins[2], maxs[2]
         tc = self.axes.tunit_cube(vals, renderer.M)
-        avgz = [tc[p1][2] + tc[p2][2] + tc[p3][2] + tc[p4][2] for \
-                p1, p2, p3, p4 in self._PLANES]
+        avgz = [tc[p1][2] + tc[p2][2] + tc[p3][2] + tc[p4][2]
+                for p1, p2, p3, p4 in self._PLANES]
         highs = np.array([avgz[2*i] < avgz[2*i+1] for i in range(3)])
 
         return mins, maxs, centers, deltas, tc, highs
@@ -301,13 +290,13 @@ class Axis(maxis.XAxis):
         ax_points_estimate = sum(72. * ax_inches)
         deltas_per_point = 48. / ax_points_estimate
         default_offset = 21.
-        labeldeltas = (self.labelpad + default_offset) * deltas_per_point\
-            * deltas
+        labeldeltas = (
+            (self.labelpad + default_offset) * deltas_per_point * deltas)
         axmask = [True, True, True]
         axmask[index] = False
         lxyz = move_from_center(lxyz, centers, labeldeltas, axmask)
-        tlx, tly, tlz = proj3d.proj_transform(lxyz[0], lxyz[1], lxyz[2], \
-                renderer.M)
+        tlx, tly, tlz = proj3d.proj_transform(lxyz[0], lxyz[1], lxyz[2],
+                                              renderer.M)
         self.label.set_position((tlx, tly))
         if self.get_rotate_label(self.label.get_text()):
             angle = art3d.norm_text_angle(math.degrees(math.atan2(dy, dx)))
@@ -425,26 +414,28 @@ class Axis(maxis.XAxis):
             # Get tick line positions
             pos = copy.copy(edgep1)
             pos[index] = loc
-            pos[tickdir] = edgep1[tickdir] + info['tick']['outward_factor'] * \
-                                             ticksign * tickdelta
-            x1, y1, z1 = proj3d.proj_transform(pos[0], pos[1], pos[2], \
-                    renderer.M)
-            pos[tickdir] = edgep1[tickdir] - info['tick']['inward_factor'] * \
-                                             ticksign * tickdelta
-            x2, y2, z2 = proj3d.proj_transform(pos[0], pos[1], pos[2], \
-                    renderer.M)
+            pos[tickdir] = (
+                edgep1[tickdir]
+                + info['tick']['outward_factor'] * ticksign * tickdelta)
+            x1, y1, z1 = proj3d.proj_transform(pos[0], pos[1], pos[2],
+                                               renderer.M)
+            pos[tickdir] = (
+                edgep1[tickdir]
+                - info['tick']['inward_factor'] * ticksign * tickdelta)
+            x2, y2, z2 = proj3d.proj_transform(pos[0], pos[1], pos[2],
+                                               renderer.M)
 
             # Get position of label
             default_offset = 8.  # A rough estimate
-            labeldeltas = (tick.get_pad() + default_offset) * deltas_per_point\
-                * deltas
+            labeldeltas = (
+                (tick.get_pad() + default_offset) * deltas_per_point * deltas)
 
             axmask = [True, True, True]
             axmask[index] = False
             pos[tickdir] = edgep1[tickdir]
             pos = move_from_center(pos, centers, labeldeltas, axmask)
-            lx, ly, lz = proj3d.proj_transform(pos[0], pos[1], pos[2], \
-                    renderer.M)
+            lx, ly, lz = proj3d.proj_transform(pos[0], pos[1], pos[2],
+                                               renderer.M)
 
             tick_update_position(tick, (x1, x2), (y1, y2), (lx, ly))
             tick.tick1line.set_linewidth(info['tick']['linewidth'])


### PR DESCRIPTION
I noticed while working on #9124 that some old codepaths seem to assume keys don't necessarily exist in rcParams, which may possibly have been the case a long time ago but is not the case anymore today -- so remove all rcParams.get by indexing into rcParams.

... except in axis3d which tries to look up the nonexistent ztick.major.width and ztick.color, so keep the fallback on xtick.major.width and xtick.color (I did not add the whole suite of ztick.* rcParams to rcsetup because in that case we'd better make sure all of them are respected, which is another project in itself).  Now that I was there I could as well do some style cleanups in axis3d.py.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
