### PR TITLE
remove evt.Skip() from EVT_PAINT handler

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -937,7 +937,6 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
             self.draw(drawDC=drawDC)
         else:
             self.gui_repaint(drawDC=drawDC)
-        evt.Skip()
 
     def _onSize(self, evt):
         """


### PR DESCRIPTION
## PR Summary
Currently evt.Skip() is called at the end of the EVT_PAINT handler.
This should not be done and causes errors on screen when the canvas is redrawn partially, e.g. when a window is dragged over the canvas.
Strange enough, the errors don't occur always, but e.g. with "embedding_in_wx2.py" on Windows 7, 64 bit.

![repaint](https://user-images.githubusercontent.com/5512021/34654348-7c2ceed4-f3f2-11e7-9663-6edaf3763a6d.png)


## PR Checklist
 -> not applicable
- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
