### PR TITLE
[WIP] Add check in text for finite values of x and y

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -208,7 +208,8 @@ class Text(Artist):
         """
 
         Artist.__init__(self)
-        self._x, self._y = x, y
+        self.set_x(x)
+        self.set_y(y)
 
         if color is None:
             color = rcParams['text.color']
@@ -1165,7 +1166,10 @@ class Text(Artist):
 
         ACCEPTS: float
         """
-        self._x = x
+        if x is None or np.isfinite(x):
+            self._x = x
+        else:
+            raise ValueError('argument x must be finite')
         self.stale = True
 
     def set_y(self, y):
@@ -1174,7 +1178,10 @@ class Text(Artist):
 
         ACCEPTS: float
         """
-        self._y = y
+        if y is None or np.isfinite(y):
+            self._y = y
+        else:
+            raise ValueError('argument y must be finite')
         self.stale = True
 
     def set_rotation(self, s):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

If we pass non-finite `x` or `y` to `ax.text` the code fails during draw rather than on instantiation or `set_x` and `set_y`.  This just adds a `np.isfinite` check to `x` and `y` and calls the internal method at instantiation.

See #9267

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->