### PR TITLE
More helpful error if requested MovieWriter not available

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -167,7 +167,12 @@ class MovieWriterRegistry(object):
         self.ensure_not_dirty()
         if not self.avail:
             raise RuntimeError("No MovieWriters available!")
-        return self.avail[name]
+        try:
+            return self.avail[name]
+        except KeyError:
+            raise RuntimeError(
+                'Requested MovieWriter ({}) not available'.format(name))
+
 
 writers = MovieWriterRegistry()
 


### PR DESCRIPTION
If the `MovieWriterRegistry` tries to access a MovieWriter that isn't available, it currently just throws a `KeyError`.

This change catches that and prints a `RuntimeError` to let the user know which writer is being accessed, but isn't available.

Discovered by running this in a notebook with an ffmpeg `MoveWriter` not available:
```python
import matplotlib.pyplot as plt
from matplotlib import animation
from IPython.display import HTML

fig, ax = plt.subplots()

def animate(i): 
    return None

anim = animation.FuncAnimation(fig, animate)
HTML(anim.to_html5_video())
```