### PR TITLE
Test if pytest without capturing crashes on Appveyor [Do Not Merge] [skip travis]

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1347,13 +1347,6 @@ default_test_modules = [
 
 
 def _init_tests():
-    try:
-        import faulthandler
-    except ImportError:
-        pass
-    else:
-        faulthandler.enable()
-
     # The version of FreeType to install locally for running the
     # tests.  This must match the value in `setupext.py`
     LOCAL_FREETYPE_VERSION = '2.6.1'

--- a/tests.py
+++ b/tests.py
@@ -49,6 +49,7 @@ if __name__ == '__main__':
         from matplotlib.testing import disable_internet
         disable_internet.turn_off_internet()
         extra_args.extend(['-m', 'not network'])
+    extra_args.extend(['-s'])
 
     print('Python byte-compilation optimization level:', sys.flags.optimize)
 


### PR DESCRIPTION
On my system, [disabling pytest capturing](https://docs.pytest.org/en/latest/capture.html) prevents crashes at exit of tests (https://github.com/matplotlib/matplotlib/issues/9176).