### PR TITLE
DOC: (subjectively) nicer annotated barchart example

### DIFF
--- a/examples/api/barchart.py
+++ b/examples/api/barchart.py
@@ -3,45 +3,50 @@
 Barchart
 ========
 
-A bar plot with errorbars and height labels on individual bars
+A bar plot with errorbars and height labels on individual bars.
 """
 import numpy as np
 import matplotlib.pyplot as plt
 
-N = 5
-men_means = (20, 35, 30, 35, 27)
-men_std = (2, 3, 4, 1, 2)
+men_means, men_std = (20, 35, 30, 35, 27), (2, 3, 4, 1, 2)
+women_means, women_std = (25, 32, 34, 20, 25), (3, 5, 2, 3, 3)
 
-ind = np.arange(N)  # the x locations for the groups
-width = 0.35       # the width of the bars
+ind = np.arange(len(men_means))  # the x locations for the groups
+width = 0.35  # the width of the bars
 
 fig, ax = plt.subplots()
-rects1 = ax.bar(ind, men_means, width, color='r', yerr=men_std)
+rects1 = ax.bar(ind - width/2, men_means, width, yerr=men_std,
+                color='SkyBlue', label='Men')
+rects2 = ax.bar(ind + width/2, women_means, width, yerr=women_std,
+                color='IndianRed', label='Women')
 
-women_means = (25, 32, 34, 20, 25)
-women_std = (3, 5, 2, 3, 3)
-rects2 = ax.bar(ind + width, women_means, width, color='y', yerr=women_std)
-
-# add some text for labels, title and axes ticks
+# Add some text for labels, title and custom x-axis tick labels, etc.
 ax.set_ylabel('Scores')
 ax.set_title('Scores by group and gender')
-ax.set_xticks(ind + width / 2)
+ax.set_xticks(ind)
 ax.set_xticklabels(('G1', 'G2', 'G3', 'G4', 'G5'))
+ax.legend()
 
-ax.legend((rects1[0], rects2[0]), ('Men', 'Women'))
 
-
-def autolabel(rects):
+def autolabel(rects, xpos='center'):
     """
-    Attach a text label above each bar displaying its height
+    Attach a text label above each bar in *rects*, displaying its height.
+
+    *xpos* indicates which side to place the text w.r.t. the center of
+    the bar. It can be one of the following {'center', 'right', 'left'}.
     """
+
+    xpos = xpos.lower()  # normalize the case of the parameter
+    ha = {'center': 'center', 'right': 'left', 'left': 'right'}
+    offset = {'center': 0.5, 'right': 0.57, 'left': 0.43}  # x_txt = x + w*off
+
     for rect in rects:
         height = rect.get_height()
-        ax.text(rect.get_x() + rect.get_width()/2., 1.05*height,
-                '%d' % int(height),
-                ha='center', va='bottom')
+        ax.text(rect.get_x() + rect.get_width()*offset[xpos], 1.01*height,
+                '{}'.format(height), ha=ha[xpos], va='bottom')
 
-autolabel(rects1)
-autolabel(rects2)
+
+autolabel(rects1, "left")
+autolabel(rects2, "right")
 
 plt.show()


### PR DESCRIPTION
## PR Summary

Here is a PR that:

1. add the possibility in the demonstrated helper function for choosing a specific side where to put the text annotation to avoid overlapping ot the latter with the errorbar. For sure the logic could be made more robust or generic, but I tried to keep it minimal and yet sufficient to get something that I find significantly less terrible than before.
2. tries to make both case a bit more symmetric from the code point of view between the women and the man case (`ind - width/2` and `ind + width/2`  instead of `ind`  and `ind + width`, etc.)
3. changes the colors: I agree that it is highly subjective but I find the previous ones quite “old fashion” (but maybe that they were chosen to be gender neutral or another peculiar reason).

I am open to revert part or all of 2. and 3. due to their subjective nature. However, I really think that 1. would help to make this example more attractive for people looking for a way to “simply” annotate bar charts (which seems rather frequent by wandering on the Internet) that is still quite pleasant to the eye.

*Original*
![vanilla](https://user-images.githubusercontent.com/17270724/33502595-93cdcec0-d695-11e7-9711-49a7e03a46ce.png)

*Suggestion*
![tweaked](https://user-images.githubusercontent.com/17270724/33502605-9a24f6ea-d695-11e7-89d5-465b319f57dc.png)

## PR Checklist

- [X] Code is PEP 8 compliant
- [ ] Documentation is sphinx and numpydoc compliant <- well, hopefully it is.
