### PR TITLE
Don't convert numbers plotted on an axis with units

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1498,6 +1498,10 @@ class Axis(artist.Artist):
         return self.converter is not None or self.units is not None
 
     def convert_units(self, x):
+        # If x is already a number, doesn't need converting
+        if munits.ConversionInterface.is_numlike(x):
+            return x
+
         if self.converter is None:
             self.converter = munits.registry.get_converter(x)
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1738,8 +1738,6 @@ class DateConverter(units.ConversionInterface):
 
         The *unit* and *axis* arguments are not used.
         """
-        if units.ConversionInterface.is_numlike(value):
-            return value
         return date2num(value)
 
     @staticmethod

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -31,7 +31,10 @@ class Quantity(object):
         return getattr(self.magnitude, attr)
 
     def __getitem__(self, item):
-        return Quantity(self.magnitude[item], self.units)
+        if iterable(self.magnitude):
+            return Quantity(self.magnitude[item], self.units)
+        else:
+            return Quantity(self.magnitude[item], self.units)
 
     def __array__(self):
         return np.asarray(self.magnitude)

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -34,7 +34,7 @@ class Quantity(object):
         if iterable(self.magnitude):
             return Quantity(self.magnitude[item], self.units)
         else:
-            return Quantity(self.magnitude[item], self.units)
+            return Quantity(self.magnitude, self.units)
 
     def __array__(self):
         return np.asarray(self.magnitude)


### PR DESCRIPTION
I've been playing around trying to get Astropy units to play nicely with Matpltolib recently. One of the things I've realised is that some of the `datetime` plotting capabilities rely on the `datetime` converter just passing through numbers without attempting to convert them. (the specific example where I came across this is axhline/axvline when the x and y units are different).

This PR means custom converters do not have to manually pass through floats (e.g.), but instead it is automatically done at "convert time". I think this makes explicit what @efiring said in [this comment ](https://github.com/matplotlib/matplotlib/pull/9776#issuecomment-356102629) about always letting unit-less data being plotted on an axis with units.

Also pinging @jklymak because this probably affects your converter PR.