### PR TITLE
FIX: put Nav Home view back inside pan/zoom

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2802,15 +2802,6 @@ class NavigationToolbar2(object):
         self.mode = ''  # a mode string for the status bar
         self.set_history_buttons()
 
-        @partial(canvas.mpl_connect, 'draw_event')
-        def update_stack(event):
-            nav_info = self._nav_stack()
-            if (nav_info is None  # True initial navigation info.
-                    # An axes has been added or removed, so update the
-                    # navigation info too.
-                    or set(nav_info) != set(self.canvas.figure.axes)):
-                self.push_current()
-
     def set_message(self, s):
         """Display a message on toolbar or in status bar."""
 
@@ -2955,6 +2946,10 @@ class NavigationToolbar2(object):
             self._button_pressed = None
             return
 
+        if self._nav_stack() is None:
+            # set the home button to this view
+            self.push_current()
+
         x, y = event.x, event.y
         self._xypress = []
         for i, a in enumerate(self.canvas.figure.get_axes()):
@@ -2989,6 +2984,10 @@ class NavigationToolbar2(object):
         else:
             self._button_pressed = None
             return
+
+        if self._nav_stack() is None:
+            # set the home button to this view
+            self.push_current()
 
         x, y = event.x, event.y
         self._xypress = []


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

Fixes #9863

The GUI home state was being set on the first `draw()` due to PRs #6598 #9359.  However, `draw` is called by some tools to get fontsizes etc, and some users were changing plot parameters after that `draw()`.  

This reverts to the home state being set in Pan and Zoom if the Home state is empty.  Other tools should include the same logic if they want to register the Home state when they are called:

```python
if self._nav_stack() is None:
            # set the home button to this view
            self.push_current()
```

Happy if someone has a better solution.  Perhaps instead of at draw time, the appropriate time is when the toolbar is created (`NavigationToolbar2.__init__`?). 

The test is the same as in #9863:

```python

import numpy as np
import matplotlib.pyplot as plt

x = np.random.rand(10, 10)

f, ax = plt.subplots()
ax.pcolormesh(x)
ax.figure.draw(ax.figure.canvas.get_renderer())
ax.invert_yaxis()

plt.show()
```

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->