### PR TITLE
Don't merge: FIX: fixing Qt5Agg speed issue

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -424,7 +424,6 @@ class FigureCanvasAgg(FigureCanvasBase):
         self.renderer = self.get_renderer(cleared=True)
         # acquire a lock on the shared font cache
         RendererAgg.lock.acquire()
-
         toolbar = self.toolbar
         try:
             if toolbar:

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -424,6 +424,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         self.renderer = self.get_renderer(cleared=True)
         # acquire a lock on the shared font cache
         RendererAgg.lock.acquire()
+
         toolbar = self.toolbar
         try:
             if toolbar:

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -156,6 +156,8 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         except Exception:
             # Uncaught exceptions are fatal for PyQt5, so catch them instead.
             traceback.print_exc()
+        finally:
+            self._agg_draw_pending = False
 
     def blit(self, bbox=None):
         """Blit the region in bbox.

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -124,7 +124,6 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         """
         # The Agg draw is done here; delaying causes problems with code that
         # uses the result of the draw() to update plot elements.
-
         super(FigureCanvasQTAggBase, self).draw()
         self.update()
 
@@ -136,11 +135,9 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         # current event loop in order to ensure thread affinity and to
         # accumulate multiple draw requests from event handling.
         # TODO: queued signal connection might be safer than singleShot
-
         if not self._agg_draw_pending:
             self._agg_draw_pending = True
             QtCore.QTimer.singleShot(0, self.__draw_idle_agg)
-
 
     def __draw_idle_agg(self, *args):
         # if nothing to do, bail

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -124,6 +124,7 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         """
         # The Agg draw is done here; delaying causes problems with code that
         # uses the result of the draw() to update plot elements.
+
         super(FigureCanvasQTAggBase, self).draw()
         self.update()
 
@@ -135,9 +136,11 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
         # current event loop in order to ensure thread affinity and to
         # accumulate multiple draw requests from event handling.
         # TODO: queued signal connection might be safer than singleShot
+
         if not self._agg_draw_pending:
             self._agg_draw_pending = True
             QtCore.QTimer.singleShot(0, self.__draw_idle_agg)
+
 
     def __draw_idle_agg(self, *args):
         # if nothing to do, bail
@@ -158,6 +161,10 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
             traceback.print_exc()
         finally:
             self._agg_draw_pending = False
+            # self.draw_idle() sets this to True, so we need to set to False
+            # or all of self.paintEvent gets called again despite the fact
+            # nothing has changed.
+
 
     def blit(self, bbox=None):
         """Blit the region in bbox.

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -162,7 +162,6 @@ class FigureCanvasQTAggBase(FigureCanvasAgg):
             # or all of self.paintEvent gets called again despite the fact
             # nothing has changed.
 
-
     def blit(self, bbox=None):
         """Blit the region in bbox.
         """


### PR DESCRIPTION
## PR Summary

This hack addresses #9406, #10140 and #10162 by partially rolling back the changes @tacaswell made to address the first two issues.  

I'm not going to pretend I actually understand why there was a performance hit from https://github.com/matplotlib/matplotlib/commit/9b8a944db954c8240e14413e517e1b781881b80b#diff-24fdb85343951b7d9bd270c47d6abe8f and why this fixes it.  I tested the other two issues and they seem fine as well.  

Feel free to close this if someone has a "proper" solution for what is going on here, and use this as a hint...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->