### PR TITLE
FIX/TST: update tests for pandas 0.21

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,10 +84,9 @@ install:
   # if conda-forge gets a new pyqt, it might be nice to install it as well to have more backends
   # https://github.com/conda-forge/conda-forge.github.io/issues/157#issuecomment-223536381
   #
-  # n.b. pandas is pinned to <0.21 due to issue 9610
   - conda create -q -n test-environment python=%PYTHON_VERSION%
     msinttypes freetype=2.6 "libpng>=1.6.21,<1.7" zlib=1.2 tk=8.5
-    pip setuptools numpy mock "pandas<0.21.0" sphinx tornado
+    pip setuptools numpy mock pandas sphinx tornado
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,11 @@ env:
 matrix:
   include:
     - python: 2.7
-      env: MOCK=mock NUMPY=numpy==1.7.1 PANDAS='pandas<0.21.0' NOSE=nose
+      env: MOCK=mock NUMPY=numpy==1.7.1 PANDAS=pandas NOSE=nose
     - python: 3.4
       env: PYTHON_ARGS=-OO
     - python: 3.6
-      env: DELETE_FONT_CACHE=1 INSTALL_PEP8=pytest-pep8 RUN_PEP8=--pep8 PANDAS='pandas<0.21.0'
+      env: DELETE_FONT_CACHE=1 INSTALL_PEP8=pytest-pep8 RUN_PEP8=--pep8 PANDAS=pandas
     - python: "nightly"
       env: PRE=--pre
     - os: osx

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5049,6 +5049,8 @@ def test_broken_barh_empty():
 
 def test_pandas_pcolormesh():
     pd = pytest.importorskip('pandas')
+    from pandas.tseries import converter
+    converter.register()
 
     time = pd.date_range('2000-01-01', periods=10)
     depth = np.arange(20)
@@ -5060,6 +5062,8 @@ def test_pandas_pcolormesh():
 
 def test_pandas_indexing_dates():
     pd = pytest.importorskip('pandas')
+    from pandas.tseries import converter
+    converter.register()
 
     dates = np.arange('2005-02', '2005-03', dtype='datetime64[D]')
     values = np.sin(np.array(range(len(dates))))
@@ -5073,6 +5077,8 @@ def test_pandas_indexing_dates():
 
 def test_pandas_errorbar_indexing():
     pd = pytest.importorskip('pandas')
+    from pandas.tseries import converter
+    converter.register()
 
     df = pd.DataFrame(np.random.uniform(size=(5, 4)),
                       columns=['x', 'y', 'xe', 'ye'],
@@ -5083,6 +5089,8 @@ def test_pandas_errorbar_indexing():
 
 def test_pandas_indexing_hist():
     pd = pytest.importorskip('pandas')
+    from pandas.tseries import converter
+    converter.register()
 
     ser_1 = pd.Series(data=[1, 2, 2, 3, 3, 4, 4, 4, 4, 5])
     ser_2 = ser_1.iloc[1:]
@@ -5093,6 +5101,8 @@ def test_pandas_indexing_hist():
 def test_pandas_bar_align_center():
     # Tests fix for issue 8767
     pd = pytest.importorskip('pandas')
+    from pandas.tseries import converter
+    converter.register()
 
     df = pd.DataFrame({'a': range(2), 'b': range(2)})
 
@@ -5101,21 +5111,6 @@ def test_pandas_bar_align_center():
     rect = ax.bar(df.loc[df['a'] == 1, 'b'],
                   df.loc[df['a'] == 1, 'b'],
                   align='center')
-
-    fig.canvas.draw()
-
-
-def test_pandas_bar_align_center():
-    # Tests fix for issue 8767
-    pd = pytest.importorskip('pandas')
-
-    df = pd.DataFrame({'a': range(2), 'b': range(2)})
-
-    fig, ax = plt.subplots(1)
-
-    rect = ax.barh(df.loc[df['a'] == 1, 'b'],
-                   df.loc[df['a'] == 1, 'b'],
-                   align='center')
 
     fig.canvas.draw()
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -446,6 +446,8 @@ def test_date2num_dst_pandas():
     # Test for github issue #3896, but in date2num around DST transitions
     # with a timezone-aware pandas date_range object.
     pd = pytest.importorskip('pandas')
+    from pandas.tseries import converter
+    converter.register()
 
     def tz_convert(*args):
         return pd.DatetimeIndex.tz_convert(*args).astype(object)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

This should fix #9610.  

As of pandas 0.21, `import pandas` no longer calls 

```python
from pandas.tseries import converter
converter.register()
```

so it has been added to the tests.  

Surprisingly no examples depend on pandas, so that made life simpler.


<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
