### PR TITLE
Rename some helper classes in dviread.

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -169,7 +169,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         if isinstance(obj, type):
             obj_type = "class"
             old_doc = obj.__doc__
-            func = obj.__init__
+            func = obj.__new__
 
             def finalize(wrapper, new_doc):
                 try:
@@ -178,7 +178,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                     # cls.__doc__ is not writeable on Py2.
                     # TypeError occurs on PyPy
                     pass
-                obj.__init__ = wrapper
+                obj.__new__ = wrapper
                 return obj
         else:
             obj_type = "function"


### PR DESCRIPTION
Currently, the existence of `matplotlib.dviread.Text` prevents one to
write `\`~.Text\`` in the docs when referring to `matplotlib.text.Text`
because sphinx does not know which of the two classes we are referring
to.  (It seems clear to favor matplotlib.text.Text which is actually public
API.)

Rename `matplotlib.dviread.Text` to `_Text`, as there isn't (AFAICT) any
reason to use it externally.  Also renamed `_Page` and `_Box` for
consistency.

It turns out that the class deprecation machinery does not work for
deprecating namedtuples, but attaching the deprecation warning to
`__new__` instead of `__init__` fixes that.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
