### PR TITLE
Gridspec doc fixes

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1186,18 +1186,42 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
 
 def subplot2grid(shape, loc, rowspan=1, colspan=1, fig=None, **kwargs):
     """
-    Create a subplot in a grid.  The grid is specified by *shape*, at
-    location of *loc*, spanning *rowspan*, *colspan* cells in each
-    direction.  The index for loc is 0-based.  The current figure will
-    be used unless *fig* is specified. ::
+    Create an axis at specific location inside a regular grid.
 
-      subplot2grid(shape, loc, rowspan=1, colspan=1)
+    Parameters
+    ----------
+    shape : sequence of 2 ints
+        Shape of grid in which to place axis.
+        First entry is number of rows, second entry is number of columns.
+
+    loc : sequence of 2 ints
+        Location to place axis within grid.
+        First entry is row number, second entry is column number.
+
+    rowspan : int
+        Number of rows for the axis to span to the right.
+
+    colspan : int
+        Number of columns for the axis to span downwards.
+
+    fig : `Figure`, optional
+        Figure to place axis in. Defaults to current figure.
+
+    **kwargs
+        Additional keyword arguments are handed to `add_subplot`.
+
+
+    Notes
+    -----
+    The following call ::
+
+        subplot2grid(shape, loc, rowspan=1, colspan=1)
 
     is identical to ::
 
-      gridspec=GridSpec(shape[0], shape[1])
-      subplotspec=gridspec.new_subplotspec(loc, rowspan, colspan)
-      subplot(subplotspec)
+        gridspec=GridSpec(shape[0], shape[1])
+        subplotspec=gridspec.new_subplotspec(loc, rowspan, colspan)
+        subplot(subplotspec)
     """
 
     if fig is None:

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -75,13 +75,13 @@ ax = plt.subplot(gs[0, 0])
 
 # A GridSpec instance provides array-like (2d or 1d) indexing that
 # returns the SubplotSpec instance. For a SubplotSpec that spans multiple
-# cells, use slice. ::
+# cells, use slice.
 
 ax2 = plt.subplot(gs[1, :-1])
 ax3 = plt.subplot(gs[1:, -1])
 
 ###############################################################################
-# The above example becomes ::
+# The above example becomes
 
 fig = plt.figure()
 gs = gridspec.GridSpec(3, 3)
@@ -96,7 +96,7 @@ ax5 = plt.subplot(gs[-1, -2])
 # ======================
 #
 # When a GridSpec is explicitly used, you can adjust the layout
-# parameters of subplots that are created from the GridSpec. ::
+# parameters of subplots that are created from the GridSpec.
 
 fig = plt.figure()
 gs1 = gridspec.GridSpec(3, 3)


### PR DESCRIPTION
- Convert `subplot2grid` docstring to numpydoc. Hopefully it makes a bit more sense now...
- Fix a couple of broken plots in the `gridspec` tutorial