### PR TITLE
Cleanup backend_cairo.

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -29,26 +29,25 @@ import warnings
 
 import numpy as np
 
+# cairocffi is more widely compatible than pycairo (in particular pgi only
+# works with cairocffi) so try it first.
 try:
     import cairocffi as cairo
 except ImportError:
     try:
         import cairo
     except ImportError:
-        raise ImportError("Cairo backend requires that cairocffi or pycairo "
-                          "is installed.")
+        raise ImportError("cairo backend requires that cairocffi or pycairo "
+                          "is installed")
     else:
         HAS_CAIRO_CFFI = False
 else:
     HAS_CAIRO_CFFI = True
 
-_version_required = (1, 2, 0)
-if cairo.version_info < _version_required:
-    raise ImportError("Pycairo %d.%d.%d is installed\n"
-                      "Pycairo %d.%d.%d or later is required"
-                      % (cairo.version_info + _version_required))
+if cairo.version_info < (1, 4, 0):
+    raise ImportError("cairo {} is installed; "
+                      "cairo>=1.4.0 is required".format(cairo.version))
 backend_version = cairo.version
-del _version_required
 
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
@@ -113,14 +112,14 @@ class RendererCairo(RendererBase):
 
     def set_ctx_from_surface(self, surface):
         self.gc.ctx = cairo.Context(surface)
+        # Although it may appear natural to automatically call
+        # `self.set_width_height(surface.get_width(), surface.get_height())`
+        # here (instead of having the caller do so separately), this would fail
+        # for PDF/PS/SVG surfaces, which have no way to report their extents.
 
     def set_width_height(self, width, height):
         self.width  = width
         self.height = height
-        self.matrix_flipy = cairo.Matrix(yy=-1, y0=self.height)
-        # use matrix_flipy for ALL rendering?
-        # - problem with text? - will need to switch matrix_flipy off, or do a
-        # font transform?
 
     def _fill_and_stroke(self, ctx, fill_c, alpha, alpha_overrides):
         if fill_c is not None:
@@ -313,11 +312,6 @@ class RendererCairo(RendererBase):
             ctx.fill_preserve()
 
         ctx.restore()
-
-    def flipy(self):
-        return True
-        #return False # tried - all draw objects ok except text (and images?)
-        # which comes out mirrored!
 
     def get_canvas_width_height(self):
         return self.width, self.height


### PR DESCRIPTION
Split out of the qt5cairo PR (#8771).

- Update to cairo 1.4.0 as minimal version (it introduced
  Context.clip_extents, which we use;
  https://pycairo.readthedocs.io/en/latest/changelog.html#id26)
- matrix_flipy is unused.
- flipy() is already True in the base class.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

  