### PR TITLE
TST: Lock pytest to 3.2.5 until 3.3.1 released

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q pytest "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest!=3.3.0" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ install:
 
     # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
     pip install $PRE \
-        pytest \
+        pytest!=3.3.0 \
         pytest-cov>=2.3.1 \
         pytest-faulthandler \
         pytest-rerunfailures \


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

As per @QuLogic comments in #9867 Appveyor tests are breaking because of a change to pytest 3.3.0 https://github.com/pytest-dev/pytest/issues/2957  Until 3.3.1 is released this locks us to 3.2.5 on appveyor.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->