### PR TITLE
WIP: Lockout new converters Part 2

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -7,9 +7,10 @@ import six
 from six.moves import xrange
 
 import itertools
-import warnings
+import logging
 import math
 from operator import attrgetter
+import warnings
 
 import numpy as np
 
@@ -37,6 +38,8 @@ from matplotlib.legend import Legend
 
 from matplotlib.rcsetup import cycler
 from matplotlib.rcsetup import validate_axisbelow
+
+_log = logging.getLogger(__name__)
 
 rcParams = matplotlib.rcParams
 
@@ -1002,7 +1005,7 @@ class _AxesBase(martist.Artist):
         else:
             self.xaxis._set_scale('linear')
             try:
-                self.set_xlim(0, 1)
+                self.set_xlim(0, 1, _converter=False)
             except TypeError:
                 pass
 
@@ -1016,7 +1019,7 @@ class _AxesBase(martist.Artist):
         else:
             self.yaxis._set_scale('linear')
             try:
-                self.set_ylim(0, 1)
+                self.set_ylim(0, 1, _converter=False)
             except TypeError:
                 pass
 
@@ -2377,6 +2380,7 @@ class _AxesBase(martist.Artist):
         case, use :meth:`matplotlib.axes.Axes.relim` prior to calling
         autoscale_view.
         """
+        _log.debug('Autoscaling x: %s y: %s', scalex, scaley)
         if tight is not None:
             self._tight = bool(tight)
 
@@ -2446,6 +2450,7 @@ class _AxesBase(martist.Artist):
 
             if not self._tight:
                 x0, x1 = locator.view_limits(x0, x1)
+            _log.debug('Autolims: %e %e', x0, x1)
             set_bound(x0, x1)
             # End of definition of internal function 'handle_single_axis'.
 
@@ -2923,6 +2928,7 @@ class _AxesBase(martist.Artist):
                 self.set_xlim(upper, lower, auto=None)
             else:
                 self.set_xlim(lower, upper, auto=None)
+                self.set_xlim(lower, upper, auto=None)
         else:
             if lower < upper:
                 self.set_xlim(lower, upper, auto=None)
@@ -3028,15 +3034,19 @@ class _AxesBase(martist.Artist):
             left = kw.pop('xmin')
         if 'xmax' in kw:
             right = kw.pop('xmax')
+        # _converter is private, usually True, but can be false
+        _converter = kw.pop('_converter', True)
         if kw:
             raise ValueError("unrecognized kwargs: %s" % list(kw))
 
         if right is None and iterable(left):
             left, right = left
 
-        self._process_unit_info(xdata=(left, right))
-        left = self._validate_converted_limits(left, self.convert_xunits)
-        right = self._validate_converted_limits(right, self.convert_xunits)
+        if _converter:
+            _log.debug('Converting xlim %s %s', left, right)
+            self._process_unit_info(xdata=(left, right))
+            left = self._validate_converted_limits(left, self.convert_xunits)
+            right = self._validate_converted_limits(right, self.convert_xunits)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -3352,14 +3362,20 @@ class _AxesBase(martist.Artist):
             bottom = kw.pop('ymin')
         if 'ymax' in kw:
             top = kw.pop('ymax')
+        _converter = kw.pop('_converter', True)
         if kw:
             raise ValueError("unrecognized kwargs: %s" % list(kw))
 
         if top is None and iterable(bottom):
             bottom, top = bottom
 
-        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
-        top = self._validate_converted_limits(top, self.convert_yunits)
+        if _converter:
+            _log.debug('Converting ylim %s %s', bottom, top)
+            self._process_unit_info(ydata=(bottom, top))
+            bottom = self._validate_converted_limits(bottom,
+                                                     self.convert_yunits)
+            top = self._validate_converted_limits(top,
+                                                  self.convert_yunits)
 
         old_bottom, old_top = self.get_ylim()
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import logging
+import warnings
 
 from matplotlib import rcParams
 import matplotlib.artist as artist
@@ -22,7 +23,8 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.units as munits
 import numpy as np
-import warnings
+
+_log = logging.getLogger(__name__)
 
 _log = logging.getLogger(__name__)
 
@@ -1434,9 +1436,24 @@ class Axis(artist.Artist):
         if *data* is registered for unit conversion.
         """
 
+        _log.debug('update_units converter due to %s %s',
+                    data, data.__class__,)
         converter = munits.registry.get_converter(data)
+        _log.debug('new converter: %s', converter)
         if converter is None:
+            _log.info('No converter found for this data')
             return False
