### PR TITLE
Fix minor bug in vertex insert

### DIFF
--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -126,10 +126,10 @@ class PolygonInteractor(object):
                 s1 = xys[i + 1]
                 d = dist_point_to_segment(p, s0, s1)
                 if d <= self.epsilon:
-                    self.poly.xy = np.array(
-                        list(self.poly.xy[:i + 1]) +
-                        [(event.xdata, event.ydata)] +
-                        list(self.poly.xy[i + 1:]))
+                    self.poly.xy = np.insert(
+                        self.poly.xy, i+1,
+                        [event.xdata, event.ydata],
+                        axis=0)
                     self.line.set_data(zip(*self.poly.xy))
                     break
 

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -114,9 +114,8 @@ class PolygonInteractor(object):
         elif event.key == 'd':
             ind = self.get_ind_under_point(event)
             if ind is not None:
-                self.poly.xy = [tup
-                                for i, tup in enumerate(self.poly.xy)
-                                if i != ind]
+                self.poly.xy = np.delete(self.poly.xy,
+                                         ind, axis=0)
                 self.line.set_data(zip(*self.poly.xy))
         elif event.key == 'i':
             xys = self.poly.get_transform().transform(self.poly.xy)

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -59,7 +59,8 @@ class PolygonInteractor(object):
         self.background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self.poly)
         self.ax.draw_artist(self.line)
-        self.canvas.blit(self.ax.bbox)
+        # do not need to blit here, this will fire before the screen is
+        # updated
 
     def poly_changed(self, poly):
         'this method is called whenever the polygon object is called'
@@ -131,8 +132,8 @@ class PolygonInteractor(object):
                         axis=0)
                     self.line.set_data(zip(*self.poly.xy))
                     break
-
-        self.canvas.draw()
+        if self.line.stale:
+            self.canvas.draw_idle()
 
     def motion_notify_callback(self, event):
         'on mouse movement'

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -127,9 +127,9 @@ class PolygonInteractor(object):
                 d = dist_point_to_segment(p, s0, s1)
                 if d <= self.epsilon:
                     self.poly.xy = np.array(
-                        list(self.poly.xy[:i]) +
+                        list(self.poly.xy[:i + 1]) +
                         [(event.xdata, event.ydata)] +
-                        list(self.poly.xy[i:]))
+                        list(self.poly.xy[i + 1:]))
                     self.line.set_data(zip(*self.poly.xy))
                     break
 


### PR DESCRIPTION
- If a vertex is inserted between the first and the second vertex, it is inserted at index 0, and the polygon automatically inserts a copy at the last index to keep the starting and ending points the same. It has an effect of inserting two vertices (one under the point, and the one previously at index 0), and the whole plot is messed up afterwards. 

It is most evident when you have only two vertices on the plot.  
![figure_1](https://user-images.githubusercontent.com/12467657/31561830-1c3c1866-b094-11e7-84c6-f632ea055001.png)

After an insert:
![figure_2](https://user-images.githubusercontent.com/12467657/31561539-240f7b38-b093-11e7-9400-08c9d8325234.png)
![figure_2-2](https://user-images.githubusercontent.com/12467657/31562429-5f7a4984-b096-11e7-8079-ae28164fb865.png)

Ensuring no new vertex is inserted at index 0 fixes the problem. 
After the fix:
![figure_3](https://user-images.githubusercontent.com/12467657/31561623-7137f52a-b093-11e7-931c-df01a5aee7a1.png)


