### PR TITLE
Check dependencies at runtime as declared in setup.py.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -137,19 +137,20 @@ e.g., if the header of some required library is in
 Dependencies
 ------------
 
-Matplotlib requires a large number of dependencies:
+Matplotlib requires the following dependencies:
 
   * `Python <https://www.python.org/downloads/>`_ (>= 3.5)
-  * `NumPy <http://www.numpy.org>`_ (>= |minimum_numpy_version|)
-  * `setuptools <https://setuptools.readthedocs.io/en/latest/>`__
+  * `setuptools <https://setuptools.readthedocs.io/en/latest/>`_
+  * `NumPy <http://www.numpy.org>`_ (>= 1.10.0)
+  * `cycler <http://matplotlib.org/cycler/>`_ (>= 0.10.0)
   * `dateutil <https://pypi.python.org/pypi/python-dateutil>`_ (>= 2.1)
-  * `pyparsing <https://pyparsing.wikispaces.com/>`__
-  * `libpng <http://www.libpng.org>`__ (>= 1.2)
-  * `pytz <http://pytz.sourceforge.net/>`__
-  * FreeType (>= 2.3)
-  * `cycler <http://matplotlib.org/cycler/>`__ (>= 0.10.0)
-  * `six <https://pypi.python.org/pypi/six>`_
   * `kiwisolver <https://github.com/nucleic/kiwi>`__ (>= 1.0.0)
+  * `pyparsing <https://pyparsing.wikispaces.com/>`_ (>= 2.1.7; some older
+    versions may work)
+  * `pytz <http://pytz.sourceforge.net/>`_
+  * `six <https://pypi.python.org/pypi/six>`_ (>= 1.10)
+  * `FreeType <https://www.freetype.org>`_ (>= 2.3)
+  * `libpng <http://www.libpng.org>`_ (>= 1.2)
 
 Optionally, you can also install a number of packages to enable better user
 interface toolkits. See :ref:`what-is-a-backend` for more details on the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -323,10 +323,6 @@ else:
 # documentation
 autoclass_content = 'both'
 
-rst_epilog = """
-.. |minimum_numpy_version| replace:: %s
-""" % matplotlib.__version__numpy__
-
 texinfo_documents = [
     ("contents", 'matplotlib', 'Matplotlib Documentation',
      'John Hunter@*Darren Dale@*Eric Firing@*Michael Droettboom@*'

--- a/setupext.py
+++ b/setupext.py
@@ -107,18 +107,6 @@ def get_win32_compiler():
 win32_compiler = get_win32_compiler()
 
 
-def extract_versions():
-    """
-    Extracts version values from the main matplotlib __init__.py and
-    returns them as a dictionary.
-    """
-    with open('lib/matplotlib/__init__.py') as fd:
-        for line in fd.readlines():
-            if (line.startswith('__version__numpy__')):
-                exec(line.strip())
-    return locals()
-
-
 def has_include_file(include_dirs, filename):
     """
     Returns `True` if `filename` can be found in one of the
@@ -925,7 +913,8 @@ class Numpy(SetupPackage):
         return [numpy.get_include()]
 
     def check(self):
-        min_version = extract_versions()['__version__numpy__']
+        # Remember to keep the version in INSTALL.rst in sync.
+        min_version = "1.7.1"
         try:
             import numpy
         except ImportError:
@@ -1391,6 +1380,7 @@ class InstallRequires(SetupPackage):
         return "handled by setuptools"
 
     def get_install_requires(self):
+        # Remember to keep the list in INSTALL.rst in sync.
         install_requires = [
             "cycler>=0.10",
             "pyparsing>=2.0.1,!=2.0.4,!=2.1.2,!=2.1.6",


### PR DESCRIPTION
The goal is to list the requirements exactly once in code (in
setupext.py) and once in the docs (in INSTALL.rst).

Instead of manually importing and checking that (python) dependencies
are installed with the correct versions, rely on pkg_resources, which
allows automatically keeping things in sync with setupext, as well as
correctly check e.g. the complex version requirements on pyparsing.

Remove the overly complex way to specify the minimum numpy version.

Add comments reminding to update INSTALL.rst when the requirements are
changed in setupext.py; reorder dependencies in INSTALL.rst in a more
logical order.

Remove unneeded reference to MATLAB being a registered trademark.

Note that if you are running Matplotlib from source by manipulating
PYTHONPATH, then it will not appear to pkg_resources.  In this case,
there is no check for other dependencies (you are assumed to be
responsible enough for that).  Conversely, Matplotlib will fail to
import if it is installed into site-packages but some dependency (six,
etc.) is only available in PYTHONPATH instead of being correctly
installed.  I think this is acceptable (or we could just completely drop
the import checks and let bad installs fail with normal ImportErrors,
like most other packages do...).

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
