### PR TITLE
Fix multiple zero labels for SymLogNorm colorbar

### DIFF
--- a/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
+++ b/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
@@ -1,0 +1,6 @@
+Legend Title Size rc parameter
+---------------------
+
+A new rc parameter has been added as an option in your matplotlibrc allowing you to control the font size of the legend title.
+
+`legend.titlesize = 'large'`

--- a/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
+++ b/doc/users/next_whats_new/2017-12-27_legend_title_size_rc.rst
@@ -1,5 +1,5 @@
 Legend Title Size rc parameter
----------------------
+------------------------------
 
 A new rc parameter has been added as an option in your matplotlibrc allowing you to control the font size of the legend title.
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -713,7 +713,7 @@ class Legend(Artist):
             self.get_frame().set_alpha(framealpha)
 
         self._loc = loc
-        self.set_title(title)
+        self.set_title(title, prop={"size": rcParams["legend.titlesize"]})
         self._last_fontsize_points = self._fontsize
         self._draggable = None
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1178,6 +1178,7 @@ defaultParams = {
     # the number of points in the legend line for scatter
     'legend.scatterpoints': [1, validate_int],
     'legend.fontsize': ['medium', validate_fontsize],
+    'legend.titlesize': ['medium', validate_fontsize],
      # the relative size of legend markers vs. original
     'legend.markerscale': [1.0, validate_float],
     'legend.shadow': [False, validate_bool],

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -190,6 +190,16 @@ def test_rc():
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 
+def test_rc_title_size():
+    test_legend_title_size = 18.0
+    mpl.rcParams['legend.titlesize'] = test_legend_title_size
+    plt.figure()
+    ax = plt.subplot(121)
+    ax.scatter(np.arange(10), np.arange(10, 0, -1), label='two')
+    leg = ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
+                title="My legend")
+    assert leg._legend_title_box._text.get_fontsize() == test_legend_title_size
+
 
 @image_comparison(baseline_images=['legend_expand'], remove_text=True)
 def test_legend_expand():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -190,6 +190,7 @@ def test_rc():
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 
+
 def test_rc_title_size():
     test_legend_title_size = 18.0
     mpl.rcParams['legend.titlesize'] = test_legend_title_size

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -198,8 +198,8 @@ def test_rc_title_size():
     ax = plt.subplot(121)
     ax.scatter(np.arange(10), np.arange(10, 0, -1), label='two')
     leg = ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
-                title="My legend")
-    assert leg._legend_title_box._text.get_fontsize() == test_legend_title_size
+                    title="My legend")
+    assert leg.get_title().get_fontsize() == test_legend_title_size
 
 
 @image_comparison(baseline_images=['legend_expand'], remove_text=True)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1063,6 +1063,7 @@ class LogFormatterMathtext(LogFormatter):
     """
     Format values for log axis using ``exponent = log_base(value)``.
     """
+    _min_zero_pos = None
 
     def _non_decade_format(self, sign_string, base, fx, usetex):
         'Return string for non-decade locations'
@@ -1076,16 +1077,21 @@ class LogFormatterMathtext(LogFormatter):
         """
         Return the format for tick value `x`.
 
-        The position `pos` is ignored.
+        The position `pos` is used for SymLogNorm for ensuring
+        only one zero entry is present.
         """
         usetex = rcParams['text.usetex']
         min_exp = rcParams['axes.formatter.min_exponent']
 
         if x == 0:  # Symlog
-            if usetex:
-                return '$0$'
+            if self._min_zero_pos is None:
+                self._min_zero_pos = pos
+                if usetex:
+                    return '$0$'
+                else:
+                    return '$%s$' % _mathdefault('0')
             else:
-                return '$%s$' % _mathdefault('0')
+                return ''
 
         sign_string = '-' if x < 0 else ''
         x = abs(x)

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -414,7 +414,7 @@ backend      : $TEMPLATE_BACKEND
 #legend.scatterpoints : 1        # number of scatter points
 #legend.markerscale   : 1.0      # the relative size of legend markers vs. original
 #legend.fontsize      : medium
-#legend.titlesize     : medium    # size of the legend title
+#legend.titlesize     : medium    # fontsize of the legend title
 # Dimensions as fraction of fontsize:
 #legend.borderpad     : 0.4      # border whitespace
 #legend.labelspacing  : 0.5      # the vertical space between the legend entries

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -414,6 +414,7 @@ backend      : $TEMPLATE_BACKEND
 #legend.scatterpoints : 1        # number of scatter points
 #legend.markerscale   : 1.0      # the relative size of legend markers vs. original
 #legend.fontsize      : medium
+#legend.titlesize     : medium    # size of the legend title
 # Dimensions as fraction of fontsize:
 #legend.borderpad     : 0.4      # border whitespace
 #legend.labelspacing  : 0.5      # the vertical space between the legend entries


### PR DESCRIPTION
## PR Summary
This adds a simple check to the log formatter to make sure only the first zero entry is labeled as multiple need to be created (see ticker.SymmetricalLogLocator.tick_values) 

Fixes issue #10122 

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- N/A New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- N/A Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- N/A Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
