### PR TITLE
Fedora build patches

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -822,7 +822,10 @@ class AxesImage(_ImageBase):
         array_extent = Bbox([[0, 0], arr.shape[:2]])
         trans = BboxTransform(boxin=data_extent, boxout=array_extent)
         y, x = event.ydata, event.xdata
-        i, j = trans.transform_point([y, x]).astype(int)
+        point = trans.transform_point([y, x])
+        if any(np.isnan(point)):
+            return None
+        i, j = point.astype(int)
         # Clip the coordinates at array bounds
         if not (0 <= i < arr.shape[0]) or not (0 <= j < arr.shape[1]):
             return None

--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -22,8 +22,7 @@ def setup_module():
     ret = call([sys.executable, '-msphinx', '--help'],
                stdout=PIPE, stderr=PIPE)
     if ret != 0:
-        raise RuntimeError(
-            "'{} -msphinx' does not return 0".format(sys.executable))
+        pytest.skip("'{} -msphinx' does not return 0".format(sys.executable))
 
 
 @cbook.deprecated("2.1", alternative="filecmp.cmp")

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1677,13 +1677,19 @@ def test_as_mpl_axes_api():
     ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     # try getting the axes given a different polar projection
-    ax_via_gca = plt.gca(projection=prj2)
+    with pytest.warns(UserWarning) as rec:
+        ax_via_gca = plt.gca(projection=prj2)
+        assert len(rec) == 1
+        assert 'Requested projection is different' in str(rec[0].message)
     assert ax_via_gca is not ax
     assert ax.get_theta_offset() == 0, ax.get_theta_offset()
     assert ax_via_gca.get_theta_offset() == np.pi, \
         ax_via_gca.get_theta_offset()
     # try getting the axes given an == (not is) polar projection
-    ax_via_gca = plt.gca(projection=prj3)
+    with pytest.warns(UserWarning):
+        ax_via_gca = plt.gca(projection=prj3)
+        assert len(rec) == 1
+        assert 'Requested projection is different' in str(rec[0].message)
     assert ax_via_gca is ax
     plt.close()
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -29,16 +29,18 @@ def test_is_hashable():
 
 def test_restrict_dict():
     d = {'foo': 'bar', 1: 2}
-    d1 = cbook.restrict_dict(d, ['foo', 1])
-    assert d1 == d
-    d2 = cbook.restrict_dict(d, ['bar', 2])
-    assert d2 == {}
-    d3 = cbook.restrict_dict(d, {'foo': 1})
-    assert d3 == {'foo': 'bar'}
-    d4 = cbook.restrict_dict(d, {})
-    assert d4 == {}
-    d5 = cbook.restrict_dict(d, {'foo', 2})
-    assert d5 == {'foo': 'bar'}
+    with pytest.warns(cbook.deprecation.MatplotlibDeprecationWarning) as rec:
+        d1 = cbook.restrict_dict(d, ['foo', 1])
+        assert d1 == d
+        d2 = cbook.restrict_dict(d, ['bar', 2])
+        assert d2 == {}
+        d3 = cbook.restrict_dict(d, {'foo': 1})
+        assert d3 == {'foo': 'bar'}
+        d4 = cbook.restrict_dict(d, {})
+        assert d4 == {}
+        d5 = cbook.restrict_dict(d, {'foo', 2})
+        assert d5 == {'foo': 'bar'}
+    assert len(rec) == 5
     # check that d was not modified
     assert d == {'foo': 'bar', 1: 2}
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -690,7 +690,7 @@ def test_tableau_order():
     assert list(mcolors.TABLEAU_COLORS.values()) == dflt_cycle
 
 
-def test_ndarray_subclass_norm():
+def test_ndarray_subclass_norm(recwarn):
     # Emulate an ndarray subclass that handles units
     # which objects when adding or subtracting with other
     # arrays. See #6622 and #8696
@@ -707,3 +707,11 @@ def test_ndarray_subclass_norm():
                  mcolors.SymLogNorm(3, vmax=5, linscale=1),
                  mcolors.PowerNorm(1)]:
         assert_array_equal(norm(data.view(MyArray)), norm(data))
+        if isinstance(norm, mcolors.PowerNorm):
+            assert len(recwarn) == 1
+            warn = recwarn.pop(UserWarning)
+            assert ('Power-law scaling on negative values is ill-defined'
+                    in str(warn.message))
+        else:
+            assert len(recwarn) == 0
+        recwarn.clear()

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -203,6 +203,10 @@ def test_nose_image_comparison(func, kwargs, errors, failures, dots,
             assert failures[self.failure_count][1] in str(err[1])
             self.failure_count += 1
 
+    # Make sure that multiple extensions work, but don't require LaTeX or
+    # Inkscape to do so.
+    kwargs.setdefault('extensions', ['png', 'png', 'png'])
+
     func = image_comparison(**kwargs)(func)
     loader = nose.loader.TestLoader()
     suite = loader.loadTestsFromGenerator(

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -96,7 +96,10 @@ def test_too_many_date_ticks():
     tf = datetime.datetime(2000, 1, 20)
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
-    ax.set_xlim((t0, tf), auto=True)
+    with pytest.warns(UserWarning) as rec:
+        ax.set_xlim((t0, tf), auto=True)
+        assert len(rec) == 1
+        assert 'Attempting to set identical left==right' in str(rec[0].message)
     ax.plot([], [])
     ax.xaxis.set_major_locator(mdates.DayLocator())
     with pytest.raises(RuntimeError):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -603,7 +603,8 @@ def test_load_from_url():
 
 @image_comparison(baseline_images=['log_scale_image'],
                   remove_text=True)
-def test_log_scale_image():
+# The recwarn fixture captures a warning in image_comparison.
+def test_log_scale_image(recwarn):
     Z = np.zeros((10, 10))
     Z[::2] = 1
 
@@ -613,7 +614,6 @@ def test_log_scale_image():
     ax.imshow(Z, extent=[1, 100, 1, 100], cmap='viridis',
               vmax=1, vmin=-1)
     ax.set_yscale('log')
-
 
 
 @image_comparison(baseline_images=['rotate_image'],

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -7,7 +7,7 @@ import tempfile
 import warnings
 
 from numpy.testing import (assert_allclose, assert_almost_equal,
-                           assert_array_equal)
+                           assert_array_equal, assert_array_almost_equal_nulp)
 import numpy.ma.testutils as matest
 import numpy as np
 import datetime as datetime
@@ -1985,7 +1985,7 @@ class TestSpectral(object):
                                 noverlap=self.nover_density,
                                 pad_to=self.pad_to_density,
                                 sides=self.sides)
-        assert_array_equal(Pxx, Pxy)
+        assert_array_almost_equal_nulp(Pxx, Pxy)
         assert_array_equal(freqsxx, freqsxy)
 
     def test_specgram_auto_default_equal(self):


### PR DESCRIPTION
## PR Summary

Patches needed to build & test on Fedora on multiple arches, with the exception of the deprecation warning capture (which is just nice to have because of the pytest bug). Of course, this does not include the tolerance bump required to build against FreeType 2.7.1 or 2.8.

This works on x86_64 and arm. I need to go through the results of aarch64/ppc64/ppc64le as well.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [-] New features are documented, with examples if plot related
- [-] Documentation is sphinx and numpydoc compliant
- [-] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [-] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way