### PR TITLE
Share and unshare axes after creation.

### DIFF
--- a/doc/api/api_changes/2017-12-06-KL.rst
+++ b/doc/api/api_changes/2017-12-06-KL.rst
@@ -1,0 +1,26 @@
+Change return value of Axes.get_shared_[x,y,z]_axes()
+-----------------------------------------------
+
+The method `matplotlib.Axes.get_shared_x_axes` (and y and z) used to return `~.cbook.Grouper` objects.
+Now it returns a `~.weakref.WeakSet` object.
+
+Workarounds:
+* If the intention is to get siblings as previous then the WeakSet contains all the siblings.
+An example::
+
+    sharedx = ax.get_shared_x_axes().get_siblings()
+    # is now
+    sharedx = list(ax.get_shared_x_axes())
+
+* If the intention was to use `join` then there is a new share axes method. An example::
+
+    ax1.get_shared_x_axes().join(ax1, ax2)
+    # is now
+    ax1.share_x_axes(ax2)
+
+* If the intention was to check if two elements are in the same group then use the `in` operator. An example::
+
+    ax1.get_shared_x_axes().joined(ax1, ax2)
+    # is now
+    ax2 in ax1.get_shared_x_axes()
+

--- a/doc/api/next_api_changes/2017-12-06-KL.rst
+++ b/doc/api/next_api_changes/2017-12-06-KL.rst
@@ -1,5 +1,5 @@
 Change return value of Axes.get_shared_[x,y,z]_axes()
------------------------------------------------
+-----------------------------------------------------
 
 The method `matplotlib.Axes.get_shared_x_axes` (and y and z) used to return `~.cbook.Grouper` objects.
 Now it returns a `~.weakref.WeakSet` object.

--- a/doc/api/next_api_changes/remove_old_share_axes_after_creation.rst
+++ b/doc/api/next_api_changes/remove_old_share_axes_after_creation.rst
@@ -1,0 +1,8 @@
+Remove share through `matplotlib.Axes.get_shared_{x,y,z}_axes`
+--------------------------------------------------------------
+
+Previously when different axes are created with different parent/master axes,
+the share would still be symmetric and transitive if an unconventional
+method through `matplotlib.Axes.get_shared_x_axes`
+is used to share the axes after creation. With the new sharing mechanism
+this is no longer possible.

--- a/doc/users/next_whats_new/2017-12-05_share_unshare_axes_after_creation.rst
+++ b/doc/users/next_whats_new/2017-12-05_share_unshare_axes_after_creation.rst
@@ -1,8 +1,12 @@
 Share and unshare `axes` after creation
 ---------------------------------------
 
-`~.Axes` have `~.Axes.unshare_x_axes`, `~.Axes.unshare_y_axes`, `~.Axes.unshare_z_axes` and `~.Axes.unshare_axes` methods to unshare axes.
-Similiar there are `~.Axes.share_x_axes`, `~.Axes.share_y_axes`, `~.Axes.share_z_axes` and `~.Axes.share_axes` methods to share axes.
+`matplotlib.axes.Axes` have `matplotlib.axes.Axes.unshare_x_axes`,
+`matplotlib.axes.Axes.unshare_y_axes`, `matplotlib.axes.Axes.unshare_z_axes`
+and `matplotlib.axes.Axes.unshare_axes` methods to unshare axes.
+Similiar there are `matplotlib.axes.Axes.share_x_axes`,
+`matplotlib.axes.Axes.share_y_axes`, `matplotlib.axes.Axes.share_z_axes` and
+`matplotlib.axes.Axes.share_axes` methods to share axes.
 
 Unshare an axis will decouple the viewlimits for further changes.
 Share an axis will couple the viewlimits.

--- a/doc/users/next_whats_new/2017-12-05_share_unshare_axes_after_creation.rst
+++ b/doc/users/next_whats_new/2017-12-05_share_unshare_axes_after_creation.rst
@@ -1,0 +1,8 @@
+Share and unshare `axes` after creation
+---------------------------------------
+
+`~.Axes` have `~.Axes.unshare_x_axes`, `~.Axes.unshare_y_axes`, `~.Axes.unshare_z_axes` and `~.Axes.unshare_axes` methods to unshare axes.
+Similiar there are `~.Axes.share_x_axes`, `~.Axes.share_y_axes`, `~.Axes.share_z_axes` and `~.Axes.share_axes` methods to share axes.
+
+Unshare an axis will decouple the viewlimits for further changes.
+Share an axis will couple the viewlimits.

