### PR TITLE
Fix scatter edgecolor for unfilled points

### DIFF
--- a/doc/api/next_api_changes/behavior/10008-HK.rst
+++ b/doc/api/next_api_changes/behavior/10008-HK.rst
@@ -1,0 +1,6 @@
+Scatter plot unfilled marker edgecolor
+--------------------------------------
+
+For :meth:`~matplotlib.axes.Axes.scatter`, when both the `facecolor`
+and `edgecolor` are specified for unfilled marker types, the `edgecolor`
+is used. Previously, the points took on the `facecolor`.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4291,9 +4291,8 @@ default: :rc:`scatter.edgecolors`
             - 'none': No patch boundary will be drawn.
             - A color or sequence of colors.
 
-            For non-filled markers, *edgecolors* is ignored. Instead, the color
-            is determined like with 'face', i.e. from *c*, *colors*, or
-            *facecolors*.
+            For non-filled markers, *edgecolors* kwarg (if it is not None,
+            'face' or 'none') dictates the color of the marker.
 
         plotnonfinite : bool, default: False
             Whether to plot points with nonfinite *c* (i.e. ``inf``, ``-inf``
@@ -4378,6 +4377,11 @@ default: :rc:`scatter.edgecolors`
         path = marker_obj.get_path().transformed(
             marker_obj.get_transform())
         if not marker_obj.is_filled():
+            # In classic mode or non-classic mode
+            if edgecolors is None or edgecolors == 'face':
+                edgecolors = colors
+            colors = 'none'
+
             if linewidths is None:
                 linewidths = rcParams['lines.linewidth']
             elif np.iterable(linewidths):
@@ -4389,8 +4393,8 @@ default: :rc:`scatter.edgecolors`
 
         collection = mcoll.PathCollection(
                 (path,), scales,
-                facecolors=colors if marker_obj.is_filled() else 'none',
-                edgecolors=edgecolors if marker_obj.is_filled() else colors,
+                facecolors=colors,
+                edgecolors=edgecolors,
                 linewidths=linewidths,
                 offsets=offsets,
                 transOffset=kwargs.pop('transform', self.transData),

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2367,6 +2367,21 @@ def test_parse_scatter_color_args_error():
             c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)
 
 
+@pytest.mark.parametrize(('facecolor', 'edgecolor', 'expected_color'), [
+    ('red', 'cyan', 'cyan'),
+    (None, 'cyan', 'cyan'),
+    ('red', None, 'red')
+])
+def test_scatter_edgecolor(facecolor, edgecolor, expected_color):
+    fig, ax = plt.subplots()
+    artist = ax.scatter(x=[1, 2, 3], y=[1, 2, 3], s=550,
+                        linewidth=5, marker='2',
+                        facecolor=facecolor,
+                        edgecolor=edgecolor)
+    result_color = artist.get_edgecolor()[0]
+    assert mcolors.to_hex(result_color) == mcolors.to_hex(expected_color)
+
+
 def test_as_mpl_axes_api():
     # tests the _as_mpl_axes api
     from matplotlib.projections.polar import PolarAxes


### PR DESCRIPTION
## PR Summary
For unfilled markers, the edgecolor -- if specified -- has precedence
over the facecolor.

```python
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
ax.scatter(x=[1, 2, 3], y=[1, 2, 3], s=550, linewidth=5, marker='2', facecolor='red', edgecolor='cyan')
```
**With PR**
![with-pr](https://user-images.githubusercontent.com/780341/34010929-f928fe0a-e0d3-11e7-8fc0-f5a451c85ea5.png)

**Without PR**
![without-pr](https://user-images.githubusercontent.com/780341/34010840-b21c6ff6-e0d3-11e7-89b7-899ae9ed26f7.png)

closes has2k1/plotnine#100

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
