### PR TITLE
DOC: Update instructions on pandas converters

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -21,14 +21,8 @@ Plot `numpy.datetime64` values
 
 For Matplotlib to plot dates (or any scalar with units) a converter
 to float needs to be registered with the `matplolib.units` module.  The
-current best converters for `datetime64` values are in `pandas`.  Simply
-importing `pandas` ::
-
-  import pandas as pd
-
-should be sufficient as `pandas` will try to install the converters
-on import.  If that does not work, or you need to reset `munits.registry`
-you can explicitly install the `pandas` converters by ::
+current best converters for `datetime64` values are in `pandas`. To enable the
+converter, import it from pandas::
 
   from pandas.tseries import converter as pdtc
   pdtc.register()


### PR DESCRIPTION
## PR Summary

In pandas 0.21 (release in a week or 2), pandas will no longer try to import matplotlib on import, see https://github.com/pandas-dev/pandas/pull/17710. This means pandas' converters won't be automatically registered. I've updated the relevant section of the matplotlib docs.

I opted for brevity, and didn't include a note saying that previous versions of pandas did the automatic registration. If you'd like, I can add one.

And of course, moving these formatters *out* of pandas is still on my todo list. Maybe someday :)

## PR Checklist

- [x] Documentation is sphinx and numpydoc compliant
