### PR TITLE
Make tick_left/right keep labels off if they are already off

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1938,7 +1938,9 @@ class XAxis(Axis):
         self.stale = True
 
     def tick_top(self):
-        'use ticks only on top'
+        """
+        Move ticks and ticklabels (if present) to the top of the axes.
+        """
         label = True
         if 'label1On' in self._major_tick_kw:
             label = (self._major_tick_kw['label1On']
@@ -1949,7 +1951,9 @@ class XAxis(Axis):
         self.set_tick_params(which='both', labeltop=label)
 
     def tick_bottom(self):
-        'use ticks only on bottom'
+        """
+        Move ticks and ticklabels (if present) to the bottom of the axes.
+        """
         label = True
         if 'label1On' in self._major_tick_kw:
             label = (self._major_tick_kw['label1On']
@@ -2288,7 +2292,9 @@ class YAxis(Axis):
         self.stale = True
 
     def tick_right(self):
-        'use ticks only on right'
+        """
+        Move ticks and ticklabels (if present) to the right of the axes.
+        """
         label = True
         if 'label1On' in self._major_tick_kw:
             label = (self._major_tick_kw['label1On']
@@ -2299,7 +2305,9 @@ class YAxis(Axis):
         self.set_tick_params(which='both', labelright=label)
 
     def tick_left(self):
-        'use ticks only on left'
+        """
+        Move ticks and ticklabels (if present) to the left of the axes.
+        """
         label = True
         if 'label1On' in self._major_tick_kw:
             label = (self._major_tick_kw['label1On']

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2275,8 +2275,10 @@ class YAxis(Axis):
 
     def tick_right(self):
         'use ticks only on right'
-        label = (self._major_tick_kw['label1On']
-                 or self._major_tick_kw['label2On'])
+        label = True
+        if 'label1On' in self._major_tick_kw:
+            label = (self._major_tick_kw['label1On']
+                     or self._major_tick_kw['label2On'])
         self.set_ticks_position('right')
         # if labels were turned off before this was called
         # leave them off
@@ -2284,8 +2286,10 @@ class YAxis(Axis):
 
     def tick_left(self):
         'use ticks only on left'
-        label = (self._major_tick_kw['label1On']
-                 or self._major_tick_kw['label2On'])
+        label = True
+        if 'label1On' in self._major_tick_kw:
+            label = (self._major_tick_kw['label1On']
+                     or self._major_tick_kw['label2On'])
         self.set_ticks_position('left')
         # if labels were turned off before this was called
         # leave them off

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2275,11 +2275,22 @@ class YAxis(Axis):
 
     def tick_right(self):
         'use ticks only on right'
+        label = (self._major_tick_kw['label1On']
+                 or self._major_tick_kw['label2On'])
         self.set_ticks_position('right')
+        # if labels were turned off before this was called
+        # leave them off
+        self.set_tick_params(which='both', labelright=label)
 
     def tick_left(self):
         'use ticks only on left'
+        label = (self._major_tick_kw['label1On']
+                 or self._major_tick_kw['label2On'])
         self.set_ticks_position('left')
+        # if labels were turned off before this was called
+        # leave them off
+        self.set_tick_params(which='both', labelleft=label)
+
 
     def get_ticks_position(self):
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2295,7 +2295,6 @@ class YAxis(Axis):
         # leave them off
         self.set_tick_params(which='both', labelleft=label)
 
-
     def get_ticks_position(self):
         """
         Return the ticks position (left, right, both or unknown)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1939,11 +1939,25 @@ class XAxis(Axis):
 
     def tick_top(self):
         'use ticks only on top'
+        label = True
+        if 'label1On' in self._major_tick_kw:
+            label = (self._major_tick_kw['label1On']
+                     or self._major_tick_kw['label2On'])
         self.set_ticks_position('top')
+        # if labels were turned off before this was called
+        # leave them off
+        self.set_tick_params(which='both', labeltop=label)
 
     def tick_bottom(self):
         'use ticks only on bottom'
+        label = True
+        if 'label1On' in self._major_tick_kw:
+            label = (self._major_tick_kw['label1On']
+                     or self._major_tick_kw['label2On'])
         self.set_ticks_position('bottom')
+        # if labels were turned off before this was called
+        # leave them off
+        self.set_tick_params(which='both', labelbottom=label)
 
     def get_ticks_position(self):
         """

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -101,6 +101,20 @@ def test_shared():
     check_visible(axs, [False, False, True, True], [True, False, True, False])
 
 
+def test_shared_and_moved():
+    # test if sharey is on, but then tick_left is called that labels don't
+    # re-appear.  Seaborn does this just to be sure yaxis is on left...
+    f, (a1, a2) = plt.subplots(1, 2, sharey=True)
+    check_visible([a2], [True], [False])
+    a2.yaxis.tick_left()
+    check_visible([a2], [True], [False])
+
+    f, (a1, a2) = plt.subplots(2, 1, sharex=True)
+    check_visible([a1], [False], [True])
+    a2.xaxis.tick_bottom()
+    check_visible([a1], [False], [True])
+
+
 def test_exceptions():
     # TODO should this test more options?
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

This modifies `XAxis.tick_left` and `X-axis.tick_right` to keep the tick labels turned off if the major
labels are already turned off.  

Not 100% convinced this is the right thing to do, but fixes #9664   Wild guess is that this doesn't break anything, whereas the new behaviour did.  

### Fixes:

```python
import matplotlib.pyplot as plt

f, axes = plt.subplots(1, 2, sharey=True)
axes[1].yaxis.tick_left()
plt.show()

```

### Breaks:

The following if the user expected `tick_left()` to turn the labeling back on.

```python
import matplotlib.pyplot as plt

f, ax = plt.subplots(1, 2)
ax.yaxis.set_tick_params(which='both', labelleft=False)
ax.yaxis.tick_left()
plt.show()
```

I'm not sure why this would happen, but this PR breaks that case...


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
- [x] fix tick_top tick_bottom

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->