### PR TITLE
include overspilling axes legends in ax.get_tightbbox

### DIFF
--- a/doc/users/next_whats_new/2017-10-19_axes_legend_in_tightbbox.rst
+++ b/doc/users/next_whats_new/2017-10-19_axes_legend_in_tightbbox.rst
@@ -1,0 +1,7 @@
+Axes legends now included in tight_bbox
+---------------------------------------
+
+Legends created via ``ax.legend()`` can sometimes overspill the limits of
+the axis.  Tools like ``fig.tight_layout()`` and
+``fig.savefig(bbox_inches='tight')`` would clip these legends.  A  change
+was made to include them in the ``tight`` calculations.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -33,6 +33,7 @@ import matplotlib.text as mtext
 import matplotlib.image as mimage
 from matplotlib.offsetbox import OffsetBox
 from matplotlib.artist import allow_rasterization
+from matplotlib.legend import Legend
 
 from matplotlib.rcsetup import cycler
 from matplotlib.rcsetup import validate_axisbelow
@@ -3969,6 +3970,8 @@ class _AxesBase(martist.Artist):
         for child in self.get_children():
             if isinstance(child, OffsetBox) and child.get_visible():
                 bb.append(child.get_window_extent(renderer))
+            elif isinstance(child, Legend) and child.get_visible():
+                bb.append(child._legend_box.get_window_extent(renderer))
 
         _bbox = mtransforms.Bbox.union(
             [b for b in bb if b.width != 0 or b.height != 0])


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Expands `ax.get_tightbbox` to include legends.

Now something like 

```python
import matplotlib.pyplot as plt
import numpy as np

fig, ax = plt.subplots(tight_layout=True)
ax.plot(range(10), label="Plot 1")
ax.plot(range(10, 0, -1), label="Plot 2")
ax.legend(loc='center right', bbox_to_anchor=(1.20, 0.5))
plt.show()
```

<img width="637" alt="figure_1_and_3__pythonw_testgettight_py__python__and_2__jklymak_valdez____dropbox_teaching_eos314_docs__zsh_" src="https://user-images.githubusercontent.com/1562854/30140583-76295294-932a-11e7-962d-23be622b1582.png">

will automatically make room for the legend (via `tight_layout`).


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

https://github.com/matplotlib/matplotlib/issues/9163
https://github.com/matplotlib/matplotlib/issues/9130

## PR Checklist

- [x] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->