### PR TITLE
Fix download of freetype 2.6.1.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1166,40 +1166,39 @@ class FreeType(SetupPackage):
                 if not os.path.exists('build'):
                     os.makedirs('build')
 
-                sourceforge_url = (
+                url_fmts = [
                     'https://downloads.sourceforge.net/project/freetype'
-                    '/freetype2/{0}/'.format(LOCAL_FREETYPE_VERSION)
-                )
-                url_fmts = (
-                    sourceforge_url + '{0}',
-                    'https://download.savannah.gnu.org/releases/freetype/{0}'
-                    )
+                    '/freetype2/{version}/{tarball}',
+                    'https://download.savannah.gnu.org/releases/freetype'
+                    '/{tarball}'
+                ]
                 for url_fmt in url_fmts:
-                    tarball_url = url_fmt.format(tarball)
+                    tarball_url = url_fmt.format(
+                        version=LOCAL_FREETYPE_VERSION, tarball=tarball)
 
                     print("Downloading {0}".format(tarball_url))
                     try:
                         urlretrieve(tarball_url, tarball_path)
-                    except:
+                    except IOError:  # URLError (a subclass) on Py3.
                         print("Failed to download {0}".format(tarball_url))
                     else:
-                        break
-                if not os.path.isfile(tarball_path):
+                        if get_file_hash(tarball_path) != LOCAL_FREETYPE_HASH:
+                            print("Invalid hash.")
+                        else:
+                            break
+                else:
                     raise IOError("Failed to download freetype")
-                if get_file_hash(tarball_path) == LOCAL_FREETYPE_HASH:
-                    try:
-                        os.makedirs(tarball_cache_dir)
-                    except OSError:
-                        # Don't care if it exists.
-                        pass
-                    try:
-                        shutil.copy(tarball_path, tarball_cache_path)
-                        print('Cached tarball at: {}'
-                              .format(tarball_cache_path))
-                    except OSError:
-                        # again, we do not care if this fails, can
-                        # always re download
-                        pass
+                try:
+                    os.makedirs(tarball_cache_dir)
+                except OSError:
+                    # Don't care if it exists.
+                    pass
+                try:
+                    shutil.copy(tarball_path, tarball_cache_path)
+                    print('Cached tarball at: {}'.format(tarball_cache_path))
+                except OSError:
+                    # If this fails, we can always re-download.
+                    pass
 
             if get_file_hash(tarball_path) != LOCAL_FREETYPE_HASH:
                 raise IOError(


### PR DESCRIPTION
by checking file hash before exiting the download loop.

attn @QuLogic

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
