### PR TITLE
FIX: copy=False for masked arrays in pcolormesh

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5576,7 +5576,11 @@ class Axes(_AxesBase):
 
         # convert to one dimensional arrays
         C = C.ravel()
-        coords = np.column_stack((X, Y)).astype(float, copy=False)
+        try:
+            coords = np.column_stack((X, Y)).astype(float, copy=False)
+        except TypeError:
+            # masked arrays, at least, don't allow copy kwarg:
+            coords = np.column_stack((X, Y)).astype(float)
 
         collection = mcoll.QuadMesh(Nx - 1, Ny - 1, coords,
                                     antialiased=antialiased, shading=shading,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1174,6 +1174,15 @@ def test_pcolor_datetime_axis():
             label.set_rotation(30)
 
 
+def test_pcolor_masked():
+    # This just tests that this runs...
+    x = np.linspace(0, 1, 4)
+    xx, yy = np.meshgrid(x, x)
+    xx = np.ma.masked_array(xx, mask=(xx > 0.5))
+    yy = np.ma.masked_array(yy, mask=(xx > 0.5))
+    plt.pcolormesh(xx, yy, xx*yy)
+
+
 def test_pcolorargs():
     n = 12
     x = np.linspace(-1.5, 1.5, n)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Fix #9720 pcolormesh wasn't working with masked arrays!  Added test...

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
