### PR TITLE
Add missing decode() in svg font embedding path.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1146,10 +1146,10 @@ end"""
         # You are lost in a maze of TrueType tables, all different...
         sfnt = font.get_sfnt()
         try:
-            ps_name = sfnt[(1, 0, 0, 6)].decode('macroman')  # Macintosh scheme
+            ps_name = sfnt[1, 0, 0, 6].decode('mac_roman')  # Macintosh scheme
         except KeyError:
             # Microsoft scheme:
-            ps_name = sfnt[(3, 1, 0x0409, 6)].decode('utf-16be')
+            ps_name = sfnt[3, 1, 0x0409, 6].decode('utf-16be')
             # (see freetype/ttnameid.h)
         ps_name = ps_name.encode('ascii', 'replace')
         ps_name = Name(ps_name)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -696,10 +696,9 @@ grestore
             self.set_color(*gc.get_rgb())
             sfnt = font.get_sfnt()
             try:
-                ps_name = sfnt[(1,0,0,6)].decode('macroman')
+                ps_name = sfnt[1, 0, 0, 6].decode('mac_roman')
             except KeyError:
-                ps_name = sfnt[(3,1,0x0409,6)].decode(
-                    'utf-16be')
+                ps_name = sfnt[3, 1, 0x0409, 6].decode('utf-16be')
             ps_name = ps_name.encode('ascii', 'replace').decode('ascii')
             self.set_font(ps_name, prop.get_size_in_points())
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -506,7 +506,7 @@ class RendererSVG(RendererBase):
             font = get_font(font_fname)
             font.set_size(72, 72)
             sfnt = font.get_sfnt()
-            writer.start('font', id=sfnt[(1, 0, 0, 4)])
+            writer.start('font', id=sfnt[1, 0, 0, 4].decode("macroman"))
             writer.element(
                 'font-face',
                 attrib={

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -506,7 +506,7 @@ class RendererSVG(RendererBase):
             font = get_font(font_fname)
             font.set_size(72, 72)
             sfnt = font.get_sfnt()
-            writer.start('font', id=sfnt[1, 0, 0, 4].decode("macroman"))
+            writer.start('font', id=sfnt[1, 0, 0, 4].decode("mac_roman"))
             writer.element(
                 'font-face',
                 attrib={

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -411,11 +411,11 @@ def ttfFontProperty(font):
     sfnt2 = sfnt.get((1,0,0,2))
     sfnt4 = sfnt.get((1,0,0,4))
     if sfnt2:
-        sfnt2 = sfnt2.decode('macroman').lower()
+        sfnt2 = sfnt2.decode('mac_roman').lower()
     else:
         sfnt2 = ''
     if sfnt4:
-        sfnt4 = sfnt4.decode('macroman').lower()
+        sfnt4 = sfnt4.decode('mac_roman').lower()
     else:
         sfnt4 = ''
     if sfnt4.find('oblique') >= 0:

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -67,9 +67,9 @@ class TextToPath(object):
         """
         sfnt = font.get_sfnt()
         try:
-            ps_name = sfnt[(1, 0, 0, 6)].decode('macroman')
+            ps_name = sfnt[1, 0, 0, 6].decode('mac_roman')
         except KeyError:
-            ps_name = sfnt[(3, 1, 0x0409, 6)].decode('utf-16be')
+            ps_name = sfnt[3, 1, 0x0409, 6].decode('utf-16be')
         char_id = urllib_quote('%s-%x' % (ps_name, ccode))
         return char_id
 


### PR DESCRIPTION
Otherwise,

    rcParams["svg.fonttype"] = "svgfont"; title("foo"); savefig("/tmp/test.svg")

fails (on Py3) with

      File ".../backend_svg.py", line 86, in escape_attrib
        s = s.replace("&", "&amp;")
    TypeError: a bytes-like object is required, not 'str'

The encoding of entry 1, 0, 0, 4 in the sfnt table is macroman
(https://www.freetype.org/freetype2/docs/reference/ft2-truetype_tables.html#TT_MAC_ID_XXX).

Note that after the fix is applied, the resulting svg file still appears
to be unopenable by inkscape, so the fix is not complete, but hopefully
a step in the correct direction.

---

Of course, this suggests that the svg.fonttype = svgfont codepath is untested, which is another problem :p

In practice it appears that the svg font standard isn't that popular or well supported, see https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/SVG_fonts.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
