### PR TITLE
Changes to better highlight development-workflow in docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,15 @@
 <!--Thank you so much for your PR! To help us review, fill out the form
 to the best of your ability.  Please make use of the development guide at
-https://matplotlib.org/devdocs/devel/index.html-->
+https://matplotlib.org/devdocs/devel/index.html
+
+For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html
+
+Please do not create the PR out of master, but out of a separate branch. -->
 
 <!--Provide a general summary of your changes in the title above, for
 example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
 non-descriptive titles such as "Addresses issue #8576".-->
 
-<!--If you are able to do so, please do not create the
-PR out of master, but out of a separate branch.  See
-https://matplotlib.org/devel/gitwash/development_workflow.html for
-instructions.-->
 
 ## PR Summary
 
@@ -21,7 +21,7 @@ detail.  Why is this change required?  What problem does it solve?-->
 ## PR Checklist
 
 - [ ] Has Pytest style unit tests
-- [ ] Code is PEP 8 compliant 
+- [ ] Code is PEP 8 compliant
 - [ ] New features are documented, with examples if plot related
 - [ ] Documentation is sphinx and numpydoc compliant
 - [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -155,7 +155,12 @@ How to contribute
 
 The preferred way to contribute to Matplotlib is to fork the `main
 repository <https://github.com/matplotlib/matplotlib/>`__ on GitHub,
-then submit a "pull request" (PR):
+then submit a "pull request" (PR).
+
+The best practices for using GitHub to make PRs to Matplotlib are
+documented in the :ref:`development-workflow` section. 
+
+A brief overview is:
 
  1. `Create an account <https://github.com/join>`_ on
     GitHub if you do not already have one.


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the
PR out of master, but out of a separate branch.  See
https://matplotlib.org/devel/gitwash/development_workflow.html for
instructions.-->

## PR Summary

The full instructions to use github are at `:ref:development-workflow`, but this is not linked in 
`dev/Contributing` except in a `seealso::`

The link in the PR template was there but was just in reference to whether I should create out of a separate branch or not.  Of course the link is much more informative than that.


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Code is PEP 8 compliant 
- [x] Documentation is sphinx and numpydoc compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->