### PR TITLE
Documented the incompatibility of shrink and cax kwargs in colorbar.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -175,14 +175,9 @@ Additional keyword arguments are of two kinds:
 If *mappable* is a :class:`~matplotlib.contours.ContourSet`, its *extend*
 kwarg is included automatically.
 
-Note that the *shrink* kwarg provides a simple way to keep a vertical
-colorbar, for example, from being taller than the axes of the mappable
-to which the colorbar is attached; but it is a manual method requiring
-some trial and error. If the colorbar is too tall (or a horizontal
-colorbar is too wide) use a smaller value of *shrink*.
-Further, *shrink* and *cax* kwargs are incompatible with each other and
-*shrink* applies only if the colorbar makes its own Axes by sharing space
-with the Axes in which it resides.
+The *shrink* kwarg provides a simple way to scale the colorbar with respect
+to the axes. Note that if *cax* is specified it determines the size of the
+colorbar and *shrink* and *aspect* kwargs are ignored.
 
 For more precise control, you can manually specify the positions of
 the axes objects in which the mappable and the colorbar are drawn.  In

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -180,9 +180,9 @@ colorbar, for example, from being taller than the axes of the mappable
 to which the colorbar is attached; but it is a manual method requiring
 some trial and error. If the colorbar is too tall (or a horizontal
 colorbar is too wide) use a smaller value of *shrink*.
-Further *shrink* and *cax* kwargs are incompatible with each other and shrink
-applies only if the colorbar makes its own Axes by sharing space from the Axes
-in which the mappable resides.
+Further, *shrink* and *cax* kwargs are incompatible with each other and
+*shrink* applies only if the colorbar makes its own Axes by sharing space
+with the Axes in which it resides.
 
 For more precise control, you can manually specify the positions of
 the axes objects in which the mappable and the colorbar are drawn.  In

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -180,6 +180,9 @@ colorbar, for example, from being taller than the axes of the mappable
 to which the colorbar is attached; but it is a manual method requiring
 some trial and error. If the colorbar is too tall (or a horizontal
 colorbar is too wide) use a smaller value of *shrink*.
+Further *shrink* and *cax* kwargs are incompatible with each other and shrink
+applies only if the colorbar makes its own Axes by sharing space from the Axes
+in which the mappable resides.
 
 For more precise control, you can manually specify the positions of
 the axes objects in which the mappable and the colorbar are drawn.  In


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
