### PR TITLE
BUG: Fix `_extent` not set in PcolorImage

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5847,6 +5847,7 @@ class Axes(_AxesBase):
                                         norm=norm,
                                         alpha=alpha,
                                         **kwargs)
+                im.set_extent((xl, xr, yb, yt))
             self.add_image(im)
             ret = im
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -561,6 +561,12 @@ def test_pcolorimage_setdata():
     assert im._A[0, 0] == im._Ax[0] == im._Ay[0] == 0, 'value changed'
 
 
+def test_pcolorimage_extent():
+    im = plt.hist2d([1, 2, 3], [3, 5, 6],
+                    bins=[[0, 3, 7], [1, 2, 3]])[-1]
+    assert im.get_extent() == (0, 7, 1, 3)
+
+
 def test_minimized_rasterized():
     # This ensures that the rasterized content in the colorbars is
     # only as thick as the colorbar, and doesn't extend to other parts


### PR DESCRIPTION
PcolorImage now sets `_extent` of AxesImage on its creation.

## PR Summary

Depending on bins argument of hist2d, style is set to either `image` or `pcolorimage` in _axes.pcolorfast. If the style is `image`, AxesImage object is created and is supplied with extents. The issue arose when style was `pcolorimage`. The `_extent` is never set in super class AxesImage of PcolorImage. 
The issue is solved by setting `_extent` after PcolorImage creation.

This PR fixes #8426.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
