### PR TITLE
Unify (parametrize) test_composite across backends.

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -81,30 +81,6 @@ def test_savefig_to_stringio(format, use_log, rcParams):
         buffer.close()
 
 
-def test_composite_image():
-    # Test that figures can be saved with and without combining multiple images
-    # (on a single set of axes) into a single composite image.
-    X, Y = np.meshgrid(np.arange(-5, 5, 1), np.arange(-5, 5, 1))
-    Z = np.sin(Y ** 2)
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
-    ax.set_xlim(0, 3)
-    ax.imshow(Z, extent=[0, 1, 0, 1])
-    ax.imshow(Z[::-1], extent=[2, 3, 0, 1])
-    plt.rcParams['image.composite_image'] = True
-    with io.BytesIO() as ps:
-        fig.savefig(ps, format="ps")
-        ps.seek(0)
-        buff = ps.read()
-        assert buff.count(six.b(' colorimage')) == 1
-    plt.rcParams['image.composite_image'] = False
-    with io.BytesIO() as ps:
-        fig.savefig(ps, format="ps")
-        ps.seek(0)
-        buff = ps.read()
-        assert buff.count(six.b(' colorimage')) == 2
-
-
 def test_patheffects():
     with matplotlib.rc_context():
         matplotlib.rcParams['path.effects'] = [

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -63,30 +63,6 @@ def test_noscale():
     ax.imshow(Z, cmap='gray', interpolation='none')
 
 
-def test_composite_images():
-    #Test that figures can be saved with and without combining multiple images
-    #(on a single set of axes) into a single composite image.
-    X, Y = np.meshgrid(np.arange(-5, 5, 1), np.arange(-5, 5, 1))
-    Z = np.sin(Y ** 2)
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
-    ax.set_xlim(0, 3)
-    ax.imshow(Z, extent=[0, 1, 0, 1])
-    ax.imshow(Z[::-1], extent=[2, 3, 0, 1])
-    plt.rcParams['image.composite_image'] = True
-    with BytesIO() as svg:
-        fig.savefig(svg, format="svg")
-        svg.seek(0)
-        buff = svg.read()
-        assert buff.count(six.b('<image ')) == 1
-    plt.rcParams['image.composite_image'] = False
-    with BytesIO() as svg:
-        fig.savefig(svg, format="svg")
-        svg.seek(0)
-        buff = svg.read()
-        assert buff.count(six.b('<image ')) == 2
-
-
 def test_text_urls():
     fig = plt.figure()
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
