### PR TITLE
Test simplifications.

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -51,63 +51,6 @@ def _copy_metadata(src_func, tgt_func):
     return tgt_func
 
 
-# stolen from pandas
-@contextmanager
-def assert_produces_warning(expected_warning=Warning, filter_level="always",
-                            clear=None):
-    """
-    Context manager for running code that expects to raise (or not raise)
-    warnings.  Checks that code raises the expected warning and only the
-    expected warning. Pass ``False`` or ``None`` to check that it does *not*
-    raise a warning. Defaults to ``exception.Warning``, baseclass of all
-    Warnings. (basically a wrapper around ``warnings.catch_warnings``).
-
-    >>> import warnings
-    >>> with assert_produces_warning():
-    ...     warnings.warn(UserWarning())
-    ...
-    >>> with assert_produces_warning(False):
-    ...     warnings.warn(RuntimeWarning())
-    ...
-    Traceback (most recent call last):
-        ...
-    AssertionError: Caused unexpected warning(s): ['RuntimeWarning'].
-    >>> with assert_produces_warning(UserWarning):
-    ...     warnings.warn(RuntimeWarning())
-    Traceback (most recent call last):
-        ...
-    AssertionError: Did not see expected warning of class 'UserWarning'.
-
-    ..warn:: This is *not* thread-safe.
-    """
-    with warnings.catch_warnings(record=True) as w:
-
-        if clear is not None:
-            # make sure that we are clearning these warnings
-            # if they have happened before
-            # to guarantee that we will catch them
-            if not _is_list_like(clear):
-                clear = [clear]
-            for m in clear:
-                getattr(m, "__warningregistry__", {}).clear()
-
-        saw_warning = False
-        warnings.simplefilter(filter_level)
-        yield w
-        extra_warnings = []
-        for actual_warning in w:
-            if (expected_warning and issubclass(actual_warning.category,
-                                                expected_warning)):
-                saw_warning = True
-            else:
-                extra_warnings.append(actual_warning.category.__name__)
-        if expected_warning:
-            assert saw_warning, ("Did not see expected warning of class %r."
-                                 % expected_warning.__name__)
-        assert not extra_warnings, ("Caused unexpected warning(s): %r."
-                                    % extra_warnings)
-
-
 def set_font_settings_for_testing():
     rcParams['font.family'] = 'DejaVu Sans'
     rcParams['text.hinting'] = False

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1712,24 +1712,21 @@ def test_as_mpl_axes_api():
 
     # testing axes creation with plt.axes
     ax = plt.axes([0, 0, 1, 1], projection=prj)
-    assert type(ax) == PolarAxes, \
-        'Expected a PolarAxes, got %s' % type(ax)
+    assert type(ax) == PolarAxes
     ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     plt.close()
 
     # testing axes creation with gca
     ax = plt.gca(projection=prj)
-    assert type(ax) == maxes._subplots._subplot_classes[PolarAxes], \
-        'Expected a PolarAxesSubplot, got %s' % type(ax)
+    assert type(ax) == maxes._subplots._subplot_classes[PolarAxes]
     ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     # try getting the axes given a different polar projection
     ax_via_gca = plt.gca(projection=prj2)
     assert ax_via_gca is not ax
-    assert ax.get_theta_offset() == 0, ax.get_theta_offset()
-    assert ax_via_gca.get_theta_offset() == np.pi, \
-        ax_via_gca.get_theta_offset()
+    assert ax.get_theta_offset() == 0
+    assert ax_via_gca.get_theta_offset() == np.pi
     # try getting the axes given an == (not is) polar projection
     ax_via_gca = plt.gca(projection=prj3)
     assert ax_via_gca is ax
@@ -1737,8 +1734,7 @@ def test_as_mpl_axes_api():
 
     # testing axes creation with subplot
     ax = plt.subplot(121, projection=prj)
