### PR TITLE
ENH: Added __repr__ for Figure

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -274,7 +274,7 @@ class Figure(Artist):
         return "Figure(%gx%g)" % tuple(self.bbox.size)
 
     def __repr__(self):
-        return "<{clsname} size {h:g}x{w:g} with {naxes} axes>".format(
+        return "<{clsname} size {h:g}x{w:g} with {naxes} Axes>".format(
             clsname=self.__class__.__name__,
             h=self.bbox.size[0], w=self.bbox.size[1],
             naxes=len(self.axes),

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -273,6 +273,13 @@ class Figure(Artist):
     def __str__(self):
         return "Figure(%gx%g)" % tuple(self.bbox.size)
 
+    def __repr__(self):
+        return "<{clsname} size {h:g}x{w:g} with {naxes} axes>".format(
+            clsname=self.__class__.__name__,
+            h=self.bbox.size[0], w=self.bbox.size[1],
+            naxes=len(self.axes),
+        )
+
     def __init__(self,
                  figsize=None,  # defaults to rc figure.figsize
                  dpi=None,  # defaults to rc figure.dpi

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -330,4 +330,4 @@ def test_savefig():
 
 def test_figure_repr():
     fig = plt.figure(figsize=(10, 20), dpi=10)
-    assert repr(fig) == "<Figure size 100x200 with 0 axes>"
+    assert repr(fig) == "<Figure size 100x200 with 0 Axes>"

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -326,3 +326,8 @@ def test_savefig():
     msg = "savefig() takes 2 positional arguments but 3 were given"
     with pytest.raises(TypeError, message=msg):
         fig.savefig("fname1.png", "fname2.png")
+
+
+def test_figure_repr():
+    fig = plt.figure(figsize=(10, 20), dpi=10)
+    assert repr(fig) == "<Figure size 100x200 with 0 axes>"


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

Adds a better repr to Figure
Eg:
```
<Figure size 640x480 with 2 axes>
```

(Maybe) Fixes Issue #9372 

Anything else that should go into the repr? Maybe dpi?

Could also do `__str__ == __repr__` seeing as they're nearly identical?

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
