### PR TITLE
Homepage: reference User Guide in text.

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -91,10 +91,10 @@ function getSnippet(id, url) {
 
   <h1>Documentation</h1>
 
-  This is the documentation for Matplotlib version {{ version }}.
+  <p>This is the documentation for Matplotlib version {{ version }}.</p>
 
-  To get started, read the <a href="{{ pathto('users/index') }}">
-  User's Guide</a>.
+  <p>To get started, read the <a href="{{ pathto('users/index') }}">
+  User's Guide</a>.</p>
 
   <p id="other_versions"></p>
   <script>

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -93,6 +93,9 @@ function getSnippet(id, url) {
 
   This is the documentation for Matplotlib version {{ version }}.
 
+  To get started, read the <a href="{{ pathto('users/index') }}">
+  User's Guide</a>.
+
   <p id="other_versions"></p>
   <script>
     getSnippet('other_versions', '/versions.html');


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

#4187 might have been over-the-top, but I actually find getting to the `User Guide` a bit mysterious every time I go to the docs.  This very small change just puts a sentence under `Documentation` to tell folks thats where to get started:

```html
<p>To get started, read the <a href="{{ pathto('users/index') }}">
  User's Guide</a>.</p>
```

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->


<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->