### PR TITLE
Make errobars work with astropy units

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3013,8 +3013,18 @@ class Axes(_AxesBase):
                 if (len(err) != len(data) or np.size(fe) > 1):
                     raise ValueError("err must be [ scalar | N, Nx1 "
                                      "or 2xN array-like ]")
-            low = data - err
-            high = data + err
+            try:
+                low = data - err
+            except TypeError:
+                # using list comps rather than arrays to preserve units
+                low = [thisx - thiserr for (thisx, thiserr)
+                       in cbook.safezip(data, err)]
+            try:
+                high = data + err
+            except TypeError:
+                # using list comps rather than arrays to preserve units
+                high = [thisx + thiserr for (thisx, thiserr)
+                       in cbook.safezip(data, err)]
             return low, high
 
         if xerr is not None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2972,14 +2972,17 @@ class Axes(_AxesBase):
             """
             assert len(xs) == len(ys)
             assert len(xs) == len(mask)
-            try:
+
+            if isinstance(xs, np.ndarray):
                 xs = xs[mask]
-            except TypeError:
+            else:
                 xs = [thisx for thisx, b in zip(xs, mask) if b]
-            try:
+
+            if isinstance(ys, np.ndarray):
                 ys = ys[mask]
-            except TypeError:
+            else:
                 ys = [thisy for thisy, b in zip(ys, mask) if b]
+
             return xs, ys
 
         def extract_err(err, data):
@@ -3013,18 +3016,18 @@ class Axes(_AxesBase):
                 if (len(err) != len(data) or np.size(fe) > 1):
                     raise ValueError("err must be [ scalar | N, Nx1 "
                                      "or 2xN array-like ]")
-            try:
+            if isinstance(data, np.ndarray):
                 low = data - err
-            except TypeError:
+            else:
                 # using list comps rather than arrays to preserve units
                 low = [thisx - thiserr for (thisx, thiserr)
                        in cbook.safezip(data, err)]
-            try:
+            if isinstance(data, np.ndarray):
                 high = data + err
-            except TypeError:
+            else:
                 # using list comps rather than arrays to preserve units
                 high = [thisx + thiserr for (thisx, thiserr)
-                       in cbook.safezip(data, err)]
+                        in cbook.safezip(data, err)]
             return low, high
 
         if xerr is not None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2965,13 +2965,21 @@ class Axes(_AxesBase):
 
         def xywhere(xs, ys, mask):
             """
-            return xs[mask], ys[mask] where mask is True but xs and
-            ys are not arrays
+            Return xs[mask], ys[mask] where mask is True but xs and
+            ys are not arrays.
+
+            If they are arrays, just return xs[mask] and ys[mask].
             """
             assert len(xs) == len(ys)
             assert len(xs) == len(mask)
-            xs = [thisx for thisx, b in zip(xs, mask) if b]
-            ys = [thisy for thisy, b in zip(ys, mask) if b]
+            try:
+                xs = xs[mask]
+            except TypeError:
+                xs = [thisx for thisx, b in zip(xs, mask) if b]
+            try:
+                ys = ys[mask]
+            except TypeError:
+                ys = [thisy for thisy, b in zip(ys, mask) if b]
             return xs, ys
 
         def extract_err(err, data):
@@ -3005,11 +3013,8 @@ class Axes(_AxesBase):
                 if (len(err) != len(data) or np.size(fe) > 1):
                     raise ValueError("err must be [ scalar | N, Nx1 "
                                      "or 2xN array-like ]")
-            # using list comps rather than arrays to preserve units
-            low = [thisx - thiserr for (thisx, thiserr)
-                   in cbook.safezip(data, err)]
-            high = [thisx + thiserr for (thisx, thiserr)
-                    in cbook.safezip(data, err)]
+            low = data - err
+            high = data + err
             return low, high
 
         if xerr is not None:


### PR DESCRIPTION
Fixes #8871. The problem was some code was doing list comprehensions, that was returning a list of `Quantity`, which is not an instance of `Quantity`, so the conversions weren't happening properly further down the line.