### PR TITLE
Fix pcolormesh and DatetimeIndex error

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5620,7 +5620,8 @@ or tuple of floats
 
         X, Y, C = self._pcolorargs('pcolormesh', *args, allmatch=allmatch)
         Ny, Nx = X.shape
-
+        X = X.ravel()
+        Y = Y.ravel()
         # unit conversion allows e.g. datetime objects as axis values
         self._process_unit_info(xdata=X, ydata=Y, kwargs=kwargs)
         X = self.convert_xunits(X)
@@ -5628,7 +5629,7 @@ or tuple of floats
 
         # convert to one dimensional arrays
         C = C.ravel()
-        coords = np.column_stack((X.flat, Y.flat)).astype(float, copy=False)
+        coords = np.column_stack((X, Y)).astype(float, copy=False)
 
         collection = mcoll.QuadMesh(Nx - 1, Ny - 1, coords,
                                     antialiased=antialiased, shading=shading,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4929,6 +4929,17 @@ def test_broken_barh_empty():
     ax.broken_barh([], (.1, .5))
 
 
+def test_pandas_pcolormesh():
+    pd = pytest.importorskip('pandas')
+
+    time = pd.date_range('2000-01-01', periods=10)
+    depth = np.arange(20)
+    data = np.random.rand(20,10)
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(time, depth, data)
+
+
 def test_pandas_indexing_dates():
     pd = pytest.importorskip('pandas')
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4934,7 +4934,7 @@ def test_pandas_pcolormesh():
 
     time = pd.date_range('2000-01-01', periods=10)
     depth = np.arange(20)
-    data = np.random.rand(20,10)
+    data = np.random.rand(20, 10)
 
     fig, ax = plt.subplots()
     ax.pcolormesh(time, depth, data)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Fixes issue with `DatetimeIndex` and `pcolormesh`: https://github.com/matplotlib/matplotlib/issues/9167

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [X ] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->