### PR TITLE
Fix matplotlib corrupting PySide

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -170,11 +170,8 @@ def _allow_super_init(__init__):
                 QtWidgets.QWidget.__init__ = cooperative_qwidget_init
                 __init__(self, **kwargs)
             finally:
-                try:
-                    # Restore __init__ to sip.simplewrapper.__init__.
-                    del QtWidgets.QWidget.__init__
-                except AttributeError:
-                    pass
+                # Restore __init__
+                QtWidgets.QWidget.__init__ = qwidget_init
 
         return wrapper
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -121,7 +121,7 @@ def _create_qApp():
                 if display is None or not re.search(r':\d', display):
                     raise RuntimeError('Invalid DISPLAY variable')
 
-            qApp = QtWidgets.QApplication(["matplotlib"])
+            qApp = QtWidgets.QApplication([b"matplotlib"])
             qApp.lastWindowClosed.connect(qApp.quit)
         else:
             qApp = app


### PR DESCRIPTION
## PR Summary

This PR avoids matplotlib Qt backend to delete `QWidget.__init__` when using PySide.
This resulted in exceptions when instantiating other QWidgets after the instantiation of a FigureCanvasQTAgg.

I tested with PySide, PyQt4 and PyQt5 with both python 2.7 and 3.4 on Debian8.
I could not test it with PySide2.
Code to reproduce is available in #9162.

Addresses #9162.

## PR Checklist

