### PR TITLE
Cleanup delaxes()

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -864,9 +864,11 @@ class Figure(Artist):
         self.frameon = b
         self.stale = True
 
-    def delaxes(self, a):
-        'remove a from the figure and update the current axes'
-        self._axstack.remove(a)
+    def delaxes(self, ax):
+        """
+        Remove the `~.Axes` *ax* from the figure and update the current axes.
+        """
+        self._axstack.remove(ax)
         for func in self._axobservers:
             func(self)
         self.stale = True

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -919,19 +919,14 @@ def axes(*args, **kwargs):
     return a
 
 
-def delaxes(*args):
+def delaxes(ax=None):
     """
-    Remove an axes from the current figure.  If *ax*
-    doesn't exist, an error will be raised.
-
-    ``delaxes()``: delete the current axes
+    Remove the given `Axes` *ax* from the current figure. If *ax* is *None*,
+    the current axes is removed. A KeyError is raised if the axes doesn't exist.
     """
-    if not len(args):
+    if ax is None:
         ax = gca()
-    else:
-        ax = args[0]
-    ret = gcf().delaxes(ax)
-    return ret
+    gcf().delaxes(ax)
 
 
 def sca(ax):


### PR DESCRIPTION
This cleans up the `delaxes()` code and docstring as discussed in #9912.

For all intended uses, the API compatibility is preserved. Unreasonable and possibly wrong uses like multiple positional arguments or invalid keyword arguments will now raise an Exception.

**Note:** So far, `Figure.delaxes()` raises a KeyError if ax does not exist. IMO a ValueError would be more appropriate. However, I've not touched this beacuse of API compatibility. Please report back if I should turn the KeyError into a ValueError.