### PR TITLE
Exclude dviread.Text from the documentation.

### DIFF
--- a/doc/api/dviread.rst
+++ b/doc/api/dviread.rst
@@ -1,6 +1,6 @@
-****************
+*******
 dviread
-****************
+*******
 
 :mod:`matplotlib.dviread`
 =========================
@@ -8,9 +8,5 @@ dviread
 .. automodule:: matplotlib.dviread
    :members:
    :undoc-members:
-   :exclude-members: Dvi
-   :show-inheritance:
-
-.. autoclass:: matplotlib.dviread.Dvi
-   :members: __iter__,close
+   :exclude-members: Page, Text, Box
    :show-inheritance:

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -56,8 +56,8 @@ interface and the object-oriented API:
 `~.pyplot.suptitle` `~.Figure.suptitle` Add a title to the `~.Figure`.
 =================== =================== ======================================
 
-All of these functions create and return a `~.text.Text` instance, which can
-be configured with a variety of font and other properties.  The example below
+All of these functions create and return a `~.Text` instance, which can be
+configured with a variety of font and other properties.  The example below
 shows all of these commands in action, and more detail is provided in the
 sections that follow.
 """
@@ -145,11 +145,11 @@ ax.set_ylabel('Damped oscillation [V]', labelpad=18)
 plt.show()
 
 ###############################################################################
-# Or, the labels accept all the `~matplotlib.text.Text` keyword arguments,
-# including *position*, via which we can manually specify the label positions.
-# Here we put the xlabel to the far left of the axis.  Note, that the
-# y-coordinate of this position has no effect - to adjust the y-position we
-# need to use the *labelpad* kwarg.
+# Or, the labels accept all the `~.Text` keyword arguments, including
+# *position*, via which we can manually specify the label positions.  Here we
+# put the xlabel to the far left of the axis.  Note, that the y-coordinate of
+# this position has no effect - to adjust the y-position we need to use the
+# *labelpad* kwarg.
 
 fig, ax = plt.subplots(figsize=(5, 3))
 fig.subplots_adjust(bottom=0.15, left=0.2)


### PR DESCRIPTION
to make `~.Text` unambiguously refer to `matplotlib.text.Text`.

Alternate to #9847.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
