### PR TITLE
fetch rcParams for Figures in fig.clf(), issue #7434

### DIFF
--- a/doc/users/next_whats_new/2017-11-12_reset_rcparams_in_clf.rst
+++ b/doc/users/next_whats_new/2017-11-12_reset_rcparams_in_clf.rst
@@ -1,0 +1,5 @@
+rcParams can be reset in clf
+----------------------------
+
+``figure.clf()`` can take an optional argument ``reset_rcparams``. If set to ``True``,
+unset figure properties will be set to the values specified in rcParams.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1234,10 +1234,14 @@ class Figure(Artist):
         """
         Clear the figure.
 
-        Set *keep_observers* to True if, for example,
-        a gui widget is tracking the axes in the figure.
-        Set *reset_rcparams* to True to reset figure
-        parameters to rcParams values.
+        Parameters
+        ----------
+        keep_observers : bool, optional
+            Set *keep_observers* to True if, for example,
+            a gui widget is tracking the axes in the figure.
+        reset_rcparams : bool, optional
+            Set *reset_rcparams* to True to reset figure
+            parameters to rcParams values.
         """
         self.suppressComposite = None
         self.callbacks = cbook.CallbackRegistry()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1230,13 +1230,13 @@ class Figure(Artist):
         if last_ax is not None:
             _reset_loc_form(last_ax.xaxis)
 
-    def clf(self, keep_observers=False, disable_rc_fetch=True):
+    def clf(self, keep_observers=False, reset_rcparams=False):
         """
         Clear the figure.
 
         Set *keep_observers* to True if, for example,
         a gui widget is tracking the axes in the figure.
-        Set *disable_rc_fetch* to False to reset figure
+        Set *reset_rcparams* to True to reset figure
         parameters to rcParams values.
         """
         self.suppressComposite = None
@@ -1258,7 +1258,7 @@ class Figure(Artist):
         self.legends = []
         if not keep_observers:
             self._axobservers = []
-        if not disable_rc_fetch:
+        if reset_rcparams:
             if self.figsize is None:
                 self.figsize = rcParams['figure.figsize']
             if self.facecolor is None:
@@ -1272,11 +1272,11 @@ class Figure(Artist):
         self._suptitle = None
         self.stale = True
 
-    def clear(self, keep_observers=False, disable_rc_fetch=True):
+    def clear(self, keep_observers=False, reset_rcparams=False):
         """
         Clear the figure -- synonym for :meth:`clf`.
         """
-        self.clf(keep_observers=keep_observers)
+        self.clf(keep_observers=keep_observers, reset_rcparams=reset_rcparams)
 
     @allow_rasterization
     def draw(self, renderer):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -367,7 +367,7 @@ class Figure(Artist):
 
         self.subplotpars = subplotpars
         self.set_tight_layout(tight_layout)
-        self.tight_layout = tight_layout
+        self.tight = tight_layout
 
         self._axstack = AxesStack()  # track all figure axes and current axes
         self.clf()
@@ -1268,7 +1268,7 @@ class Figure(Artist):
             if self.frameon is None:
                 self.frameon = rcParams['figure.frameon']
             self.subplotpars.update()
-            self.set_tight_layout(self.tight_layout)
+            self.set_tight_layout(self.tight)
         self._suptitle = None
         self.stale = True
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -336,6 +336,7 @@ class Figure(Artist):
             raise ValueError('figure size must be finite not '
                              '{}'.format(figsize))
         self.bbox_inches = Bbox.from_bounds(0, 0, *figsize)
+        self.figsize = figsize
 
         self.dpi_scale_trans = Affine2D().scale(dpi, dpi)
         # do not use property as it will trigger
@@ -351,6 +352,8 @@ class Figure(Artist):
             facecolor=facecolor, edgecolor=edgecolor, linewidth=linewidth)
         self._set_artist_props(self.patch)
         self.patch.set_aa(False)
+        self.facecolor = facecolor
+        self.edgecolor = edgecolor
 
         self._hold = rcParams['axes.hold']
         if self._hold is None:
@@ -364,6 +367,7 @@ class Figure(Artist):
 
         self.subplotpars = subplotpars
         self.set_tight_layout(tight_layout)
+        self.tight_layout = tight_layout
 
         self._axstack = AxesStack()  # track all figure axes and current axes
         self.clf()
@@ -1226,12 +1230,14 @@ class Figure(Artist):
         if last_ax is not None:
             _reset_loc_form(last_ax.xaxis)
 
