### PR TITLE
Fix figure.colorbar() with axes keywords

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1891,7 +1891,12 @@ class Figure(Artist):
             else:
                 cax, kw = cbar.make_axes(ax, **kw)
         cax._hold = True
-        cb = cbar.colorbar_factory(cax, mappable, **kw)
+
+        # need to remove kws that cannot be passed to Colorbar
+        NON_COLORBAR_KEYS = ['fraction', 'pad', 'shrink', 'aspect', 'anchor',
+                             'panchor']
+        cb_kw = {k: v for k, v in kw.items() if k not in NON_COLORBAR_KEYS}
+        cb = cbar.colorbar_factory(cax, mappable, **cb_kw)
 
         self.sca(current_ax)
         self.stale = True

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -306,3 +306,12 @@ def test_colorbar_lognorm_extension():
     cb = ColorbarBase(ax, norm=LogNorm(vmin=0.1, vmax=1000.0),
                       orientation='vertical', extend='both')
     assert cb._values[0] >= 0.0
+
+
+def test_colorbar_axes_kw():
+    # test fix for #8493: This does only test, that axes-related keywords pass
+    # and do not raise an exception.
+    plt.figure()
+    plt.imshow(([[1, 2], [3, 4]]))
+    plt.colorbar(orientation='horizontal', fraction=0.2, pad=0.2, shrink=0.5,
+                 aspect=10, anchor=(0., 0.), panchor=(0., 1.))


### PR DESCRIPTION
Fixes #8493.

The problem was that `Figure.colorbar()` accepts `Axes` as well as `Colorbar` keywords. However they are all passed on to the `Colorbar` constructor. This has an explicit signature of supported keywords and complains on the `Axes` keywords 'anchor' and 'panchor'.

The fix is to filter out `Axes` keywords that are not allowed in `Colorbar`. Note: 'orientation' has to be passed to both.