### PR TITLE
ENH color brightening

### DIFF
--- a/doc/users/next_whats_new/2017-12_color_brightening.rst
+++ b/doc/users/next_whats_new/2017-12_color_brightening.rst
@@ -1,0 +1,9 @@
+Color brightening
+----------------------
+
+Often we would like the ability add subtle color variation to our plots,
+especially when similar element are plotted in close proximity to one another.
+`matplotlib.colors.brighten_color` can be used to take an existing color and
+brighten or darken it, by giving a positive or negative fraction.
+
+.. plot:: mpl_examples/color/color_brighten_demo.py

--- a/examples/color/color_brighten_demo.py
+++ b/examples/color/color_brighten_demo.py
@@ -1,0 +1,31 @@
+"""
+===================
+Brighten color demo
+===================
+
+Demo of `~.brighten_color` utility.
+
+"""
+
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import numpy as np
+
+fig, ax = plt.subplots()
+
+lightfacs = [-1., -0.5, 0., 0.5, 0.75, 1.0]
+N = len(lightfacs)
+y = np.linspace(0., 1., N+1) * N - 0.5
+for n, lightfac in enumerate(lightfacs):
+    brightened_color = mcolors.brighten_color('blue', lightfac)
+    ax.fill_between([0, 1], [y[n], y[n]], [y[n+1], y[n+1]],
+            facecolor=brightened_color, edgecolor='k')
+
+ax.set_yticklabels([''] + lightfacs)
+
+ax.set_xlim([0, 1])
+ax.set_ylim(np.min(y), np.max(y))
+ax.set_ylabel('Brightening Fraction')
+ax.set_xticks([])
+ax.set_title('Brightening of Color Blue')
+plt.show()

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -10,7 +10,8 @@ from distutils.version import LooseVersion as V
 import numpy as np
 import pytest
 
-from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
+from numpy.testing.utils import (assert_array_equal,
+                                 assert_array_almost_equal, assert_equal)
 
 from matplotlib import cycler
 import matplotlib
@@ -715,3 +716,34 @@ def test_ndarray_subclass_norm(recwarn):
         else:
             assert len(recwarn) == 0
         recwarn.clear()
+
+
+def _brighten_test_helper(color, shade, expected):
+    sc = mcolors.brighten_color(color, shade)
+    assert_equal(sc, expected)
+
+
+def test_color_brightening():
+    test_colors = (
+        'red',
+        'red',
+        'red',
+        'red',
+        'red',
+        [0, .5, .9],
+        'slategrey',
+    )
+    test_brighten = (0, 0.50, 1.00, -0.50, -1.00, 0.20, -0.20)
+    known_brighten_result = (
+        (1.0, 0.0, 0.0),
+        (1.0, 0.5, 0.5),
+        (1.0, 1.0, 1.0),
+        (0.5, 0.0, 0.0),
+        (0.0, 0.0, 0.0),
+        (0.080000000000000071, 0.59111111111111092, 1.0),
+        (0.35097730430754981, 0.40156862745098038, 0.45215995059441105)
+    )
+    for color, brighten, expected in zip(test_colors,
+                                      test_brighten,
+                                      known_brighten_result):
+        _brighten_test_helper(color, brighten, expected)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

Redo of #8895.  Simple utility to brighten a color.  Changed name from shade to brighten because positive was brightening.  "Lightening" is also possible, since we are changing the L channel in HSL, but is clunky linguistically.  



<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->