### PR TITLE
Set widget background color to white.

### DIFF
--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -99,10 +99,6 @@ class PlotPanel(wx.Panel):
 
         self.canvas.draw()
 
-    def onEraseBackground(self, evt):
-        # this is supposed to prevent redraw flicker on some X servers...
-        pass
-
 
 class MyApp(wx.App):
     def OnInit(self):

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -233,20 +233,12 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     @_allow_super_init
     def __init__(self, figure):
         _create_qApp()
-        figure._original_dpi = figure.dpi
-
         super(FigureCanvasQT, self).__init__(figure=figure)
 
+        figure._original_dpi = figure.dpi
         self.figure = figure
         self._update_figure_dpi()
-
-        w, h = self.get_width_height()
-        self.resize(w, h)
-
-        self.setMouseTracking(True)
-        # Key auto-repeat enabled by default
-        self._keyautorepeat = True
-
+        self.resize(*self.get_width_height())
         # In cases with mixed resolution displays, we need to be careful if the
         # dpi_ratio changes - in this case we need to resize the canvas
         # accordingly. We could watch for screenChanged events from Qt, but
@@ -255,6 +247,10 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         # dpi_ratio value here and in paintEvent we resize the canvas if
         # needed.
         self._dpi_ratio_prev = None
+
+        self.setMouseTracking(True)
+        # Key auto-repeat enabled by default
+        self._keyautorepeat = True
 
     @property
     def _dpi_ratio(self):

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -252,6 +252,9 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         # Key auto-repeat enabled by default
         self._keyautorepeat = True
 
+        palette = QtGui.QPalette(QtCore.Qt.white)
+        self.setPalette(palette)
+
     @property
     def _dpi_ratio(self):
         # Not available on Qt4 or some older Qt5.

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -661,7 +661,6 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
     def __init__(self, canvas, window):
         self.canvas = canvas
         self.window = window
-        self._idle = True
         NavigationToolbar2.__init__(self, canvas)
 
     def destroy(self, *args):

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -176,8 +176,8 @@ class FigureCanvasTkAgg(FigureCanvasAgg):
         t1,t2,w,h = self.figure.bbox.bounds
         w, h = int(w), int(h)
         self._tkcanvas = Tk.Canvas(
-            master=master, width=w, height=h, borderwidth=0,
-            highlightthickness=0)
+            master=master, background="white",
+            width=w, height=h, borderwidth=0, highlightthickness=0)
         self._tkphoto = Tk.PhotoImage(
             master=self._tkcanvas, width=w, height=h)
         self._tkcanvas.create_image(w//2, h//2, image=self._tkphoto)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -684,8 +684,8 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         self.Bind(wx.EVT_MOUSE_CAPTURE_CHANGED, self._onCaptureLost)
         self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._onCaptureLost)
 
-        # Reduce flicker.
-        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)  # Reduce flicker.
+        self.SetBackgroundColour(wx.WHITE)
 
         self.macros = {}  # dict from wx id to seq of macros
 
@@ -940,13 +940,6 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         else:
             self.gui_repaint(drawDC=drawDC)
         evt.Skip()
-
-    def _onEraseBackground(self, evt):
-        """
-        Called when window is redrawn; since we are blitting the entire
-        image, we can leave this blank to suppress flicker.
-        """
-        pass
 
     def _onSize(self, evt):
         """


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

Set widget background to white.

The background color of the widget can be seen by setting a transparent
figure facecolor, e.g.

    from pylab import *
    rcParams["figure.facecolor"] = (0, 0, 0, 0); gca(); show()

The goal is to ultimately replace setting `savefig.transparent` by
`figure.facecolor = (0, 0, 0, 0)`.
(see #9080 for example for the slight trickiness of savefig.transparent).

As far as I can tell, gtk3 already defaults to a white background.  Not
sure what the situation is on OSX.

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
