### PR TITLE
Use keyword arguments for setp() in examples

### DIFF
--- a/examples/lines_bars_and_markers/arctest.py
+++ b/examples/lines_bars_and_markers/arctest.py
@@ -18,7 +18,7 @@ def f(t):
 t1 = np.arange(0.0, 5.0, .2)
 
 l = plt.plot(t1, f(t1), 'ro')
-plt.setp(l, 'markersize', 30)
-plt.setp(l, 'markerfacecolor', 'C0')
+plt.setp(l, markersize=30)
+plt.setp(l, markerfacecolor='C0')
 
 plt.show()

--- a/examples/lines_bars_and_markers/stem_plot.py
+++ b/examples/lines_bars_and_markers/stem_plot.py
@@ -10,6 +10,6 @@ import numpy as np
 
 x = np.linspace(0.1, 2 * np.pi, 10)
 markerline, stemlines, baseline = plt.stem(x, np.cos(x), '-.')
-plt.setp(baseline, 'color', 'r', 'linewidth', 2)
+plt.setp(baseline, color='r', linewidth=2)
 
 plt.show()


### PR DESCRIPTION
## PR Summary

Migrate `setp()` usage in examples from MATLAB-like name-val positional arguments to keyword arguments.

Motivation: Keyword arguments are clearer, safer and more pythonic. We want to encourage their use over the alternative MATLAB-like API of `setp()`. All examples should thus use the keyword-API.

