### PR TITLE
Add set_data_3d and get_data_3d to Line3d

### DIFF
--- a/doc/users/next_whats_new/2018_01_02_line3d_get_set_data.rst
+++ b/doc/users/next_whats_new/2018_01_02_line3d_get_set_data.rst
@@ -1,0 +1,7 @@
+mplot3d Line3D now allows {set,get}_data_3d
+-------------------------------------------
+
+Lines created with the 3d projection in mplot3d can now access the data using
+``mplot3d.art3d.Line3D.get_data_3d()`` which returns a tuple of array_likes containing
+the (x, y, z) data. The equivalent ``mplot3d.art3d.Line3D.set_data_3d(x, y, z)``
+can be used to modify the data of an existing Line3D.

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -172,6 +172,7 @@ class Line3D(lines.Line2D):
             self._verts3d = args[0]
         else:
             self._verts3d = args
+        self.stale = True
 
     def get_data_3d(self):
         """

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -166,6 +166,12 @@ class Line3D(lines.Line2D):
         self.set_ydata(y)
         self.set_3d_properties(zs=z)
 
+    def get_data_3d(self):
+        """
+        Return the xdata, ydata, zdata.
+        """
+        return self._verts3d
+
     @artist.allow_rasterization
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -155,20 +155,32 @@ class Line3D(lines.Line2D):
         """
         Set the x, y and z data
 
-        ACCEPTS: 3D array (rows are x, y, z) or three 1D arrays
+        Parameters
+        ----------
+        x : array_like
+            The x-data to be plotted
+        y : array_like
+            The y-data to be plotted
+        z : array_like
+            The z-data to be plotted
+
+        Notes
+        -----
+        Accepts x, y, z arguments or a single array_like (x, y, z)
         """
         if len(args) == 1:
-            x, y, z = args[0]
+            self._verts3d = args[0]
         else:
-            x, y, z = args
-
-        self.set_xdata(x)
-        self.set_ydata(y)
-        self.set_3d_properties(zs=z)
+            self._verts3d = args
 
     def get_data_3d(self):
         """
-        Return the xdata, ydata, zdata.
+        Get the current data
+
+        Returns
+        -------
+        verts3d : length-3 tuple or array_likes
+            The current data as a tuple or array_likes
         """
         return self._verts3d
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -151,6 +151,21 @@ class Line3D(lines.Line2D):
         self._verts3d = juggle_axes(xs, ys, zs, zdir)
         self.stale = True
 
+    def set_data_3d(self, *args):
+        """
+        Set the x, y and z data
+
+        ACCEPTS: 3D array (rows are x, y, z) or three 1D arrays
+        """
+        if len(args) == 1:
+            x, y, z = args[0]
+        else:
+            x, y, z = args
+
+        self.set_xdata(x)
+        self.set_ydata(y)
+        self.set_3d_properties(zs=z)
+
     @artist.allow_rasterization
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -765,6 +765,18 @@ class TestVoxels(object):
             ax.voxels(filled=filled, x=x, y=y, z=z)
 
 
+def test_line3d_set_get_data_3d():
+    x, y, z = [0, 1], [2, 3], [4, 5]
+    x2, y2, z2 = [6, 7], [8, 9], [10, 11]
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    lines = ax.plot(x, y, z)
+    line = lines[0]
+    np.testing.assert_array_equal((x, y, z), line.get_data_3d())
+    line.set_data_3d(x2, y2, z2)
+    np.testing.assert_array_equal((x2, y2, z2), line.get_data_3d())
+
+
 def test_inverted_cla():
     # Github PR #5450. Setting autoscale should reset
     # axes to be non-inverted.


### PR DESCRIPTION
## PR Summary
Fixes #8914 by adding set_data_3d and get_data_3d methods to Line3D. This allows for setting and getting of 3d data without overriding the widely used set_data and get_data methods. 

```
> from mpl_toolkits.mplot3d import Axes3D
> x = [0, 1]
> y = [0, 1]
> z = [0, 1]
> fig = plt.figure()
> ax = fig.add_subplot(111, projection='3d')
> line = ax.plot(x,y,z)[0]
> line.get_data_3d()
(array([0, 1]), array([0, 1]), array([0, 1]))
> line.set_data_3d([0,2], [0,2], [0,2])
> line.get_data_3d()
([0, 2], [0, 2], [0, 2])
```


I looked for testing and documentation and did not see any testing or documentation related to Line3D would require updating. Please let me know if this is incorrect. 

## PR Checklist

- [x] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
