### PR TITLE
Allow rasterization for 3D plots

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -22,6 +22,7 @@ from matplotlib.cm import ScalarMappable
 from matplotlib.patches import Patch
 from matplotlib.colors import Normalize
 from matplotlib.cbook import iterable
+from matplotlib.artist import allow_rasterization
 
 import warnings
 import numpy as np
@@ -82,6 +83,7 @@ class Text3D(mtext.Text):
         self._dir_vec = get_dir_vector(zdir)
         self.stale = True
 
+    @allow_rasterization
     def draw(self, renderer):
         proj = proj3d.proj_trans_points([self._position3d, \
                 self._position3d + self._dir_vec], renderer.M)
@@ -130,6 +132,7 @@ class Line3D(lines.Line2D):
         self._verts3d = juggle_axes(xs, ys, zs, zdir)
         self.stale = True
 
+    @allow_rasterization
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
         xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
@@ -235,6 +238,7 @@ class Line3DCollection(LineCollection):
             minz = min(minz, min(zs))
         return minz
 
+    @allow_rasterization
     def draw(self, renderer, project=False):
         if project:
             self.do_3d_projection(renderer)
@@ -280,6 +284,7 @@ class Patch3D(Patch):
         self._facecolor2d = self._facecolor3d
         return min(vzs)
 
+    @allow_rasterization
     def draw(self, renderer):
         Patch.draw(self, renderer)
 
@@ -706,6 +711,7 @@ class Poly3DCollection(PolyCollection):
         return self._edgecolors2d
     get_edgecolor = get_edgecolors
 
+    @allow_rasterization
     def draw(self, renderer):
         return Collection.draw(self, renderer)
 


### PR DESCRIPTION
3D plots do not allow for rasterization. It seems this is only due to the missing decorator (`@allow_rasterization`) of the respecive `draw` methods. 

In this patch I'm adding the decorator to all draw methods in `art3d.py` to see what happens. 

This would allow to rasterize 3D objects, like

```
from mpl_toolkits.mplot3d import Axes3D
import matplotlib.pyplot as plt
import numpy as np

fig = plt.figure()
ax = fig.gca(projection=Axes3D.name)

x = np.arange(-5, 5, 0.25)
X, Y = np.meshgrid(x, x)
Z = np.sin(np.sqrt(X**2 + Y**2))

surf = ax.plot_surface(X, Y, Z, cmap="coolwarm",
                       linewidth=0, antialiased=True)
surf.set_rasterized(True)

plt.savefig("rasterizedsurface.pdf")
plt.show()
```

resulting in (screenshot from pdf):

![image](https://user-images.githubusercontent.com/23121882/34019891-5176d070-e131-11e7-8707-ad4fd97dda67.png)
