### PR TITLE
Don't mark a patch transform as set if the parent transform is not set.

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -588,14 +588,9 @@ class Shadow(Patch):
         if self.props is not None:
             self.update(self.props)
         else:
-            r, g, b, a = colors.to_rgba(self.patch.get_facecolor())
-            rho = 0.3
-            r = rho * r
-            g = rho * g
-            b = rho * b
-
-            self.set_facecolor((r, g, b, 0.5))
-            self.set_edgecolor((r, g, b, 0.5))
+            color = .3 * np.asarray(colors.to_rgb(self.patch.get_facecolor()))
+            self.set_facecolor(color)
+            self.set_edgecolor(color)
             self.set_alpha(0.5)
 
     def _update_transform(self, renderer):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -175,6 +175,9 @@ class Patch(artist.Artist):
         self._us_dashes = other._us_dashes
         self.set_linewidth(other._linewidth)  # also sets dash properties
         self.set_transform(other.get_data_transform())
+        # If the transform of other needs further initialization, then it will
+        # be the case for this artist too.
+        self._transformSet = other.is_transform_set()
 
     def get_extents(self):
         """

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -5,15 +5,12 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
-from matplotlib.patches import Polygon
-from matplotlib.patches import Rectangle
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.patches import Polygon, Rectangle
+from matplotlib.testing.decorators import image_comparison, check_figures_equal
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
-import matplotlib.collections as mcollections
-from matplotlib import path as mpath
-from matplotlib import transforms as mtransforms
-import matplotlib.style as mstyle
+from matplotlib import (
+    collections as mcollections, colors as mcolors, patches as mpatches,
+    path as mpath, style as mstyle, transforms as mtransforms)
 
 import sys
 on_win = (sys.platform == 'win32')
@@ -443,3 +440,29 @@ def test_contains_points():
     expected = path.contains_points(points, transform, radius)
     result = ell.contains_points(points)
     assert np.all(result == expected)
+
+
+# Currently fails with pdf/svg, probably because some parts assume a dpi of 72.
+@check_figures_equal(extensions=["png"])
+def test_shadow(fig_test, fig_ref):
+    xy = np.array([.2, .3])
+    dxy = np.array([.1, .2])
+    # We need to work around the nonsensical (dpi-dependent) interpretation of
+    # offsets by the Shadow class...
+    plt.rcParams["savefig.dpi"] = "figure"
+    # Test image.
+    a1 = fig_test.subplots()
+    rect = mpatches.Rectangle(xy=xy, width=.5, height=.5)
+    shadow = mpatches.Shadow(rect, ox=dxy[0], oy=dxy[1])
+    a1.add_patch(rect)
+    a1.add_patch(shadow)
+    # Reference image.
+    a2 = fig_ref.subplots()
+    rect = mpatches.Rectangle(xy=xy, width=.5, height=.5)
+    shadow = mpatches.Rectangle(
+        xy=xy + fig_ref.dpi / 72 * dxy, width=.5, height=.5,
+        fc=np.asarray(mcolors.to_rgb(rect.get_fc())) * .3,
+        ec=np.asarray(mcolors.to_rgb(rect.get_fc())) * .3,
+        alpha=.5)
+    a2.add_patch(shadow)
+    a2.add_patch(rect)


### PR DESCRIPTION
When updating a patch from another artist, if the other artist's
transform is marked as "uninitialized" (`_transformSet == False`), then
don't mark the updatee's transform as set either.

Typically, this occurs if the updator has not been added to an Axes yet;
its transform will be set when that adding occurs.  In that case, the
updatee's transform also needs to be set when actually being added to an
Axes.

Closes the incorrect transform part of #9377.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
