### PR TITLE
FIX: Always update tick labels (fixes #9397)

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1052,11 +1052,12 @@ class Axis(artist.Artist):
         for tick, loc, label in tick_tups:
             if tick is None:
                 continue
-            if not mtransforms.interval_contains(interval_expanded, loc):
-                continue
+            # NB: always update labels and position to avoid issues like #9397
             tick.update_position(loc)
             tick.set_label1(label)
             tick.set_label2(label)
+            if not mtransforms.interval_contains(interval_expanded, loc):
+                continue
             ticks_to_draw.append(tick)
 
         return ticks_to_draw

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4570,6 +4570,25 @@ def test_set_get_ticklabels():
     ax[1].set_yticklabels(ax[0].get_yticklabels())
 
 
+def test_tick_label_update():
+    # test issue 9397
+
+    fig, ax = plt.subplots()
+
+    # Set up a dummy formatter
+    def formatter_func(x, pos):
+        return "unit value" if x == 1 else ""
+    ax.xaxis.set_major_formatter(plt.FuncFormatter(formatter_func))
+
+    # Force some of the x-axis ticks to be outside of the drawn range
+    ax.set_xticks([-1, 0, 1, 2, 3])
+    ax.set_xlim(-0.5, 2.5)
+
+    ax.figure.canvas.draw()
+    tick_texts = [tick.get_text() for tick in ax.xaxis.get_ticklabels()]
+    assert tick_texts == ["", "", "unit value", "", ""]
+
+
 @image_comparison(baseline_images=['o_marker_path_snap'], extensions=['png'],
                   savefig_kwarg={'dpi': 72})
 def test_o_marker_path_snap():


### PR DESCRIPTION
## PR Summary

Force the update of **all** the tick labels, even the ones that are not drawn. This addresses the issue #9397 where incorrect labels are returned when some ticks are outside of the displayed range. Please note that the fix idea is @anntzer's one.

## PR Checklist

- [x] Has Pytest style unit tests
- [?] Code is PEP 8 compliant _=> Well let's CI confirm ^^_ 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [?] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way _=> @tacaswell Should I add an entry?_

~~Milestoning it for 2.1.1 as it looks like a minor bugfix to me but feel free to postpone it to 2.2 if somebody thinks that it would be better.~~ (see edit)

Supplementary question: should I rebase against the 2.1.x branch?

**Edit:** re-milestoning it for v2.2, accordingly to what @dstansby suggested in #9397.