### PR TITLE
Deprecate nbagg.transparent rcParam.

### DIFF
--- a/doc/api/api_changes/2017-12-15-AL.rst
+++ b/doc/api/api_changes/2017-12-15-AL.rst
@@ -1,0 +1,5 @@
+Deprecation of the ``nbagg.transparent`` rcParam
+````````````````````````````````````````````````
+
+To control transparency of figure patches in the nbagg (or any other) backend,
+directly set ``figure.patch.facecolor``, or the ``figure.facecolor`` rcParam.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -857,7 +857,7 @@ _deprecated_map = {
     'svg.image_noscale': ('image.interpolation', None, None),
     }
 
-_deprecated_ignore_map = {}
+_deprecated_ignore_map = {'nbagg.transparent': 'figure.facecolor'}
 
 _obsolete_set = {'text.dvipnghack', 'legend.isaxes'}
 
@@ -883,7 +883,7 @@ class RcParams(MutableMapping, dict):
     msg_depr = "%s is deprecated and replaced with %s; please use the latter."
     msg_depr_set = ("%s is deprecated. Please remove it from your "
                     "matplotlibrc and/or style files.")
-    msg_depr_ignore = "%s is deprecated and ignored. Use %s"
+    msg_depr_ignore = "%s is deprecated and ignored. Use %s instead."
     msg_obsolete = ("%s is obsolete. Please remove it from your matplotlibrc "
                     "and/or style files.")
 

--- a/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
+++ b/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
@@ -399,7 +399,7 @@
     "\n",
     "### UAT 15 - Figure face colours\n",
     "\n",
-    "The nbagg honours all colours appart from that of the figure.patch. The two plots below should produce a figure with a transparent background and a red background respectively (check the transparency by closing the figure, and dragging the resulting image over other content). There should be no yellow figure."
+    "The nbagg honours all colours appart from that of the figure.patch. The two plots below should produce a figure with a red background. There should be no yellow figure."
    ]
   },
   {
@@ -416,10 +416,6 @@
     "plt.figure()\n",
     "plt.plot([3, 2, 1])\n",
     "\n",
-    "with matplotlib.rc_context({'nbagg.transparent': False}):\n",
-    "    plt.figure()\n",
-    "\n",
-    "plt.plot([3, 2, 1])\n",
     "plt.show()"
    ]
   },

--- a/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
@@ -423,8 +423,6 @@ savefig.transparent : False    # setting that controls whether figures are saved
 savefig.frameon : True
 savefig.orientation : portrait
 
-nbagg.transparent: True
-
 # ps backend params
 ps.papersize      : letter   # auto, letter, legal, ledger, A0-A10, B0-B10
 ps.useafm         : False    # use of afm fonts, results in small files

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -425,8 +425,6 @@ savefig.transparent : False    # setting that controls whether figures are saved
 savefig.frameon : True
 savefig.orientation : portrait
 
-nbagg.transparent: True
-
 # ps backend params
 ps.papersize      : letter   # auto, letter, legal, ledger, A0-A10, B0-B10
 ps.useafm         : False    # use of afm fonts, results in small files

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -63,10 +63,6 @@ backend      : $TEMPLATE_BACKEND
 # When True, open the webbrowser to the plot that is shown
 # webagg.open_in_browser : True
 
-# When True, the figures rendered in the nbagg backend are created with
-# a transparent background.
-# nbagg.transparent : False
-
 # if you are running pyplot inside a GUI and your backend choice
 # conflicts, we will automatically try to find a compatible one for
 # you if backend_fallback is True


### PR DESCRIPTION
See rationale in #8654, also discussion in #5419.

Unlike for #10023 I am not sure of the best way to handle the deprecation, as this is a change of defaults (from transparent to nontransparent), so the deprecation warning doesn't really help before the default is changed, but it's too late after...

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
