### PR TITLE
Property tables

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -538,9 +538,9 @@ class Artist(object):
 
         Parameters
         ----------
-        snap : Optional[bool]
+        snap : bool or None
             ..
-                ACCEPTS: Optional[bool]
+                ACCEPTS: bool or None
         """
         self._snap = snap
         self.stale = True
@@ -783,13 +783,13 @@ class Artist(object):
         """
         Force rasterized (bitmap) drawing in vector backend output.
 
-        Defaults to None, which implies the backend's default behavior
+        Defaults to None, which implies the backend's default behavior.
 
         Parameters
         ----------
-        rasterized : Optional[bool]
+        rasterized : bool or None
             ..
-                ACCEPTS: [True | False | None]
+                ACCEPTS: bool or None
         """
         if rasterized and not hasattr(self.draw, "_supports_rasterization"):
             warnings.warn("Rasterization of '%s' will be ignored" % self)

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -307,9 +307,8 @@ class Artist(object):
         Parameters
         ----------
         t : `~.Transform`
-
-        ..
-            ACCEPTS: `~.Transform`
+            ..
+                ACCEPTS: `~.Transform`
         """
         self._transform = t
         self._transformSet = True
@@ -377,7 +376,11 @@ class Artist(object):
         and *props* is a dictionary of properties you want returned
         with the contains test.
 
-        ACCEPTS: a callable function
+        Parameters
+        ----------
+        picker : callable
+            ..
+                ACCEPTS: a callable function
         """
         self._contains = picker
 
@@ -454,46 +457,51 @@ class Artist(object):
             artist, return *hit=True* and props is a dictionary of
             properties you want added to the PickEvent attributes.
 
-        ACCEPTS: [None|float|boolean|callable]
+        Parameters
+        ----------
+        picker : None or bool or float or callable
+            ..
+                ACCEPTS: [None | bool | float | callable]
         """
         self._picker = picker
 
     def get_picker(self):
-        'Return the picker object used by this artist'
+        """Return the picker object used by this artist."""
         return self._picker
 
     def is_figure_set(self):
-        """
-        Returns True if the artist is assigned to a
-        :class:`~matplotlib.figure.Figure`.
-        """
+        """Returns whether the artist is assigned to a `~.Figure`."""
         return self.figure is not None
 
     def get_url(self):
-        """
-        Returns the url
-        """
+        """Returns the url."""
         return self._url
 
     def set_url(self, url):
         """
-        Sets the url for the artist
+        Sets the url for the artist.
 
-        ACCEPTS: a url string
+        Parameters
+        ----------
+        url : str
+            ..
+                ACCEPTS: a url string
         """
         self._url = url
 
     def get_gid(self):
-        """
-        Returns the group id
-        """
+        """Returns the group id."""
         return self._gid
 
     def set_gid(self, gid):
         """
-        Sets the (group) id for the artist
+        Sets the (group) id for the artist.
 
-        ACCEPTS: an id string
+        Parameters
+        ----------
+        gid : str
+            ..
+                ACCEPTS: an id string
         """
         self._gid = gid
 
@@ -528,8 +536,11 @@ class Artist(object):
 
         Only supported by the Agg and MacOSX backends.
 
-        ..
-            ACCEPTS: Optional[bool]
+        Parameters
+        ----------
+        snap : Optional[bool]
+            ..
+                ACCEPTS: Optional[bool]
         """
         self._snap = snap
         self.stale = True
@@ -560,9 +571,6 @@ class Artist(object):
         """
         Sets the sketch parameters.
 
-        ..
-            ACCEPTS: (scale: float, length: float, randomness: float)
-
         Parameters
         ----------
 
@@ -578,6 +586,9 @@ class Artist(object):
         randomness : float, optional
             The scale factor by which the length is shrunken or
             expanded (default 16.0)
+
+            ..
+                ACCEPTS: (scale: float, length: float, randomness: float)
         """
         if scale is None:
             self._sketch = None
@@ -588,12 +599,11 @@ class Artist(object):
     def set_path_effects(self, path_effects):
         """Set the path effects.
 
-        ..
-            ACCEPTS: `~.AbstractPathEffect`
-
         Parameters
         ----------
         path_effects : `~.AbstractPathEffect`
+            ..
+                ACCEPTS: `~.AbstractPathEffect`
         """
         self._path_effects = path_effects
         self.stale = True
@@ -602,18 +612,18 @@ class Artist(object):
         return self._path_effects
 
     def get_figure(self):
-        """
-        Return the :class:`~matplotlib.figure.Figure` instance the
-        artist belongs to.
-        """
+        """Return the `~.Figure` instance the artist belongs to."""
         return self.figure
 
     def set_figure(self, fig):
         """
