### PR TITLE
Use subplots() instead of axes_grid in suitable examples.

### DIFF
--- a/examples/userdemo/annotate_explain.py
+++ b/examples/userdemo/annotate_explain.py
@@ -7,28 +7,13 @@ Annotate Explain
 
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-from mpl_toolkits.axes_grid1.axes_grid import AxesGrid
-from matplotlib.offsetbox import AnchoredText
 
+
+fig, axs = plt.subplots(2, 2)
 x1, y1 = 0.3, 0.3
 x2, y2 = 0.7, 0.7
 
-fig = plt.figure(1, figsize=(8, 3))
-fig.clf()
-
-
-def add_at(ax, t, loc=2):
-    fp = dict(size=10)
-    _at = AnchoredText(t, loc=loc, prop=fp)
-    ax.add_artist(_at)
-    return _at
-
-
-grid = AxesGrid(fig, 111, (1, 4), label_mode="1", share_all=True)
-
-grid[0].set_autoscale_on(False)
-
-ax = grid[0]
+ax = axs.flat[0]
 ax.plot([x1, x2], [y1, y2], ".")
 el = mpatches.Ellipse((x1, y1), 0.3, 0.4, angle=30, alpha=0.2)
 ax.add_artist(el)
@@ -42,10 +27,9 @@ ax.annotate("",
                             connectionstyle="arc3,rad=0.3",
                             ),
             )
+ax.text(.05, .95, "connect", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "connect", loc=2)
-
-ax = grid[1]
+ax = axs.flat[1]
 ax.plot([x1, x2], [y1, y2], ".")
 el = mpatches.Ellipse((x1, y1), 0.3, 0.4, angle=30, alpha=0.2)
 ax.add_artist(el)
@@ -59,11 +43,9 @@ ax.annotate("",
                             connectionstyle="arc3,rad=0.3",
                             ),
             )
+ax.text(.05, .95, "clip", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "clip", loc=2)
-
-
-ax = grid[2]
+ax = axs.flat[2]
 ax.plot([x1, x2], [y1, y2], ".")
 el = mpatches.Ellipse((x1, y1), 0.3, 0.4, angle=30, alpha=0.2)
 ax.add_artist(el)
@@ -77,11 +59,9 @@ ax.annotate("",
                             connectionstyle="arc3,rad=0.3",
                             ),
             )
+ax.text(.05, .95, "shrink", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "shrink", loc=2)
-
-
-ax = grid[3]
+ax = axs.flat[3]
 ax.plot([x1, x2], [y1, y2], ".")
 el = mpatches.Ellipse((x1, y1), 0.3, 0.4, angle=30, alpha=0.2)
 ax.add_artist(el)
@@ -95,13 +75,9 @@ ax.annotate("",
                             connectionstyle="arc3,rad=0.3",
                             ),
             )
+ax.text(.05, .95, "mutate", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "mutate", loc=2)
-
-grid[0].set_xlim(0, 1)
-grid[0].set_ylim(0, 1)
-grid[0].axis["bottom"].toggle(ticklabels=False)
-grid[0].axis["left"].toggle(ticklabels=False)
-fig.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=0.95)
+for ax in axs.flat:
+    ax.set(xlim=(0, 1), ylim=(0, 1), xticks=[], yticks=[], aspect=1)
 
 plt.show()

--- a/examples/userdemo/connectionstyle_demo.py
+++ b/examples/userdemo/connectionstyle_demo.py
@@ -7,33 +7,14 @@ Connectionstyle Demo
 
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-from mpl_toolkits.axes_grid1.axes_grid import AxesGrid
-from matplotlib.offsetbox import AnchoredText
 
 
-fig = plt.figure(1, figsize=(8, 5))
-fig.clf()
-
-
-def add_at(ax, t, loc=2):
-    fp = dict(size=8)
-    _at = AnchoredText(t, loc=loc, prop=fp)
-    ax.add_artist(_at)
-    return _at
-
-
-grid = AxesGrid(fig, 111, (3, 5), label_mode="1", share_all=True)
-
-grid[0].set_autoscale_on(False)
-
+fig, axs = plt.subplots(3, 5, figsize=(8, 4.8))
 x1, y1 = 0.3, 0.3
 x2, y2 = 0.7, 0.7
 
 
 def demo_con_style(ax, connectionstyle, label=None):
-    if label is None:
-        label = connectionstyle
-
     x1, y1 = 0.3, 0.2
     x2, y2 = 0.8, 0.6
 
@@ -50,53 +31,27 @@ def demo_con_style(ax, connectionstyle, label=None):
                                 ),
                 )
 
