### PR TITLE
Fix scatterplot categorical support

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -40,6 +40,12 @@ class StrCategoryConverter(units.ConversionInterface):
         """Uses axis.unit_data map to encode
         data as floats
         """
+        value = np.atleast_1d(value)
+        # try and update from here....
+        if hasattr(axis.unit_data, 'update'):
+            for val in value:
+                if isinstance(val, six.string_types):
+                    axis.unit_data.update(val)
         vmap = dict(zip(axis.unit_data.seq, axis.unit_data.locs))
 
         if isinstance(value, six.string_types):

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -243,3 +243,16 @@ class TestPlot(object):
         unit_data = MockUnitData(list(zip(labels, ticks)))
 
         self.axis_test(ax.yaxis, ticks, labels, unit_data)
+
+    def test_scatter_update(self):
+        fig, ax = plt.subplots()
+
+        ax.scatter(['a', 'b'], [0., 3.])
+        ax.scatter(['a', 'b', 'd'], [1., 2., 3.])
+        ax.scatter(['b', 'c', 'd'], [4., 1., 2.])
+        fig.canvas.draw()
+
+        labels = ['a', 'b', 'd', 'c']
+        ticks = [0, 1, 2, 3]
+        unit_data = MockUnitData(list(zip(labels, ticks)))
+        self.axis_test(ax.xaxis, ticks, labels, unit_data)


### PR DESCRIPTION
Fix Categorical Scatterplot support

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

Fixes #9700 

```python

import matplotlib.pyplot as plt
plt.scatter(["a", "b"], [0,2])
plt.scatter(["a","c"], [1,4])
```

failed.  New fix adds new categories if needed when `convert` is called.  

Not sure if this is right, so feel free to scratch.  Passes the tests and examples, so I guess its OK.



<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests (old ones)
- [x] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->