### PR TITLE
Fix mixed_subplots example

### DIFF
--- a/examples/mplot3d/mixed_subplots.py
+++ b/examples/mplot3d/mixed_subplots.py
@@ -16,16 +16,11 @@ def f(t):
     return np.multiply(s1, e1)
 
 
-#############################################
 # Set up a figure twice as tall as it is wide
-#############################################
 fig = plt.figure(figsize=plt.figaspect(2.))
 fig.suptitle('A tale of 2 subplots')
 
-
-#############################################
 # First subplot
-#############################################
 ax = fig.add_subplot(2, 1, 1)
 
 t1 = np.arange(0.0, 5.0, 0.1)
@@ -37,10 +32,7 @@ ax.plot(t1, f(t1), 'bo',
 ax.grid(True)
 ax.set_ylabel('Damped oscillation')
 
-
-#############################################
 # Second subplot
-#############################################
 ax = fig.add_subplot(2, 1, 2, projection='3d')
 
 X = np.arange(-5, 5, 0.25)
@@ -52,6 +44,5 @@ Z = np.sin(R)
 surf = ax.plot_surface(X, Y, Z, rstride=1, cstride=1,
                        linewidth=0, antialiased=False)
 ax.set_zlim(-1, 1)
-
 
 plt.show()


### PR DESCRIPTION
The separators should old be used to separate different plots, breaking the mixed_subplots example: http://matplotlib.org/devdocs/gallery/mplot3d/mixed_subplots.html#sphx-glr-gallery-mplot3d-mixed-subplots-py

This removes the separators to fix the example.