### PR TITLE
[WiP] FIX/ENH: include (offset, on-off seq) as a valid pattern to the linestyle validator (fix #9792)

### DIFF
--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -375,14 +375,18 @@ def generate_validator_testcases(valid):
                            (['1.23', '4.56'], (None, [1.23, 4.56])),
                            ([1.23, 456], (None, [1.23, 456.0])),
                            ([1, 2, 3, 4], (None, [1.0, 2.0, 3.0, 4.0])),
+                           ((-1, [1.23, 456]), (-1, [1.23, 456.0])),
+                           ((None, [1.23, 456]), (None, [1.23, 456.0])),
+                           ((9.87, [1.23, 456]), (9.87, [1.23, 456.0])),
+                           ((np.float128(1), [1.23, 4]), (1.0, [1.23, 4.0])),
                           ),
                'fail': (('aardvark', ValueError),  # not a valid string
                         ('dotted'.encode('utf-16'), ValueError),  # even on PY2
-                        ((None, [1, 2]), ValueError),  # (offset, dashes) != OK
-                        ((0, [1, 2]), ValueError),  # idem
-                        ((-1, [1, 2]), ValueError),  # idem
                         ([1, 2, 3], ValueError),  # sequence with odd length
                         (1.23, ValueError),  # not a sequence
+                        (("a", [1, 2]), ValueError),  # wrong explicit offset
+                        ((1, [1, 2, 3]), ValueError),  # odd length sequence
+                        (([1, 2], 1), ValueError),  # inverted offset/onoff
                        )
                 }
     # Add some cases of bytes arguments that Python 2 can convert silently:


### PR DESCRIPTION
## PR Summary

Currently, the linestyle validation considers the pattern `(offset, on-off sequence)` as invalid, which can raise issues as linestyle can be converted internally to such a pattern. See for example the issue #9792 for an example where it occurs when existing a style context manager. 

To be honest, I do not remember exactly why I chose not to support this kind of linestyle patterns in `_validate_linestyle` when I made it stricter in #8040 🐑...

This PR:
- adds a bit of extra logic in `_validate_linestyle` to accept inputs of the form `(offset, (valid...) on-off sequence)`;
- update the relevant test in `test_rcparams`, notably because such inputs were formerly raising exceptions;
- tries to preserve the former behavior with other corner cases (mainly something like `["1.23", "4.56"]`, which was OK before, as unfortunate it may be).

With this PR, the example given in #7972 now goes smoothly and as expected. *Should I add an (non image) test in `test_style` inspired from this issue, or are the updates that I made in `test_rcparams` enough?*

## PR Checklist

- [x] Has Pytest style unit tests  (at least locally with Python 3)
- [?] Code is PEP 8 compliant (waiting for CI to decide)
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [?] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

*Should I add an entry in `api_changes`?*
