### PR TITLE
[Proof of Concept] Preserve custom tickers when toggling axis scale (through keyboard shortcut)

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2596,27 +2596,39 @@ def key_press_handler(event, canvas, toolbar=None):
     elif event.key in toggle_yscale_keys:
         scale = ax.get_yscale()
         if scale == 'log':
+            ax.yaxis._shallowcopy_current_tickers('log')
             ax.set_yscale('linear')
+            ax.yaxis._restore_previous_tickers('linear')
             ax.figure.canvas.draw_idle()
         elif scale == 'linear':
+            ax.yaxis._shallowcopy_current_tickers('linear')
             try:
                 ax.set_yscale('log')
+                ax.yaxis._restore_previous_tickers('log')
             except ValueError as exc:
                 warnings.warn(str(exc))
+                # NB: no need to keep track of the aborted log tickers
                 ax.set_yscale('linear')
+                ax.yaxis._restore_previous_tickers('linear')
             ax.figure.canvas.draw_idle()
     # toggle scaling of x-axes between 'log and 'linear' (default key 'k')
     elif event.key in toggle_xscale_keys:
         scalex = ax.get_xscale()
         if scalex == 'log':
+            ax.xaxis._shallowcopy_current_tickers('log')
             ax.set_xscale('linear')
+            ax.xaxis._restore_previous_tickers('linear')
             ax.figure.canvas.draw_idle()
         elif scalex == 'linear':
+            ax.xaxis._shallowcopy_current_tickers('linear')
             try:
                 ax.set_xscale('log')
+                ax.xaxis._restore_previous_tickers('log')
             except ValueError as exc:
                 warnings.warn(str(exc))
+                # NB: no need to keep track of the aborted log tickers
                 ax.set_xscale('linear')
+                ax.xaxis._restore_previous_tickers('linear')
             ax.figure.canvas.draw_idle()
 
     elif (event.key.isdigit() and event.key != '0') or event.key in all_keys:


### PR DESCRIPTION
## Work in Progress!

_Disclaimer:_ (At the moment) kind of address a subcase of the more general ticket #8740. But it was simpler to start with :)... I am opening this PR mostly to get any kind of feedback, especially if I am going into a wall and should try to find a better solution.

### Issue

When toggling between the 'linear' and the 'log' scales with the proper keyboard shortcut, the axis ticker(s) are reset, dropping any custom locator or formatter. As a lover of non-default tickers, I found this behavior particularly annoying when exploring data and trying different scales during an interactive session. 

Please note, that this issue also occurs when changing the scale through the pyplot or OO interfaces, but is not addressed _for the moment_.

### Summary of the (current) changes
This PR introduces a container of the last axis tickers used for the 'linear' and 'log' scales, which allows to restore custom locators (if any) when toggling between them through the relevant keyboard shortcut.

In a nutshell, it is simply doing something like:
```
... (keyboboard event for linear -> log) ...
... (copy minor and major linear tickers to a private container) ...
ax.set_xscale()
... (restore minor and major log tickers if any previously stored) ...
```
etc.

Locally it seems to behave as I expect, and I can cycle through linear and log scales without loosing my custom formatters :). Below is a small snippet to play with it if some are brave enough to play with the commit.
```python
#import matplotlib
#matplotlib.use("tkagg")
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.ticker import (
    StrMethodFormatter, FixedLocator, AutoMinorLocator, MultipleLocator)

plt.ion()

xx = np.geomspace(1, 100, 21)
yy = np.exp(-xx / 10.0)

fig, ax = plt.subplots(num="TEST", clear=True)
ax.plot(xx, yy)

ax.set_xscale("log")
ax.xaxis.set_major_locator(FixedLocator(xx[::10]))
ax.xaxis.set_major_formatter(StrMethodFormatter("{x:0.0f}"))
# NB: currently no minor ticks with log scale

ax.set_yscale("linear")
ax.yaxis.set_major_locator(MultipleLocator(base=0.5))
ax.yaxis.set_major_formatter(StrMethodFormatter("{x:0.3e}"))
ax.yaxis.set_minor_locator(AutoMinorLocator(n=2))
ax.yaxis.set_minor_formatter(StrMethodFormatter("minor"))

fig.tight_layout()
```

### What's next?

The current changes may appear a bit too specialized to be worth merging them in a form close to what they currently are. But maybe that I am biased ^^.

However, I am afraid that extending the concept to also solve #8740 might be a bit tricky. I am thinking about putting the logic described above directly into some of the relevant `_set_scale` method, which would make it independent of being triggered by a keyboard event. If I am correct, this means that
```python
plt.plot(...)
plt.yscale('log')
# yada yada yada
plt.yscale('linear')
```
could also keep track of any custom ticker, which would be neat during in interactive session.
It would also raise the question of what to do with the other scales, like 'symlog' (or user-custom scales?), but I guess that one could simply add new keys to the dict currently used to store the tickers. 

Would there be other thing to be careful about? For example, I think that at least I have to handle things like
```
# in Axis
        self.isDefault_majloc = True
        self.isDefault_minloc = True
        self.isDefault_majfmt = True
        self.isDefault_minfmt = True
```
which are not dealt with with the current changes :/.

### Notes to self

- more general solution by putting a similar (but more general) logic *directly* into the `_set_scale` method?
- will need tests if going further
- may need a what's new entry if going further


### PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way