### PR TITLE
Fix multiple unreferenced local variable warnings

### DIFF
--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -378,7 +378,7 @@ PyRendererAgg_draw_path_collection(PyRendererAgg *self, PyObject *args, PyObject
                                                 antialiaseds,
                                                 offset_position)));
     }
-    catch (py::exception &e)
+    catch (const py::exception &)
     {
         return NULL;
     }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -283,7 +283,7 @@ static PyObject *Py_get_path_collection_extents(PyObject *self, PyObject *args, 
                  (get_path_collection_extents(
                      master_transform, paths, transforms, offsets, offset_trans, e)));
     }
-    catch (py::exception &e)
+    catch (const py::exception &)
     {
         return NULL;
     }
@@ -351,7 +351,7 @@ static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args, PyO
                                            offset_position,
                                            result)));
     }
-    catch (py::exception &e)
+    catch (const py::exception &)
     {
         return NULL;
     }

--- a/src/py_exceptions.h
+++ b/src/py_exceptions.h
@@ -23,7 +23,7 @@ class exception : public std::exception
     {                                                                        \
         a;                                                                   \
     }                                                                        \
-    catch (const py::exception &e)                                           \
+    catch (const py::exception &)                                            \
     {                                                                        \
         {                                                                    \
             cleanup;                                                         \


### PR DESCRIPTION
Complete list of these warnings:
```
    src/ft2font_wrapper.cpp(53): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(78): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(97): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(530): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(554): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(573): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(591): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(609): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(632): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(686): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(731): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(769): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(788): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(803): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(819): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(840): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(860): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(900): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(919): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(1071): warning C4101: 'e': unreferenced local variable
    src/ft2font_wrapper.cpp(1431): warning C4101: 'e': unreferenced local variable
    src/_image_wrapper.cpp(389): warning C4101: 'e': unreferenced local variable
    src/_image_wrapper.cpp(434): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(52): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(85): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(111): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(144): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(163): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(164): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(212): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(232): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(284): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(286): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(352): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(354): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(390): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(418): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(442): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(450): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(476): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(505): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(509): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(513): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(548): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(584): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(648): warning C4101: 'e': unreferenced local variable
    src/_path_wrapper.cpp(731): warning C4101: 'e': unreferenced local variable
    src/_contour_wrapper.cpp(68): warning C4101: 'e': unreferenced local variable
    src/_contour_wrapper.cpp(91): warning C4101: 'e': unreferenced local variable
    src/_contour_wrapper.cpp(118): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(91): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(122): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(134): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(151): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(179): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(265): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(289): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(316): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(391): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(423): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(435): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(446): warning C4101: 'e': unreferenced local variable
    lib/matplotlib/tri/_tri_wrapper.cpp(457): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(87): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(189): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(224): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(249): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(285): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(312): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(379): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(381): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(434): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(475): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(522): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(538): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(554): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(570): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(580): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(623): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(638): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(665): warning C4101: 'e': unreferenced local variable
    src/_backend_agg_wrapper.cpp(667): warning C4101: 'e': unreferenced local variable
```