### PR TITLE
Apply hinting factor rcParam in all cases.

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -267,9 +267,7 @@ class RendererAgg(RendererBase):
         Get the font for text instance t, cacheing for efficiency
         """
         fname = findfont(prop)
-        font = get_font(
-            fname,
-            hinting_factor=rcParams['text.hinting_factor'])
+        font = get_font(fname)
 
         font.clear()
         size = prop.get_size_in_points()

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1366,7 +1366,12 @@ fontManager = None
 _fmcache = None
 
 
-get_font = lru_cache(64)(ft2font.FT2Font)
+_get_font = lru_cache(64)(ft2font.FT2Font)
+
+def get_font(filename, hinting_factor=None):
+    if hinting_factor is None:
+        hinting_factor = rcParams['text.hinting_factor']
+    return _get_font(filename, hinting_factor)
 
 
 # The experimental fontconfig-based backend.

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import warnings
 
+import numpy as np
 import pytest
 
 from matplotlib.font_manager import (
@@ -86,3 +87,22 @@ def test_otf():
 @pytest.mark.skipif(not has_fclist, reason='no fontconfig installed')
 def test_get_fontconfig_fonts():
     assert len(get_fontconfig_fonts()) > 1
+
+
+@pytest.mark.parametrize('factor', [2, 4, 6, 8])
+def test_hinting_factor(factor):
+    font = findfont(FontProperties(family=["sans-serif"]))
+
+    font1 = get_font(font, hinting_factor=1)
+    font1.clear()
+    font1.set_size(12, 100)
+    font1.set_text('abc')
+    expected = font1.get_width_height()
+
+    hinted_font = get_font(font, hinting_factor=factor)
+    hinted_font.clear()
+    hinted_font.set_size(12, 100)
+    hinted_font.set_text('abc')
+    # Check that hinting only changes text layout by a small (10%) amount.
+    np.testing.assert_allclose(hinted_font.get_width_height(), expected,
+                               rtol=0.1)

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -2,6 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
+
+import io
 import warnings
 
 import numpy as np
@@ -448,3 +450,17 @@ def test_nonfinite_pos():
     ax.text(0, np.nan, 'nan')
     ax.text(np.inf, 0, 'inf')
     fig.canvas.draw()
+
+
+def test_hinting_factor_backends():
+    plt.rcParams['text.hinting_factor'] = 1
+    fig = plt.figure()
+    t = fig.text(0.5, 0.5, 'some text')
+
+    fig.savefig(io.BytesIO(), format='svg')
+    expected = t.get_window_extent().intervalx
+
+    fig.savefig(io.BytesIO(), format='png')
+    # Backends should apply hinting_factor consistently (within 10%).
+    np.testing.assert_allclose(t.get_window_extent().intervalx, expected,
+                               rtol=0.1)

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -515,7 +515,7 @@ FT2Font::FT2Font(FT_Open_Args &open_args, long hinting_factor_) : image(), face(
         face->face_flags |= FT_FACE_FLAG_EXTERNAL_STREAM;
     }
 
-    static FT_Matrix transform = { 65536 / hinting_factor, 0, 0, 65536 };
+    FT_Matrix transform = { 65536 / hinting_factor, 0, 0, 65536 };
     FT_Set_Transform(face, &transform, 0);
 }
 
@@ -548,7 +548,7 @@ void FT2Font::set_size(double ptsize, double dpi)
 {
     int error = FT_Set_Char_Size(
         face, (long)(ptsize * 64), 0, (unsigned int)(dpi * hinting_factor), (unsigned int)dpi);
-    static FT_Matrix transform = { 65536 / hinting_factor, 0, 0, 65536 };
+    FT_Matrix transform = { 65536 / hinting_factor, 0, 0, 65536 };
     FT_Set_Transform(face, &transform, 0);
 
     if (error) {


### PR DESCRIPTION
This is only explicitly used in Agg, so any other users get the default in the C++ code. Thus if you modify this setting and use some other backend, you get very weird behaviour. Positioning sometimes breaks and glyphs are shrunk or cropped.

@anntzer this is why just changing a random `hinting_factor` produced super-weird results yesterday.

Don't know if it's worth backporting; I guess no-one ever tried modifying this setting or they would have complained. Also, trying to see if a simple test of some sort can be done.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [?] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way