### PR TITLE
Don't sort categorical keys.

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -4,61 +4,45 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 
-import collections
 from collections import OrderedDict
-from distutils.version import LooseVersion
 import itertools
+from numbers import Number
 
 import numpy as np
 
-import matplotlib.units as units
-import matplotlib.ticker as ticker
+from matplotlib import units, ticker
 
 
-if LooseVersion(np.__version__) >= LooseVersion('1.8.0'):
-    def shim_array(data):
-        return np.array(data, dtype=np.unicode)
-else:
-    def shim_array(data):
-        if (isinstance(data, six.string_types) or
-                not isinstance(data, collections.Iterable)):
-            data = [data]
-        try:
-            data = [str(d) for d in data]
-        except UnicodeEncodeError:
-            # this yields gibberish but unicode text doesn't
-            # render under numpy1.6 anyway
-            data = [d.encode('utf-8', 'ignore').decode('utf-8')
-                    for d in data]
-        return np.array(data, dtype=np.unicode)
+def _to_str(s):
+    return s.decode("ascii") if isinstance(s, bytes) else str(s)
 
 
 class StrCategoryConverter(units.ConversionInterface):
     @staticmethod
     def convert(value, unit, axis):
         """Uses axis.unit_data map to encode data as floats."""
-        vmap = dict(zip(axis.unit_data.seq, axis.unit_data.locs))
-
-        if isinstance(value, six.string_types):
-            return vmap[value]
-
-        vals = shim_array(value)
-
-        for lab, loc in vmap.items():
-            vals[vals == lab] = loc
-
-        return vals.astype('float')
+        mapping = axis.unit_data._mapping
+        if isinstance(value, (Number, np.number)):
+            return value
+        elif isinstance(value, (str, bytes)):
+            return mapping[_to_str(value)]
+        else:
+            return np.array([v if isinstance(v, (Number, np.number))
+                             else mapping[_to_str(v)]
+                             for v in value],
+                            float)
 
     @staticmethod
     def axisinfo(unit, axis):
-        majloc = StrCategoryLocator(axis.unit_data.locs)
-        majfmt = StrCategoryFormatter(axis.unit_data.seq)
+        # Note that mapping may get mutated by later calls to plotting methods,
+        # so the locator and formatter must dynamically recompute locs and seq.
+        majloc = StrCategoryLocator(axis.unit_data._mapping)
+        majfmt = StrCategoryFormatter(axis.unit_data._mapping)
         return units.AxisInfo(majloc=majloc, majfmt=majfmt)
 
     @staticmethod
     def default_units(data, axis):
-        # the conversion call stack is:
-        # default_units->axis_info->convert
+        # the conversion call stack is default_units->axis_info->convert
         if axis.unit_data is None:
             axis.unit_data = UnitData(data)
         else:
@@ -67,21 +51,26 @@ class StrCategoryConverter(units.ConversionInterface):
 
 
 class StrCategoryLocator(ticker.FixedLocator):
-    def __init__(self, locs):
-        self.locs = locs
+    def __init__(self, mapping):
+        self._mapping = mapping
         self.nbins = None
+
+    @property
+    def locs(self):
+        return list(self._mapping.values())
 
 
 class StrCategoryFormatter(ticker.FixedFormatter):
-    def __init__(self, seq):
-        self.seq = seq
-        self.offset_string = ''
+    def __init__(self, mapping):
+        self._mapping = mapping
+        self.offset_string = ""
+
+    @property
+    def seq(self):
+        return list(self._mapping)
 
 
 class UnitData(object):
-    # debatable makes sense to special code missing values
-    spdict = {'nan': -1.0, 'inf': -2.0, '-inf': -3.0}
-
     def __init__(self, data):
         """Create mapping between unique categorical values and numerical id.
 
@@ -90,21 +79,18 @@ class UnitData(object):
         data: iterable
             sequence of values
         """
-        self.seq, self.locs = [], []
+        self._mapping = {}
         self._counter = itertools.count()
         self.update(data)
 
     def update(self, data):
