### PR TITLE
Adds option for Slider to snap to discrete values

### DIFF
--- a/doc/users/next_whats_new/2017-08-31_discrete-sliders.rst
+++ b/doc/users/next_whats_new/2017-08-31_discrete-sliders.rst
@@ -1,5 +1,5 @@
 Slider UI widget can snap to discrete values
---------------------------
+--------------------------------------------
 
 The slider UI widget can take the optional argument *valstep*.  Doing so
 forces the slider to take on only discrete values, starting from *valmin* and

--- a/doc/users/next_whats_new/2017-08-31_discrete-sliders.rst
+++ b/doc/users/next_whats_new/2017-08-31_discrete-sliders.rst
@@ -1,0 +1,8 @@
+Slider UI widget can snap to discrete values
+--------------------------
+
+The slider UI widget can take the optional argument `valstep`.  Doing so
+forces the slider to take on only discrete values, starting from `valmin` and
+counting up to `valmax` with steps of size `valstep`.
+
+If `closedmax==True`, then the slider will snap to `valmax` as well.  

--- a/doc/users/next_whats_new/2017-08-31_discrete-sliders.rst
+++ b/doc/users/next_whats_new/2017-08-31_discrete-sliders.rst
@@ -1,8 +1,8 @@
 Slider UI widget can snap to discrete values
 --------------------------
 
-The slider UI widget can take the optional argument `valstep`.  Doing so
-forces the slider to take on only discrete values, starting from `valmin` and
-counting up to `valmax` with steps of size `valstep`.
+The slider UI widget can take the optional argument *valstep*.  Doing so
+forces the slider to take on only discrete values, starting from *valmin* and
+counting up to *valmax* with steps of size *valstep*.
 
-If `closedmax==True`, then the slider will snap to `valmax` as well.  
+If *closedmax==True*, then the slider will snap to *valmax* as well.  

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -13,6 +13,7 @@ plt.subplots_adjust(left=0.25, bottom=0.25)
 t = np.arange(0.0, 1.0, 0.001)
 a0 = 5
 f0 = 3
+delta_f = 5.0
 s = a0*np.sin(2*np.pi*f0*t)
 l, = plt.plot(t, s, lw=2, color='red')
 plt.axis([0, 1, -10, 10])
@@ -21,7 +22,7 @@ axcolor = 'lightgoldenrodyellow'
 axfreq = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
 axamp = plt.axes([0.25, 0.15, 0.65, 0.03], facecolor=axcolor)
 
-sfreq = Slider(axfreq, 'Freq', 0.1, 30.0, valinit=f0)
+sfreq = Slider(axfreq, 'Freq', 0.1, 30.0, valinit=f0, valstep=delta_f)
 samp = Slider(axamp, 'Amp', 0.1, 10.0, valinit=a0)
 
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -271,9 +271,9 @@ class Slider(AxesWidget):
 
     Call :meth:`on_changed` to connect to the slider event
     """
-    def __init__(self, ax, label, valmin, valmax, valinit=0.5, valfmt='%1.2f',
-                 closedmin=True, closedmax=True, slidermin=None,
-                 slidermax=None, dragging=True, **kwargs):
+    def __init__(self, ax, label, valmin, valmax, valstep=None, valinit=0.5,
+                 valfmt='%1.2f', closedmin=True, closedmax=True,
+                 slidermin=None, slidermax=None, dragging=True, **kwargs):
         """
         Parameters
         ----------
@@ -334,6 +334,7 @@ class Slider(AxesWidget):
         self.drag_active = False
         self.valmin = valmin
         self.valmax = valmax
+        self.valstep = valstep
         valinit = self._value_in_bounds(valinit)
         if valinit is None:
             valinit = valmin
@@ -368,6 +369,8 @@ class Slider(AxesWidget):
 
     def _value_in_bounds(self, val):
         """ Makes sure self.val is with given bounds."""
