### PR TITLE
documentation fix regarding contour and tricontour (#9088)

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1672,7 +1672,7 @@ class QuadContourSet(ContourSet):
           contour(Z,N)
           contour(X,Y,Z,N)
 
-        contour up to *N+1* automatically chosed contour levels
+        contour up to *N+1* automatically chosen contour levels
         (*N* intervals).
 
         ::

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1672,7 +1672,9 @@ class QuadContourSet(ContourSet):
           contour(Z,N)
           contour(X,Y,Z,N)
 
-        contour up to *N* automatically-chosen levels.
+        contour up to *N+1* automatically-chosen levels.
+        If exactly *N* levels are required either *V* or an
+        optional :class:`~matplotlib.ticker.Locator` can be passed.
 
         ::
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1672,7 +1672,8 @@ class QuadContourSet(ContourSet):
           contour(Z,N)
           contour(X,Y,Z,N)
 
-        contour up to *N+1* automatically chosed contour levels (*N* intervals).
+        contour up to *N+1* automatically chosed contour levels
+        (*N* intervals).
 
         ::
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1672,9 +1672,7 @@ class QuadContourSet(ContourSet):
           contour(Z,N)
           contour(X,Y,Z,N)
 
-        contour up to *N+1* automatically-chosen levels.
-        If exactly *N* levels are required either *V* or an
-        optional :class:`~matplotlib.ticker.Locator` can be passed.
+        contour up to *N+1* automatically chosed contour levels (*N* intervals).
 
         ::
 

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -132,7 +132,9 @@ class TriContourSet(ContourSet):
 
           tricontour(..., Z, N)
 
-        contour *N* automatically-chosen levels.
+        contour up to *N+1* automatically-chosen levels.
+        If exactly *N* levels are required either *V* or an
+        optional :class:`~matplotlib.ticker.Locator` can be passed.
 
         ::
 

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -132,7 +132,8 @@ class TriContourSet(ContourSet):
 
           tricontour(..., Z, N)
 
-        contour up to *N+1* automatically chosed contour levels (*N* intervals).
+        contour up to *N+1* automatically chosed contour levels
+        (*N* intervals).
 
         ::
 

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -132,7 +132,7 @@ class TriContourSet(ContourSet):
 
           tricontour(..., Z, N)
 
-        contour up to *N+1* automatically chosed contour levels
+        contour up to *N+1* automatically chosen contour levels
         (*N* intervals).
 
         ::

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -132,9 +132,7 @@ class TriContourSet(ContourSet):
 
           tricontour(..., Z, N)
 
-        contour up to *N+1* automatically-chosen levels.
-        If exactly *N* levels are required either *V* or an
-        optional :class:`~matplotlib.ticker.Locator` can be passed.
+        contour up to *N+1* automatically chosed contour levels (*N* intervals).
 
         ::
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

I have changed the doc string of `contour` and `tricontour` to address the issue raised in (#9088).
Regarding the ambiguous number of levels.


<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

The change clarifies what `N` does in the contour functions and states that it can be as high
as `N+1` which would otherwise be surprising.

<!--If it fixes an open issue, please link to the issue here.-->
Related issue: #9088

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant 
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
