### PR TITLE
Correct https git URIs in documentation

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -79,7 +79,7 @@ We use `Git <https://git-scm.com/>`_ for version control and
 You can check out the latest sources with the command (see
 :ref:`set-up-fork` for more details)::
 
-    git clone https://github.com:matplotlib/matplotlib.git
+    git clone https://github.com/matplotlib/matplotlib.git
 
 and navigate to the :file:`matplotlib` directory. If you have the proper privileges,
 you can use ``git@`` instead of  ``https://``, which works through the ssh protocol
@@ -185,7 +185,7 @@ A brief overview is:
 
  3. Clone this copy to your local disk::
 
-        $ git clone https://github.com:YourLogin/matplotlib.git
+        $ git clone https://github.com/YourLogin/matplotlib.git
 
  4. Create a branch to hold your changes::
 

--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -208,7 +208,7 @@ collaborator:
 
 Now all those people can do::
 
-    git clone https://gith hub.com:your-user-name/matplotlib.git
+    git clone https://github.com/your-user-name/matplotlib.git
 
 Remember that links starting with ``https`` or ``git@`` are read-write, and that 
 ``git@`` uses the ssh protocol; links starting with ``git://`` are read-only.

--- a/doc/devel/gitwash/set_up_fork.rst
+++ b/doc/devel/gitwash/set_up_fork.rst
@@ -13,7 +13,7 @@ Overview
 
 ::
 
-   git clone https://github.com:your-user-name/matplotlib.git
+   git clone https://github.com/your-user-name/matplotlib.git
    cd matplotlib
    git remote add upstream git://github.com/matplotlib/matplotlib.git
 
@@ -24,7 +24,7 @@ Clone your fork
 ---------------
 
 #. Clone your fork to the local computer with ``git clone
-   https://github.com:your-user-name/matplotlib.git``
+   https://github.com/your-user-name/matplotlib.git``
 #. Investigate.  Change directory to your new repo: ``cd matplotlib``. Then
    ``git branch -a`` to show you all branches.  You'll get something
    like:
@@ -67,7 +67,7 @@ Just for your own satisfaction, show yourself that you now have a new
 
    upstream	git://github.com/matplotlib/matplotlib.git (fetch)
    upstream	git://github.com/matplotlib/matplotlib.git (push)
-   origin	https://github.com:your-user-name/matplotlib.git (fetch)
-   origin	https://github.com:your-user-name/matplotlib.git (push)
+   origin	https://github.com/your-user-name/matplotlib.git (fetch)
+   origin	https://github.com/your-user-name/matplotlib.git (push)
 
 .. include:: links.inc


### PR DESCRIPTION
Fix a few instances in the documentation where `http(s)://` git URIs contained a `:` rather than a `/` to separate the host from the path.

Using a colon is malformed, and results in an error (at least on my git 2.13.3, perhaps other versions try harder to guess):

```
$ git clone https://github.com:matplotlib/matplotlib.git
Cloning into 'matplotlib'...
fatal: unable to access 'https://github.com:matplotlib/matplotlib.git/':
Port number ended with 'm'
```

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
