### PR TITLE
cairo backends do not support blitting; mark them as such.

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -450,6 +450,8 @@ class GraphicsContextCairo(GraphicsContextBase):
 
 
 class FigureCanvasCairo(FigureCanvasBase):
+    supports_blit = False
+
     def print_png(self, fobj, *args, **kwargs):
         width, height = self.get_width_height()
 


### PR DESCRIPTION
Trying to run a blitting animation example on gtk3cairo currently fails
with

    AttributeError: 'FigureCanvasGTK3Cairo' object has no attribute 'copy_from_bbox'

While blitting can be made to work for e.g. qt5cairo, it cannot be for
gtk3cairo which relies on gtk's windowing code to handle us a cairo
context to directly draw on when a draw event occurs: the animation
blitting code fundamentally assumes that it can modify the underlying
buffer whenever it wants and that the windowing system simply displayes
that buffer at each draw event.

This PR simply prevents the animation code from trying to use blitting with these backends.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