-        Set the :class:`~matplotlib.figure.Figure` instance the artist
-        belongs to.
+        Set the `~.Figure` instance the artist belongs to.
 
-        ACCEPTS: a :class:`matplotlib.figure.Figure` instance
+        Parameters
+        ----------
+        fig : `~.Figure`
+            ..
+                ACCEPTS: a `~.Figure` instance
         """
         # if this is a no-op just return
         if self.figure is fig:
@@ -633,9 +643,13 @@ class Artist(object):
 
     def set_clip_box(self, clipbox):
         """
-        Set the artist's clip :class:`~matplotlib.transforms.Bbox`.
+        Set the artist's clip `~.Bbox`.
 
-        ACCEPTS: a :class:`matplotlib.transforms.Bbox` instance
+        Parameters
+        ----------
+        clipbox : `~.Bbox`
+            ..
+                ACCEPTS: a `~.Bbox` instance
         """
         self.clipbox = clipbox
         self.pchanged()
@@ -656,9 +670,7 @@ class Artist(object):
         this method will set the clipping box to the corresponding rectangle
         and set the clipping path to ``None``.
 
-        ACCEPTS: [ (:class:`~matplotlib.path.Path`,
-        :class:`~matplotlib.transforms.Transform`) |
-        :class:`~matplotlib.patches.Patch` | None ]
+        ACCEPTS: [(`~matplotlib.path.Path`, `~.Transform`) | `~.Patch` | None]
         """
         from matplotlib.patches import Patch, Rectangle
 
@@ -741,7 +753,11 @@ class Artist(object):
         When False artists will be visible out side of the axes which
         can lead to unexpected results.
 
-        ACCEPTS: [True | False]
+        Parameters
+        ----------
+        b : bool
+            ..
+                ACCEPTS: bool
         """
         self._clipon = b
         # This may result in the callbacks being hit twice, but ensures they
@@ -760,7 +776,7 @@ class Artist(object):
             gc.set_clip_path(None)
 
     def get_rasterized(self):
-        "return True if the artist is to be rasterized"
+        """Return whether the artist is to be rasterized."""
         return self._rasterized
 
     def set_rasterized(self, rasterized):
@@ -769,7 +785,11 @@ class Artist(object):
 
         Defaults to None, which implies the backend's default behavior
 
-        ACCEPTS: [True | False | None]
+        Parameters
+        ----------
+        rasterized : Optional[bool]
+            ..
+                ACCEPTS: [True | False | None]
         """
         if rasterized and not hasattr(self.draw, "_supports_rasterization"):
             warnings.warn("Rasterization of '%s' will be ignored" % self)
@@ -783,15 +803,15 @@ class Artist(object):
     def set_agg_filter(self, filter_func):
         """Set the agg filter.
 
-        ..
-            ACCEPTS: a filter function, which takes a (m, n, 3) float array and
-            a dpi value, and returns a (m, n, 3) array
-
         Parameters
         ----------
         filter_func : callable
             A filter function, which takes a (m, n, 3) float array and a dpi
             value, and returns a (m, n, 3) array.
+
+            ..
+                ACCEPTS: a filter function, which takes a (m, n, 3) float array
+                and a dpi value, and returns a (m, n, 3) array
         """
         self._agg_filter = filter_func
         self.stale = True
@@ -807,7 +827,11 @@ class Artist(object):
         Set the alpha value used for blending - not supported on
         all backends.
 
-        ACCEPTS: float (0.0 transparent through 1.0 opaque)
+        Parameters
+        ----------
+        alpha : float
+            ..
+                ACCEPTS: float (0.0 transparent through 1.0 opaque)
         """
         self._alpha = alpha
         self.pchanged()
@@ -815,9 +839,13 @@ class Artist(object):
 
     def set_visible(self, b):
         """
-        Set the artist's visiblity.
+        Set the artist's visibility.
 
-        ACCEPTS: [True | False]
+        Parameters
+        ----------
+        b : bool
+            ..
+                ACCEPTS: bool
         """
         self._visible = b
         self.pchanged()
@@ -827,7 +855,11 @@ class Artist(object):
         """
         Set the artist's animation state.
 
-        ACCEPTS: [True | False]
+        Parameters
+        ----------
+        b : bool
+            ..
+                ACCEPTS: bool
         """
         if self._animated != b:
             self._animated = b
@@ -835,11 +867,10 @@ class Artist(object):
 
     def update(self, props):
         """