-    assert type(ax) == maxes._subplots._subplot_classes[PolarAxes], \
-        'Expected a PolarAxesSubplot, got %s' % type(ax)
+    assert type(ax) == maxes._subplots._subplot_classes[PolarAxes]
     plt.close()
 
 
@@ -4956,12 +4952,7 @@ def shared_axis_remover(request):
         r = ax.yaxis.get_major_locator()()
         assert r[-1] > 14
 
-    if request.param == 'x':
-        return _helper_x
-    elif request.param == 'y':
-        return _helper_y
-    else:
-        assert False, 'Request param %s is invalid.' % (request.param, )
+    return {"x": _helper_x, "y": _helper_y}[request.param]
 
 
 @pytest.fixture(params=['gca', 'subplots', 'subplots_shared', 'add_axes'])
@@ -4978,9 +4969,6 @@ def shared_axes_generator(request):
     elif request.param == 'add_axes':
         fig = plt.figure()
         ax = fig.add_axes([.1, .1, .8, .8])
-    else:
-        assert False, 'Request param %s is invalid.' % (request.param, )
-
     return fig, ax
 
 

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -179,7 +179,7 @@ def test_cycle_reset():
     assert prop != next(ax._get_lines.prop_cycler)
     ax.set_prop_cycle(None)
     got = next(ax._get_lines.prop_cycler)
-    assert prop == got, "expected %s, got %s" % (prop, got)
+    assert prop == got
 
     fig, ax = plt.subplots()
     # Need to double-check the old set/get_color_cycle(), too
@@ -190,7 +190,7 @@ def test_cycle_reset():
         assert prop != next(ax._get_lines.prop_cycler)
         ax.set_color_cycle(None)
         got = next(ax._get_lines.prop_cycler)
-        assert prop == got, "expected %s, got %s" % (prop, got)
+        assert prop == got
 
 
 def test_invalid_input_forms():

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -201,8 +201,7 @@ def test_cursor_data():
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    z = im.get_cursor_data(event)
-    assert z == 44, "Did not get 44, got %d" % z
+    assert im.get_cursor_data(event) == 44
 
     # Now try for a point outside the image
     # Tests issue #4957
@@ -210,8 +209,7 @@ def test_cursor_data():
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    z = im.get_cursor_data(event)
-    assert z is None, "Did not get None, got %d" % z
+    assert im.get_cursor_data(event) is None
 
     # Hmm, something is wrong here... I get 0, not None...
     # But, this works further down in the tests with extents flipped
@@ -229,8 +227,7 @@ def test_cursor_data():
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    z = im.get_cursor_data(event)
-    assert z == 44, "Did not get 44, got %d" % z
+    assert im.get_cursor_data(event) == 44
 
     fig, ax = plt.subplots()
     im = ax.imshow(np.arange(100).reshape(10, 10), extent=[0, 0.5, 0, 0.5])
@@ -239,8 +236,7 @@ def test_cursor_data():
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    z = im.get_cursor_data(event)
-    assert z == 55, "Did not get 55, got %d" % z
+    assert im.get_cursor_data(event) == 55
 
     # Now try for a point outside the image
     # Tests issue #4957
