### PR TITLE
Ask Appveyor to ignore certain branches.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,9 @@
 # https://github.com/rmcgibbo/python-appveyor-conda-example
 
 # Backslashes in quotes need to be escaped: \ -> "\\"
+branches:
+  except:
+    - /auto-backport-.*/
 
 environment:
 


### PR DESCRIPTION
This should prevent the automatic backports to be tested both when the
branch is pushed by the backport bot, and when the PR is opened.

Hopefully the PR will be still be tested (that's unclear from the
AppVeyor docs).

This was discussed in
https://github.com/matplotlib/matplotlib/pull/9283#issuecomment-334530421

And likely need to be also applied to other CI, but Appveyor is the most
annoying.

From this page: 
https://www.appveyor.com/docs/branches/

I'm guessing this will have to be backported to all relevant branches.

cc @QuLogic @anntzer and @tacaswell 
