### PR TITLE
Fix docstring of ScalarMappable constructor

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -177,7 +177,7 @@ class ScalarMappable(object):
 
     """
     def __init__(self, norm=None, cmap=None):
-        r"""
+        """
 
         Parameters
         ----------


### PR DESCRIPTION
Removed an 'r' character leading the first set of triple quotes of the ScalarMappable constructor docstring.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ x] Code is PEP 8 compliant
- [ x] New features are documented, with examples if plot related
- [ x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
