### PR TITLE
FIX: handle fully masked data

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -368,14 +368,14 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     scaled_dtype = A.dtype
                 else:
                     scaled_dtype = np.float32
-                    
+
                 a_min = A.min()
                 if a_min is np.ma.masked:
                     a_min, a_max = 0, 1  # all masked, so values don't matter
                 else:
                     a_min = a_min.astype(scaled_dtype)
                     a_max = A.max().astype(scaled_dtype)
-                
+
                 # scale the input data to [.1, .9].  The Agg
                 # interpolators clip to [0, 1] internally, use a
                 # smaller input scale to identify which of the

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -370,8 +370,19 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     scaled_dtype = np.float32
                 # old versions of numpy do not work with `np.nammin`
                 # and `np.nanmax` as inputs
-                a_min = np.ma.min(A).astype(scaled_dtype)
-                a_max = np.ma.max(A).astype(scaled_dtype)
+                a_min = np.ma.min(A)
+                a_max = np.ma.max(A)
+
+                # we need these try/except blocks to handle
+                # fully-masked/invalid input
+                try:
+                    a_min = a_min.astype(scaled_dtype)
+                except AttributeError:
+                    a_min = 0
+                try:
+                    a_max = a_max.astype(scaled_dtype)
+                except AttributeError:
+                    a_min = 1
                 # scale the input data to [.1, .9].  The Agg
                 # interpolators clip to [0, 1] internally, use a
                 # smaller input scale to identify which of the

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -368,21 +368,14 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     scaled_dtype = A.dtype
                 else:
                     scaled_dtype = np.float32
-                # old versions of numpy do not work with `np.nammin`
-                # and `np.nanmax` as inputs
-                a_min = np.ma.min(A)
-                a_max = np.ma.max(A)
-
-                # we need these try/except blocks to handle
-                # fully-masked/invalid input
-                try:
+                    
+                a_min = A.min()
+                if a_min is np.ma.masked:
+                    a_min, a_max = 0, 1  # all masked, so values don't matter
+                else:
                     a_min = a_min.astype(scaled_dtype)
-                except AttributeError:
-                    a_min = 0
-                try:
-                    a_max = a_max.astype(scaled_dtype)
-                except AttributeError:
-                    a_min = 1
+                    a_max = A.max().astype(scaled_dtype)
+                
                 # scale the input data to [.1, .9].  The Agg
                 # interpolators clip to [0, 1] internally, use a
                 # smaller input scale to identify which of the

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -835,3 +835,13 @@ def test_imshow_deprecated_interd_warn():
         with warnings.catch_warnings(record=True) as warns:
             getattr(im, k)
         assert len(warns) == 1
+
+
+def test_full_invalid():
+    x = np.ones((10, 10))
+    x[:] = np.nan
+
+    f, ax = plt.subplots()
+    ax.imshow(x)
+
+    f.canvas.draw()


### PR DESCRIPTION
As min/max do not make sense for an array with no non-masked values
numpy returns a singleton, `np.ma.masked`, which can not be cast to
a number.  In this case just treat numbers as in range (0, 1) (even
though it will just be ignored due to the masking).

closes #9280

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
