### PR TITLE
Simplify mpl.testing._copy_metadata.

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import functools
 import inspect
 import warnings
 from contextlib import contextmanager
@@ -20,34 +21,10 @@ def is_called_from_pytest():
     return getattr(matplotlib, '_called_from_pytest', False)
 
 
-# stolen from pytest
-def _getrawcode(obj, trycall=True):
-    """Return code object for given function."""
-    try:
-        return obj.__code__
-    except AttributeError:
-        obj = getattr(obj, 'im_func', obj)
-        obj = getattr(obj, 'func_code', obj)
-        obj = getattr(obj, 'f_code', obj)
-        obj = getattr(obj, '__code__', obj)
-        if trycall and not hasattr(obj, 'co_firstlineno'):
-            if hasattr(obj, '__call__') and not inspect.isclass(obj):
-                x = getrawcode(obj.__call__, trycall=False)
-                if hasattr(x, 'co_firstlineno'):
-                    return x
-        return obj
-
-
 def _copy_metadata(src_func, tgt_func):
     """Replicates metadata of the function. Returns target function."""
-    tgt_func.__dict__.update(src_func.__dict__)
-    tgt_func.__doc__ = src_func.__doc__
-    tgt_func.__module__ = src_func.__module__
-    tgt_func.__name__ = src_func.__name__
-    if hasattr(src_func, '__qualname__'):
-        tgt_func.__qualname__ = src_func.__qualname__
-    if not hasattr(tgt_func, 'compat_co_firstlineno'):
-        tgt_func.compat_co_firstlineno = _getrawcode(src_func).co_firstlineno
+    functools.update_wrapper(tgt_func, src_func)
+    tgt_func.__wrapped__ = src_func  # Python2 compatibility.
     return tgt_func
 
 


### PR DESCRIPTION
`mpl.testing._copy_metadata` was basically doing the job
of `functools.update_wrapper`.  We don't need to specify
`compat_co_firstlineono` either as pytest will look up the
lineno in the wrapped function (`_pytest.compat.get_real_func`,
`_pytest.compat.getfslineno`).  It's also for this reason that we need
to make sure `__wrapped__` is properly set, even on Py2.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
