### PR TITLE
FIX: cast max/min to scaled dtype

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -367,8 +367,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     scaled_dtype = np.float32
                 # old versions of numpy do not work with `np.nammin`
                 # and `np.nanmax` as inputs
-                a_min = np.ma.min(A)
-                a_max = np.ma.max(A)
+                a_min = np.ma.min(A).astype(scaled_dtype)
+                a_max = np.ma.max(A).astype(scaled_dtype)
                 # scale the input data to [.1, .9].  The Agg
                 # interpolators clip to [0, 1] internally, use a
                 # smaller input scale to identify which of the

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -802,3 +802,8 @@ def test_empty_imshow():
 def test_imshow_float128():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((3, 3), dtype=np.longdouble))
+
+
+def test_imshow_bool():
+    fig, ax = plt.subplots()
+    ax.imshow(np.array([[True, False], [False, True]], dtype=bool))


### PR DESCRIPTION
This fixes a future issue with '-' between bool being deprecated by numpy.
