### PR TITLE
New FreeType wrapper.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,8 @@ environment:
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
       TEST_ALL: "no"
 
+image: Visual Studio 2017
+
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable
 platform:
@@ -42,6 +44,7 @@ init:
   - echo %PYTHON_VERSION% %CONDA_INSTALL_LOCN%
 
 install:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
   - set PYTHONUNBUFFERED=1
   # for msinttypes and newer stuff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,20 +13,24 @@ apt-run:  &apt-install
   command: |
     sudo apt-get -qq update
     sudo apt-get install -y \
+      cm-super \
+      dvipng \
+      graphviz \
       inkscape \
       libav-tools \
-      dvipng \
-      pgf \
+      libgeos-dev \
       lmodern \
-      cm-super \
+      otf-freefont \
+      pgf \
+      software-properties-common \
+      texlive-fonts-recommended \
       texlive-latex-base \
       texlive-latex-extra \
-      texlive-fonts-recommended \
       texlive-latex-recommended \
-      texlive-xetex \
-      graphviz \
-      libgeos-dev \
-      otf-freefont
+      texlive-xetex
+    sudo add-apt-repository 'deb http://ftp.us.debian.org/debian testing main'
+    sudo apt-get update
+    sudo apt-get install g++-7
 
 fonts-run:  &fonts-install
   name: Install custom fonts
@@ -64,7 +68,10 @@ deps-run: &deps-install
 
 mpl-run: &mpl-install
   name: Install Matplotlib
-  command: pip install --user -ve .
+  command: |
+    ls /usr/include/freetype2
+    cat /usr/include/freetype2/ft2build.h
+    CC=gcc-7 CXX=g++-7 pip install --user -ve .
 
 doc-run: &doc-build
   name: Build documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 
 branches:
   except:
-  - /^auto-backport-of-pr-\d*/
+    - /^auto-backport-of-pr-\d*/
 
 cache:
   pip: true
@@ -16,11 +16,14 @@ cache:
 addons:
   artifacts:
     paths:
-    - result_images.tar.bz2
+      - result_images.tar.bz2
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - cm-super
       - dvipng
+      - g++-7
       - gdb
       - gir1.2-gtk-3.0
       - graphviz
@@ -68,6 +71,8 @@ matrix:
     - python: 3.5
       # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124.
       env:
+        - CC=gcc-7
+        - CXX=g++-7
         - CYCLER=cycler==0.10
         - DATEUTIL=python-dateutil==2.1
         - NOSE=nose
@@ -78,14 +83,30 @@ matrix:
         - PYTEST_COV=pytest-cov==2.3.1
         - SPHINX=sphinx==1.3
     - python: 3.5
-      env: PYTHON_ARGS=-OO
+      env:
+        - CC=gcc-7
+        - CXX=g++-7
+        - PYTHON_ARGS=-OO
     - python: 3.6
-      env: DELETE_FONT_CACHE=1 PANDAS='pandas<0.21.0' PYTEST_PEP8=pytest-pep8 RUN_PEP8=--pep8
+      env:
+        - CC=gcc-7
+        - CXX=g++-7
+        - DELETE_FONT_CACHE=1
+        - PANDAS='pandas<0.21.0'
+        - PYTEST_PEP8=pytest-pep8
+        - RUN_PEP8=--pep8
     - python: "nightly"
-      env: PRE=--pre
+      env:
+        - CC=gcc-7
+        - CXX=g++-7
+        - PRE=--pre
     - os: osx
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       only: master
+      env:
+        - PATH="/usr/local/opt/llvm/bin:$PATH"
+        - CPPFLAGS=-L/usr/local/opt/llvm/include
+        - LDFLAGS='-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib'
       cache:
         # As for now travis caches only "$HOME/.cache/pip"
         # https://docs.travis-ci.com/user/caching/#pip-cache
@@ -108,7 +129,9 @@ before_install:
     else
       ci/travis/silence brew update
       brew upgrade python
-      brew install ffmpeg imagemagick mplayer ccache
+      brew install ccache llvm
+      brew info llvm
+      brew install ffmpeg imagemagick mplayer
       hash -r
       which python
       python --version

--- a/examples/misc/font_indexing.py
+++ b/examples/misc/font_indexing.py
@@ -4,39 +4,27 @@ Font Indexing
 =============
 
 A little example that shows how the various indexing into the font
-tables relate to one another.  Mainly for mpl developers....
+tables relate to one another.  Mainly for Matplotlib developers...
 
 """
-import matplotlib
-from matplotlib.ft2font import FT2Font, KERNING_DEFAULT, KERNING_UNFITTED, KERNING_UNSCALED
+
+from matplotlib._ft2 import Kerning
+import matplotlib.font_manager
 
 
 fname = matplotlib.get_data_path() + '/fonts/ttf/DejaVuSans.ttf'
-font = FT2Font(fname)
-font.set_charmap(0)
+font = matplotlib.font_manager.get_font(fname)
 
-codes = font.get_charmap().items()
-#dsu = [(ccode, glyphind) for ccode, glyphind in codes]
-#dsu.sort()
-#for ccode, glyphind in dsu:
-#    try: name = font.get_glyph_name(glyphind)
-#    except RuntimeError: pass
-#    else: print('% 4d % 4d %s %s' % (glyphind, ccode, hex(int(ccode)), name))
+# This assumes FreeType>=2.8.1, which automatically picks or synthesizes a
+# Unicode charmap.
+
+def get_kerning(c1, c2, mode):
+    i1 = font.get_char_index(ord(c1))
+    i2 = font.get_char_index(ord(c2))
+    return font.get_kerning(i1, i2, mode)
 
 
-# make a charname to charcode and glyphind dictionary
-coded = {}
-glyphd = {}
-for ccode, glyphind in codes:
-    name = font.get_glyph_name(glyphind)
-    coded[name] = ccode
-    glyphd[name] = glyphind
-
-code = coded['A']
-glyph = font.load_char(code)
-print(glyph.bbox)
-print(glyphd['A'], glyphd['V'], coded['A'], coded['V'])
-print('AV', font.get_kerning(glyphd['A'], glyphd['V'], KERNING_DEFAULT))
-print('AV', font.get_kerning(glyphd['A'], glyphd['V'], KERNING_UNFITTED))
-print('AV', font.get_kerning(glyphd['A'], glyphd['V'], KERNING_UNSCALED))
-print('AV', font.get_kerning(glyphd['A'], glyphd['T'], KERNING_UNSCALED))
+print('AV default ', get_kerning('A', 'V', Kerning.DEFAULT))
+print('AV unfitted', get_kerning('A', 'V', Kerning.UNFITTED))
+print('AT default ', get_kerning('A', 'T', Kerning.DEFAULT))
+print('AT unfitted', get_kerning('A', 'T', Kerning.UNFITTED))

--- a/examples/misc/ftface_props.py
+++ b/examples/misc/ftface_props.py
@@ -1,67 +1,53 @@
 """
-============
-Ftface Props
-============
+===============
+Face properties
+===============
 
