### PR TITLE
Add deprecation for Axes.set_thetagrids(frac).

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -111,13 +111,16 @@ negative values are simply used as labels, and the real radius is shifted by
 the configured minimum. This release also allows negative radii to be used for
 grids and ticks, which were previously silently ignored.
 
-Radial ticks have been modified to be parallel to the circular grid
-line, and angular ticks have been modified to be parallel to the grid
-line. It may also be useful to rotate tick *labels* to match the
-boundary. Calling ``ax.tick_params(rotation='auto')`` will enable the
-new behavior: radial tick labels will be parallel to the circular grid
-line, and angular tick labels will be perpendicular to the grid line
-(i.e., parallel to the outer boundary).
+Radial ticks have been modified to be parallel to the circular grid line, and
+angular ticks have been modified to be parallel to the grid line. It may also
+be useful to rotate tick *labels* to match the boundary. Calling
+``ax.tick_params(rotation='auto')`` will enable the new behavior: radial tick
+labels will be parallel to the circular grid line, and angular tick labels will
+be perpendicular to the grid line (i.e., parallel to the outer boundary).
+Additionally, tick labels now obey the padding settings that previously only
+worked on Cartesian plots. Consequently, the ``frac`` argument to
+`.PolarAxes.set_thetagrids` is no longer applied. Tick padding can be modified
+with the ``pad`` argument to `.Axes.tick_params` or `.Axis.set_tick_params`.
 
 
 ``Figure`` class now has ``subplots`` method

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1173,6 +1173,11 @@ class PolarAxes(Axes):
 
         ACCEPTS: sequence of floats
         """
+        if frac is not None:
+            cbook.warn_deprecated('2.1', name='frac', obj_type='parameter',
+                                  alternative='tick padding via '
+                                              'Axes.tick_params')
+
         # Make sure we take into account unitized data
         angles = self.convert_yunits(angles)
         angles = np.asarray(angles, float)


### PR DESCRIPTION
## PR Summary

Using `frac` is no longer possible, but replaced by setting the padding on the ticks. Unfortunately, it is not straightforward to simply restore the behaviour of this parameter within the bounds of the current implementation, since padding is now radius-independent. I think it could be done with a bit of work, but I'm not sure it'd be worth it.

Closes #9744.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
