### PR TITLE
Fix for axes.errorbars to enable use of line style and marker propert…

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2822,8 +2822,8 @@ class Axes(_AxesBase):
         plot_line = (fmt.lower() != 'none')
         label = kwargs.pop("label", None)
 
-        if fmt=='':
-            fmt_style_kwargs={}
+        if fmt == '':
+            fmt_style_kwargs = {}
         else:
             fmt_style_kwargs = {k: v for k, v in
                             zip(('linestyle', 'marker', 'color'),

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2822,7 +2822,10 @@ class Axes(_AxesBase):
         plot_line = (fmt.lower() != 'none')
         label = kwargs.pop("label", None)
 
-        fmt_style_kwargs = {k: v for k, v in
+        if fmt=='':
+            fmt_style_kwargs={}
+        else:
+            fmt_style_kwargs = {k: v for k, v in
                             zip(('linestyle', 'marker', 'color'),
                                 _process_plot_format(fmt)) if v is not None}
         if fmt == 'none':
@@ -2886,6 +2889,9 @@ class Axes(_AxesBase):
         eb_cap_style = dict(base_style)
         # eject any marker information from format string
         eb_cap_style.pop('marker', None)
+        eb_lines_style.pop('markerfacecolor', None)
+        eb_lines_style.pop('markeredgewidth', None)
+        eb_lines_style.pop('markeredgecolor', None)
         eb_cap_style.pop('ls', None)
         eb_cap_style['linestyle'] = 'none'
         if capsize is None:


### PR DESCRIPTION
…ies from axes.prop_cycle

Fixes issues #9922 and #9920
It is just few lines of code, but I might have messed some tabs and spaces or such. Similar changes work with matplotlib 2.1.0. I can't test the one from master because it won't work with my WinPython as is and I can't compile Matplotlib.  https://github.com/jbmohler/matplotlib-winbuild is obsolete. It demands VS2010 while Python 3.6 requires VC 2015