+        if self.valstep:
+            val = round(val/self.valstep)*self.valstep
         if val <= self.valmin:
             if not self.closedmin:
                 return

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -271,9 +271,9 @@ class Slider(AxesWidget):
 
     Call :meth:`on_changed` to connect to the slider event
     """
-    def __init__(self, ax, label, valmin, valmax, valstep=None, valinit=0.5,
-                 valfmt='%1.2f', closedmin=True, closedmax=True,
-                 slidermin=None, slidermax=None, dragging=True, **kwargs):
+    def __init__(self, ax, label, valmin, valmax, valinit=0.5, valfmt='%1.2f',
+                 closedmin=True, closedmax=True, slidermin=None, slidermax=None,
+                 dragging=True, valstep=None, **kwargs):
         """
         Parameters
         ----------
@@ -288,9 +288,6 @@ class Slider(AxesWidget):
 
         valmax : float
             The maximum value of the slider.
-
-        valstep : float, optional, default: None
-            If given, the slider will snap to multiples of `valstep`.
 
         valinit : float, optional, default: 0.5
             The slider initial position.
@@ -314,6 +311,9 @@ class Slider(AxesWidget):
 
         dragging : bool, optional, default: True
             If True the slider can be dragged by the mouse.
+
+        valstep : float, optional, default: None
+            If given, the slider will snap to multiples of `valstep`.
 
         Notes
         -----
@@ -419,6 +419,7 @@ class Slider(AxesWidget):
         if (val is not None) and (val != self.val):
             self.set_val(val)
 
+    
     def set_val(self, val):
         xy = self.poly.xy
         xy[2] = val, 1

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -289,6 +289,9 @@ class Slider(AxesWidget):
         valmax : float
             The maximum value of the slider.
 
+        valstep : float, optional, default: None
+            If given, the slider will snap to multiples of `valstep`.
+
         valinit : float, optional, default: 0.5
             The slider initial position.
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -416,12 +416,10 @@ class Slider(AxesWidget):
             event.canvas.release_mouse(self.ax)
             return
         val = self._value_in_bounds(event.xdata)
-        if val is not None:
+        if (val is not None) and (val != self.val):
             self.set_val(val)
 
     def set_val(self, val):
-        if self.val == val:
-            return
         xy = self.poly.xy
         xy[2] = val, 1
         xy[3] = val, 0

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -420,6 +420,8 @@ class Slider(AxesWidget):
             self.set_val(val)
 
     def set_val(self, val):
+        if self.val == val:
+            return
         xy = self.poly.xy
         xy[2] = val, 1
         xy[3] = val, 0

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -373,7 +373,9 @@ class Slider(AxesWidget):
     def _value_in_bounds(self, val):
         """ Makes sure self.val is with given bounds."""
         if self.valstep:
-            val = np.round(val/self.valstep)*self.valstep
+            val = np.round((val - self.valmin)/self.valstep)*self.valstep
+            val += self.valmin
+
         if val <= self.valmin:
             if not self.closedmin:
                 return

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -272,8 +272,8 @@ class Slider(AxesWidget):
     Call :meth:`on_changed` to connect to the slider event
     """
     def __init__(self, ax, label, valmin, valmax, valinit=0.5, valfmt='%1.2f',
-                 closedmin=True, closedmax=True, slidermin=None, slidermax=None,
-                 dragging=True, valstep=None, **kwargs):
+                 closedmin=True, closedmax=True, slidermin=None,
+                 slidermax=None, dragging=True, valstep=None, **kwargs):
         """
         Parameters
         ----------
@@ -419,7 +419,6 @@ class Slider(AxesWidget):
         if (val is not None) and (val != self.val):
             self.set_val(val)
 
-    
     def set_val(self, val):
         xy = self.poly.xy
         xy[2] = val, 1

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -373,7 +373,7 @@ class Slider(AxesWidget):
     def _value_in_bounds(self, val):
         """ Makes sure self.val is with given bounds."""
         if self.valstep:
-            val = round(val/self.valstep)*self.valstep
+            val = np.round(val/self.valstep)*self.valstep
         if val <= self.valmin:
             if not self.closedmin:
                 return


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
Addresses #9129, allows the slider UI widget to snap to multiples of optional kwarg `valstep`.
 
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
