### PR TITLE
Support userdefined dot size for short lengths

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -457,6 +457,7 @@ class Quiver(mcollections.PolyCollection):
         self.angles = kw.pop('angles', 'uv')
         self.width = kw.pop('width', None)
         self.color = kw.pop('color', 'k')
+        self.dotsize = kw.pop('dotsize', 0.5)
 
         pivot = kw.pop('pivot', 'tail').lower()
         # validate pivot
@@ -734,8 +735,8 @@ class Quiver(mcollections.PolyCollection):
         if tooshort.any():
             # Use a heptagonal dot:
             th = np.arange(0, 8, 1, np.float64) * (np.pi / 3.0)
-            x1 = np.cos(th) * self.minlength * 0.5
-            y1 = np.sin(th) * self.minlength * 0.5
+            x1 = np.cos(th) * self.minlength * self.dotsize
+            y1 = np.sin(th) * self.minlength * self.dotsize
             X1 = np.repeat(x1[np.newaxis, :], N, axis=0)
             Y1 = np.repeat(y1[np.newaxis, :], N, axis=0)
             tooshort = np.repeat(tooshort, 8, 1)


### PR DESCRIPTION
Add key 'dotsize' to control size of dots used for too short arrows. 

## PR Summary

Sometimes the size of the dots, which are used when arrows are very short, can be tiny and hard to see. The size of the dots is hardcoded. This update adds a new key 'dotsize' with a default value the same as the old hardcoded value (0.5), to ensure backwards compatibility.

## PR Checklist

Changes are very minor (one new line, two modified slightly).

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
