### PR TITLE
Add version to documentation header

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -172,9 +172,13 @@ parents[-1].link|e }}" />
 {%- endif %}
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px; position: relative;">
 {%- if builder in ('htmlhelp', 'devhelp', 'latex') %}
-<a href="{{ pathto('index') }}"><img src="{{pathto("_static/logo2.png", 1) }}" width="540px" border="0" alt="matplotlib"/></a>
+<a href="{{ pathto('index') }}">
+    <div style="float: left; position: absolute; width: 496px; bottom: 0; padding-bottom: 24px"><span style="float: right; color: #789; background: white">Version {{ version|e }}</span></div>
+    <img src="{{pathto("_static/logo2.png", 1) }}" height="125px" border="0" alt="matplotlib"/></a>
 {%- else %}
-<a href="{{ pathto('index') }}"><img src="{{pathto("_static/logo2.svg", 1) }}" width="540px" border="0" alt="matplotlib"/></a>
+<a href="{{ pathto('index') }}">
+    <div style="float: left; position: absolute; width: 496px; bottom: 0; padding-bottom: 24px"><span style="float: right; color: #789; background: white">Version {{ version|e }}</span></div>
+    <img src="{{pathto("_static/logo2.png", 1) }}" height="125px" border="0" alt="matplotlib"/></a>
 {%- endif %}
 
 <!-- The "Fork me on github" ribbon -->


### PR DESCRIPTION
## PR Summary

### Version number

This adds a version number to the header section of the documentation. The motivation is to make it always obvious, which version of the documentation one is using:

![grafik](https://user-images.githubusercontent.com/2836374/34234834-f5a40472-e5ed-11e7-98ac-df2a96322c37.png)


### Minor header height correction

While working on this, I realized that the header is probably slightly higher than intended (compare the white pixels below the github badge in the current docs).

![grafik](https://user-images.githubusercontent.com/2836374/34234944-a0494edc-e5ee-11e7-966c-650920d978d2.png)

The reason was a fixed-width logo, which takes slightly too much height (129px instead of 125px). I've changed this for a fixed height. As a result, the logo is slightly smaller, but I assume this is the actually desired layout.