### PR TITLE
Change set_figwidth/height to be consistent w/ set_size_inches

### DIFF
--- a/doc/api/api_changes/2017-11-07-JMK.rst
+++ b/doc/api/api_changes/2017-11-07-JMK.rst
@@ -1,0 +1,7 @@
+`Figure.set_figwidth` and `Figure.set_figheight` default forward to True
+------------------------------------------------------------------------
+
+`matplotlib.Figure.set_figwidth` and `matplotlib.Figure.set_figheight`
+had the kwarg `forward=False`
+by default, but `Figure.set_size_inches` now defaults to `forward=True`.  
+This makes these functions conistent.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -829,7 +829,7 @@ class Figure(Artist):
         self.dpi = val
         self.stale = True
 
-    def set_figwidth(self, val, forward=False):
+    def set_figwidth(self, val, forward=True):
         """
         Set the width of the figure in inches
 
@@ -837,7 +837,7 @@ class Figure(Artist):
         """
         self.set_size_inches(val, self.get_figheight(), forward=forward)
 
-    def set_figheight(self, val, forward=False):
+    def set_figheight(self, val, forward=True):
         """
         Set the height of the figure in inches
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

Makes set_figwidth/height to be consistent w/ set_size_inches as per #9669.  Not called elsewhere in our code base, but theoretically an API change...

See #6131 for cross-ref of the change w/ `set_size_inches`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Code is PEP 8 compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->