### PR TITLE
expose Path.contains_points as a method of Patch

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -159,7 +159,7 @@ class Patch(artist.Artist):
         contains the corresponding point.
         (transformed with its transform attribute).
 
-        *points* should be an N x 2 array.
+        *points* must be Nx2 array.
         *radius* allows the path to be made slightly larger or smaller.
         """
         radius = self._process_radius(radius)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -145,7 +145,7 @@ class Patch(artist.Artist):
         """
         Returns `True` if the given *point* is inside the path
         (transformed with its transform attribute).
-        
+
         *radius* allows the path to be made slightly larger or smaller.
         """
         radius = self._process_radius(radius)
@@ -155,10 +155,11 @@ class Patch(artist.Artist):
 
     def contains_points(self, points, radius=None):
         """
-        Returns a bool array which is `True` if the (closed) path contains the corresponding point.
+        Returns a bool array which is `True` if the (closed) path
+        contains the corresponding point.
         (transformed with its transform attribute).
-        
-        *points* should be an N x 2 array. 
+
+        *points* should be an N x 2 array.
         *radius* allows the path to be made slightly larger or smaller.
         """
         radius = self._process_radius(radius)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -143,11 +143,26 @@ class Patch(artist.Artist):
 
     def contains_point(self, point, radius=None):
         """
-        Returns *True* if the given point is inside the path
+        Returns `True` if the given point is inside the path
         (transformed with its transform attribute).
+        
+        `radius` allows the path to be made slightly larger or smaller.
         """
         radius = self._process_radius(radius)
         return self.get_path().contains_point(point,
+                                              self.get_transform(),
+                                              radius)
+
+    def contains_points(self, points, radius=None):
+        """
+        Returns a bool array which is `True` if the (closed) path contains the corresponding point.
+        (transformed with its transform attribute).
+        
+        `points` should be an N x 2 array. 
+        `radius` allows the path to be made slightly larger or smaller.
+        """
+        radius = self._process_radius(radius)
+        return self.get_path().contains_points(points,
                                               self.get_transform(),
                                               radius)
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -163,8 +163,8 @@ class Patch(artist.Artist):
         """
         radius = self._process_radius(radius)
         return self.get_path().contains_points(points,
-                                              self.get_transform(),
-                                              radius)
+                                               self.get_transform(),
+                                               radius)
 
     def update_from(self, other):
         """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -143,7 +143,7 @@ class Patch(artist.Artist):
 
     def contains_point(self, point, radius=None):
         """
-        Returns `True` if the given *point* is inside the path
+        Returns ``True`` if the given *point* is inside the path
         (transformed with its transform attribute).
 
         *radius* allows the path to be made slightly larger or smaller.
@@ -155,7 +155,7 @@ class Patch(artist.Artist):
 
     def contains_points(self, points, radius=None):
         """
-        Returns a bool array which is `True` if the (closed) path
+        Returns a bool array which is ``True`` if the (closed) path
         contains the corresponding point.
         (transformed with its transform attribute).
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -143,10 +143,10 @@ class Patch(artist.Artist):
 
     def contains_point(self, point, radius=None):
         """
-        Returns `True` if the given point is inside the path
+        Returns `True` if the given *point* is inside the path
         (transformed with its transform attribute).
         
-        `radius` allows the path to be made slightly larger or smaller.
+        *radius* allows the path to be made slightly larger or smaller.
         """
         radius = self._process_radius(radius)
         return self.get_path().contains_point(point,
@@ -158,8 +158,8 @@ class Patch(artist.Artist):
         Returns a bool array which is `True` if the (closed) path contains the corresponding point.
         (transformed with its transform attribute).
         
-        `points` should be an N x 2 array. 
-        `radius` allows the path to be made slightly larger or smaller.
+        *points* should be an N x 2 array. 
+        *radius* allows the path to be made slightly larger or smaller.
         """
         radius = self._process_radius(radius)
         return self.get_path().contains_points(points,

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -386,3 +386,27 @@ def test_datetime_datetime_fails():
 
     with pytest.raises(TypeError):
         mpatches.Rectangle((0, start), 1, dt_delta)
+
+
+def test_contains_point():
+    ell = mpatches.Ellipse((0.5, 0.5), 0.5, 1.0, 0)
+    points = [(0.0, 0.5), (0.2, 0.5), (0.25, 0.5), (0.5, 0.5)]
+    path = ell.get_path()
+    transform = ell.get_transform()
+    radius = ell._process_radius(None)
+    expected = np.array([path.contains_point(point,
+                                             transform,
+                                             radius) for point in points])
+    result = np.array([ell.contains_point(point) for point in points])
+    assert np.all(result == expected)
+
+
+def test_contains_points():
+    ell = mpatches.Ellipse((0.5, 0.5), 0.5, 1.0, 0)
+    points = [(0.0, 0.5), (0.2, 0.5), (0.25, 0.5), (0.5, 0.5)]
+    path = ell.get_path()
+    transform = ell.get_transform()
+    radius = ell._process_radius(None)
+    expected = path.contains_points(points, transform, radius)
+    result = ell.contains_points(points)
+    assert np.all(result == expected)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

`Patch` has the method `contains_point` but not `contains_points`, but the latter is supported by `Path`. This PR adds `contains_points` to `Patch`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
