### PR TITLE
Rethink categoricals.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -397,11 +397,7 @@ class _process_plot_var_args(object):
                                   "with non-matching shapes is deprecated.")
         for j in xrange(max(ncx, ncy)):
             if self.command == "plot":
-                seg = self._makeline([], [], kw, kwargs)
-                # This ensures that the line remembers both the unitized and
-                # deunitized data.
-                seg.set_xdata(xt[j % ncx])
-                seg.set_ydata(yt[j % ncy])
+                seg = self._makeline(xt[j % ncx], yt[j % ncy], kw, kwargs)
             else:
                 kw['closed'] = kwargs.get('closed', True)
                 seg = self._makefill(deunitized_x[:, j % ncx],

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -216,24 +216,10 @@ class _process_plot_var_args(object):
         if self.axes.xaxis is not None and self.axes.yaxis is not None:
             bx = self.axes.xaxis.update_units(x)
             by = self.axes.yaxis.update_units(y)
-
-            if self.command != 'plot':
-                # the Line2D class can handle unitized data, with
-                # support for post hoc unit changes etc.  Other mpl
-                # artists, e.g., Polygon which _process_plot_var_args
-                # also serves on calls to fill, cannot.  So this is a
-                # hack to say: if you are not "plot", which is
-                # creating Line2D, then convert the data now to
-                # floats.  If you are plot, pass the raw data through
-                # to Line2D which will handle the conversion.  So
-                # polygons will not support post hoc conversions of
-                # the unit type since they are not storing the orig
-                # data.  Hopefully we can rationalize this at a later
-                # date - JDH
-                if bx:
-                    x = self.axes.convert_xunits(x)
-                if by:
-                    y = self.axes.convert_yunits(y)
+            if bx:
+                x = self.axes.convert_xunits(x)
+            if by:
+                y = self.axes.convert_yunits(y)
 
         # like asanyarray, but converts scalar to array, and doesn't change
         # existing compatible sequences
@@ -376,11 +362,12 @@ class _process_plot_var_args(object):
         if 'label' not in kwargs or kwargs['label'] is None:
             kwargs['label'] = get_label(tup[-1], None)
 
-        if len(tup) == 2:
-            x = _check_1d(tup[0])
-            y = _check_1d(tup[-1])
+        if len(tup) == 1:
+            x, y = index_of(tup[0])
+        elif len(tup) == 2:
+            x, y = tup
         else:
-            x, y = index_of(tup[-1])
+            assert False
 
         x, y = self._xy_from_xy(x, y)
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -668,7 +668,6 @@ class Axis(artist.Artist):
         self.offsetText = self._get_offset_text()
         self.majorTicks = []
         self.minorTicks = []
-        self._unit_data = None  # Categorical mapping data.
         self.pickradius = pickradius
 
         # Initialize here for testing; later add API

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -718,6 +718,16 @@ class Axis(artist.Artist):
     def limit_range_for_scale(self, vmin, vmax):
         return self._scale.limit_range_for_scale(vmin, vmax, self.get_minpos())
 
+    @property
+    @cbook.deprecated("2.1.1")
+    def unit_data(self):
+        return self.units
+
+    @unit_data.setter
+    @cbook.deprecated("2.1.1")
+    def unit_data(self, value):
+        self.set_units = value
+
     def get_children(self):
         children = [self.label, self.offsetText]
         majorticks = self.get_major_ticks()

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -668,7 +668,7 @@ class Axis(artist.Artist):
         self.offsetText = self._get_offset_text()
         self.majorTicks = []
         self.minorTicks = []
-        self.unit_data = None
+        self._unit_data = None  # Categorical mapping data.
         self.pickradius = pickradius
 
         # Initialize here for testing; later add API
@@ -718,17 +718,6 @@ class Axis(artist.Artist):
 
     def limit_range_for_scale(self, vmin, vmax):
         return self._scale.limit_range_for_scale(vmin, vmax, self.get_minpos())
-
-    @property
-    def unit_data(self):
-        """Holds data that a ConversionInterface subclass uses
-        to convert between labels and indexes
-        """
-        return self._unit_data
-
-    @unit_data.setter
-    def unit_data(self, unit_data):
-        self._unit_data = unit_data
 
     def get_children(self):
         children = [self.label, self.offsetText]

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -21,24 +21,20 @@ class StrCategoryConverter(units.ConversionInterface):
         if np.issubdtype(np.asarray(value).dtype.type, np.number):
             return value
         else:
-            axis._unit_data.update(value)
-            return np.vectorize(axis._unit_data._val_to_idx.__getitem__)(value)
+            unit.update(value)
+            return np.vectorize(unit._val_to_idx.__getitem__)(value)
 
     @staticmethod
     def axisinfo(unit, axis):
         # Note that mapping may get mutated by later calls to plotting methods,
         # so the locator and formatter must dynamically recompute locs and seq.
         return units.AxisInfo(
-            majloc=StrCategoryLocator(axis._unit_data),
-            majfmt=StrCategoryFormatter(axis._unit_data))
+            majloc=StrCategoryLocator(unit),
+            majfmt=StrCategoryFormatter(unit))
 
     @staticmethod
     def default_units(data, axis):