-        Update the properties of this :class:`Artist` from the
-        dictionary *prop*.
+        Update this artist's properties from the dictionary *prop*.
         """
         def _update_property(self, k, v):
-            """sorting out how to update property (setter or setattr)
+            """Sorting out how to update property (setter or setattr).
 
             Parameters
             ----------
@@ -847,6 +878,7 @@ class Artist(object):
                 The name of property to update
             v : obj
                 The value to assign to the property
+
             Returns
             -------
             ret : obj or None
@@ -877,28 +909,31 @@ class Artist(object):
         return ret
 
     def get_label(self):
-        """
-        Get the label used for this artist in the legend.
-        """
+        """Get the label used for this artist in the legend."""
         return self._label
 
     def set_label(self, s):
         """
         Set the label to *s* for auto legend.
 
-        ACCEPTS: string or anything printable with '%s' conversion.
+        Parameters
+        ----------
+        s : object
+            *s* will be converted to a string by calling `str` (`unicode` on
+            Py2).
+
+            ..
+                ACCEPTS: object
         """
         if s is not None:
-            self._label = '%s' % (s, )
+            self._label = six.text_type(s)
         else:
             self._label = None
         self.pchanged()
         self.stale = True
 
     def get_zorder(self):
-        """
-        Return the :class:`Artist`'s zorder.
-        """
+        """Return the artist's zorder."""
         return self.zorder
 
     def set_zorder(self, level):
@@ -906,7 +941,11 @@ class Artist(object):
         Set the zorder for the artist.  Artists with lower zorder
         values are drawn first.
 
-        ACCEPTS: any number
+        Parameters
+        ----------
+        level : float
+            ..
+                ACCEPTS: float
         """
         self.zorder = level
         self.pchanged()

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -302,10 +302,14 @@ class Artist(object):
 
     def set_transform(self, t):
         """
-        Set the :class:`~matplotlib.transforms.Transform` instance
-        used by this artist.
+        Set the artist transform.
 
-        ACCEPTS: :class:`~matplotlib.transforms.Transform` instance
+        Parameters
+        ----------
+        t : `~.Transform`
+
+        ..
+            ACCEPTS: `~.Transform`
         """
         self._transform = t
         self._transformSet = True
@@ -523,6 +527,9 @@ class Artist(object):
             segments, round to the nearest pixel center
 
         Only supported by the Agg and MacOSX backends.
+
+        ..
+            ACCEPTS: Optional[bool]
         """
         self._snap = snap
         self.stale = True
@@ -553,6 +560,9 @@ class Artist(object):
         """
         Sets the sketch parameters.
 
+        ..
+            ACCEPTS: (scale: float, length: float, randomness: float)
+
         Parameters
         ----------
 
@@ -576,9 +586,14 @@ class Artist(object):
         self.stale = True
 
     def set_path_effects(self, path_effects):
-        """
-        set path_effects, which should be a list of instances of
-        matplotlib.patheffect._Base class or its derivatives.
+        """Set the path effects.
+
+        ..
+            ACCEPTS: `~.AbstractPathEffect`
+
+        Parameters
+        ----------
+        path_effects : `~.AbstractPathEffect`
         """
         self._path_effects = path_effects
         self.stale = True
@@ -762,13 +777,21 @@ class Artist(object):
         self._rasterized = rasterized
 
     def get_agg_filter(self):
-        "return filter function to be used for agg filter"
+        """Return filter function to be used for agg filter."""
         return self._agg_filter
 
     def set_agg_filter(self, filter_func):
-        """
-        set agg_filter function.
+        """Set the agg filter.
 
+        ..
+            ACCEPTS: a filter function, which takes a (m, n, 3) float array and
+            a dpi value, and returns a (m, n, 3) array
+
+        Parameters
+        ----------
+        filter_func : callable
+            A filter function, which takes a (m, n, 3) float array and a dpi
+            value, and returns a (m, n, 3) array.
         """
         self._agg_filter = filter_func
         self.stale = True

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2203,23 +2203,20 @@ class _AxesBase(martist.Artist):
 
     def set_rasterization_zorder(self, z):
         """
-        Set zorder value below which artists will be rasterized.  Set to
-        ``None`` to disable rasterizing of artists below a particular zorder.
-
-        ..
-            ACCEPTS: Optional[float]
-
         Parameters
         ----------
-        z : Optional[float]
+        z : float or None
+            zorder below which artists are rasterized.  ``None`` means that
+            artists do not get rasterized based on zorder.
+
+            ..
+                ACCEPTS: float or None
         """
         self._rasterization_zorder = z
         self.stale = True
 
     def get_rasterization_zorder(self):
-        """
-        Get zorder value below which artists will be rasterized
-        """
+        """Return the zorder value below which artists will be rasterized."""
         return self._rasterization_zorder
 
     def autoscale(self, enable=True, axis='both', tight=None):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -618,9 +618,14 @@ class _AxesBase(martist.Artist):
 
     def set_figure(self, fig):
         """
