### PR TITLE
Deprecate passing strings instead of booleans to control tick state (and other states).

### DIFF
--- a/doc/api/api_changes/171225-AL-tickbools.rst
+++ b/doc/api/api_changes/171225-AL-tickbools.rst
@@ -1,0 +1,7 @@
+Using strings instead of booleans to control grid and tick visibility is deprecated
+```````````````````````````````````````````````````````````````````````````````````
+
+Using ``"on"``, ``"off"``, ``"true"``, or ``"false"`` to control grid
+and tick visibility has been deprecated.  Instead, use normal booleans
+(``True``/``False``) or boolean-likes.  In the future, all non-empty strings
+may be interpreted as ``True``.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2645,8 +2645,7 @@ class _AxesBase(martist.Artist):
         """
         Turn the axes grids on or off.
 
-        Set the axes grids on or off; *b* is a boolean.  (For MATLAB
-        compatibility, *b* may also be a string, 'on' or 'off'.)
+        Set the axes grids on or off; *b* is a boolean.
 
         If *b* is *None* and ``len(kwargs)==0``, toggle the grid state.  If
         *kwargs* are supplied, it is assumed that you want a grid and *b*
@@ -2861,12 +2860,11 @@ class _AxesBase(martist.Artist):
         zorder : float
             Tick and label zorder.
 
-        bottom, top, left, right : bool or  {'on', 'off'}
-            controls whether to draw the respective ticks.
+        bottom, top, left, right : bool
+            Whether to draw the respective ticks.
 
-        labelbottom, labeltop, labelleft, labelright : bool or  {'on', 'off'}
-            controls whether to draw the
-            respective tick labels.
+        labelbottom, labeltop, labelleft, labelright : bool
+            Whether to draw the respective tick labels.
 
         labelrotation : float
             Tick label rotation

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -623,6 +623,9 @@ def _string_to_bool(s):
     """Parses the string argument as a boolean"""
     if not isinstance(s, six.string_types):
         return bool(s)
+    warn_deprecated("2.2", "Passing one of 'on', 'true', 'off', 'false' as a "
+                    "boolean is deprecated; use an actual boolean "
+                    "(True/False) instead.")
     if s.lower() in ['on', 'true']:
         return True
     if s.lower() in ['off', 'false']:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1372,10 +1372,12 @@ def tight_layout(pad=1.08, h_pad=None, w_pad=None, rect=None):
 
 def box(on=None):
     """
-    Turn the axes box on or off.  *on* may be a boolean or a string,
-    'on' or 'off'.
+    Turn the axes box on or off.
 
-    If *on* is *None*, toggle state.
+    Parameters
+    ----------
+    on : bool or None
+        The new axes box state.  If ``None``, toggle the state.
     """
     ax = gca()
     on = _string_to_bool(on)


### PR DESCRIPTION
Passing "off" or "false" to mean False is so MATLAB like...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
