### PR TITLE
Make pcolor(mesh) preserve all data

### DIFF
--- a/doc/users/next_whats_new/2019-12-18-pcolordropdata.rst
+++ b/doc/users/next_whats_new/2019-12-18-pcolordropdata.rst
@@ -1,0 +1,17 @@
+Pcolor and Pcolormesh now have *dropdata* kwarg and rcParam
+-----------------------------------------------------------
+
+Previously `.axes.Axes.pcolor` and  `.axes.Axes.pcolormesh` handled
+the situation where *x* and *y* have the same (respective) size as *Z* by
+dropping the last row and column of *Z*, and *x* and *y* are regarded as the
+edges of the remaining rows and columns in *Z*.  However, most users probably
+really want *x* and *y* centered on the rows and columns of *Z*, so if
+they specify *dropdata* as True, both methods will now linearly interpolate to
+get the edges of the bins, and *x* and *y* will specify the (linear) center of
+each gridcell in the pseudocolor plot.
+
+Users can also specify this by the new :rc:`pcolor.dropdata` in their
+``.matplotlibrc`` or via `.rcParams`.
+
+See :doc:`pcolormesh </gallery/images_contours_and_fields/pcolormesh_levels>`
+for an example.  

--- a/examples/images_contours_and_fields/pcolormesh_levels.py
+++ b/examples/images_contours_and_fields/pcolormesh_levels.py
@@ -1,11 +1,11 @@
 """
 ==========
-pcolormesh
+Pcolormesh
 ==========
 
-Shows how to combine Normalization and Colormap instances to draw "levels" in
-`~.axes.Axes.pcolor`, `~.axes.Axes.pcolormesh` and `~.axes.Axes.imshow` type
-plots in a similar way to the levels keyword argument to contour/contourf.
+`.axes.Axes.pcolormesh` allows you to generate 2-D image-style plots.  Note it
+is somewhat faster than `~.axes.Axes.pcolor`.
+
 """
 
 import matplotlib
@@ -14,6 +14,66 @@ from matplotlib.colors import BoundaryNorm
 from matplotlib.ticker import MaxNLocator
 import numpy as np
 
+###############################################################################
+# Basic Pcolormesh
+# ----------------
+#
+# We usually specify a pcolormesh by defining the edge of quadrilaterals and
+# the value of the quadrilateral.  Note that here *x* and *y* each have one
+# extra element than Z in the respective dimension.
+
+np.random.seed(19680801)
+Z = np.random.rand(6, 10)
+x = np.arange(-0.5, 10, 1)  # len = 11
+y = np.arange(4.5, 11, 1)  # len = 7
+
+fig, ax = plt.subplots()
+ax.pcolormesh(x, y, Z)
+
+###############################################################################
+# Non-rectilinear Pcolormesh
+# --------------------------
+#
+# Note that we can also specify matrices for *X* and *Y* and have
+# non-rectilinear quadrilaterals.
+
+x = np.arange(-0.5, 10, 1)  # len = 11
+y = np.arange(4.5, 11, 1)  # len = 7
+X, Y = np.meshgrid(x, y)
+X = X + 0.2 * Y  # tilt the co-ordinates.
+Y = Y + 0.3 * X
+
+fig, ax = plt.subplots()
+ax.pcolormesh(X, Y, Z)
+
+###############################################################################
+# Centered Co-ordinates
+# ---------------------
+#
+# Often a user wants to pass *X* and *Y* with the same sizes as *Z* to
+# `.axes.Axes.pcolormesh`.  Matplotlib will either drop the last row and
+# column of *Z* (default, h=istorically compatible with Matlab), or if
+# ``dropdata=True`` assume the user wanted *X* and *Y* centered on the
+# quadrilateral and linearly interpolate to get the edges.
+
+x = np.arange(10)  # len = 10
+y = np.arange(6)  # len = 6
+X, Y = np.meshgrid(x, y)
+
+fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
+axs[0].pcolormesh(X, Y, Z, vmin=np.min(Z), vmax=np.max(Z))
+axs[0].set_title('dropdata=True (default)')
+axs[1].pcolormesh(X, Y, Z, vmin=np.min(Z), vmax=np.max(Z), dropdata=False)
+axs[1].set_title('dropdata=False')
+
+###############################################################################
+# Making levels using Norms
+# -------------------------
+#
+# Shows how to combine Normalization and Colormap instances to draw
+# "levels" in `.axes.Axes.pcolor`, `.axes.Axes.pcolormesh`
+# and `.axes.Axes.imshow` type plots in a similar
+# way to the levels keyword argument to contour/contourf.
 
 # make these smaller to increase the resolution
 dx, dy = 0.05, 0.05
@@ -53,8 +113,6 @@ ax1.set_title('contourf with levels')
 # adjust spacing between subplots so `ax1` title and `ax0` tick labels
 # don't overlap
 fig.tight_layout()
-
-plt.show()
 
 #############################################################################
 #

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2515,11 +2515,11 @@ def minorticks_on():
 @docstring.copy(Axes.pcolor)
 def pcolor(
         *args, alpha=None, norm=None, cmap=None, vmin=None,
-        vmax=None, data=None, **kwargs):
+        vmax=None, dropdata=None, data=None, **kwargs):
     __ret = gca().pcolor(
         *args, alpha=alpha, norm=norm, cmap=cmap, vmin=vmin,
-        vmax=vmax, **({"data": data} if data is not None else {}),
-        **kwargs)
+        vmax=vmax, dropdata=dropdata, **({"data": data} if data is not
+        None else {}), **kwargs)
     sci(__ret)
     return __ret
 