-    def clf(self, keep_observers=False):
+    def clf(self, keep_observers=False, disable_rc_fetch=True):
         """
         Clear the figure.
 
         Set *keep_observers* to True if, for example,
         a gui widget is tracking the axes in the figure.
+        Set *disable_rc_fetch* to False to reset figure
+        parameters to rcParams values.
         """
         self.suppressComposite = None
         self.callbacks = cbook.CallbackRegistry()
@@ -1252,10 +1258,21 @@ class Figure(Artist):
         self.legends = []
         if not keep_observers:
             self._axobservers = []
+        if not disable_rc_fetch:
+            if self.figsize is None:
+                self.figsize = rcParams['figure.figsize']
+            if self.facecolor is None:
+                self.facecolor = rcParams['figure.facecolor']
+            if self.edgecolor is None:
+                self.edgecolor = rcParams['figure.edgecolor']
+            if self.frameon is None:
+                self.frameon = rcParams['figure.frameon']
+            self.subplotpars.update()
+            self.set_tight_layout(self.tight_layout)
         self._suptitle = None
         self.stale = True
 
-    def clear(self, keep_observers=False):
+    def clear(self, keep_observers=False, disable_rc_fetch=True):
         """
         Clear the figure -- synonym for :meth:`clf`.
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -336,7 +336,7 @@ class Figure(Artist):
             raise ValueError('figure size must be finite not '
                              '{}'.format(figsize))
         self.bbox_inches = Bbox.from_bounds(0, 0, *figsize)
-        self.figsize = figsize
+        self._figsize = figsize
 
         self.dpi_scale_trans = Affine2D().scale(dpi, dpi)
         # do not use property as it will trigger
@@ -352,8 +352,8 @@ class Figure(Artist):
             facecolor=facecolor, edgecolor=edgecolor, linewidth=linewidth)
         self._set_artist_props(self.patch)
         self.patch.set_aa(False)
-        self.facecolor = facecolor
-        self.edgecolor = edgecolor
+        self._facecolor = facecolor
+        self._edgecolor = edgecolor
 
         self._hold = rcParams['axes.hold']
         if self._hold is None:
@@ -367,7 +367,7 @@ class Figure(Artist):
 
         self.subplotpars = subplotpars
         self.set_tight_layout(tight_layout)
-        self.tight = tight_layout
+        self._tight = tight_layout
 
         self._axstack = AxesStack()  # track all figure axes and current axes
         self.clf()
@@ -1259,16 +1259,24 @@ class Figure(Artist):
         if not keep_observers:
             self._axobservers = []
         if reset_rcparams:
-            if self.figsize is None:
-                self.figsize = rcParams['figure.figsize']
-            if self.facecolor is None:
-                self.facecolor = rcParams['figure.facecolor']
-            if self.edgecolor is None:
-                self.edgecolor = rcParams['figure.edgecolor']
+            if self._figsize is None:
+                self._figsize = rcParams['figure.figsize']
+            if self._dpi is None:
+                self._dpi = rcParams['figure.dpi']
+            if self._facecolor is None:
+                self._facecolor = rcParams['figure.facecolor']
+            if self._edgecolor is None:
+                self._edgecolor = rcParams['figure.edgecolor']
             if self.frameon is None:
                 self.frameon = rcParams['figure.frameon']
+            self.bbox_inches = Bbox.from_bounds(0, 0, *self._figsize)
+            self.dpi_scale_trans = Affine2D().scale(self._dpi, self._dpi)
+            self.bbox = TransformedBbox(self.bbox_inches, self.dpi_scale_trans)
+            self.transFigure = BboxTransformTo(self.bbox)
+            self.set_facecolor(self._facecolor)
+            self.set_edgecolor(self._edgecolor)
             self.subplotpars.update()
-            self.set_tight_layout(self.tight)
+            self.set_tight_layout(self._tight)
         self._suptitle = None
         self.stale = True
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -6,6 +6,7 @@ from matplotlib.testing.decorators import image_comparison
 from matplotlib.axes import Axes
 from matplotlib.ticker import AutoMinorLocator, FixedFormatter
 import matplotlib.pyplot as plt
+import matplotlib.colors as colors
 import matplotlib.dates as mdates
 import numpy as np
 import warnings
@@ -71,27 +72,33 @@ def test_clf_keyword():
 def test_reset_rcparams():
     # test whether clf resets unset figure properties to rcParams values
     fig0 = plt.figure()
-    fig0.figsize = None
-    fig0.facecolor = None
-    fig0.edgecolor = None
+    fig0._figsize = None
+    fig0._dpi = None
+    fig0._facecolor = None
+    fig0._edgecolor = None
     fig0.frameon = None
     fig0.clf(reset_rcparams=True)
-    assert fig0.figsize == rcParams['figure.figsize']
-    assert fig0.facecolor == rcParams['figure.facecolor']
-    assert fig0.edgecolor == rcParams['figure.edgecolor']
-    assert fig0.frameon == rcParams['figure.frameon']
+    assert fig0.get_figwidth() == rcParams['figure.figsize'][0]
+    assert fig0.get_figheight() == rcParams['figure.figsize'][1]
+    assert fig0.get_dpi() == rcParams['figure.dpi']
+    assert fig0.get_facecolor() == colors.to_rgba(rcParams['figure.facecolor'])
+    assert fig0.get_edgecolor() == colors.to_rgba(rcParams['figure.edgecolor'])
+    assert fig0.get_frameon() == rcParams['figure.frameon']
 
     # set figure properties should not be reset to rcParams
     fig1 = plt.figure()
-    fig1.figsize = (10, 10)
-    fig1.facecolor = 'red'
-    fig1.edgecolor = 'blue'
-    fig1.frameon = False
+    fig1._figsize = (11, 13)
+    fig1._figsize
+    fig1._dpi = 251
+    fig1._facecolor = 'red'
+    fig1._edgecolor = 'blue'
     fig1.clf(reset_rcparams=True)
-    assert not fig1.figsize == rcParams['figure.figsize']
-    assert not fig1.facecolor == rcParams['figure.facecolor']
-    assert not fig1.edgecolor == rcParams['figure.edgecolor']
-    assert not fig1.frameon == rcParams['figure.frameon']
+    fig1._figsize
+    assert not fig1.get_figwidth() == rcParams['figure.figsize'][0]
+    assert not fig1.get_figheight() == rcParams['figure.figsize'][1]
+    assert not fig1.get_dpi() == rcParams['figure.dpi']
+    assert not fig1.get_facecolor() == colors.to_rgba(rcParams['figure.facecolor'])
+    assert not fig1.get_edgecolor() == colors.to_rgba(rcParams['figure.edgecolor'])
 
 
 @image_comparison(baseline_images=['figure_today'])

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -97,8 +97,10 @@ def test_reset_rcparams():
     assert not fig1.get_figwidth() == rcParams['figure.figsize'][0]
     assert not fig1.get_figheight() == rcParams['figure.figsize'][1]
     assert not fig1.get_dpi() == rcParams['figure.dpi']
-    assert not fig1.get_facecolor() == colors.to_rgba(rcParams['figure.facecolor'])
-    assert not fig1.get_edgecolor() == colors.to_rgba(rcParams['figure.edgecolor'])
+    assert not fig1.get_facecolor() == colors.to_rgba(
+        rcParams['figure.facecolor'])
+    assert not fig1.get_edgecolor() == colors.to_rgba(
+        rcParams['figure.edgecolor'])
 
 
 @image_comparison(baseline_images=['figure_today'])

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -68,6 +68,32 @@ def test_clf_keyword():
     assert [t.get_text() for t in fig2.texts] == []
 
 
+def test_reset_rcparams():
+    # test whether clf resets unset figure properties to rcParams values
+    fig0 = plt.figure()
+    fig0.figsize = None
+    fig0.facecolor = None
+    fig0.edgecolor = None
+    fig0.frameon = None
+    fig0.clf(reset_rcparams=True)
+    assert fig0.figsize == rcParams['figure.figsize']
+    assert fig0.facecolor == rcParams['figure.facecolor']
+    assert fig0.edgecolor == rcParams['figure.edgecolor']
+    assert fig0.frameon == rcParams['figure.frameon']
+
+    # set figure properties should not be reset to rcParams
+    fig1 = plt.figure()
+    fig1.figsize = (10, 10)
+    fig1.facecolor = 'red'
+    fig1.edgecolor = 'blue'
+    fig1.frameon = False
+    fig1.clf(reset_rcparams=True)
+    assert not fig1.figsize == rcParams['figure.figsize']
+    assert not fig1.facecolor == rcParams['figure.facecolor']
+    assert not fig1.edgecolor == rcParams['figure.edgecolor']
+    assert not fig1.frameon == rcParams['figure.frameon']
+
+
 @image_comparison(baseline_images=['figure_today'])
 def test_figure():
     # named figure support


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary
Optionally consult rcParams again in clf, issue #7434
The parameters that `Figure` gets from rcParams on creation are optionally fetched again in `clf` if `reset_rcparams` is set to True. By default, this is set to False and thus disabled.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