-        # the conversion call stack is default_units->axis_info->convert
-        if axis._unit_data is None:
-            axis._unit_data = _UnitData()
-        axis._unit_data.update(data)
-        return None
+        return _CategoricalUnit()
 
 
 class StrCategoryLocator(ticker.Locator):
@@ -63,7 +59,7 @@ class StrCategoryFormatter(ticker.Formatter):
             return ""
 
 
-class _UnitData(object):
+class _CategoricalUnit(object):
     def __init__(self):
         """Create mapping between unique categorical values and numerical id.
         """

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -66,6 +66,10 @@ class UnitData(object):
         self._vals = []
         self._val_to_idx = OrderedDict()
         self._counter = itertools.count()
+        if np.size(data):
+            cbook.warn_deprecated(
+                "2.1.1",
+                "Passing data to the UnitData constructor is deprecated.")
         self.update(data)
 
     def update(self, new_data):

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -34,7 +34,7 @@ class StrCategoryConverter(units.ConversionInterface):
 
     @staticmethod
     def default_units(data, axis):
-        return _CategoricalUnit()
+        return UnitData()
 
 
 class StrCategoryLocator(ticker.Locator):
@@ -53,24 +53,25 @@ class StrCategoryFormatter(ticker.Formatter):
         if pos in range(len(self._unit_data._vals)):
             s = self._unit_data._vals[pos]
             if isinstance(s, bytes):
-                s = s.decode("latin-1")
+                s = s.decode("utf-8")
             return s
         else:
             return ""
 
 
-class _CategoricalUnit(object):
-    def __init__(self):
+class UnitData(object):
+    def __init__(self, data=()):
         """Create mapping between unique categorical values and numerical id.
         """
         self._vals = []
         self._val_to_idx = OrderedDict()
         self._counter = itertools.count()
+        self.update(data)
 
-    def update(self, data):
-        if isinstance(data, six.string_types):
-            data = [data]
-        sorted_unique = OrderedDict.fromkeys(data)
+    def update(self, new_data):
+        if isinstance(new_data, six.string_types):
+            new_data = [new_data]
+        sorted_unique = OrderedDict.fromkeys(new_data)
         for val in sorted_unique:
             if val in self._val_to_idx:
                 continue

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -74,6 +74,8 @@ class _CategoricalUnit(object):
         for val in sorted_unique:
             if val in self._val_to_idx:
                 continue
+            if not isinstance(val, (six.text_type, six.binary_type)):
+                raise TypeError("Not a string")
             self._vals.append(val)
             self._val_to_idx[val] = next(self._counter)
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2295,7 +2295,8 @@ def index_of(y):
     try:
         return y.index.values, y.values
     except AttributeError:
