### PR TITLE
Warn on freetype missing glyphs.

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -162,8 +162,18 @@ FT2Image::draw_rect_filled(unsigned long x0, unsigned long y0, unsigned long x1,
 
 inline double conv(long v)
 {
-    return double(v) / 64.0;
+    return v / 64.;
 }
+
+FT_UInt ft_get_char_index_or_warn(FT_Face face, FT_ULong charcode)
+{
+    FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
+    if (!glyph_index) {
+        PyErr_WarnEx(NULL, "Required glyph missing from current font.", 1);
+    }
+    return glyph_index;
+}
+
 
 int FT2Font::get_path_count()
 {
@@ -611,7 +621,7 @@ void FT2Font::set_text(
         FT_BBox glyph_bbox;
         FT_Pos last_advance;
 
-        glyph_index = FT_Get_Char_Index(face, codepoints[n]);
+        glyph_index = ft_get_char_index_or_warn(face, codepoints[n]);
 
         // retrieve kerning distance and move pen position
         if (use_kerning && previous && glyph_index) {
@@ -664,7 +674,8 @@ void FT2Font::set_text(
 
 void FT2Font::load_char(long charcode, FT_Int32 flags)
 {
-    int error = FT_Load_Char(face, (unsigned long)charcode, flags);
+    FT_UInt glyph_index = ft_get_char_index_or_warn(face, (FT_ULong)charcode);
+    int error = FT_Load_Glyph(face, glyph_index, flags);
 
     if (error) {
         throw std::runtime_error("Could not load charcode");

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -998,8 +998,8 @@ static PyObject *PyFT2Font_get_char_index(PyFT2Font *self, PyObject *args, PyObj
 const char *PyFT2Font_get_sfnt__doc__ =
     "get_sfnt(name)\n"
     "\n"
-    "Get all values from the SFNT names table.  Result is a dictionary whose"
-    "key is the platform-ID, ISO-encoding-scheme, language-code, and"
+    "Get all values from the SFNT names table.  Result is a dictionary whose "
+    "key is the platform-ID, ISO-encoding-scheme, language-code, and "
     "description.\n";
 
 static PyObject *PyFT2Font_get_sfnt(PyFT2Font *self, PyObject *args, PyObject *kwds)


### PR DESCRIPTION
There is an additional call site to FT_Get_Char_Index in
PyFT2Font_get_char_index but that value is directly returned to Python
so it would be easier to check for the value there and handle it
accordingly (plus, in practice, the same warning will be triggered at
the other two call sites at some point anyways).  But I can replace that
by a warning too.

Fixes part 3 of https://github.com/matplotlib/matplotlib/issues/8765, by triggering the warning
> Required glyph missing from current font.

in the relevant case.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [NA] Has Pytest style unit tests
- [NA] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [NA] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [NA] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
