### PR TITLE
Update doc strings

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -797,7 +797,9 @@ class rrulewrapper(object):
 
 class DateLocator(ticker.Locator):
     """
-    Determines the tick locations when plotting dates. This class is subclassed by other Locators and is not meant to be used on its own.
+    Determines the tick locations when plotting dates. 
+    
+    This class is subclassed by other Locators and is not meant to be used on its own.
     """
     hms0d = {'byhour': 0, 'byminute': 0, 'bysecond': 0}
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -797,9 +797,10 @@ class rrulewrapper(object):
 
 class DateLocator(ticker.Locator):
     """
-    Determines the tick locations when plotting dates. 
+    Determines the tick locations when plotting dates.
     
-    This class is subclassed by other Locators and is not meant to be used on its own.
+    This class is subclassed by other Locators and 
+    is not meant to be used on its own.
     """
     hms0d = {'byhour': 0, 'byminute': 0, 'bysecond': 0}
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -798,7 +798,7 @@ class rrulewrapper(object):
 class DateLocator(ticker.Locator):
     """
     Determines the tick locations when plotting dates.
-    
+
     This class is subclassed by other Locators and
     is not meant to be used on its own.
     """

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -799,7 +799,7 @@ class DateLocator(ticker.Locator):
     """
     Determines the tick locations when plotting dates.
     
-    This class is subclassed by other Locators and 
+    This class is subclassed by other Locators and
     is not meant to be used on its own.
     """
     hms0d = {'byhour': 0, 'byminute': 0, 'bysecond': 0}

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -71,6 +71,10 @@ The rrule locator allows completely general date ticking::
 
 Here are all the date tickers:
 
+    * :class:`MicrosecondLocator`: locate microseconds
+
+    * :class:`SecondLocator`: locate seconds
+
     * :class:`MinuteLocator`: locate minutes
 
     * :class:`HourLocator`: locate hours
@@ -793,7 +797,7 @@ class rrulewrapper(object):
 
 class DateLocator(ticker.Locator):
     """
-    Determines the tick locations when plotting dates.
+    Determines the tick locations when plotting dates. This class is subclassed by other Locators and is not meant to be used on its own.
     """
     hms0d = {'byhour': 0, 'byminute': 0, 'bysecond': 0}
 


### PR DESCRIPTION
Updating doc strings:
* Added SecondLocator and MicrosecondLocator to the list of possible Locators. 
* Added a sentence for DateLocator saying that it is not meant to be used on its own.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

