### PR TITLE
Fix TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1031,6 +1031,8 @@ def find_tex_file(filename, format=None):
     """
 
     if six.PY3:
+        # we expect these to always be ascii encoded, but use utf-8
+        # out of caution
         if isinstance(filename, bytes):
             filename = filename.decode('utf-8', errors='replace')
         if isinstance(format, bytes):

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1030,6 +1030,12 @@ def find_tex_file(filename, format=None):
         The library that :program:`kpsewhich` is part of.
     """
 
+    if six.PY3:
+        if isinstance(filename, bytes):
+            filename = filename.decode('utf-8', errors='replace')
+        if isinstance(format, bytes):
+            format = format.decode('utf-8', errors='replace')
+
     cmd = [str('kpsewhich')]
     if format is not None:
         cmd += ['--format=' + format]


### PR DESCRIPTION
Fix [multipage_pdf.py](https://github.com/matplotlib/matplotlib/blob/master/examples/misc/multipage_pdf.py) failing on Python 3 (tested on Windows with matplotlib-2.1):
```
Traceback (most recent call last):
  File "multipage_pdf.py", line 33, in <module>
    pdf.savefig()
  File "X:\Python36\lib\site-packages\matplotlib\backends\backend_pdf.py", line 2537, in savefig
    **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\figure.py", line 1814, in savefig
    self.canvas.print_figure(fname, **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\backend_bases.py", line 2259, in print_figure
    **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\backends\backend_pdf.py", line 2592, in print_pdf
    self.figure.draw(renderer)
  File "X:\Python36\lib\site-packages\matplotlib\artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\figure.py", line 1295, in draw
    renderer, self, artists, self.suppressComposite)
  File "X:\Python36\lib\site-packages\matplotlib\image.py", line 138, in _draw_list_compositing_images
    a.draw(renderer)
  File "X:\Python36\lib\site-packages\matplotlib\artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\axes\_base.py", line 2399, in draw
    mimage._draw_list_compositing_images(renderer, self, artists)
  File "X:\Python36\lib\site-packages\matplotlib\image.py", line 138, in _draw_list_compositing_images
    a.draw(renderer)
  File "X:\Python36\lib\site-packages\matplotlib\artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\axis.py", line 1138, in draw
    tick.draw(renderer)
  File "X:\Python36\lib\site-packages\matplotlib\artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\axis.py", line 282, in draw
    self.label1.draw(renderer)
  File "X:\Python36\lib\site-packages\matplotlib\artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "X:\Python36\lib\site-packages\matplotlib\text.py", line 799, in draw
    mtext=mtext)
  File "X:\Python36\lib\site-packages\matplotlib\backends\backend_pdf.py", line 1944, in draw_tex
    pdfname = self.file.dviFontName(dvifont)
  File "X:\Python36\lib\site-packages\matplotlib\backends\backend_pdf.py", line 688, in dviFontName
    psfont = self.texFontMap[dvifont.texname]
  File "X:\Python36\lib\site-packages\matplotlib\dviread.py", line 866, in __getitem__
    fn = find_tex_file(fn)
  File "X:\Python36\lib\site-packages\matplotlib\dviread.py", line 1045, in find_tex_file
    stderr=subprocess.PIPE)
  File "X:\Python36\lib\subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "X:\Python36\lib\subprocess.py", line 971, in _execute_child
    args = list2cmdline(args)
  File "X:\Python36\lib\subprocess.py", line 461, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: a bytes-like object is required, not 'str'
```