### PR TITLE
adding links to color examples and tutorials in the api page

### DIFF
--- a/doc/api/colors_api.rst
+++ b/doc/api/colors_api.rst
@@ -2,7 +2,7 @@
 colors
 ******
 
-For a visual representation of the matplotlib colormaps, see:
+For a visual representation of the Matplotlib colormaps, see:
 
 * The :ref:`color_examples` examples for examples of controlling color with
   Matplotlib.

--- a/doc/api/colors_api.rst
+++ b/doc/api/colors_api.rst
@@ -2,9 +2,12 @@
 colors
 ******
 
-For a visual representation of the matplotlib colormaps, see the
-"Color" section in the gallery.
+For a visual representation of the matplotlib colormaps, see:
 
+* The :ref:`color_examples` examples for examples of controlling color with
+  Matplotlib.
+* The :ref:`tutorials-colors` tutorial for an in-depth guide on controlling
+  color.
 
 :mod:`matplotlib.colors`
 ========================
@@ -50,4 +53,3 @@ Functions
    is_color_like
    makeMappingArray
    get_named_colors_mapping
-


### PR DESCRIPTION
per @anntzer 's suggestion, this adds links on the colors API page to the gallery and tutorial section.