### PR TITLE
Fix PDFpages bug

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2591,7 +2591,8 @@ class FigureCanvasPdf(FigureCanvasBase):
                 bbox_inches_restore=_bbox_inches_restore)
             self.figure.draw(renderer)
             renderer.finalize()
-            file.finalize()
+            if not isinstance(filename, PdfPages):
+                file.finalize()
         finally:
             if isinstance(filename, PdfPages):  # finish off this page
                 file.endStream()

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -7,6 +7,7 @@ import six
 
 import io
 import os
+import sys
 import tempfile
 
 import pytest
@@ -69,6 +70,19 @@ def test_multipage_pagecount():
         assert pdf.get_pagecount() == 1
         pdf.savefig()
         assert pdf.get_pagecount() == 2
+
+
+def test_multipage_properfinalize():
+    pdfio = io.BytesIO()
+    with PdfPages(pdfio) as pdf:
+        for i in range(10):
+            fig = plt.figure()
+            ax = fig.add_subplot(111)
+            ax.set_title('This is a long title')
+            fig.savefig(pdf, format="pdf")
+    pdfio.seek(0)
+    assert sum(b'startxref' in line for line in pdfio) == 1
+    assert sys.getsizeof(pdfio) < 40000
 
 
 def test_multipage_keep_empty():


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

Fixes #9716, I think.

Pre 433b8996347dad2c144000a1d1e7b6b1e50f7cbe code didn't call the `finalize` code path if the filename was a  PdfPages instance. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->