### PR TITLE
TST: Fix flaky tests order

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,9 +18,6 @@ environment:
     # Workaround for https://github.com/conda/conda-build/issues/636
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -rawR --timeout=300 --durations=25 --cov-report= --cov=lib -m "not network"
-    PYTHONHASHSEED: 0  # Workaround for pytest-xdist flaky collection order
-                       # https://github.com/pytest-dev/pytest/issues/920
-                       # https://github.com/pytest-dev/pytest/issues/1075
 
   matrix:
     # for testing purpose: numpy 1.8 on py2.7, for the rest use 1.10/latest

--- a/ci/travis/test_script.sh
+++ b/ci/travis/test_script.sh
@@ -14,11 +14,6 @@ set -ev
 if [[ $DELETE_FONT_CACHE == 1 ]]; then
   rm -rf ~/.cache/matplotlib
 fi
-# Workaround for pytest-xdist flaky collection order
-# https://github.com/pytest-dev/pytest/issues/920
-# https://github.com/pytest-dev/pytest/issues/1075
-export PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
-echo PYTHONHASHSEED=$PYTHONHASHSEED
 
 echo The following args are passed to pytest $PYTEST_ARGS $RUN_PEP8
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -617,7 +617,7 @@ def test_pandas_iterable():
     assert_array_equal(cm1.colors, cm2.colors)
 
 
-@pytest.mark.parametrize('name', cm.cmap_d)
+@pytest.mark.parametrize('name', sorted(cm.cmap_d))
 def test_colormap_reversing(name):
     """Check the generated _lut data of a colormap and corresponding
     reversed colormap if they are almost the same."""


### PR DESCRIPTION
It looks like `test_colormap_reversing` is the last order-flaky test