-        Set the class:`~matplotlib.axes.Axes` figure
+        Set the `~.Figure` for this `~.Axes`.
 
-        accepts a class:`~matplotlib.figure.Figure` instance
+        ..
+            ACCEPTS: `~.Figure`
+
+        Parameters
+        ----------
+        fig : `~.Figure`
         """
         martist.Artist.set_figure(self, fig)
 
@@ -866,7 +871,6 @@ class _AxesBase(martist.Artist):
         used, but which may be modified by :meth:`apply_aspect`, and a
         second which is the starting point for :meth:`apply_aspect`.
 
-
         Optional keyword arguments:
           *which*
 
@@ -877,7 +881,6 @@ class _AxesBase(martist.Artist):
             'original'   to change the second
             'both'       to change both
             ==========   ====================
-
         """
         if not isinstance(pos, mtransforms.BboxBase):
             pos = mtransforms.Bbox.from_bounds(*pos)
@@ -894,10 +897,17 @@ class _AxesBase(martist.Artist):
 
     def set_axes_locator(self, locator):
         """
-        set axes_locator
+        Set the axes locator.
 
-        ACCEPT: a callable object which takes an axes instance and renderer and
-                 returns a bbox.
+        ..
+            ACCEPTS: a callable object which takes an axes instance and
+            renderer and returns a bbox.
+
+        Parameters
+        ----------
+        locator : callable
+            A locator function, which takes an axes and a renderer and returns
+            a bbox.
         """
         self._axes_locator = locator
         self.stale = True
@@ -1111,6 +1121,15 @@ class _AxesBase(martist.Artist):
     get_fc = get_facecolor
 
     def set_facecolor(self, color):
+        """Set the Axes facecolor.
+
+        ..
+            ACCEPTS: color
+
+        Parameters
+        ----------
+        color : color
+        """
         self._facecolor = color
         return self.patch.set_facecolor(color)
     set_fc = set_facecolor
@@ -1306,7 +1325,7 @@ class _AxesBase(martist.Artist):
           =====  ============
           value  description
           =====  ============
-          'C'    Center
+          'C'    center
           'SW'   bottom left
           'S'    bottom
           'SE'   bottom right
@@ -1317,6 +1336,9 @@ class _AxesBase(martist.Artist):
           'W'    left
           =====  ============
 
+        ..
+            ACCEPTS:
+            [ 'C' | 'SW' | 'S' | 'SE' | 'E' | 'NE' | 'N' | 'NW' | 'W' ]
         """
         if anchor in mtransforms.Bbox.coefs or len(anchor) == 2:
             self._anchor = anchor
@@ -2026,7 +2048,12 @@ class _AxesBase(martist.Artist):
         """
         Set whether autoscaling is applied on plot commands
 
-        accepts: [ *True* | *False* ]
+        ..
+            ACCEPTS: bool
+
+        Parameters
+        ----------
+        b : bool
         """
         self._autoscaleXon = b
         self._autoscaleYon = b
@@ -2035,7 +2062,12 @@ class _AxesBase(martist.Artist):
         """
         Set whether autoscaling for the x-axis is applied on plot commands
 
-        accepts: [ *True* | *False* ]
+        ..
+            ACCEPTS: bool
+
+        Parameters
+        ----------
+        b : bool
         """
         self._autoscaleXon = b
 
@@ -2043,7 +2075,12 @@ class _AxesBase(martist.Artist):
         """
         Set whether autoscaling for the y-axis is applied on plot commands
 
-        accepts: [ *True* | *False* ]
+        ..
+            ACCEPTS: bool
+
+        Parameters
+        ----------
+        b : bool
         """
         self._autoscaleYon = b
 
@@ -2076,7 +2113,12 @@ class _AxesBase(martist.Artist):
         *m* times the data interval will be added to each
         end of that interval before it is used in autoscaling.
 
-        accepts: float greater than -0.5
+        ..
+            ACCEPTS: float greater than -0.5
+
+        Parameters
+        ----------
+        m : float greater than -0.5
         """
         if m <= -0.5:
             raise ValueError("margin must be greater than -0.5")
@@ -2090,7 +2132,12 @@ class _AxesBase(martist.Artist):
         *m* times the data interval will be added to each
         end of that interval before it is used in autoscaling.
 
-        accepts: float greater than -0.5
+        ..
+            ACCEPTS: float greater than -0.5
+
+        Parameters
+        ----------
+        m : float greater than -0.5
         """
         if m <= -0.5:
             raise ValueError("margin must be greater than -0.5")
@@ -2156,9 +2203,15 @@ class _AxesBase(martist.Artist):
 
     def set_rasterization_zorder(self, z):
         """
