### PR TITLE
Unify querying of executable versions

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -445,7 +445,8 @@ def get_executable_info(name):
     -------
     If the executable is found, a namedtuple with fields ``executable`` (`str`)
     and ``version`` (`distutils.version.LooseVersion`, or ``None`` if the
-    version cannot be determined); ``None`` if the executable is not found.
+    version cannot be determined); ``None`` if the executable is not found or
+    older that the oldest version supported by Matplotlib.
     """
 
     def impl(args, regex, min_ver=None):
@@ -519,14 +520,16 @@ def get_all_executable_infos():
 
 @cbook.deprecated("3.0")
 def checkdep_dvipng():
-    return str(get_executable_info("dvipng").version)
+    info = get_executable_info("dvipng")
+    return str(info.version) if info else None
 
 
 @cbook.deprecated("3.0")
 def checkdep_ghostscript():
     info = get_executable_info("gs")
-    checkdep_ghostscript.executable = info.executable
-    checkdep_ghostscript.version = str(info.version)
+    if info:
+        checkdep_ghostscript.executable = info.executable
+        checkdep_ghostscript.version = str(info.version)
     return checkdep_ghostscript.executable, checkdep_ghostscript.version
 checkdep_ghostscript.executable = None
 checkdep_ghostscript.version = None
@@ -534,12 +537,15 @@ checkdep_ghostscript.version = None
 
 @cbook.deprecated("3.0")
 def checkdep_pdftops():
-    return str(get_executable_info("pdftops").version)
+    info = get_executable_info("pdftops")
+    return str(info.version) if info else None
 
 
 @cbook.deprecated("3.0")
 def checkdep_inkscape():
-    checkdep_inkscape.version = str(get_executable_info("inkscape").version)
+    info = get_executable_info("inkscape")
+    if info:
+        checkdep_inkscape.version = str(info.version)
     return checkdep_inkscape.version
 checkdep_inkscape.version = None
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -146,32 +146,16 @@ def _font_properties_str(prop):
 
 
 def make_pdf_to_png_converter():
-    """
-    Returns a function that converts a pdf file to a png file.
-    """
-
-    tools_available = []
-    # check for pdftocairo
-    try:
-        subprocess.check_output(["pdftocairo", "-v"], stderr=subprocess.STDOUT)
-        tools_available.append("pdftocairo")
-    except OSError:
-        pass
-    # check for ghostscript
-    gs, ver = mpl.checkdep_ghostscript()
-    if gs:
-        tools_available.append("gs")
-
-    # pick converter
-    if "pdftocairo" in tools_available:
+    """Returns a function that converts a pdf file to a png file."""
+    if shutil.which("pdftocairo"):
         def cairo_convert(pdffile, pngfile, dpi):
             cmd = ["pdftocairo", "-singlefile", "-png", "-r", "%d" % dpi,
                    pdffile, os.path.splitext(pngfile)[0]]
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         return cairo_convert
-    elif "gs" in tools_available:
+    if mpl.get_executable_info("gs"):
         def gs_convert(pdffile, pngfile, dpi):
-            cmd = [gs,
+            cmd = [mpl.get_executable_info("gs").executable,
                    '-dQUIET', '-dSAFER', '-dBATCH', '-dNOPAUSE', '-dNOPROMPT',
                    '-dUseCIEColor', '-dTextAlphaBits=4',
                    '-dGraphicsAlphaBits=4', '-dDOINTERPOLATE',
@@ -179,8 +163,7 @@ def make_pdf_to_png_converter():
                    '-r%d' % dpi, pdffile]
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         return gs_convert
-    else:
-        raise RuntimeError("No suitable pdf to png renderer found.")
+    raise RuntimeError("No suitable pdf to png renderer found")
 
 
 class LatexError(Exception):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -13,6 +13,7 @@ that actually reflects the values given here. Any additions or deletions to the
 parameter set listed here should also be visited to the
 :file:`matplotlibrc.template` in matplotlib's root source directory.
 """
+
 import six
 
 from collections import Iterable, Mapping
@@ -22,6 +23,7 @@ import os
 import warnings
 import re
 
+import matplotlib as mpl
 from matplotlib import cbook
 from matplotlib.cbook import mplDeprecation, deprecated, ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
@@ -507,7 +509,12 @@ def validate_ps_distiller(s):
     elif s in ('false', False):
         return False
     elif s in ('ghostscript', 'xpdf'):
-        return s
+        if not mpl.get_executable_info("gs"):
+            warnings.warn("Setting ps.usedistiller requires ghostscript.")
+            return False
+        if s == "xpdf" and not mpl.get_executable_info("pdftops"):
+            warnings.warn("Setting ps.usedistiller to 'xpdf' requires xpdf.")
+            return False
     else:
         raise ValueError('matplotlibrc ps.usedistiller must either be none, '
                          'ghostscript or xpdf')

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -16,7 +16,7 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
 
 
 needs_ghostscript = pytest.mark.xfail(
-    matplotlib.checkdep_ghostscript()[0] is None,
+    matplotlib.get_executable_info("gs") is None,
     reason="This test needs a ghostscript installation")
 
 


### PR DESCRIPTION
## PR Summary

Provide `get_executable_info` to replace the various checkdep_foo checkers (now deprecated), as suggested in #9571.  Provide `get_all_executable_infos` for the purpose of quickly checking installed versions of all "relevant" executables.

Bump minimal supported ghostscript version to 9.0 (released in 2010, https://www.ghostscript.com/doc/current/History9.htm) in order to remove a conditional path.

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
