### PR TITLE
Agg: When a single Text uses usetex, don't pass it through mathtext parser

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -222,7 +222,7 @@ class RendererAgg(RendererBase):
         to the baseline), in display coords, of the string *s* with
         :class:`~matplotlib.font_manager.FontProperties` *prop*
         """
-        if rcParams['text.usetex']:
+        if ismath in ["TeX", "TeX!"]:
             # todo: handle props
             size = prop.get_size_in_points()
             texmanager = self.get_texmanager()

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -14,6 +14,11 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
+needs_usetex = pytest.mark.xfail(
+    not matplotlib.checkdep_usetex(True),
+    reason="This test needs a TeX installation")
+
+
 @image_comparison(baseline_images=['font_styles'])
 def test_font_styles():
     from matplotlib import _get_data_path
@@ -459,3 +464,13 @@ def test_hinting_factor_backends():
     # Backends should apply hinting_factor consistently (within 10%).
     np.testing.assert_allclose(t.get_window_extent().intervalx, expected,
                                rtol=0.1)
+
+
+@needs_usetex
+def test_single_artist_usetex():
+    # Check that a single artist marked with usetex does not get passed through
+    # the mathtext parser at all (for the Agg backend) (the mathtext parser
+    # currently fails to parse \frac12, requiring \frac{1}{2} instead).
+    fig, ax = plt.subplots()
+    ax.text(.5, .5, r"$\frac12$", usetex=True)
+    fig.canvas.draw()


### PR DESCRIPTION
... because the artist may have tex constructs that are not handled by
mathtext but are handled by a real tex interpreter; e.g.

    plt.text(.5, .5, r"\frac12", usetex=True)

should not fail.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
