### PR TITLE
Add legend title size rc parameter

### DIFF
--- a/doc/api/api_changes/2017-12-28-RH.rst
+++ b/doc/api/api_changes/2017-12-28-RH.rst
@@ -1,0 +1,4 @@
+New rcParam for Legend Title Font Size
+``````````````````````````````````````
+
+The introduction of a new rcParam for legend title font size (``legend.titlesize``) deprecates the previous usage of the ``font.size`` rcParam for modification of the legend title font size.

--- a/doc/api/api_changes/2017-12-28-RH.rst
+++ b/doc/api/api_changes/2017-12-28-RH.rst
@@ -1,4 +1,0 @@
-New rcParam for Legend Title Font Size
-``````````````````````````````````````
-
-The introduction of a new rcParam for legend title font size (``legend.titlesize``) replaces the previous usage of the ``font.size`` rcParam for modification of the legend title font size. The default is ``medium`` which is also the default of ``font.size``. Any code which uses ``font.size`` to change the size of the legend title will now need to also modify ``legend.titlesize`` to achieve the same outcome.

--- a/doc/api/api_changes/2017-12-28-RH.rst
+++ b/doc/api/api_changes/2017-12-28-RH.rst
@@ -1,4 +1,4 @@
 New rcParam for Legend Title Font Size
 ``````````````````````````````````````
 
-The introduction of a new rcParam for legend title font size (``legend.titlesize``) deprecates the previous usage of the ``font.size`` rcParam for modification of the legend title font size.
+The introduction of a new rcParam for legend title font size (``legend.titlesize``) replaces the previous usage of the ``font.size`` rcParam for modification of the legend title font size. The default is ``medium`` which is also the default of ``font.size``. Any code which uses ``font.size`` to change the size of the legend title will now need to also modify ``legend.titlesize`` to achieve the same outcome.

--- a/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
+++ b/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
@@ -1,0 +1,6 @@
+Legend Title Size rc parameter
+---------------------
+
+A new rc parameter has been added as an option in your matplotlibrc allowing you to control the font size of the legend title.
+
+`legend.titlesize = 'large'`

--- a/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
+++ b/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
@@ -4,3 +4,8 @@ Legend Title Size rc parameter
 A new rc parameter has been added as an option in your matplotlibrc allowing you to control the font size of the legend title.
 
 `legend.titlesize = 'large'`
+
+.. code-block:: python
+    import matplotlib.rcParams as rcParams
+
+    rcParams['legend.titlesize'] = 'large'

--- a/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
+++ b/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
@@ -1,9 +1,10 @@
 Legend Title Size rc parameter
 ------------------------------
 
-A new rc parameter has been added as an option in your matplotlibrc allowing you to control the font size of the legend title.
+A new rc parameter has been added as an option in matplotlibrc allowing you to explicitly control the font size of the legend title.
+The default option is ``inherit`` which reverts to the previous behavior of inheriting font size from ``font.size``.
 
-`legend.titlesize = 'large'`
+``legend.titlesize = 'large'``
 
 .. code-block:: python
 

--- a/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
+++ b/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
@@ -1,5 +1,5 @@
 Legend Title Size rc parameter
----------------------
+------------------------------
 
 A new rc parameter has been added as an option in your matplotlibrc allowing you to control the font size of the legend title.
 

--- a/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
+++ b/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
@@ -6,6 +6,7 @@ A new rc parameter has been added as an option in your matplotlibrc allowing you
 `legend.titlesize = 'large'`
 
 .. code-block:: python
+
     import matplotlib.rcParams as rcParams
 
     rcParams['legend.titlesize'] = 'large'

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -713,7 +713,10 @@ class Legend(Artist):
             self.get_frame().set_alpha(framealpha)
 
         self._loc = loc
-        self.set_title(title, prop={"size": rcParams["legend.titlesize"]})
+        if rcParams["legend.titlesize"] == 'inherit':
+            self.set_title(title)
+        else:
+            self.set_title(title, prop={"size": rcParams["legend.titlesize"]})
         self._last_fontsize_points = self._fontsize
         self._draggable = None
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -713,7 +713,7 @@ class Legend(Artist):
             self.get_frame().set_alpha(framealpha)
 
         self._loc = loc
-        self.set_title(title)
+        self.set_title(title, prop={"size": rcParams["legend.titlesize"]})
         self._last_fontsize_points = self._fontsize
         self._draggable = None
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -440,6 +440,13 @@ def validate_fontsize(s):
 validate_fontsizelist = _listify_validator(validate_fontsize)
 
 
+def validate_fontsize_or_inherit(s):
+    'return a valid fontsize arg'
+    if s == 'inherit':
+        return s
+    return validate_fontsize(s)
+
+
 def validate_font_properties(s):
     parse_fontconfig_pattern(s)
     return s
