### PR TITLE
Lazy initialization of axis default tick list

### DIFF
--- a/doc/api/api_changes/2017-11-13-TH.rst
+++ b/doc/api/api_changes/2017-11-13-TH.rst
@@ -1,0 +1,13 @@
+Internal handling of axis ticks optimized
+-----------------------------------------
+
+No officially documented parts of the API have changed. However, you may have
+implicitly relied on a certain behavior.
+
+`Axis.majorTicks` and `Axis.minorTicks` are deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The undocumented attributes `majorTicks` and `minorTicks` of
+:class:`matplotlib.axis.Axis` are now explicitly considered private and may be
+removed in the future. Please uses :meth:`matplotlib.axis.Axis.get_major_ticks`
+and :meth:`matplotlib.axis.Axis.get_minor_ticks` only.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -644,11 +644,9 @@ class _LazyDefaultTickList(object):
     def _instantiate_list(self):
         if self.major:
             self.axis.majorTicks = [self.axis._get_tick(major=True)]
-            self.axis._lastNumMajorTicks = 1
             return self.axis.majorTicks
         else:
             self.axis.minorTicks = [self.axis._get_tick(major=False)]
-            self.axis._lastNumMinorTicks = 1
             return self.axis.minorTicks
 
     def __iter__(self):
@@ -1376,22 +1374,15 @@ class Axis(artist.Artist):
             numticks = len(self.get_major_locator()())
         if len(self.majorTicks) < numticks:
             # update the new tick label properties from the old
+            protoTick = self.majorTicks[0]
             for i in range(numticks - len(self.majorTicks)):
                 tick = self._get_tick(major=True)
-                self.majorTicks.append(tick)
-
-        if self._lastNumMajorTicks < numticks:
-            protoTick = self.majorTicks[0]
-            for i in range(self._lastNumMajorTicks, len(self.majorTicks)):
-                tick = self.majorTicks[i]
                 if self._gridOnMajor:
                     tick.gridOn = True
                 self._copy_tick_props(protoTick, tick)
+                self.majorTicks.append(tick)
 
-        self._lastNumMajorTicks = numticks
-        ticks = self.majorTicks[:numticks]
-
-        return ticks
+        return self.majorTicks[:numticks]
 
     def get_minor_ticks(self, numticks=None):
         'get the minor tick instances; grow as necessary'
@@ -1400,22 +1391,15 @@ class Axis(artist.Artist):
 
         if len(self.minorTicks) < numticks:
             # update the new tick label properties from the old
+            protoTick = self.minorTicks[0]
             for i in range(numticks - len(self.minorTicks)):
                 tick = self._get_tick(major=False)
-                self.minorTicks.append(tick)
-
-        if self._lastNumMinorTicks < numticks:
-            protoTick = self.minorTicks[0]
-            for i in range(self._lastNumMinorTicks, len(self.minorTicks)):
-                tick = self.minorTicks[i]
                 if self._gridOnMinor:
                     tick.gridOn = True
                 self._copy_tick_props(protoTick, tick)
+                self.minorTicks.append(tick)
 
-        self._lastNumMinorTicks = numticks
-        ticks = self.minorTicks[:numticks]
-
-        return ticks
+        return self.minorTicks[:numticks]
 
     def grid(self, b=None, which='major', **kwargs):
         """


### PR DESCRIPTION
## PR Summary

Improves #6664 by lazily initializing the axis ticks.

### Implementation details

Instead of initializing `self.majorTicks` and `self.minorTicks` to 1-element default lists, we use `LazyDefaultTickList` as a proxy, that instantiates the default list and replaces itself with it on access.

This is almost a drop-in replacement. The only thing I didn't get to work transparently is mimicking concatenation. Where `self.majorTicks + self.minorTicks` works for lists, it does not for the `LazyDefaultTickList`. There's one occurence of this in the code. It could be replaced by `list(self.majorTicks) + list(self.minorTicks)`, but I chose to rewrite this using iterator 

I assume that `self.majorTicks` and `self.minorTicks` are considered private (they do not show in the docs) and that they should only be modified using the methods of `Axis`. Therefore, I think it's ok that `self.majorTicks + self.minorTicks` does not work with `LazyDefaultTickList`.

### Performace Gain

Instatiation of a plot with many axes has become faster by a factor of three.

before change:
![grafik](https://user-images.githubusercontent.com/2836374/32596331-3ac98346-c533-11e7-9191-2956274f7fb4.png)

after change:
![grafik](https://user-images.githubusercontent.com/2836374/32596351-4a859b80-c533-11e7-85fc-131ea48d8ede.png)

As a nice side effect, the test suite runs 10% faster after the change.

### Tests

Since this is an drop-in replacement, I don't think that it needs extra tests. I ran the test suite and saw no difference. Before and after the change I had 4 failing tests, so I suppose their failure is unrelated.



<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Code is PEP 8 compliant

Other checklist items do not apply.

