### PR TITLE
Macosx fixes

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -104,6 +104,7 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
 
     def draw(self):
         self.invalidate()
+        self.flush_events()
 
     def draw_idle(self, *args, **kwargs):
         self.invalidate()

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -1,8 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
-
 import os
 
 from matplotlib._pylab_helpers import Gcf
@@ -99,10 +97,9 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
     def _draw(self):
         renderer = self.get_renderer()
 
-        if not self.figure.stale:
-            return renderer
+        if self.figure.stale:
+            self.figure.draw(renderer)
 
-        self.figure.draw(renderer)
         return renderer
 
     def draw(self):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1206,6 +1206,7 @@ class Axes3D(Axes):
             self.elev = art3d.norm_angle(self.elev - (dy/h)*180)
             self.azim = art3d.norm_angle(self.azim - (dx/w)*180)
             self.get_proj()
+            self.stale = True
             self.figure.canvas.draw_idle()
 
 #        elif self.button_pressed == 2:


### PR DESCRIPTION
Fixes a couple of mac-specific problems, plus a bit of cleanup:

- Fix #9491. Previously draw() on the osx backend was just calling invalidate, which didn't ensure that a draw event actually happened. This resulted in the cached renderer not being available when expected

- Fix #8814. Nothing in Axes3D was triggering a stale setting on camera rotation; it only called `draw_idle`. While this might be ok on other backends, on OSX it explicitly only redraws when the figure is stale.

An alternative to the fix here for #9306 is to call `self.stale = True` in `Axes3D.get_proj()`, which is the function that recalculates the projection. What do you think @WeatherGod ?