### PR TITLE
Remove some test warnings

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6111,14 +6111,14 @@ class Axes(_AxesBase):
         if histtype == 'barstacked' and not stacked:
             stacked = True
 
-        if normed is not None:
-            warnings.warn("The 'normed' kwarg is deprecated, and has been "
-                          "replaced by the 'density' kwarg.")
         if density is not None and normed is not None:
             raise ValueError("kwargs 'density' and 'normed' cannot be used "
                              "simultaneously. "
                              "Please only use 'density', since 'normed'"
                              "is deprecated.")
+        if normed is not None:
+            warnings.warn("The 'normed' kwarg is deprecated, and has been "
+                          "replaced by the 'density' kwarg.")
 
         # basic input validation
         input_empty = np.size(x) == 0

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1198,7 +1198,8 @@ def test_pcolorargs():
     x[0] = np.NaN
     with pytest.raises(ValueError):
         ax.pcolormesh(x, y, Z[:-1, :-1])
-    x = np.ma.array(x, mask=(x < 0))
+    with np.errstate(invalid='ignore'):
+        x = np.ma.array(x, mask=(x < 0))
     with pytest.raises(ValueError):
         ax.pcolormesh(x, y, Z[:-1, :-1])
 


### PR DESCRIPTION
Removes a `numpy` warning when two infinite `numpy` `float64` objects are subtracted, by turning them into normal floats. Removes warnings like this from testing: https://travis-ci.org/matplotlib/matplotlib/jobs/314377016#L2398

Another few warning removal fixes