### PR TITLE
Bump test coverage of Qt5 UI.

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -161,3 +161,23 @@ def test_dpi_ratio_change():
         assert size.height() == 240
         assert_equal(qt_canvas.get_width_height(), (600, 240))
         assert_equal(fig.get_size_inches(), (5, 2))
+
+
+@pytest.mark.backend('Qt5Agg')
+def test_subplottool():
+    fig, ax = plt.subplots()
+    with mock.patch(
+            "matplotlib.backends.backend_qt5.SubplotToolQt.exec_",
+            lambda self: None):
+        fig.canvas.manager.toolbar.configure_subplots()
+
+
+@pytest.mark.backend('Qt5Agg')
+def test_figureoptions():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2])
+    ax.imshow([[1]])
+    with mock.patch(
+            "matplotlib.backends.qt_editor.formlayout.FormDialog.exec_",
+            lambda self: None):
+        fig.canvas.manager.toolbar.edit_parameters()


### PR DESCRIPTION
This does not actually test user input, only that the UIs can be
constructed from the toolbar.

Would probably have caught #9332.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
