### PR TITLE
ENH/MacOS Allow shift modifiers to key events

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2608,8 +2608,11 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
 
     unichar uc = [[event charactersIgnoringModifiers] characterAtIndex:0];
     NSString* specialchar = [specialkeymappings objectForKey:[NSNumber numberWithUnsignedLong:uc]];
-    if (specialchar)
+    if (specialchar){
+        if ([event modifierFlags] & NSShiftKeyMask)
+            [returnkey appendString:@"shift+" ];
         [returnkey appendString:specialchar];
+    }
     else
         [returnkey appendString:[event charactersIgnoringModifiers]];
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

#9835 points out that "shift-left" etc not allowed for macOS.  This PR fixes that by allowing a 
shift modifier if the other key is a special key...

To test, use the script by the OP:

```python 
import matplotlib.pyplot as plt
fig = plt.figure()

def on_key(event):
    print('you pressed', event.key, event.xdata, event.ydata)

fig.canvas.mpl_connect('key_press_event', on_key)
plt.show()
```

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [N/A] Has Pytest style unit tests
- [N/A] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->