### PR TITLE
FIX: segfault on truncated png

### DIFF
--- a/lib/matplotlib/tests/test_png.py
+++ b/lib/matplotlib/tests/test_png.py
@@ -5,14 +5,12 @@ import six
 from six import BytesIO
 import glob
 import os
-import shutil
 import numpy as np
 import pytest
 
 from matplotlib.testing.decorators import image_comparison
 from matplotlib import pyplot as plt
 import matplotlib.cm as cm
-import tempfile
 import sys
 on_win = (sys.platform == 'win32')
 
@@ -49,10 +47,10 @@ def test_imread_png_uint16():
     assert np.sum(img.flatten()) == 134184960
 
 
-def test_truncated_file():
-    d = tempfile.mkdtemp()
-    fname = os.path.join(d, 'test.png')
-    fname_t = os.path.join(d, 'test_truncated.png')
+def test_truncated_file(tmpdir):
+    d = tmpdir.mkdir('test')
+    fname = str(d.join('test.png'))
+    fname_t = str(d.join('test_truncated.png'))
     plt.savefig(fname)
     with open(fname, 'rb') as fin:
         buf = fin.read()
@@ -61,8 +59,6 @@ def test_truncated_file():
 
     with pytest.raises(Exception):
         plt.imread(fname_t)
-
-    shutil.rmtree(d)
 
 
 def test_truncated_buffer():

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -194,18 +194,18 @@ static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
 
     switch (channels) {
     case 1:
-	png_color_type = PNG_COLOR_TYPE_GRAY;
-	break;
+        png_color_type = PNG_COLOR_TYPE_GRAY;
+        break;
     case 3:
-	png_color_type = PNG_COLOR_TYPE_RGB;
-	break;
+        png_color_type = PNG_COLOR_TYPE_RGB;
+        break;
     case 4:
-	png_color_type = PNG_COLOR_TYPE_RGB_ALPHA;
-	break;
+        png_color_type = PNG_COLOR_TYPE_RGB_ALPHA;
+        break;
     default:
         PyErr_SetString(PyExc_ValueError,
-			"Buffer must be an NxMxD array with D in 1, 3, 4 "
-			"(grayscale, RGB, RGBA)");
+                        "Buffer must be an NxMxD array with D in 1, 3, 4 "
+                        "(grayscale, RGB, RGBA)");
         goto exit;
     }
 
@@ -349,20 +349,20 @@ static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
     sig_bit.alpha = 0;
     switch (png_color_type) {
     case PNG_COLOR_TYPE_GRAY:
-	sig_bit.gray = 8;
-	sig_bit.red = 0;
-	sig_bit.green = 0;
-	sig_bit.blue = 0;
-	break;
+        sig_bit.gray = 8;
+        sig_bit.red = 0;
+        sig_bit.green = 0;
+        sig_bit.blue = 0;
+        break;
     case PNG_COLOR_TYPE_RGB_ALPHA:
-	sig_bit.alpha = 8;
-	// fall through
+        sig_bit.alpha = 8;
+        // fall through
     case PNG_COLOR_TYPE_RGB:
-	sig_bit.gray = 0;
-	sig_bit.red = 8;
-	sig_bit.green = 8;
-	sig_bit.blue = 8;
-	break;
+        sig_bit.gray = 0;
+        sig_bit.red = 8;
+        sig_bit.green = 8;
+        sig_bit.blue = 8;
+        break;
     default:
         PyErr_SetString(PyExc_RuntimeError, "internal error, bad png_color_type");
         goto exit;

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -416,10 +416,10 @@ static void _read_png_data(PyObject *py_file_obj, png_bytep data, png_size_t len
                     PyErr_SetString(PyExc_IOError, "read past end of file");
                 }
             } else {
-                PyErr_SetString(PyExc_IOError, "Failed to copy buffer");
+                PyErr_SetString(PyExc_IOError, "failed to copy buffer");
             }
         } else  {
-            PyErr_SetString(PyExc_IOError, "Failed to read file");
+            PyErr_SetString(PyExc_IOError, "failed to read file");
         }
 
 
@@ -519,7 +519,7 @@ static PyObject *_read_png(PyObject *filein, bool float_result)
 
     if (setjmp(png_jmpbuf(png_ptr))) {
         if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_RuntimeError, "Error setting jump");
+            PyErr_SetString(PyExc_RuntimeError, "error setting jump");
         }
         goto exit;
     }

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -408,19 +408,19 @@ static void _read_png_data(PyObject *py_file_obj, png_bytep data, png_size_t len
     Py_ssize_t bufflen;
     if (read_method) {
         result = PyObject_CallFunction(read_method, (char *)"i", length);
-	if (result) {
-	    if (PyBytes_AsStringAndSize(result, &buffer, &bufflen) == 0) {
-		if (bufflen == (Py_ssize_t)length) {
-		    memcpy(data, buffer, length);
-		} else {
-		    PyErr_SetString(PyExc_IOError, "read past end of file");
-		}
-	    } else {
-		PyErr_SetString(PyExc_IOError, "Failed to copy buffer");
-	    }
-	} else 	{
-	    PyErr_SetString(PyExc_IOError, "Failed to read file");
-	}
+        if (result) {
+            if (PyBytes_AsStringAndSize(result, &buffer, &bufflen) == 0) {
+                if (bufflen == (Py_ssize_t)length) {
+                    memcpy(data, buffer, length);
+                } else {
+                    PyErr_SetString(PyExc_IOError, "read past end of file");
+                }
+            } else {
+                PyErr_SetString(PyExc_IOError, "Failed to copy buffer");
+            }
+        } else  {
+            PyErr_SetString(PyExc_IOError, "Failed to read file");
+        }
 
 
     }
@@ -432,9 +432,8 @@ static void read_png_data(png_structp png_ptr, png_bytep data, png_size_t length
 {
     PyObject *py_file_obj = (PyObject *)png_get_io_ptr(png_ptr);
     _read_png_data(py_file_obj, data, length);
-    if (PyErr_Occurred())
-    {
-	png_error(png_ptr, "failed to read file");
+    if (PyErr_Occurred()) {
+        png_error(png_ptr, "failed to read file");
     }
 
 }
@@ -494,9 +493,9 @@ static PyObject *_read_png(PyObject *filein, bool float_result)
         }
         Py_XDECREF(read_method);
         _read_png_data(py_file, header, 8);
-	if (PyErr_Occurred()){
-	    goto exit;
-	}
+        if (PyErr_Occurred()) {
+            goto exit;
+        }
     }
 
     if (png_sig_cmp(header, 0, 8)) {
@@ -519,10 +518,9 @@ static PyObject *_read_png(PyObject *filein, bool float_result)
     }
 
     if (setjmp(png_jmpbuf(png_ptr))) {
-	if (!PyErr_Occurred())
-	{
-	    PyErr_SetString(PyExc_RuntimeError, "Error setting jump");
-	}
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(PyExc_RuntimeError, "Error setting jump");
+        }
         goto exit;
     }
 


### PR DESCRIPTION


<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary
 - be more paranoid in _read_png_data about failed reads and check for
   exceptions after both calls to it
 - in read_png_data kick the png error handling
 - only override the exception in the body of `setjmp` handler if
   there is not already one set

closes #9256
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests

OP has a test case, just need to add it.
