### PR TITLE
Add a proper docstring to AutoLocator

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2484,7 +2484,16 @@ class LogitLocator(Locator):
 
 
 class AutoLocator(MaxNLocator):
+    """
+    Dynamically find major tick positions. This is actually a subclass
+    of `~matplotlib.ticker.MaxNLocator`, with parameters *nbins = 'auto'*
+    and *steps = [1, 2, 2.5, 5, 10]*.
+    """
     def __init__(self):
+        """
+        To know the values of the non-public parameters, please have a
+        look to the defaults of `~matplotlib.ticker.MaxNLocator`.
+        """
         if rcParams['_internal.classic_mode']:
             nbins = 9
             steps = [1, 2, 5, 10]


### PR DESCRIPTION
## PR Summary

Original discussion on Gitter is [October 24, 2017 2:29 PM](https://gitter.im/matplotlib/matplotlib?at=59efb0b40182fa5f4d730b9f)

Currently `matplotlib.ticker.AutoLocator` uses the docstring(s) of `matplotlib.ticker.MaxNLocator`, which can be confusing as the former actually does not provide any public parameter when one instantiates it, while the latter does... (For example, I quickly looked at `AutoLocator?` in an IPython session, and it then took me a few minutes to realize that `AutoLocator(nbins=3)` could never work...) 

This PR simply adds dedicated docstring(s) to `AutoLocator` to prevent it from relying on the one(s) of `MaxNLocator`.

## PR Checklist

- [x] Code is PEP 8 compliant *-> apparently CI agrees...*
- [x] Documentation is sphinx and numpydoc compliant *-> apparently CI agrees...*

*Sorry, not sure which milestone to target.*
