### PR TITLE
DOC: Add kwargs to class Axes docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -108,7 +108,7 @@ class Axes(_AxesBase):
     """
     ### Labelling, legend and texts
 
-    __init__.__doc__ = Axes.__init__.__doc__
+    __init__.__doc__ = AxesBase.__init__.__doc__
 
     aname = 'Axes'
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -108,6 +108,8 @@ class Axes(_AxesBase):
     """
     ### Labelling, legend and texts
 
+    __init__.__doc__ = Axes.__init__.__doc__
+
     aname = 'Axes'
 
     def get_title(self, loc="center"):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -105,10 +105,9 @@ class Axes(_AxesBase):
     instance.  The events you can connect to are 'xlim_changed' and
     'ylim_changed' and the callback will be called with func(*ax*)
     where *ax* is the :class:`Axes` instance.
-    """
-    ### Labelling, legend and texts
+    """ + _AxesBase.__init__.__doc__
 
-    __init__.__doc__ = _AxesBase.__init__.__doc__
+    ### Labelling, legend and texts
 
     aname = 'Axes'
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -108,7 +108,7 @@ class Axes(_AxesBase):
     """
     ### Labelling, legend and texts
 
-    __init__.__doc__ = AxesBase.__init__.__doc__
+    __init__.__doc__ = _AxesBase.__init__.__doc__
 
     aname = 'Axes'
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

The `~.Axes` docstring was buried in `axes/_base.py` where FAIKT it does not ever get rendered in the docs.  This just copies the same docstring into `axes/_axes.py`.   

This sattisfies concern raised on gitter:  https://gitter.im/matplotlib/matplotlib?at=5a26c670a2be46682863a850

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->