@@ -1178,7 +1185,7 @@ defaultParams = {
     # the number of points in the legend line for scatter
     'legend.scatterpoints': [1, validate_int],
     'legend.fontsize': ['medium', validate_fontsize],
-    'legend.titlesize': ['medium', validate_fontsize],
+    'legend.titlesize': ['inherit', validate_fontsize_or_inherit],
      # the relative size of legend markers vs. original
     'legend.markerscale': [1.0, validate_float],
     'legend.shadow': [False, validate_bool],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1178,6 +1178,7 @@ defaultParams = {
     # the number of points in the legend line for scatter
     'legend.scatterpoints': [1, validate_int],
     'legend.fontsize': ['medium', validate_fontsize],
+    'legend.titlesize': ['medium', validate_fontsize],
      # the relative size of legend markers vs. original
     'legend.markerscale': [1.0, validate_float],
     'legend.shadow': [False, validate_bool],

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -190,6 +190,16 @@ def test_rc():
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 
+def test_rc_title_size():
+    test_legend_title_size = 18.0
+    mpl.rcParams['legend.titlesize'] = test_legend_title_size
+    plt.figure()
+    ax = plt.subplot(121)
+    ax.scatter(np.arange(10), np.arange(10, 0, -1), label='two')
+    leg = ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
+                title="My legend")
+    assert leg._legend_title_box._text.get_fontsize() == test_legend_title_size
+
 
 @image_comparison(baseline_images=['legend_expand'], remove_text=True)
 def test_legend_expand():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -202,6 +202,18 @@ def test_rc_title_size():
     assert leg.get_title().get_fontsize() == test_legend_title_size
 
 
+def test_rc_title_size_inherit():
+    test_legend_title_size = 18.0
+    mpl.rcParams['legend.titlesize'] = 'inherit'
+    mpl.rcParams['font.size'] = test_legend_title_size
+    plt.figure()
+    ax = plt.subplot(121)
+    ax.scatter(np.arange(10), np.arange(10, 0, -1), label='one')
+    leg = ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
+                    title="My Inherited Legend Title")
+    assert leg.get_title().get_fontsize() == test_legend_title_size
+
+
 @image_comparison(baseline_images=['legend_expand'], remove_text=True)
 def test_legend_expand():
     'Test expand mode'

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -190,6 +190,7 @@ def test_rc():
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 
+
 def test_rc_title_size():
     test_legend_title_size = 18.0
     mpl.rcParams['legend.titlesize'] = test_legend_title_size

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -198,8 +198,8 @@ def test_rc_title_size():
     ax = plt.subplot(121)
     ax.scatter(np.arange(10), np.arange(10, 0, -1), label='two')
     leg = ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
-                title="My legend")
-    assert leg._legend_title_box._text.get_fontsize() == test_legend_title_size
+                    title="My legend")
+    assert leg.get_title().get_fontsize() == test_legend_title_size
 
 
 @image_comparison(baseline_images=['legend_expand'], remove_text=True)

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -414,7 +414,7 @@ backend      : $TEMPLATE_BACKEND
 #legend.scatterpoints : 1        # number of scatter points
 #legend.markerscale   : 1.0      # the relative size of legend markers vs. original
 #legend.fontsize      : medium
-#legend.titlesize     : medium    # size of the legend title
+#legend.titlesize     : medium    # fontsize of the legend title
 # Dimensions as fraction of fontsize:
 #legend.borderpad     : 0.4      # border whitespace
 #legend.labelspacing  : 0.5      # the vertical space between the legend entries

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -414,7 +414,7 @@ backend      : $TEMPLATE_BACKEND
 #legend.scatterpoints : 1        # number of scatter points
 #legend.markerscale   : 1.0      # the relative size of legend markers vs. original
 #legend.fontsize      : medium
-#legend.titlesize     : medium    # fontsize of the legend title
+#legend.titlesize     : inherit    # fontsize of the legend title, or inherit from font.size
 # Dimensions as fraction of fontsize:
 #legend.borderpad     : 0.4      # border whitespace
 #legend.labelspacing  : 0.5      # the vertical space between the legend entries

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -414,6 +414,7 @@ backend      : $TEMPLATE_BACKEND
 #legend.scatterpoints : 1        # number of scatter points
 #legend.markerscale   : 1.0      # the relative size of legend markers vs. original
 #legend.fontsize      : medium
+#legend.titlesize     : medium    # size of the legend title
 # Dimensions as fraction of fontsize:
 #legend.borderpad     : 0.4      # border whitespace
 #legend.labelspacing  : 0.5      # the vertical space between the legend entries


### PR DESCRIPTION
## PR Summary
Fixes #9201 by adding an rc parameter to customize legend title size. Following the checklist from that issue to add this parameter. This allows for customization of the legend title font size from the matplotlibrc file, a requested feature addition. 


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
