### PR TITLE
Allow mplot3d rasterization; adjacent cleanups.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -107,6 +107,7 @@ class Text3D(mtext.Text):
         self._dir_vec = get_dir_vector(zdir)
         self.stale = True
 
+    @artist.allow_rasterization
     def draw(self, renderer):
         proj = proj3d.proj_trans_points(
             [self._position3d, self._position3d + self._dir_vec], renderer.M)
@@ -155,6 +156,7 @@ class Line3D(lines.Line2D):
         self._verts3d = juggle_axes(xs, ys, zs, zdir)
         self.stale = True
 
+    @artist.allow_rasterization
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
         xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
@@ -257,6 +259,7 @@ class Line3DCollection(LineCollection):
             minz = min(minz, min(zs))
         return minz
 
+    @artist.allow_rasterization
     def draw(self, renderer, project=False):
         if project:
             self.do_3d_projection(renderer)
@@ -301,9 +304,6 @@ class Patch3D(Patch):
         # FIXME: coloring
         self._facecolor2d = self._facecolor3d
         return min(vzs)
-
-    def draw(self, renderer):
-        Patch.draw(self, renderer)
 
 
 class PathPatch3D(Patch3D):
@@ -728,9 +728,6 @@ class Poly3DCollection(PolyCollection):
 
     def get_edgecolor(self):
         return self._edgecolors2d
-
-    def draw(self, renderer):
-        return Collection.draw(self, renderer)
 
 
 def poly_collection_2d_to_3d(col, zs=0, zdir='z'):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -21,6 +21,7 @@ import warnings
 
 import numpy as np
 
+from matplotlib import artist
 import matplotlib.axes as maxes
 import matplotlib.cbook as cbook
 import matplotlib.collections as mcoll
@@ -250,6 +251,7 @@ class Axes3D(Axes):
                  (tc[7], tc[4])]
         return edges
 
+    @artist.allow_rasterization
     def draw(self, renderer):
         # draw the background patch
         self.patch.draw(renderer)

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -7,13 +7,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-import math
 import copy
 
-from matplotlib import lines as mlines, axis as maxis, patches as mpatches
-from matplotlib import rcParams
-from . import art3d
-from . import proj3d
+from matplotlib import (
+    artist, lines as mlines, axis as maxis, patches as mpatches, rcParams)
+from . import art3d, proj3d
 
 import numpy as np
 
@@ -222,6 +220,7 @@ class Axis(maxis.XAxis):
 
         renderer.close_group('pane3d')
 
+    @artist.allow_rasterization
     def draw(self, renderer):
         self.label._transform = self.axes.transData
         renderer.open_group('axis3d')
@@ -299,7 +298,7 @@ class Axis(maxis.XAxis):
                                               renderer.M)
         self.label.set_position((tlx, tly))
         if self.get_rotate_label(self.label.get_text()):
-            angle = art3d.norm_text_angle(math.degrees(math.atan2(dy, dx)))
+            angle = art3d.norm_text_angle(np.rad2deg(np.arctan2(dy, dx)))
             self.label.set_rotation(angle)
         self.label.set_va(info['label']['va'])
         self.label.set_ha(info['label']['ha'])
@@ -322,7 +321,7 @@ class Axis(maxis.XAxis):
             pos[0], pos[1], pos[2], renderer.M)
         self.offsetText.set_text(self.major.formatter.get_offset())
         self.offsetText.set_position((olx, oly))
-        angle = art3d.norm_text_angle(math.degrees(math.atan2(dy, dx)))
+        angle = art3d.norm_text_angle(np.rad2deg(np.arctan2(dy, dx)))
         self.offsetText.set_rotation(angle)
         # Must set rotation mode to "anchor" so that
         # the alignment point is used as the "fulcrum" for rotation.


### PR DESCRIPTION
## PR Summary

Redo of #10013 which has gone stale and the OP seems uninterested in learning git (and the PR needs a rebase...).

Add allow_rasterization decorators to all relevant mplot3d artists to, well, let them respect the rasterized=True option.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
