### PR TITLE
Remove some uses of unicode_literals

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -99,8 +99,7 @@ Occasionally the internal documentation (python docstrings) will refer
 to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 
@@ -277,10 +276,7 @@ def _parse_commandline():
               'info', 'warning')
 
     for arg in sys.argv[1:]:
-        # cast to str because we are using unicode_literals,
-        # and argv is always str
-
-        if arg.startswith(str('--verbose-')):
+        if arg.startswith('--verbose-'):
             level_str = arg[10:]
             # If it doesn't match one of ours, then don't even
             # bother noting it, we are just a 3rd-party library
@@ -305,9 +301,7 @@ class Verbose(object):
     _commandLineVerbose = None
 
     for arg in sys.argv[1:]:
-        # cast to str because we are using unicode_literals,
-        # and argv is always str
-        if not arg.startswith(str('--verbose-')):
+        if not arg.startswith('--verbose-'):
             continue
         level_str = arg[10:]
         # If it doesn't match one of ours, then don't even

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -710,7 +710,7 @@ get_cachedir = _wrap('CACHEDIR=%s', _get_cachedir, always=False)
 
 
 def _decode_filesystem_path(path):
-    if isinstance(path, bytes):
+    if not isinstance(path, str):
         return path.decode(sys.getfilesystemencoding())
     else:
         return path

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -6,8 +6,7 @@ This module is safe to import from anywhere within matplotlib;
 it imports matplotlib only at runtime.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from six.moves import xrange, zip

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -17,8 +17,7 @@ Interface::
               ...
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from six.moves import xrange
@@ -764,13 +763,13 @@ class Tfm(object):
         with open(filename, 'rb') as file:
             header1 = file.read(24)
             lh, bc, ec, nw, nh, nd = \
-                struct.unpack(str('!6H'), header1[2:14])
+                struct.unpack('!6H', header1[2:14])
             _log.debug(
                 'lh=%d, bc=%d, ec=%d, nw=%d, nh=%d, nd=%d' % (
                     lh, bc, ec, nw, nh, nd))
             header2 = file.read(4*lh)
             self.checksum, self.design_size = \
-                struct.unpack(str('!2I'), header2[:8])
+                struct.unpack('!2I', header2[:8])
             # there is also encoding information etc.
             char_info = file.read(4*(ec-bc+1))
             widths = file.read(4*nw)
@@ -779,7 +778,7 @@ class Tfm(object):
 
         self.width, self.height, self.depth = {}, {}, {}
         widths, heights, depths = \
-            [struct.unpack(str('!%dI') % (len(x)/4), x)
+            [struct.unpack('!%dI' % (len(x)/4), x)
              for x in (widths, heights, depths)]
         for idx, char in enumerate(xrange(bc, ec+1)):
             byte0 = ord(char_info[4*idx])
@@ -1040,7 +1039,7 @@ def find_tex_file(filename, format=None):
         if isinstance(format, bytes):
             format = format.decode('utf-8', errors='replace')
 
-    cmd = [str('kpsewhich')]
+    cmd = ['kpsewhich']
     if format is not None:
         cmd += ['--format=' + format]
     cmd += [filename]

--- a/lib/matplotlib/finance.py
+++ b/lib/matplotlib/finance.py
@@ -5,8 +5,7 @@ financial data.
 This module is deprecated in 2.0 and has been moved to a module called
 `mpl_finance`.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from six.moves import xrange, zip
@@ -57,31 +56,31 @@ else:
 
 
 stock_dt_ohlc = np.dtype([
-    (str('date'), object),
-    (str('year'), np.int16),
-    (str('month'), np.int8),
-    (str('day'), np.int8),
-    (str('d'), float),     # mpl datenum
-    (str('open'), float),
-    (str('high'), float),
-    (str('low'), float),
-    (str('close'), float),
-    (str('volume'), float),
-    (str('aclose'), float)])
+    ('date', object),
+    ('year', np.int16),
+    ('month', np.int8),
+    ('day', np.int8),
+    ('d', float),     # mpl datenum
+    ('open', float),
+    ('high', float),
+    ('low', float),
+    ('close', float),
+    ('volume', float),
+    ('aclose', float)])
 
 
 stock_dt_ochl = np.dtype(
-    [(str('date'), object),
-     (str('year'), np.int16),
-     (str('month'), np.int8),
-     (str('day'), np.int8),
-     (str('d'), float),     # mpl datenum
-     (str('open'), float),
-     (str('close'), float),
-     (str('high'), float),
-     (str('low'), float),
-     (str('volume'), float),
-     (str('aclose'), float)])
+    [('date', object),
+     ('year', np.int16),
+     ('month', np.int8),
+     ('day', np.int8),
+     ('d', float),     # mpl datenum
+     ('open', float),
+     ('close', float),
+     ('high', float),
+     ('low', float),
+     ('volume', float),
+     ('aclose', float)])
 
 
 def parse_yahoo_historical_ochl(fh, adjusted=True, asobject=False):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -19,8 +19,7 @@ the advantage that it is the standard way to look up fonts on X11
 platforms, so if a font is installed, it is much more likely to be
 found.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from six.moves import cPickle as pickle

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -13,8 +13,7 @@ that actually reflects the values given here. Any additions or deletions to the
 parameter set listed here should also be visited to the
 :file:`matplotlibrc.template` in matplotlib's root source directory.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 