-        data = np.atleast_1d(shim_array(data))
-        sorted_unique = list(OrderedDict(zip(data, itertools.repeat(None))))
+        if isinstance(data, six.string_types):
+            data = [data]
+        sorted_unique = OrderedDict.fromkeys(map(_to_str, data))
         for s in sorted_unique:
-            if s in self.seq:
+            if s in self._mapping:
                 continue
-            self.seq.append(s)
-            if s in UnitData.spdict:
-                self.locs.append(UnitData.spdict[s])
-            else:
-                self.locs.append(next(self._counter))
+            self._mapping[s] = next(self._counter)
 
 
 # Connects the convertor to matplotlib

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -6,7 +6,6 @@ import six
 
 from collections import OrderedDict
 import itertools
-from numbers import Number
 
 import numpy as np
 
@@ -22,15 +21,8 @@ class StrCategoryConverter(units.ConversionInterface):
     def convert(value, unit, axis):
         """Uses axis.unit_data map to encode data as floats."""
         mapping = axis.unit_data._mapping
-        if isinstance(value, (Number, np.number)):
-            return value
-        elif isinstance(value, (str, bytes)):
-            return mapping[_to_str(value)]
-        else:
-            return np.array([v if isinstance(v, (Number, np.number))
-                             else mapping[_to_str(v)]
-                             for v in value],
-                            float)
+        return (mapping[_to_str(value)] if np.isscalar(value)
+                else np.array([mapping[_to_str(v)] for v in value], float))
 
     @staticmethod
     def axisinfo(unit, axis):

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -16,8 +16,8 @@ class TestUnitData(object):
     testdata = [("hello world", ["hello world"], [0]),
                 ("Здравствуйте мир", ["Здравствуйте мир"], [0]),
                 (['A', 'A', np.nan, 'B', -np.inf, 3.14, np.inf],
-                 ['-inf', '3.14', 'A', 'B', 'inf', 'nan'],
-                 [-3.0, 0, 1, 2, -2.0, -1.0])]
+                 ['A', 'nan', 'B', '-inf', '3.14', 'inf'],
+                 [0, -1, 1, -3, 2, -2])]
 
     ids = ["single", "unicode", "mixed"]
 
@@ -28,21 +28,13 @@ class TestUnitData(object):
         assert act.locs == locs
 
     def test_update_map(self):
-        data = ['a', 'd']
-        oseq = ['a', 'd']
-        olocs = [0, 1]
+        unitdata = cat.UnitData(['a', 'd'])
+        assert unitdata.seq == ['a', 'd']
+        assert unitdata.locs == [0, 1]
 
-        data_update = ['b', 'd', 'e', np.inf]
-        useq = ['a', 'd', 'b', 'e', 'inf']
-        ulocs = [0, 1, 2, 3, -2]
-
-        unitdata = cat.UnitData(data)
-        assert unitdata.seq == oseq
-        assert unitdata.locs == olocs
-
-        unitdata.update(data_update)
-        assert unitdata.seq == useq
-        assert unitdata.locs == ulocs
+        unitdata.update(['b', 'd', 'e', np.inf])
+        assert unitdata.seq == ['a', 'd', 'b', 'e', 'inf']
+        assert unitdata.locs == [0, 1, 2, 3, -2]
 
 
 class FakeAxis(object):

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -52,8 +52,8 @@ class TestStrCategoryConverter(object):
                  {'a': 0, 'b': 1, 'c': 2},
                  [0, 1, 1, 0, 0, 2, 2, 2]),
                 (['A', 'A', 'B', 3.14],
-                 {'A': 1, 'B': 2},
-                 [1, 1, 2, 3.14])]
+                 {'3.14': 0, 'A': 1, 'B': 2},
+                 [1, 1, 2, 0])]
     ids = ["unicode", "single", "basic", "mixed"]
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

I may have missed something in the categorical PR discussion but if I write
```
plt.bar(["foo", "bar", "quux"], [1, 2, 3])
```
I expect the categories to appear in the order I explicitly give, not in alphabetical order...

Milestoning this to 2.1.1 as, in case we agree that's the correct behavior, I'd like to minimize the time the sorting behavior is present in the wild...

attn @story645 
xref #9312 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
