### PR TITLE
Fix using .get_color() and friends in labels handling

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1350,17 +1350,17 @@ def _get_legend_handles_labels(axs, legend_handler_map=None):
             if type(f_h) != type(h):
                 continue
             try:
-                if f_h.get_color() != h.get_color():
+                if (f_h.get_color() != h.get_color()).any():
                     continue
             except AttributeError:
                 pass
             try:
-                if f_h.get_facecolor() != h.get_facecolor():
+                if (f_h.get_facecolor() != h.get_facecolor()).any():
                     continue
             except AttributeError:
                 pass
             try:
-                if f_h.get_edgecolor() != h.get_edgecolor():
+                if (f_h.get_edgecolor() != h.get_edgecolor()).any():
                     continue
             except AttributeError:
                 pass


### PR DESCRIPTION
## PR Summary

This code was introduced in v2.1.1 and, apparently, wasn't tested, because .get_color() returns array.

Here is examples (raises ValueError):
https://github.com/sympy/sympy/issues/13730#issuecomment-351027060
or
https://travis-ci.org/diofant/diofant/jobs/316670834

## PR Checklist

- [ ] Has Pytest style unit tests
