### PR TITLE
Fix stay_span to reset onclick in SpanSelector.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1820,6 +1820,8 @@ class SpanSelector(_SelectorWidget):
             self.pressv = xdata
         else:
             self.pressv = ydata
+
+        self._set_span_xy(event)
         return False
 
     def _release(self, event):
@@ -1858,6 +1860,26 @@ class SpanSelector(_SelectorWidget):
         """on motion notify event"""
         if self.pressv is None:
             return
+
+        self._set_span_xy(event)
+
+        if self.onmove_callback is not None:
+            vmin = self.pressv
+            xdata, ydata = self._get_data(event)
+            if self.direction == 'horizontal':
+                vmax = xdata or self.prev[0]
+            else:
+                vmax = ydata or self.prev[1]
+
+            if vmin > vmax:
+                vmin, vmax = vmax, vmin
+            self.onmove_callback(vmin, vmax)
+
+        self.update()
+        return False
+
+    def _set_span_xy(self, event):
+        """Setting the span coordinates"""
         x, y = self._get_data(event)
         if x is None:
             return
@@ -1877,21 +1899,6 @@ class SpanSelector(_SelectorWidget):
         else:
             self.rect.set_y(minv)
             self.rect.set_height(maxv - minv)
-
-        if self.onmove_callback is not None:
-            vmin = self.pressv
-            xdata, ydata = self._get_data(event)
-            if self.direction == 'horizontal':
-                vmax = xdata or self.prev[0]
-            else:
-                vmax = ydata or self.prev[1]
-
-            if vmin > vmax:
-                vmin, vmax = vmax, vmin
-            self.onmove_callback(vmin, vmax)
-
-        self.update()
-        return False
 
 
 class ToolHandles(object):


### PR DESCRIPTION
## PR Summary
`SpanSelector` with the option span_stay will leave the span on the plot. However, when a button is pressed without moving the min max value is equal but the span stays the same. This PR reset the span coordinates in onpress event.

```
from pylab import *
from matplotlib.widgets import SpanSelector

x = arange(100)/(99.0)
y = sin(x)
fig = figure
ax = subplot(111)
ax.plot(x,y)

span = SpanSelector(ax, print, useblit=True,
                    direction="horizontal", span_stays=True)
show()
```
 
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
