### PR TITLE
Do not hardcode fill=False in mark_inset

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -578,8 +578,9 @@ def mark_inset(parent_axes, inset_axes, loc1, loc2, **kwargs):
         The patches connecting two corners of the inset axes and its area.
     """
     rect = TransformedBbox(inset_axes.viewLim, parent_axes.transData)
-
-    pp = BboxPatch(rect, fill=False, **kwargs)
+    
+    fill = kwargs.pop("fill", False)
+    pp = BboxPatch(rect, fill=fill, **kwargs)
     parent_axes.add_patch(pp)
 
     p1 = BboxConnector(inset_axes.bbox, rect, loc1=loc1, **kwargs)


### PR DESCRIPTION
There should not be any reason to hardcode `fill=False` in `mark_inset`. This prevents having a filled `BboxPatch`. With the proposed change, something like 

`mark_inset(ax,axins,loc1=1,loc2=3, fill=True, edgecolor="k", facecolor="lightgrey")` 

will be possible and would look like 

![image](https://user-images.githubusercontent.com/23121882/32146447-edf6aff2-bcd7-11e7-83d2-3ec45e9e6a0d.png)

(See [this stackoverflow question](https://stackoverflow.com/questions/46990233/filling-box-for-zoomed-plot-with-a-colour-in-mpl-toolkits-axes-grid1-inset-locat))

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
