### PR TITLE
FIX: Check for fontsize smaller than 1 pt and round up

### DIFF
--- a/doc/api/api_changes/2017-12-14-JMK.rst
+++ b/doc/api/api_changes/2017-12-14-JMK.rst
@@ -1,0 +1,10 @@
+Fontsizes less than 1 pt are clipped to be 1 pt.
+------------------------------------------------
+
+FreeType doesn't allow fonts to get smaller than 1 pt, so all Agg
+backends were silently rounding up to 1 pt.  PDF (other vector
+backends?) were letting us write fonts that were less than 1 pt, but
+they could not be placed properly because position information comes from
+FreeType.  This change makes it so no backends can use fonts smaller than
+1 pt, consistent with FreeType and ensuring more consistent results across
+backends.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -875,6 +875,10 @@ class FontProperties(object):
                     + ", ".join(map(str, font_scalings)))
             else:
                 size = scale * FontManager.get_default_size()
+        if size < 1.0:
+            _log.info('Fontsize %1.2f < 1.0 pt not allowed by FreeType. '
+                      'Setting fontsize = 1 pt', size)
+            size = 1.0
         self._size = size
 
     def set_file(self, file):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

FreeType doesn't allow fonts to get smaller than 1 pt, so all Agg backends were silently rounding up to 1 pt.  PDF (other vector backends?) were letting us write fonts that were less than 1 pt, but they could not be placed properly because position information comes from FreeType.  This change makes it so no backends can use fonts smaller than 1 pt, consistent with FreeType and ensuring more consistent results across backends.  

A message is logged at the `logger.INFO` level.    Could be convinced this should be higher level or a `warning.warn`

The argument against this is that small fonts can currently be written in PDF, but given that their positioning is all borked, this doesn't seem like a good thing to offer.  

Its not clear why FreeType doesn't allow smaller fonts.  

This addresses, if it doesn't solve #9963


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->