### PR TITLE
Trivial doc fixes.

### DIFF
--- a/doc/faq/osx_framework.rst
+++ b/doc/faq/osx_framework.rst
@@ -13,16 +13,14 @@ Working with Matplotlib on OSX
 Introduction
 ============
 
-On OSX, two different types of Python Builds exist: a regular build and a
-framework build. In order to interact correctly with OSX through the native
-GUI frameworks you need a framework build of Python.
-At the time of writing the ``macosx`` and ``WXAgg`` backends require a
-framework build to function correctly. This can result in issues for
-a python installation not build as a framework and may also happen in
-virtual envs and when using (Ana)Conda.
-From Matplotlib 1.5 onwards the ``macosx`` backend
-checks that a framework build is available and fails if a non framework
-build is found. WX has a similar check build in.
+On OSX, two different types of Python builds exist: a regular build and a
+framework build.  In order to interact correctly with OSX through the native
+GUI frameworks you need a framework build of Python.  At the time of writing
+the ``macosx`` and ``WXAgg`` backends require a framework build to function
+correctly. This can result in issues for a Python installation not build as a
+framework and may also happen in virtual envs and when using (Ana)Conda.  From
+Matplotlib 1.5 onwards, both backends check that a framework build is available
+and fail if a non framework build is found.
 
 Without this check a partially functional figure is created.
 Among the issues with it is that it is produced in the background and
@@ -103,9 +101,9 @@ build within the virtual environment you can do ``frameworkpython -m IPython``
 ``PYTHONHOME`` and Jupyter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This approach can be followed even if using `Jupyter <https://jupyter.org/>`_ 
-notebooks: you just need to setup a kernel with the suitable ``PYTHONHOME`` 
-definition. The  `jupyter-virtualenv-osx  <https://github.com/mapio/jupyter-virtualenv-osx>`_ 
+This approach can be followed even if using `Jupyter <https://jupyter.org/>`_
+notebooks: you just need to setup a kernel with the suitable ``PYTHONHOME``
+definition. The  `jupyter-virtualenv-osx  <https://github.com/mapio/jupyter-virtualenv-osx>`_
 script automates the creation of such a kernel.
 
 
@@ -139,7 +137,7 @@ With this in place you can run ``frameworkpython`` as above but will need to add
 to every virtualenv
 
 PythonW Compiler
-^^^^^^^^^^^^^^^^
+----------------
 
 In addition
 `virtualenv-pythonw-osx <https://github.com/gldnspud/virtualenv-pythonw-osx>`_

--- a/doc/faq/virtualenv_faq.rst
+++ b/doc/faq/virtualenv_faq.rst
@@ -4,14 +4,6 @@
 Working with Matplotlib in Virtual environments
 ***********************************************
 
-.. contents::
-   :backlinks: none
-
-.. _virtualenv_introduction:
-
-Introduction
-============
-
 When running Matplotlib in a `virtual environment
 <https://virtualenv.pypa.io/en/latest/>`_ you may discover a few issues.
 Matplotlib itself has no issue with virtual environments.  However, some of


### PR DESCRIPTION
- Header level in OSX framework faq was incorrect (pythonw compiler
  should be at the same level as PYTHONHOME).  Some trivial rewordings.
- There are no more subdivisions in the virtualenv faq so we can drop
  the intro header and the TOC.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
