### PR TITLE
FIX: provide __ne__ implementation for transforms in py2

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5353,3 +5353,19 @@ def test_patch_deprecations():
         assert fig.patch == fig.figurePatch
 
     assert len(w) == 2
+
+
+def test_polar_gridlines():
+    fig = plt.figure()
+    ax = fig.add_subplot(111, polar=True)
+
+    # make all major grid lines lighter, only x grid lines set in 2.1.0
+    ax.grid(alpha=0.2)
+
+    # hide y tick labels, no effect in 2.1.0
+    plt.setp(ax.yaxis.get_ticklabels(), visible=False)
+
+    fig.canvas.draw()
+
+    assert ax.xaxis.majorTicks[0].gridline.get_alpha() == .2
+    assert ax.yaxis.majorTicks[0].gridline.get_alpha() == .2

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1287,6 +1287,10 @@ class Transform(TransformNode):
     # override `__eq__`), but some subclasses, such as TransformWrapper &
     # AffineBase, override this behavior.
 
+    if six.PY2:
+        def __ne__(self, other):
+            return not (self == other)
+
     def _iter_break_from_left_to_right(self):
         """
         Returns an iterator breaking down this transform stack from left to


### PR DESCRIPTION
Closes #9455

The issue is that due to `!=` not defaulting to `not a == b` in
python2 (unlike python3) an internal check was failing and the y
ticks (aka the radial ticks) were being regenerated on every draw
and the alpha settings did not properly propagate.

This fix is a band-aid to make the behavior the same on all versions
of python.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
