### PR TITLE
Sanitizer fixes

### DIFF
--- a/extern/ttconv/pprdrv_tt.cpp
+++ b/extern/ttconv/pprdrv_tt.cpp
@@ -137,7 +137,7 @@ BYTE *GetTable(struct TTFONT *font, const char *name)
 
             offset = getULONG( ptr + 8 );
             length = getULONG( ptr + 12 );
-            table = (BYTE*)calloc( sizeof(BYTE), length );
+            table = (BYTE*)calloc( sizeof(BYTE), length + 2 );
 
             try
             {
@@ -160,6 +160,9 @@ BYTE *GetTable(struct TTFONT *font, const char *name)
                 free(table);
                 throw;
             }
+            /* Always NUL-terminate; add two in case of UTF16 strings. */
+            table[length] = '\0';
+            table[length + 1] = '\0';
             return table;
         }
 

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -601,9 +601,7 @@ void FT2Font::set_text(
     FT_Bool use_kerning = FT_HAS_KERNING(face);
     FT_UInt previous = 0;
 
-    glyphs.resize(0);
-    pen.x = 0;
-    pen.y = 0;
+    clear();
 
     bbox.xMin = bbox.yMin = 32000;
     bbox.xMax = bbox.yMax = -32000;


### PR DESCRIPTION
## PR Summary

I ran the tests through ASan, LSan, and UBSan; most tests pass without issue. This PR fixes a leak and a heap buffer read overflow.

There is also a `memcpy(NULL, ` in the FreeType version we bundle, which may or may not be the cause of #9176 as noted in #9229. Unfortunately, it's a bit more difficult to fix as it has to do with the bundled code, so it's not done here..

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [-] New features are documented, with examples if plot related
- [-] Documentation is sphinx and numpydoc compliant
- [-] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [-] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