-        return np.arange((np.shape(y) or (1,))[0]), y
+        # Ensure that scalar y gives x == [0].
+        return np.arange((np.shape(y) or (1,))[0], dtype=float), y
 
 
 def safe_first_element(obj):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2295,7 +2295,7 @@ def index_of(y):
     try:
         return y.index.values, y.values
     except AttributeError:
-        return np.arange(len(y)), y
+        return np.arange((np.shape(y) or (1,))[0]), y
 
 
 def safe_first_element(obj):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2295,8 +2295,7 @@ def index_of(y):
     try:
         return y.index.values, y.values
     except AttributeError:
-        y = _check_1d(y)
-        return np.arange(y.shape[0], dtype=float), y
+        return np.arange(len(y)), y
 
 
 def safe_first_element(obj):

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -5,193 +5,59 @@ from __future__ import (absolute_import, division, print_function,
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
-import matplotlib.pyplot as plt
-import matplotlib.category as cat
-
-import unittest
-
-
-class TestUnitData(object):
-    testdata = [("hello world", {"hello world": 0}),
-                ("Здравствуйте мир", {"Здравствуйте мир": 0})]
-    ids = ["single", "unicode"]
-
-    @pytest.mark.parametrize("data, mapping", testdata, ids=ids)
-    def test_unit(self, data, mapping):
-        assert cat.UnitData(data)._mapping == mapping
-
-    def test_update_map(self):
-        unitdata = cat.UnitData(['a', 'd'])
-        assert unitdata._mapping == {'a': 0, 'd': 1}
-        unitdata.update(['b', 'd', 'e'])
-        assert unitdata._mapping == {'a': 0, 'd': 1, 'b': 2, 'e': 3}
+from matplotlib import category as cat, pyplot as plt
+from matplotlib.axes import Axes
 
 
-def _mock_unit_data(mapping):
-    ud = cat.UnitData([])
-    ud._mapping.update(mapping)
-    return ud
+@pytest.fixture
+def ax():
+    return plt.figure().subplots()
 
 
-class FakeAxis(object):
-    def __init__(self, unit_data):
-        self.unit_data = unit_data
+@pytest.mark.parametrize(
+    "data, expected_indices, expected_labels",
+    [("hello world", [0], ["hello world"]),
+     (["Здравствуйте мир"], [0], ["Здравствуйте мир"]),
+     (["a", "b", "b", "a", "c", "c"], [0, 1, 1, 0, 2, 2], ["a", "b", "c"]),
+     ([b"foo", b"bar"], range(2), ["foo", "bar"]),
+     (np.array(["1", "11", "3"]), range(3), ["1", "11", "3"]),
+     (np.array([b"1", b"11", b"3"]), range(3), ["1", "11", "3"])])
+def test_simple(ax, data, expected_indices, expected_labels):
+    l, = ax.plot(data)
+    assert_array_equal(l.get_ydata(orig=False), expected_indices)
+    assert isinstance(ax.yaxis.major.locator, cat.StrCategoryLocator)
+    assert isinstance(ax.yaxis.major.formatter, cat.StrCategoryFormatter)
+    ax.figure.canvas.draw()
+    labels = [label.get_text() for label in ax.yaxis.get_majorticklabels()]
+    assert labels == expected_labels
 
 
-class TestStrCategoryConverter(object):
-    """Based on the pandas conversion and factorization tests:
-
-    ref: /pandas/tseries/tests/test_converter.py
-         /pandas/tests/test_algos.py:TestFactorize
-    """
-    testdata = [("Здравствуйте мир", {"Здравствуйте мир": 42}, 42),
-                ("hello world", {"hello world": 42}, 42),
-                (['a', 'b', 'b', 'a', 'a', 'c', 'c', 'c'],
-                 {'a': 0, 'b': 1, 'c': 2},
-                 [0, 1, 1, 0, 0, 2, 2, 2])]
-    ids = ["unicode", "single", "basic"]
-
-    @pytest.fixture(autouse=True)
-    def mock_axis(self, request):
-        self.cc = cat.StrCategoryConverter()
-
-    @pytest.mark.parametrize("data, unitmap, exp", testdata, ids=ids)
-    def test_convert(self, data, unitmap, exp):
-        axis = FakeAxis(_mock_unit_data(unitmap))
-        act = self.cc.convert(data, None, axis)
-        np.testing.assert_array_equal(act, exp)
-
-    def test_axisinfo(self):
-        axis = FakeAxis(_mock_unit_data({None: None}))
-        ax = self.cc.axisinfo(None, axis)
-        assert isinstance(ax.majloc, cat.StrCategoryLocator)
-        assert isinstance(ax.majfmt, cat.StrCategoryFormatter)
-
-    def test_default_units(self):
-        axis = FakeAxis(None)
-        assert self.cc.default_units(["a"], axis) is None
+def test_default_units(ax):
+    ax.plot(["a"])
+    assert ax.yaxis.converter.default_units(["a"], ax.yaxis) is None
 
 
-class TestStrCategoryLocator(object):
-    def test_StrCategoryLocator(self):
-        locs = list(range(10))
-        ticks = cat.StrCategoryLocator({str(x): x for x in locs})
-        np.testing.assert_array_equal(ticks.tick_values(None, None), locs)
+def test_update(ax):
+    l1, = ax.plot(["a", "d"])
+    l2, = ax.plot(["b", "d", "e"])
+    assert_array_equal(l1.get_ydata(orig=False), [0, 1])
+    assert_array_equal(l2.get_ydata(orig=False), [2, 1, 3])
+    assert ax.yaxis._unit_data._vals == ["a", "d", "b", "e"]
+    assert ax.yaxis._unit_data._val_to_idx == {"a": 0, "d": 1, "b": 2, "e": 3}
 
 
-class TestStrCategoryFormatter(unittest.TestCase):
-    def test_StrCategoryFormatter(self):
-        seq = ["hello", "world", "hi"]
-        labels = cat.StrCategoryFormatter(seq)
-        assert labels('a', 1) == "world"
-
-    def test_StrCategoryFormatterUnicode(self):
-        seq = ["Здравствуйте", "привет"]
-        labels = cat.StrCategoryFormatter(seq)
-        assert labels('a', 1) == "привет"
+@pytest.mark.parametrize("plotter", [Axes.plot, Axes.scatter, Axes.bar])
+def test_StrCategoryLocator(ax, plotter):
+    ax.plot(["a", "b", "c"])
+    assert_array_equal(ax.yaxis.major.locator(), range(3))
 
 
-def lt(tl):
-    return [l.get_text() for l in tl]
-
-
-class TestPlot(object):
-    bytes_data = [
-        ['a', 'b', 'c'],
-        [b'a', b'b', b'c'],
-        np.array([b'a', b'b', b'c'])
-    ]
-
-    bytes_ids = ['string list', 'bytes list', 'bytes ndarray']
-
-    numlike_data = [
-        ['1', '11', '3'],
-        np.array(['1', '11', '3']),
-        [b'1', b'11', b'3'],
-        np.array([b'1', b'11', b'3']),
-    ]
-
-    numlike_ids = [
-        'string list', 'string ndarray', 'bytes list', 'bytes ndarray'
-    ]
-
-    @pytest.fixture
-    def data(self):
-        self.d = ['a', 'b', 'c', 'a']
-        self.dticks = [0, 1, 2]
-        self.dlabels = ['a', 'b', 'c']
-
-    def axis_test(self, axis, ticks, labels, unit_data):
-        np.testing.assert_array_equal(axis.get_majorticklocs(), ticks)
-        assert lt(axis.get_majorticklabels()) == labels
-        assert axis.unit_data._mapping == unit_data._mapping
-
-    def test_plot_unicode(self):
-        words = ['Здравствуйте', 'привет']
-        locs = [0.0, 1.0]
-        unit_data = _mock_unit_data(dict(zip(words, locs)))
-
-        fig, ax = plt.subplots()
-        ax.plot(words)
-        fig.canvas.draw()
-
-        self.axis_test(ax.yaxis, locs, words, unit_data)
-
-    @pytest.mark.usefixtures("data")
-    def test_plot_1d(self):
-        fig, ax = plt.subplots()
-        ax.plot(self.d)
-        fig.canvas.draw()
-
-        unit_data = _mock_unit_data({'a': 0, 'b': 1, 'c': 2})
-        self.axis_test(ax.yaxis, self.dticks, self.dlabels, unit_data)
-
-    @pytest.mark.usefixtures("data")
-    @pytest.mark.parametrize("bars", bytes_data, ids=bytes_ids)
-    def test_plot_bytes(self, bars):
-        counts = np.array([4, 6, 5])
-
-        fig, ax = plt.subplots()
-        ax.bar(bars, counts)
-        fig.canvas.draw()
-
-        unit_data = _mock_unit_data(dict(zip(bars, range(3))))
-        self.axis_test(ax.xaxis, self.dticks, self.dlabels, unit_data)
-
-    @pytest.mark.parametrize("bars", numlike_data, ids=numlike_ids)
-    def test_plot_numlike(self, bars):
-        counts = np.array([4, 6, 5])
-
-        fig, ax = plt.subplots()
-        ax.bar(bars, counts)
-        fig.canvas.draw()
-
-        unit_data = _mock_unit_data(dict(zip(bars, range(3))))
-        self.axis_test(ax.xaxis, [0, 1, 2], ['1', '11', '3'], unit_data)
-
-    def test_plot_update(self):
-        fig, ax = plt.subplots()
-
-        ax.plot(['a', 'b'])
-        ax.plot(['a', 'b', 'd'])
-        ax.plot(['b', 'c', 'd'])
-        fig.canvas.draw()
-
-        labels = ['a', 'b', 'd', 'c']
-        ticks = [0, 1, 2, 3]
-        unit_data = _mock_unit_data(dict(zip(labels, ticks)))
-        self.axis_test(ax.yaxis, ticks, labels, unit_data)
-
-    def test_scatter_update(self):
-        fig, ax = plt.subplots()
-
-        ax.scatter(['a', 'b'], [0., 3.])
-        ax.scatter(['a', 'b', 'd'], [1., 2., 3.])
-        ax.scatter(['b', 'c', 'd'], [4., 1., 2.])
-        fig.canvas.draw()
-
-        labels = ['a', 'b', 'd', 'c']
-        ticks = [0, 1, 2, 3]
-        unit_data = _mock_unit_data(dict(zip(labels, ticks)))
-        self.axis_test(ax.xaxis, ticks, labels, unit_data)
+@pytest.mark.parametrize("plotter", [Axes.plot, Axes.scatter, Axes.bar])
+def test_StrCategoryFormatter(ax, plotter):
+    plotter(ax, range(2), ["hello", "мир"])
+    assert ax.yaxis.major.formatter(object(), 0) == "hello"
+    assert ax.yaxis.major.formatter(object(), 1) == "мир"
+    assert ax.yaxis.major.formatter(object(), 2) == ""
+    assert ax.yaxis.major.formatter(object(), None) == ""

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -36,7 +36,7 @@ def test_simple(ax, data, expected_indices, expected_labels):
 def test_default_units(ax):
     ax.plot(["a"])
     du = ax.yaxis.converter.default_units(["a"], ax.yaxis)
-    assert isinstance(du, cat._CategoricalUnit)
+    assert isinstance(du, cat.UnitData)
 
 
 def test_update(ax):

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -13,48 +13,30 @@ import unittest
 
 
 class TestUnitData(object):
-    testdata = [("hello world", ["hello world"], [0]),
-                ("Здравствуйте мир", ["Здравствуйте мир"], [0]),
-                (['A', 'A', np.nan, 'B', -np.inf, 3.14, np.inf],
-                 ['-inf', '3.14', 'A', 'B', 'inf', 'nan'],
-                 [-3.0, 0, 1, 2, -2.0, -1.0])]
+    testdata = [("hello world", {"hello world": 0}),
+                ("Здравствуйте мир", {"Здравствуйте мир": 0})]
+    ids = ["single", "unicode"]
 
-    ids = ["single", "unicode", "mixed"]
-
-    @pytest.mark.parametrize("data, seq, locs", testdata, ids=ids)
-    def test_unit(self, data, seq, locs):
-        act = cat.UnitData(data)
-        assert act.seq == seq
-        assert act.locs == locs
+    @pytest.mark.parametrize("data, mapping", testdata, ids=ids)
+    def test_unit(self, data, mapping):
+        assert cat.UnitData(data)._mapping == mapping
 
     def test_update_map(self):
-        data = ['a', 'd']
-        oseq = ['a', 'd']
-        olocs = [0, 1]
+        unitdata = cat.UnitData(['a', 'd'])
+        assert unitdata._mapping == {'a': 0, 'd': 1}
+        unitdata.update(['b', 'd', 'e'])
+        assert unitdata._mapping == {'a': 0, 'd': 1, 'b': 2, 'e': 3}
 
-        data_update = ['b', 'd', 'e', np.inf]
-        useq = ['a', 'd', 'b', 'e', 'inf']
-        ulocs = [0, 1, 2, 3, -2]
 
-        unitdata = cat.UnitData(data)
-        assert unitdata.seq == oseq
-        assert unitdata.locs == olocs
-
-        unitdata.update(data_update)
-        assert unitdata.seq == useq
-        assert unitdata.locs == ulocs
+def _mock_unit_data(mapping):
+    ud = cat.UnitData([])
+    ud._mapping.update(mapping)
+    return ud
 
 
 class FakeAxis(object):
     def __init__(self, unit_data):
         self.unit_data = unit_data
-
-
-class MockUnitData(object):
-    def __init__(self, data):
-        seq, locs = zip(*data)
-        self.seq = list(seq)
-        self.locs = list(locs)
 
 
 class TestStrCategoryConverter(object):
@@ -63,16 +45,12 @@ class TestStrCategoryConverter(object):
     ref: /pandas/tseries/tests/test_converter.py
          /pandas/tests/test_algos.py:TestFactorize
     """
-    testdata = [("Здравствуйте мир", [("Здравствуйте мир", 42)], 42),
-                ("hello world", [("hello world", 42)], 42),
+    testdata = [("Здравствуйте мир", {"Здравствуйте мир": 42}, 42),
+                ("hello world", {"hello world": 42}, 42),
                 (['a', 'b', 'b', 'a', 'a', 'c', 'c', 'c'],
-                 [('a', 0), ('b', 1), ('c', 2)],
-                 [0, 1, 1, 0, 0, 2, 2, 2]),
-                (['A', 'A', np.nan, 'B', -np.inf, 3.14, np.inf],
-                 [('nan', -1), ('3.14', 0), ('A', 1), ('B', 2),
-                  ('-inf', 100), ('inf', 200)],
-                 [1, 1, -1, 2, 100, 0, 200])]
-    ids = ["unicode", "single", "basic", "mixed"]
+                 {'a': 0, 'b': 1, 'c': 2},
+                 [0, 1, 1, 0, 0, 2, 2, 2])]
+    ids = ["unicode", "single", "basic"]
 
     @pytest.fixture(autouse=True)
     def mock_axis(self, request):
@@ -80,14 +58,12 @@ class TestStrCategoryConverter(object):
 
     @pytest.mark.parametrize("data, unitmap, exp", testdata, ids=ids)
     def test_convert(self, data, unitmap, exp):
-        MUD = MockUnitData(unitmap)
-        axis = FakeAxis(MUD)
+        axis = FakeAxis(_mock_unit_data(unitmap))
         act = self.cc.convert(data, None, axis)
         np.testing.assert_array_equal(act, exp)
 
     def test_axisinfo(self):
-        MUD = MockUnitData([(None, None)])
-        axis = FakeAxis(MUD)
+        axis = FakeAxis(_mock_unit_data({None: None}))
         ax = self.cc.axisinfo(None, axis)
         assert isinstance(ax.majloc, cat.StrCategoryLocator)
         assert isinstance(ax.majfmt, cat.StrCategoryFormatter)
@@ -99,8 +75,8 @@ class TestStrCategoryConverter(object):
 
 class TestStrCategoryLocator(object):
     def test_StrCategoryLocator(self):
-        locs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        ticks = cat.StrCategoryLocator(locs)
+        locs = list(range(10))
+        ticks = cat.StrCategoryLocator({str(x): x for x in locs})
         np.testing.assert_array_equal(ticks.tick_values(None, None), locs)
 
 
@@ -145,27 +121,16 @@ class TestPlot(object):
         self.d = ['a', 'b', 'c', 'a']
         self.dticks = [0, 1, 2]
         self.dlabels = ['a', 'b', 'c']
-        unitmap = [('a', 0), ('b', 1), ('c', 2)]
-        self.dunit_data = MockUnitData(unitmap)
-
-    @pytest.fixture
-    def missing_data(self):
-        self.dm = ['here', np.nan, 'here', 'there']
-        self.dmticks = [0, -1, 1]
-        self.dmlabels = ['here', 'nan', 'there']
-        unitmap = [('here', 0), ('nan', -1), ('there', 1)]
-        self.dmunit_data = MockUnitData(unitmap)
 
     def axis_test(self, axis, ticks, labels, unit_data):
         np.testing.assert_array_equal(axis.get_majorticklocs(), ticks)
         assert lt(axis.get_majorticklabels()) == labels
-        np.testing.assert_array_equal(axis.unit_data.locs, unit_data.locs)
-        assert axis.unit_data.seq == unit_data.seq
+        assert axis.unit_data._mapping == unit_data._mapping
 
     def test_plot_unicode(self):
         words = ['Здравствуйте', 'привет']
         locs = [0.0, 1.0]
-        unit_data = MockUnitData(zip(words, locs))
+        unit_data = _mock_unit_data(dict(zip(words, locs)))
 
         fig, ax = plt.subplots()
         ax.plot(words)
@@ -179,15 +144,8 @@ class TestPlot(object):
         ax.plot(self.d)
         fig.canvas.draw()
 
-        self.axis_test(ax.yaxis, self.dticks, self.dlabels, self.dunit_data)
-
-    @pytest.mark.usefixtures("missing_data")
-    def test_plot_1d_missing(self):
-        fig, ax = plt.subplots()
-        ax.plot(self.dm)
-        fig.canvas.draw()
-
-        self.axis_test(ax.yaxis, self.dmticks, self.dmlabels, self.dmunit_data)
+        unit_data = _mock_unit_data({'a': 0, 'b': 1, 'c': 2})
+        self.axis_test(ax.yaxis, self.dticks, self.dlabels, unit_data)
 
     @pytest.mark.usefixtures("data")
     @pytest.mark.parametrize("bars", bytes_data, ids=bytes_ids)
@@ -198,7 +156,8 @@ class TestPlot(object):
         ax.bar(bars, counts)
         fig.canvas.draw()
 
-        self.axis_test(ax.xaxis, self.dticks, self.dlabels, self.dunit_data)
+        unit_data = _mock_unit_data(dict(zip(bars, range(3))))
+        self.axis_test(ax.xaxis, self.dticks, self.dlabels, unit_data)
 
     @pytest.mark.parametrize("bars", numlike_data, ids=numlike_ids)
     def test_plot_numlike(self, bars):
@@ -208,27 +167,8 @@ class TestPlot(object):
         ax.bar(bars, counts)
         fig.canvas.draw()
 
-        unitmap = MockUnitData([('1', 0), ('11', 1), ('3', 2)])
-        self.axis_test(ax.xaxis, [0, 1, 2], ['1', '11', '3'], unitmap)
-
-    @pytest.mark.usefixtures("data", "missing_data")
-    def test_plot_2d(self):
-        fig, ax = plt.subplots()
-        ax.plot(self.dm, self.d)
-        fig.canvas.draw()
-
-        self.axis_test(ax.xaxis, self.dmticks, self.dmlabels, self.dmunit_data)
-        self.axis_test(ax.yaxis, self.dticks, self.dlabels, self.dunit_data)
-
-    @pytest.mark.usefixtures("data", "missing_data")
-    def test_scatter_2d(self):
-
-        fig, ax = plt.subplots()
-        ax.scatter(self.dm, self.d)
-        fig.canvas.draw()
-
-        self.axis_test(ax.xaxis, self.dmticks, self.dmlabels, self.dmunit_data)
-        self.axis_test(ax.yaxis, self.dticks, self.dlabels, self.dunit_data)
+        unit_data = _mock_unit_data(dict(zip(bars, range(3))))
+        self.axis_test(ax.xaxis, [0, 1, 2], ['1', '11', '3'], unit_data)
 
     def test_plot_update(self):
         fig, ax = plt.subplots()
@@ -240,8 +180,7 @@ class TestPlot(object):
 
         labels = ['a', 'b', 'd', 'c']
         ticks = [0, 1, 2, 3]
-        unit_data = MockUnitData(list(zip(labels, ticks)))
-
+        unit_data = _mock_unit_data(dict(zip(labels, ticks)))
         self.axis_test(ax.yaxis, ticks, labels, unit_data)
 
     def test_scatter_update(self):
@@ -254,5 +193,5 @@ class TestPlot(object):
 
         labels = ['a', 'b', 'd', 'c']
         ticks = [0, 1, 2, 3]
-        unit_data = MockUnitData(list(zip(labels, ticks)))
+        unit_data = _mock_unit_data(dict(zip(labels, ticks)))
         self.axis_test(ax.xaxis, ticks, labels, unit_data)

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -36,7 +36,8 @@ def test_simple(ax, data, expected_indices, expected_labels):
 
 def test_default_units(ax):
     ax.plot(["a"])
-    assert ax.yaxis.converter.default_units(["a"], ax.yaxis) is None
+    du = ax.yaxis.converter.default_units(["a"], ax.yaxis)
+    assert isinstance(du, cat._CategoricalUnit)
 
 
 def test_update(ax):
@@ -44,8 +45,8 @@ def test_update(ax):
     l2, = ax.plot(["b", "d", "e"])
     assert_array_equal(l1.get_ydata(orig=False), [0, 1])
     assert_array_equal(l2.get_ydata(orig=False), [2, 1, 3])
-    assert ax.yaxis._unit_data._vals == ["a", "d", "b", "e"]
-    assert ax.yaxis._unit_data._val_to_idx == {"a": 0, "d": 1, "b": 2, "e": 3}
+    assert ax.yaxis.units._vals == ["a", "d", "b", "e"]
+    assert ax.yaxis.units._val_to_idx == {"a": 0, "d": 1, "b": 2, "e": 3}
 
 
 @pytest.mark.parametrize("plotter", [Axes.plot, Axes.scatter, Axes.bar])

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -18,8 +18,7 @@ def ax():
 
 @pytest.mark.parametrize(
     "data, expected_indices, expected_labels",
-    [("hello world", [0], ["hello world"]),
-     (["Здравствуйте мир"], [0], ["Здравствуйте мир"]),
+    [(["Здравствуйте мир"], [0], ["Здравствуйте мир"]),
      (["a", "b", "b", "a", "c", "c"], [0, 1, 1, 0, 2, 2], ["a", "b", "c"]),
      ([b"foo", b"bar"], range(2), ["foo", "bar"]),
      (np.array(["1", "11", "3"]), range(3), ["1", "11", "3"]),


### PR DESCRIPTION
Don't support mixed type inputs.
Don't sort keys.

Edited: I accidentally relied on Py3.6's dict ordering behavior in the previous version :-)
Made private what can be.

@story645 @tacaswell 

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
