### PR TITLE
animation: Remove examples keyword

### DIFF
--- a/examples/animation/animate_decay.py
+++ b/examples/animation/animate_decay.py
@@ -3,7 +3,7 @@
 Decay
 =====
 
-This example showcases a sinusoidal decay animation.
+A sinusoidal decay animation.
 """
 
 

--- a/examples/animation/basic_example.py
+++ b/examples/animation/basic_example.py
@@ -3,8 +3,8 @@
 Simple animation examples
 =========================
 
-This example contains two animations. The first is a random walk plot. The
-second is an image animation.
+Two animations where the first is a random walk plot and
+the second is an image animation.
 """
 
 import numpy as np

--- a/examples/animation/dynamic_image.py
+++ b/examples/animation/dynamic_image.py
@@ -3,7 +3,7 @@
 An animated image
 =================
 
-This example demonstrates how to animate an image.
+Animation of an image.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/animation/dynamic_image2.py
+++ b/examples/animation/dynamic_image2.py
@@ -3,8 +3,7 @@
 An animated image using a list of images
 ========================================
 
-This examples demonstrates how to animate an image from a list of images (or
-Artists).
+Animate an image from a list of images (or Artists).
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/animation/image_slices_viewer.py
+++ b/examples/animation/image_slices_viewer.py
@@ -3,7 +3,7 @@
 Image Slices Viewer
 ===================
 
-This example demonstrates how to scroll through 2D image slices of a 3D array.
+Scroll through 2D image slices of a 3D array.
 """
 from __future__ import print_function
 

--- a/examples/animation/moviewriter_sgskip.py
+++ b/examples/animation/moviewriter_sgskip.py
@@ -3,7 +3,7 @@
 MovieWriter
 ===========
 
-This example uses a MovieWriter directly to grab individual frames and write
+Use a MovieWriter directly to grab individual frames and write
 them to a file. This avoids any event loop integration, but has the advantage
 of working with even the Agg backend. This is not recommended for use in an
 interactive setting.

--- a/examples/animation/simple_3danim.py
+++ b/examples/animation/simple_3danim.py
@@ -3,7 +3,7 @@
 3D animation
 ============
 
-A simple example of an animated plot... In 3D!
+An animated plot in 3D.
 """
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## PR Summary
Remove the redundant example keyword in animation examples.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way