--- a/examples/mplot3d/share_unshare_3d_axes.py
+++ b/examples/mplot3d/share_unshare_3d_axes.py
@@ -33,7 +33,7 @@ ax1.share_axes(ax)
 ax2 = fig.add_subplot(313, projection='3d', sharex=ax)
 ax2.plot(x, y, z)
 
-ax2.unshare_x_axes(ax)
+ax2.unshare_x_axes()
 ax2.share_z_axes(ax)
 
 plt.show()

--- a/examples/mplot3d/share_unshare_3d_axes.py
+++ b/examples/mplot3d/share_unshare_3d_axes.py
@@ -1,0 +1,39 @@
+"""
+============================================
+Parametric Curve with Share and Unshare Axes
+============================================
+
+This example demonstrates plotting a parametric curve in 3D,
+and how to share and unshare 3D plot axes.
+"""
+import matplotlib as mpl
+from mpl_toolkits.mplot3d import Axes3D
+import numpy as np
+import matplotlib.pyplot as plt
+
+mpl.rcParams['legend.fontsize'] = 10
+
+# Prepare arrays x, y, z
+theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
+z = np.linspace(-2, 2, 100)
+r = z ** 2 + 1
+x = r * np.sin(theta)
+y = r * np.cos(theta)
+
+fig = plt.figure()
+ax = fig.add_subplot(311, projection='3d')
+
+ax.plot(x, y, z, label='parametric curve')
+ax.legend()
+
+ax1 = fig.add_subplot(312)
+ax1.plot(range(10))
+ax1.share_axes(ax)
+
+ax2 = fig.add_subplot(313, projection='3d', sharex=ax)
+ax2.plot(x, y, z)
+
+ax2.unshare_x_axes(ax)
+ax2.share_z_axes(ax)
+
+plt.show()

--- a/examples/subplots_axes_and_figures/unshare_axis_demo.py
+++ b/examples/subplots_axes_and_figures/unshare_axis_demo.py
@@ -1,0 +1,36 @@
+"""
+======================
+Unshare and share axis
+======================
+
+The example shows how to share and unshare axes after they are created.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+t = np.arange(0.01, 5.0, 0.01)
+s1 = np.sin(2 * np.pi * t)
+s2 = np.exp(-t)
+s3 = np.sin(4 * np.pi * t)
+
+ax1 = plt.subplot(311)
+plt.plot(t, s1)
+
+ax2 = plt.subplot(312)
+plt.plot(t, s2)
+
+ax3 = plt.subplot(313)
+plt.plot(t, s3)
+
+ax1.share_x_axes(ax2)
+ax1.share_y_axes(ax2)
+
+# Share both axes.
+ax3.share_axes(ax1)
+plt.xlim(0.01, 5.0)
+
+ax3.unshare_y_axes()
+ax2.unshare_x_axes()
+
+plt.show()

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4288,11 +4288,15 @@ class _AxesBase(martist.Artist):
         self.unshare_y_axes()
 
     def _share_axes(self, axes, shared_axes):
-        shared = getattr(self, shared_axes)
-        shared |= getattr(axes, shared_axes)
+        if not iterable(axes):
+            axes = [axes]
+
+        shared = getattr(self, "_shared_{}_axes".format(shared_axes))
+        for ax in axes:
+            shared |= getattr(ax, "_shared_{}_axes".format(shared_axes))
 
         for ax in shared:
-            setattr(ax, shared_axes, shared)
+            setattr(ax, "_shared_{}_axes".format(shared_axes), shared)
 
     def share_x_axes(self, axes):
         """
@@ -4303,7 +4307,7 @@ class _AxesBase(martist.Artist):
         axes: Axes
             Axes to share.
         """
-        self._share_axes(axes, '_shared_x_axes')
+        self._share_axes(axes, 'x')
 
     def share_y_axes(self, axes):
         """
