### PR TITLE
Improve test_backend_svg.test_determinism.

### DIFF
--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -152,7 +152,12 @@ def _test_determinism_save(filename, usetex):
     FigureCanvasSVG(fig).print_svg(filename)
 
 
-def _test_determinism(filename, usetex):
+@pytest.mark.parametrize(
+    "filename, usetex",
+    # unique filenames to allow for parallel testing
+    [("determinism_notex.svg", False),
+     needs_usetex(("determinism_tex.svg", True))])
+def test_determinism(filename, usetex):
     import sys
     from subprocess import check_output, STDOUT, CalledProcessError
     plots = []
@@ -160,37 +165,28 @@ def _test_determinism(filename, usetex):
         # Using check_output and setting stderr to STDOUT will capture the real
         # problem in the output property of the exception
         try:
-            check_output([sys.executable, '-R', '-c',
-                          'import matplotlib; '
-                          'matplotlib._called_from_pytest = True;'
-                          'matplotlib.use("svg"); '
-                          'from matplotlib.tests.test_backend_svg '
-                          'import _test_determinism_save;'
-                          '_test_determinism_save(%r, %r)' % (filename,
-                                                              usetex)],
-                         stderr=STDOUT)
+            check_output(
+                [sys.executable, '-R', '-c',
+                 'import matplotlib; '
+                 'matplotlib._called_from_pytest = True; '
+                 'matplotlib.use("svg"); '
+                 'from matplotlib.tests.test_backend_svg '
+                 'import _test_determinism_save;'
+                 '_test_determinism_save(%r, %r)' % (filename, usetex)],
+                stderr=STDOUT)
         except CalledProcessError as e:
             # it's easier to use utf8 and ask for forgiveness than try
             # to figure out what the current console has as an
             # encoding :-/
             print(e.output.decode(encoding="utf-8", errors="ignore"))
             raise e
-        with open(filename, 'rb') as fd:
-            plots.append(fd.read())
-        os.unlink(filename)
+        else:
+            with open(filename, 'rb') as fd:
+                plots.append(fd.read())
+        finally:
+            os.unlink(filename)
     for p in plots[1:]:
         assert p == plots[0]
-
-
-def test_determinism_notex():
-    # unique filename to allow for parallel testing
-    _test_determinism('determinism_notex.svg', usetex=False)
-
-
-@needs_usetex
-def test_determinism_tex():
-    # unique filename to allow for parallel testing
-    _test_determinism('determinism_tex.svg', usetex=True)
 
 
 @needs_usetex


### PR DESCRIPTION
1. Use standard parametrization mechanisms.
2. Always cleanup the created temporary file, even if the subprocess
   fails (e.g. due to missing tex packages).

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
