### PR TITLE
backend_agg cleanup.

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -28,7 +28,7 @@ import threading
 import numpy as np
 from collections import OrderedDict
 from math import radians, cos, sin
-from matplotlib import rcParams, __version__
+from matplotlib import cbook, rcParams, __version__
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, RendererBase, cursors)
 from matplotlib.figure import Figure
@@ -68,7 +68,11 @@ class RendererAgg(RendererBase):
     The renderer handles all the drawing primitives using a graphics
     context instance that controls the colors/styles
     """
-    debug=1
+
+    @property
+    @cbook.deprecated("2.2")
+    def debug(self):
+        return 1
 
     # we want to cache the fonts at the class level so that when
     # multiple figures are created we can reuse them.  This helps with
@@ -79,16 +83,17 @@ class RendererAgg(RendererBase):
     # draw, and release it when it is done.  This allows multiple
     # renderers to share the cached fonts, but only one figure can
     # draw at time and so the font cache is used by only one
-    # renderer at a time
+    # renderer at a time.
 
     lock = threading.RLock()
+
     def __init__(self, width, height, dpi):
         RendererBase.__init__(self)
 
         self.dpi = dpi
         self.width = width
         self.height = height
-        self._renderer = _RendererAgg(int(width), int(height), dpi, debug=False)
+        self._renderer = _RendererAgg(int(width), int(height), dpi)
         self._filter_renderers = []
 
         self._update_methods()
@@ -158,12 +163,14 @@ class RendererAgg(RendererBase):
                 try:
                     self._renderer.draw_path(gc, p, transform, rgbFace)
                 except OverflowError:
-                    raise OverflowError("Exceeded cell block limit (set 'agg.path.chunksize' rcparam)")
+                    raise OverflowError("Exceeded cell block limit (set "
+                                        "'agg.path.chunksize' rcparam)")
         else:
             try:
                 self._renderer.draw_path(gc, path, transform, rgbFace)
             except OverflowError:
-                raise OverflowError("Exceeded cell block limit (set 'agg.path.chunksize' rcparam)")
+                raise OverflowError("Exceeded cell block limit (set "
+                                    "'agg.path.chunksize' rcparam)")
 
 
     def draw_mathtext(self, gc, x, y, s, prop, angle):
@@ -232,8 +239,8 @@ class RendererAgg(RendererBase):
 
         flags = get_hinting_flag()
         font = self._get_agg_font(prop)
-        font.set_text(s, 0.0, flags=flags)  # the width and height of unrotated string
-        w, h = font.get_width_height()
+        font.set_text(s, 0.0, flags=flags)
+        w, h = font.get_width_height()  # width and height of unrotated string
         d = font.get_descent()
         w /= 64.0  # convert from subpixels
         h /= 64.0
@@ -367,9 +374,8 @@ class RendererAgg(RendererBase):
         post_processing is plotted (using draw_image) on it.
         """
 
-        # WARNING.
-        # For agg_filter to work, the rendere's method need
-        # to overridden in the class. See draw_markers, and draw_path_collections
+        # WARNING:  For agg_filter to work, the renderer's method need to
+        # overridden in the class. See draw_markers and draw_path_collections.
 
         width, height = int(self.width), int(self.height)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,7 +23,7 @@ pep8ignore =
     tools/subset.py E221 E231 E251 E261 E302 E501 E701 E703
 
     matplotlib/backends/qt_editor/formlayout.py E301 E402 E501
-    matplotlib/backends/backend_agg.py E225 E228 E231 E261 E301 E302 E303 E501 E701
+    matplotlib/backends/backend_agg.py E225 E228 E231 E261 E301 E302 E303 E701
     matplotlib/backends/backend_cairo.py E203 E211 E221 E231 E261 E272 E302 E303 E401 E402 E501 E701 E711
     matplotlib/backends/backend_gdk.py E202 E203 E211 E221 E225 E231 E261 E302 E303 E402 E501 E702 E711
     matplotlib/backends/backend_gtk.py E201 E202 E203 E211 E221 E222 E225 E231 E251 E261 E262 E301 E302 E303 E401 E402 E501 E701 E702 E703


### PR DESCRIPTION
- Deprecate unused RendererAgg.debug variable.
- Passing debug=False to _RendererAgg has no effect (PyRendererAgg_init
  actually ignores kwds, and doesn't do anything with debug if it is
  passed positionally either).
- Moved a comment that was at the wrong line.
- Wrapped lines to 79 chars; removed allowance in pep8 checker.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