-        Set zorder value below which artists will be rasterized.  Set
-        to `None` to disable rasterizing of artists below a particular
-        zorder.
+        Set zorder value below which artists will be rasterized.  Set to
+        ``None`` to disable rasterizing of artists below a particular zorder.
+
+        ..
+            ACCEPTS: Optional[float]
+
+        Parameters
+        ----------
+        z : Optional[float]
         """
         self._rasterization_zorder = z
         self.stale = True
@@ -2434,31 +2487,40 @@ class _AxesBase(martist.Artist):
 
     def get_frame_on(self):
         """
-        Get whether the axes rectangle patch is drawn
+        Get whether the axes rectangle patch is drawn.
         """
         return self._frameon
 
     def set_frame_on(self, b):
         """
-        Set whether the axes rectangle patch is drawn
+        Set whether the axes rectangle patch is drawn.
 
-        ACCEPTS: [ *True* | *False* ]
+        ..
+            ACCEPTS: bool
+
+        Parameters
+        ----------
+        b : bool
         """
         self._frameon = b
         self.stale = True
 
     def get_axisbelow(self):
         """
-        Get whether axis below is true or not
+        Get whether axis ticks and gridlines are above or below most artists.
         """
         return self._axisbelow
 
     def set_axisbelow(self, b):
         """
-        Set whether the axis ticks and gridlines are above or below most
-        artists
+        Set whether axis ticks and gridlines are above or below most artists.
 
-        ACCEPTS: [ *True* | *False* | 'line' ]
+        ..
+            ACCEPTS: [ bool | 'line' ]
+
+        Parameters
+        ----------
+        b : bool or 'line'
         """
         self._axisbelow = validate_axisbelow(b)
         self.stale = True
@@ -2776,8 +2838,12 @@ class _AxesBase(martist.Artist):
     def set_xbound(self, lower=None, upper=None):
         """
         Set the lower and upper numerical bounds of the x-axis.
+
         This method will honor axes inversion regardless of parameter order.
         It will not change the _autoscaleXon attribute.
+
+        ..
+            ACCEPTS: (lower: float, upper: float)
         """
         if upper is None and iterable(lower):
             lower, upper = lower
@@ -2840,6 +2906,9 @@ class _AxesBase(martist.Artist):
     def set_xlim(self, left=None, right=None, emit=True, auto=False, **kw):
         """
         Set the data limits for the x-axis
+
+        ..
+            ACCEPTS: (left: float, right: float)
 
         Parameters
         ----------
@@ -2949,7 +3018,10 @@ class _AxesBase(martist.Artist):
 
     def set_xscale(self, value, **kwargs):
         """
-        Set the x-axis scale
+        Set the x-axis scale.
+
+        ..
+            ACCEPTS: [ 'linear' | 'log' | 'symlog' | 'logit' | ... ]
 
         Parameters
         ----------
@@ -2992,10 +3064,13 @@ class _AxesBase(martist.Artist):
         """
         Set the x ticks with list of *ticks*
 
+        ..
+            ACCEPTS: list of tick locations.
+
         Parameters
         ----------
         ticks : list
-            List of x-axis tick locations
+            List of x-axis tick locations.
 
         minor : bool, optional
             If ``False`` sets major ticks, if ``True`` sets minor ticks.
@@ -3007,7 +3082,7 @@ class _AxesBase(martist.Artist):
 
     def get_xmajorticklabels(self):
         """
-        Get the xtick major labels
+        Get the major x tick labels.
 
         Returns
         -------
@@ -3019,7 +3094,7 @@ class _AxesBase(martist.Artist):
 
     def get_xminorticklabels(self):
         """
-        Get the x minor tick labels
+        Get the minor x tick labels.
 
         Returns
         -------
@@ -3056,7 +3131,10 @@ class _AxesBase(martist.Artist):
 
     def set_xticklabels(self, labels, fontdict=None, minor=False, **kwargs):
         """
-        Set the xtick labels with list of string labels
+        Set the x-tick labels with list of string labels.
+
+        ..
+            ACCEPTS: list of string labels
 
         Parameters
         ----------
@@ -3119,6 +3197,9 @@ class _AxesBase(martist.Artist):
         Set the lower and upper numerical bounds of the y-axis.
         This method will honor axes inversion regardless of parameter order.
         It will not change the _autoscaleYon attribute.
+
+        ..
+            ACCEPTS: (lower: float, upper: float)
         """
         if upper is None and iterable(lower):
             lower, upper = lower
