### PR TITLE
Trivial aliases.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -251,21 +251,11 @@ def to_hex(c, keep_alpha=False):
 
 ### Backwards-compatible color-conversion API
 
+
 cnames = CSS4_COLORS
 hexColorPattern = re.compile(r"\A#[a-fA-F0-9]{6}\Z")
-
-
-def rgb2hex(c):
-    'Given an rgb or rgba sequence of 0-1 floats, return the hex string'
-    return to_hex(c)
-
-
-def hex2color(c):
-    """
-    Take a hex string *s* and return the corresponding rgb 3-tuple
-    Example: #efefef -> (0.93725, 0.93725, 0.93725)
-    """
-    return ColorConverter.to_rgb(c)
+rgb2hex = to_hex
+hex2color = to_rgb
 
 
 class ColorConverter(object):
@@ -327,6 +317,7 @@ class ColorConverter(object):
 
 
 colorConverter = ColorConverter()
+
 
 ### End of backwards-compatible color-conversion API
 


### PR DESCRIPTION
colors.rgb2hex and colors.hex2color are trivial aliases of to_hex and
to_rgb.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
