### PR TITLE
Fix stale draws on MacOSX backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -76,24 +76,6 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
             self.figure.dpi = self.figure.dpi / self._device_scale * value
             self._device_scale = value
 
-    def get_renderer(self, cleared=False):
-        l, b, w, h = self.figure.bbox.bounds
-        key = w, h, self.figure.dpi
-        try:
-            self._lastKey, self._renderer
-        except AttributeError:
-            need_new_renderer = True
-        else:
-            need_new_renderer = (self._lastKey != key)
-
-        if need_new_renderer:
-            self._renderer = RendererAgg(w, h, self.figure.dpi)
-            self._lastKey = key
-        elif cleared:
-            self._renderer.clear()
-
-        return self._renderer
-
     def _draw(self):
         renderer = self.get_renderer()
 

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -77,7 +77,7 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
             self._device_scale = value
 
     def _draw(self):
-        renderer = self.get_renderer()
+        renderer = self.get_renderer(cleared=self.figure.stale)
 
         if self.figure.stale:
             self.figure.draw(renderer)


### PR DESCRIPTION
This took awhile to understand and I thought I was going nuts trying to get OSX Core Graphics to clear a rectangle. It turns out the stale drawing was coming from Agg itself. After comparing against Qt5Agg, it turns out that before this PR, MacOSX never called `get_renderer` with `cleared=True`, which causes the Agg renderer to clear its buffer; it only happened on resize/dpi change. With this patch, we now pass the stale flag as the value for `cleared`.

Fixes #8282.

It also turns out that `get_renderer` was a complete copy of what's in `FigureCanvasAgg`, so I just nuked the method in `FigureCanvasMac`.

Testing was accomplished with a slight modification of the code from #8282:
```python
import matplotlib.pyplot as plt
fig,ax = plt.subplots(facecolor='none')
ax.set_facecolor('none')

plt.subplots_adjust(left=0.25, bottom=0.25)
plt.axis([0, 4, 0,2])
l, = ax.plot([1,2,3],[1,0,1])
ax.set_title('down')
def update():
    l.set_ydata([1,2,1])
    ax.set_title('up')

plt.pause(1.0)
update()
plt.pause(1.0)
plt.show()
```
Before this patch, you get a diamond-shaped plot and titles overlaid. After, the whole plot changes between subsequent draws.