### PR TITLE
documentation: fix url for pillow

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -674,7 +674,7 @@ or by saving to a file handle::
     import sys
     fig.savefig(sys.stdout)
 
-Here is an example using `Pillow <http://python-imaging.github.io/>`_.
+Here is an example using `Pillow <https://python-pillow.org/>`_.
 First, the figure is saved to a BytesIO object which is then fed to
 Pillow for further processing::
 

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -58,7 +58,7 @@ import numpy as np
 # ===============================================
 #
 # Loading image data is supported by the `Pillow
-# <http://python-imaging.github.io/>`_ library.  Natively, matplotlib only
+# <https://python-pillow.org/>`_ library.  Natively, matplotlib only
 # supports PNG images.  The commands shown below fall back on Pillow if the
 # native read fails.
 #


### PR DESCRIPTION
## PR Summary

in some cases ([example](https://matplotlib.org/users/image_tutorial.html#importing-image-data-into-numpy-arrays)), pillow links point to https://python-imaging.github.io/, which seems to be squatted by some strange person (scam?)

this PR corrects these to https://python-pillow.org/

first time matplotlib contributor (big fan :heart:), please let me know if I've done anything wrong

following [these guidelines](https://matplotlib.org/devel/coding_guide.html#pull-request-checklist) I looked for a maintenance branch... finding none I'm trying a PR into master

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way