### PR TITLE
Fix imsave output format when format keyword is None

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1351,9 +1351,9 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
     from matplotlib.figure import Figure
 
     # Fast path for saving to PNG
-    if (format == 'png' or format is None or
-            isinstance(fname, six.string_types) and
-            fname.lower().endswith('.png')):
+    if (format == 'png' or (format is None and
+                            isinstance(fname, six.string_types) and
+                            fname.lower().endswith('.png'))):
         image = AxesImage(None, cmap=cmap, origin=origin)
         image.set_data(arr)
         image.set_clim(vmin, vmax)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -176,6 +176,16 @@ def test_imsave_color_alpha():
 
         assert_array_equal(data, arr_buf)
 
+def test_imsave_format(tmpdir):
+    # Test imsave output format based on the input filename
+    # (i.e. when the "format" keyword is None).
+    import imghdr
+
+    filename = str(tmpdir.join('test_imsave.jpg'))
+    plt.imsave(filename, np.zeros((10, 10)))
+
+    assert imghdr.what(filename) == 'jpeg'
+
 @image_comparison(baseline_images=['image_alpha'], remove_text=True)
 def test_image_alpha():
     plt.figure()

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -179,12 +179,13 @@ def test_imsave_color_alpha():
 def test_imsave_format(tmpdir):
     # Test imsave output format based on the input filename
     # (i.e. when the "format" keyword is None).
-    import imghdr
 
-    filename = str(tmpdir.join('test_imsave.jpg'))
+    filename = str(tmpdir.join('test_imsave.svg'))
     plt.imsave(filename, np.zeros((10, 10)))
 
-    assert imghdr.what(filename) == 'jpeg'
+    lines = open(filename).readlines()
+    assert lines[0].startswith('<?xml')
+    assert lines[1].startswith('<!DOCTYPE svg')
 
 @image_comparison(baseline_images=['image_alpha'], remove_text=True)
 def test_image_alpha():


### PR DESCRIPTION
## PR Summary

Calling `imsave` without explicitly setting the `format` keyword (default=`None`) is supposed to determine the format of the output file from the output filename extension.  Currently, if format is not specified (i.e. `None`), `imsave` always saves a  PNG (despite the output filename):

```python
>>> import imghdr
>>> import matplotlib.pyplot as plt

>>> fn = 'imsave_test.jpg'
>>> plt.imsave(fn, np.zeros((10, 10)))
>>> imghdr.what(fn)    # should return 'jpeg'
'png'
```

This PR fixes this issue.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
