### PR TITLE
FIX: always decode byte strings from AFM files as utf8

### DIFF
--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -189,7 +189,9 @@ def _parse_char_metrics(fh):
     ascii_d = {}
     name_d = {}
     for line in fh:
-        line = line.rstrip().decode('ascii')  # Convert from byte-literal
+        # We are defensively letting values be utf8. The spec requires
+        # ascii, but there are non-compliant fonts in circulation
+        line = _to_str(line.rstrip())  # Convert from byte-literal
         if line.startswith('EndCharMetrics'):
             return ascii_d, name_d
         # Split the metric line into a dictionary, keyed by metric identifiers
@@ -392,7 +394,7 @@ class AFM(object):
         maxy = 0
         left = 0
         if not isinstance(s, six.text_type):
-            s = s.decode('ascii')
+            s = _to_str(s)
         for c in s:
             if c == '\n':
                 continue


### PR DESCRIPTION
closes #9196

This fixes a (long standing) 'can not import' bug.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
