### PR TITLE
Make _get_rgba_face actually always return a RGBA.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -495,13 +495,13 @@ grestore
         """
         Draws a Path instance using the given affine transform.
         """
-        clip = (rgbFace is None and gc.get_hatch_path() is None)
+        clip = rgbFace is None and gc.get_hatch_path() is None
         simplify = path.should_simplify and clip
-        ps = self._convert_path(
-            path, transform, clip=clip, simplify=simplify)
+        ps = self._convert_path(path, transform, clip=clip, simplify=simplify)
         self._draw_ps(ps, gc, rgbFace)
 
-    def draw_markers(self, gc, marker_path, marker_trans, path, trans, rgbFace=None):
+    def draw_markers(
+            self, gc, marker_path, marker_trans, path, trans, rgbFace=None):
         """
         Draw the markers defined by path at each of the positions in x
         and y.  path coordinates are points, x and y coords will be
@@ -510,7 +510,9 @@ grestore
         if debugPS: self._pswriter.write('% draw_markers \n')
 
         if rgbFace:
-            if rgbFace[0]==rgbFace[1] and rgbFace[0]==rgbFace[2]:
+            if len(rgbFace) == 4 and rgbFace[3] == 0:
+                return
+            if rgbFace[0] == rgbFace[1] == rgbFace[2]:
                 ps_color = '%1.3f setgray' % rgbFace[0]
             else:
                 ps_color = '%1.3f %1.3f %1.3f setrgbcolor' % rgbFace[:3]

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2766,3 +2766,23 @@ def _topmost_artist(
     in reverse order.
     """
     return _cached_max(reversed(artists))
+
+
+def _str_equal(obj, s):
+    """Return whether *obj* is a string equal to string *s*.
+
+    This helper solely exists to handle the case where *obj* is a numpy array,
+    because in such cases, a naive ``obj == s`` would yield an array, which
+    cannot be used in a boolean context.
+    """
+    return isinstance(obj, six.string_types) and obj == s
+
+
+def _str_lower_equal(obj, s):
+    """Return whether *obj* is a string equal, when lowercased, to string *s*.
+
+    This helper solely exists to handle the case where *obj* is a numpy array,
+    because in such cases, a naive ``obj == s`` would yield an array, which
+    cannot be used in a boolean context.
+    """
+    return isinstance(obj, six.string_types) and obj.lower() == s

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -13,7 +13,7 @@ import warnings
 
 import numpy as np
 
-from . import artist, colors as mcolors, docstring, rcParams
+from . import artist, cbook, colors as mcolors, docstring, rcParams
 from .artist import Artist, allow_rasterization
 from .cbook import (
     _to_unmasked_float_array, iterable, is_numlike, ls_mapper, ls_mapper_r,
@@ -793,16 +793,16 @@ class Line2D(Artist):
             rgbaFace = self._get_rgba_face()
             rgbaFaceAlt = self._get_rgba_face(alt=True)
             edgecolor = self.get_markeredgecolor()
-            if (isinstance(edgecolor, six.string_types)
-                    and edgecolor.lower() == 'none'):
+            if cbook._str_lower_equal(edgecolor, "none"):
                 gc.set_linewidth(0)
                 gc.set_foreground(rgbaFace, isRGBA=True)
             else:
                 gc.set_foreground(edgecolor)
                 gc.set_linewidth(self._markeredgewidth)
                 mec = self._markeredgecolor
-                if (isinstance(mec, six.string_types) and mec == 'auto' and
-                        rgbaFace is not None):
+                if (cbook._str_equal(mec, "auto")
+                        and not cbook._str_lower_equal(
+                            self.get_markerfacecolor(), "none")):
                     gc.set_alpha(rgbaFace[3])
                 else:
                     gc.set_alpha(self.get_alpha())
@@ -828,8 +828,7 @@ class Line2D(Artist):
                 marker_trans = marker.get_transform()
                 w = renderer.points_to_pixels(self._markersize)
 
-                if (isinstance(marker.get_marker(), six.string_types) and
-                        marker.get_marker() == ','):
+                if cbook._str_equal(marker.get_marker(), ","):
                     gc.set_linewidth(0)
                 else:
                     # Don't scale for pixels, and don't stroke them
@@ -843,8 +842,9 @@ class Line2D(Artist):
                 if alt_marker_path:
                     alt_marker_trans = marker.get_alt_transform()
                     alt_marker_trans = alt_marker_trans.scale(w)
-                    if (isinstance(mec, six.string_types) and mec == 'auto' and
-                            rgbaFaceAlt is not None):
+                    if (cbook._str_equal(mec, "auto")
+                            and not cbook._str_lower_equal(
+                                self.get_markerfacecoloralt(), "none")):
                         gc.set_alpha(rgbaFaceAlt[3])
                     else:
                         gc.set_alpha(self.get_alpha())
@@ -1257,13 +1257,7 @@ class Line2D(Artist):
         self._drawstyle = other._drawstyle
 
     def _get_rgba_face(self, alt=False):
-        facecolor = self._get_markerfacecolor(alt=alt)
-        if (isinstance(facecolor, six.string_types)
-                and facecolor.lower() == 'none'):
-            rgbaFace = None
-        else:
-            rgbaFace = mcolors.to_rgba(facecolor, self._alpha)
-        return rgbaFace
+        return mcolors.to_rgba(self._get_markerfacecolor(alt=alt), self._alpha)
 
     def _get_rgba_ln_color(self, alt=False):
         return mcolors.to_rgba(self._color, self._alpha)


### PR DESCRIPTION
_get_rgba_face is an internal function that is only use to set the
graphicscontext's foreground color (in Line2D.draw); it is always
effectively called as `gc.set_foreground(line._get_rgba_face(...),
isRGBA=True)`.  So it makes sense to have it actually always return a
RGBA quadruplet, including when the color is "none" (in which case
`mcolors.to_rgba` returns (0, 0, 0, 0) regardless of alpha, which works
just fine).

This removes the need for third party graphicscontexts to handle
non-RGBA-quadruplets (specifically, None) even when set_foreground is
actually called with isRGBA=True.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
