### PR TITLE
CI: do not run pushes to the auto-backport branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 dist: trusty
 sudo: false
 
+branches:
+  except:
+  - /^auto-backport-of-pr-\d*/
+
 cache:
   pip: true
   directories:


### PR DESCRIPTION
Same function as https://github.com/matplotlib/matplotlib/pull/9286