### PR TITLE
Force clipped-log when drawing log-histograms.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2158,6 +2158,7 @@ or tuple of floats
                 r.sticky_edges.y.append(b)
             elif orientation == 'horizontal':
                 r.sticky_edges.x.append(l)
+            r._force_clip_in_log_scale = True
             self.add_patch(r)
             patches.append(r)
 
@@ -3053,7 +3054,9 @@ or tuple of floats
             if xlolims.any():
                 yo, _ = xywhere(y, right, xlolims & everymask)
                 lo, ro = xywhere(x, right, xlolims & everymask)
-                barcols.append(self.hlines(yo, lo, ro, **eb_lines_style))
+                ebs = self.hlines(yo, lo, ro, **eb_lines_style)
+                ebs._force_clip_in_log_scale = True
+                barcols.append(ebs)
                 rightup, yup = xywhere(right, y, xlolims & everymask)
                 if self.xaxis_inverted():
                     marker = mlines.CARETLEFTBASE
@@ -3092,7 +3095,9 @@ or tuple of floats
             if noylims.any():
                 xo, _ = xywhere(x, lower, noylims & everymask)
                 lo, uo = xywhere(lower, upper, noylims & everymask)
-                barcols.append(self.vlines(xo, lo, uo, **eb_lines_style))
+                ebs = self.vlines(xo, lo, uo, **eb_lines_style)
+                ebs._force_clip_in_log_scale = True
+                barcols.append(ebs)
                 if capsize > 0:
                     caplines.append(mlines.Line2D(xo, lo, marker='_',
                                                   **eb_cap_style))
@@ -4905,6 +4910,7 @@ or tuple of floats
             polys.append(X)
 
         collection = mcoll.PolyCollection(polys, **kwargs)
+        collection._force_clip_in_log_scale = True
 
         # now update the datalim and autoscale
         XY1 = np.array([x[where], y1[where]]).T
@@ -5057,6 +5063,7 @@ or tuple of floats
             polys.append(Y)
 
         collection = mcoll.PolyCollection(polys, **kwargs)
+        collection._force_clip_in_log_scale = True
 
         # now update the datalim and autoscale
         X1Y = np.array([x1[where], y[where]]).T

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -232,8 +232,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 offsets = np.column_stack([xs, ys])
 
         if not transform.is_affine:
-            paths = [transform.transform_path_non_affine(path)
-                     for path in paths]
+            with self._forcing_clip_in_log_scale():
+                paths = [transform.transform_path_non_affine(path)
+                         for path in paths]
             transform = transform.get_affine()
         if not transOffset.is_affine:
             offsets = transOffset.transform_non_affine(offsets)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -564,7 +564,10 @@ class Patch(artist.Artist):
 
         path = self.get_path()
         transform = self.get_transform()
-        tpath = transform.transform_path_non_affine(path)
+
+        with self._forcing_clip_in_log_scale():
+            tpath = transform.transform_path_non_affine(path)
+
         affine = transform.get_affine()
 
         if self.get_path_effects():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5412,3 +5412,21 @@ def test_patch_deprecations():
         assert fig.patch == fig.figurePatch
 
     assert len(w) == 2
+
+
+@pytest.mark.parametrize("plotter",
+                         [lambda ax: ax.bar([0, 1], [1, 2]),
+                          lambda ax: ax.errorbar([0, 1], [2, 2], [1, 3]),
+                          lambda ax: ax.fill_between([0, 1], [1, 2], [1, 0])])
+def test_clipped_log_zero(plotter):
+    fig, ax = plt.subplots()
+    plotter(ax)
+    ax.set_yscale("log")
+    png1 = io.BytesIO()
+    fig.savefig(png1, format="png")
+    fig, ax = plt.subplots()
+    plotter(ax)
+    ax.set_yscale("log", nonposy="clip")
+    png2 = io.BytesIO()
+    fig.savefig(png2, format="png")
+    assert png1.getvalue() == png2.getvalue()


### PR DESCRIPTION
Fixes #9288 & #9457 .
Note that because the clipping occurs only at draw time, the autolimits are simply picked using the nonzero values (at the time the autolimits are computed, clipping is not in effect) (so the autolimits are going to be a little bit different but I am happy with relying on the margins system to handle them).
If we go this route we may ultimately want to strip out the special casing of log-scale plots on bar().
Also need to decide whether we want to allow force-clipping both x and y.
I would prefer not making this a public API for now :/

Edit: I think #9477 is a better fix.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