@@ -248,15 +244,13 @@ def test_cursor_data():
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    z = im.get_cursor_data(event)
-    assert z is None, "Did not get None, got %d" % z
+    assert im.get_cursor_data(event) is None
 
     x, y = 0.01, -0.01
     xdisp, ydisp = ax.transData.transform_point([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    z = im.get_cursor_data(event)
-    assert z is None, "Did not get None, got %d" % z
+    assert im.get_cursor_data(event) is None
 
 
 @image_comparison(baseline_images=['image_clip'], style='mpl20')
@@ -295,14 +289,18 @@ def test_imshow():
     ax.set_xlim(0,3)
     ax.set_ylim(0,3)
 
-@image_comparison(baseline_images=['no_interpolation_origin'], remove_text=True)
+
+@image_comparison(baseline_images=['no_interpolation_origin'],
+                  remove_text=True)
 def test_no_interpolation_origin():
     fig = plt.figure()
     ax = fig.add_subplot(211)
-    ax.imshow(np.arange(100).reshape((2, 50)), origin="lower", interpolation='none')
+    ax.imshow(np.arange(100).reshape((2, 50)), origin="lower",
+              interpolation='none')
 
     ax = fig.add_subplot(212)
     ax.imshow(np.arange(100).reshape((2, 50)), interpolation='none')
+
 
 @image_comparison(baseline_images=['image_shift'], remove_text=True,
                   extensions=['pdf', 'svg'])
@@ -318,6 +316,7 @@ def test_image_shift():
     ax.imshow(imgData, norm=LogNorm(), interpolation='none',
               extent=(tMin, tMax, 1, 100))
     ax.set_aspect('auto')
+
 
 def test_image_edges():
     f = plt.figure(figsize=[1, 1])
@@ -514,11 +513,10 @@ def test_jpeg_alpha():
     # If this fails, there will be only one color (all black). If this
     # is working, we should have all 256 shades of grey represented.
     num_colors = len(image.getcolors(256))
-    assert 175 <= num_colors <= 185, 'num colors: %d' % (num_colors, )
-    # The fully transparent part should be red, not white or black
-    # or anything else
+    assert 175 <= num_colors <= 185
+    # The fully transparent part should be red.
     corner_pixel = image.getpixel((0, 0))
-    assert corner_pixel == (254, 0, 0), "corner pixel: %r" % (corner_pixel, )
+    assert corner_pixel == (254, 0, 0)
 
 
 def test_nonuniformimage_setdata():

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -111,10 +111,7 @@ def test_PathEffect_points_to_pixels():
     renderer = fig.canvas.get_renderer()
     pe_renderer = path_effects.SimpleLineShadow().get_proxy_renderer(renderer)
 
-    assert isinstance(pe_renderer, path_effects.PathEffectRenderer), (
-                'Expected a PathEffectRendere instance, got '
-                'a {0} instance.'.format(type(pe_renderer)))
-
+    assert isinstance(pe_renderer, path_effects.PathEffectRenderer)
     # Confirm that using a path effects renderer maintains point sizes
     # appropriately. Otherwise rendered font would be the wrong size.
     assert renderer.points_to_pixels(15) == pe_renderer.points_to_pixels(15)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -128,7 +128,7 @@ def test_ellipse():
                     key=' ')
     do_event(tool, 'onmove', xdata=30, ydata=30, button=1)
     do_event(tool, 'release', xdata=30, ydata=30, button=1)
-    assert tool.extents == (120, 170, 120, 170), tool.extents
+    assert tool.extents == (120, 170, 120, 170)
 
     # create from center
     do_event(tool, 'on_key_press', xdata=100, ydata=100, button=1,
@@ -138,7 +138,7 @@ def test_ellipse():
     do_event(tool, 'release', xdata=125, ydata=125, button=1)
     do_event(tool, 'on_key_release', xdata=100, ydata=100, button=1,
                     key='control')
-    assert tool.extents == (75, 125, 75, 125), tool.extents
+    assert tool.extents == (75, 125, 75, 125)
 
     # create a square
     do_event(tool, 'on_key_press', xdata=10, ydata=10, button=1,
@@ -160,7 +160,7 @@ def test_ellipse():
     do_event(tool, 'on_key_release', xdata=100, ydata=100, button=1,
                       key='ctrl+shift')
     extents = [int(e) for e in tool.extents]
-    assert extents == [70, 129, 70, 130], extents
+    assert extents == [70, 129, 70, 130]
 
     assert tool.geometry.shape == (2, 73)
     assert_allclose(tool.geometry[:, 0], [70., 100])


### PR DESCRIPTION
- `assert_produces_warning` is now unused and has been replaced in the
  test suite by `pytest.warns`.

- Replace `assert x, y` by `assert x` when the information in `y` is
  clearly redundant with what pytest's assert rewrite would produce.
  (There are a few cases where the message actually provides more
  information, these are left as is.)

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
