### PR TITLE
Fix docstring typo in Rectangle, Ellipse, and Spine.

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -705,7 +705,7 @@ class Rectangle(Patch):
     def _update_patch_transform(self):
         """NOTE: This cannot be called until after this has been added
                  to an Axes, otherwise unit conversion will fail. This
-                 maxes it very important to call the accessor method and
+                 makes it very important to call the accessor method and
                  not directly access the transformation member variable.
         """
         x = self.convert_xunits(self._x)
@@ -1465,7 +1465,7 @@ class Ellipse(Patch):
     def _recompute_transform(self):
         """NOTE: This cannot be called until after this has been added
                  to an Axes, otherwise unit conversion will fail. This
-                 maxes it very important to call the accessor method and
+                 makes it very important to call the accessor method and
                  not directly access the transformation member variable.
         """
         center = (self.convert_xunits(self.center[0]),

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -136,7 +136,7 @@ class Spine(mpatches.Patch):
     def _recompute_transform(self):
         """NOTE: This cannot be called until after this has been added
                  to an Axes, otherwise unit conversion will fail. This
-                 maxes it very important to call the accessor method and
+                 makes it very important to call the accessor method and
                  not directly access the transformation member variable.
         """
         assert self._patch_type in ('arc', 'circle')


### PR DESCRIPTION
## PR Summary

Fixes a typo in three docstrings for Rectangle, Ellipse, and Spine transform methods.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