@@ -3162,6 +3243,9 @@ class _AxesBase(martist.Artist):
     def set_ylim(self, bottom=None, top=None, emit=True, auto=False, **kw):
         """
         Set the data limits for the y-axis
+
+        ..
+            ACCEPTS: (bottom: float, top: float)
 
         Parameters
         ----------
@@ -3271,7 +3355,10 @@ class _AxesBase(martist.Artist):
 
     def set_yscale(self, value, **kwargs):
         """
-        Set the y-axis scale
+        Set the y-axis scale.
+
+        ..
+            ACCEPTS: [ 'linear' | 'log' | 'symlog' | 'logit' | ... ]
 
         Parameters
         ----------
@@ -3313,6 +3400,9 @@ class _AxesBase(martist.Artist):
         """
         Set the y ticks with list of *ticks*
 
+        ..
+            ACCEPTS: list of tick locations.
+
         Parameters
         ----------
         ticks : sequence
@@ -3327,7 +3417,7 @@ class _AxesBase(martist.Artist):
 
     def get_ymajorticklabels(self):
         """
-        Get the major y tick labels
+        Get the major y tick labels.
 
         Returns
         -------
@@ -3339,7 +3429,7 @@ class _AxesBase(martist.Artist):
 
     def get_yminorticklabels(self):
         """
-        Get the minor y tick labels
+        Get the minor y tick labels.
 
         Returns
         -------
@@ -3376,7 +3466,10 @@ class _AxesBase(martist.Artist):
 
     def set_yticklabels(self, labels, fontdict=None, minor=False, **kwargs):
         """
-        Set the y-tick labels with list of strings labels
+        Set the y-tick labels with list of strings labels.
+
+        ..
+            ACCEPTS: list of string labels
 
         Parameters
         ----------
@@ -3514,7 +3607,12 @@ class _AxesBase(martist.Artist):
         """
         Set whether the axes responds to navigation toolbar commands
 
-        ACCEPTS: [ *True* | *False* ]
+        ..
+            ACCEPTS: bool
+
+        Parameters
+        ----------
+        b : bool
         """
         self._navigate = b
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2210,14 +2210,17 @@ class YAxis(Axis):
         )
 
     def set_offset_position(self, position):
+        """
+        ..
+            ACCEPTS: [ 'left' | 'right' ]
+        """
         x, y = self.offsetText.get_position()
         if position == 'left':
             x = 0
         elif position == 'right':
             x = 1
         else:
-            msg = "Position accepts only [ 'left' | 'right' ]"
-            raise ValueError(msg)
+            raise ValueError("Position accepts only [ 'left' | 'right' ]")
 
         self.offsetText.set_ha(position)
         self.offsetText.set_position((x, y))

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -277,7 +277,15 @@ class ScalarMappable(object):
         return rgba
 
     def set_array(self, A):
-        'Set the image array from numpy array *A*'
+        """Set the image array from numpy array *A*.
+
+        ..
+            ACCEPTS: ndarray
+
+        Parameters
+        ----------
+        A : ndarray
+        """
         self._A = A
         self.update_dict['array'] = True
 
@@ -323,7 +331,15 @@ class ScalarMappable(object):
         self.changed()
 
     def set_norm(self, norm):
-        'set the normalization instance'
+        """Set the normalization instance.
+
+        ..
+            ACCEPTS: `~.Normalize`
+
+        Parameters
+        ----------
+        norm : `~.Normalize`
+        """
         if norm is None:
             norm = colors.Normalize()
         self.norm = norm

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -373,13 +373,13 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
     def set_urls(self, urls):
         """
-        ..
-            ACCEPTS: Optional[Iterable[str]]
+        Parameters
+        ----------
+        urls : List[str] or None
+            ..
+                ACCEPTS: List[str] or None
         """
