### PR TITLE
FIX: set_url() without effect in the plot for instances of Tick

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -312,6 +312,7 @@ class Tick(artist.Artist):
 
         ACCEPTS: str
         """
+        super(Tick, self).set_url(s)
         self.label1.set_url(s)
         self.label2.set_url(s)
         self.stale = True

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -306,6 +306,16 @@ class Tick(artist.Artist):
         self.label2.set_text(s)
         self.stale = True
 
+    def set_url(self, s):
+        """
+        Set the url of label1 and label2
+
+        ACCEPTS: str
+        """
+        self.label1.set_url(s)
+        self.label2.set_url(s)
+        self.stale = True
+
     def _set_artist_props(self, a):
         a.set_figure(self.figure)
 


### PR DESCRIPTION
## PR Summary

In the class Tick, the url attribute is not passed to any of the objects that are to be drawn, so it is useless, as detailed in issue #9695. Suggested solution is to override the `set_url()` method in Tick to transfer the url attribute content to the tick labels, that are to be drawn.

Fixes issue #9695.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [OK] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [OK] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way


