### PR TITLE
TST: centralize and standardize pandas imports

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -76,3 +76,26 @@ def mpl_image_comparison_parameters(request, extension):
         yield
     finally:
         delattr(func.__wrapped__, 'parameters')
+
+
+@pytest.fixture
+def pd(request):
+    '''fixture to import and configure pandas'''
+
+    pd = pytest.importorskip('pandas')
+    if pd:
+        try:
+            from pandas.plotting import (
+                register_matplotlib_converters as register)
+        except ImportError:
+            from pandas.tseries.converter import register
+        register()
+
+        try:
+            from pandas.plotting import (
+                deregister_matplotlib_converters as deregister)
+            request.addfinalizer(deregister)
+        except ImportError:
+            pass
+
+    return pd

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import, division, print_function
 
 from matplotlib.testing.conftest import (mpl_test_settings,
                                          mpl_image_comparison_parameters,
-                                         pytest_configure, pytest_unconfigure)
+                                         pytest_configure, pytest_unconfigure,
+                                         pd)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5091,27 +5091,7 @@ def test_broken_barh_empty():
     ax.broken_barh([], (.1, .5))
 
 
-def _pandas_wrapper(func):
-    '''Decorator to centralize pandas setup / conditional import'''
-    import functools
-
-    @functools.wraps(func)
-    def wrapped_for_pandas(*args, **kwargs):
-        pytest.importorskip('pandas')
-        try:
-            from pandas.plotting import (
-                register_matplotlib_converters as register)
-        except ImportError:
-            from pandas.tseries.converter import register
-        register()
-        return func(*args, **kwargs)
-
-    return wrapped_for_pandas
-
-
-@_pandas_wrapper
-def test_pandas_pcolormesh():
-    import pandas as pd
+def test_pandas_pcolormesh(pd):
     time = pd.date_range('2000-01-01', periods=10)
     depth = np.arange(20)
     data = np.random.rand(20, 10)
@@ -5120,10 +5100,7 @@ def test_pandas_pcolormesh():
     ax.pcolormesh(time, depth, data)
 
 
-@_pandas_wrapper
-def test_pandas_indexing_dates():
-    import pandas as pd
-
+def test_pandas_indexing_dates(pd):
     dates = np.arange('2005-02', '2005-03', dtype='datetime64[D]')
     values = np.sin(np.array(range(len(dates))))
     df = pd.DataFrame({'dates': dates, 'values': values})
@@ -5134,10 +5111,7 @@ def test_pandas_indexing_dates():
     ax.plot('dates', 'values', data=without_zero_index)
 
 
-@_pandas_wrapper
-def test_pandas_errorbar_indexing():
-    import pandas as pd
-
+def test_pandas_errorbar_indexing(pd):
     df = pd.DataFrame(np.random.uniform(size=(5, 4)),
                       columns=['x', 'y', 'xe', 'ye'],
                       index=[1, 2, 3, 4, 5])
@@ -5145,21 +5119,15 @@ def test_pandas_errorbar_indexing():
     ax.errorbar('x', 'y', xerr='xe', yerr='ye', data=df)
 
 
-@_pandas_wrapper
-def test_pandas_indexing_hist():
-    import pandas as pd
-
+def test_pandas_indexing_hist(pd):
     ser_1 = pd.Series(data=[1, 2, 2, 3, 3, 4, 4, 4, 4, 5])
     ser_2 = ser_1.iloc[1:]
     fig, axes = plt.subplots()
     axes.hist(ser_2)
 
 
-@_pandas_wrapper
-def test_pandas_bar_align_center():
+def test_pandas_bar_align_center(pd):
     # Tests fix for issue 8767
-    import pandas as pd
-
     df = pd.DataFrame({'a': range(2), 'b': range(2)})
 
     fig, ax = plt.subplots(1)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -593,8 +593,7 @@ def test_size_in_xy():
     ax.set_ylim(0, 30)
 
 
-def test_pandas_indexing():
-    pd = pytest.importorskip('pandas')
+def test_pandas_indexing(pd):
 
     # Should not fail break when faced with a
     # non-zero indexed series

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -604,8 +604,7 @@ def _azimuth2math(azimuth, elevation):
     return theta, phi
 
 
-def test_pandas_iterable():
-    pd = pytest.importorskip('pandas')
+def test_pandas_iterable(pd):
     # Using a list or series yields equivalent
     # color maps, i.e the series isn't seen as
     # a single color

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -552,12 +552,9 @@ def test_date2num_dst():
     _test_date2num_dst(date_range, tz_convert)
 
 
-def test_date2num_dst_pandas():
+def test_date2num_dst_pandas(pd):
     # Test for github issue #3896, but in date2num around DST transitions
     # with a timezone-aware pandas date_range object.
-    pd = pytest.importorskip('pandas')
-    from pandas.tseries import converter
-    converter.register()
 
     def tz_convert(*args):
         return pd.DatetimeIndex.tz_convert(*args).astype(object)

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -162,10 +162,8 @@ def test_function_call_with_dict_data_not_in_data(func):
 
 
 @pytest.mark.parametrize('func', all_funcs, ids=all_func_ids)
-def test_function_call_with_pandas_data(func):
+def test_function_call_with_pandas_data(func, pd):
     """test with pandas dataframe -> label comes from data["col"].name """
-    pd = pytest.importorskip('pandas')
-
     data = pd.DataFrame({"a": np.array([1, 2], dtype=np.int32),
                          "b": np.array([8, 9], dtype=np.int32),
                          "w": ["NOT", "NOT"]})


### PR DESCRIPTION
Added a decorator to handle:

 - importorskip
 - using the correct unit-handler registration function to deal with:
    - pandas not auto-registering
    - pandas moving an renaming the registration function

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