@@ -4314,7 +4318,7 @@ class _AxesBase(martist.Artist):
         axes: Axes
             Axes to share.
         """
-        self._share_axes(axes, '_shared_y_axes')
+        self._share_axes(axes, 'y')
 
     def share_axes(self, axes):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1289,8 +1289,7 @@ class _AxesBase(martist.Artist):
         if not (isinstance(aspect, str) and aspect in ('equal', 'auto')):
             aspect = float(aspect)  # raise ValueError if necessary
         if share:
-            axes = set(self._shared_x_axes.get_siblings(self)
-                       + self._shared_y_axes.get_siblings(self))
+            axes = set(self._shared_x_axes | self._shared_y_axes)
         else:
             axes = [self]
         for ax in axes:
@@ -4325,7 +4324,7 @@ class _AxesBase(martist.Artist):
 
         for ax in shared:
             setattr(ax, shared_axes, shared)
-            ax._adjustable = 'datalim'
+            # ax._adjustable = 'datalim'
 
     def share_x_axes(self, axes):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -999,7 +999,6 @@ class _AxesBase(martist.Artist):
         self.ignore_existing_data_limits = True
         self.callbacks = cbook.CallbackRegistry()
 
-
         if self._sharex is not None:
             # major and minor are axis.Ticker class instances with
             # locator and formatter attributes

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -7,6 +7,7 @@ import logging
 import warnings
 
 import numpy as np
+import copy
 
 from matplotlib import rcParams
 import matplotlib.artist as artist
@@ -650,6 +651,31 @@ class YTick(Tick):
 class Ticker(object):
     locator = None
     formatter = None
+
+    def __deepcopy__(self, memodict={}):
+        """
+        Perform deep copy by disable axis attribute from
+        locator and formatter.
+
+        """
+        axisLocator = self.locator.axis
+        axisFormatter = self.formatter.axis
+        self.locator.axis = None
+        self.formatter.axis = None
+
+        cls = self.__class__
+        result = cls.__new__(cls)
+        result.locator = copy.deepcopy(self.locator)
+        result.formatter = copy.deepcopy(self.formatter)
+
+        self.locator.axis = axisLocator
+        self.formatter.axis = axisFormatter
+
+        return result
+
+    def set_axis(self, axis):
+        self.locator.axis = axis
+        self.formatter.axis = axis
 
 
 class _LazyTickList(object):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2922,9 +2922,9 @@ class NavigationToolbar2(object):
             twinx, twiny = False, False
             if last_a:
                 for la in last_a:
-                    if a.get_shared_x_axes().joined(a, la):
+                    if la in a.get_shared_x_axes():
                         twinx = True
-                    if a.get_shared_y_axes().joined(a, la):
+                    if la in a.get_shared_y_axes():
                         twiny = True
             last_a.append(a)
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -934,9 +934,9 @@ class ToolZoom(ZoomPanBase):
             twinx, twiny = False, False
             if last_a:
                 for la in last_a:
-                    if a.get_shared_x_axes().joined(a, la):
+                    if la in a.get_shared_x_axes():
                         twinx = True
-                    if a.get_shared_y_axes().joined(a, la):
+                    if la in a.get_shared_y_axes():
                         twiny = True
             last_a.append(a)
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1395,21 +1395,17 @@ default: 'top'
             axis.set_minor_formatter(axis.get_minor_formatter())
             axis.set_minor_locator(axis.get_minor_locator())
 
-        def _break_share_link(ax, grouper):
-            siblings = grouper.get_siblings(ax)
-            if len(siblings) > 1:
-                grouper.remove(ax)
-                for last_ax in siblings:
-                    if ax is not last_ax:
-                        return last_ax
-            return None
-
         self.delaxes(ax)
-        last_ax = _break_share_link(ax, ax._shared_y_axes)
+
+        shared_y_axes = ax._shared_y_axes
+        shared_x_axes = ax._shared_x_axes
+        ax.unshare_axes()
+
+        last_ax = next((a for a in shared_y_axes if a is not ax), None)
         if last_ax is not None:
             _reset_loc_form(last_ax.yaxis)
 
-        last_ax = _break_share_link(ax, ax._shared_x_axes)
+        last_ax = next((a for a in shared_x_axes if a is not ax), None)
         if last_ax is not None:
             _reset_loc_form(last_ax.xaxis)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5719,3 +5719,115 @@ def test_tick_padding_tightbbox():
     bb2 = ax.get_window_extent(fig.canvas.get_renderer())
     assert bb.x0 < bb2.x0
     assert bb.y0 < bb2.y0
+
+
+def test_share_unshare_axes():
+    fig = plt.figure()
+    ax1 = fig.add_subplot(211)
+    ax2 = fig.add_subplot(212, sharex=ax1, sharey=ax1)
+
+    # Testing unsharing
+    ax1.unshare_axes()
+    assert ax2._sharex is None
+    assert ax2._sharey is None
+
+    sharedx = ax2._shared_x_axes
+    sharedy = ax2._shared_y_axes
+
+    assert ax1 not in sharedx
+    assert ax1 not in sharedy
+
+    sharedx = ax1._shared_x_axes
+    sharedy = ax1._shared_y_axes
+
+    assert ax2 not in sharedx
+    assert ax2 not in sharedy
+
+    assert not ax1.is_sharing_x_axes()
+    assert not ax1.is_sharing_y_axes()
+
+    assert not ax2.is_sharing_x_axes()
+    assert not ax2.is_sharing_y_axes()
+
+    # Testing sharing
+    ax1.share_x_axes(ax2)
+
+    sharedx = ax1._shared_x_axes
+    assert ax2 in sharedx
+
+    sharedx = ax2._shared_x_axes
+    assert ax1 in sharedx
+
+    ax2.share_y_axes(ax1)
+
+    sharedy = ax1._shared_y_axes
+    assert ax2 in sharedy
+
+    sharedy = ax2._shared_y_axes
+    assert ax1 in sharedy
+
+    assert ax1.is_sharing_x_axes()
+    assert ax1.is_sharing_y_axes()
+
+    assert ax2.is_sharing_x_axes()
+    assert ax2.is_sharing_y_axes()
+
+
+def test_share_unshare_3d_axes():
+    fig = plt.figure()
+    ax1 = fig.add_subplot(211, projection="3d")
+    ax2 = fig.add_subplot(212, projection="3d",
+                          sharex=ax1,
+                          sharey=ax1,
+                          sharez=ax1)
+
+    # Testing unsharing
+    ax1.unshare_axes()
+    assert ax2._sharex is None
+    assert ax2._sharey is None
+    assert ax2._sharez is None
+
+    sharedx = ax2._shared_x_axes
+    sharedy = ax2._shared_y_axes
+    sharedz = ax2._shared_z_axes
+
+    assert ax1 not in sharedx
+    assert ax1 not in sharedy
+    assert ax1 not in sharedz
+
+    sharedx = ax1._shared_x_axes
+    sharedy = ax1._shared_y_axes
+    sharedz = ax1._shared_z_axes
+
+    assert ax2 not in sharedx
+    assert ax2 not in sharedy
+    assert ax2 not in sharedz
+
+    # Testing sharing
+
+    # x axis
+    ax1.share_x_axes(ax2)
+
+    sharedx = ax1._shared_x_axes
+    assert ax2 in sharedx
+
+    sharedx = ax2._shared_x_axes
+    assert ax1 in sharedx
+
+    # y axis
+    ax2.share_y_axes(ax1)
+
+    sharedy = ax1._shared_y_axes
+    assert ax2 in sharedy
+
+    sharedy = ax2._shared_y_axes
+    assert ax1 in sharedy
+
+    # z axis
+    ax1.share_z_axes(ax2)
+
+    sharedz = ax2._shared_z_axes
+    assert ax1 in sharedz
+
+    sharedz = ax1._shared_z_axes
+    assert ax2 in sharedz

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -147,6 +147,45 @@ def test_polar():
     plt.draw()
 
 
+def test_sharing_axes():
+    fig = plt.figure()
+    ax1 = fig.add_subplot(211)
+    ax2 = fig.add_subplot(212, sharex=ax1, sharey=ax1)
+
+    pf = pickle.dumps(fig)
+    fig1 = pickle.loads(pf)
+
+    ax = fig1.axes
+
+    assert ax[0] in ax[1]._shared_x_axes
+    assert ax[0] in ax[1]._shared_y_axes
+
+    assert ax[1] in ax[0]._shared_x_axes
+    assert ax[1] in ax[0]._shared_y_axes
+
+
+def test_sharing_3d_axes():
+    fig = plt.figure()
+    ax1 = fig.add_subplot(211, projection="3d")
+    ax2 = fig.add_subplot(212, projection="3d",
+                          sharex=ax1,
+                          sharey=ax1,
+                          sharez=ax1)
+
+    pf = pickle.dumps(fig)
+    fig1 = pickle.loads(pf)
+
+    ax = fig1.axes
+
+    assert ax[0] in ax[1]._shared_x_axes
+    assert ax[0] in ax[1]._shared_y_axes
+    assert ax[0] in ax[1]._shared_z_axes
+
+    assert ax[1] in ax[0]._shared_x_axes
+    assert ax[1] in ax[0]._shared_y_axes
+    assert ax[1] in ax[0]._shared_z_axes
+
+
 class TransformBlob(object):
     def __init__(self):
         self.identity = mtransforms.IdentityTransform()

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -19,8 +19,10 @@ def check_shared(axs, x_shared, y_shared):
             enumerate(zip("xy", [x_shared, y_shared]))):
         if i2 <= i1:
             continue
+        share = getattr(ax1, "_shared_{}_axes".format(name))
+        share = ax2 in share
         assert \
-            (getattr(axs[0], "_shared_{}_axes".format(name)).joined(ax1, ax2)
+            (share
              == shared[i1, i2]), \
             "axes %i and %i incorrectly %ssharing %s axis" % (
                 i1, i2, "not " if shared[i1, i2] else "", name)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2900,35 +2900,15 @@ class Axes3D(Axes):
 
         return polygons
 
-    def unshare_z_axes(self, axes=None):
-        """
-        Unshare z axis.
+    def unshare_z_axes(self):
+        """ Unshare z axis. """
+        self._unshare_axes("z")
 
