### PR TITLE
Make tutorial code reproducible

### DIFF
--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -79,7 +79,7 @@ import numpy as np
 # And here we go...
 
 img = mpimg.imread('../../doc/_static/stinkbug.png')
-print(img)
+img
 
 ###############################################################################
 # Note the dtype there - float32.  Matplotlib has rescaled the 8 bit


### PR DESCRIPTION
Instead of using `print(img)`, directly call the object (i.e. just `img`), which results in a reproducible line of code, as opposed to hard-coding the result into the tutorial text which isn't reproducible. In other words, in IPython this correction results to an output `Out[5]:` which actually corresponds to the input `In[5]: img`. In its current state, an output `Out[5]` is generated by the `print()`-command which isn't visible in the tutorial; only the assignment `In[5]: img = mpimg.imread('../../doc/_static/stinkbug.png')` is. Hence the relation in the tutorial between `In[5]:` and `Out[5]` is simply incorrect and not reproducible.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
