### PR TITLE
Throw std::runtime_exception instead of char*.

### DIFF
--- a/lib/matplotlib/tri/_tri.cpp
+++ b/lib/matplotlib/tri/_tri.cpp
@@ -1400,7 +1400,7 @@ TrapezoidMapTriFinder::initialize()
     unsigned int nedges = _edges.size();
     for (unsigned int index = 2; index < nedges; ++index) {
         if (!add_edge_to_tree(_edges[index]))
-            throw "Triangulation is invalid";
+            throw std::runtime_error("Triangulation is invalid");
         _tree->assert_valid(index == nedges-1);
     }
 }

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -101,7 +101,7 @@ BufferRegion *RendererAgg::copy_from_bbox(agg::rect_d in_rect)
 void RendererAgg::restore_region(BufferRegion &region)
 {
     if (region.get_data() == NULL) {
-        throw "Cannot restore_region from NULL data";
+        throw std::runtime_error("Cannot restore_region from NULL data");
     }
 
     agg::rendering_buffer rbuf;
@@ -115,7 +115,7 @@ void
 RendererAgg::restore_region(BufferRegion &region, int xx1, int yy1, int xx2, int yy2, int x, int y )
 {
     if (region.get_data() == NULL) {
-        throw "Cannot restore_region from NULL data";
+        throw std::runtime_error("Cannot restore_region from NULL data");
     }
 
     agg::rect_i &rrect = region.get_rect();

--- a/src/_contour.cpp
+++ b/src/_contour.cpp
@@ -398,7 +398,7 @@ void QuadContourGenerator::append_contour_line_to_vertices(
     }
     if (PyList_Append(vertices_list, line.pyobj_steal())) {
         Py_XDECREF(vertices_list);
-        throw "Unable to add contour line to vertices_list";
+        throw std::runtime_error("Unable to add contour line to vertices_list");
     }
 
     contour_line.clear();
@@ -475,7 +475,7 @@ void QuadContourGenerator::append_contour_to_vertices_and_codes(
                 Py_XDECREF(vertices_list);
                 Py_XDECREF(codes_list);
                 contour.delete_contour_lines();
-                throw "Unable to add contour line to vertices and codes lists";
+                throw std::runtime_error("Unable to add contour line to vertices and codes lists");
             }
 
             delete *line_it;
@@ -510,7 +510,7 @@ PyObject* QuadContourGenerator::create_contour(const double& level)
 
     PyObject* vertices_list = PyList_New(0);
     if (vertices_list == 0)
-        throw "Failed to create Python list";
+        throw std::runtime_error("Failed to create Python list");
 
     // Lines that start and end on boundaries.
     long ichunk, jchunk, istart, iend, jstart, jend;
@@ -602,12 +602,12 @@ PyObject* QuadContourGenerator::create_filled_contour(const double& lower_level,
 
     PyObject* vertices = PyList_New(0);
     if (vertices == 0)
-        throw "Failed to create Python list";
+        throw std::runtime_error("Failed to create Python list");
 
     PyObject* codes = PyList_New(0);
     if (codes == 0) {
         Py_XDECREF(vertices);
-        throw "Failed to create Python list";
+        throw std::runtime_error("Failed to create Python list");
     }
 
     long ichunk, jchunk, istart, iend, jstart, jend;
@@ -644,7 +644,7 @@ PyObject* QuadContourGenerator::create_filled_contour(const double& lower_level,
     if (tuple == 0) {
         Py_XDECREF(vertices);
         Py_XDECREF(codes);
-        throw "Failed to create Python tuple";
+        throw std::runtime_error("Failed to create Python tuple");
     }
 
     // No error checking here as filling in a brand new pre-allocated tuple.

--- a/src/_image.h
+++ b/src/_image.h
@@ -35,7 +35,7 @@ void pcolor(CoordinateArray &x,
             OutputArray &out)
 {
     if (rows >= 32768 || cols >= 32768) {
-        throw "rows and cols must both be less than 32768";
+        throw std::runtime_error("rows and cols must both be less than 32768");
     }
 
     float x_min = bounds[0];
@@ -49,18 +49,18 @@ void pcolor(CoordinateArray &x,
 
     // Check we have something to output to
     if (rows == 0 || cols == 0) {
-        throw "Cannot scale to zero size";
+        throw std::runtime_error("Cannot scale to zero size");
     }
 
     if (d.dim(2) != 4) {
-        throw "data must be in RGBA format";
+        throw std::runtime_error("data must be in RGBA format");
     }
 
     // Check dimensions match
     unsigned long nx = x.dim(0);
     unsigned long ny = y.dim(0);
     if (nx != (unsigned long)d.dim(1) || ny != (unsigned long)d.dim(0)) {
-        throw "data and axis dimensions do not match";
+        throw std::runtime_error("data and axis dimensions do not match");
     }
 
     // Allocate memory for pointer arrays
@@ -150,22 +150,22 @@ void pcolor2(CoordinateArray &x,
 
     // Check we have something to output to
     if (rows == 0 || cols == 0) {
-        throw "rows or cols is zero; there are no pixels";
+        throw std::runtime_error("rows or cols is zero; there are no pixels");
     }
 
     if (d.dim(2) != 4) {
-        throw "data must be in RGBA format";
+        throw std::runtime_error("data must be in RGBA format");
     }
 
     // Check dimensions match
     unsigned long nx = x.dim(0);
     unsigned long ny = y.dim(0);
     if (nx != (unsigned long)d.dim(1) + 1 || ny != (unsigned long)d.dim(0) + 1) {
-        throw "data and axis bin boundary dimensions are incompatible";
+        throw std::runtime_error("data and axis bin boundary dimensions are incompatible");
     }
 
     if (bg.dim(0) != 4) {
-        throw "bg must be in RGBA format";
+        throw std::runtime_error("bg must be in RGBA format");
     }
 
     std::vector<int> irows(rows);

--- a/src/_path.h
+++ b/src/_path.h
@@ -393,7 +393,7 @@ void get_path_collection_extents(agg::trans_affine &master_transform,
                                  extent_limits &extent)
 {
     if (offsets.size() != 0 && offsets.dim(1) != 2) {
-        throw "Offsets array must be Nx2";
+        throw std::runtime_error("Offsets array must be Nx2");
     }
 
     size_t Npaths = paths.size();
@@ -728,7 +728,7 @@ template <class VerticesArray, class ResultArray>
 void affine_transform_2d(VerticesArray &vertices, agg::trans_affine &trans, ResultArray &result)
 {
     if (vertices.size() != 0 && vertices.dim(1) != 2) {
-        throw "Invalid vertices array.";
+        throw std::runtime_error("Invalid vertices array.");
     }
 
     size_t n = vertices.size();
@@ -758,7 +758,7 @@ template <class VerticesArray, class ResultArray>
 void affine_transform_1d(VerticesArray &vertices, agg::trans_affine &trans, ResultArray &result)
 {
     if (vertices.dim(0) != 2) {
-        throw "Invalid vertices array.";
+        throw std::runtime_error("Invalid vertices array.");
     }
 
     double x;

--- a/src/array.h
+++ b/src/array.h
@@ -52,12 +52,12 @@ class empty
 
     T &operator()(int i, int j = 0, int k = 0)
     {
-        throw "Accessed empty array";
+        throw std::runtime_error("Accessed empty array");
     }
 
     const T &operator()(int i, int j = 0, int k = 0) const
     {
-        throw "Accessed empty array";
+        throw std::runtime_error("Accessed empty array");
     }
 
     sub_t operator[](int i) const

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -2,8 +2,9 @@
 
 #define NO_IMPORT_ARRAY
 
-#include <string>
 #include <algorithm>
+#include <stdexcept>
+#include <string>
 
 #include "ft2font.h"
 #include "mplutils.h"
@@ -115,7 +116,7 @@ void FT2Image::draw_bitmap(FT_Bitmap *bitmap, FT_Int x, FT_Int y)
             }
         }
     } else {
-        throw "Unknown pixel mode";
+        throw std::runtime_error("Unknown pixel mode");
     }
 
     m_dirty = true;
@@ -124,7 +125,7 @@ void FT2Image::draw_bitmap(FT_Bitmap *bitmap, FT_Int x, FT_Int y)
 void FT2Image::draw_rect(unsigned long x0, unsigned long y0, unsigned long x1, unsigned long y1)
 {
     if (x0 > m_width || x1 > m_width || y0 > m_height || y1 > m_height) {
-        throw "Rect coords outside image bounds";
+        throw std::runtime_error("Rect coords outside image bounds");
     }
 
     size_t top = y0 * m_width;
@@ -170,7 +171,7 @@ int FT2Font::get_path_count()
     // this code is from agg's decompose_ft_outline with minor modifications
 
     if (!face->glyph) {
-        throw "No glyph loaded";
+        throw std::runtime_error("No glyph loaded");
     }
 
     FT_Outline &outline = face->glyph->outline;
@@ -208,7 +209,7 @@ int FT2Font::get_path_count()
 
         // A contour cannot start with a cubic control point!
         if (tag == FT_CURVE_TAG_CUBIC) {
-            throw "A contour cannot start with a cubic control point";
+            throw std::runtime_error("A contour cannot start with a cubic control point");
         } else if (tag == FT_CURVE_TAG_CONIC) {
             starts_with_last = true;
         } else {
@@ -246,7 +247,7 @@ int FT2Font::get_path_count()
                     }
 
                     if (tag != FT_CURVE_TAG_CONIC) {
-                        throw "Invalid font";
+                        throw std::runtime_error("Invalid font");
                     }
 
                     count += 2;
@@ -262,7 +263,7 @@ int FT2Font::get_path_count()
             default: // FT_CURVE_TAG_CUBIC
             {
                 if (point + 1 > limit || FT_CURVE_TAG(tags[1]) != FT_CURVE_TAG_CUBIC) {
-                    throw "Invalid font";
+                    throw std::runtime_error("Invalid font");
                 }
 
                 point += 2;
@@ -492,13 +493,13 @@ FT2Font::FT2Font(FT_Open_Args &open_args, long hinting_factor_) : image(), face(
     int error = FT_Open_Face(_ft2Library, &open_args, 0, &face);
 
     if (error == FT_Err_Unknown_File_Format) {
-        throw "Can not load face.  Unknown file format.";
+        throw std::runtime_error("Can not load face.  Unknown file format.");
     } else if (error == FT_Err_Cannot_Open_Resource) {
-        throw "Can not load face.  Can not open resource.";
+        throw std::runtime_error("Can not load face.  Can not open resource.");
     } else if (error == FT_Err_Invalid_File_Format) {
-        throw "Can not load face.  Invalid file format.";
+        throw std::runtime_error("Can not load face.  Invalid file format.");
     } else if (error) {
-        throw "Can not load face.";
+        throw std::runtime_error("Can not load face.");
     }
 
     // set a default fontsize 12 pt at 72dpi
@@ -507,7 +508,7 @@ FT2Font::FT2Font(FT_Open_Args &open_args, long hinting_factor_) : image(), face(
     error = FT_Set_Char_Size(face, 12 * 64, 0, 72 * (unsigned int)hinting_factor, 72);
     if (error) {
         FT_Done_Face(face);
-        throw "Could not set the fontsize";
+        throw std::runtime_error("Could not set the fontsize");
     }
 
     if (open_args.stream != NULL) {
@@ -551,25 +552,25 @@ void FT2Font::set_size(double ptsize, double dpi)
     FT_Set_Transform(face, &transform, 0);
 
     if (error) {
-        throw "Could not set the fontsize";
+        throw std::runtime_error("Could not set the fontsize");
     }
 }
 
 void FT2Font::set_charmap(int i)
 {
     if (i >= face->num_charmaps) {
-        throw "i exceeds the available number of char maps";
+        throw std::runtime_error("i exceeds the available number of char maps");
     }
     FT_CharMap charmap = face->charmaps[i];
     if (FT_Set_Charmap(face, charmap)) {
-        throw "Could not set the charmap";
+        throw std::runtime_error("Could not set the charmap");
     }
 }
 
 void FT2Font::select_charmap(unsigned long i)
 {
     if (FT_Select_Charmap(face, (FT_Encoding)i)) {
-        throw "Could not set the charmap";
+        throw std::runtime_error("Could not set the charmap");
     }
 }
 
@@ -624,7 +625,7 @@ void FT2Font::set_text(
         }
         error = FT_Load_Glyph(face, glyph_index, flags);
         if (error) {
-            throw "could not load glyph";
+            throw std::runtime_error("could not load glyph");
         }
         // ignore errors, jump to next glyph
 
@@ -634,7 +635,7 @@ void FT2Font::set_text(
         error = FT_Get_Glyph(face->glyph, &thisGlyph);
 
         if (error) {
-            throw "could not get glyph";
+            throw std::runtime_error("could not get glyph");
         }
         // ignore errors, jump to next glyph
 
@@ -670,14 +671,14 @@ void FT2Font::load_char(long charcode, FT_Int32 flags)
     int error = FT_Load_Char(face, (unsigned long)charcode, flags);
 
     if (error) {
-        throw "Could not load charcode";
+        throw std::runtime_error("Could not load charcode");
     }
 
     FT_Glyph thisGlyph;
     error = FT_Get_Glyph(face->glyph, &thisGlyph);
 
     if (error) {
-        throw "Could not get glyph";
+        throw std::runtime_error("Could not get glyph");
     }
 
     glyphs.push_back(thisGlyph);
@@ -688,14 +689,14 @@ void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
     int error = FT_Load_Glyph(face, glyph_index, flags);
 
     if (error) {
-        throw "Could not load glyph";
+        throw std::runtime_error("Could not load glyph");
     }
 
     FT_Glyph thisGlyph;
     error = FT_Get_Glyph(face->glyph, &thisGlyph);
 
     if (error) {
-        throw "Could not load glyph";
+        throw std::runtime_error("Could not load glyph");
     }
 
     glyphs.push_back(thisGlyph);
@@ -729,7 +730,7 @@ void FT2Font::draw_glyphs_to_bitmap(bool antialiased)
         error = FT_Glyph_To_Bitmap(
             &glyphs[n], antialiased ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO, 0, 1);
         if (error) {
-            throw "Could not convert glyph to bitmap";
+            throw std::runtime_error("Could not convert glyph to bitmap");
         }
 
         FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyphs[n];
@@ -750,7 +751,7 @@ void FT2Font::get_xys(bool antialiased, std::vector<double> &xys)
         error = FT_Glyph_To_Bitmap(
             &glyphs[n], antialiased ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO, 0, 1);
         if (error) {
-            throw "Could not convert glyph to bitmap";
+            throw std::runtime_error("Could not convert glyph to bitmap");
         }
 
         FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyphs[n];
@@ -773,7 +774,7 @@ void FT2Font::draw_glyph_to_bitmap(FT2Image &im, int x, int y, size_t glyphInd, 
     sub_offset.y = 0; // int((yd - (double)y) * 64.0);
 
     if (glyphInd >= glyphs.size()) {
-        throw "glyph num is out of range";
+        throw std::runtime_error("glyph num is out of range");
     }
 
     error = FT_Glyph_To_Bitmap(&glyphs[glyphInd],
@@ -782,7 +783,7 @@ void FT2Font::draw_glyph_to_bitmap(FT2Image &im, int x, int y, size_t glyphInd, 
                                1 // destroy image
                                );
     if (error) {
-        throw "Could not convert glyph to bitmap";
+        throw std::runtime_error("Could not convert glyph to bitmap");
     }
 
     FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyphs[glyphInd];
@@ -798,7 +799,7 @@ void FT2Font::get_glyph_name(unsigned int glyph_number, char *buffer)
         PyOS_snprintf(buffer, 128, "uni%08x", glyph_number);
     } else {
         if (FT_Get_Glyph_Name(face, glyph_number, buffer, 128)) {
-            throw "Could not get glyph names.";
+            throw std::runtime_error("Could not get glyph names.");
         }
     }
 }

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -362,7 +362,7 @@ static void close_file_callback(FT_Stream stream)
     PyFT2Font *def = (PyFT2Font *)stream->descriptor.pointer;
 
     if (mpl_PyFile_DupClose(def->py_file, def->fp, def->offset)) {
-        throw "Couldn't close file";
+        throw std::runtime_error("Couldn't close file");
     }
 
     if (def->close_file) {

--- a/src/py_exceptions.h
+++ b/src/py_exceptions.h
@@ -18,49 +18,41 @@ class exception : public std::exception
 };
 }
 
-#define CALL_CPP_FULL(name, a, cleanup, errorcode)                                                 \
-    try                                                                                            \
-    {                                                                                              \
-        a;                                                                                         \
-    }                                                                                              \
-    catch (const py::exception &e)                                                                 \
-    {                                                                                              \
-        {                                                                                          \
-            cleanup;                                                                               \
-        }                                                                                          \
-        return (errorcode);                                                                        \
-    }                                                                                              \
-    catch (const std::bad_alloc)                                                                   \
-    {                                                                                              \
-        PyErr_Format(PyExc_MemoryError, "In %s: Out of memory", (name));                         \
-        {                                                                                          \
-            cleanup;                                                                               \
-        }                                                                                          \
-        return (errorcode);                                                                        \
-    }                                                                                              \
-    catch (const std::overflow_error &e)                                                           \
-    {                                                                                              \
-        PyErr_Format(PyExc_OverflowError, "In %s: %s", (name), e.what());                        \
-        {                                                                                          \
-            cleanup;                                                                               \
-        }                                                                                          \
-        return (errorcode);                                                                        \
-    }                                                                                              \
-    catch (char const *e)                                                                          \
-    {                                                                                              \
-        PyErr_Format(PyExc_RuntimeError, "In %s: %s", (name), e);                                \
-        {                                                                                          \
-            cleanup;                                                                               \
-        }                                                                                          \
-        return (errorcode);                                                                        \
-    }                                                                                              \
-    catch (...)                                                                                    \
-    {                                                                                              \
-        PyErr_Format(PyExc_RuntimeError, "Unknown exception in %s", (name));                       \
-        {                                                                                          \
-            cleanup;                                                                               \
-        }                                                                                          \
-        return (errorcode);                                                                        \
+#define CALL_CPP_FULL(name, a, cleanup, errorcode)                           \
+    try                                                                      \
+    {                                                                        \
+        a;                                                                   \
+    }                                                                        \
+    catch (const py::exception &e)                                           \
+    {                                                                        \
+        {                                                                    \
+            cleanup;                                                         \
+        }                                                                    \
+        return (errorcode);                                                  \
+    }                                                                        \
+    catch (const std::bad_alloc)                                             \
+    {                                                                        \
+        PyErr_Format(PyExc_MemoryError, "In %s: Out of memory", (name));     \
+        {                                                                    \
+            cleanup;                                                         \
+        }                                                                    \
+        return (errorcode);                                                  \
+    }                                                                        \
+    catch (const std::overflow_error &e)                                     \
+    {                                                                        \
+        PyErr_Format(PyExc_OverflowError, "In %s: %s", (name), e.what());    \
+        {                                                                    \
+            cleanup;                                                         \
+        }                                                                    \
+        return (errorcode);                                                  \
+    }                                                                        \
+    catch (...)                                                              \
+    {                                                                        \
+        PyErr_Format(PyExc_RuntimeError, "Unknown exception in %s", (name)); \
+        {                                                                    \
+            cleanup;                                                         \
+        }                                                                    \
+        return (errorcode);                                                  \
     }
 
 #define CALL_CPP_CLEANUP(name, a, cleanup) CALL_CPP_FULL(name, a, cleanup, NULL)


### PR DESCRIPTION
This should make it easier to debug exceptions falling out of the C++
code, as the C++ runtime will print the error message (the `what()` of
the exception) on its way to aborting the program.

Did a regex replace; removed the `char*` handler in CALL_CPP_FULL; and
remove a bunch of extra whitespace.

For example, before application of the patch in #9074, the failing code now gives
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Couldn't close file
Fatal Python error: Aborted
```

Should also help with #9244.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
