### PR TITLE
FIX: remove repeated label legend logic

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -10,6 +10,29 @@ out what caused the breakage and how to fix it by updating your code.
 For new features that were added to Matplotlib, please see
 :ref:`whats-new`.
 
+API Changes in 2.1.2
+====================
+
+`Figure.legend` no longer checks for repeated lines to ignore
+-------------------------------------------------------------
+
+`matplotlib.Figure.legend` used to check if a line had the
+same label as an existing legend entry. If it also had the same line color
+or marker color legend didn't add a new entry for that line. However, the
+list of conditions was incomplete, didn't handle RGB tupples,
+didn't handle linewidths or linestyles etc.
+
+This logic did not exist in `Axes.legend`.  It was included (erroneously)
+in Matplotlib 2.1.1 when the legend argument parsing was unified
+[#9324](https://github.com/matplotlib/matplotlib/pull/9324).  This change
+removes that check in `Axes.legend` again to restore the old behavior.
+
+This logic has also been dropped from `.Figure.legend`, where it
+was previously undocumented. Repeated
+lines with the same label will now each have an entry in the legend.  If
+you do not want the duplicate entries, don't add a label to the line, or
+prepend the label with an underscore.
+
 API Changes in 2.1.1
 ====================
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1346,43 +1346,9 @@ def _get_legend_handles_labels(axs, legend_handler_map=None):
     handles = []
     labels = []
 
-    def _in_handles(h, l):
-        # Method to check if we already have a given handle and label.
-        # Consider two handles to be the same if they share a label,
-        # color, facecolor, and edgecolor.
-
-        # Loop through each handle and label already collected
-        for f_h, f_l in zip(handles, labels):
-            if f_l != l:
-                continue
-            if type(f_h) != type(h):
-                continue
-            try:
-                if (colors.to_rgba_array(f_h.get_color()) !=
-                        colors.to_rgba_array(h.get_color())).any():
-                    continue
-            except AttributeError:
-                pass
-            try:
-                if (colors.to_rgba_array(f_h.get_facecolor()) !=
-                        colors.to_rgba_array(h.get_facecolor())).any():
-                    continue
-            except AttributeError:
-                pass
-            try:
-                if (colors.to_rgba_array(f_h.get_edgecolor()) !=
-                        colors.to_rgba_array(h.get_edgecolor())).any():
-                    continue
-            except AttributeError:
-                pass
-            return True
-        return False
-
     for handle in _get_legend_handles(axs, legend_handler_map):
         label = handle.get_label()
-        if (label and
-                not label.startswith('_') and
-                not _in_handles(handle, label)):
+        if (label and not label.startswith('_')):
             handles.append(handle)
             labels.append(label)
     return handles, labels

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -90,7 +90,7 @@ def test_figure_legend():
     axes[0].plot([0, 1], [0, 1], label='y', color='r')
     axes[0].plot([0, 1], [0.5, 0.5], label='y', color='k')
 
-    axes[1].plot([0, 1], [1, 0], label='y', color='r')
+    axes[1].plot([0, 1], [1, 0], label='_y', color='r')
     axes[1].plot([0, 1], [0, 1], label='z', color='b')
     fig.legend()
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -16,6 +16,7 @@ import matplotlib as mpl
 import matplotlib.transforms as mtransforms
 import matplotlib.collections as mcollections
 from matplotlib.legend_handler import HandlerTuple
+import matplotlib.legend as mlegend
 import inspect
 
 
@@ -421,6 +422,21 @@ def test_nanscatter():
 
     ax.legend()
     ax.grid(True)
+
+
+def test_legend_repeatcheckok():
+    fig, ax = plt.subplots()
+    ax.scatter(0.0, 1.0, color='k', marker='o', label='test')
+    ax.scatter(0.5, 0.0, color='r', marker='v', label='test')
+    hl = ax.legend()
+    hand, lab = mlegend._get_legend_handles_labels([ax])
+    assert len(lab) == 2
+    fig, ax = plt.subplots()
+    ax.scatter(0.0, 1.0, color='k', marker='o', label='test')
+    ax.scatter(0.5, 0.0, color='k', marker='v', label='test')
+    hl = ax.legend()
+    hand, lab = mlegend._get_legend_handles_labels([ax])
+    assert len(lab) == 2
 
 
 @image_comparison(baseline_images=['not_covering_scatter'], extensions=['png'])


### PR DESCRIPTION
## PR Summary

Fixes #10030, #10053, #10056.  

Pre #9324, there was logic in `Figure.legend()` to not include duplicate labels in the legend if the linecolors or marker colors were the same.  That logic was buggy, and didn't include all possible line properties, but presumably users of `Figure.legend()` worked around this. 

In #9324, I homogenized the logic between `Figure.legend()` and `Axes.legend()`. I still think that re-factoring was a good thing to do, but I missed that `Axes.legend()` didn't have the no-duplicate logic in it.   That exposed the bugs noted above.  

This PR, goes the other way of making `Figure.legend()` the same as pre-9324 `Axes.legend()` and *not* removing the duplicate legend entries.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->