### PR TITLE
Fix exception when guessing the AFM familyname

### DIFF
--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -312,11 +312,13 @@ def _parse_optional(fh):
 def parse_afm(fh):
     """
     Parse the Adobe Font Metics file in file handle *fh*. Return value
-    is a (*dhead*, *dcmetrics*, *dkernpairs*, *dcomposite*) tuple where
-    *dhead* is a :func:`_parse_header` dict, *dcmetrics* is a
-    :func:`_parse_composites` dict, *dkernpairs* is a
-    :func:`_parse_kern_pairs` dict (possibly {}), and *dcomposite* is a
-    :func:`_parse_composites` dict (possibly {})
+    is a (*dhead*, *dcmetrics_ascii*, *dmetrics_name*, *dkernpairs*,
+    *dcomposite*) tuple where
+    *dhead* is a :func:`_parse_header` dict,
+    *dcmetrics_ascii* and *dcmetrics_name* are the two resulting dicts
+    from :func:`_parse_char_metrics`,
+    *dkernpairs* is a :func:`_parse_kern_pairs` dict (possibly {}) and
+    *dcomposite* is a :func:`_parse_composites` dict (possibly {})
     """
     _sanity_check(fh)
     dhead = _parse_header(fh)
@@ -503,8 +505,8 @@ class AFM(object):
 
         # FamilyName not specified so we'll make a guess
         name = self.get_fullname()
-        extras = (br'(?i)([ -](regular|plain|italic|oblique|bold|semibold|'
-                  br'light|ultralight|extra|condensed))+$')
+        extras = (r'(?i)([ -](regular|plain|italic|oblique|bold|semibold|'
+                  r'light|ultralight|extra|condensed))+$')
         return re.sub(extras, '', name)
 
     @property

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -2,8 +2,33 @@
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from six import BytesIO
 
 import matplotlib.afm as afm
+
+
+AFM_TEST_DATA = b"""StartFontMetrics 2.0
+Comment Comments are ignored.
+Comment Creation Date:Mon Nov 13 12:34:11 GMT 2017
+FontName MyFont-Bold
+EncodingScheme FontSpecific
+FullName My Font Bold
+FamilyName Test Fonts
+Weight Bold
+ItalicAngle 0.0
+IsFixedPitch false
+UnderlinePosition -100
+UnderlineThickness 50
+Version 001.000
+Notice Copyright (c) 2017 No one.
+FontBBox 0 -321 1234 369
+StartCharMetrics 3
+C 0 ; WX 250 ; N space ; B 0 0 0 0 ;
+C 42 ; WX 1141 ; N foo ; B 40 60 800 360 ;
+C 99 ; WX 583 ; N bar ; B 40 -10 543 210 ;
+EndCharMetrics
+EndFontMetrics
+"""
 
 
 def test_nonascii_str():
@@ -14,3 +39,46 @@ def test_nonascii_str():
 
     ret = afm._to_str(byte_str)
     assert ret == inp_str
+
+
+def test_parse_header():
+    fh = BytesIO(AFM_TEST_DATA)
+    header = afm._parse_header(fh)
+    assert header == {
+        b'StartFontMetrics': 2.0,
+        b'FontName': 'MyFont-Bold',
+        b'EncodingScheme': 'FontSpecific',
+        b'FullName': 'My Font Bold',
+        b'FamilyName': 'Test Fonts',
+        b'Weight': 'Bold',
+        b'ItalicAngle': 0.0,
+        b'IsFixedPitch': False,
+        b'UnderlinePosition': -100,
+        b'UnderlineThickness': 50,
+        b'Version': '001.000',
+        b'Notice': 'Copyright (c) 2017 No one.',
+        b'FontBBox': [0, -321, 1234, 369],
+        b'StartCharMetrics': 3,
+    }
+
+
+def test_parse_char_metrics():
+    fh = BytesIO(AFM_TEST_DATA)
+    afm._parse_header(fh)  # position
+    metrics = afm._parse_char_metrics(fh)
+    assert metrics == (
+        {0: (250.0, 'space', [0, 0, 0, 0]),
+         42: (1141.0, 'foo', [40, 60, 800, 360]),
+         99: (583.0, 'bar', [40, -10, 543, 210]),
+         },
+        {'space': (250.0, [0, 0, 0, 0]),
+         'foo': (1141.0, [40, 60, 800, 360]),
+         'bar': (583.0, [40, -10, 543, 210]),
+         })
+
+
+def test_get_familyname_guessed():
+    fh = BytesIO(AFM_TEST_DATA)
+    fm = afm.AFM(fh)
+    del fm._header[b'FamilyName']  # remove FamilyName, so we have to guess
+    assert fm.get_familyname() == 'My Font'


### PR DESCRIPTION
## PR Summary

Fixes #8347.

As opposed to the suggestion in #8347, it's not the replacement argument that needs to be `bytes`. Instead, the regexp has to be `str` because all header values (here 'FullName') are converted to 'appropriate python types' (here `str`).

Cleaned up a docstring and added some tests on the way. The actual fix is just `afm.py` l.508f

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
