### PR TITLE
Don't update style-blacklisted rcparams in rc_* functions

### DIFF
--- a/doc/api/api_changes/2017-09-02-AL-rc-blacklist.rst
+++ b/doc/api/api_changes/2017-09-02-AL-rc-blacklist.rst
@@ -1,0 +1,7 @@
+Blacklisted rcparams no longer updated by `rcdefaults`, `rc_file_defaults`, `rc_file`
+-------------------------------------------------------------------------------------
+
+The rc modifier functions `rcdefaults`, `rc_file_defaults` and `rc_file`
+now ignore rcParams in the `matplotlib.style.core.STYLE_BLACKLIST` set.  In
+particular, this prevents the ``backend`` and ``interactive`` rcParams from
+being incorrectly modified by these functions.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1205,7 +1205,11 @@ def rc(group, **kwargs):
 
 
 def rcdefaults():
-    """Restore the rc params from Matplotlib's internal defaults.
+    """
+    Restore the rc params from Matplotlib's internal default style.
+
+    Style-blacklisted rc params (defined in
+    `matplotlib.style.core.STYLE_BLACKLIST`) are not updated.
 
     See Also
     --------
@@ -1219,29 +1223,42 @@ def rcdefaults():
     # no need to reemit them here.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", mplDeprecation)
+        from .style.core import STYLE_BLACKLIST
         rcParams.clear()
-        rcParams.update(rcParamsDefault)
+        rcParams.update({k: v for k, v in rcParamsDefault.items()
+                         if k not in STYLE_BLACKLIST})
 
 
 def rc_file_defaults():
-    """Restore the rc params from the original rc file loaded by Matplotlib.
+    """
+    Restore the rc params from the original rc file loaded by Matplotlib.
+
+    Style-blacklisted rc params (defined in
+    `matplotlib.style.core.STYLE_BLACKLIST`) are not updated.
     """
     # Deprecation warnings were already handled when creating rcParamsOrig, no
     # need to reemit them here.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", mplDeprecation)
-        rcParams.update(rcParamsOrig)
+        from .style.core import STYLE_BLACKLIST
+        rcParams.update({k: v for k, v in rcParamsOrig.items()
+                         if k not in STYLE_BLACKLIST})
 
 
 def rc_file(fname):
     """
     Update rc params from file.
+
+    Style-blacklisted rc params (defined in
+    `matplotlib.style.core.STYLE_BLACKLIST`) are not updated.
     """
     # Deprecation warnings were already handled in rc_params_from_file, no need
     # to reemit them here.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", mplDeprecation)
-        rcParams.update(rc_params_from_file(fname))
+        from .style.core import STYLE_BLACKLIST
+        rcParams.update({k: v for k, v in rc_params_from_file(fname).items()
+                         if k not in STYLE_BLACKLIST})
 
 
 class rc_context:


### PR DESCRIPTION
xref #9135

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Don't update style-blacklisted rcparams in rc_* functions.
This avoids e.g. incorrectly updating the "backend" or "interactive" rcParams.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [X] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
