### PR TITLE
Remove unused import in toolmanager example

### DIFF
--- a/examples/user_interfaces/toolmanager_sgskip.py
+++ b/examples/user_interfaces/toolmanager_sgskip.py
@@ -20,7 +20,6 @@ matplotlib.use('GTK3Cairo')
 matplotlib.rcParams['toolbar'] = 'toolmanager'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase, ToolToggleBase
-from gi.repository import Gtk, Gdk
 
 
 class ListTools(ToolBase):


### PR DESCRIPTION
I have no idea what these imports are meant to do, but they aren't referenced anywhere else and I can run the example fine without them.