### PR TITLE
Fix inconsistent behavior in pcolormesh with Gouraud shading

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -246,6 +246,14 @@ volumetric model.
 Improvements
 ++++++++++++
 
+New ``interpolate_grids`` keyword arg to `pcolormesh`
+-----------------------------------------------------
+
+`pcolormesh` now has a keyword argument ``interpolate_grids`` that will allow
+interpolation of the boundary grids ``X``, ``Y`` to match the dimension of
+``C`` if Gouraud shading is used. This will simplify changing between flat
+and Gouraud shading.
+
 CheckButtons widget ``get_status`` function
 -------------------------------------------
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5538,7 +5538,7 @@ class Axes(_AxesBase):
         thrown. However, for compatibility with the flat shading case, the
         ``interpolate_grids`` keyword argument is provided. When set to
         ``True`` and *X* and *Y* have one row and column more then *C*,
-         *X* and *Y* will be linearly interpolated to obtain the corresponding
+        *X* and *Y* will be linearly interpolated to obtain the corresponding
         centerpoints.
 
         Keyword arguments:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5159,8 +5159,8 @@ class Axes(_AxesBase):
         # This function takes care of resizing the grids X and Y
         # to match the size of the color grid C.
         #
-        # If only a color grid is given dummy grids for X and Y are
-        # created, matching the dimensions of C.
+        # If only a color grid is given uniform grids with step size 1.0
+        # are created for X and Y are, matching the dimensions of C.
         #
         # If given, the X and Y grids must have the same size or
         # one more row and column than C.
@@ -5233,8 +5233,10 @@ class Axes(_AxesBase):
                 else:
 
                     raise TypeError('Dimensions of C %s are incompatible with'
-                                    ' X (%d) and/or Y (%d); see help(%s)' % (
-                                        C.shape, Nx, Ny, funcname))
+                                    ' X (%d) and/or Y (%d); To allow linear '
+                                    ' interpolation of the grids to match C '
+                                    ' set the keyword interpolate_grids to '
+                                    ' True' % (C.shape, Nx, Ny, funcname))
 
         else:
             C = C[:Ny - 1, :Nx - 1]

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1186,10 +1186,6 @@ def test_pcolorargs():
         ax.pcolormesh(y, x, Z)
     with pytest.raises(TypeError):
         ax.pcolormesh(X, Y, Z.T)
-    with pytest.raises(TypeError):
-        ax.pcolormesh(x, y, Z[:-1, :-1], shading="gouraud")
-    with pytest.raises(TypeError):
-        ax.pcolormesh(X, Y, Z[:-1, :-1], shading="gouraud")
 
 
 @image_comparison(baseline_images=['canonical'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1180,12 +1180,22 @@ def test_pcolorargs():
     y = np.linspace(-1.5, 1.5, n*2)
     X, Y = np.meshgrid(x, y)
     Z = np.sqrt(X**2 + Y**2)/5
+    Z_1 = Z[:-1, :-1]
 
     _, ax = plt.subplots()
     with pytest.raises(TypeError):
         ax.pcolormesh(y, x, Z)
     with pytest.raises(TypeError):
         ax.pcolormesh(X, Y, Z.T)
+    with pytest.raises(TypeError):
+        ax.pcolormesh(y, x, Z, shading="gouraud")
+    with pytest.raises(TypeError):
+        ax.pcolormesh(X, Y, Z.T, shading="gouraud")
+    with pytest.raises(TypeError):
+        ax.pcolormesh(X, Y, Z_1, shading="gouraud")
+
+    ax.pcolormesh(X, Y, Z_1)
+    ax.pcolormesh(x, y, Z_1, shading="gouraud", interpolate_grids=True)
 
 
 @image_comparison(baseline_images=['canonical'])


### PR DESCRIPTION


## PR Summary

As described in issue [8422](https://github.com/matplotlib/matplotlib/issues/8422) behavior of  `pcolormesh` was inconsistent when using Gouraud shading. The documentation states that the X and Y grids, if given, should have the same or one row and column more than the color grid C. However, if Gouraud shading is used, this would result in an error.

To handle the case where the X and Y grid have on row and column more than the color grid, I propose to interpolate the grids linearly to obtain the center points of each quadrilateral. This should ensure that the resulting image has the right colors at the centers of each of the quadrilaterals given.

The disadvantage, however, is that the plotted grid will cover a smaller range than X and Y grids given to `pcolormesh`. It is up for discussion if the grid should be so avoided by padding the resulting grids.


## Example
````
import numpy as np
import matplotlib.pyplot as plt
x = np.arange(-1, 2)
y = np.arange(-1, 2)
xe = np.linspace(-1.5, 1.5, 4)
ye = np.linspace(-1.5, 1.5, 4)
c = np.exp(-0.5*0.125*(x.reshape(1, -1)**2 + y.reshape(-1, 1)**2))
plt.figure()
plt.pcolormesh(xe, ye, c, shading='gouraud')  # didn't work before
````

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
