### PR TITLE
Fix NameError: name 'os' is not defined

### DIFF
--- a/examples/animation/movie_demo_sgskip.py
+++ b/examples/animation/movie_demo_sgskip.py
@@ -7,6 +7,7 @@ Movie Demo
 
 from __future__ import print_function
 
+import os
 import subprocess
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
Fixes the `movie_demo_sgskip.py` example.