### PR TITLE
Remove Artist.{get,set}_axes.

### DIFF
--- a/doc/api/api_changes/2017-08-29-AL-getset_axes.rst
+++ b/doc/api/api_changes/2017-08-29-AL-getset_axes.rst
@@ -1,0 +1,4 @@
+Removal of deprecated methods
+`````````````````````````````
+The deprecated `Artist.get_axes` and `Artist.set_axes` methods have been
+removed

--- a/doc/api/artist_api.rst
+++ b/doc/api/artist_api.rst
@@ -126,8 +126,6 @@ Figure and Axes
    Artist.remove
 
    Artist.axes
-   Artist.get_axes
-   Artist.set_axes
 
    Artist.set_figure
    Artist.get_figure

--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -581,6 +581,7 @@ General Artist Properties
    :template: autosummary.rst
    :nosignatures:
 
+   Axes.set_agg_filter
    Axes.set_alpha
    Axes.set_animated
    Axes.set_clip_box
@@ -588,18 +589,16 @@ General Artist Properties
    Axes.set_clip_path
    Axes.set_gid
    Axes.set_label
+   Axes.set_path_effects
+   Axes.set_rasterized
+   Axes.set_sketch_params
+   Axes.set_snap
+   Axes.set_transform
    Axes.set_url
    Axes.set_visible
    Axes.set_zorder
-   Axes.set_rasterized
-   Axes.set_sketch_params
-   Axes.set_agg_filter
-   Axes.set_snap
-   Axes.set_transform
-   Axes.set_path_effects
 
    Axes.get_agg_filter
-   Axes.get_sketch_params
    Axes.get_alpha
    Axes.get_animated
    Axes.get_clip_box
@@ -607,18 +606,16 @@ General Artist Properties
    Axes.get_clip_path
    Axes.get_gid
    Axes.get_label
+   Axes.get_path_effects
+   Axes.get_rasterized
+   Axes.get_sketch_params
+   Axes.get_snap
+   Axes.get_transform
    Axes.get_url
    Axes.get_visible
    Axes.get_zorder
-   Axes.get_rasterized
-   Axes.get_transform
-   Axes.get_snap
-   Axes.get_path_effects
-
 
    Axes.axes
-   Axes.get_axes
-   Axes.set_axes
    Axes.set_figure
    Axes.get_figure
 

--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -481,7 +481,6 @@ Ticks
    Tick.get_agg_filter
    Tick.get_alpha
    Tick.get_animated
-   Tick.get_axes
    Tick.get_children
    Tick.get_clip_box
    Tick.get_clip_on
@@ -517,7 +516,6 @@ Ticks
    Tick.set_agg_filter
    Tick.set_alpha
    Tick.set_animated
-   Tick.set_axes
    Tick.set_clip_box
    Tick.set_clip_on
    Tick.set_clip_path
@@ -551,7 +549,6 @@ Ticks
    XTick.get_agg_filter
    XTick.get_alpha
    XTick.get_animated
-   XTick.get_axes
    XTick.get_children
    XTick.get_clip_box
    XTick.get_clip_on
@@ -587,7 +584,6 @@ Ticks
    XTick.set_agg_filter
    XTick.set_alpha
    XTick.set_animated
-   XTick.set_axes
    XTick.set_clip_box
    XTick.set_clip_on
    XTick.set_clip_path
@@ -621,7 +617,6 @@ Ticks
    YTick.get_agg_filter
    YTick.get_alpha
    YTick.get_animated
-   YTick.get_axes
    YTick.get_children
    YTick.get_clip_box
    YTick.get_clip_on
@@ -657,7 +652,6 @@ Ticks
    YTick.set_agg_filter
    YTick.set_alpha
    YTick.set_animated
-   YTick.set_axes
    YTick.set_clip_box
    YTick.set_clip_on
    YTick.set_clip_path
@@ -701,7 +695,6 @@ Axis
    Axis.get_agg_filter
    Axis.get_alpha
    Axis.get_animated
-   Axis.get_axes
    Axis.get_children
    Axis.get_clip_box
    Axis.get_clip_on
@@ -737,7 +730,6 @@ Axis
    Axis.set_agg_filter
    Axis.set_alpha
    Axis.set_animated
-   Axis.set_axes
    Axis.set_clip_box
    Axis.set_clip_on
    Axis.set_clip_path
@@ -771,7 +763,6 @@ Axis
    XAxis.get_agg_filter
    XAxis.get_alpha
    XAxis.get_animated
-   XAxis.get_axes
    XAxis.get_children
    XAxis.get_clip_box
    XAxis.get_clip_on
@@ -807,7 +798,6 @@ Axis
    XAxis.set_agg_filter
    XAxis.set_alpha
    XAxis.set_animated
-   XAxis.set_axes
    XAxis.set_clip_box
    XAxis.set_clip_on
    XAxis.set_clip_path
@@ -841,7 +831,6 @@ Axis
    YAxis.get_agg_filter
    YAxis.get_alpha
    YAxis.get_animated
-   YAxis.get_axes
    YAxis.get_children
    YAxis.get_clip_box
    YAxis.get_clip_on
@@ -877,7 +866,6 @@ Axis
    YAxis.set_agg_filter
    YAxis.set_alpha
    YAxis.set_animated
-   YAxis.set_axes
    YAxis.set_clip_box
    YAxis.set_clip_on
    YAxis.set_clip_path

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -10,7 +10,6 @@ import inspect
 import numpy as np
 import matplotlib
 import matplotlib.cbook as cbook
-from matplotlib.cbook import mplDeprecation
 from matplotlib import docstring, rcParams
 from .transforms import (Bbox, IdentityTransform, TransformedBbox,
                          TransformedPatchPath, TransformedPath, Transform)
@@ -207,32 +206,6 @@ class Artist(object):
             return y
         return ax.yaxis.convert_units(y)
 
-    def set_axes(self, axes):
-        """
-        Set the :class:`~matplotlib.axes.Axes` instance in which the
-        artist resides, if any.
-
-        This has been deprecated in mpl 1.5, please use the
-        axes property.  Will be removed in 1.7 or 2.0.
-
-        ACCEPTS: an :class:`~matplotlib.axes.Axes` instance
-        """
-        warnings.warn(_get_axes_msg.format('set_axes'), mplDeprecation,
-                      stacklevel=1)
-        self.axes = axes
-
-    def get_axes(self):
-        """
-        Return the :class:`~matplotlib.axes.Axes` instance the artist
-        resides in, or *None*.
-
-        This has been deprecated in mpl 1.5, please use the
-        axes property.  Will be removed in 1.7 or 2.0.
-        """
-        warnings.warn(_get_axes_msg.format('get_axes'), mplDeprecation,
-                      stacklevel=1)
-        return self.axes
-
     @property
     def axes(self):
         """
@@ -243,18 +216,14 @@ class Artist(object):
 
     @axes.setter
     def axes(self, new_axes):
-
-        if (new_axes is not None and
-                (self._axes is not None and new_axes != self._axes)):
-            raise ValueError("Can not reset the axes.  You are "
-                             "probably trying to re-use an artist "
-                             "in more than one Axes which is not "
-                             "supported")
-
+        if (new_axes is not None and self._axes is not None
+                and new_axes != self._axes):
+            raise ValueError("Can not reset the axes.  You are probably "
+                             "trying to re-use an artist in more than one "
+                             "Axes which is not supported")
         self._axes = new_axes
         if new_axes is not None and new_axes is not self:
             self.stale_callback = _stale_axes_callback
-
         return new_axes
 
     @property

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -2,20 +2,21 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from collections import OrderedDict, namedtuple
 
+from collections import OrderedDict, namedtuple
+from contextlib import contextmanager
+from functools import wraps
+import inspect
 import re
 import warnings
-import inspect
+
 import numpy as np
+
 import matplotlib
-import matplotlib.cbook as cbook
-from matplotlib import docstring, rcParams
-from .transforms import (Bbox, IdentityTransform, TransformedBbox,
-                         TransformedPatchPath, TransformedPath, Transform)
+from . import cbook, docstring, rcParams
 from .path import Path
-from functools import wraps
-from contextlib import contextmanager
+from .transforms import (Bbox, IdentityTransform, Transform, TransformedBbox,
+                         TransformedPatchPath, TransformedPath)
 # Note, matplotlib artists use the doc strings for set and get
 # methods to enable the introspection methods of setp and getp.  Every
 # set_* method should have a docstring containing the line


### PR DESCRIPTION
They are deprecated, and have been planned for removal in 2.0.  (2.1 will be the second minor release since deprecation, 2.2 the third).

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
