### PR TITLE
Avoid dividing by zero in AutoMinorLocator (fixes #8804)

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -80,6 +80,26 @@ class TestAutoMinorLocator(object):
                                0.95, 1, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35])
         assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), test_value)
 
+    # NB: the following values are assuming that *xlim* is [0, 5]
+    params = [
+        (0, 0),  # no major tick => no minor tick either
+        (1, 0),  # a single major tick => no minor tick
+        (2, 4),  # 1 "nice" major step => 1*5 minor **divisions**
+        (3, 6)   # 2 "not nice" major steps => 2*4 minor **divisions**
+    ]
+
+    @pytest.mark.parametrize('nb_majorticks, expected_nb_minorticks', params)
+    def test_low_number_of_majorticks(
+            self, nb_majorticks, expected_nb_minorticks):
+        # This test is related to issue #8804
+        fig, ax = plt.subplots()
+        xlims = (0, 5)  # easier to test the different code paths
+        ax.set_xlim(*xlims)
+        ax.set_xticks(np.linspace(xlims[0], xlims[1], nb_majorticks))
+        ax.minorticks_on()
+        ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
+        assert len(ax.xaxis.get_minorticklocs()) == expected_nb_minorticks
+
 
 class TestLogLocator(object):
     def test_basic(self):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2524,18 +2524,14 @@ class AutoMinorLocator(Locator):
             # TODO: Figure out a way to still be able to display minor
             # ticks without two major ticks visible. For now, just display
             # no ticks at all.
-            majorstep = 0
+            return []
 
         if self.ndivs is None:
-            if majorstep == 0:
-                # TODO: Need a better way to figure out ndivs
-                ndivs = 1
+            x = int(np.round(10 ** (np.log10(majorstep) % 1)))
+            if x in [1, 5, 10]:
+                ndivs = 5
             else:
-                x = int(np.round(10 ** (np.log10(majorstep) % 1)))
-                if x in [1, 5, 10]:
-                    ndivs = 5
-                else:
-                    ndivs = 4
+                ndivs = 4
         else:
             ndivs = self.ndivs
 
@@ -2545,15 +2541,12 @@ class AutoMinorLocator(Locator):
         if vmin > vmax:
             vmin, vmax = vmax, vmin
 
-        if len(majorlocs) > 0:
-            t0 = majorlocs[0]
-            tmin = ((vmin - t0) // minorstep + 1) * minorstep
-            tmax = ((vmax - t0) // minorstep + 1) * minorstep
-            locs = np.arange(tmin, tmax, minorstep) + t0
-            cond = np.abs((locs - t0) % majorstep) > minorstep / 10.0
-            locs = locs.compress(cond)
-        else:
-            locs = []
+        t0 = majorlocs[0]
+        tmin = ((vmin - t0) // minorstep + 1) * minorstep
+        tmax = ((vmax - t0) // minorstep + 1) * minorstep
+        locs = np.arange(tmin, tmax, minorstep) + t0
+        cond = np.abs((locs - t0) % majorstep) > minorstep / 10.0
+        locs = locs.compress(cond)
 
         return self.raise_if_exceeds(np.array(locs))
 


### PR DESCRIPTION
## PR Summary

Get rid of 2 `DivisionByZero` warnings by performing an proper early return, which prevents the case noticed by @ffteja in #8804 from happening.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way