@@ -97,11 +96,10 @@ def _listify_validator(scalar_validator, allow_stringlist=False):
         else:
             raise ValueError("{!r} must be of type: string or non-dictionary "
                              "iterable".format(s))
-    # Cast `str` to keep Py2 happy despite `unicode_literals`.
     try:
-        f.__name__ = str("{}list".format(scalar_validator.__name__))
+        f.__name__ = "{}list".format(scalar_validator.__name__)
     except AttributeError:  # class instance.
-        f.__name__ = str("{}List".format(type(scalar_validator).__name__))
+        f.__name__ = "{}List".format(type(scalar_validator).__name__)
     f.__doc__ = scalar_validator.__doc__
     return f
 
@@ -185,7 +183,7 @@ def validate_string_or_None(s):
     if s is None:
         return None
     try:
-        return six.text_type(s)
+        return validate_string(s)
     except ValueError:
         raise ValueError('Could not convert "%s" to string' % s)
 
@@ -409,7 +407,15 @@ def deprecate_axes_colorcycle(value):
 validate_colorlist = _listify_validator(validate_color, allow_stringlist=True)
 validate_colorlist.__doc__ = 'return a list of colorspecs'
 
-validate_stringlist = _listify_validator(six.text_type)
+def validate_string(s):
+    if isinstance(s, str):  # Always leave str as str
+        return s
+    elif isinstance(s, six.text_type):
+        return s
+    else:
+        return str(s)
+
+validate_stringlist = _listify_validator(str)
 validate_stringlist.__doc__ = 'return a list'
 
 validate_orientation = ValidateInStrings(
@@ -483,7 +489,7 @@ def validate_whiskers(s):
 def update_savefig_format(value):
     # The old savefig.extension could also have a value of "auto", but
     # the new savefig.format does not.  We need to fix this here.
-    value = six.text_type(value)
+    value = validate_string(value)
     if value == 'auto':
         value = 'png'
     return value
@@ -962,17 +968,17 @@ defaultParams = {
     'datapath':          [None, validate_path_exists],  # handled by
                                                         # _get_data_path_cached
     'interactive':       [False, validate_bool],
-    'timezone':          ['UTC', six.text_type],
+    'timezone':          ['UTC', validate_string],
 
     # the verbosity setting
     'verbose.level': ['silent', validate_verbose],
-    'verbose.fileo': ['sys.stdout', six.text_type],
+    'verbose.fileo': ['sys.stdout', validate_string],
 
     # line props
     'lines.linewidth':       [1.5, validate_float],  # line width in points
     'lines.linestyle':       ['-', _validate_linestyle],  # solid line
     'lines.color':           ['C0', validate_color],  # first color in color cycle
-    'lines.marker':          ['None', six.text_type],  # marker name
+    'lines.marker':          ['None', validate_string],  # marker name
     'lines.markeredgewidth': [1.0, validate_float],
     'lines.markersize':      [6, validate_float],    # markersize, in points
     'lines.antialiased':     [True, validate_bool],  # antialiased (no jaggies)
@@ -1016,7 +1022,7 @@ defaultParams = {
     'boxplot.meanline': [False, validate_bool],
 
     'boxplot.flierprops.color': ['k', validate_color],
-    'boxplot.flierprops.marker': ['o', six.text_type],
+    'boxplot.flierprops.marker': ['o', validate_string],
     'boxplot.flierprops.markerfacecolor': ['none', validate_color_or_auto],
     'boxplot.flierprops.markeredgecolor': ['k', validate_color],
     'boxplot.flierprops.markersize': [6, validate_float],
@@ -1040,7 +1046,7 @@ defaultParams = {
     'boxplot.medianprops.linestyle': ['-', _validate_linestyle],
 
     'boxplot.meanprops.color': ['C2', validate_color],
-    'boxplot.meanprops.marker': ['^', six.text_type],
+    'boxplot.meanprops.marker': ['^', validate_string],
     'boxplot.meanprops.markerfacecolor': ['C2', validate_color],
     'boxplot.meanprops.markeredgecolor': ['C2', validate_color],
     'boxplot.meanprops.markersize': [6, validate_float],
@@ -1049,10 +1055,10 @@ defaultParams = {
 
     ## font props
     'font.family':     [['sans-serif'], validate_stringlist],  # used by text object
-    'font.style':      ['normal', six.text_type],
-    'font.variant':    ['normal', six.text_type],
-    'font.stretch':    ['normal', six.text_type],
-    'font.weight':     ['normal', six.text_type],
+    'font.style':      ['normal', validate_string],
+    'font.variant':    ['normal', validate_string],
+    'font.stretch':    ['normal', validate_string],
+    'font.weight':     ['normal', validate_string],
     'font.size':       [10, validate_float],      # Base font size in points
     'font.serif':      [['DejaVu Serif', 'Bitstream Vera Serif',
                          'Computer Modern Roman',
@@ -1100,10 +1106,10 @@ defaultParams = {
     'mathtext.fallback_to_cm': [True, validate_bool],
 
     'image.aspect':        ['equal', validate_aspect],  # equal, auto, a number
-    'image.interpolation': ['nearest', six.text_type],
-    'image.cmap':          ['viridis', six.text_type],        # one of gray, jet, etc
+    'image.interpolation': ['nearest', validate_string],
+    'image.cmap':          ['viridis', validate_string],        # one of gray, jet, etc
     'image.lut':           [256, validate_int],  # lookup table
-    'image.origin':        ['upper', six.text_type],  # lookup table
+    'image.origin':        ['upper', validate_string],  # lookup table
     'image.resample':      [True, validate_bool],
     # Specify whether vector graphics backends will combine all images on a
     # set of axes into a single composite image
@@ -1130,7 +1136,7 @@ defaultParams = {
 
     'axes.titlesize':        ['large', validate_fontsize],  # fontsize of the
                                                             # axes title
-    'axes.titleweight':      ['normal', six.text_type],  # font weight of axes title
+    'axes.titleweight':      ['normal', validate_string],  # font weight of axes title
     'axes.titlepad':         [6.0, validate_float],  # pad from axes top to title in points
     'axes.grid':             [False, validate_bool],   # display grid or not
     'axes.grid.which':       ['major', validate_axis_locator],  # set wether the gid are by
@@ -1142,7 +1148,7 @@ defaultParams = {
     'axes.labelsize':        ['medium', validate_fontsize],  # fontsize of the
                                                              # x any y labels
     'axes.labelpad':         [4.0, validate_float], # space between label and axis
-    'axes.labelweight':      ['normal', six.text_type],  # fontsize of the x any y labels
+    'axes.labelweight':      ['normal', validate_string],  # fontsize of the x any y labels
     'axes.labelcolor':       ['k', validate_color],    # color of axis label
     'axes.formatter.limits': [[-7, 7], validate_nseq_int(2)],
                                # use scientific notation if log10
@@ -1187,16 +1193,16 @@ defaultParams = {
     'axes3d.grid': [True, validate_bool],  # display 3d grid
 
     # scatter props
-    'scatter.marker': ['o', six.text_type],
+    'scatter.marker': ['o', validate_string],
 
     # TODO validate that these are valid datetime format strings
-    'date.autoformatter.year': ['%Y', six.text_type],
-    'date.autoformatter.month': ['%Y-%m', six.text_type],
-    'date.autoformatter.day': ['%Y-%m-%d', six.text_type],
-    'date.autoformatter.hour': ['%m-%d %H', six.text_type],
-    'date.autoformatter.minute': ['%d %H:%M', six.text_type],
-    'date.autoformatter.second': ['%H:%M:%S', six.text_type],
-    'date.autoformatter.microsecond': ['%M:%S.%f', six.text_type],
+    'date.autoformatter.year': ['%Y', validate_string],
+    'date.autoformatter.month': ['%Y-%m', validate_string],
+    'date.autoformatter.day': ['%Y-%m-%d', validate_string],
+    'date.autoformatter.hour': ['%m-%d %H', validate_string],
+    'date.autoformatter.minute': ['%d %H:%M', validate_string],
+    'date.autoformatter.second': ['%H:%M:%S', validate_string],
+    'date.autoformatter.microsecond': ['%M:%S.%f', validate_string],
 
     #legend properties
     'legend.fancybox': [True, validate_bool],
@@ -1249,7 +1255,7 @@ defaultParams = {
 
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
-    'xtick.direction':   ['out', six.text_type],            # direction of xticks
+    'xtick.direction':   ['out', validate_string],            # direction of xticks
     'xtick.alignment': ["center", _validate_alignment],
 
     'ytick.left':        [True, validate_bool],  # draw ticks on the left side
@@ -1269,7 +1275,7 @@ defaultParams = {
 
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],
-    'ytick.direction':   ['out', six.text_type],            # direction of yticks
+    'ytick.direction':   ['out', validate_string],            # direction of yticks
     'ytick.alignment': ["center_baseline", _validate_alignment],
 
 
@@ -1282,7 +1288,7 @@ defaultParams = {
     ## figure props
     # figure title
     'figure.titlesize':   ['large', validate_fontsize],
-    'figure.titleweight': ['normal', six.text_type],
+    'figure.titleweight': ['normal', validate_string],
 
     # figure size in inches: width by height
     'figure.figsize':    [[6.4, 4.8], validate_nseq_float(2)],
@@ -1320,7 +1326,7 @@ defaultParams = {
     'savefig.bbox':       ['standard', validate_bbox],
     'savefig.pad_inches': [0.1, validate_float],
     # default directory in savefig dialog box
-    'savefig.directory': ['~', six.text_type],
+    'savefig.directory': ['~', validate_string],
     'savefig.transparent': [False, validate_bool],
 
     # Maintain shell focus for TkAgg
@@ -1361,7 +1367,7 @@ defaultParams = {
     # set this when you want to generate hardcopy docstring
     'docstring.hardcopy': [False, validate_bool],
     # where plugin directory is locate
-    'plugins.directory':  ['.matplotlib_plugins', six.text_type],
+    'plugins.directory':  ['.matplotlib_plugins', validate_string],
 
     'path.simplify': [True, validate_bool],
     'path.simplify_threshold': [1.0 / 9.0, ValidateInterval(0.0, 1.0)],
@@ -1387,7 +1393,7 @@ defaultParams = {
     'keymap.all_axes':     [['a'], validate_stringlist],
 
     # sample data
-    'examples.directory': ['', six.text_type],
+    'examples.directory': ['', validate_string],
 
     # Animation settings
     'animation.html':         ['none', validate_movie_html_fmt],
@@ -1395,7 +1401,7 @@ defaultParams = {
     # (i.e. IPython notebook)
     'animation.embed_limit':  [20, validate_float],
     'animation.writer':       ['ffmpeg', validate_movie_writer],
-    'animation.codec':        ['h264', six.text_type],
+    'animation.codec':        ['h264', validate_string],
     'animation.bitrate':      [-1, validate_int],
     # Controls image format when frames are written to disk
     'animation.frame_format': ['png', validate_movie_frame_fmt],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -408,9 +408,8 @@ validate_colorlist = _listify_validator(validate_color, allow_stringlist=True)
 validate_colorlist.__doc__ = 'return a list of colorspecs'
 
 def validate_string(s):
-    if isinstance(s, str):  # Always leave str as str
-        return s
-    elif isinstance(s, six.text_type):
+    if isinstance(s, (str, six.text_type)):
+        # Always leave str as str and unicode as unicode
         return s
     else:
         return str(s)

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -2,8 +2,7 @@
 Provides a collection of utilities for comparing (image) results.
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/__init__.py
+++ b/lib/matplotlib/tests/__init__.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from matplotlib.testing.conftest import (mpl_test_settings,
                                          mpl_image_comparison_parameters,

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 from six import BytesIO
 
 import matplotlib.afm as afm
@@ -34,7 +33,7 @@ EndFontMetrics
 def test_nonascii_str():
     # This tests that we also decode bytes as utf-8 properly.
     # Else, font files with non ascii characters fail to load.
-    inp_str = "привет"
+    inp_str = u"привет"
     byte_str = inp_str.encode("utf8")
 
     ret = afm._to_str(byte_str)

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import io
 

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import io
 import warnings

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from six.moves import xrange

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 
@@ -35,7 +34,7 @@ def test_use14corefonts():
     rcParams['font.sans-serif'] = ['Helvetica']
     rcParams['pdf.compression'] = 0
 
-    text = '''A three-line text positioned just above a blue line
+    text = u'''A three-line text positioned just above a blue line
 and containing some French characters and the euro symbol:
 "Merci pépé pour les 10 €"'''
 

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import os
 import shutil
@@ -71,7 +70,7 @@ def create_figure():
 
     # text and typesetting
     plt.plot([0.9], [0.5], "ro", markersize=3)
-    plt.text(0.9, 0.5, 'unicode (ü, °, µ) and math ($\\mu_i = x_i^2$)',
+    plt.text(0.9, 0.5, u'unicode (ü, °, µ) and math ($\\mu_i = x_i^2$)',
              ha='right', fontsize=20)
     plt.ylabel('sans-serif, blue, $\\frac{\\sqrt{x}}{y^2}$..',
                family='sans-serif', color='blue')

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import io
 import re
@@ -59,7 +58,7 @@ def test_savefig_to_stringio(format, use_log, rcParams):
         ax.set_yscale('log')
 
     ax.plot([1, 2], [1, 2])
-    ax.set_title("Déjà vu")
+    ax.set_title(u"Déjà vu")
     for buffer in buffers:
         fig.savefig(buffer, format=format)
 

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from matplotlib import pyplot as plt
 from matplotlib._pylab_helpers import Gcf

--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import copy
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 import sys

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Catch all for categorical functions"""
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import pytest
 import numpy as np
@@ -14,7 +13,7 @@ import unittest
 
 class TestUnitData(object):
     testdata = [("hello world", ["hello world"], [0]),
-                ("Здравствуйте мир", ["Здравствуйте мир"], [0]),
+                (u"Здравствуйте мир", [u"Здравствуйте мир"], [0]),
                 (['A', 'A', np.nan, 'B', -np.inf, 3.14, np.inf],
                  ['-inf', '3.14', 'A', 'B', 'inf', 'nan'],
                  [-3.0, 0, 1, 2, -2.0, -1.0])]
@@ -63,7 +62,7 @@ class TestStrCategoryConverter(object):
     ref: /pandas/tseries/tests/test_converter.py
          /pandas/tests/test_algos.py:TestFactorize
     """
-    testdata = [("Здравствуйте мир", [("Здравствуйте мир", 42)], 42),
+    testdata = [(u"Здравствуйте мир", [(u"Здравствуйте мир", 42)], 42),
                 ("hello world", [("hello world", 42)], 42),
                 (['a', 'b', 'b', 'a', 'a', 'c', 'c', 'c'],
                  [('a', 0), ('b', 1), ('c', 2)],
@@ -163,7 +162,7 @@ class TestPlot(object):
         assert axis.unit_data.seq == unit_data.seq
 
     def test_plot_unicode(self):
-        words = ['Здравствуйте', 'привет']
+        words = [u'Здравствуйте', u'привет']
         locs = [0.0, 1.0]
         unit_data = MockUnitData(zip(words, locs))
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 import itertools
 import pickle
 from weakref import ref

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1,8 +1,7 @@
 """
 Tests specific to the collections module.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import io
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pytest

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import copy
 import six

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_container.py
+++ b/lib/matplotlib/tests/test_container.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import datetime
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from six.moves import map
 

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from matplotlib.testing.decorators import skip_if_command_unavailable

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 try:
     # mock in python 3.3+
@@ -89,7 +88,7 @@ def test_various_labels():
     fig = plt.figure()
     ax = fig.add_subplot(121)
     ax.plot(np.arange(4), 'o', label=1)
-    ax.plot(np.linspace(4, 4.1), 'o', label='D\xe9velopp\xe9s')
+    ax.plot(np.linspace(4, 4.1), 'o', label=u'D\xe9velopp\xe9s')
     ax.plot(np.arange(4, 1, -1), 'o', label='__nolegend__')
     ax.legend(numpoints=1, loc=0)
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -1,8 +1,7 @@
 """
 Tests specific to the lines module.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import itertools
 import matplotlib.lines as mlines

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -1,8 +1,7 @@
 """
 Tests specific to the patches module.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 import copy
 
 import numpy as np

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pytest

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from six.moves import cPickle as pickle
 from six.moves import range

--- a/lib/matplotlib/tests/test_png.py
+++ b/lib/matplotlib/tests/test_png.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from six import BytesIO

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 
@@ -74,8 +73,7 @@ def test_RcParams_class():
                        'font.weight': 'normal',
                        'font.size': 12})
 
-    if six.PY3:
-        expected_repr = """
+    expected_repr = """
 RcParams({'font.cursive': ['Apple Chancery',
                            'Textile',
                            'Zapf Chancery',
@@ -83,28 +81,12 @@ RcParams({'font.cursive': ['Apple Chancery',
           'font.family': ['sans-serif'],
           'font.size': 12.0,
           'font.weight': 'normal'})""".lstrip()
-    else:
-        expected_repr = """
-RcParams({u'font.cursive': [u'Apple Chancery',
-                            u'Textile',
-                            u'Zapf Chancery',
-                            u'cursive'],
-          u'font.family': [u'sans-serif'],
-          u'font.size': 12.0,
-          u'font.weight': u'normal'})""".lstrip()
 
     assert expected_repr == repr(rc)
 
-    if six.PY3:
-        expected_str = """
+    expected_str = """
 font.cursive: ['Apple Chancery', 'Textile', 'Zapf Chancery', 'cursive']
 font.family: ['sans-serif']
-font.size: 12.0
-font.weight: normal""".lstrip()
-    else:
-        expected_str = """
-font.cursive: [u'Apple Chancery', u'Textile', u'Zapf Chancery', u'cursive']
-font.family: [u'sans-serif']
 font.size: 12.0
 font.weight: normal""".lstrip()
 

--- a/lib/matplotlib/tests/test_sankey.py
+++ b/lib/matplotlib/tests/test_sankey.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from matplotlib.sankey import Sankey
 

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import io
 

--- a/lib/matplotlib/tests/test_skew.py
+++ b/lib/matplotlib/tests/test_skew.py
@@ -1,8 +1,7 @@
 """
 Testing that skewed axes properly work
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import itertools
 

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import os
 import shutil

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import warnings
 

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import matplotlib.pyplot as plt
 from matplotlib.texmanager import TexManager

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from numpy.testing import assert_almost_equal
 import numpy as np
@@ -579,7 +578,7 @@ class TestEngFormatter(object):
         (-0.0, ('0', '0', '0.00')),
         (-0, ('0', '0', '0.00')),
         (0, ('0', '0', '0.00')),
-        (1.23456789e-6, ('1.23457 \u03bc', '1 \u03bc', '1.23 \u03bc')),
+        (1.23456789e-6, (u'1.23457 \u03bc', u'1 \u03bc', u'1.23 \u03bc')),
         (0.123456789, ('123.457 m', '123 m', '123.46 m')),
         (0.1, ('100 m', '100 m', '100.00 m')),
         (1, ('1', '1', '1.00')),

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 import warnings

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from six.moves import zip
 

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/tests/test_ttconv.py
+++ b/lib/matplotlib/tests/test_ttconv.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import pytest
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 try:
     # mock in python 3.3+

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -33,8 +33,7 @@ your script::
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1,8 +1,7 @@
 """
 Classes for including text in a figure.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 from six.moves import zip

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -1,5 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import six
 


### PR DESCRIPTION
## PR Summary

This provides a minimal fix to the issue I described in #10017.  This does not attempt to go through and remove *all* instances of `unicode_literals`, which would be rash.  Instead it just removes it from `matplotlib.__init__` in order to fix the problem with directories containing non-ASCII characters as I described in the issue.  It also removes `unicode_literals` from most test modules, opting instead to use unicode literals only for specific strings that contain non-ASCII characters.  Finally, it fixes a handful of other modules that were then necessary to update in order for the tests to pass.

With these changes the test suite passed for me on Linux (minus some tests that were skipped due to not having the prerequisites, so this is something that would still need to be checked) on Python 2 and 3, and with home directories that both do or do not contain non-ASCII characters.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way