### PR TITLE
fix xkcd context

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -389,24 +389,28 @@ def xkcd(scale=1, length=100, randomness=2):
             "xkcd mode is not compatible with text.usetex = True")
 
     from matplotlib import patheffects
+
+    rc = dict()
     context = rc_context()
     try:
-        rcParams['font.family'] = ['xkcd', 'Humor Sans', 'Comic Sans MS']
-        rcParams['font.size'] = 14.0
-        rcParams['path.sketch'] = (scale, length, randomness)
-        rcParams['path.effects'] = [
+        rc['font.family'] = ['xkcd', 'Humor Sans', 'Comic Sans MS']
+        rc['font.size'] = 14.0
+        rc['path.sketch'] = (scale, length, randomness)
+        rc['path.effects'] = [
             patheffects.withStroke(linewidth=4, foreground="w")]
-        rcParams['axes.linewidth'] = 1.5
-        rcParams['lines.linewidth'] = 2.0
-        rcParams['figure.facecolor'] = 'white'
-        rcParams['grid.linewidth'] = 0.0
-        rcParams['axes.grid'] = False
-        rcParams['axes.unicode_minus'] = False
-        rcParams['axes.edgecolor'] = 'black'
-        rcParams['xtick.major.size'] = 8
-        rcParams['xtick.major.width'] = 3
-        rcParams['ytick.major.size'] = 8
-        rcParams['ytick.major.width'] = 3
+        rc['axes.linewidth'] = 1.5
+        rc['lines.linewidth'] = 2.0
+        rc['figure.facecolor'] = 'white'
+        rc['grid.linewidth'] = 0.0
+        rc['axes.grid'] = False
+        rc['axes.unicode_minus'] = False
+        rc['axes.edgecolor'] = 'black'
+        rc['xtick.major.size'] = 8
+        rc['xtick.major.width'] = 3
+        rc['ytick.major.size'] = 8
+        rc['ytick.major.width'] = 3
+        context = rc_context(rc)
+
     except:
         context.__exit__(*sys.exc_info())
         raise


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes xkcd context so that one can do (as per #9520):

```python

import matplotlib.pyplot as plt

with plt.xkcd():
    plt.figure()
    plt.plot([1, 2, 3])
    plt.savefig('xkcd.png', dpi=300)

plt.figure()
plt.plot([1, 2, 3])
plt.savefig('not_xkcd.png', dpi=300)

```

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->