### PR TITLE
Move missing font message to debug level

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1331,7 +1331,7 @@ class FontManager(object):
                     UserWarning)
                 result = self.defaultFont[fontext]
         else:
-            _log.info(
+            _log.debug(
                 'findfont: Matching %s to %s (%s) with score of %f' %
                 (prop, best_font.name, repr(best_font.fname), best_score))
             result = best_font.fname


### PR DESCRIPTION
Currently building the docs (locally and on circleci) results in lots of annoying findfont messages that are like
```
findfont: Matching :family=STIXGeneral:style=normal:variant=normal:weight=bold:stretch=normal:size=10.0 to STIXGeneral ('/home/circleci/project/lib/matplotlib/mpl-data/fonts/ttf/STIXGeneralBol.ttf') with score of 0.000000
```

This PR gets rid of them by changing the log level from 'info' to 'debug'.