### PR TITLE
blocking_input: Fix "manager" attr check

### DIFF
--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -101,7 +101,7 @@ class BlockingInput(object):
         self.events = []
         self.callbacks = []
 
-        if hasattr(self.fig, "manager"):
+        if hasattr(self.fig.canvas, "manager"):
             # Ensure that the figure is shown, if we are managing it.
             self.fig.show()
 


### PR DESCRIPTION
## PR Summary

Fixes #9758, so now `plt.ginput` will properly show the plot again. This copies the check from

https://github.com/matplotlib/matplotlib/blob/72521581898870c0a624baca2068cb63cfb1e7ef/lib/matplotlib/figure.py#L419-L425
