### PR TITLE
Test if Python 3.6 crashes on Appveyor [Do Not Merge] [skip travis]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,18 +28,6 @@ environment:
     # one for 64bit because we construct envs anyway. But using one for the
     # right python version is hopefully making it fast due to package caching.
     - TARGET_ARCH: "x64"
-      CONDA_PY: "27"
-      CONDA_NPY: "18"
-      PYTHON_VERSION: "2.7"
-      TEST_ALL: "no"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-    - TARGET_ARCH: "x64"
-      CONDA_PY: "35"
-      CONDA_NPY: "110"
-      PYTHON_VERSION: "3.5"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
-      TEST_ALL: "no"
-    - TARGET_ARCH: "x64"
       CONDA_PY: "36"
       PYTHON_VERSION: "3.6"
       CONDA_NPY: "111"


### PR DESCRIPTION
Just checking if Python 3.6 also crashes on Appveyor [Do Not Merge]