### PR TITLE
AFM fonts don't have .postscript_name, but .get_fontname().

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1146,7 +1146,7 @@ class StandardPsFonts(Fonts):
             num = ord(glyph)
             found_symbol = True
         else:
-            warn("No TeX to built-in Postscript mapping for '%s'" % sym,
+            warn("No TeX to built-in Postscript mapping for {!r}".format(sym),
                  MathTextWarning)
 
         slanted = (fontname == 'it')
@@ -1156,9 +1156,8 @@ class StandardPsFonts(Fonts):
             try:
                 symbol_name = font.get_name_char(glyph)
             except KeyError:
-                warn("No glyph in standard Postscript font '%s' for '%s'" %
-                     (font.postscript_name, sym),
-                     MathTextWarning)
+                warn("No glyph in standard Postscript font {!r} for {!r}"
+                     .format(font.get_fontname(), sym), MathTextWarning)
                 found_symbol = False
 
         if not found_symbol:


### PR DESCRIPTION
```
rcdefaults()
rcParams["ps.useafm"] = True
rcParams["axes.formatter.use_mathtext"] = True
xlim(-1, 1)
savefig("/tmp/test.ps")
```
would result in a crash when trying to format a warning because AFM
fonts (which are the only ones used by the StandardPSFonts class (see
constructor and _get_class) don't have a postscript_name attribute;
the corresponding method is get_fontname().

cf #9127, which this partially fixes; however the unicode minus sign is still replaced by a question mark, and given how frequent it is I wonder whether it would make sense to map it to a hyphen or an endash when using afm).

Edit regarding the last note: Or we may just update to a newer version (2.000 (1997) instead of 1.006 (1990)) of the AFM file which *is* available at http://www.adobe.com/devnet/font.html and includes a "minus" entry (the license for the file is "This file and the 14 PostScript(R) AFM files it accompanies may be used, copied, and distributed for any purpose and without charge, with or without modification, provided that all copyright notices are retained; that the AFM files are not distributed without this file; that all modifications to this file or any of the AFM files are prominently noted in the modified file(s); and that this paragraph is not modified. Adobe Systems has no responsibility or obligation to support the use of the AFM files." which sounds acceptable?)
Note for self: if we switch to the new AFM files, use https://github.com/adobe-type-tools/agl-aglfn for mapping adobe glyph names to unicode entries.

Re-edit: actually the file we ship (phvr8a.afm) *already* includes a "minus" entry, we just don't map it because we don't have the glyph names mapping... https://www-cdf.fnal.gov/offline/PostScript/PLRM2.pdf page 591 etc for the nitty gritty details

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

  
  