### PR TITLE
Shadow patch now initializes zorder behind argument patch

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -621,6 +621,10 @@ class Shadow(Patch):
 
     def _update(self):
         self.update_from(self.patch)
+
+        # Place the shadow patch directly behind the inherited patch.
+        self.set_zorder(np.nextafter(self.patch.zorder, -np.inf))
+
         if self.props is not None:
             self.update(self.props)
         else:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

When initializing a `patch.Shadow` instance the object inherits the same zorder as the passed patch. This behavior draws the two patches in the same plane. This PR initializes the `patch.Shadow` to take the next smaller `zorder` by default.

---

<!--If it fixes an open issue, please link to the issue here.-->
This fixes an issue about zorder stacking for Shadow patches referenced here: #9377

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
