### PR TITLE
Assign event to later Axes if zorders are tied.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1527,22 +1527,19 @@ class LocationEvent(Event):
         else:
             axes_list = [self.canvas.mouse_grabber]
 
-        if axes_list:  # Use highest zorder.
-            self.inaxes = max(axes_list, key=lambda x: x.zorder)
-        else:  # None found.
-            self.inaxes = None
-            self._update_enter_leave()
-            return
-
-        try:
-            trans = self.inaxes.transData.inverted()
-            xdata, ydata = trans.transform_point((x, y))
-        except ValueError:
-            self.xdata = None
-            self.ydata = None
+        if axes_list:
+            self.inaxes = cbook._topmost_artist(axes_list)
+            try:
+                trans = self.inaxes.transData.inverted()
+                xdata, ydata = trans.transform_point((x, y))
+            except ValueError:
+                self.xdata = None
+                self.ydata = None
+            else:
+                self.xdata = xdata
+                self.ydata = ydata
         else:
-            self.xdata = xdata
-            self.ydata = ydata
+            self.inaxes = None
 
         self._update_enter_leave()
 
@@ -1805,7 +1802,7 @@ class FigureCanvasBase(object):
             canvas.mpl_connect('mouse_press_event',canvas.onRemove)
         """
         # Find the top artist under the cursor
-        under = sorted(self.figure.hitlist(ev), key=lambda x: x.zorder)
+        under = cbook._topmost_artist(self.figure.hitlist(ev))
         h = None
         if under:
             h = under[-1]
@@ -2893,7 +2890,7 @@ class NavigationToolbar2(object):
                            if a.contains(event) and a.get_visible()]
 
                 if artists:
-                    a = max(artists, key=lambda x: x.zorder)
+                    a = cbook._topmost_artist(artists)
                     if a is not event.inaxes.patch:
                         data = a.get_cursor_data(event)
                         if data is not None:

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -340,7 +340,7 @@ class ToolCursorPosition(ToolBase):
                            if a.contains(event) and a.get_visible()]
 
                 if artists:
-                    a = max(artists, key=lambda x: x.zorder)
+                    a = cbook._topmost_artist(artists)
                     if a is not event.inaxes.patch:
                         data = a.get_cursor_data(event)
                         if data is not None:

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -21,6 +21,7 @@ import io
 from itertools import repeat
 import locale
 import numbers
+import operator
 import os
 import re
 import sys
@@ -2752,3 +2753,16 @@ class _StringFuncParser(object):
                              (params, str_func))
 
         return str_func, params
+
+
+def _topmost_artist(
+        artists,
+        _cached_max=functools.partial(max, key=operator.attrgetter("zorder"))):
+    """Get the topmost artist of a list.
+
+    In case of a tie, return the *last* of the tied artists, as it will be
+    drawn on top of the others. `max` returns the first maximum in case of ties
+    (on Py2 this is undocumented but true), so we need to iterate over the list
+    in reverse order.
+    """
+    return _cached_max(reversed(artists))


### PR DESCRIPTION
If axes zorders are tied, axes appearing later in figure.axes get
drawn above those appearing earlier, so events should be preferably
assigned to them.  By default, max() returns the *first* maximum in case
of ties, so the previous implementation was not satisfactory.

Closes #9388.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
