### PR TITLE
Update background in SpanSelector._press whenever useblit=True.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1811,10 +1811,8 @@ class SpanSelector(_SelectorWidget):
         self.rect.set_visible(self.visible)
         if self.span_stays:
             self.stay_rect.set_visible(False)
-            # really force a draw so that the stay rect is not in
-            # the blit background
-            if self.useblit:
-                self.canvas.draw()
+        if self.useblit:
+            self.canvas.draw()
         xdata, ydata = self._get_data(event)
         if self.direction == 'horizontal':
             self.pressv = xdata


### PR DESCRIPTION
Previously, the canvas would only get redrawn when useblit=True only if
span_stays is set.  This causes e.g.

    import sys
    from PyQt5.QtWidgets import *
    from matplotlib.backends.backend_qt5agg import *
    from matplotlib.figure import Figure
    from matplotlib.widgets import SpanSelector

    class App(QMainWindow):
        def __init__(self):
            super().__init__()
            self.setCentralWidget(QWidget())
            layout = QVBoxLayout()
            self.centralWidget().setLayout(layout)
            self._fig = Figure()
            self._fig.subplots()
            layout.addWidget(FigureCanvas(self._fig))
            layout.addWidget(QPushButton("span", clicked=self._span_cb))

        def _span_cb(self):
            self._span = SpanSelector(
                self._fig.axes[0], print, "horizontal", useblit=True)

    qapp = QApplication(sys.argv)
    app = App()
    app.show()
    qapp.exec_()

to use an incorrect background(?) when clicking and starting a span for
the first time.

To be honest I'm not sure this is exactly the correct solution, although
it does fix the issue...

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
