### PR TITLE
make SubplotTool into a modal dialog, keep ref to SubplotTool

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -735,12 +735,13 @@ class NavigationToolbar2TkAgg(NavigationToolbar2, Tk.Frame):
 
     def configure_subplots(self):
         toolfig = Figure(figsize=(6,3))
-        window = Tk.Tk()
+        window = Tk.Toplevel()
         canvas = FigureCanvasTkAgg(toolfig, master=window)
         toolfig.subplots_adjust(top=0.9)
-        tool =  SubplotTool(self.canvas.figure, toolfig)
+        canvas.tool =  SubplotTool(self.canvas.figure, toolfig)
         canvas.show()
         canvas.get_tk_widget().pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
+        window.grab_set()
 
     def save_figure(self, *args):
         from six.moves import tkinter_tkfiledialog, tkinter_messagebox


### PR DESCRIPTION
In using matplotlib (after PR #9356) on PyPy, I ran into an issue that the ``TkAGG`` ``SubplotTool`` python object was being collected by the PyPy garbage collector (GC). It turns out that the ``SubplotTool`` holds circular references, and these are resolved in the CPython GC much much later than in PyPy. I also noticed that the ``SubPlotTool`` on ``TkAGG`` is not a modal window, I can open many at the same time. 

## PR Summary

This pull request solves both problems: holds a reference to the ``SubplotTool`` and makes the dialog into a modal dialog.

Here is code that provides a basis for a manual test, I am not sure how to test the modality of a dialog box via a unittest:

```
import matplotlib
matplotlib.use('TkAgg')
from matplotlib import pylab
fig = pylab.plot(range(10))
pylab.show()
# press the subplot button in the toolbar
# try to press the button again, the SubplotTool dialog should hold focus
# make sure the SubplotTool is functioning, that the sliders affect the main window
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
