### PR TITLE
Fix C++ warnings

### DIFF
--- a/src/_path.h
+++ b/src/_path.h
@@ -904,8 +904,6 @@ bool path_intersects_rectangle(PathIterator &path,
 
     double cx = (rect_x1 + rect_x2) * 0.5, cy = (rect_y1 + rect_y2) * 0.5;
     double w = fabs(rect_x1 - rect_x2), h = fabs(rect_y1 - rect_y2);
-    double xmin = std::min(rect_x1, rect_x2), xmax = std::max(rect_x1, rect_x2);
-    double ymin = std::min(rect_x1, rect_x2), ymax = std::max(rect_x1, rect_x2);
 
     double x1, y1, x2, y2;
 

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -841,8 +841,8 @@ class PathSimplifier : protected EmbeddedQueue<9>
 
     bool m_moveto;
     bool m_after_moveto;
-    double m_lastx, m_lasty;
     bool m_clipped;
+    double m_lastx, m_lasty;
 
     double m_origdx;
     double m_origdy;


### PR DESCRIPTION
A backport of #9258 plus one more small change to remove the warnings from the extensions.