### PR TITLE
ENH: rely on non-rectangular patch paths rather than bboxes for legend auto-placing (fix #9580)

### DIFF
--- a/doc/api/next_api_changes/behavior/9598-AFV.rst
+++ b/doc/api/next_api_changes/behavior/9598-AFV.rst
@@ -1,0 +1,6 @@
+Change of ``legend(loc="best")`` behavior
+-----------------------------------------
+
+The algorithm of the auto-legend locator has been tweaked to better handle
+non rectangular patches. Additional details on this change can be found in
+:ghissue:`9580` and :ghissue:`9598`.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -865,12 +865,14 @@ class Legend(Artist):
                 bboxes.append(
                     artist.get_bbox().transformed(artist.get_data_transform()))
             elif isinstance(artist, Patch):
-                bboxes.append(
-                    artist.get_path().get_extents(artist.get_transform()))
+                lines.append(
+                    artist.get_transform().transform_path(artist.get_path()))
             elif isinstance(artist, Collection):
-                _, offset_trf, hoffsets, _ = artist._prepare_points()
-                for offset in offset_trf.transform(hoffsets):
-                    offsets.append(offset)
+                transform, transOffset, hoffsets, _ = artist._prepare_points()
+                if len(hoffsets):
+                    for offset in transOffset.transform(hoffsets):
+                        offsets.append(offset)
+
         return bboxes, lines, offsets
 
     def get_children(self):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -10,6 +10,7 @@ from matplotlib.testing.decorators import check_figures_equal, image_comparison
 from matplotlib.testing._markers import needs_usetex
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import matplotlib.patches as mpatches
 import matplotlib.transforms as mtransforms
 import matplotlib.collections as mcollections
 import matplotlib.lines as mlines
@@ -17,6 +18,7 @@ from matplotlib.legend_handler import HandlerTuple
 import matplotlib.legend as mlegend
 from matplotlib import rc_context
 from matplotlib.font_manager import FontProperties
+from numpy.testing import assert_allclose
 
 
 def test_legend_ordereddict():
@@ -67,6 +69,60 @@ def test_legend_auto3():
     ax.set_xlim(0.0, 1.0)
     ax.set_ylim(0.0, 1.0)
     ax.legend(loc='best')
+
+
+def test_legend_auto4():
+    """
+    Check that the legend location with automatic placement is the same,
+    whatever the histogram type is. Related to issue #9580.
+    """
+    # NB: barstacked is pointless with a single dataset.
+    fig, axs = plt.subplots(ncols=3, figsize=(6.4, 2.4))
+    leg_bboxes = []
+    for ax, ht in zip(axs.flat, ('bar', 'step', 'stepfilled')):
+        ax.set_title(ht)
+        # A high bar on the left but an even higher one on the right.
+        ax.hist([0] + 5*[9], bins=range(10), label="Legend", histtype=ht)
+        leg = ax.legend(loc="best")
+        fig.canvas.draw()
+        leg_bboxes.append(
+            leg.get_window_extent().transformed(ax.transAxes.inverted()))
+
+    # The histogram type "bar" is assumed to be the correct reference.
+    assert_allclose(leg_bboxes[1].bounds, leg_bboxes[0].bounds)
+    assert_allclose(leg_bboxes[2].bounds, leg_bboxes[0].bounds)
+
+
+def test_legend_auto5():
+    """
+    Check that the automatic placement handle a rather complex
+    case with non rectangular patch. Related to issue #9580.
+    """
+    fig, axs = plt.subplots(ncols=2, figsize=(9.6, 4.8))
+
+    leg_bboxes = []
+    for ax, loc in zip(axs.flat, ("center", "best")):
+        # An Ellipse patch at the top, a U-shaped Polygon patch at the
+        # bottom and a ring-like Wedge patch: the correct placement of
+        # the legend should be in the center.
+        for _patch in [
+                mpatches.Ellipse(
+                    xy=(0.5, 0.9), width=0.8, height=0.2, fc="C1"),
+                mpatches.Polygon(np.array([
+                    [0, 1], [0, 0], [1, 0], [1, 1], [0.9, 1.0], [0.9, 0.1],
+                    [0.1, 0.1], [0.1, 1.0], [0.1, 1.0]]), fc="C1"),
+                mpatches.Wedge((0.5, 0.5), 0.5, 0, 360, width=0.05, fc="C0")
+                ]:
+            ax.add_patch(_patch)
+
+        ax.plot([0.1, 0.9], [0.9, 0.9], label="A segment")  # sthg to label
+
+        leg = ax.legend(loc=loc)
+        fig.canvas.draw()
+        leg_bboxes.append(
+            leg.get_window_extent().transformed(ax.transAxes.inverted()))
+
+    assert_allclose(leg_bboxes[1].bounds, leg_bboxes[0].bounds)
 
 
 @image_comparison(['legend_various_labels'], remove_text=True)


### PR DESCRIPTION
## PR Summary

This PR addresses issue #9580.

### Rationale

Currently, when using the legend auto-placing (NB: default since 2.0), one can get significantly surprising results as 
![orig_test](https://user-images.githubusercontent.com/17270724/32126983-9c26b6d2-bb28-11e7-9e07-a23f2ce9826b.png)
where things are OK with the two upper subplots but the two lower ones are not.

As @anntzer explained in #9580, this is because "step*" histogram types return a single `Polygon` patch while non-"step*" types return a list of `Rectangle` patches. As the legend auto-placing algorithm relies on the *bbox* of the patches, it can significantly overestimates the actual patch area (e.g. as in the case displayed above). **This PR simply suggests to use the path that defines non-rectangular patches instead of their _bbox_ in the legend auto-placing algorithm.** By doing this the algorithm should handle these patches as well (or bad) as any Line2D instances.

At least, it fixes the previous example...
![with_cleverer_auto_legend](https://user-images.githubusercontent.com/17270724/32127353-230da4c4-bb2b-11e7-98e0-f57c6157b2c0.png)

### Remaining concerns

*NB: the followings points are kind of related actually.*

#### Is it not kind of a nuke to treat every non-rectangular patches as a path?

A less radical change may be to keep the current bbox-based approach for some other patches like `Ellipse`, `Circle`, etc. where the issue stated above is less “severe” and the bbox provide a quite good approximation of the area that is covered by the patch.

#### What about speed?

A [very crude and genuine benchmark](https://github.com/matplotlib/matplotlib/issues/9580#issuecomment-340040536) with a ~ 1000 bin-histogram is given in #9580 and suggest than this change is not likely to be the performance bottleneck of legend. If I am correct, at least for histograms, the new approach should not be really more computationally expensive than the cost of the non-step* histogram types, where the legend bbox is tested against *every* `Rectangle` patch the histogram is made of, isn't it? *However, it may be worth to check that performance does not become a issue for plot with very high amounts of “complex” patches.*

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [?] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

This breaks the previously “incorrect” behavior, and there will be no way to recover it. @tacaswell  *Should I add a proper entry in `api_changes.rst` about it?*