### PR TITLE
TST: test mlab cohere

### DIFF
--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -2136,6 +2136,20 @@ class TestSpectral(object):
         assert_allclose(speca, specb, atol=1e-08)
 
 
+# extra test for cohere...
+def test_cohere():
+    N = 1024
+    np.random.seed(19680801)
+    x = np.random.randn(N)
+    # phase offset
+    y = np.roll(x, 20)
+    # high-freq roll-off
+    y = np.convolve(y, np.ones(20) / 20., mode='same')
+    cohsq, f = mlab.cohere(x, y, NFFT=256, Fs=2, noverlap=128)
+    assert_allclose(np.mean(cohsq), 0.837, atol=1.e-3)
+    assert np.isreal(np.mean(cohsq))
+
+
 def test_griddata_linear():
     # z is a linear function of x and y.
     def get_z(x, y):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

This is a simple test for `mlab.cohere`.  Would have caught #10003 (fixed by #10004).  Mean to close #10012.

Perfectly happy if someone else re-writes to take advantage of the parameterized framework for the rest of the spectral tests just above this test.  I still grok that framework because I don't know how to run it locally as a script outside the test environment to see what is going on.   For now, I think a dumb test is better than a hypothetical fancy test.  

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
