### PR TITLE
Added support for displaying percentiles to violinplot function

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2047,7 +2047,7 @@ def _reshape_2D(X, name):
         raise ValueError("{} must have 2 or fewer dimensions".format(name))
 
 
-def violin_stats(X, method, points=100):
+def violin_stats(X, method, points=100, percentiles=[]):
     """
     Returns a list of dictionaries of data which can be used to draw a series
     of violin plots. See the `Returns` section below to view the required keys
@@ -2071,6 +2071,9 @@ def violin_stats(X, method, points=100):
         Defines the number of points to evaluate each of the gaussian kernel
         density estimates at.
 
+    percentiles : array-like, default = []
+        Defines a set of percentiles, if any, that will be displayed per plotted point
+
     Returns
     -------
 
@@ -2085,6 +2088,7 @@ def violin_stats(X, method, points=100):
         - median: The median value for this column of data.
         - min: The minimum value for this column of data.
         - max: The maximum value for this column of data.
+        - percentiles: The set of percentiles that will be rendered for this data.
     """
 
     # List of dictionaries describing each of the violins.
@@ -2093,7 +2097,13 @@ def violin_stats(X, method, points=100):
     # Want X to be a list of data sequences
     X = _reshape_2D(X, "X")
 
-    for x in X:
+    if percentiles is None:
+        percentiles = []
+    percentiles = _reshape_2D(percentiles, "percentiles")
+    while len(percentiles) < len(X):
+        percentiles.append([])
+
+    for x, pcs in zip(X, percentiles):
         # Dictionary of results for this distribution
         stats = {}
 
@@ -2111,6 +2121,7 @@ def violin_stats(X, method, points=100):
         stats['median'] = np.median(x)
         stats['min'] = min_val
         stats['max'] = max_val
+        stats['percentiles'] = np.percentile(x, pcs)
 
         # Append to output
         vpstats.append(stats)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3652,8 +3652,8 @@ def triplot(*args, **kwargs):
 # changes will be lost
 @_autogen_docstring(Axes.violinplot)
 def violinplot(dataset, positions=None, vert=True, widths=0.5, showmeans=False,
-               showextrema=True, showmedians=False, points=100, bw_method=None,
-               hold=None, data=None):
+               showextrema=True, showmedians=False, percentiles=[], points=100,
+               bw_method=None, hold=None, data=None):
     ax = gca()
     # Deprecated: allow callers to override the hold state
     # by passing hold=True|False
@@ -3668,7 +3668,8 @@ def violinplot(dataset, positions=None, vert=True, widths=0.5, showmeans=False,
         ret = ax.violinplot(dataset, positions=positions, vert=vert,
                             widths=widths, showmeans=showmeans,
                             showextrema=showextrema, showmedians=showmedians,
-                            points=points, bw_method=bw_method, data=data)
+                            points=points, bw_method=bw_method, data=data,
+                            percentiles=percentiles)
     finally:
         ax._hold = washold
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
    These changes will add the option for displaying percentile lines in the violinplot function. For each list given as input (2D for more than one plot), the respective plots will display lines at the percentiles given by that list.
    I also wanted to mention KurtWink, my collaborator for this project. We needed to remake the repository we were using to set it up for a PR (a bit new to GitHub), and I ended up pushing all our final changes at once.

<!--If it fixes an open issue, please link to the issue here.-->https://github.com/matplotlib/matplotlib/issues/8532

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
