### PR TITLE
Minor fixes to gallery build.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,7 +132,8 @@ sphinx_gallery_conf = {
         'scipy': 'https://docs.scipy.org/doc/scipy/reference',
     },
     'backreferences_dir': 'api/_as_gen',
-    'subsection_order': ExplicitOrder(explicit_order_folders)
+    'subsection_order': ExplicitOrder(explicit_order_folders),
+    'min_reported_time': 1,
 }
 
 plot_gallery = 'True'

--- a/examples/misc/svg_filter_line.py
+++ b/examples/misc/svg_filter_line.py
@@ -10,9 +10,6 @@ support it.
 """
 
 from __future__ import print_function
-import matplotlib
-
-matplotlib.use("Svg")
 
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms

--- a/examples/misc/svg_filter_pie.py
+++ b/examples/misc/svg_filter_pie.py
@@ -10,10 +10,6 @@ Note that the filtering effects are only effective if your svg renderer
 support it.
 """
 
-
-import matplotlib
-matplotlib.use("Svg")
-
 import matplotlib.pyplot as plt
 from matplotlib.patches import Shadow
 

--- a/examples/subplots_axes_and_figures/subplots_adjust.py
+++ b/examples/subplots_axes_and_figures/subplots_adjust.py
@@ -3,7 +3,8 @@
 Subplots Adjust
 ===============
 
-Adjusting the spacing of margins and subplots using :func:~matplotlib.pyplot.subplots_adjust.
+Adjusting the spacing of margins and subplots using
+`~matplotlib.pyplot.subplots_adjust`.
 """
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
1. Do not call `matplotlib.use("svg")` in the svg-specific examples, as
this is unneeded (matplotlib will internally switch the canvas at save
time) and triggers a warning because s-g already set the canvas to agg.

2. Do not report computation times for examples than ran faster than 1s
(i.e., most of them) -- for fast examples, we are timing and reporting
noise.

3. Some markup fixes.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
