### PR TITLE
Masking invalid x and/or weights in hist

### DIFF
--- a/doc/users/next_whats_new/2017-11-09_hist-ignores-nans.rst
+++ b/doc/users/next_whats_new/2017-11-09_hist-ignores-nans.rst
@@ -4,3 +4,5 @@ Histogram function now accepts nan values in input
 The `~.Axes.hist` function now accepts nan values in both the *data* and
 *weights* input. Previously this would just error. Now any invalid values
 are simply ignored when calculating the histogram values.
+
+In addition, masked arrays are now valid input for both *data* and *weights*.

--- a/doc/users/next_whats_new/2017-11-09_hist-ignores-nans.rst
+++ b/doc/users/next_whats_new/2017-11-09_hist-ignores-nans.rst
@@ -1,0 +1,6 @@
+Histogram function now accepts nan values in input
+--------------------------------------------------
+
+The `~.Axes.hist` function now accepts nan values in both the *data* and
+*weights* input. Previously this would just error. Now any invalid values
+are simply ignored when calculating the histogram values.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5893,7 +5893,9 @@ class Axes(_AxesBase):
         ----------
         x : (n,) array or sequence of (n,) arrays
             Input values, this takes either a single array or a sequence of
-            arrays which are not required to be of the same length
+            arrays which are not required to be of the same length.
+            Masked arrays or arrays with invalid values (e.g. ``nan``) are
+            allowed.
 
         bins : integer or sequence or 'auto', optional
             If an integer is given, ``bins + 1`` bin edges are calculated and
@@ -5949,7 +5951,8 @@ class Axes(_AxesBase):
             only contributes its associated weight towards the bin count
             (instead of 1).  If *normed* or *density* is ``True``,
             the weights are normalized, so that the integral of the density
-            over the range remains 1.
+            over the range remains 1. Masked arrays or arrays with invalid
+            values (e.g. ``nan``) are allowed.
 
             Default is ``None``
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6130,6 +6130,7 @@ class Axes(_AxesBase):
         else:
             w = [None] * nx
 
+        # Comparing shape of weights vs. x
         if len(w) != nx:
             raise ValueError('weights should have the same shape as x')
 
@@ -6137,6 +6138,18 @@ class Axes(_AxesBase):
             if wi is not None and len(wi) != len(xi):
                 raise ValueError(
                     'weights should have the same shape as x')
+
+        # Combine the masks from x[i] and w[i] (if applicable) into a single
+        # mask and apply it to both.
+        if not input_empty:
+            for i, (xi, wi) in enumerate(zip(x, w)):
+                xi = cbook.safe_masked_invalid(xi)
+                mask = xi.mask
+                if wi is not None:
+                    wi = cbook.safe_masked_invalid(wi)
+                    mask = mask | wi.mask
+                    w[i] = np.ma.masked_array(wi, mask=mask)
+                x[i] = np.ma.masked_array(xi, mask=mask)
 
         if color is None:
             color = [self._get_lines.get_next_color() for i in xrange(nx)]

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1479,6 +1479,13 @@ def test_barh_tick_label():
             align='center')
 
 
+def test_hist_nans():
+    # Check that histogram input data can include nans
+    fig, ax = plt.subplots()
+    ax.hist([1, 2, 1, 2, 3, np.nan],
+            weights=[1, 1, 1, np.nan, 1, 1])
+
+
 @image_comparison(baseline_images=['hist_log'],
                   remove_text=True)
 def test_hist_log():


### PR DESCRIPTION
A rebase of #7133, fixes #6483.