### PR TITLE
Tell user to try installing pkg-config if packages not found

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -578,8 +578,14 @@ class SetupPackage(object):
                         # is dropped. It is available in Python 3.3+
                         _ = check_output(["which", manager],
                                          stderr=subprocess.STDOUT)
-                        return ('Try installing {0} with `{1} install {2}`'
-                                .format(self.name, manager, pkg_name))
+                        if manager == 'port':
+                            pkgconfig = 'pkgconfig'
+                        else:
+                            pkgconfig = 'pkg-config'
+                        return ('Try installing {0} with `{1} install {2}` '
+                                'and pkg-config with `{1} install {3}`'
+                                .format(self.name, manager, pkg_name,
+                                        pkgconfig))
                     except subprocess.CalledProcessError:
                         pass
 


### PR DESCRIPTION
I didn't have `pkg-config` installed, and got very confused when `setupext.py` kept telling me to install `freetype` (which was installed). This tells users to try installing `pkg-config` too if an external package can't be found.