### PR TITLE
Replace mlab functions

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -376,7 +376,7 @@ class ContourLabeler(object):
         not empty (lc defaults to the empty list if None).  *spacing*
         is the space around the label in pixels to leave empty.
 
-        Do both of these tasks at once to avoid calling mlab.path_length
+        Do both of these tasks at once to avoid calculating path lengths
         multiple times, which is relatively costly.
 
         The method used here involves calculating the path length
@@ -400,8 +400,10 @@ class ContourLabeler(object):
 
             ind = 0
 
-        # Path length in pixel space
-        pl = mlab.path_length(slc)
+        # Calculate path lengths
+        pl = np.zeros(slc.shape[0], dtype=float)
+        dx = np.diff(slc, axis=0)
+        pl[1:] = np.cumsum(np.hypot(dx[:, 0], dx[:, 1]))
         pl = pl - pl[ind]
 
         # Use linear interpolation to get points around label

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -391,7 +391,7 @@ class ContourLabeler(object):
         hlw = lw / 2.0
 
         # Check if closed and, if so, rotate contour so label is at edge
-        closed = mlab.is_closed_polygon(slc)
+        closed = _is_closed_polygon(slc)
         if closed:
             slc = np.r_[slc[ind:-1], slc[:ind + 1]]
 
@@ -646,7 +646,7 @@ class ContourLabeler(object):
                 # zero in print_label and locate_label.  Other than these
                 # functions, this is not necessary and should probably be
                 # eventually removed.
-                if mlab.is_closed_polygon(lc):
+                if _is_closed_polygon(lc):
                     slc = np.r_[slc0, slc0[1:2, :]]
                 else:
                     slc = slc0
@@ -707,6 +707,15 @@ def _find_closest_point_on_leg(p1, p2, p0):
     return d, pc
 
 
+def _is_closed_polygon(X):
+    """
+    Tests whether first and last object in a sequence are the same.  These are
+    presumably coordinates on a polygonal curve, in which case this function
+    tests if that curve is closed.
+    """
+    return np.all(X[0] == X[-1])
+
+
 def _find_closest_point_on_path(lc, point):
     """
     lc: coordinates of vertices
@@ -721,7 +730,7 @@ def _find_closest_point_on_path(lc, point):
     xcmin = None
     legmin = (None, None)
 
-    closed = mlab.is_closed_polygon(lc)
+    closed = _is_closed_polygon(lc)
 
     # build list of legs before and after this vertex
     legs = []

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3911,6 +3911,7 @@ def cross_from_above(x, threshold):
 ##################################################
 # Vector and path length geometry calculations
 ##################################################
+@cbook.deprecated('2.2')
 def vector_lengths(X, P=2., axis=None):
     """
     Finds the length of a set of vectors in *n* dimensions.  This is
@@ -3925,6 +3926,7 @@ def vector_lengths(X, P=2., axis=None):
     return (np.sum(X**(P), axis=axis))**(1./P)
 
 
+@cbook.deprecated('2.2')
 def distances_along_curve(X):
     """
     Computes the distance between a set of successive points in *N* dimensions.
@@ -3937,6 +3939,7 @@ def distances_along_curve(X):
     return vector_lengths(X, axis=1)
 
 
+@cbook.deprecated('2.2')
 def path_length(X):
     """
     Computes the distance travelled along a polygonal curve in *N* dimensions.

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -3812,6 +3812,7 @@ def poly_between(x, ylower, yupper):
     return x, y
 
 
+@cbook.deprecated('2.2')
 def is_closed_polygon(X):
     """
     Tests whether first and last object in a sequence are the same.  These are

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1868,6 +1868,7 @@ def rk4(derivs, y0, t):
     return yout
 
 
+@cbook.deprecated('2.2')
 def bivariate_normal(X, Y, sigmax=1.0, sigmay=1.0,
                      mux=0.0, muy=0.0, sigmaxy=0.0):
     """

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 import datetime
 
 import numpy as np
-from matplotlib import mlab
 from matplotlib.testing.decorators import image_comparison
 from matplotlib import pyplot as plt
 from numpy.testing import assert_array_almost_equal
@@ -243,8 +242,10 @@ def test_labels():
     x = np.arange(-3.0, 3.0, delta)
     y = np.arange(-2.0, 2.0, delta)
     X, Y = np.meshgrid(x, y)
-    Z1 = mlab.bivariate_normal(X, Y, 1.0, 1.0, 0.0, 0.0)
-    Z2 = mlab.bivariate_normal(X, Y, 1.5, 0.5, 1, 1)
+    Z1 = np.exp(-(X**2 + Y**2) / 2) / (2 * np.pi)
+    Z2 = (np.exp(-(((X - 1) / 1.5)**2 + ((Y - 1) / 0.5)**2) / 2) /
+          (2 * np.pi * 0.5 * 1.5))
+
     # difference of Gaussians
     Z = 10.0 * (Z2 - Z1)
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -17,7 +17,6 @@ from matplotlib import rcParams, rc_context
 from matplotlib import patches
 import matplotlib.pyplot as plt
 
-from matplotlib import mlab
 import pytest
 
 from copy import copy
@@ -611,8 +610,9 @@ def test_rotate_image():
     delta = 0.25
     x = y = np.arange(-3.0, 3.0, delta)
     X, Y = np.meshgrid(x, y)
-    Z1 = mlab.bivariate_normal(X, Y, 1.0, 1.0, 0.0, 0.0)
-    Z2 = mlab.bivariate_normal(X, Y, 1.5, 0.5, 1, 1)
+    Z1 = np.exp(-(X**2 + Y**2) / 2) / (2 * np.pi)
+    Z2 = (np.exp(-(((X - 1) / 1.5)**2 + ((Y - 1) / 0.5)**2) / 2) /
+          (2 * np.pi * 0.5 * 1.5))
     Z = Z2 - Z1  # difference of Gaussians
 
     fig, ax1 = plt.subplots(1, 1)
@@ -673,8 +673,9 @@ def test_mask_image_over_under():
     delta = 0.025
     x = y = np.arange(-3.0, 3.0, delta)
     X, Y = np.meshgrid(x, y)
-    Z1 = mlab.bivariate_normal(X, Y, 1.0, 1.0, 0.0, 0.0)
-    Z2 = mlab.bivariate_normal(X, Y, 1.5, 0.5, 1, 1)
+    Z1 = np.exp(-(X**2 + Y**2) / 2) / (2 * np.pi)
+    Z2 = (np.exp(-(((X - 1) / 1.5)**2 + ((Y - 1) / 0.5)**2) / 2) /
+          (2 * np.pi * 0.5 * 1.5))
     Z = 10*(Z2 - Z1)  # difference of Gaussians
 
     palette = copy(plt.cm.gray)


### PR DESCRIPTION
Allows a few functions in `mlab.py` to be deprecated.