-        Parameters
-        ----------
-        axes: Axes
-            Axes to unshare, if related. None will unshare itself.
-        """
-        if axes is None or axes is self:
-            children = self._unshare_axes('_shared_z_axes', '_sharez')
-            for ax in children:
-                self._copy_axis_major_minor(ax.zaxis)
-            self._copy_axis_major_minor(self.zaxis)
-        elif axes in self._shared_z_axes:
-            axes.unshare_z_axes()
-
-    def unshare_axes(self, axes=None):
-        """
-        Unshare x, y and z axes.
-
-        Parameters
-        ----------
-        axes: Axes
-            Axes to unshare, if related. None will unshare itself.
-        """
-        self.unshare_x_axes(axes)
-        self.unshare_y_axes(axes)
-        self.unshare_z_axes(axes)
+    def unshare_axes(self):
+        """ Unshare x, y and z axes. """
+        self.unshare_x_axes()
+        self.unshare_y_axes()
+        self.unshare_z_axes()
 
     def share_z_axes(self, axes):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2919,7 +2919,7 @@ class Axes3D(Axes):
         axes: Axes
             Axes to share.
         """
-        self._share_axes(axes, '_shared_z_axes')
+        self._share_axes(axes, 'z')
 
     def share_axes(self, axes):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -541,7 +541,6 @@ class Axes3D(Axes):
             _tight = self._tight = bool(tight)
 
         if scalex and self._autoscaleXon:
