### PR TITLE
FIX: treat `zorder=None` as falling back to the default

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -885,6 +885,8 @@ class Artist(object):
 
         ACCEPTS: any number
         """
+        if level is None:
+            level = self.__class__.zorder
         self.zorder = level
         self.pchanged()
         self.stale = True

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -246,3 +246,13 @@ def test_setp():
     sio = io.StringIO()
     plt.setp(lines1, 'zorder', file=sio)
     assert sio.getvalue() == '  zorder: any number \n'
+
+
+def test_None_zorder():
+    fig, ax = plt.subplots()
+    ln, = ax.plot(range(5), zorder=None)
+    assert ln.get_zorder() == mlines.Line2D.zorder
+    ln.set_zorder(123456)
+    assert ln.get_zorder() == 123456
+    ln.set_zorder(None)
+    assert ln.get_zorder() == mlines.Line2D.zorder


### PR DESCRIPTION
closes #9785

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->


## PR Summary

If `set_zorder` gets `None` as input, fall back to the class level `zorder` (the default).

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant


<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
