### PR TITLE
Fix wx_compat code for wxPython >= 4.0.0b2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ install:
       echo 'PyQt5 is available' ||
       echo 'PyQt5 is not available'
     pip install -U --pre \
-      -f https://wxpython.org/Phoenix/release-extras/linux/gtk3/ubuntu-14.04 \
+      -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 \
       wxPython &&
       python -c 'import wx' &&
       echo 'wxPython is available' ||

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -139,35 +139,37 @@ else:
     StockCursor = wx.StockCursor
 
 
+# wxPython Classic's DoAddTool has become AddTool in Phoenix. Otherwise
+# they are the same, except for early betas and prerelease builds of
+# Phoenix. This function provides a shim that does the RightThing based on
+# which wxPython is in use.
 def _AddTool(parent, wx_ids, text, bmp, tooltip_text):
-    if is_phoenix:
-        if text in ['Pan', 'Zoom']:
-            kind = wx.ITEM_CHECK
-        else:
-            kind = wx.ITEM_NORMAL
-
-        if LooseVersion(wx.VERSION_STRING) >= LooseVersion("4.0.0b2"):
-            kwargs = dict(label=text,
-                          bitmap=bmp,
-                          bmpDisabled=wx.NullBitmap,
-                          shortHelp=text,
-                          longHelp=tooltip_text,
-                          kind=kind)
-        else:
-            kwargs = dict(label=text,
-                          bitmap=bmp,
-                          bmpDisabled=wx.NullBitmap,
-                          shortHelpString=text,
-                          longHelpString=tooltip_text,
-                          kind=kind)
-
-        parent.AddTool(wx_ids[text], **kwargs)
+    if text in ['Pan', 'Zoom']:
+        kind = wx.ITEM_CHECK
     else:
-        if text in ['Pan', 'Zoom']:
-            parent.AddCheckTool(
-                wx_ids[text],
-                bmp,
-                shortHelp=text,
-                longHelp=tooltip_text)
-        else:
-            parent.AddSimpleTool(wx_ids[text], bmp, text, tooltip_text)
+        kind = wx.ITEM_NORMAL
+    if is_phoenix:
+        add_tool = parent.AddTool
+    else:
+        add_tool = parent.DoAddTool
+
+    if not is_phoenix or LooseVersion(wx.VERSION_STRING) >= LooseVersion("4.0.0b2"):
+        # NOTE: when support for Phoenix prior to 4.0.0b2 is dropped then
+        # all that is needed is this clause, and the if and else clause can
+        # be removed.
+        kwargs = dict(label=text,
+                      bitmap=bmp,
+                      bmpDisabled=wx.NullBitmap,
+                      shortHelp=text,
+                      longHelp=tooltip_text,
+                      kind=kind)
+    else:
+        kwargs = dict(label=text,
+                      bitmap=bmp,
+                      bmpDisabled=wx.NullBitmap,
+                      shortHelpString=text,
+                      longHelpString=tooltip_text,
+                      kind=kind)
+
+    return add_tool(wx_ids[text], **kwargs)
+

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -145,12 +145,23 @@ def _AddTool(parent, wx_ids, text, bmp, tooltip_text):
             kind = wx.ITEM_CHECK
         else:
             kind = wx.ITEM_NORMAL
-        parent.AddTool(wx_ids[text], label=text,
-                       bitmap=bmp,
-                       bmpDisabled=wx.NullBitmap,
-                       shortHelpString=text,
-                       longHelpString=tooltip_text,
-                       kind=kind)
+
+        if LooseVersion(wx.VERSION_STRING) >= LooseVersion("4.0.0b2"):
+            kwargs = dict(label=text,
+                          bitmap=bmp,
+                          bmpDisabled=wx.NullBitmap,
+                          shortHelp=text,
+                          longHelp=tooltip_text,
+                          kind=kind)
+        else:
+            kwargs = dict(label=text,
+                          bitmap=bmp,
+                          bmpDisabled=wx.NullBitmap,
+                          shortHelpString=text,
+                          longHelpString=tooltip_text,
+                          kind=kind)
+
+        parent.AddTool(wx_ids[text], **kwargs)
     else:
         if text in ['Pan', 'Zoom']:
             parent.AddCheckTool(

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -153,7 +153,7 @@ def _AddTool(parent, wx_ids, text, bmp, tooltip_text):
     else:
         add_tool = parent.DoAddTool
 
-    if not is_phoenix or LooseVersion(wx.VERSION_STRING) >= LooseVersion("4.0.0b2"):
+    if not is_phoenix or LooseVersion(wx.VERSION_STRING) >= "4.0.0b2":
         # NOTE: when support for Phoenix prior to 4.0.0b2 is dropped then
         # all that is needed is this clause, and the if and else clause can
         # be removed.

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -172,4 +172,3 @@ def _AddTool(parent, wx_ids, text, bmp, tooltip_text):
                       kind=kind)
 
     return add_tool(wx_ids[text], **kwargs)
-


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Some arg names in `wx.ToolBar.AddTool` are being changed in order to be more consistent with other tool methods, and also for better compatibility with Classic. This change trips up the code in `wx_compat` since it is using keyword args when calling `AddTool`. This PR is one possible fix. Another would be to not use the keyword args and just use positional args since the order and types have not changed.

<!--If it fixes an open issue, please link to the issue here.-->

See: https://github.com/wxWidgets/Phoenix/issues/527

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
