### PR TITLE
Replace normed with density in examples

### DIFF
--- a/examples/frontpage/histogram.py
+++ b/examples/frontpage/histogram.py
@@ -14,7 +14,7 @@ random_state = np.random.RandomState(19680801)
 X = random_state.randn(10000)
 
 fig, ax = plt.subplots()
-ax.hist(X, bins=25, normed=True)
+ax.hist(X, bins=25, density=True)
 x = np.linspace(-5, 5, 1000)
 ax.plot(x, 1 / np.sqrt(2*np.pi) * np.exp(-(x**2)/2), linewidth=4)
 ax.set_xticks([])

--- a/examples/pyplots/pyplot_text.py
+++ b/examples/pyplots/pyplot_text.py
@@ -14,7 +14,7 @@ mu, sigma = 100, 15
 x = mu + sigma * np.random.randn(10000)
 
 # the histogram of the data
-n, bins, patches = plt.hist(x, 50, normed=1, facecolor='g', alpha=0.75)
+n, bins, patches = plt.hist(x, 50, density=True, facecolor='g', alpha=0.75)
 
 
 plt.xlabel('Smarts')

--- a/examples/statistics/histogram_cumulative.py
+++ b/examples/statistics/histogram_cumulative.py
@@ -49,7 +49,7 @@ x = np.random.normal(mu, sigma, size=100)
 fig, ax = plt.subplots(figsize=(8, 4))
 
 # plot the cumulative histogram
-n, bins, patches = ax.hist(x, n_bins, normed=1, histtype='step',
+n, bins, patches = ax.hist(x, n_bins, density=True, histtype='step',
                            cumulative=True, label='Empirical')
 
 # Add a line showing the expected distribution.
@@ -59,7 +59,7 @@ y /= y[-1]
 ax.plot(bins, y, 'k--', linewidth=1.5, label='Theoretical')
 
 # Overlay a reversed cumulative histogram.
-ax.hist(x, bins=bins, normed=1, histtype='step', cumulative=-1,
+ax.hist(x, bins=bins, density=True, histtype='step', cumulative=-1,
         label='Reversed emp.')
 
 # tidy up the figure

--- a/examples/statistics/histogram_histtypes.py
+++ b/examples/statistics/histogram_histtypes.py
@@ -23,12 +23,12 @@ x = np.random.normal(mu, sigma, size=100)
 
 fig, (ax0, ax1) = plt.subplots(ncols=2, figsize=(8, 4))
 
-ax0.hist(x, 20, normed=1, histtype='stepfilled', facecolor='g', alpha=0.75)
+ax0.hist(x, 20, density=True, histtype='stepfilled', facecolor='g', alpha=0.75)
 ax0.set_title('stepfilled')
 
 # Create a histogram by providing the bin edges (unequally spaced).
 bins = [100, 150, 180, 195, 205, 220, 250, 300]
-ax1.hist(x, bins, normed=1, histtype='bar', rwidth=0.8)
+ax1.hist(x, bins, density=True, histtype='bar', rwidth=0.8)
 ax1.set_title('unequal bins')
 
 fig.tight_layout()

--- a/examples/statistics/histogram_multihist.py
+++ b/examples/statistics/histogram_multihist.py
@@ -28,11 +28,11 @@ fig, axes = plt.subplots(nrows=2, ncols=2)
 ax0, ax1, ax2, ax3 = axes.flatten()
 
 colors = ['red', 'tan', 'lime']
-ax0.hist(x, n_bins, normed=1, histtype='bar', color=colors, label=colors)
+ax0.hist(x, n_bins, density=True, histtype='bar', color=colors, label=colors)
 ax0.legend(prop={'size': 10})
 ax0.set_title('bars with legend')
 
-ax1.hist(x, n_bins, normed=1, histtype='bar', stacked=True)
+ax1.hist(x, n_bins, density=True, histtype='bar', stacked=True)
 ax1.set_title('stacked bar')
 
 ax2.hist(x, n_bins, histtype='step', stacked=True, fill=False)

--- a/examples/style_sheets/bmh.py
+++ b/examples/style_sheets/bmh.py
@@ -18,7 +18,7 @@ plt.style.use('bmh')
 
 def plot_beta_hist(ax, a, b):
     ax.hist(beta(a, b, size=10000), histtype="stepfilled",
-            bins=25, alpha=0.8, normed=True)
+            bins=25, alpha=0.8, density=True)
 
 
 fig, ax = plt.subplots()

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -88,7 +88,8 @@ def plot_histograms(ax, prng, nb_samples=10000):
     params = ((10, 10), (4, 12), (50, 12), (6, 55))
     for a, b in params:
         values = prng.beta(a, b, size=nb_samples)
-        ax.hist(values, histtype="stepfilled", bins=30, alpha=0.8, normed=True)
+        ax.hist(values, histtype="stepfilled", bins=30,
+                alpha=0.8, density=True)
     # Add a small annotation.
     ax.annotate('Annotation', xy=(0.25, 4.25), xycoords='data',
                 xytext=(0.9, 0.9), textcoords='axes fraction',

--- a/examples/subplots_axes_and_figures/axes_demo.py
+++ b/examples/subplots_axes_and_figures/axes_demo.py
@@ -28,7 +28,7 @@ plt.title('Gaussian colored noise')
 
 # this is an inset axes over the main axes
 a = plt.axes([.65, .6, .2, .2], facecolor='k')
-n, bins, patches = plt.hist(s, 400, normed=1)
+n, bins, patches = plt.hist(s, 400, density=True)
 plt.title('Probability')
 plt.xticks([])
 plt.yticks([])

--- a/examples/user_interfaces/histogram_demo_canvasagg_sgskip.py
+++ b/examples/user_interfaces/histogram_demo_canvasagg_sgskip.py
@@ -26,7 +26,7 @@ mu, sigma = 100, 15
 x = mu + sigma * np.random.randn(10000)
 
 # the histogram of the data
-n, bins, patches = ax.hist(x, 50, normed=1)
+n, bins, patches = ax.hist(x, 50, density=True)
 
 # add a 'best fit' line
 y = normpdf(bins, mu, sigma)


### PR DESCRIPTION
The `normed` kwarg was deprecated a while ago, and replaced with `density`.