### PR TITLE
BUG: Fix savefig GUI in GTK backend

### DIFF
--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -711,6 +711,7 @@ class NavigationToolbar2GTK(NavigationToolbar2, gtk.Toolbar):
         fname, format = chooser.get_filename_from_user()
         chooser.destroy()
         if fname:
+            startpath = os.path.expanduser(rcParams['savefig.directory'])
             # Save dir for next time, unless empty str (i.e., use cwd).
             if startpath != "":
                 rcParams['savefig.directory'] = (


### PR DESCRIPTION
Fixes #9407 

## PR Summary

This fixes a bug in  #9407 that the line defining `startpath` was mistakenyl removed in the gtk backend, causing users to be unable to save figures. Compare this line to line [567 in backend_gtk3.py (link)](https://github.com/matplotlib/matplotlib/blob/4033abd0f21440d6fea0c7854af99a9cebe55e58/lib/matplotlib/backends/backend_gtk3.py#L567) which correctly kept the definition.

As far as I understand the desired logic is that the startpath rc param is only overwritten if the user didn't explicitly set it to an empty string, which would signify to always use the current dir.

I don't have experience writing unit tests for gui behavior.. If you would like one, could you point me to where this would go?