-    add_at(ax, label, loc=2)
+    ax.text(.05, .95, connectionstyle.replace(",", ",\n"),
+            transform=ax.transAxes, ha="left", va="top")
 
 
-column = grid.axes_column[0]
+demo_con_style(axs[0, 0], "angle3,angleA=90,angleB=0")
+demo_con_style(axs[1, 0], "angle3,angleA=0,angleB=90")
+demo_con_style(axs[0, 1], "arc3,rad=0.")
+demo_con_style(axs[1, 1], "arc3,rad=0.3")
+demo_con_style(axs[2, 1], "arc3,rad=-0.3")
+demo_con_style(axs[0, 2], "angle,angleA=-90,angleB=180,rad=0")
+demo_con_style(axs[1, 2], "angle,angleA=-90,angleB=180,rad=5")
+demo_con_style(axs[2, 2], "angle,angleA=-90,angleB=10,rad=5")
+demo_con_style(axs[0, 3], "arc,angleA=-90,angleB=0,armA=30,armB=30,rad=0")
+demo_con_style(axs[1, 3], "arc,angleA=-90,angleB=0,armA=30,armB=30,rad=5")
+demo_con_style(axs[2, 3], "arc,angleA=-90,angleB=0,armA=0,armB=40,rad=0")
+demo_con_style(axs[0, 4], "bar,fraction=0.3")
+demo_con_style(axs[1, 4], "bar,fraction=-0.3")
+demo_con_style(axs[2, 4], "bar,angle=180,fraction=-0.2")
 
-demo_con_style(column[0], "angle3,angleA=90,angleB=0",
-               label="angle3,\nangleA=90,\nangleB=0")
-demo_con_style(column[1], "angle3,angleA=0,angleB=90",
-               label="angle3,\nangleA=0,\nangleB=90")
-
-column = grid.axes_column[1]
-
-demo_con_style(column[0], "arc3,rad=0.")
-demo_con_style(column[1], "arc3,rad=0.3")
-demo_con_style(column[2], "arc3,rad=-0.3")
-
-column = grid.axes_column[2]
-
-demo_con_style(column[0], "angle,angleA=-90,angleB=180,rad=0",
-               label="angle,\nangleA=-90,\nangleB=180,\nrad=0")
-demo_con_style(column[1], "angle,angleA=-90,angleB=180,rad=5",
-               label="angle,\nangleA=-90,\nangleB=180,\nrad=5")
-demo_con_style(column[2], "angle,angleA=-90,angleB=10,rad=5",
-               label="angle,\nangleA=-90,\nangleB=10,\nrad=0")
-
-column = grid.axes_column[3]
-
-demo_con_style(column[0], "arc,angleA=-90,angleB=0,armA=30,armB=30,rad=0",
-               label="arc,\nangleA=-90,\nangleB=0,\narmA=30,\narmB=30,\nrad=0")
-demo_con_style(column[1], "arc,angleA=-90,angleB=0,armA=30,armB=30,rad=5",
-               label="arc,\nangleA=-90,\nangleB=0,\narmA=30,\narmB=30,\nrad=5")
-demo_con_style(column[2], "arc,angleA=-90,angleB=0,armA=0,armB=40,rad=0",
-               label="arc,\nangleA=-90,\nangleB=0,\narmA=0,\narmB=40,\nrad=0")
-
-column = grid.axes_column[4]
-
-demo_con_style(column[0], "bar,fraction=0.3",
-               label="bar,\nfraction=0.3")
-demo_con_style(column[1], "bar,fraction=-0.3",
-               label="bar,\nfraction=-0.3")
-demo_con_style(column[2], "bar,angle=180,fraction=-0.2",
-               label="bar,\nangle=180,\nfraction=-0.2")
-
-grid[0].set_xlim(0, 1)
-grid[0].set_ylim(0, 1)
-grid.axes_llc.axis["bottom"].toggle(ticklabels=False)
-grid.axes_llc.axis["left"].toggle(ticklabels=False)
-fig.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=0.95)
+for ax in axs.flat:
+    ax.set(xlim=(0, 1), ylim=(0, 1), xticks=[], yticks=[], aspect=1)
+fig.tight_layout(pad=0)
 
 plt.show()

--- a/examples/userdemo/simple_annotate01.py
+++ b/examples/userdemo/simple_annotate01.py
@@ -8,49 +8,20 @@ Simple Annotate01
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 
+
+fig, axs = plt.subplots(2, 4)
 x1, y1 = 0.3, 0.3
 x2, y2 = 0.7, 0.7
 
