### PR TITLE
Plot directive preserve

### DIFF
--- a/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
+++ b/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
@@ -24,11 +24,12 @@ ReadTheDocs, you may wish to build imagery locally to avoid hitting resource
 limits on the server. Using the new changes allows extensive dynamically
 generated imagery to be used on services like ReadTheDocs.
 
-The `:outname:` property
-~~~~~~~~~~~~~~~~~~~~~~~~
+The ``:outname:`` property
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These problems are addressed through two new features in the plot directive. The
-first is the introduction of the `:outname:` property. It is used like so:
+These problems are addressed through two new features in the plot directive.
+The first is the introduction of the ``:outname:`` property. It is used like
+so:
 
 .. code-block:: rst
 
@@ -41,20 +42,20 @@ first is the introduction of the `:outname:` property. It is used like so:
        img = mpimg.imread('_static/stinkbug.png')
        imgplot = plt.imshow(img)
 
-Without `:outname:`, the figure generated above would normally be called, e.g.
-`docfile3-4-01.png` or something equally mysterious. With `:outname:` the figure
-generated will instead be named `stinkbug_plot-01.png` or even
-`stinkbug_plot.png`. This makes it easy to understand which output image is
-which and, more importantly, uniquely keys output images to code snippets.
+Without ``:outname:``, the figure generated above would normally be called,
+e.g. :file:`docfile3-4-01.png` or something equally mysterious. With
+``:outname:`` the figure generated will instead be named
+:file:`stinkbug_plot-01.png` or even :file:`stinkbug_plot.png`. This makes it
+easy to understand which output image is which and, more importantly, uniquely
+keys output images to code snippets.
 
-The `plot_preserve_dir` configuration value
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``plot_preserve_dir`` configuration value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Setting the `plot_preserve_dir` configuration value to the name of a directory
-will cause all images with `:outname:` set to be copied to this directory upon
-generation.
+Setting the ``plot_preserve_dir`` configuration value to the name of a
+directory will cause all images with ``:outname:`` set to be copied to this
+directory upon generation.
 
-If an image is already in `plot_preserve_dir` when documentation is being
+If an image is already in ``plot_preserve_dir`` when documentation is being
 generated, this image is copied to the build directory thereby pre-empting
 generation and reducing computation time in low-resource environments.
-

--- a/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
+++ b/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
@@ -1,0 +1,56 @@
+Plot Directive `outname` and `plot_preserve_dir`
+----------------------------------------------------
+
+The Sphinx plot directive can be used to automagically generate figures for
+documentation like so:
+
+    .. plot::
+
+       import matplotlib.pyplot as plt
+       import matplotlib.image as mpimg
+       import numpy as np
+       img = mpimg.imread('_static/stinkbug.png')
+       imgplot = plt.imshow(img)
+
+But, if you reorder the figures in the documentation then all the figures may
+need to be rebuilt. This takes time. The names given to the figures are also
+fairly meaningless, making them more difficult to index by search engines or to
+find on a filesystem.
+
+Alternatively, if you are compiling on a limited-resource service like
+ReadTheDocs, you may wish to build imagery locally to avoid hitting resource
+limits on the server. Using the new changes allows extensive dynamically
+generated imagery to be used on services like ReadTheDocs.
+
+The `:outname:` property
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+These problems are address through two new features in the plot directive. The
+first is the introduction of the `:outname:` property. It is used like so:
+
+    .. plot::
+       :outname: stinkbug_plot
+
+       import matplotlib.pyplot as plt
+       import matplotlib.image as mpimg
+       import numpy as np
+       img = mpimg.imread('_static/stinkbug.png')
+       imgplot = plt.imshow(img)
+
+Without `:outname:`, the figure generated above would normally be called, e.g.
+`docfile3-4-01.png` or something equally mysterious. With `:outname:` the figure
+generated will instead be named `stinkbug_plot-01.png` or even
+`stinkbug_plot.png`. This makes it easy to understand which output image is
+which and, more importantly, uniquely keys output images to code snippets.
+
+The `plot_preserve_dir` configuration value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setting the `plot_preserve_dir` configuration value to the name of a directory
+will cause all images with `:outname:` set to be copied to this directory upon
+generation.
+
+If an image is already in `plot_preserve_dir` when documentation is being
+generated, this image is copied to the build directory thereby pre-empting
+generation and reducing computation time in low-resource environments.
+

