### PR TITLE
FIX: Catch IOError on font-cache write

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -964,8 +964,10 @@ def json_dump(data, filename):
     Handles FontManager and its fields."""
 
     with open(filename, 'w') as fh:
-        json.dump(data, fh, cls=JSONEncoder, indent=2)
-
+        try:
+            json.dump(data, fh, cls=JSONEncoder, indent=2)
+        except IOError as e:
+            warnings.warn('Could not save font_manager cache ', e)
 
 def json_load(filename):
     """Loads a data structure as JSON from the named file.


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Fails gracefully if font-manager cache cannot be written.

Fixes #9548

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->