### PR TITLE
Don't fail on empty autoscale_None.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -961,15 +961,17 @@ class Normalize(object):
         """
         Set *vmin*, *vmax* to min, max of *A*.
         """
-        self.vmin = np.ma.min(A)
-        self.vmax = np.ma.max(A)
+        A = np.asanyarray(A)
+        self.vmin = A.min()
+        self.vmax = A.max()
 
     def autoscale_None(self, A):
-        ' autoscale only None-valued vmin or vmax'
-        if self.vmin is None and np.size(A) > 0:
-            self.vmin = np.ma.min(A)
-        if self.vmax is None and np.size(A) > 0:
-            self.vmax = np.ma.max(A)
+        """autoscale only None-valued vmin or vmax."""
+        A = np.asanyarray(A)
+        if self.vmin is None and A.size:
+            self.vmin = A.min()
+        if self.vmax is None and A.size:
+            self.vmax = A.max()
 
     def scaled(self):
         'return true if vmin and vmax set'
@@ -1037,14 +1039,14 @@ class LogNorm(Normalize):
         self.vmax = np.ma.max(A)
 
     def autoscale_None(self, A):
-        ' autoscale only None-valued vmin or vmax'
+        """autoscale only None-valued vmin or vmax."""
         if self.vmin is not None and self.vmax is not None:
             return
         A = np.ma.masked_less_equal(A, 0, copy=False)
-        if self.vmin is None:
-            self.vmin = np.ma.min(A)
-        if self.vmax is None:
-            self.vmax = np.ma.max(A)
+        if self.vmin is None and A.size:
+            self.vmin = A.min()
+        if self.vmax is None and A.size:
+            self.vmax = A.max()
 
 
 class SymLogNorm(Normalize):
@@ -1153,13 +1155,14 @@ class SymLogNorm(Normalize):
         self._transform_vmin_vmax()
 
     def autoscale_None(self, A):
-        """ autoscale only None-valued vmin or vmax """
+        """autoscale only None-valued vmin or vmax."""
         if self.vmin is not None and self.vmax is not None:
             pass
-        if self.vmin is None:
-            self.vmin = np.ma.min(A)
-        if self.vmax is None:
-            self.vmax = np.ma.max(A)
+        A = np.asanyarray(A)
+        if self.vmin is None and A.size:
+            self.vmin = A.min()
+        if self.vmax is None and A.size:
+            self.vmax = A.max()
         self._transform_vmin_vmax()
 
 
@@ -1223,20 +1226,19 @@ class PowerNorm(Normalize):
             self.vmin = 0
             warnings.warn("Power-law scaling on negative values is "
                           "ill-defined, clamping to 0.")
-
         self.vmax = np.ma.max(A)
 
     def autoscale_None(self, A):
-        ' autoscale only None-valued vmin or vmax'
-        if self.vmin is None and np.size(A) > 0:
-            self.vmin = np.ma.min(A)
+        """autoscale only None-valued vmin or vmax."""
+        A = np.asanyarray(A)
+        if self.vmin is None and A.size:
+            self.vmin = A.min()
             if self.vmin < 0:
                 self.vmin = 0
                 warnings.warn("Power-law scaling on negative values is "
                               "ill-defined, clamping to 0.")
-
-        if self.vmax is None and np.size(A) > 0:
-            self.vmax = np.ma.max(A)
+        if self.vmax is None and A.size:
+            self.vmax = A.max()
 
 
 class BoundaryNorm(Normalize):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -2,28 +2,25 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
+
+from copy import copy
 import io
 import os
 import warnings
 
 import numpy as np
+from numpy import ma
 from numpy.testing import assert_array_equal
 
-from matplotlib.testing.decorators import image_comparison
+from matplotlib import (
+    colors, image as mimage, mlab, patches, pyplot as plt,
+    rc_context, rcParams)
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
+from matplotlib.testing.decorators import image_comparison
 from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
-from matplotlib import rcParams, rc_context
-from matplotlib import patches
-import matplotlib.pyplot as plt
 
-from matplotlib import mlab
 import pytest
-
-from copy import copy
-from numpy import ma
-import matplotlib.image as mimage
-import matplotlib.colors as colors
 
 
 try:
@@ -789,9 +786,16 @@ def test_imshow_flatfield():
     im.set_clim(.5, 1.5)
 
 
-def test_empty_imshow():
+@pytest.mark.parametrize(
+    "make_norm",
+    [colors.Normalize,
+     colors.LogNorm,
+     lambda: colors.SymLogNorm(1),
+     lambda: colors.PowerNorm(1)])
+@pytest.mark.filterwarnings("ignore:Attempting to set identical left==right")
+def test_empty_imshow(make_norm):
     fig, ax = plt.subplots()
-    im = ax.imshow([[]])
+    im = ax.imshow([[]], norm=make_norm())
     im.set_extent([-5, 5, -5, 5])
     fig.canvas.draw()
 


### PR DESCRIPTION
Closes #9194.

We reuse the same strategy as in the default Normalize.autoscale_None.

First convert the input to an array because that's what np.size and
np.ma.min/max do anyways, so it's more efficient to do it just once.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