-            self._shared_x_axes.clean()
             x0, x1 = self.xy_dataLim.intervalx
             xlocator = self.xaxis.get_major_locator()
             try:
@@ -558,7 +557,6 @@ class Axes3D(Axes):
             self.set_xbound(x0, x1)
 
         if scaley and self._autoscaleYon:
-            self._shared_y_axes.clean()
             y0, y1 = self.xy_dataLim.intervaly
             ylocator = self.yaxis.get_major_locator()
             try:
@@ -575,7 +573,6 @@ class Axes3D(Axes):
             self.set_ybound(y0, y1)
 
         if scalez and self._autoscaleZon:
-            self._shared_z_axes.clean()
             z0, z1 = self.zz_dataLim.intervalx
             zlocator = self.zaxis.get_major_locator()
             try:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary
Implementing share and unshare axes after creation ref PR #1312.

Currently sharing axes has a parent/master `axes`. The class attribute is `_sharex`, `_sharey` and `_sharez`.
In addition there is a `Grouper` object which store which `axes` share their axes. Because of technical limitation, it is suggested that sharing should be transitive and there is no master `axes`. That is if the master `axes` is unshared the other `axes` in the group will still share their axes. The parent/master attribute are kept for backward compatibility of the behaviour of cla().

Reverting back to WeakSet implementation to fix #4827 too.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Test code

```
import matplotlib.pyplot as plt
import numpy as np

t = np.arange(0.01, 5.0, 0.01)
s1 = np.sin(2 * np.pi * t)
s2 = np.exp(-t)
s3 = np.sin(4 * np.pi * t)

ax1 = plt.subplot(311)
plt.plot(t, s1)

ax2 = plt.subplot(312)
plt.plot(t, s2)

ax3 = plt.subplot(313)
plt.plot(t, s3)

ax1.share_x_axes(ax2)
ax1.share_y_axes(ax2)

# Share both axes.
ax3.share_axes(ax1)
plt.xlim(0.01, 5.0)

ax3.unshare_y_axes()
ax2.unshare_x_axes()

plt.show()
```



<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
