### PR TITLE
[Doc] add pcolor and contour to tutorials/introductory/sample_plots.py

### DIFF
--- a/tutorials/introductory/sample_plots.py
+++ b/tutorials/introductory/sample_plots.py
@@ -36,6 +36,23 @@ Multiple axes (i.e. subplots) are created with the
 
    Subplot
 
+.. _screenshots_pcolormesh_demo
+
+Contouring and pseudocolor
+==========================
+
+The :func:`~matplotlib.pyplot.pcolormesh` command can make a colored
+representation of a two-dimensional array.  The
+:func:`~matplotlib.pyplot.contour` command is another way to representation
+the same data:
+
+.. figure:: ../../gallery/images_contours_and_fields/images/sphx_glr_pcolormesh_levels_001.png
+   :target: ../../gallery/images_contours_and_fields/pcolormesh_levels.html
+   :align: center
+   :scale: 50
+
+   Contour and Pcolormesh 
+
 .. _screenshots_histogram_demo:
 
 Histograms

--- a/tutorials/introductory/sample_plots.py
+++ b/tutorials/introductory/sample_plots.py
@@ -36,14 +36,14 @@ Multiple axes (i.e. subplots) are created with the
 
    Subplot
 
-.. _screenshots_pcolormesh_demo
+.. _screenshots_pcolormesh_demo:
 
 Contouring and pseudocolor
 ==========================
 
 The :func:`~matplotlib.pyplot.pcolormesh` command can make a colored
 representation of a two-dimensional array.  The
-:func:`~matplotlib.pyplot.contour` command is another way to representation
+:func:`~matplotlib.pyplot.contour` command is another way to represent
 the same data:
 
 .. figure:: ../../gallery/images_contours_and_fields/images/sphx_glr_pcolormesh_levels_001.png
@@ -51,7 +51,7 @@ the same data:
    :align: center
    :scale: 50
 
-   Contour and Pcolormesh 
+   Contour and Pcolormesh
 
 .. _screenshots_histogram_demo:
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

`tutorials/introductory/sample_plots.py` didn't have a `pcolor` plot or an example of `contour`!

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Documentation is sphinx and numpydoc compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->