### PR TITLE
Documentation mistake in pyplot.py corrected

### DIFF
--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -267,7 +267,7 @@ plt.show()
 # ``figure(1)`` will be created by default, just as a ``subplot(111)``
 # will be created by default if you don't manually specify any axes.  The
 # :func:`~matplotlib.pyplot.subplot` command specifies ``numrows,
-# numcols, fignum`` where ``fignum`` ranges from 1 to
+# numcols, plot_number`` where ``plot_number`` ranges from 1 to
 # ``numrows*numcols``.  The commas in the ``subplot`` command are
 # optional if ``numrows*numcols<10``.  So ``subplot(211)`` is identical
 # to ``subplot(2, 1, 1)``.


### PR DESCRIPTION
Issue #10037 

## PR summary
I have corrected the documentation mistake in pyplot introductory tutorial

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