@@ -2528,12 +2528,13 @@ def pcolor(
 @docstring.copy(Axes.pcolormesh)
 def pcolormesh(
         *args, alpha=None, norm=None, cmap=None, vmin=None,
-        vmax=None, shading='flat', antialiased=False, data=None,
-        **kwargs):
+        vmax=None, shading='flat', antialiased=False, dropdata=None,
+        data=None, **kwargs):
     __ret = gca().pcolormesh(
         *args, alpha=alpha, norm=norm, cmap=cmap, vmin=vmin,
         vmax=vmax, shading=shading, antialiased=antialiased,
-        **({"data": data} if data is not None else {}), **kwargs)
+        dropdata=dropdata, **({"data": data} if data is not None else
+        {}), **kwargs)
     sci(__ret)
     return __ret
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1030,6 +1030,9 @@ defaultParams = {
     # marker props
     'markers.fillstyle': ['full', validate_fillstyle],
 
+    ## pcolor(mesh) props:
+    'pcolor.dropdata': [True, validate_bool],
+
     ## patch props
     'patch.linewidth':   [1.0, validate_float],     # line width in points
     'patch.edgecolor':   ['black', validate_color],

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1268,6 +1268,52 @@ def test_pcolorargs():
         ax.pcolormesh(x, y, Z[:-1, :-1])
 
 
+@check_figures_equal(extensions=["png"])
+def test_pcolornodropdata(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    x = np.arange(0, 10)
+    y = np.arange(0, 3)
+    np.random.seed(19680801)
+    Z = np.random.randn(2, 9)
+    ax.pcolormesh(x, y, Z)
+
+    ax = fig_ref.subplots()
+    x2 = x[:-1] + np.diff(x) / 2
+    y2 = y[:-1] + np.diff(y) / 2
+    ax.pcolormesh(x2, y2, Z, dropdata=False)
+
+
+@check_figures_equal(extensions=["png"])
+def test_pcolornodropdatarc(fig_test, fig_ref):
+    matplotlib.rcParams['pcolor.dropdata'] = False
+    ax = fig_test.subplots()
+    x = np.arange(0, 10)
+    y = np.arange(0, 3)
+    np.random.seed(19680801)
+    Z = np.random.randn(2, 9)
+    ax.pcolormesh(x, y, Z)
+
+    ax = fig_ref.subplots()
+    x2 = x[:-1] + np.diff(x) / 2
+    y2 = y[:-1] + np.diff(y) / 2
+    ax.pcolormesh(x2, y2, Z)
+
+
+@check_figures_equal(extensions=["png"])
+def test_pcolordropdata(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    x = np.arange(0, 10)
+    y = np.arange(0, 4)
+    np.random.seed(19680801)
+    Z = np.random.randn(3, 9)
+    ax.pcolormesh(x[:-1], y[:-1], Z[:-1, :-1])
+
+    ax = fig_ref.subplots()
+    x2 = x[:-1]
+    y2 = y[:-1]
+    ax.pcolormesh(x2, y2, Z)
+
+
 @image_comparison(['canonical'])
 def test_canonical():
     fig, ax = plt.subplots()

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -135,6 +135,7 @@
 
 #markers.fillstyle : full  ## {full, left, right, bottom, top, none}
 
+# pcolor.dropdata : True
 
 ## ***************************************************************************
 ## * PATCHES                                                                 *


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->



## PR Summary

**UPDATE: 17 Dec 2019**

New docs: https://27917-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/_as_gen/matplotlib.axes.Axes.pcolormesh.html#matplotlib.axes.Axes.pcolormesh

Revamped example: https://27917-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/images_contours_and_fields/pcolormesh_levels.html#sphx-glr-gallery-images-contours-and-fields-pcolormesh-levels-py

Right now, if you supply C = MxN matrix and x = N and y = M `pcolor` drops the last column and row of C.

```python

import numpy as np
import matplotlib
import matplotlib.pyplot as plt

x = np.arange(4)
y = np.arange(4)
X, Y = np.meshgrid(x, y)
z = (X+1)*(Y+1)
fig, ax = plt.subplots(3, 2, sharex=True, sharey=True, constrained_layout=True)

for nn,drop in enumerate([True, False]):
    vmin = np.min(z)
    vmax = np.max(z)
    ax[0, nn].pcolor(x, y, z, vmin=vmin, vmax=vmax, dropdata=drop)
    ax[1, nn].pcolor(X+0.2*Y, Y, z, vmin=vmin, vmax=vmax, dropdata=drop)
    pc = ax[2, nn].pcolor(X +0.2 * Y, Y + 0.2*X, z,
                     vmin=vmin, vmax=vmax, dropdata=drop)

fig.colorbar(pc, ax=ax)
plt.show()
```

![pcolor](https://user-images.githubusercontent.com/1562854/71040907-94d36f80-20dc-11ea-8381-e8d00831db3b.png)


Pluses: no data thrown out!
Minuses: need to add a kwarg to not lose the data.  



<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
- [x] Fix handling of dates in x/y axes...

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->