### PR TITLE
IGNORE: Lockout new axis converters

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1434,6 +1434,13 @@ class Axis(artist.Artist):
         if converter is None:
             return False
 
+        if (self.converter is not None) and (self.converter != converter):
+            raise TypeError('Attempting to plot data that is '
+                            'registered to be converted with %s but '
+                            'is incompatible with existing axis data '
+                            'converter %s' % (converter.__class__,
+                                self.converter.__class__))
+
         neednew = self.converter != converter
         self.converter = converter
         default = self.converter.default_units(data, self)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -477,3 +477,14 @@ def test_tz_utc():
 def test_num2timedelta(x, tdelta):
     dt = mdates.num2timedelta(x)
     assert dt == tdelta
+
+
+def test_one_non_None_converter():
+    # test that we only allow one non-None converter at once:
+    base = datetime.datetime(2017, 1, 1, 0, 10, 0)
+    time = [base - datetime.timedelta(days=x) for x in range(0, 3)]
+    data = [0., 2., 4.]
+    fig, ax = plt.subplots()
+    ax.plot(time, data)
+    with pytest.raises(TypeError):
+        ax.plot(['a', 'b'], [1., 2.])


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Keeping here in case we want to use instead of #9776, but #9776 is my preferred solution.

## PR Summary

A script like:

```python
    base = datetime.datetime(2017, 1, 1, 0, 10, 0)
    time = [base - datetime.timedelta(days=x) for x in range(0, 3)]
    data = [0., 2., 4.]
    fig, ax = plt.subplots()
    ax.plot(time, data)
    ax.plot(['a', 'b'], [1., 2.])
```

would run and make a very non-sensical and mislabeled plot.  This now returns a `TypeError` if this is done.  

Note that the following will *not* be caught, and will result in an ugly error that pops up all the time:

```
    dt = datetime.datetime.fromordinal(ix).replace(tzinfo=UTC)
ValueError: ordinal must be >= 1
```

```python
    base = datetime.datetime(2017, 1, 1, 0, 10, 0)
    time = [base - datetime.timedelta(days=x) for x in range(0, 3)]
    data = [0., 2., 4.]
    fig, ax = plt.subplots()
    ax.plot(time, data)
    ax.plot([0., 3.], [1., 2.])
```

The problem here is that the `update_units` function also gets called by `set_xlim` and `set_ylim`, and if these are on auto it passes bare floats.  Maybe that can be fixed, but is a bigger project...

See #9713 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
  