### PR TITLE
refactor non wx.ToolBar specific parts of NavigationToolbar2Wx/Agg into NavigationController2Wx/Agg

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -17,6 +17,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from six.moves import xrange
+import six
 
 import sys
 import os
@@ -1483,9 +1484,13 @@ class SubplotToolWX(wx.Frame):
         tool = SubplotTool(targetfig, toolfig)
 
 
-class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
+class NavigationController2Wx(NavigationToolbar2):
+    """
+    The parts from NavigationToolbar2Wx that are not specific to wx.ToolBar;
+    so this functionality can be used without adding a toolbar.
+    """
+
     def __init__(self, canvas):
-        wx.ToolBar.__init__(self, canvas.GetParent(), -1)
         NavigationToolbar2.__init__(self, canvas)
         self.canvas = canvas
         self._idle = True
@@ -1501,32 +1506,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         return FigureCanvasWx(frame, -1, fig)
 
     def _init_toolbar(self):
-        DEBUG_MSG("_init_toolbar", 1, self)
-
         self._parent = self.canvas.GetParent()
-
-        self.wx_ids = {}
-        for text, tooltip_text, image_file, callback in self.toolitems:
-            if text is None:
-                self.AddSeparator()
-                continue
-            self.wx_ids[text] = wx.NewId()
-            wxc._AddTool(self, self.wx_ids, text,
-                        _load_bitmap(image_file + '.png'),
-                        tooltip_text)
-
-            self.Bind(wx.EVT_TOOL, getattr(self, callback),
-                      id=self.wx_ids[text])
-
-        self.Realize()
-
-    def zoom(self, *args):
-        self.ToggleTool(self.wx_ids['Pan'], False)
-        NavigationToolbar2.zoom(self, *args)
-
-    def pan(self, *args):
-        self.ToggleTool(self.wx_ids['Zoom'], False)
-        NavigationToolbar2.pan(self, *args)
 
     def configure_subplots(self, evt):
         frame = wx.Frame(None, -1, "Configure subplots")
@@ -1687,6 +1667,40 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def set_message(self, s):
         if self.statbar is not None:
             self.statbar.set_function(s)
+
+
+class NavigationToolbar2Wx(NavigationController2Wx, wx.ToolBar):
+    def __init__(self, canvas):
+        wx.ToolBar.__init__(self, canvas.GetParent(), -1)
+        NavigationController2Wx.__init__(self, canvas)
+
+    def _init_toolbar(self):
+        DEBUG_MSG("_init_toolbar", 1, self)
+
+        self._parent = self.canvas.GetParent()
+
+        self.wx_ids = {}
+        for text, tooltip_text, image_file, callback in self.toolitems:
+            if text is None:
+                self.AddSeparator()
+                continue
+            self.wx_ids[text] = wx.NewId()
+            wxc._AddTool(self, self.wx_ids, text,
+                        _load_bitmap(image_file + '.png'),
+                        tooltip_text)
+
+            self.Bind(wx.EVT_TOOL, getattr(self, callback),
+                      id=self.wx_ids[text])
+
+        self.Realize()
+
+    def zoom(self, *args):
+        self.ToggleTool(self.wx_ids['Pan'], False)
+        NavigationToolbar2.zoom(self, *args)
+
+    def pan(self, *args):
+        self.ToggleTool(self.wx_ids['Zoom'], False)
+        NavigationToolbar2.pan(self, *args)
 
     def set_history_buttons(self):
         can_backward = self._nav_stack._pos > 0

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -9,8 +9,8 @@ import matplotlib
 from . import wx_compat as wxc
 from . import backend_wx
 from .backend_agg import FigureCanvasAgg
-from .backend_wx import (
-    _BackendWx, FigureCanvasWx, FigureFrameWx, NavigationToolbar2Wx, DEBUG_MSG)
+from .backend_wx import (_BackendWx, FigureCanvasWx, FigureFrameWx,
+    NavigationToolbar2Wx, NavigationController2Wx, DEBUG_MSG)
 
 
 class FigureFrameWxAgg(FigureFrameWx):
@@ -89,6 +89,10 @@ class FigureCanvasWxAgg(FigureCanvasAgg, FigureCanvasWx):
         if self._isDrawn:
             self.draw()
 
+
+class NavigationController2WxAgg(NavigationController2Wx):
+    def get_canvas(self, frame, fig):
+        return FigureCanvasWxAgg(frame, -1, fig)    
 
 class NavigationToolbar2WxAgg(NavigationToolbar2Wx):
     def get_canvas(self, frame, fig):

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -92,7 +92,8 @@ class FigureCanvasWxAgg(FigureCanvasAgg, FigureCanvasWx):
 
 class NavigationController2WxAgg(NavigationController2Wx):
     def get_canvas(self, frame, fig):
-        return FigureCanvasWxAgg(frame, -1, fig)    
+        return FigureCanvasWxAgg(frame, -1, fig)
+
 
 class NavigationToolbar2WxAgg(NavigationToolbar2Wx):
     def get_canvas(self, frame, fig):


### PR DESCRIPTION
plus bug fix: add missing 'import six'

## PR Summary

When embedding a FigureCanvasWx or FigureCanvasWxAgg into a larger
application, the functionality of NavigationToolbar2Wx/Agg is quite useful,
but actually having to integrate the ToolBar is not too nice.

With this pull request you still can use the functionality (pan, zoom, save_figure etc.) now
as the non-ToolBar specific code is refactored into NavigationController2Wx/Agg.

I'm currently using this to prepare a more comprehensive example of a
matplotlib application to be supplied with wxGlade.

## PR Checklist

I don't think that NavigationToolbar2Wx is documented anywhere except
in the examples. If anyone wants to use NavigationController2Wx/Agg, he/she
probably needs to look into the sources anyway.

If the pull request is accepted, I could prepare an example with 
standard wx Buttons instead of the toolbar.

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way


