### PR TITLE
update link to IPython stable doc

### DIFF
--- a/doc/users/shell.rst
+++ b/doc/users/shell.rst
@@ -34,7 +34,7 @@ IPython to the rescue
     shadow python built-in and can lead to hard to track bugs. To get IPython
     integration without imports the use of the  `%matplotlib` magic is
     preferred. See
-    `ipython documentation <http://ipython.org/ipython-doc/stable/interactive/reference.html#plotting-with-matplotlib>`_
+    `ipython documentation <https://ipython.readthedocs.io/en/stable/interactive/reference.html#plotting-with-matplotlib>`_
     .
 
 Fortunately, `ipython <http://ipython.org/>`_, an enhanced


### PR DESCRIPTION
## PR Summary

Link was pointing to the old docs location which has not been updated in a couple of years. 
Updating the link point users toward newer version of the same page; without warnings that this is old docs. 

Hopefully it will also improve ranking of both page on Google,.


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way