### PR TITLE
DOC Demote container headings one level Artist tutorial (minor)

### DIFF
--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -280,7 +280,7 @@ plt.show()
 # .. _figure-container:
 #
 # Figure container
-# ================
+# ----------------
 #
 # The top level container ``Artist`` is the
 # :class:`matplotlib.figure.Figure`, and it contains everything in the
@@ -366,7 +366,7 @@ plt.show()
 # .. _axes-container:
 #
 # Axes container
-# ==============
+# --------------
 #
 # The :class:`matplotlib.axes.Axes` is the center of the matplotlib
 # universe -- it contains the vast majority of all the ``Artists`` used
@@ -544,7 +544,7 @@ plt.show()
 # .. _axis-container:
 #
 # Axis containers
-# ===============
+# ---------------
 #
 # The :class:`matplotlib.axis.Axis` instances handle the drawing of the
 # tick lines, the grid lines, the tick labels and the axis label.  You
@@ -648,7 +648,7 @@ plt.show()
 # .. _tick-container:
 #
 # Tick containers
-# ===============
+# ---------------
 #
 # The :class:`matplotlib.axis.Tick` is the final container object in our
 # descent from the :class:`~matplotlib.figure.Figure` to the


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

Minor Change: `intermediate/artist.rst` tutorial had "Object Containers" and then "Figure Container", "Axes Container" etc right after at the same heading level.  This demotes them a level..

<!--If it fixes an open issue, please link to the issue here.-->