-This is a demo script to show you how to use all the properties of an
-FT2Font object.  These describe global font properties.  For
-individual character metrics, use the Glyph object, as returned by
-load_char
+This is a demo script to show you how to use all the properties of a Face
+object.  These describe global font properties.  For individual character
+metrics, use the Glyph object, as loaded from the glyph attribute after calling
+load_char.
 """
 import matplotlib
-import matplotlib.ft2font as ft
+from matplotlib import font_manager, _ft2
 
 
-#fname = '/usr/local/share/matplotlib/VeraIt.ttf'
-fname = matplotlib.get_data_path() + '/fonts/ttf/DejaVuSans-Oblique.ttf'
-#fname = '/usr/local/share/matplotlib/cmr10.ttf'
+fname = matplotlib.get_data_path() + "/fonts/ttf/DejaVuSans-Oblique.ttf"
+font = font_manager.get_font(fname)
 
-font = ft.FT2Font(fname)
+print("Faces in file          :", font.num_faces)
+print("Glyphs in face         :", font.num_glyphs)
+print("Family name            :", font.family_name)
+print("Style name             :", font.style_name)
+print("Postscript name        :", font.get_postscript_name())
+print("Embedded bitmap strikes:", font.num_fixed_sizes)
 
-print('Num faces   :', font.num_faces)        # number of faces in file
-print('Num glyphs  :', font.num_glyphs)       # number of glyphs in the face
-print('Family name :', font.family_name)      # face family name
-print('Style name  :', font.style_name)       # face style name
-print('PS name     :', font.postscript_name)  # the postscript name
-print('Num fixed   :', font.num_fixed_sizes)  # number of embedded bitmap in face
+if font.face_flags & _ft2.FACE_FLAG_SCALABLE:
+    print('Global bbox (xmin, ymin, xmax, ymax):', font.bbox)
+    print('Font units per EM                   :', font.units_per_EM)
+    print('Ascender (pixels)                   :', font.ascender)
+    print('Descender (pixels)                  :', font.descender)
+    print('Height (pixels)                     :', font.height)
+    print('Max horizontal advance              :', font.max_advance_width)
+    print('Max vertical advance                :', font.max_advance_height)
+    print('Underline position                  :', font.underline_position)
+    print('Underline thickness                 :', font.underline_thickness)
 
-# the following are only available if face.scalable
-if font.scalable:
-    # the face global bounding box (xmin, ymin, xmax, ymax)
-    print('Bbox                :', font.bbox)
-    # number of font units covered by the EM
-    print('EM                  :', font.units_per_EM)
-    # the ascender in 26.6 units
-    print('Ascender            :', font.ascender)
-    # the descender in 26.6 units
-    print('Descender           :', font.descender)
-    # the height in 26.6 units
-    print('Height              :', font.height)
-    # maximum horizontal cursor advance
-    print('Max adv width       :', font.max_advance_width)
-    # same for vertical layout
-    print('Max adv height      :', font.max_advance_height)
-    # vertical position of the underline bar
-    print('Underline pos       :', font.underline_position)
-    # vertical thickness of the underline
-    print('Underline thickness :', font.underline_thickness)
+for style in ['Style flag italic',
+              'Style flag bold']:
+    flag = getattr(_ft2, style.replace(' ', '_').upper()) - 1
+    print('%-26s:' % style, bool(font.style_flags & flag))
 
-for style in ('Italic',
-              'Bold',
-              'Scalable',
-              'Fixed sizes',
-              'Fixed width',
-              'SFNT',
-              'Horizontal',
-              'Vertical',
-              'Kerning',
-              'Fast glyphs',
-              'Multiple masters',
-              'Glyph names',
-              'External stream'):
-    bitpos = getattr(ft, style.replace(' ', '_').upper()) - 1
-    print('%-17s:' % style, bool(font.style_flags & (1 << bitpos)))
-
-print(dir(font))
-
-print(font.get_kerning)
+for style in ['Face flag scalable',
+              'Face flag fixed sizes',
+              'Face flag fixed width',
+              'Face flag SFNT',
+              'Face flag horizontal',
+              'Face flag vertical',
+              'Face flag kerning',
+              'Face flag fast glyphs',
+              'Face flag multiple masters',
+              'Face flag glyph names',
+              'Face flag external stream']:
+    flag = getattr(_ft2, style.replace(' ', '_').upper())
+    print('%-26s:' % style, bool(font.face_flags & flag))

--- a/examples/text_labels_and_annotations/font_table_ttf_sgskip.py
+++ b/examples/text_labels_and_annotations/font_table_ttf_sgskip.py
@@ -15,7 +15,7 @@ import sys
 import os
 
 import matplotlib
-from matplotlib.ft2font import FT2Font
+from matplotlib import _ft2
 from matplotlib.font_manager import FontProperties
 import matplotlib.pyplot as plt
 
@@ -32,8 +32,8 @@ else:
     fontname = os.path.join(matplotlib.get_data_path(),
                             'fonts', 'ttf', 'DejaVuSans.ttf')
 
-font = FT2Font(fontname)
-codes = sorted(font.get_charmap().items())
+font = _ft2.Face(fontname)
+codes = sorted(font.get_charmap().items())  # FIXME
 
 # a 16,16 array of character strings
 chars = [['' for c in range(16)] for r in range(16)]

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -276,7 +276,7 @@ class ContourLabeler(object):
                 self._mathtext_parser = mathtext.MathTextParser('bitmap')
             img, _ = self._mathtext_parser.parse(lev, dpi=72,
                                                  prop=self.labelFontProps)
-            lw = img.get_width()  # at dpi=72, the units are PostScript points
+            lh, lw = img.shape  # at dpi=72, the units are PostScript points
         else:
             # width is much less than "font size"
             lw = (len(lev)) * fsize * 0.6

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -15,18 +15,13 @@ import warnings
 # This allows other functions here to be used by pytest-based testing suites
 # without requiring nose to be installed.
 
-
 import matplotlib as mpl
 import matplotlib.style
 import matplotlib.units
 import matplotlib.testing
-from matplotlib import cbook
-from matplotlib import ticker
-from matplotlib import pyplot as plt
-from matplotlib import ft2font
-from matplotlib.testing.compare import (
-    comparable_formats, compare_images, make_test_filename)
+from matplotlib import _ft2, cbook, pyplot as plt, ticker
 from . import _copy_metadata, is_called_from_pytest
+from .compare import comparable_formats, compare_images, make_test_filename
 from .exceptions import ImageComparisonFailure
 
 
@@ -152,7 +147,7 @@ def check_freetype_version(ver):
     if isinstance(ver, six.string_types):
         ver = (ver, ver)
     ver = [version.StrictVersion(x) for x in ver]
-    found = version.StrictVersion(ft2font.__freetype_version__)
+    found = version.StrictVersion(_ft2.__freetype_version__)
 
     return found >= ver[0] and found <= ver[1]
 
@@ -163,7 +158,7 @@ def _checked_on_freetype_version(required_freetype_version):
 
     reason = ("Mismatched version of freetype. "
               "Test requires '%s', you have '%s'" %
-              (required_freetype_version, ft2font.__freetype_version__))
+              (required_freetype_version, _ft2.__freetype_version__))
     return _knownfailureif('indeterminate', msg=reason,
                            known_exception_class=ImageComparisonFailure)
 

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -197,11 +197,10 @@ def test_mathfont_rendering(baseline_images, fontset, index, test):
 
 def test_fontinfo():
     import matplotlib.font_manager as font_manager
-    import matplotlib.ft2font as ft2font
-    fontpath = font_manager.findfont("DejaVu Sans")
-    font = ft2font.FT2Font(fontpath)
+    from matplotlib._ft2 import Face
+    face = Face(font_manager.findfont("DejaVu Sans"))
     table = font.get_sfnt_table("head")
-    assert table['version'] == (1, 0)
+    assert table['Table_Version'] == 65536
 
 
 @pytest.mark.parametrize(

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ mpl_packages = [
     setupext.LibAgg(),
     setupext.FreeType(),
     setupext.FT2Font(),
+    setupext.FT2(),
     setupext.Png(),
     setupext.Qhull(),
     setupext.Image(),

--- a/src/ft2/_ft2.cpp
+++ b/src/ft2/_ft2.cpp
@@ -1,0 +1,729 @@
+#include "_ft2.h"
+#include "_layout.h"
+
+namespace matplotlib::ft2 {
+
+Face::Face(std::string const& path, FT_Long index, double hinting_factor) :
+  ptr{
+    [&]() -> std::shared_ptr<FT_FaceRec_> {
+      auto face = FT_Face{};
+      FT_CHECK(FT_New_Face, library, path.data(), index, &face);
+      auto transform = FT_Matrix{FT_Fixed(65536 / hinting_factor), 0, 0, 65536};
+      FT_Set_Transform(face, &transform, nullptr);
+      return {face, FT_Done_Face};
+    }()
+  },
+  path{path},
+  hinting_factor{hinting_factor}
+{}
+
+Glyph::Glyph(FT_Face const& face, double hinting_factor) :
+  ptr{
+    [&]() -> std::shared_ptr<FT_GlyphRec_> {
+      auto glyph = FT_Glyph{};
+      FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+      return {glyph, FT_Done_Glyph};
+    }()
+  },
+  metrics{face->glyph->metrics},
+  linearHoriAdvance{face->glyph->linearHoriAdvance},
+  linearVertAdvance{face->glyph->linearVertAdvance},
+  hinting_factor{hinting_factor}
+{}
+
+PYBIND11_MODULE(_ft2, m)
+{
+  using namespace pybind11::literals;
+
+  m.doc() = R"__doc__(
+A wrapper extension module for FreeType2.
+
+Unless stated otherwise, all methods directly wrap a corresponding FreeType
+function, and all lengths of this API are either in pixels (if FreeType
+intenally uses 26.6 or 16.16 fixed point -- conversion is handled by this
+module) or in font units (if FreeType internally uses font units).  The latter
+case is explicitly mentioned where applicable.
+)__doc__";
+
+  FT_CHECK(FT_Init_FreeType, &library);
+
+  auto major = FT_Int{}, minor = FT_Int{}, patch = FT_Int{};
+  FT_Library_Version(library, &major, &minor, &patch);
+  m.attr("__freetype_version__")
+    = std::to_string(major) + "."
+      + std::to_string(minor) + "."
+      + std::to_string(patch);
+
+#define DECLARE_FLAG(name) m.attr(#name) = FT_##name
+  DECLARE_FLAG(FACE_FLAG_SCALABLE);
+  DECLARE_FLAG(FACE_FLAG_FIXED_SIZES);
+  DECLARE_FLAG(FACE_FLAG_FIXED_WIDTH);
+  DECLARE_FLAG(FACE_FLAG_SFNT);
+  DECLARE_FLAG(FACE_FLAG_HORIZONTAL);
+  DECLARE_FLAG(FACE_FLAG_VERTICAL);
+  DECLARE_FLAG(FACE_FLAG_KERNING);
+  DECLARE_FLAG(FACE_FLAG_FAST_GLYPHS);
+  DECLARE_FLAG(FACE_FLAG_MULTIPLE_MASTERS);
+  DECLARE_FLAG(FACE_FLAG_GLYPH_NAMES);
+  DECLARE_FLAG(FACE_FLAG_EXTERNAL_STREAM);
+  DECLARE_FLAG(FACE_FLAG_HINTER);
+  DECLARE_FLAG(FACE_FLAG_CID_KEYED);
+  DECLARE_FLAG(FACE_FLAG_TRICKY);
+  DECLARE_FLAG(FACE_FLAG_COLOR);
+
+  DECLARE_FLAG(LOAD_DEFAULT);
+  DECLARE_FLAG(LOAD_NO_SCALE);
+  DECLARE_FLAG(LOAD_NO_HINTING);
+  DECLARE_FLAG(LOAD_RENDER);
+  DECLARE_FLAG(LOAD_NO_BITMAP);
+  DECLARE_FLAG(LOAD_VERTICAL_LAYOUT);
+  DECLARE_FLAG(LOAD_FORCE_AUTOHINT);
+  DECLARE_FLAG(LOAD_CROP_BITMAP);
+  DECLARE_FLAG(LOAD_PEDANTIC);
+  DECLARE_FLAG(LOAD_IGNORE_GLOBAL_ADVANCE_WIDTH);
+  DECLARE_FLAG(LOAD_NO_RECURSE);
+  DECLARE_FLAG(LOAD_IGNORE_TRANSFORM);
+  DECLARE_FLAG(LOAD_MONOCHROME);
+  DECLARE_FLAG(LOAD_LINEAR_DESIGN);
+  DECLARE_FLAG(LOAD_NO_AUTOHINT);
+  DECLARE_FLAG(LOAD_COLOR);
+#ifdef FT_LOAD_COMPUTE_METRICS  // backcompat: ft 2.6.1.
+  DECLARE_FLAG(LOAD_COMPUTE_METRICS);
+#endif
+#ifdef FT_LOAD_BITMAP_METRICS_ONLY  // backcompat: ft 2.7.1.
+  DECLARE_FLAG(LOAD_BITMAP_METRICS_ONLY);
+#endif
+
+  DECLARE_FLAG(LOAD_TARGET_NORMAL);
+  DECLARE_FLAG(LOAD_TARGET_LIGHT);
+  DECLARE_FLAG(LOAD_TARGET_MONO);
+  DECLARE_FLAG(LOAD_TARGET_LCD);
+  DECLARE_FLAG(LOAD_TARGET_LCD_V);
+
+  DECLARE_FLAG(STYLE_FLAG_ITALIC);
+  DECLARE_FLAG(STYLE_FLAG_BOLD);
+#undef DECLARE_FLAG
+
+  py::enum_<FT_Encoding>(m, "Encoding")
+#define DECLARE_ENUM(name) .value(#name, FT_ENCODING_##name)
+  DECLARE_ENUM(NONE)
+  DECLARE_ENUM(UNICODE)
+  DECLARE_ENUM(MS_SYMBOL)
+  DECLARE_ENUM(ADOBE_LATIN_1)
+  DECLARE_ENUM(OLD_LATIN_2)
+  DECLARE_ENUM(SJIS)
+#ifdef FT_ENCODING_PRC  // backcompat: ft 2.8.0.1.
+  DECLARE_ENUM(PRC)
+#endif
+  DECLARE_ENUM(BIG5)
+  DECLARE_ENUM(WANSUNG)
+  DECLARE_ENUM(JOHAB)
+  DECLARE_ENUM(ADOBE_STANDARD)
+  DECLARE_ENUM(ADOBE_EXPERT)
+  DECLARE_ENUM(ADOBE_CUSTOM)
+  DECLARE_ENUM(APPLE_ROMAN);
+#undef DECLARE_ENUM
+
+  py::enum_<FT_Glyph_BBox_Mode>(m, "GlyphBbox")
+#define DECLARE_ENUM(name) .value(#name, FT_GLYPH_BBOX_##name)
+  DECLARE_ENUM(UNSCALED)
+  DECLARE_ENUM(SUBPIXELS)
+  DECLARE_ENUM(GRIDFIT)
+  DECLARE_ENUM(TRUNCATE)
+  DECLARE_ENUM(PIXELS);
+#undef DECLARE_ENUM
+
+  py::enum_<FT_Kerning_Mode>(m, "Kerning")
+#define DECLARE_ENUM(name) .value(#name, FT_KERNING_##name)
+  DECLARE_ENUM(DEFAULT)
+  DECLARE_ENUM(UNFITTED)
+  DECLARE_ENUM(UNSCALED);
+#undef DECLARE_ENUM
+
+  py::class_<Face>(m, "Face", R"__doc__(
+A lightweight wrapper around a ``FT_Face``.
+
+Length attributes of this class (`ascender`, `descender`, etc.) are in font
+units.
+)__doc__")
+    .def(
+      py::init(
+        [](py::object path, FT_Long index, double hinting_factor) -> Face* {
+          PyBytesObject* bytes = nullptr;
+          char* buffer = nullptr;
+          auto length = std::string::size_type{};  // i.e. size_t.
+          PyUnicode_FSConverter(path.ptr(), &bytes)
+            && PyBytes_AsStringAndSize(
+                 reinterpret_cast<PyObject*>(bytes),
+                 &buffer,
+                 reinterpret_cast<Py_ssize_t*>(&length));
+          Py_XDECREF(bytes);
+          if (PyErr_Occurred()) {
+            throw py::error_already_set();
+          }
+          return new Face{std::string{buffer, length}, index, hinting_factor};
+        }),
+      "path"_a, "index"_a, "hinting_factor"_a=1,
+      R"__doc__(
+Load a `Face` from a path and an index.
+)__doc__")
+
+    .def_property_readonly(
+      "pathname",
+      [](Face const& pyface) -> py::handle {
+        return
+          PyUnicode_DecodeFSDefaultAndSize(
+            pyface.path.c_str(), pyface.path.size());
+      },
+      R"__doc__(
+The path from which the `Face` was loaded, as a string.  This is the only
+attribute that does not come from FreeType itself.
+)__doc__")
+
+#define DECLARE_FIELD(prop) \
+  .def_property_readonly( \
+    #prop, [](Face const& pyface) { return pyface.ptr->prop; })
+    DECLARE_FIELD(num_faces)
+    DECLARE_FIELD(face_flags)
+    DECLARE_FIELD(style_flags)
+    DECLARE_FIELD(num_glyphs)
+    DECLARE_FIELD(family_name)
+    DECLARE_FIELD(style_name)
+    DECLARE_FIELD(num_fixed_sizes)
+    // available_sizes -> not supported.
+    DECLARE_FIELD(num_charmaps)
+    // charmaps -> not supported.
+    // generic -> not supported.
+    .def_property_readonly(
+      "bbox",
+      [](Face const& pyface) -> std::tuple<FT_Pos, FT_Pos, FT_Pos, FT_Pos> {
+        auto [xmin, ymin, xmax, ymax] = pyface.ptr->bbox;
+        return {xmin, ymin, xmax, ymax};
+      })
+    DECLARE_FIELD(units_per_EM)
+    DECLARE_FIELD(ascender)
+    DECLARE_FIELD(descender)
+    DECLARE_FIELD(height)
+    DECLARE_FIELD(max_advance_width)
+    DECLARE_FIELD(max_advance_height)
+    DECLARE_FIELD(underline_position)
+    DECLARE_FIELD(underline_thickness)
+    .def_property_readonly(
+      "glyph",
+      [](Face const& pyface) -> Glyph {
+        return {pyface.ptr.get(), pyface.hinting_factor};
+      })
+    // size -> set_char_size.
+    // charmap -> not supported.
+#undef DECLARE_FIELD
+    .def(
+      "get_char_index",
+      [](Face const& pyface, FT_ULong codepoint) -> FT_UInt {
+        return FT_Get_Char_Index(pyface.ptr.get(), codepoint);
+      },
+      "codepoint"_a)
+    .def(
+      "get_font_format",
+      [](Face const& pyface) -> std::string {
+        // backcompat: FT_Get_Font_Format in ft 2.6.
+        return FT_Get_X11_Font_Format(pyface.ptr.get());
+      })
+    .def(
+      "get_glyph_name",
+      [](Face const& pyface, FT_UInt index) -> std::string {
+        auto face = pyface.ptr.get();
+        char buf[128];  // Limit to PS identifier size.
+        // This branch is copied from ft2font.cpp.
+        if (!FT_HAS_GLYPH_NAMES(face)) {
+          /* Note that this generated name must match the name that
+            is generated by ttconv in ttfont_CharStrings_getname. */
+          PyOS_snprintf(buf, 128, "uni%08x", index);
+        } else {
+          FT_CHECK(FT_Get_Glyph_Name, face, index, buf, 128);
+        }
+        return buf;
+      },
+      "index"_a)
+    .def(
+      "get_kerning",
+      [](Face const& pyface, FT_UInt left, FT_UInt right, FT_Kerning_Mode mode)
+      -> std::tuple<double, double> {
+        if (FT_HAS_KERNING(pyface.ptr.get())) {
+          if (mode == FT_KERNING_UNSCALED) {
+            // So that whoever *actually* needs this can implement the correct
+            // conversion factor.
+            throw
+              std::runtime_error("Unknown conversion for FT_KERNING_UNSCALED");
+          }
+          auto delta = FT_Vector{};
+          FT_CHECK(
+            FT_Get_Kerning, pyface.ptr.get(), left, right, mode, &delta);
+          return {delta.x / 64., delta.y / 64.};
+        } else {
+          return {0, 0};
+        }
+      },
+      "left"_a, "right"_a, "mode"_a)
+    .def(
+      "get_postscript_name",
+      [](Face const& pyface) -> char const* {
+        return FT_Get_Postscript_Name(pyface.ptr.get());
+      })
+    .def(
+      "get_ps_font_info",
+      [](Face const& pyface) -> py::dict {
+        auto info = PS_FontInfoRec{};
+        FT_CHECK(FT_Get_PS_Font_Info, pyface.ptr.get(), &info);
+        auto pyinfo = py::dict{};
+#define COPY_FIELD(field) pyinfo[#field] = info.field
+        COPY_FIELD(version);
+        COPY_FIELD(notice);
+        COPY_FIELD(full_name);
+        COPY_FIELD(family_name);
+        COPY_FIELD(weight);
+        COPY_FIELD(italic_angle);
+        COPY_FIELD(is_fixed_pitch);
+        COPY_FIELD(underline_position);
+        COPY_FIELD(underline_thickness);
+#undef COPY_FIELD
+        return pyinfo;
+      })
+    .def(
+      "get_sfnt_name_table",
+      // Don't bother returning a
+      //   std::unordered_map<
+      //     std::tuple<FT_UShort, FT_UShort, FT_UShort, FT_UShort>, py::bytes>
+      // because std::hash is not specialized for tuples...
+      [](Face const& pyface) -> py::dict {
+        auto face = pyface.ptr.get();
+        if (!FT_IS_SFNT(face)) {
+          throw std::runtime_error("Font not using the SFNT storage scheme");
+        }
+        auto table = py::dict{};
+        auto name_count = FT_Get_Sfnt_Name_Count(face);
+        for (auto i = 0u; i < name_count; ++i) {
+          auto sfnt_name = FT_SfntName{};
+          FT_CHECK(FT_Get_Sfnt_Name, face, i, &sfnt_name);
+          table[py::make_tuple(sfnt_name.platform_id, sfnt_name.encoding_id,
+                               sfnt_name.language_id, sfnt_name.name_id)]
+            = py::bytes((char*)(sfnt_name.string), sfnt_name.string_len);
+        }
+        return table;
+      }, R"__doc__(
+Return the SFNT names table.
+
+The returned dict maps ``(platform_id, encoding_id, language_id, name_id)``
+keys to the corresponding 'name' bytestrings.
+)__doc__")
+    .def(
+      "get_sfnt_table",
+      [](Face const& pyface, std::string tag) -> std::optional<py::dict> {
+        auto face = pyface.ptr.get();
+        if (!FT_IS_SFNT(face)) {
+          throw std::runtime_error("Font not using the SFNT storage scheme");
+        }
+        auto table = py::dict{};
+        auto copy_field = [&](char const* name, auto value) -> void {
+          if constexpr (std::is_array_v<decltype(value)>) {
+            table[name] =
+              py::bytes(
+                static_cast<char*>(value), std::extent_v<decltype(value)>);
+          } else {
+            table[name] = value;
+          }
+        };
+#define COPY_FIELD(field) copy_field(#field, ptr->field)
+        if (tag == "head") {
+          auto ptr =
+            // backcompat: FT_SFNT_HEAD in ft 2.5.4.  Same for other ft_sfnt's.
+            static_cast<TT_Header*>(FT_Get_Sfnt_Table(face, ft_sfnt_head));
+          if (!ptr) {
+            return {};
+          }
+          COPY_FIELD(Table_Version);
+          COPY_FIELD(Font_Revision);
+          COPY_FIELD(CheckSum_Adjust);
+          COPY_FIELD(Magic_Number);
+          COPY_FIELD(Flags);
+          COPY_FIELD(Units_Per_EM);
+          table["Created"] = py::make_tuple(ptr->Created[0], ptr->Created[1]);
+          table["Modified"] = py::make_tuple(ptr->Modified[0], ptr->Modified[1]);
+          COPY_FIELD(xMin);
+          COPY_FIELD(yMin);
+          COPY_FIELD(xMax);
+          COPY_FIELD(yMax);
+          COPY_FIELD(Mac_Style);
+          COPY_FIELD(Lowest_Rec_PPEM);
+          COPY_FIELD(Font_Direction);
+          COPY_FIELD(Index_To_Loc_Format);
+          COPY_FIELD(Glyph_Data_Format);
+        } else if (tag == "maxp") {
+          auto ptr =
+            static_cast<TT_MaxProfile*>(FT_Get_Sfnt_Table(face, ft_sfnt_maxp));
+          COPY_FIELD(version);
+          COPY_FIELD(numGlyphs);
+          COPY_FIELD(maxPoints);
+          COPY_FIELD(maxContours);
+          COPY_FIELD(maxCompositePoints);
+          COPY_FIELD(maxCompositeContours);
+          COPY_FIELD(maxZones);
+          COPY_FIELD(maxTwilightPoints);
+          COPY_FIELD(maxStorage);
+          COPY_FIELD(maxFunctionDefs);
+          COPY_FIELD(maxInstructionDefs);
+          COPY_FIELD(maxStackElements);
+          COPY_FIELD(maxSizeOfInstructions);
+          COPY_FIELD(maxComponentElements);
+          COPY_FIELD(maxComponentDepth);
+        } else if (tag == "OS/2") {
+          auto ptr =
+            static_cast<TT_OS2*>(FT_Get_Sfnt_Table(face, ft_sfnt_os2));
+          if (!ptr) {
+            return {};
+          }
+          // NOTE: Don't bother with optional tags.
+          COPY_FIELD(version);
+          COPY_FIELD(xAvgCharWidth);
+          COPY_FIELD(usWeightClass);
+          COPY_FIELD(usWidthClass);
+          COPY_FIELD(fsType);
+          COPY_FIELD(ySubscriptXSize);
+          COPY_FIELD(ySubscriptYSize);
+          COPY_FIELD(ySubscriptXOffset);
+          COPY_FIELD(ySubscriptYOffset);
+          COPY_FIELD(ySuperscriptXSize);
+          COPY_FIELD(ySuperscriptYSize);
+          COPY_FIELD(ySuperscriptXOffset);
+          COPY_FIELD(ySuperscriptYOffset);
+          COPY_FIELD(yStrikeoutSize);
+          COPY_FIELD(yStrikeoutPosition);
+          COPY_FIELD(sFamilyClass);
+          COPY_FIELD(panose);
+          COPY_FIELD(ulUnicodeRange1);
+          COPY_FIELD(ulUnicodeRange2);
+          COPY_FIELD(ulUnicodeRange3);
+          COPY_FIELD(ulUnicodeRange4);
+          COPY_FIELD(achVendID);
+          COPY_FIELD(fsSelection);
+          COPY_FIELD(usFirstCharIndex);
+          COPY_FIELD(usLastCharIndex);
+          COPY_FIELD(sTypoAscender);
+          COPY_FIELD(sTypoDescender);
+          COPY_FIELD(sTypoLineGap);
+          COPY_FIELD(usWinAscent);
+          COPY_FIELD(usWinDescent);
+        } else if (tag == "hhea") {
+          auto ptr =
+            static_cast<TT_HoriHeader*>(FT_Get_Sfnt_Table(face, ft_sfnt_hhea));
+          if (!ptr) {
+            return {};
+          }
+          // NOTE: Skip reserved, {long,short}_metrics.
+          COPY_FIELD(Version);
+          COPY_FIELD(Ascender);
+          COPY_FIELD(Descender);
+          COPY_FIELD(Line_Gap);
+          COPY_FIELD(advance_Width_Max);
+          COPY_FIELD(min_Left_Side_Bearing);
+          COPY_FIELD(min_Right_Side_Bearing);
+          COPY_FIELD(xMax_Extent);
+          COPY_FIELD(caret_Slope_Rise);
+          COPY_FIELD(caret_Slope_Run);
+          COPY_FIELD(caret_Offset);
+          COPY_FIELD(metric_Data_Format);
+          COPY_FIELD(number_Of_HMetrics);
+        } else if (tag == "vhea") {
+          auto ptr =
+            static_cast<TT_VertHeader*>(FT_Get_Sfnt_Table(face, ft_sfnt_vhea));
+          if (!ptr) {
+            throw std::runtime_error("No \"vhea\" table");
+          }
+          // NOTE: Skip reserved, {long,short}_metrics.
+          COPY_FIELD(Version);
+          COPY_FIELD(Ascender);
+          COPY_FIELD(Descender);
+          COPY_FIELD(Line_Gap);
+          COPY_FIELD(advance_Height_Max);
+          COPY_FIELD(min_Top_Side_Bearing);
+          COPY_FIELD(min_Bottom_Side_Bearing);
+          COPY_FIELD(yMax_Extent);
+          COPY_FIELD(caret_Slope_Rise);
+          COPY_FIELD(caret_Slope_Run);
+          COPY_FIELD(caret_Offset);
+          COPY_FIELD(metric_Data_Format);
+          COPY_FIELD(number_Of_VMetrics);
+        } else if (tag == "post") {
+          auto ptr =
+            static_cast<TT_Postscript*>(FT_Get_Sfnt_Table(face, ft_sfnt_post));
+          if (!ptr) {
+            return {};
+          }
+          COPY_FIELD(FormatType);
+          // NOTE: ft2font splits italicAngle into two uint16s but this seems wrong.
+          COPY_FIELD(italicAngle);
+          COPY_FIELD(underlinePosition);
+          COPY_FIELD(underlineThickness);
+          COPY_FIELD(isFixedPitch);
+          COPY_FIELD(minMemType42);
+          COPY_FIELD(maxMemType42);
+          COPY_FIELD(minMemType1);
+          COPY_FIELD(maxMemType1);
+        } else if (tag == "pclt") {
+          auto ptr =
+            static_cast<TT_PCLT*>(FT_Get_Sfnt_Table(face, ft_sfnt_pclt));
+          if (!ptr) {
+            return {};
+          }
+          // NOTE: Skip reserved.
+          COPY_FIELD(Version);
+          COPY_FIELD(FontNumber);
+          COPY_FIELD(Pitch);
+          COPY_FIELD(xHeight);
+          COPY_FIELD(Style);
+          COPY_FIELD(TypeFamily);
+          COPY_FIELD(CapHeight);
+          COPY_FIELD(SymbolSet);
+          COPY_FIELD(TypeFace);
+          COPY_FIELD(CharacterComplement);
+          COPY_FIELD(FileName);
+          COPY_FIELD(StrokeWeight);
+          COPY_FIELD(WidthType);
+          COPY_FIELD(SerifStyle);
+        } else {
+          throw std::runtime_error("Invalid SFNT table");
+        }
+#undef COPY_FIELD
+        return table;
+      })
+    .def(
+      "load_char",
+      [](Face const& pyface, FT_ULong codepoint, FT_Int32 flags) -> void {
+        FT_CHECK(FT_Load_Char, pyface.ptr.get(), codepoint, flags);
+      },
+      "codepoint"_a, "flags"_a)
+    .def(
+      "select_charmap",
+      [](Face const& pyface, FT_Encoding encoding) -> void {
+        FT_CHECK(FT_Select_Charmap, pyface.ptr.get(), encoding);
+      },
+      "encoding"_a)
+    .def(
+      "set_char_size",
+      [](Face const& pyface, double pt_size, double dpi) -> void {
+        auto face = pyface.ptr.get();
+        FT_CHECK(FT_Set_Char_Size,
+                 face, pt_size * 64, 0, dpi * pyface.hinting_factor, dpi);
+        auto transform =
+          FT_Matrix{FT_Fixed(65536 / pyface.hinting_factor), 0, 0, 65536};
+        FT_Set_Transform(face, &transform, nullptr);
+      },
+      "pt_size"_a, "dpi"_a)
+    ;
+
+  py::class_<Glyph>(m, "Glyph", R"__doc__(
+A lightweight wrapper around a ``FT_Glyph``.
+
+This object cannot be constructed directly.  Instead, load a glyph in a face's
+glyph slot with `Face.load_char`, then access the face's `glyph` property
+(which calls ``FT_Get_Glyph``).
+
+This class exposes the attributes of the original glyph slot and its glyph
+metrics.  Length attibutes are in pixels (this module handles conversion from
+26.6 and 16.6 fixed point formats internally).
+)__doc__")
+    .def_property_readonly(
+      "width",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.width / 64. / pyglyph.hinting_factor;
+      })
+    .def_property_readonly(
+      "height",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.height / 64.;
+      })
+    .def_property_readonly(
+      "horiBearingX",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.horiBearingX / 64. / pyglyph.hinting_factor;
+      })
+    .def_property_readonly(
+      "horiBearingY",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.horiBearingY / 64.;
+      })
+    .def_property_readonly(
+      "horiAdvance",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.horiAdvance / 64.;
+      })
+    .def_property_readonly(
+      "vertBearingX",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.vertBearingX / 64.;
+      })
+    .def_property_readonly(
+      "vertBearingY",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.vertBearingY / 64.;
+      })
+    .def_property_readonly(
+      "vertAdvance",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.metrics.vertAdvance / 64.;
+      })
+    .def_property_readonly(
+      "linearHoriAdvance",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.linearHoriAdvance / 65536. / pyglyph.hinting_factor;
+      })
+    .def_property_readonly(
+      "linearVertAdvance",
+      [](Glyph& pyglyph) -> double {
+        return pyglyph.linearVertAdvance / 65536.;
+      })
+    .def(
+      "get_cbox",
+      [](Glyph& pyglyph, FT_UInt mode)
+      -> std::tuple<double, double, double, double> {
+        auto bbox = FT_BBox{};
+        FT_Glyph_Get_CBox(pyglyph.ptr.get(), mode, &bbox);
+        auto conv = ((mode == FT_GLYPH_BBOX_SUBPIXELS)
+                     || mode == FT_GLYPH_BBOX_GRIDFIT) ? 1. / 64 : 1.;
+        return {bbox.xMin * conv, bbox.xMax * conv,
+                bbox.yMin * conv, bbox.yMax * conv};
+      });
+
+  py::class_<Layout>(m, "Layout", R"__doc__(
+A text (and rectangles) layout engine.
+
+Use as follows::
+
+   # Construct a layout.
+   layout = Layout.simple(...)
+   # or
+   layout = Layout.manual(...)
+   # Access the layout's bounds:
+   layout.xMin, layout.xMax, layout.yMin, layout.yMax
+   # Render the text into a numpy array:
+   result = layout.render()
+)__doc__")
+    .def("render", &Layout::render, "antialiased"_a, R"__doc__(
+Render the laid out text into a numpy array.
+)__doc__")
+    .def_property_readonly(
+      "xMin",
+      [](Layout& layout) -> double { return layout.bbox.xMin / 64.; })
+    .def_property_readonly(
+      "xMax",
+      [](Layout& layout) -> double { return layout.bbox.xMax / 64.; })
+    .def_property_readonly(
+      "yMin",
+      [](Layout& layout) -> double { return layout.bbox.yMin / 64.; })
+    .def_property_readonly(
+      "yMax",
+      [](Layout& layout) -> double { return layout.bbox.yMax / 64.; })
+    .def_static(
+      "simple",
+      [](std::u32string const& string, Face const& pyface, FT_Int32 flags)
+      -> Layout {
+        return Layout::simple(string, pyface.ptr.get(), flags);
+      },
+      "string"_a, "face"_a, "flags"_a, R"__doc__(
+Layout a string by positioning individual glyphs one after the other.
+
+After each glyph, the current position is advanced by the glyph's advance and
+the kerning between this glyph and the next one.
+)__doc__")
+    .def_static(
+      "manual",
+      [](std::vector<std::tuple<Glyph, double, double>> const& positioned_pyglyphs,
+         std::vector<rect_t> const& rectangles,
+         FT_Int32 flags)
+      -> Layout {
+        auto positioned_glyphs
+          = std::vector<std::tuple<FT_Glyph, double, double>>{};
+        std::transform(
+          positioned_pyglyphs.begin(), positioned_pyglyphs.end(),
+          std::back_inserter(positioned_glyphs),
+          [](std::tuple<Glyph, double, double> const& positioned_pyglyph)
+          -> std::tuple<FT_Glyph, double, double> {
+            auto& [pyglyph, x, y] = positioned_pyglyph;
+            return {pyglyph.ptr.get(), x, y};
+          });
+        return Layout::manual(positioned_glyphs, rectangles, flags);
+      },
+      "positioned_glyphs"_a, "rectangles"_a, "flags"_a, R"__doc__(
+Prepare a list of manually laid out glyphs and rectangles for rendering.
+)__doc__");
+
+  m.def(
+    "glyph_to_path",
+    [](Glyph const& glyph)
+    -> std::tuple<std::vector<std::tuple<double, double>>, std::vector<int>> {
+      if (glyph.ptr->format != FT_GLYPH_FORMAT_OUTLINE) {
+        throw std::runtime_error("Not an outline glyph");
+      }
+      // outline.n_points seems invalid :-(
+      auto path = std::tuple<std::vector<std::tuple<double, double>>,
+                             std::vector<int>>{};
+      auto& [vertices, codes] = path;
+      auto move_to =
+        [](FT_Vector const* to, void* raw) -> int {
+        auto& [vertices, codes] = *static_cast<decltype(&path)>(raw);
+        if (vertices.size()) {
+          vertices.push_back({NAN, NAN});
+          codes.push_back(79);
+        }
+        vertices.push_back({to->x / 64., to->y / 64.});
+        codes.push_back(1);
+        return 0;
+      };
+      auto line_to =
+        [](FT_Vector const* to, void* raw) -> int {
+        auto& [vertices, codes] = *static_cast<decltype(&path)>(raw);
+        vertices.push_back({to->x / 64., to->y / 64.});
+        codes.push_back(2);
+        return 0;
+      };
+      auto conic_to =
+        [](FT_Vector const* control, FT_Vector const* to, void* raw) -> int {
+        auto& [vertices, codes] = *static_cast<decltype(&path)>(raw);
+        vertices.push_back({control->x / 64., control->y / 64.});
+        vertices.push_back({to->x / 64., to->y / 64.});
+        codes.push_back(3);
+        codes.push_back(3);
+        return 0;
+      };
+      auto cubic_to =
+        [](FT_Vector const* control1, FT_Vector const* control2,
+           FT_Vector const* to, void* raw) -> int {
+        auto& [vertices, codes] = *static_cast<decltype(&path)>(raw);
+        vertices.push_back({control1->x / 64., control1->y / 64.});
+        vertices.push_back({control2->x / 64., control2->y / 64.});
+        vertices.push_back({to->x / 64., to->y / 64.});
+        codes.push_back(4);
+        codes.push_back(4);
+        codes.push_back(4);
+        return 0;
+      };
+      auto outline_funcs =
+        FT_Outline_Funcs{move_to, line_to, conic_to, cubic_to, 0, 0};
+      FT_Outline_Decompose(
+        &reinterpret_cast<FT_OutlineGlyph>(glyph.ptr.get())->outline,
+        &outline_funcs,
+        &path);
+      if (vertices.size()) {
+        vertices.push_back({NAN, NAN});
+        codes.push_back(79);
+      } else {
+        vertices.push_back({0, 0});
+        codes.push_back(1);
+      }
+      return path;
+    },
+    "glyph"_a, R"__doc__(
+Extract a glyph's outline in Matplotlib's ``(vertices, codes)`` format.
+)__doc__");
+}
+
+}

--- a/src/ft2/_ft2.h
+++ b/src/ft2/_ft2.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "_util.h"
+
+namespace matplotlib::ft2 {
+
+FT_Library library;
+
+struct Face {
+  std::shared_ptr<FT_FaceRec_> const ptr;
+  std::string const path;
+  double const hinting_factor;
+
+  Face(std::string const& path, FT_Long index, double hinting_factor);
+};
+
+struct Glyph {
+  std::shared_ptr<FT_GlyphRec_> const ptr;
+
+  // Fields copied from the glyph slot.
+  FT_Glyph_Metrics const metrics;
+  FT_Fixed const linearHoriAdvance;
+  FT_Fixed const linearVertAdvance;
+  double const hinting_factor;
+
+  Glyph(FT_Face const& face, double hinting_factor);
+};
+
+}

--- a/src/ft2/_layout.cpp
+++ b/src/ft2/_layout.cpp
@@ -1,0 +1,200 @@
+#include "_layout.h"
+// Use 26.6 throughout.
+
+namespace matplotlib::ft2 {
+
+FT_BBox compute_bbox(
+  FT_Vector pos,
+  std::vector<FT_Glyph> const& glyphs,
+  std::vector<rect_t> const& rectangles)
+{
+  // Use the advance, because spaces are reported as xMin = xMax = 0, so those
+  // at the end would be ignored (OTOH, (0, 0) is always in the bbox so we
+  // don't need to special-case that).
+  auto bbox = FT_BBox{0, 0, pos.x, pos.y};
+  for (auto& glyph: glyphs) {
+    auto glyph_bbox = FT_BBox{};
+    FT_Glyph_Get_CBox(glyph, FT_GLYPH_BBOX_SUBPIXELS, &glyph_bbox);
+    bbox.xMin = std::min(bbox.xMin, glyph_bbox.xMin);
+    bbox.xMax = std::max(bbox.xMax, glyph_bbox.xMax);
+    bbox.yMin = std::min(bbox.yMin, glyph_bbox.yMin);
+    bbox.yMax = std::max(bbox.yMax, glyph_bbox.yMax);
+  }
+  for (auto& [x0, x1, y0, y1]: rectangles) {
+    bbox.xMin = std::min(bbox.xMin, FT_Pos(std::floor(x0 * 64)));
+    bbox.xMax = std::max(bbox.xMax, FT_Pos(std::ceil(x1 * 64)));
+    bbox.yMin = std::min(bbox.yMin, FT_Pos(std::floor(-y1 * 64)));
+    bbox.yMax = std::max(bbox.yMax, FT_Pos(std::ceil(-y0 * 64)));
+  }
+  return bbox;
+}
+
+Layout::Layout(
+  std::vector<FT_Glyph> const& glyphs,
+  std::vector<rect_t> const& rectangles,
+  FT_Int32 flags,
+  FT_BBox const& bbox) :
+  glyphs{glyphs}, rectangles{rectangles}, flags{flags}, bbox{bbox}
+{}
+
+Layout Layout::simple(
+  std::u32string const& string,
+  FT_Face const& face,
+  FT_Int32 flags)
+{
+  auto has_kerning = FT_HAS_KERNING(face);
+  auto previous = char32_t{};
+  auto pos = FT_Vector{};
+  auto glyphs = std::vector<FT_Glyph>{};
+  glyphs.reserve(string.size());
+  for (auto& codepoint: string) {
+    auto current = FT_Get_Char_Index(face, codepoint);
+    if (has_kerning && previous && current) {
+      auto delta = FT_Vector{};
+      FT_CHECK(
+        FT_Get_Kerning, face, previous, current, FT_KERNING_DEFAULT, &delta);
+      pos.x += delta.x;
+      pos.y += delta.y;
+    }
+    FT_CHECK(FT_Load_Glyph, face, current, flags);
+    auto glyph = FT_Glyph{};
+    FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+    FT_CHECK(FT_Glyph_Transform, glyph, nullptr, &pos);
+    glyphs.push_back(glyph);
+    // 16.16 -> 26.6.
+    pos.x += glyph->advance.x >> 10;
+    pos.y += glyph->advance.y >> 10;
+  }
+  return {glyphs, {}, flags, compute_bbox(pos, glyphs, {})};
+}
+
+Layout Layout::manual(
+  std::vector<std::tuple<FT_Glyph, double, double>> const& positioned_glyphs,
+  std::vector<rect_t> const& rectangles,
+  FT_Int32 flags)
+{
+  auto glyphs = std::vector<FT_Glyph>{};
+  glyphs.reserve(positioned_glyphs.size());
+  for (auto& [glyph, x, y]: positioned_glyphs) {
+    auto copy = FT_Glyph{};
+    FT_CHECK(FT_Glyph_Copy, glyph, &copy);
+    auto pos =
+      FT_Vector{FT_Pos(std::round(x * 64)), FT_Pos(std::round(-y * 64))};
+    FT_Glyph_Transform(copy, nullptr, &pos);
+    glyphs.push_back(copy);
+  }
+  return {glyphs, rectangles, flags, compute_bbox({}, glyphs, rectangles)};
+}
+
+Layout::~Layout()
+{
+  if (!moved) {
+    std::for_each(glyphs.begin(), glyphs.end(), FT_Done_Glyph);
+  }
+}
+
+Layout::Layout(Layout&& other) :
+  glyphs{std::move(other.glyphs)},
+  rectangles{std::move(other.rectangles)},
+  flags{std::move(other.flags)},
+  bbox{std::move(other.bbox)},
+  moved{true}
+{}
+
+py::array_t<uint8_t> Layout::render(bool antialiased)
+{
+  auto xmin = int(std::floor(bbox.xMin / 64.)),
+       xmax = int(std::ceil(bbox.xMax / 64.)),
+       ymin = int(std::floor(bbox.yMin / 64.)),
+       ymax = int(std::ceil(bbox.yMax / 64.)),
+       width = xmax - xmin,
+       height = ymax - ymin;
+  auto array =
+    py::array_t<uint8_t>{size_t(height * width), nullptr}
+    .attr("reshape")(height, width).cast<py::array_t<uint8_t>>();
+  auto buf = array.mutable_unchecked().mutable_data(0);
+  std::memset(buf, 0, width * height);
+  for (auto glyph: glyphs) {
+    if (glyph->format != FT_GLYPH_FORMAT_BITMAP) {
+      // Do *not* destroy the previous glyph: this would invalidate a
+      // Python-level Glyph holding the old value.
+      FT_CHECK(
+        FT_Glyph_To_Bitmap, &glyph,
+        antialiased ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO,
+        nullptr, false);
+    }
+    auto b_glyph = reinterpret_cast<FT_BitmapGlyph>(glyph);
+    auto bitmap = b_glyph->bitmap;
+    if (bitmap.pitch < 0) {  // FIXME: Pitch can be negative.
+      throw std::runtime_error("Negative pitches are not supported");
+    }
+    switch (bitmap.pixel_mode) {
+      case FT_PIXEL_MODE_MONO:
+        for (auto i = 0u; i < bitmap.rows; ++i) {
+          auto src = bitmap.buffer + i * bitmap.pitch,
+              dst = buf + (ymax - b_glyph->top + i) * width
+                    + b_glyph->left - xmin;
+          uint8_t k = 7;
+          for (auto j = 0u; j < bitmap.width; ++j, --k, k %= 8) {
+            if (*src & (1 << k)) {  // MSB order.
+              *dst = 0xff;
+            }
+            if (!k) {
+              ++src;
+            }
+            ++dst;
+          }
+        }
+        break;
+      case FT_PIXEL_MODE_GRAY:
+        for (auto i = 0u; i < bitmap.rows; ++i) {
+          auto src = bitmap.buffer + i * bitmap.pitch,
+              dst = buf + (ymax - b_glyph->top + i) * width
+                    + b_glyph->left - xmin;
+          for (auto j = 0u; j < bitmap.width; ++j) {
+            *dst = std::max(*dst, *src);
+            ++src;
+            ++dst;
+          }
+        }
+        break;
+      default:
+        throw std::runtime_error(
+          "Unsupported pixel mode: " + std::to_string(bitmap.pixel_mode));
+    }
+    FT_Done_Glyph(glyph);  // Destroy the new glyph.
+  }
+  for (auto& [x0, x1, y0, y1]: rectangles) {
+    // FIXME: Aliased version.
+    auto x0i = int(std::ceil(x0)), x1i = int(std::floor(x1)),
+         y0i = int(std::ceil(y0)), y1i = int(std::floor(y1));
+    for (auto y = y0i; y < y1i; ++y) {
+      std::memset(buf + y * width + x0i - xmin, 0xff, x1i - x0i);
+    }
+    // We only bother with antialiasing of thin horizontal lines.
+    if (y0i > y1i) {  // e.g. y0 = 1.2, y1 = 1.8 -> fill = 0.6.
+      auto fill = uint8_t(0xff * (y1 - y0));
+      std::transform(
+        buf + y1i * width + x0i - xmin,
+        buf + y1i * width + x1i - xmin,
+        buf + y1i * width + x0i - xmin,
+        [&](uint8_t value) { return std::max(fill, value); });
+    } else if (y0i == y1i) {  // e.g. y0 = 1.6, y1 = 2.3.
+      auto fill0 = uint8_t(0xff * (y0i - y0));
+      auto fill1 = uint8_t(0xff * (y1 - y1i));
+      std::transform(
+        buf + (y0i - 1) * width + x0i - xmin,
+        buf + (y0i - 1) * width + x1i - xmin,
+        buf + (y0i - 1) * width + x0i - xmin,
+        [&](uint8_t value) { return std::max(fill0, value); });
+      std::transform(
+        buf + y0i * width + x0i - xmin,
+        buf + y0i * width + x1i - xmin,
+        buf + y0i * width + x0i - xmin,
+        [&](uint8_t value) { return std::max(fill1, value); });
+    }
+  }
+  return array;
+}
+
+}

--- a/src/ft2/_layout.h
+++ b/src/ft2/_layout.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "_util.h"
+
+namespace matplotlib::ft2 {
+
+using rect_t = std::tuple<double, double, double, double>;
+
+FT_BBox compute_bbox(
+  FT_Vector pos,
+  std::vector<FT_Glyph> const& glyphs,
+  std::vector<rect_t> const& rectangles);
+
+struct Layout {
+  private:
+  std::vector<FT_Glyph> glyphs;  // Needs to be non-const for rendering :-(
+  std::vector<rect_t> rectangles;
+
+  public:
+  FT_Int32 const flags;
+  FT_BBox const bbox;  // 26.6.
+
+  private:
+  bool moved = false;
+
+  Layout(
+    std::vector<FT_Glyph> const& glyphs,
+    std::vector<rect_t> const& rectangles,
+    FT_Int32 flags,
+    FT_BBox const& bbox);
+
+  public:
+  static Layout simple(
+    std::u32string const& string,
+    FT_Face const& face,
+    FT_Int32 flags);
+  static Layout manual(
+    std::vector<std::tuple<FT_Glyph, double, double>> const& positioned_glyphs,
+    std::vector<rect_t> const& rectangles,
+    FT_Int32 flags);
+  ~Layout();
+  Layout(const Layout& other) = delete;
+  Layout(Layout&& other);
+
+  py::array_t<uint8_t> render(bool antialiased);
+};
+
+}

--- a/src/ft2/_util.cpp
+++ b/src/ft2/_util.cpp
@@ -1,0 +1,20 @@
+#include "_util.h"
+
+namespace matplotlib::ft2 {
+
+namespace detail {
+// Load FreeType error codes.  This approach (modified to use
+// std::unordered_map) is documented in fterror.h.
+// NOTE: If we require FreeType>=2.6.3 then the macro can be replaced by
+// FTERRORS_H_.
+#undef __FTERRORS_H__
+#define FT_ERRORDEF( e, v, s )  { e, s },
+#define FT_ERROR_START_LIST     {
+#define FT_ERROR_END_LIST       };
+
+std::unordered_map<FT_Error, std::string> ft_errors =
+
+#include FT_ERRORS_H
+}
+
+}

--- a/src/ft2/_util.h
+++ b/src/ft2/_util.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_GLYPH_H
+#include FT_OUTLINE_H
+#include FT_SFNT_NAMES_H
+#include FT_TRUETYPE_TABLES_H
+#include FT_TYPE1_TABLES_H
+// backcompat: FT_FONT_FORMATS_H in ft 2.6.1.
+#include FT_XFREE86_H
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <unordered_map>
+#include <vector>
+
+namespace matplotlib::ft2 {
+
+namespace py = pybind11;
+
+namespace detail {
+
+extern std::unordered_map<FT_Error, std::string> ft_errors;
+
+}
+
+}
+
+#define FT_CHECK(func, ...) { \
+  if (auto error_ = func(__VA_ARGS__)) { \
+    throw \
+      std::runtime_error( \
+        #func " (" __FILE__ " line " + std::to_string(__LINE__) + ") failed " \
+        "with error: " + ft2::detail::ft_errors.at(error_)); \
+  } \
+}


### PR DESCRIPTION
A FreeType wrapper rewrite based on pybind11.  See #5414 (which sadly appears to be abandoned) for the motivation.  Also implements (essentially) a [MEP14](https://matplotlib.org/devel/MEP/MEP14.html)-style API (see the `Layout` class), which should make it fairly easy (based on my experience with mplcairo) to support complex text layout (Indic scripts #8765; Right-to-left languages) (if we accept to bring in new (optional?) dependencies).  The layout class should also make mathtext rendering (a bit) faster: the current implementation requires the parser to go *twice* through the string (once just to compute the extents of result, once with the actual rendering); this implementation just asks the parser to pass a list of positioned glyphs and rectangles (single pass) and does the sizing itself (with an iteration over the glyphs/rectangles, rather than an additional parsing round).

This requires a C++17 compiler, but such compilers are now directly [available on conda](https://www.anaconda.com/blog/developer-blog/utilizing-the-new-compilers-in-anaconda-distribution-5/).  Note, however, that Matplotlib's setupext.py does not play well with non-system compilers (#9737) so you can effectively only test this PR locally with a modern system compiler (this is also why the PR is marked [ci skip]).  Solving #9737 is probably a strict prerequisite for this PR.

The new wrapper weights <1000 lines of code, which is ~3x shorter than the old ones.

Adaptation of the codebase to the new wrapper is mostly complete.  Non-antialiased text rendering is currently missing (but should be easy to implement).

Although I tried to reproduce the (dubious) `hinting_factor` option that currently exists, I haven't actually managed to make the text layout as bad as ft2font sometime does (cf. the wiggly baselines mentioned in #5414) :-), and I don't think it's really worth trying to do that -- but that means that test images will need to be updated.

Unlike #5414, I haven't moved the wrapper to a library separate from matplotlib, because I'd rather take advantage of the FreeType-related build scripts (including `local_freetype`) rather than replicating them.