### PR TITLE
Support (first font of) TTC files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,12 @@ matrix:
         - EXTRAREQS='-r requirements/testing/travis36.txt'
     - python: 3.7
       sudo: true
+      env:
+        - DELETE_FONT_CACHE=1
     - python: "nightly"
-      env: PRE=--pre
+      env:
+        - PRE=--pre
+        - DELETE_FONT_CACHE=1
     - os: osx
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ addons:
       - texlive-latex-recommended
       - texlive-xetex
       - texlive-luatex
+      - ttf-wqy-zenhei
 
 env:
   global:
@@ -110,7 +111,7 @@ before_install: |
     ci/silence brew update
     brew uninstall numpy gdal postgis
     brew upgrade python
-    brew install ffmpeg imagemagick mplayer ccache
+    brew install ffmpeg imagemagick mplayer ccache font-wenquanyi-zen-hei
     hash -r
     which python
     python --version

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -973,8 +973,13 @@ end"""
 
             # Make the charprocs array (using ttconv to generate the
             # actual outlines)
-            rawcharprocs = ttconv.get_pdf_charprocs(
-                os.fsencode(filename), glyph_ids)
+            try:
+                rawcharprocs = ttconv.get_pdf_charprocs(
+                    os.fsencode(filename), glyph_ids)
+            except RuntimeError:
+                _log.warning("The PDF backend does not currently support the "
+                             "selected font.")
+                raise
             charprocs = {}
             for charname in sorted(rawcharprocs):
                 stream = rawcharprocs[charname]

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1117,8 +1117,14 @@ class FigureCanvasPS(FigureCanvasBase):
                                 "time; consider using the Cairo backend")
                         else:
                             fh.flush()
-                            convert_ttf_to_ps(os.fsencode(font_filename),
-                                              fh, fonttype, glyph_ids)
+                            try:
+                                convert_ttf_to_ps(os.fsencode(font_filename),
+                                                  fh, fonttype, glyph_ids)
+                            except RuntimeError:
+                                _log.warning("The PostScript backend does not "
+                                             "currently support the selected "
+                                             "font.")
+                                raise
             print("end", file=fh)
             print("%%EndProlog", file=fh)
 

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -129,9 +129,12 @@ def get_fontext_synonyms(fontext):
     Return a list of file extensions extensions that are synonyms for
     the given file extension *fileext*.
     """
-    return {'ttf': ('ttf', 'otf'),
-            'otf': ('ttf', 'otf'),
-            'afm': ('afm',)}[fontext]
+    return {
+        'afm': ['afm'],
+        'otf': ['otf', 'ttc', 'ttf'],
+        'ttc': ['otf', 'ttc', 'ttf'],
+        'ttf': ['otf', 'ttc', 'ttf'],
+    }[fontext]
 
 
 def list_fonts(directory, extensions):


### PR DESCRIPTION
TTC is a TrueType Collection file (a collection of TTFs).  Currently,
ft2font only supports getting the first font from the collection, and
neither the pdf nor ps backends are able to use them (due to limitations
of ttconv).  Still, it seems better than nothing to support them for Agg
and SVG (that comes for free via FreeType).

xref #3135, #3912.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
