### PR TITLE
FIX: check if contour level in format dictionary, or return a default

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -328,7 +328,7 @@ class ContourLabeler(object):
             return lev
         else:
             if isinstance(fmt, dict):
-                return fmt[lev]
+                return fmt.get(lev, '%1.3f')
             elif callable(fmt):
                 return fmt(lev)
             else:

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -143,6 +143,25 @@ def test_contour_empty_levels():
     assert len(record) == 1
 
 
+def test_contour_badlevel_fmt():
+    # test funny edge case from
+    # https://github.com/matplotlib/matplotlib/issues/9742
+    # User supplied fmt for each level as a dictionary, but
+    # MPL changed the level to the minimum data value because
+    # no contours possible.
+    # This would error out pre
+    # https://github.com/matplotlib/matplotlib/pull/9743
+    x = np.arange(9)
+    z = np.zeros((9, 9))
+
+    fig, ax = plt.subplots()
+    fmt = {1.: '%1.2f'}
+    with pytest.warns(UserWarning) as record:
+        cs = ax.contour(x, x, z, levels=[1.])
+        ax.clabel(cs, fmt=fmt)
+    assert len(record) == 1
+
+
 def test_contour_uniform_z():
 
     x = np.arange(9)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

As per #9742 the user could pass a format dictionary to `clabel` that doesn't contain a contour level.  Normally this would be a too-bad-so-sad sort of thing, except if there are not contours we *change* the value of the contour ( 6ac197f ).

This fix is maybe suboptimal in that the user may wonder why a contour label sneaks in with a different format.  However, I doubt too many users would specify the contour formats but not the levels, so this really only handles the edgecase in #9742.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->