### PR TITLE
FIX: PyQt versions where showing the Qt versions

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -2080,7 +2080,7 @@ def backend_pyqt4_internal_check(self):
 
     try:
         qt_version = QtCore.QT_VERSION
-        pyqt_version_str = QtCore.QT_VERSION_STR
+        pyqt_version_str = QtCore.PYQT_VERSION_STR
     except AttributeError:
         raise CheckFailed('PyQt4 not correctly imported')
     else:
@@ -2130,7 +2130,7 @@ def backend_pyqt5_internal_check(self):
 
     try:
         qt_version = QtCore.QT_VERSION
-        pyqt_version_str = QtCore.QT_VERSION_STR
+        pyqt_version_str = QtCore.PYQT_VERSION_STR
     except AttributeError:
         raise CheckFailed('PyQt5 not correctly imported')
     else:


### PR DESCRIPTION
This fixes the correct versions shown.

See #9040 for details.

## PR Summary

The PyQt versions shown when building was referring to the Qt library (C-library) and was not reflecting the used PyQt version which sometimes is different. This corrects this inconsistency (but shouldn't matter, build wise).