### PR TITLE
Import time module so that pyplot.pause works

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -22,6 +22,7 @@ import six
 
 import sys
 import warnings
+import time
 import types
 
 from cycler import cycler


### PR DESCRIPTION
At the moment, there is a bug (GH #9412) during the last frame in pyplot interactive mode.
pause() uses time.sleep, but doesn't import the time module.
