### PR TITLE
DOC fix set_xticklabels docstring

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3074,7 +3074,7 @@ class _AxesBase(martist.Artist):
 
         minor : bool, optional
             If True select the minor ticklabels,
-            else select the minor ticklabels
+            else select the major ticklabels
 
         Returns
         -------
@@ -3394,7 +3394,7 @@ class _AxesBase(martist.Artist):
 
         minor : bool, optional
             If True select the minor ticklabels,
-            else select the minor ticklabels
+            else select the major ticklabels
 
         Returns
         -------


### PR DESCRIPTION
Major change in `axes.set_xticklabels` and `axes.set_yticklabels` docstrings