+
+        if self.converter is not None:
+            if self.converter == converter:
+                _log.debug('Axis already has a converter that matches '
+                           'data units')
+                return True
+            else:
+                _log.info('Axis already has a converter, but it does '
+                          'not match new data units.')
+                return False
+
 
         neednew = self.converter != converter
         self.converter = converter
@@ -1487,6 +1504,10 @@ class Axis(artist.Artist):
         return self.converter is not None or self.units is not None
 
     def convert_units(self, x):
+        """
+        convert the units given
+        """
+
         if self.converter is None:
             self.converter = munits.registry.get_converter(x)
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -122,6 +122,7 @@ import six
 from six.moves import zip
 import re
 import time
+import logging
 import math
 import datetime
 import functools

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -607,3 +607,14 @@ def test_tz_utc():
 def test_num2timedelta(x, tdelta):
     dt = mdates.num2timedelta(x)
     assert dt == tdelta
+
+
+def test_one_non_None_converter():
+    # test that we only allow one non-None converter at once:
+    base = datetime.datetime(2017, 1, 1, 0, 10, 0)
+    time = [base - datetime.timedelta(days=x) for x in range(0, 3)]
+    data = [0., 2., 4.]
+    fig, ax = plt.subplots()
+    ax.plot(time, data)
+    with pytest.raises(AttributeError):
+        ax.plot(['a', 'b'], [1., 2.])

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -171,4 +171,25 @@ class Registry(dict):
         return converter
 
 
+class DefaultConverter(ConversionInterface):
+    """
+    Do-nothing converter to catch good entries and lock out other
+    converters.
+    """
+    @staticmethod
+    def convert(obj, unit, axis):
+        """
+        convert obj using unit for the specified axis.  If obj is a sequence,
+        return the converted sequence.  The output must be a sequence of
+        scalars that can be used by the numpy array layer
+        """
+        return np.asarray(obj, dtype=np.float64)
+
+
 registry = Registry()
+registry[np.float64] = DefaultConverter()
+registry[np.float32] = DefaultConverter()
+registry[np.int32] = DefaultConverter()
+registry[np.int64] = DefaultConverter()
+registry[float] = DefaultConverter()
+registry[int] = DefaultConverter()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -612,15 +612,17 @@ class Axes3D(Axes):
             left = kw.pop('xmin')
         if 'xmax' in kw:
             right = kw.pop('xmax')
+        _converter = kw.pop('_converter', True)
         if kw:
             raise ValueError("unrecognized kwargs: %s" % list(kw))
 
         if right is None and cbook.iterable(left):
             left, right = left
 
-        self._process_unit_info(xdata=(left, right))
-        left = self._validate_converted_limits(left, self.convert_xunits)
-        right = self._validate_converted_limits(right, self.convert_xunits)
+        if _converter:
+            self._process_unit_info(xdata=(left, right))
+            left = self._validate_converted_limits(left, self.convert_xunits)
+            right = self._validate_converted_limits(right, self.convert_xunits)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -664,15 +666,18 @@ class Axes3D(Axes):
             bottom = kw.pop('ymin')
         if 'ymax' in kw:
             top = kw.pop('ymax')
+        _converter = kw.pop('_converter', True)
         if kw:
             raise ValueError("unrecognized kwargs: %s" % list(kw))
 
         if top is None and cbook.iterable(bottom):
             bottom, top = bottom
 
-        self._process_unit_info(ydata=(bottom, top))
-        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
-        top = self._validate_converted_limits(top, self.convert_yunits)
+        if _converter:
+            self._process_unit_info(ydata=(bottom, top))
+            bottom = self._validate_converted_limits(bottom,
+                                                     self.convert_yunits)
+            top = self._validate_converted_limits(top, self.convert_yunits)
 
         old_bottom, old_top = self.get_ylim()
         if bottom is None:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

See #9713 and #9736 

This version, which supplants #9736 makes an axis only have a `DefaultConverter` if the first thing plotted on it is a float array.  This allows the units converting machinery to pass through `None` for things like axis limits, but stop Dates or Categoricals from being plotted on the same axis as floats.

Still a WIP, but posting to help w/ #9774 

Now changed so that the first units used are set for the axis, and further convert calls are sent to the same converter.  If the converter wants to handle the data type it can.  This makes mixed-use calls, i.e. 

```python

ax.plot(['a', 'b', 'c'])
ax.plot([1, 'd', 3])
```
work so long as the converter can handle the data in the second call.

Helps issues like #10147

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] More-informative error handling 
- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
  