### PR TITLE
MAINT Documentation on doc is outdated

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -340,21 +340,6 @@ Plot directive documentation
 
 .. automodule:: matplotlib.sphinxext.plot_directive
 
-Static figures
---------------
-
-Any figures that rely on optional system configurations need to be handled a
-little differently. These figures are not to be generated during the
-documentation build, in order to keep the prerequisites to the documentation
-effort as low as possible. Please run the :file:`doc/pyplots/make.py` script
-when adding such figures, and commit the script **and** the images to
-git. Please also add a line to the README in doc/pyplots for any additional
-requirements necessary to generate a new figure. Once these steps have been
-taken, these figures can be included in the usual way::
-
-   .. plot:: mpl_examples/text_labels_and_annotations/tex_demo.py
-      :include-source:
-
 Examples
 --------
 


### PR DESCRIPTION
Remove the references to static images. The make.py in question does not exist
anymore.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
