### PR TITLE
Prefer vendored qhull if sys-wide version can't be determined.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1033,7 +1033,7 @@ class LibAgg(SetupPackage):
         if self.found_external:
             pkg_config.setup_extension(ext, 'libagg')
         else:
-            ext.include_dirs.append('extern/agg24-svn/include')
+            ext.include_dirs.insert(0, 'extern/agg24-svn/include')
             if add_sources:
                 agg_sources = [
                     'agg_bezier_arc.cpp',
@@ -1348,23 +1348,15 @@ class Qhull(SetupPackage):
                 'libqhull', 'libqhull/qhull_a.h', min_version='2015.2')
         except CheckFailed as e:
             self.__class__.found_pkgconfig = False
-            # Qhull may not be in the pkg-config system but may still be
-            # present on this system, so check if the header files can be
-            # found.
-            include_dirs = [
-                os.path.join(x, 'libqhull') for x in get_include_dirs()]
-            if has_include_file(include_dirs, 'qhull_a.h'):
-                return 'Using system Qhull (version unknown, no pkg-config info)'
-            else:
-                self.__class__.found_external = False
-                return str(e) + ' Using local copy.'
+            self.__class__.found_external = False
+            return str(e) + ' Using local copy.'
 
     def add_flags(self, ext):
         if self.found_external:
             pkg_config.setup_extension(ext, 'qhull',
                                        default_libraries=['qhull'])
         else:
-            ext.include_dirs.append('extern')
+            ext.include_dirs.insert(0, 'extern')
             ext.sources.extend(sorted(glob.glob('extern/libqhull/*.c')))
 
 
@@ -1380,7 +1372,7 @@ class TTConv(SetupPackage):
             ]
         ext = make_extension('matplotlib.ttconv', sources)
         Numpy().add_flags(ext)
-        ext.include_dirs.append('extern')
+        ext.include_dirs.insert(0, 'extern')
         return ext
 
 
@@ -1536,7 +1528,7 @@ class BackendTkAgg(OptionalBackendPackage):
         return ext
 
     def add_flags(self, ext):
-        ext.include_dirs.extend(['src'])
+        ext.include_dirs.insert(0, 'src')
         if sys.platform == 'win32':
             # PSAPI library needed for finding Tcl / Tk at run time
             ext.libraries.extend(['psapi'])


### PR DESCRIPTION
1. When qhull is available system-wide but its version cannot be
determined, ignore it (there is no guarantee that it will, in fact,
work) and fallback to the vendored version.
2. When adding header paths to vendored libraries, prepend the paths to
give them higher priority than /usr/{,local/}include.  (In reality we
should just not add the system /usr/{,local/}include paths to the
compiler invocations at all, but that's a more complicated patch.

Closes #8390, closes #8872; partial fix for #9737 (though not actually sufficient for the issue described in #9737).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