-fig = plt.figure(1)
-fig.clf()
-from mpl_toolkits.axes_grid1.axes_grid import Grid
-from matplotlib.offsetbox import AnchoredText
-
-from matplotlib.font_manager import FontProperties
-
-
-def add_at(ax, t, loc=2):
-    fp = dict(size=10)
-    _at = AnchoredText(t, loc=loc, prop=fp)
-    ax.add_artist(_at)
-    return _at
-
-
-grid = Grid(fig, 111, (4, 4), label_mode="1", share_all=True)
-
-grid[0].set_autoscale_on(False)
-
-ax = grid[0]
+ax = axs.flat[0]
 ax.plot([x1, x2], [y1, y2], "o")
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
             xytext=(x2, y2), textcoords='data',
             arrowprops=dict(arrowstyle="->"))
+ax.text(.05, .95, "A $->$ B", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "A $->$ B", loc=2)
-
-
-ax = grid[1]
-ax.plot([x1, x2], [y1, y2], "o")
-ax.annotate("",
-            xy=(x1, y1), xycoords='data',
-            xytext=(x2, y2), textcoords='data',
-            arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.3"))
-
-add_at(ax, "connectionstyle=arc3", loc=2)
-
-
-ax = grid[2]
+ax = axs.flat[2]
 ax.plot([x1, x2], [y1, y2], "o")
 ax.annotate("",
             xy=(x1, y1), xycoords='data',
@@ -58,11 +29,17 @@ ax.annotate("",
             arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.3",
                             shrinkB=5)
             )
+ax.text(.05, .95, "shrinkB=5", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "shrinkB=5", loc=2)
+ax = axs.flat[3]
+ax.plot([x1, x2], [y1, y2], "o")
+ax.annotate("",
+            xy=(x1, y1), xycoords='data',
+            xytext=(x2, y2), textcoords='data',
+            arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.3"))
+ax.text(.05, .95, "connectionstyle=arc3", transform=ax.transAxes, ha="left", va="top")
 
-
-ax = grid[3]
+ax = axs.flat[4]
 ax.plot([x1, x2], [y1, y2], "o")
 el = mpatches.Ellipse((x1, y1), 0.3, 0.4, angle=30, alpha=0.5)
 ax.add_artist(el)
@@ -72,8 +49,7 @@ ax.annotate("",
             arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.2")
             )
 
-
-ax = grid[4]
+ax = axs.flat[5]
 ax.plot([x1, x2], [y1, y2], "o")
 el = mpatches.Ellipse((x1, y1), 0.3, 0.4, angle=30, alpha=0.5)
 ax.add_artist(el)
@@ -83,11 +59,9 @@ ax.annotate("",
             arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.2",
                             patchB=el)
             )
+ax.text(.05, .95, "patchB", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "patchB", loc=2)
-
-
-ax = grid[5]
+ax = axs.flat[6]
 ax.plot([x1], [y1], "o")
 ax.annotate("Test",
             xy=(x1, y1), xycoords='data',
@@ -96,11 +70,9 @@ ax.annotate("Test",
             bbox=dict(boxstyle="round", fc="w"),
             arrowprops=dict(arrowstyle="->")
             )
+ax.text(.05, .95, "annotate", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "annotate", loc=2)
-
-
-ax = grid[6]
+ax = axs.flat[7]
 ax.plot([x1], [y1], "o")
 ax.annotate("Test",
             xy=(x1, y1), xycoords='data',
@@ -109,7 +81,9 @@ ax.annotate("Test",
             bbox=dict(boxstyle="round", fc="w", ),
             arrowprops=dict(arrowstyle="->", relpos=(0., 0.))
             )
+ax.text(.05, .95, "relpos=(0,0)", transform=ax.transAxes, ha="left", va="top")
 
-add_at(ax, "relpos=(0,0)", loc=2)
+for ax in axs.flat:
+    ax.set(xlim=(0, 1), ylim=(0, 1), xticks=[], yticks=[], aspect=1)
 
 plt.show()


### PR DESCRIPTION
## PR Summary

These are examples where subplots() is just as good as axes_grid to set up the axes.

In simple_annotate01, the subplots order was swapped to allow the
"connectionstyle=arc3" label to overflow without being cut off.

For reference, compare

https://matplotlib.org/gallery/userdemo/annotate_explain.html#sphx-glr-gallery-userdemo-annotate-explain-py
https://matplotlib.org/gallery/userdemo/simple_annotate01.html#sphx-glr-gallery-userdemo-simple-annotate01-py
https://matplotlib.org/gallery/userdemo/connectionstyle_demo.html#sphx-glr-gallery-userdemo-connectionstyle-demo-py

and

https://955-7439715-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/userdemo/annotate_explain.html#sphx-glr-gallery-userdemo-annotate-explain-py
https://955-7439715-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/userdemo/simple_annotate01.html#sphx-glr-gallery-userdemo-simple-annotate01-py
https://955-7439715-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/userdemo/connectionstyle_demo.html#sphx-glr-gallery-userdemo-connectionstyle-demo-py

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
