### PR TITLE
DOC: tweak template to use automodule (not currentmodule)

### DIFF
--- a/doc/_templates/autofunctions.rst
+++ b/doc/_templates/autofunctions.rst
@@ -2,7 +2,8 @@
 {{ fullname | escape | underline }}
 
 
-.. currentmodule:: {{ fullname }}
+.. automodule:: {{ fullname }}
+   :no-members:
 
 {% block functions %}
 {% if functions %}
@@ -10,7 +11,7 @@
 Functions
 ---------
 
-.. autosummary:: 
+.. autosummary::
    :template: autosummary.rst
    :toctree:
 {% for item in functions %}{% if item not in ['plotting', 'colormaps'] %}


### PR DESCRIPTION
This ensure that the module gets created a link target added.  The
trick is tell `automodule` to not document members.

This is slightly better than using the `module` directive as it at
least pulls the docstring.

closes #9331


<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