--- a/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
+++ b/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
@@ -25,7 +25,7 @@ generated imagery to be used on services like ReadTheDocs.
 The `:outname:` property
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-These problems are address through two new features in the plot directive. The
+These problems are addressed through two new features in the plot directive. The
 first is the introduction of the `:outname:` property. It is used like so:
 
     .. plot::

--- a/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
+++ b/doc/users/next_whats_new/2018_12_03_sphinx_plot_preserve.rst
@@ -4,6 +4,8 @@ Plot Directive `outname` and `plot_preserve_dir`
 The Sphinx plot directive can be used to automagically generate figures for
 documentation like so:
 
+.. code-block:: rst
+
     .. plot::
 
        import matplotlib.pyplot as plt
@@ -27,6 +29,8 @@ The `:outname:` property
 
 These problems are addressed through two new features in the plot directive. The
 first is the introduction of the `:outname:` property. It is used like so:
+
+.. code-block:: rst
 
     .. plot::
        :outname: stinkbug_plot

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -670,7 +670,7 @@ def run(arguments, content, options, state_machine, state, lineno):
 
     #Ensure that the outname is unique, otherwise copied images will
     #not be what user expects
-    if outname in outname_list:
+    if outname and outname in outname_list:
       raise Exception("The outname '{0}' is not unique!".format(outname))
     else:
       outname_list.add(outname)

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -639,8 +639,11 @@ def render_figures(code, code_path, output_dir, output_base, context,
                 try:
                     figman.canvas.figure.savefig(img.filename(fmt), dpi=dpi)
                     if config.plot_preserve_dir and outname:
-                      _log.info("Preserving '{0}' into '{1}'".format(img.filename(format), config.plot_preserve_dir))
-                      shutil.copy2(img.filename(format), config.plot_preserve_dir)
+                        _log.info(
+                            "Preserving '{0}' into '{1}'".format(
+                                img.filename(fmt), config.plot_preserve_dir))
+                        shutil.copy2(img.filename(fmt),
+                                     config.plot_preserve_dir)
                 except Exception as err:
                     raise PlotError(traceback.format_exc())
                 img.formats.append(fmt)

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -772,7 +772,7 @@ def run(arguments, content, options, state_machine, state, lineno):
     #this copies them into the build directory so that they will
     #not be remade
     if config.plot_preserve_dir and outname:
-      outfiles = glob.glob(os.path.join(config.plot_preserve_dir,outname) + '*')
+      outfiles = glob.glob(os.path.join(config.plot_preserve_dir, outname) + '*')
       for of in outfiles:
         _log.info("Copying preserved copy of '{0}' into '{1}'".format(of, build_dir))
         shutil.copy2(of, build_dir)

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -140,8 +140,8 @@ The plot directive has the following configuration options:
 
     plot_preserve_dir
         Files with outnames are copied to this directory and files in this
-        directory are copied back from into the build directory prior to the
-        build beginning.
+        directory are copied back into the build directory prior to the build
+        beginning.
 
 """
 
@@ -672,11 +672,11 @@ def run(arguments, content, options, state_machine, state, lineno):
     rst_file = document.attributes['source']
     rst_dir = os.path.dirname(rst_file)
 
-    #Get output name of the images, if the option was provided
+    # Get output name of the images, if the option was provided
     outname = options.get('outname', '')
 
-    #Ensure that the outname is unique, otherwise copied images will
-    #not be what user expects
+    # Ensure that the outname is unique, otherwise copied images will
+    # not be what user expects
     if outname and outname in _outname_list:
         raise Exception("The outname '{0}' is not unique!".format(outname))
     else:
@@ -722,8 +722,8 @@ def run(arguments, content, options, state_machine, state, lineno):
     else:
         source_ext = ''
 
-    #outname, if present, overrides output_base, but preserve
-    #numbering of multi-figure code snippets
+    # outname, if present, overrides output_base, but preserve
+    # numbering of multi-figure code snippets
     if outname:
         output_base = re.sub('^[^-]*', outname, output_base)
 
@@ -773,9 +773,8 @@ def run(arguments, content, options, state_machine, state, lineno):
         build_dir_link = build_dir
     source_link = dest_dir_link + '/' + output_base + source_ext
 
-    #If we previously preserved copies of the generated figures
-    #this copies them into the build directory so that they will
-    #not be remade
+    # If we previously preserved copies of the generated figures this copies
+    # them into the build directory so that they will not be remade.
     if config.plot_preserve_dir and outname:
         outfiles = glob.glob(
             os.path.join(config.plot_preserve_dir, outname) + '*')

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -279,7 +279,7 @@ class PlotDirective(Directive):
         'context': _option_context,
         'nofigs': directives.flag,
         'encoding': directives.encoding,
-        'outname': str
+        'outname': str,
         }
 
     def run(self):
@@ -304,7 +304,7 @@ def setup(app):
     app.add_config_value('plot_apply_rcparams', False, True)
     app.add_config_value('plot_working_directory', None, True)
     app.add_config_value('plot_template', None, True)
-    app.add_config_value('plot_preserve_dir',          '',    True)
+    app.add_config_value('plot_preserve_dir', '', True)
 
     app.connect('doctree-read', mark_plot_labels)
 

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -785,7 +785,7 @@ def run(arguments, content, options, state_machine, state, lineno):
                                  config,
                                  context_reset=context_opt == 'reset',
                                  close_figs=context_opt == 'close-figs',
-                                 outname = outname)
+                                 outname=outname)
         errors = []
     except PlotError as err:
         reporter = state.memo.reporter

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -71,10 +71,10 @@ The ``plot`` directive supports the following options:
         inserted.  This is usually useful with the ``:context:`` option.
 
     outname : str
-        If specified, the names of the generated plots will start with the value
-        of `:outname:`. This is handy for preserving output results if code is
-        reordered between runs. The value of `:outname:` must be unique across
-        the generated documentation.
+        If specified, the names of the generated plots will start with the
+        value of `:outname:`. This is handy for preserving output results if
+        code is reordered between runs. The value of `:outname:` must be
+        unique across the generated documentation.
 
 Additionally, this directive supports all of the options of the `image`
 directive, except for *target* (since plot will add its own target).  These
@@ -142,6 +142,7 @@ The plot directive has the following configuration options:
         Files with outnames are copied to this directory and files in this
         directory are copied back from into the build directory prior to the
         build beginning.
+
 """
 
 import contextlib
@@ -677,13 +678,14 @@ def run(arguments, content, options, state_machine, state, lineno):
     #Ensure that the outname is unique, otherwise copied images will
     #not be what user expects
     if outname and outname in _outname_list:
-      raise Exception("The outname '{0}' is not unique!".format(outname))
+        raise Exception("The outname '{0}' is not unique!".format(outname))
     else:
-      _outname_list.add(outname)
+        _outname_list.add(outname)
 
     if config.plot_preserve_dir:
-      #Ensure `preserve_dir` ends with a slash, otherwise `copy2` will misbehave
-      config.plot_preserve_dir = os.path.join(config.plot_preserve_dir, '')
+        # Ensure `preserve_dir` ends with a slash, otherwise `copy2`
+        # will misbehave
+        config.plot_preserve_dir = os.path.join(config.plot_preserve_dir, '')
 
     if len(arguments):
         if not config.plot_basedir:
@@ -723,7 +725,7 @@ def run(arguments, content, options, state_machine, state, lineno):
     #outname, if present, overrides output_base, but preserve
     #numbering of multi-figure code snippets
     if outname:
-      output_base = re.sub('^[^-]*', outname, output_base)
+        output_base = re.sub('^[^-]*', outname, output_base)
 
     # ensure that LaTeX includegraphics doesn't choke in foo.bar.pdf filenames
     output_base = output_base.replace('.', '-')
@@ -775,10 +777,12 @@ def run(arguments, content, options, state_machine, state, lineno):
     #this copies them into the build directory so that they will
     #not be remade
     if config.plot_preserve_dir and outname:
-      outfiles = glob.glob(os.path.join(config.plot_preserve_dir, outname) + '*')
-      for of in outfiles:
-        _log.info("Copying preserved copy of '{0}' into '{1}'".format(of, build_dir))
-        shutil.copy2(of, build_dir)
+        outfiles = glob.glob(
+            os.path.join(config.plot_preserve_dir, outname) + '*')
+        for of in outfiles:
+            _log.info("Copying preserved copy of '{0}' into '{1}'".format(
+                of, build_dir))
+            shutil.copy2(of, build_dir)
 
     # make figures
     try:

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -154,6 +154,7 @@ import io
 import re
 import textwrap
 import glob
+import logging
 from os.path import relpath
 from pathlib import Path
 import re
@@ -176,10 +177,12 @@ align = Image.align
 
 __version__ = 2
 
+_log = logging.getLogger(__name__)
+
 #Outnames must be unique. This variable stores the outnames that
 #have been seen so we can guarantee this and warn the user if a
 #duplicate is encountered.
-outname_list = set()
+_outname_list = set()
 
 #------------------------------------------------------------------------------
 # Registration hook
@@ -636,7 +639,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
                 try:
                     figman.canvas.figure.savefig(img.filename(fmt), dpi=dpi)
                     if config.plot_preserve_dir and outname:
-                      print("Preserving '{0}' into '{1}'".format(img.filename(format), config.plot_preserve_dir))
+                      _log.info("Preserving '{0}' into '{1}'".format(img.filename(format), config.plot_preserve_dir))
                       shutil.copy2(img.filename(format), config.plot_preserve_dir)
                 except Exception as err:
                     raise PlotError(traceback.format_exc())
@@ -670,10 +673,10 @@ def run(arguments, content, options, state_machine, state, lineno):
 
     #Ensure that the outname is unique, otherwise copied images will
     #not be what user expects
-    if outname and outname in outname_list:
+    if outname and outname in _outname_list:
       raise Exception("The outname '{0}' is not unique!".format(outname))
     else:
-      outname_list.add(outname)
+      _outname_list.add(outname)
 
     if config.plot_preserve_dir:
       #Ensure `preserve_dir` ends with a slash, otherwise `copy2` will misbehave
@@ -771,7 +774,7 @@ def run(arguments, content, options, state_machine, state, lineno):
     if config.plot_preserve_dir and outname:
       outfiles = glob.glob(os.path.join(config.plot_preserve_dir,outname) + '*')
       for of in outfiles:
-        print("Copying preserved copy of '{0}' into '{1}'".format(of, build_dir))
+        _log.info("Copying preserved copy of '{0}' into '{1}'".format(of, build_dir))
         shutil.copy2(of, build_dir)
 
     # make figures

--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -126,4 +126,11 @@ Plot 16 uses a specific function in a file with plot commands:
 
 .. plot:: range6.py range6
 
+Plot 17 has an outname
 
+.. plot::
+    :context: close-figs
+    :outname: plot17out
+
+    plt.figure()
+    plt.plot(range(4))


### PR DESCRIPTION
## PR Summary

The Sphinx plot directive can be used to automagically generate figures for documentation like so:

    .. plot::

       import matplotlib.pyplot as plt
       import matplotlib.image as mpimg
       import numpy as np
       img = mpimg.imread('_static/stinkbug.png')
       imgplot = plt.imshow(img)

But, if you reorder the figures in the documentation then all the figures may need to be rebuilt. This takes time. The names given to the figures are also fairly meaningless, making them more difficult to index by search engines or to find on a filesystem.

Alternatively, if you are compiling on a limited-resource service like ReadTheDocs, you may wish to build imagery locally to avoid hitting resource limits on the server. Using the new changes allows extensive dynamically generated imagery to be used on services like ReadTheDocs.

### The `:outname:` property

These problems are addressed through two new features in the plot directive. The first is the introduction of the `:outname:` property. It is used like so:

    .. plot::
       :outname: stinkbug_plot

       import matplotlib.pyplot as plt
       import matplotlib.image as mpimg
       import numpy as np
       img = mpimg.imread('_static/stinkbug.png')
       imgplot = plt.imshow(img)

Without `:outname:`, the figure generated above would normally be called, e.g. `docfile3-4-01.png` or something equally mysterious. With `:outname:` the figure generated will instead be named `stinkbug_plot-01.png` or even `stinkbug_plot.png`. This makes it easy to understand which output image is which and, more importantly, uniquely keys output images to code snippets.

### The `plot_preserve_dir` configuration value

Setting the `plot_preserve_dir` configuration value to the name of a directory will cause all images with `:outname:` set to be copied to this directory upon generation.

If an image is already in `plot_preserve_dir` when documentation is being generated, this image is copied to the build directory thereby pre-empting generation and reducing computation time in low-resource environments.


Related issues were raised on ReadTheDocs ([link](https://github.com/rtfd/readthedocs.org/issues/3468)) and on StackOverflow ([link](https://stackoverflow.com/q/48066337/752843)).












## PR Checklist

- [ ] Has Pytest style unit tests
 - It would, but I'm not sure how to go about writing them. Sorry :-/
- [X] Code is PEP 8 compliant
 - Leastwise, nothing new is added to the numerous pre-existing violations. PEP8 adherence makes code difficult to read :-/
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [X] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [X] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
