### PR TITLE
Deprecate column cycling when plot() inputs have nonmatching shapes.

### DIFF
--- a/doc/api/api_changes/2017-11-24-AL.rst
+++ b/doc/api/api_changes/2017-11-24-AL.rst
@@ -1,0 +1,7 @@
+Deprecations
+````````````
+
+When given 2D inputs with non-matching numbers of columns, `~.pyplot.plot`
+currently cycles through the columns of the narrower input, until all the
+columns of the wider input have been plotted.  This behavior is deprecated; in
+the future, only broadcasting (1 column to *n* columns) will be performed.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -391,6 +391,9 @@ class _process_plot_var_args(object):
             func = self._makefill
 
         ncx, ncy = x.shape[1], y.shape[1]
+        if ncx > 1 and ncy > 1 and ncx != ncy:
+            cbook.warn_deprecated("2.2", "cycling among columns of inputs "
+                                  "with non-matching shapes is deprecated.")
         for j in xrange(max(ncx, ncy)):
             seg = func(x[:, j % ncx], y[:, j % ncy], kw, kwargs)
             ret.append(seg)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -26,7 +26,8 @@ import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
 import matplotlib.colors as mcolors
 from numpy.testing import assert_allclose, assert_array_equal
-from matplotlib.cbook import IgnoredKeywordWarning
+from matplotlib.cbook import (
+    IgnoredKeywordWarning, MatplotlibDeprecationWarning)
 from matplotlib.cbook._backports import broadcast_to
 
 # Note: Some test cases are run twice: once normally and once with labeled data
@@ -5498,3 +5499,8 @@ def test_empty_errorbar_legend():
     ax.errorbar([], [], xerr=[], label='empty y')
     ax.errorbar([], [], yerr=[], label='empty x')
     ax.legend()
+
+
+def test_plot_columns_cycle_deprecation():
+    with pytest.warns(MatplotlibDeprecationWarning):
+        plt.plot(np.zeros((2, 2)), np.zeros((2, 3)))


### PR DESCRIPTION
Currently, something like

    plot([[0, 1, 2], [3, 4, 5]], [[0, 1], [2, 3]])

will plot column 0 of x vs column 0 of y; column 1 of x vs column 1 of
y; and column 2 of x vs column 1 of y (i.e. cycle among columns).  This
behavior appears to be error-prone to say the least.

Note that "normal" broadcasting (1->n) is not deprecated.

Closes #9784.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
