### PR TITLE
DOC: update the datetime64 HowTo

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -19,10 +19,11 @@ Plotting: howto
 Plot `numpy.datetime64` values
 ------------------------------
 
-For Matplotlib to plot dates (or any scalar with units) a converter
-to float needs to be registered with the `matplolib.units` module.  The
-current best converters for `datetime64` values are in `pandas`. To enable the
-converter, import it from pandas::
+As of Matplotlib 2.2, `numpy.datetime64` objects are handled the same way
+as `datetime.datetime` objects.
+
+If you prefer the pandas converters and locators, you can register their
+converter with the `matplolib.units` module::
 
   from pandas.tseries import converter as pdtc
   pdtc.register()


### PR DESCRIPTION
## PR Summary

Changed Howto to reflect that we have native `np.datetime64` handling now.  Still kept old info about pandas in there.

## PR Checklist

- [x] Documentation is sphinx and numpydoc compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

  