### PR TITLE
Fix multiple zero labels when using SymLogNorm

### DIFF
--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -247,6 +247,18 @@ def test_SymLogNorm_colorbar():
     plt.close(fig)
 
 
+def test_SymLogNorm_single_zero():
+    """
+    Test SymLogNorm to ensure it is not adding sub-ticks to zero label
+    """
+    fig = plt.figure()
+    norm = mcolors.SymLogNorm(1e-5, vmin=-1, vmax=1)
+    cbar = mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
+    ticks = cbar.get_ticks()
+    assert sum(ticks == 0) == 1
+    plt.close(fig)
+
+
 def _inverse_tester(norm_instance, vals):
     """
     Checks if the inverse of the given normalization is working.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2346,7 +2346,10 @@ class SymmetricalLogLocator(Locator):
         if len(subs) > 1 or subs[0] != 1.0:
             ticklocs = []
             for decade in decades:
-                ticklocs.extend(subs * decade)
+                if decade == 0:
+                    ticklocs.append(decade)
+                else:
+                    ticklocs.extend(subs * decade)
         else:
             ticklocs = decades
 


### PR DESCRIPTION
## PR Summary
~~Use the previously unused position of a tick label to ensure that only a single zero label is rendered when using SymLogNorm. I store the first time a zero label is encountered and return blanks for all following zeros. The documentation on the `ticker.SymmetricalLogLocator.tick_values` shows how these multiple zeros come to be through the linear approximation near zero.~~

As per discussion below I have taken a different approach, trying to fix the root cause of the problem in the locator (`ticker.SymmetricalLogLocator.tick_values`) so that the extra zero ticks are never created in the first place. 

Fixes #10122 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- N/A New features are documented, with examples if plot related
- N/A Documentation is sphinx and numpydoc compliant
- N/A Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- N/A Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
