### PR TITLE
Fix passing shape (2,) input to Collections.set_offsets.

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -143,10 +143,13 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self.set_offset_position(offset_position)
         self.set_zorder(zorder)
 
+        self._offsets = np.zeros((1, 2))
         self._uniform_offsets = None
-        self._offsets = np.array([[0, 0]], float)
         if offsets is not None:
             offsets = np.asanyarray(offsets, float)
+            # Broadcast (2,) -> (1, 2) but nothing else.
+            if offsets.shape == (2,):
+                offsets = offsets[None, :]
             if transOffset is not None:
                 self._offsets = offsets
                 self._transOffset = transOffset
@@ -400,7 +403,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self.stale = True
 
     def get_hatch(self):
-        'Return the current hatching pattern'
+        """Return the current hatching pattern."""
         return self._hatch
 
     def set_offsets(self, offsets):
@@ -411,7 +414,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
         ACCEPTS: float or sequence of floats
         """
         offsets = np.asanyarray(offsets, float)
-        #This decision is based on how they are initialized above
+        if offsets.shape == (2,):  # Broadcast (2,) -> (1, 2) but nothing else.
+            offsets = offsets[None, :]
+        # This decision is based on how they are initialized above in __init__.
         if self._uniform_offsets is None:
             self._offsets = offsets
         else:
@@ -419,10 +424,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self.stale = True
 
     def get_offsets(self):
-        """
-        Return the offsets for the collection.
-        """
-        #This decision is based on how they are initialized above in __init__()
+        """Return the offsets for the collection."""
+        # This decision is based on how they are initialized above in __init__.
         if self._uniform_offsets is None:
             return self._offsets
         else:


### PR DESCRIPTION
The logic with uniform_offsets seems a bit crazy but let's just
reproduce it for now...

xref https://gitter.im/matplotlib/matplotlib?at=59c9cfe7f7299e8f5371689b

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
