### PR TITLE
Change axes.prop_cycle to single line in matplotlibrc.template

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -330,14 +330,9 @@ backend      : $TEMPLATE_BACKEND
 #axes.unicode_minus  : True    # use unicode for the minus symbol
                                # rather than hyphen.  See
                                # http://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
-#axes.prop_cycle    : cycler('color',
-#                            ['1f77b4', 'ff7f0e', '2ca02c', 'd62728',
-#                              '9467bd', '8c564b', 'e377c2', '7f7f7f',
-#                              'bcbd22', '17becf'])
-                                            # color cycle for plot lines
-                                            # as list of string colorspecs:
-                                            # single letter, long name, or
-                                            # web-style hex
+# axes.prop_cycle    : cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
+                      # color cycle for plot lines  as list of string
+                      # colorspecs: single letter, long name, or web-style hex
 #axes.autolimit_mode : data # How to scale axes limits to the data.
                             # Use "data" to use data limits, plus some margin
                             # Use "round_number" move to the nearest "round" number


### PR DESCRIPTION
Otherwise the example is invalid because the matplotlibrc parser
doesn't understand multi-line commands. See #9184.

This is a temporary fix, the true fix is to fix the parser (again, see #9184).

I thought about adding a test but couldn't figure out the best way to do so given the comment structure of the file: uncommenting all lines won't work, uncommenting the specific line of `axes.prop_cycle` is brittle, uncommenting only lines that start with an rcParams key will break when we do add multi-line support. Suggestions welcome, but otherwise, this can always be merged while keeping #9184 open.

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
