### PR TITLE
fixed typo

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -238,7 +238,7 @@ class Axes(_AxesBase):
             y label
 
         labelpad : scalar, optional, default: None
-            spacing in points between the label and the x-axis
+            spacing in points between the label and the y-axis
 
         Other Parameters
         ----------------


### PR DESCRIPTION
The documentation for the labelpad parameter of set_ylabel describes it as "spacing in points between the label and the x-axis" when it should be "spacing in points between the label and the **y**-axis."