### PR TITLE
DOC: Update color tutorial to explain alpha

### DIFF
--- a/tutorials/colors/colors.py
+++ b/tutorials/colors/colors.py
@@ -6,7 +6,7 @@ Specifying Colors
 Matplotlib recognizes the following formats to specify a color:
 
 * an RGB or RGBA tuple of float values in ``[0, 1]`` (e.g., ``(0.1, 0.2, 0.5)``
-  or  ``(0.1, 0.2, 0.5, 0.3)``);
+  or  ``(0.1, 0.2, 0.5, 0.3)``).  RGBA is short for Red, Green, Blue, Alpha;
 * a hex RGB or RGBA string (e.g., ``'#0F0F0F'`` or ``'#0F0F0F0F'``);
 * a string representation of a float value in ``[0, 1]`` inclusive for gray
   level (e.g., ``'0.5'``);
@@ -22,6 +22,19 @@ Matplotlib recognizes the following formats to specify a color:
   into the default property cycle (``matplotlib.rcParams['axes.prop_cycle']``);
   the indexing occurs at artist creation time and defaults to black if the
   cycle does not include color.
+
+"Red", "Green" and "Blue", are the intensities of those colors, the combination
+of which span the colorspace.
+
+How "Alpha" behaves depends on the ``zorder`` of the Artist.  Higher
+``zorder`` Artists are drawn on top of lower Artists, and "Alpha" determines
+whether the lower artist is covered by the higher.
+If the old RGB of a pixel is ``RGBold`` and the RGB of the
+pixel of the Artist being added is ``RGBnew`` with Alpha ``alpha``,
+then the RGB of the pixel is updated to:
+``RGB = RGBOld * (1 - Alpha) + RGBnew * Alpha``.  Alpha
+of 1 means the old color is completely covered by the new Artist, Alpha of 0
+means that pixel of the Artist is transparent.
 
 All string specifications of color, other than "CN", are case-insensitive.
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

Based on the discussion in #9906 we really should define `alpha` somewhere.  Here is my attempt.  Edits welcome.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->