### PR TITLE
FIX scipy is not a requirement

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -12,5 +12,4 @@ ipython
 mock
 numpydoc
 pillow
-scipy
 sphinx-gallery>=0.1.12

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,7 +46,6 @@ def _check_deps():
              "matplotlib": 'matplotlib',
              "numpydoc": 'numpydoc',
              "PIL.Image": 'pillow',
-             "scipy": 'scipy',
              "sphinx_gallery": 'sphinx_gallery'}
     if sys.version_info < (3, 3):
         names["mock"] = 'mock'


### PR DESCRIPTION
Scipy is not a requirement for the documentation build.