### PR TITLE
Remove some deprecated rcParams.

### DIFF
--- a/doc/api/api_changes/2017-12-17-AL.rst
+++ b/doc/api/api_changes/2017-12-17-AL.rst
@@ -1,0 +1,10 @@
+Removal of deprecated rcParams
+``````````````````````````````
+
+The following deprecated rcParams have been removed:
+- ``axes.color_cycle`` (see ``axes.prop_cycle``),
+- ``legend.isaxes``,
+- ``svg.embed_char_paths`` (see ``svg.fonttype``),
+- ``text.fontstyle``, ``text.fontangle``, ``text.fontvariant``,
+  ``text.fontweight``, ``text.fontsize`` (renamed to ``text.style``, etc.),
+- ``tick.size`` (renamed to ``tick.major.size``).

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -843,23 +843,11 @@ def matplotlib_fname():
 # names of keys to deprecate
 # the values are a tuple of (new_name, f_old_2_new, f_new_2_old)
 # the inverse function may be `None`
-_deprecated_map = {
-    'text.fontstyle':   ('font.style', lambda x: x, None),
-    'text.fontangle':   ('font.style', lambda x: x, None),
-    'text.fontvariant': ('font.variant', lambda x: x, None),
-    'text.fontweight':  ('font.weight', lambda x: x, None),
-    'text.fontsize':    ('font.size', lambda x: x, None),
-    'tick.size':        ('tick.major.size', lambda x: x, None),
-    'svg.embed_char_paths': ('svg.fonttype',
-                             lambda x: "path" if x else "none", None),
-    'axes.color_cycle': ('axes.prop_cycle', lambda x: cycler('color', x),
-                         lambda x: [c.get('color', None) for c in x]),
-    'svg.image_noscale': ('image.interpolation', None, None),
-    }
+_deprecated_map = {}
 
 _deprecated_ignore_map = {}
 
-_obsolete_set = {'text.dvipnghack', 'legend.isaxes'}
+_obsolete_set = {'text.dvipnghack'}
 
 # The following may use a value of None to suppress the warning.
 _deprecated_set = {'axes.hold'}  # do NOT include in _all_deprecated

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -399,13 +399,6 @@ def validate_color(s):
     raise ValueError('%s does not look like a color arg%s' % (s, msg))
 
 
-def deprecate_axes_colorcycle(value):
-    warnings.warn("axes.color_cycle is deprecated.  Use axes.prop_cycle "
-                  "instead. Will be removed in 2.1.0",
-                  mplDeprecation)
-    return validate_colorlist(value)
-
-
 validate_colorlist = _listify_validator(validate_color, allow_stringlist=True)
 validate_colorlist.__doc__ = 'return a list of colorspecs'
 
@@ -570,18 +563,6 @@ validate_legend_loc = ValidateInStrings(
      'lower center',
      'upper center',
      'center'], ignorecase=True)
-
-
-def deprecate_svg_image_noscale(value):
-    warnings.warn("svg.image_noscale is deprecated. Set "
-                  "image.interpolation to 'none' instead.",
-                  mplDeprecation)
-
-
-def deprecate_svg_embed_char_paths(value):
-    warnings.warn("svg.embed_char_paths is deprecated.  Use "
-                  "svg.fonttype instead.",
-                  mplDeprecation)
 
 
 validate_svg_fonttype = ValidateInStrings('svg.fonttype',
@@ -1155,12 +1136,6 @@ defaultParams = {
     'axes.formatter.useoffset': [True, validate_bool],
     'axes.formatter.offset_threshold': [4, validate_int],
     'axes.unicode_minus': [True, validate_bool],
-    'axes.color_cycle': [
-        ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728',
-         '#9467bd', '#8c564b', '#e377c2', '#7f7f7f',
-         '#bcbd22', '#17becf'],
-                         deprecate_axes_colorcycle],  # cycle of plot
-                                                      # line colors
     # This entry can be either a cycler object or a
     # string repr of a cycler-object, which gets eval()'ed
     # to create the object.
@@ -1351,10 +1326,7 @@ defaultParams = {
 
     # write raster image data directly into the svg file
     'svg.image_inline':     [True, validate_bool],
-    # suppress scaling of raster data embedded in SVG
-    'svg.image_noscale':    [False, deprecate_svg_image_noscale],
     # True to save all characters as paths in the SVG
-    'svg.embed_char_paths': [True, deprecate_svg_embed_char_paths],
     'svg.fonttype':         ['path', validate_svg_fonttype],
     'svg.hashsalt':         [None, validate_string_or_None],
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -160,11 +160,6 @@ def test_Bug_2543():
         # real test is that this does not raise
         assert validate_bool_maybe_none(None) is None
         assert validate_bool_maybe_none("none") is None
-        _fonttype = mpl.rcParams['svg.fonttype']
-        assert _fonttype == mpl.rcParams['svg.embed_char_paths']
-        with mpl.rc_context():
-            mpl.rcParams['svg.embed_char_paths'] = False
-            assert mpl.rcParams['svg.fonttype'] == "none"
 
     with pytest.raises(ValueError):
         validate_bool_maybe_none("blah")

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -45,9 +45,9 @@ def temp_style(style_name, settings=None):
         style.reload_library()
 
 
-def test_deprecated_rc_warning_includes_filename():
-    SETTINGS = {'axes.color_cycle': 'ffffff'}
-    basename = 'color_cycle'
+def test_invalid_rc_warning_includes_filename():
+    SETTINGS = {'foo': 'bar'}
+    basename = 'basename'
     with warnings.catch_warnings(record=True) as warns:
         with temp_style(basename, SETTINGS):
             # style.reload_library() in temp_style() triggers the warning


### PR DESCRIPTION
- axes.color_cycle was deprecated in 1.5 (68f0afb).
- legend.isaxes was deprecated in 2.0 (64accfd).
- svg.embed_char_paths was deprecated in 1.3.1 (6d660ce).
- svg.image_noscale was deprecated in 2.1 (4a05302) but note that the
  deprecation was broken to start with as it used None as converter (so
  trying to set `rcParams["svg.image_noscale"]` currently raises
  `'NoneType' object is not callable`).
- text.* and tick.size were deprecated before 1.3.1 (e34a333).

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
https://matplotlib.org/devdocs/devel/index.html

For help with git and github workflow, please see https://matplotlib.org/devel/gitwash/development_workflow.html

Please do not create the PR out of master, but out of a separate branch. -->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are contributing fixes to docstrings, please pay attention to
http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
note the difference between using single backquotes, double backquotes, and
asterisks in the markup.-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
