### PR TITLE
Implement Qt4 backend by fully reexporting Qt5 backend.

### DIFF
--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -2,20 +2,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six import unichr
-import os
-import re
-import signal
-import sys
-
-from matplotlib._pylab_helpers import Gcf
-from matplotlib.backend_bases import (
-    FigureCanvasBase, FigureManagerBase, NavigationToolbar2, TimerBase,
-    cursors)
-from matplotlib.figure import Figure
-from matplotlib.widgets import SubplotTool
-
-from .qt_compat import QtCore, QtWidgets, _getSaveFileName, __version__
 
 from .backend_qt5 import (
     backend_version, SPECIAL_KEYS, SUPER, ALT, CTRL, SHIFT, MODIFIER_KEYS,
@@ -23,24 +9,7 @@ from .backend_qt5 import (
     NavigationToolbar2QT, SubplotToolQt, error_msg_qt, exception_handler)
 from .backend_qt5 import FigureCanvasQT as FigureCanvasQT5
 
-DEBUG = False
-
-
-class FigureCanvasQT(FigureCanvasQT5):
-
-    def wheelEvent(self, event):
-        x = event.x()
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y()
-        # from QWheelEvent::delta doc
-        steps = event.delta()/120
-        if (event.orientation() == QtCore.Qt.Vertical):
-            FigureCanvasBase.scroll_event(self, x, y, steps)
-            if DEBUG:
-                print('scroll event: delta = %i, '
-                      'steps = %i ' % (event.delta(), steps))
-
 
 @_BackendQT5.export
 class _BackendQT4(_BackendQT5):
-    FigureCanvas = FigureCanvasQT
+    pass

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -6,25 +6,10 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-from .backend_agg import FigureCanvasAgg
-from .backend_qt4 import (
-    QtCore, _BackendQT4, FigureCanvasQT, FigureManagerQT, NavigationToolbar2QT)
-from .backend_qt5agg import FigureCanvasQTAggBase
+from .backend_qt5agg import (
+    _BackendQT5Agg, FigureCanvasQTAgg, FigureManagerQT, NavigationToolbar2QT)
 
 
-class FigureCanvasQTAgg(FigureCanvasQTAggBase, FigureCanvasQT):
-    """
-    The canvas the figure renders into.  Calls the draw and print fig
-    methods, creates the renderers, etc...
-
-    Attributes
-    ----------
-    figure : `matplotlib.figure.Figure`
-        A high-level Figure instance
-
-    """
-
-
-@_BackendQT4.export
-class _BackendQT4Agg(_BackendQT4):
-    FigureCanvas = FigureCanvasQTAgg
+@_BackendQT5Agg.export
+class _BackendQT4Agg(_BackendQT5Agg):
+    pass

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -317,15 +317,27 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             FigureCanvasBase.button_release_event(self, x, y, button,
                                                   guiEvent=event)
 
-    def wheelEvent(self, event):
-        x, y = self.mouseEventCoords(event)
-        # from QWheelEvent::delta doc
-        if event.pixelDelta().x() == 0 and event.pixelDelta().y() == 0:
-            steps = event.angleDelta().y() / 120
-        else:
-            steps = event.pixelDelta().y()
-        if steps:
-            FigureCanvasBase.scroll_event(self, x, y, steps, guiEvent=event)
+    if is_pyqt5():
+        def wheelEvent(self, event):
+            x, y = self.mouseEventCoords(event)
+            # from QWheelEvent::delta doc
+            if event.pixelDelta().x() == 0 and event.pixelDelta().y() == 0:
+                steps = event.angleDelta().y() / 120
+            else:
+                steps = event.pixelDelta().y()
+            if steps:
+                FigureCanvasBase.scroll_event(
+                    self, x, y, steps, guiEvent=event)
+    else:
+        def wheelEvent(self, event):
+            x = event.x()
+            # flipy so y=0 is bottom of canvas
+            y = self.figure.bbox.height - event.y()
+            # from QWheelEvent::delta doc
+            steps = event.delta() / 120
+            if event.orientation() == QtCore.Qt.Vertical:
+                FigureCanvasBase.scroll_event(
+                    self, x, y, steps, guiEvent=event)
 
     def keyPressEvent(self, event):
         key = self._get_key(event)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

All's in the title: transform the Qt4 backend into a thin shell that just reexports everything from the Qt5 backend.

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
