### PR TITLE
Fix undefined variable 'warnings'

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -11,6 +11,8 @@ line segemnts)
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import warnings
+
 import six
 from six.moves import zip
 try:


### PR DESCRIPTION
Warnings is used at https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/collections.py#L268 but is not imported.