### PR TITLE
BUG: clear events before destroying windows in tkagg

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -208,6 +208,7 @@ class FigureCanvasTkAgg(FigureCanvasAgg):
         # to the window and filter.
         def filter_destroy(evt):
             if evt.widget is self._tkcanvas:
+                self._master.update_idletasks()
                 self.close_event()
         root.bind("<Destroy>", filter_destroy, "+")
 


### PR DESCRIPTION
Fixes issue #9856 by clearing events while destroying. 

Alternative implementation: call ``flush_events()`` in ``close_events()`` in ``FigureCanvasAgg``, which might help other backends?

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way