### PR TITLE
Fix broken link to proxy artists documentation

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -616,11 +616,12 @@ class Legend(Artist):
         for orig_handle, lab in zip(handles, labels):
             handler = self.get_legend_handler(legend_handler_map, orig_handle)
             if handler is None:
+                fragment = "#creating-artists-specifically-for-adding-to-the-legend-aka-proxy-artists"
                 warnings.warn(
                     "Legend does not support {!r} instances.\nA proxy artist "
                     "may be used instead.\nSee: "
                     "http://matplotlib.org/users/legend_guide.html"
-                    "#using-proxy-artist".format(orig_handle)
+                    "{}".format(orig_handle, fragment)
                 )
                 # We don't have a handle for this artist, so we just defer
                 # to None.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -616,12 +616,12 @@ class Legend(Artist):
         for orig_handle, lab in zip(handles, labels):
             handler = self.get_legend_handler(legend_handler_map, orig_handle)
             if handler is None:
-                fragment = "#creating-artists-specifically-for-adding-to-the-legend-aka-proxy-artists"
                 warnings.warn(
                     "Legend does not support {!r} instances.\nA proxy artist "
                     "may be used instead.\nSee: "
                     "http://matplotlib.org/users/legend_guide.html"
-                    "{}".format(orig_handle, fragment)
+                    "#creating-artists-specifically-for-adding-to-the-legend-"
+                    "aka-proxy-artists".format(orig_handle)
                 )
                 # We don't have a handle for this artist, so we just defer
                 # to None.


### PR DESCRIPTION
http://matplotlib.org/users/legend_guide.html#using-proxy-artist refers
to a named anchor that is unavailable.  Use
http://matplotlib.org/users/legend_guide.html#creating-artists-specifically-for-adding-to-the-legend-aka-proxy-artists
instead.