### PR TITLE
WIP: internal_faces option for axes3d voxels

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2753,6 +2753,12 @@ class Axes3D(Axes):
               - A 4D ndarray of rgb/rgba data, with the components along the
                 last axis.
 
+        internal_faces : boolean
+            By default, only exposed faces of a voxel are rendered,
+            but you can force the rendering of all faces of the voxels
+            by setting this keyword argument to True.
+        .. versionadded:: 2.1
+
         **kwargs
             Additional keyword arguments to pass onto
             :func:`~mpl_toolkits.mplot3d.art3d.Poly3DCollection`
@@ -2823,6 +2829,9 @@ class Axes3D(Axes):
         edgecolors = kwargs.pop('edgecolors', None)
         edgecolors = _broadcast_color_arg(edgecolors, 'edgecolors')
 
+        # include possibly occluded internal faces or not
+        internal_faces = kwargs.pop('internal_faces', False)
+
         # always scale to the full array, even if the data is only in the center
         self.auto_scale_xyz(x, y, z)
 
@@ -2875,9 +2884,9 @@ class Axes3D(Axes):
                         i1 = tuple(p1)
                         i2 = tuple(p2)
 
-                        if filled[i1] and not filled[i2]:
+                        if filled[i1] and (internal_faces or not filled[i2]):
                             voxel_faces[i1].append(p2 + square_rot)
-                        elif not filled[i1] and filled[i2]:
+                        elif (internal_faces or not filled[i1]) and filled[i2]:
                             voxel_faces[i2].append(p2 + square_rot)
 
                     # draw upper faces

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -656,6 +656,37 @@ class TestVoxels(object):
             assert isinstance(poly, art3d.Poly3DCollection)
 
     @image_comparison(
+        baseline_images=['voxels-internal-faces'],
+        extensions=['png'],
+        remove_text=True
+    )
+    def test_internal_faces(self):
+        # Create 3 voxels (with one of them nearly invisible)
+        # and adjust the view so that we can see if the adjacent
+        # voxels are drawn or not.
+        fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+
+        test_data = np.array(
+              [[[ 0.,  1],
+                [ 0.,  2]],
+
+               [[ 0.,  0.],
+                [ 0.,  1]]])
+        alphas = np.divide(test_data, np.max(test_data))/2.0
+        colors = np.empty(test_data.shape + (4,))
+        colors[:, :, :] = [1, 0, 0, 1.0]
+        colors[:, :, :, 3] = alphas
+
+        v = ax.voxels(test_data, facecolors=colors, internal_faces=True)
+        ax.view_init(azim=45, elev=45)
+
+        assert type(v) is dict
+        assert len(v) == 3
+        for coord, poly in v.items():
+            assert isinstance(poly, art3d.Poly3DCollection)
+            assert len(poly.get_paths()) == 6, "voxel %s is wrong" % (coord,)
+
+    @image_comparison(
         baseline_images=['voxels-xyz'],
         extensions=['png'],
         tol=0.01


### PR DESCRIPTION
Can only get 5 of the 6 faces, though... Must have done something wrong.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
