### PR TITLE
Include the default of "plot_pre_code" of the plot directive in the documentation

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -90,7 +90,11 @@ The plot directive has the following configuration options:
         Whether to show a link to the source in HTML.
 
     plot_pre_code
-        Code that should be executed before each plot.
+        Code that should be executed before each plot. If not specified or None
+        it will default to a string containing::
+
+            import numpy as np
+            from matplotlib import pyplot as plt
 
     plot_basedir
         Base directory, to which ``plot::`` file names are relative


### PR DESCRIPTION
## PR Summary

It's not really obvious that the `plot_pre_code` option for the plot-directive contains a default even if it's not given.

## PR Checklist

- [x] Documentation is sphinx and numpydoc compliant