### PR TITLE
Add `ealpha` option to `errorbar`

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2697,7 +2697,7 @@ class Axes(_AxesBase):
                       label_namer="y")
     @docstring.dedent_interpd
     def errorbar(self, x, y, yerr=None, xerr=None,
-                 fmt='', ecolor=None, elinewidth=None, capsize=None,
+                 fmt='', ecolor=None, elinewidth=None, ealpha=None, capsize=None,
                  barsabove=False, lolims=False, uplims=False,
                  xlolims=False, xuplims=False, errorevery=1, capthick=None,
                  **kwargs):
@@ -2737,6 +2737,9 @@ class Axes(_AxesBase):
 
         elinewidth : scalar, optional, default: None
             The linewidth of the errorbar lines. If None, use the linewidth.
+            
+        ealpha : scalar, optional, default: None
+            The alpha of the errorbar lines. If None, use alpha.
 
         capsize : scalar, optional, default: None
             The length of the error bar caps in points; if None, it will
@@ -2877,8 +2880,13 @@ class Axes(_AxesBase):
             eb_lines_style['linewidth'] = elinewidth
         elif 'linewidth' in kwargs:
             eb_lines_style['linewidth'] = kwargs['linewidth']
+            
+        if ealpha:
+            eb_lines_style['alpha'] = ealpha
+        elif 'alpha' in kwargs:
+            eb_lines_style['alpha'] = kwargs['alpha']
 
-        for key in ('transform', 'alpha', 'zorder', 'rasterized'):
+        for key in ('transform', 'zorder', 'rasterized'):
             if key in kwargs:
                 eb_lines_style[key] = kwargs[key]
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

This enhances `errorbar` to allow for a different `alpha` for the line as opposed to the marker.

Demonstration:

    plt.errorbar([0.0], [0.0], xerr=[0.5], yerr=[0.5], fmt='s', ealpha=0.5, alpha=0.5, label='ealpha=0.5, alpha=0.5')
    plt.errorbar([0.0], [1.0], xerr=[0.5], yerr=[0.5], fmt='s', ealpha=0.5, alpha=1.0, label='ealpha=0.5, alpha=1.0')
    plt.errorbar([1.0], [0.0], xerr=[0.5], yerr=[0.5], fmt='s', ealpha=1.0, alpha=0.5, label='ealpha=0.5, alpha=0.5')
    plt.errorbar([1.0], [1.0], xerr=[0.5], yerr=[0.5], fmt='s', ealpha=1.0, alpha=1.0, label='ealpha=1.0, alpha=1.0')
    plt.legend(loc='center', fontsize=10)

![ealpha](https://user-images.githubusercontent.com/16648303/33669836-d0564a2c-daa3-11e7-84dc-351cc0055273.png)

I would be happy if people could help out with the below checklist.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->