### PR TITLE
FIX: better handling of multi-line text objects in draw

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -722,7 +722,9 @@ class Text(Artist):
             # position in Text, and dash position in TextWithDash:
             posx = float(textobj.convert_xunits(textobj._x))
             posy = float(textobj.convert_yunits(textobj._y))
+            _log.debug('posx %1.1f, posy %1.1f', posx, posy)
             posx, posy = trans.transform_point((posx, posy))
+            _log.debug('trans posx %1.1f, posy %1.1f', posx, posy)
             if not np.isfinite(posx) or not np.isfinite(posy):
                 _log.warning("posx and posy should be finite values")
                 return
@@ -741,10 +743,17 @@ class Text(Artist):
             angle = textobj.get_rotation()
 
             for line, wh, x, y in info:
-
-                mtext = textobj if len(info) == 1 else None
                 x = x + posx
                 y = y + posy
+                # note that y is the bottom of the text...
+                if len(info) > 1:
+                    _log.debug('info > 1')
+                    x_, y_ = trans.inverted().transform_point((x, y))
+                    mtext = Text(text=line, x=textobj._x, y=y_)
+                    mtext.update_from(textobj)
+                    mtext._verticalalignment = 'bottom'
+                else:
+                    mtext = textobj
                 if renderer.flipy():
                     y = canvash - y
                 clean_line, ismath = textobj.is_math_text(line,


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

This does a slightly better job with multiline text for at least the PGF backend, and doesn't seem to 
break other backends.  See #9747 

PGF accepts the original text object for positioning and entering etc.  However the previous version would not pass the text object if the text string was multi-lined.  The text was placed OK, but based on the default renderer font sizes, which could be quite different from the PGF font sizes.   This ruined centering of the two title lines in #9747 

This attempts to fix that by passing one text object per line.  vertical position is taken from the default layout, which assumes a vertical alignment of `bottom` so that gets set. 

I tried doing this in general, but it breaks other layout choices for single-line text.  So it only goes into this layout mode if there are multiple lines.  

This fails some hinting tests.  Not sure what the status of those are given work @anntzer and @QuLogic  are doing on font handling...

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->