### PR TITLE
In text, warn and return instead of raise exception for non-finite x, y

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -441,3 +441,10 @@ def test_two_2line_texts(spacing1, spacing2):
         assert box1.height == box2.height
     else:
         assert box1.height != box2.height
+
+
+def test_nonfinite_pos():
+    fig, ax = plt.subplots()
+    ax.text(0, np.nan, 'nan')
+    ax.text(np.inf, 0, 'inf')
+    fig.canvas.draw()

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -20,7 +20,7 @@ from matplotlib import rcParams
 import matplotlib.artist as artist
 from matplotlib.artist import Artist
 from matplotlib.cbook import maxdict
-from matplotlib import docstring
+from matplotlib import docstring, verbose
 from matplotlib.font_manager import FontProperties
 from matplotlib.patches import FancyBboxPatch
 from matplotlib.patches import FancyArrowPatch, Rectangle
@@ -759,9 +759,12 @@ class Text(Artist):
             # position in Text, and dash position in TextWithDash:
             posx = float(textobj.convert_xunits(textobj._x))
             posy = float(textobj.convert_yunits(textobj._y))
-            if not np.isfinite(posx) or not np.isfinite(posy):
-                raise ValueError("posx and posy should be finite values")
             posx, posy = trans.transform_point((posx, posy))
+            if not np.isfinite(posx) or not np.isfinite(posy):
+                verbose.report("x and y are not finite values for text "
+                              "string '{}'.  Not rendering "
+                              "text.".format(self.get_text()), 'helpful')
+                return
             canvasw, canvash = renderer.get_canvas_width_height()
 
             # draw the FancyBboxPatch


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Redo of #9281.  Making `text.draw` warn and return instead of raising an exception if `x` or `y` are non-finite.  

Open to removing the warning, but I think it is less mysterious than simply not rendering the text.

Addresses the easy part of #9267

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->