### PR TITLE
DOC: update sphinx-gallery configuration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -135,7 +135,7 @@ sphinx_gallery_conf = {
     'subsection_order': ExplicitOrder(explicit_order_folders)
 }
 
-plot_gallery = True
+plot_gallery = 'True'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This is due to an intentional change in sphinx-gallery between 0.1.12 and 0.1.13.  See https://github.com/sphinx-gallery/sphinx-gallery/pull/195

If this passes circle I plan to self merge and then merge up to v2.1.x and master to un-break all of the PRs.