### PR TITLE
FIX: qt recursive draw

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1845,6 +1845,7 @@ class FigureCanvasBase(object):
         s = 'resize_event'
         event = ResizeEvent(s, self)
         self.callbacks.process(s, event)
+        self.draw_idle()
 
     def close_event(self, guiEvent=None):
         """Pass a `CloseEvent` to all functions connected to ``close_event``.

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -359,9 +359,10 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         winch = w / dpival
         hinch = h / dpival
         self.figure.set_size_inches(winch, hinch, forward=False)
-        FigureCanvasBase.resize_event(self)
-        self.draw_idle()
+        # pass back into Qt to let it finish
         QtWidgets.QWidget.resizeEvent(self, event)
+        # emit our resize events
+        FigureCanvasBase.resize_event(self)
 
     def sizeHint(self):
         w, h = self.get_width_height()

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -72,7 +72,6 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
             # since the latter doesn't guarantee that the event will be emitted
             # straight away, and this causes visual delays in the changes.
             self.resizeEvent(event)
-            QtWidgets.QApplication.instance().processEvents()
             # resizeEvent triggers a paintEvent itself, so we exit this one.
             return
 

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -56,7 +56,10 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         In Qt, all drawing should be done inside of here when a widget is
         shown onscreen.
         """
-
+        # if there is a pending draw, run it now as we need the updated render
+        # to paint the widget
+        if self._agg_draw_pending:
+            self.__draw_idle_agg()
         # As described in __init__ above, we need to be careful in cases with
         # mixed resolution displays if dpi_ratio is changing between painting
         # events.
@@ -137,6 +140,8 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
             QtCore.QTimer.singleShot(0, self.__draw_idle_agg)
 
     def __draw_idle_agg(self, *args):
+        if not self._agg_draw_pending:
+            return
         if self.height() < 0 or self.width() < 0:
             self._agg_draw_pending = False
             return

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -708,14 +708,14 @@ class Figure(Artist):
 
         Usage ::
 
-             fig.set_size_inches(w,h)  # OR
-             fig.set_size_inches((w,h))
+             fig.set_size_inches(w, h)  # OR
+             fig.set_size_inches((w, h))
 
         optional kwarg *forward=True* will cause the canvas size to be
         automatically updated; e.g., you can resize the figure window
         from the shell
 
-        ACCEPTS: a w,h tuple with w,h in inches
+        ACCEPTS: a w, h tuple with w, h in inches
 
         See Also
         --------

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -145,6 +145,10 @@ def test_dpi_ratio_change():
 
         qt_canvas.draw()
         qApp.processEvents()
+        # this second processEvents is required to fully run the draw.
+        # On `update` we notice the DPI has changed and trigger a
+        # resize event to refresh, the second processEvents is
+        # required to process that and fully update the window sizes.
         qApp.processEvents()
 
         # The DPI and the renderer width/height change

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -145,6 +145,7 @@ def test_dpi_ratio_change():
 
         qt_canvas.draw()
         qApp.processEvents()
+        qApp.processEvents()
 
         # The DPI and the renderer width/height change
         assert fig.dpi == 240


### PR DESCRIPTION
 - put draw_idle in the base canvas resize event
 - re-order our resize handling and Qt's resize handling (let Qt go
   first)
 - do not call processEvents from inside of the paint event (this
   maybe the critical fix)

closes #9134 

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
