### PR TITLE
Fix typo in isinstance

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -2330,7 +2330,7 @@ def rec_append_fields(rec, names, arrs, dtypes=None):
     values themselves.
     """
     if (not isinstance(names, six.string_types) and cbook.iterable(names)
-            and len(names) and isinstance(names[0]), six.string_types):
+            and len(names) and isinstance(names[0], six.string_types)):
         if len(names) != len(arrs):
             raise ValueError("number of arrays do not match number of names")
     else:  # we have only 1 name and 1 array


### PR DESCRIPTION
A typo in `isinstance` caused the logic here to evaluate to, for example, `(False, (basestring,))` which evaluates to `True`.