### PR TITLE
Use consistent float-to-str formatting for tests with units

### DIFF
--- a/lib/matplotlib/testing/jpl_units/UnitDblFormatter.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDblFormatter.py
@@ -36,12 +36,12 @@ class UnitDblFormatter( ticker.ScalarFormatter ):
       if len(self.locs) == 0:
          return ''
       else:
-         return str(x)
+         return '{:.12}'.format(x)
 
    def format_data_short( self, value ):
       "Return the value formatted in 'short' format."
-      return str(value)
+      return '{:.12}'.format(value)
 
    def format_data( self, value ):
       "Return the value formatted into a string."
-      return str(value)
+      return '{:.12}'.format(value)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -631,8 +631,8 @@ def test_polar_units():
     units.register()
 
     pi = np.pi
-    deg = units.UnitDbl(1.0, "deg")
-    km = units.UnitDbl(1.0, "km")
+    deg = units.deg
+    km = units.km
 
     x1 = [pi/6.0, pi/4.0, pi/3.0, pi/2.0]
     x2 = [30.0*deg, 45.0*deg, 60.0*deg, 90.0*deg]


### PR DESCRIPTION
## PR Summary

Adding explicit formatting should ensure that the resulting image is always the same. At the very least, this seems to affect Python 2 on Fedora Rawhide (which is a bit odd, TBH, since Py2 is tested on Travis) and _hopefully_ fixes nightly builds too.

## PR Checklist

- [x] Has Pytest style unit tests
- [mostly] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
