### PR TITLE
Deprecate Artist.is_figure_set.

### DIFF
--- a/doc/api/artist_api.rst
+++ b/doc/api/artist_api.rst
@@ -44,7 +44,6 @@ Interactive
    Artist.set_picker
    Artist.contains
 
-
 Margins and Autoscaling
 -----------------------
 
@@ -80,7 +79,6 @@ Bulk Properties
    Artist.properties
    Artist.set
 
-
 Drawing
 -------
 
@@ -114,8 +112,6 @@ Drawing
    Artist.get_path_effects
    Artist.get_transformed_clip_path_and_affine
 
-
-
 Figure and Axes
 ---------------
 
@@ -129,7 +125,6 @@ Figure and Axes
 
    Artist.set_figure
    Artist.get_figure
-   Artist.is_figure_set
 
 Children
 --------
@@ -141,7 +136,6 @@ Children
    Artist.get_children
    Artist.findobj
 
-
 Transform
 ---------
 
@@ -152,8 +146,6 @@ Transform
    Artist.set_transform
    Artist.get_transform
    Artist.is_transform_set
-
-
 
 Units
 -----

--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -619,7 +619,6 @@ Artist Methods
    :template: autosummary.rst
    :nosignatures:
 
-   Axes.is_figure_set
    Axes.remove
    Axes.is_transform_set
 

--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -503,7 +503,6 @@ Ticks
    Tick.get_zorder
    Tick.have_units
    Tick.hitlist
-   Tick.is_figure_set
    Tick.is_transform_set
    Tick.mouseover
    Tick.pchanged
@@ -571,7 +570,6 @@ Ticks
    XTick.get_zorder
    XTick.have_units
    XTick.hitlist
-   XTick.is_figure_set
    XTick.is_transform_set
    XTick.mouseover
    XTick.pchanged
@@ -639,7 +637,6 @@ Ticks
    YTick.get_zorder
    YTick.have_units
    YTick.hitlist
-   YTick.is_figure_set
    YTick.is_transform_set
    YTick.mouseover
    YTick.pchanged
@@ -717,7 +714,6 @@ Axis
    Axis.get_zorder
    Axis.have_units
    Axis.hitlist
-   Axis.is_figure_set
    Axis.is_transform_set
    Axis.mouseover
    Axis.pchanged
@@ -785,7 +781,6 @@ Axis
    XAxis.get_zorder
    XAxis.have_units
    XAxis.hitlist
-   XAxis.is_figure_set
    XAxis.is_transform_set
    XAxis.mouseover
    XAxis.pchanged
@@ -853,7 +848,6 @@ Axis
    YAxis.get_zorder
    YAxis.have_units
    YAxis.hitlist
-   YAxis.is_figure_set
    YAxis.is_transform_set
    YAxis.mouseover
    YAxis.pchanged

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -458,6 +458,7 @@ class Artist(object):
         'Return the picker object used by this artist'
         return self._picker
 
+    @cbook.deprecated("2.2", "artist.figure is not None")
     def is_figure_set(self):
         """
         Returns True if the artist is assigned to a


### PR DESCRIPTION
Implicit boolean conversion of artist.figure works just as well.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