-        if urls is None:
-            self._urls = [None, ]
-        else:
-            self._urls = urls
+        self._urls = urls if urls is not None else [None]
         self.stale = True
 
     def get_urls(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -327,6 +327,16 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self.stale = False
 
     def set_pickradius(self, pr):
+        """Set the pick radius used for containment tests.
+
+        ..
+            ACCEPTS: float distance in points
+
+        Parameters
+        ----------
+        d : float
+            Pick radius, in points.
+        """
         self._pickradius = pr
 
     def get_pickradius(self):
@@ -362,6 +372,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
         return len(ind) > 0, dict(ind=ind)
 
     def set_urls(self, urls):
+        """
+        ..
+            ACCEPTS: Optional[Iterable[str]]
+        """
         if urls is None:
             self._urls = [None, ]
         else:
@@ -440,6 +454,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
         been applied, that is, the offsets are in screen coordinates.
         If offset_position is 'data', the offset is applied before the
         master transform, i.e., the offsets are in data coordinates.
+
+        ..
+            ACCEPTS: [ 'screen' | 'data' ]
         """
         if offset_position not in ('screen', 'data'):
             raise ValueError("offset_position must be 'screen' or 'data'")

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -618,7 +618,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         """
         Retained for backwards compatibility - use set_data instead
 
-        ACCEPTS: numpy array A or PIL Image"""
+        ACCEPTS: numpy array A or PIL Image
+        """
         # This also needs to be here to override the inherited
         # cm.ScalarMappable.set_array method so it is not invoked
         # by mistake.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -512,9 +512,15 @@ class Line2D(Artist):
         return self.pickradius
 
     def set_pickradius(self, d):
-        """Sets the pick radius used for containment tests
+        """Set the pick radius used for containment tests.
 
-        ACCEPTS: float distance in points
+        ..
+            ACCEPTS: float distance in points
+
+        Parameters
+        ----------
+        d : float
+            Pick radius, in points.
         """
         self.pickradius = d
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -27,36 +27,6 @@ from matplotlib.bezier import split_path_inout, get_cos_sin
 from matplotlib.bezier import make_path_regular, concatenate_paths
 
 
-# these are not available for the object inspector until after the
-# class is built so we define an initial set here for the init
-# function and they will be overridden after object definition
-docstring.interpd.update(Patch="""
-
-          =================   ==============================================
-          Property            Description
-          =================   ==============================================
-          alpha               float
-          animated            [True | False]
-          antialiased or aa   [True | False]
-          capstyle            ['butt' | 'round' | 'projecting']
-          clip_box            a matplotlib.transform.Bbox instance
-          clip_on             [True | False]
-          edgecolor or ec     any matplotlib color
-          facecolor or fc     any matplotlib color
-          figure              a matplotlib.figure.Figure instance
-          fill                [True | False]
-          hatch               unknown
-          joinstyle           ['miter' | 'round' | 'bevel']
-          label               any string
-          linewidth or lw     float
-          lod                 [True | False]
-          transform           a matplotlib.transform transformation instance
-          visible             [True | False]
-          zorder              any number
-          =================   ==============================================
-
-          """)
-
 _patch_alias_map = {
         'antialiased': ['aa'],
         'edgecolor': ['ec'],

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -245,4 +245,4 @@ def test_setp():
     # Check `file` argument
     sio = io.StringIO()
     plt.setp(lines1, 'zorder', file=sio)
-    assert sio.getvalue() == '  zorder: any number \n'
+    assert sio.getvalue() == '  zorder: float \n'

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -246,11 +246,17 @@ class Text(Artist):
 
     def set_rotation_mode(self, m):
         """
-        set text rotation mode. If "anchor", the un-rotated text
-        will first aligned according to their *ha* and
-        *va*, and then will be rotated with the alignement
-        reference point as a origin. If None (default), the text will be
-        rotated first then will be aligned.
+        Set text rotation mode.
+
+        ..
+            ACCEPTS: [ None | "default" | "anchor" ]
+
+        Parameters
+        ----------
+        m : ``None`` or ``"default"`` or ``"anchor"``
+            If ``None`` or ``"default"``, the text will be first rotated, then
+            aligned according to their horizontal and vertical alignments.  If
+            ``"anchor"``, then alignment occurs before rotation.
         """
         if m is None or m in ["anchor", "default"]:
             self._rotation_mode = m
@@ -583,8 +589,14 @@ class Text(Artist):
         return self._wrap
 
     def set_wrap(self, wrap):
-        """
-        Sets the wrapping state for the text.
+        """Sets the wrapping state for the text.
+
+        ..
+            ACCEPTS: bool
+
+        Parameters
+        ----------
+        wrap : bool
         """
         self._wrap = wrap
 
@@ -1207,10 +1219,13 @@ class Text(Artist):
 
     def set_usetex(self, usetex):
         """
-        Set this `Text` object to render using TeX (or not).
+        Set whether to render using TeX.
 
-        If `None` is given, the option will be reset to use the value of
-        `rcParams['text.usetex']`
+        If ``None`` is given, the option will be reset to use the value of
+        ``rcParams['text.usetex']``.
+
+        ..
+            ACCEPTS: Optional[bool]
         """
         if usetex is None:
             self._usetex = rcParams['text.usetex']

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1219,13 +1219,14 @@ class Text(Artist):
 
     def set_usetex(self, usetex):
         """
-        Set whether to render using TeX.
+        Parameters
+        ----------
+        usetex : bool or None
+            Whether to render using TeX, ``None`` means to use the
+            ``rcParams['text.usetex']``.
 
-        If ``None`` is given, the option will be reset to use the value of
-        ``rcParams['text.usetex']``.
-
-        ..
-            ACCEPTS: Optional[bool]
+            ..
+                ACCEPTS: bool or None
         """
         if usetex is None:
             self._usetex = rcParams['text.usetex']

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -46,8 +46,7 @@ def _process_text_args(override, fontdict=None, **kwargs):
 
 @contextlib.contextmanager
 def _wrap_text(textobj):
-    """
-    Temporarily inserts newlines to the text if the wrap option is enabled.
+    """Temporarily inserts newlines to the text if the wrap option is enabled.
     """
     if textobj.get_wrap():
         old_text = textobj.get_text()
@@ -82,62 +81,6 @@ def get_rotation(rotation):
                              "None".format(rotation))
 
     return angle % 360
-# these are not available for the object inspector until after the
-# class is build so we define an initial set here for the init
-# function and they will be overridden after object defn
-docstring.interpd.update(Text="""
-    ========================== ================================================
-    Property                   Value
-    ========================== ================================================
-    alpha                      float or None
-    animated                   [True | False]
-    backgroundcolor            any matplotlib color
-    bbox                       rectangle prop dict plus key 'pad' which is a
-                               pad in points; if a boxstyle is supplied as
-                               a string, then pad is instead a fraction
-                               of the font size
-    clip_box                   a matplotlib.transform.Bbox instance
-    clip_on                    [True | False]
-    color                      any matplotlib color
-    family                     ['serif' | 'sans-serif' | 'cursive' |
-                                'fantasy' | 'monospace']
-    figure                     a matplotlib.figure.Figure instance
-    fontproperties             a matplotlib.font_manager.FontProperties
-                               instance
-    horizontalalignment or ha  ['center' | 'right' | 'left']
-    label                      any string
-    linespacing                float
-    lod                        [True | False]
-    multialignment             ['left' | 'right' | 'center' ]
-    name or fontname           string e.g.,
-                               ['Sans' | 'Courier' | 'Helvetica' ...]
-    position                   (x,y)
-    rotation                   [ angle in degrees 'vertical' | 'horizontal'
-    rotation_mode              [ None | 'anchor']
-    size or fontsize           [size in points | relative size e.g., 'smaller',
-                                                                  'x-large']
-    style or fontstyle         [ 'normal' | 'italic' | 'oblique']
-    text                       string
-    transform                  a matplotlib.transform transformation instance
-    usetex                     [True | False | None]
-    variant                    ['normal' | 'small-caps']
-    verticalalignment or va    ['center' | 'top' | 'bottom' | 'baseline' |
-                                'center_baseline' ]
-    visible                    [True | False]
-    weight or fontweight       ['normal' | 'bold' | 'heavy' | 'light' |
-                                'ultrabold' | 'ultralight']
-    wrap                       [True | False]
-    x                          float
-    y                          float
-    zorder                     any number
-    ========================== ===============================================
-    """)
-
-# TODO : This function may move into the Text class as a method. As a
-# matter of fact, The information from the _get_textbox function
-# should be available during the Text._get_layout() call, which is
-# called within the _get_textbox. So, it would better to move this
-# function as a method with some refactoring of _get_layout method.
 
 
 def _get_textbox(text, renderer):
@@ -146,6 +89,11 @@ def _get_textbox(text, renderer):
     :meth:`matplotlib.text.Text.get_extents` method, The bbox size of
     the text before the rotation is calculated.
     """
+    # TODO : This function may move into the Text class as a method. As a
+    # matter of fact, The information from the _get_textbox function
+    # should be available during the Text._get_layout() call, which is
+    # called within the _get_textbox. So, it would better to move this
+    # function as a method with some refactoring of _get_layout method.
 
     projected_xs = []
     projected_ys = []


### PR DESCRIPTION
As mentoned by @efiring in https://github.com/matplotlib/matplotlib/issues/9414#issuecomment-336742969, the "unknown" entries in the property tables are rather, hum, unsightly.  Fix this by adding ACCEPTS entries to the relevant setters (or at least most of them).  Also added a numpydoc Parameters table when appropriate.

I can't say I particularly like the approach, but it's what we have right now.  The "dot dot" syntax puts the entry in a rst comment, so they won't appear in the rendered docs.  I would also have preferred putting them *after* the numpydoc Parameters table, but numpydoc is apparently unaware that these are comments, and think that they are documentation for an argument named `..`.

Also deleted some useless explicit renderings of the table (Text and Patch) -- these get overwritten after the corresponding artist class is fully defined.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
