### PR TITLE
New color blind-friendly color cycle

### DIFF
--- a/doc/users/next_whats_new/new_color_cycle.rst
+++ b/doc/users/next_whats_new/new_color_cycle.rst
@@ -1,4 +1,5 @@
-New colorblind-friendly color cycle
-===================================
+New style colorblind-friendly color cycle
+=========================================
 
-A new color cycle has been added, tableau-colorblind10, to provide another option for colorblind-friendly plots.
+A new style defining a color cycle has been added, tableau-colorblind10, to provide another option for 
+colorblind-friendly plots.

--- a/doc/users/next_whats_new/new_color_cycle.rst
+++ b/doc/users/next_whats_new/new_color_cycle.rst
@@ -1,0 +1,4 @@
+New colorblind-friendly color cycle
+===================================
+
+A new color cycle has been added, tableau-colorblind10, to provide another option for colorblind-friendly plots.

--- a/lib/matplotlib/mpl-data/stylelib/tableau-colorblind10.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/tableau-colorblind10.mplstyle
@@ -1,0 +1,3 @@
+# Tableau colorblind 10 palette
+axes.prop_cycle: cycler('color', ['006BA4', 'FF800E', 'ABABAB', '595959', '5F9ED1', 'C85200', '898989', 'A2C8EC', 'FFBC79', 'CFCFCF'])
+patch.facecolor: 006BA4


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

There is only one color blind-friendly color cycle included in matplotlib at present (not counting the grayscale cycle). This pull request adds another defined from the color blind 10 cycle from Tableau. This uses more colors than the seaborn-colorblind cycle.

I assume the use of the name is fine given the discussion in this pull request: https://github.com/matplotlib/matplotlib/pull/7639

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

Most of this 
- [x] N/A Has Pytest style unit tests
- [x] N/A Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
