### PR TITLE
Various backend cleanups.

### DIFF
--- a/doc/api/api_changes/2018-08-17-AL-deprecations.rst
+++ b/doc/api/api_changes/2018-08-17-AL-deprecations.rst
@@ -1,0 +1,9 @@
+API deprecations
+````````````````
+
+The following API elements are deprecated:
+
+- ``backend_gtk3cairo.FigureCanvasGTK3Cairo``,
+- ``backend_wx.debug_on_error``, ``backend_wx.fake_stderr``,
+  ``backend_wx.raise_msg_to_str``, ``backend_wx.MenuButtonWx``,
+  ``backend_wx.PrintoutWx``,

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -1,19 +1,17 @@
-import math
+from contextlib import contextmanager
 import logging
+import math
 import os.path
 import sys
 import tkinter as tk
 from tkinter.simpledialog import SimpleDialog
 import tkinter.filedialog
 import tkinter.messagebox
-from contextlib import contextmanager
 
 import numpy as np
 
-from . import _tkagg
-
 import matplotlib
-from matplotlib import backend_tools, rcParams
+from matplotlib import backend_tools, cbook, rcParams
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
     StatusbarBase, TimerBase, ToolContainerBase, cursors)
@@ -21,6 +19,7 @@ from matplotlib.backend_managers import ToolManager
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.figure import Figure
 from matplotlib.widgets import SubplotTool
+from . import _tkagg
 
 try:
     from ._tkagg import Win32_GetForegroundWindow, Win32_SetForegroundWindow
@@ -54,18 +53,6 @@ cursord = {
     cursors.SELECT_REGION: "tcross",
     cursors.WAIT: "watch",
     }
-
-
-def raise_msg_to_str(msg):
-    """msg is a return arg from a raise.  Join with new lines"""
-    if not isinstance(msg, str):
-        msg = '\n'.join(map(str, msg))
-    return msg
-
-
-def error_msg_tkpaint(msg, parent=None):
-    import tkinter.messagebox
-    tkinter.messagebox.showerror("matplotlib", msg)
 
 
 def blit(photoimage, aggimage, offsets, bbox=None):

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -385,16 +385,11 @@ class FigureCanvasAgg(FigureCanvasBase):
         Draw the figure using the renderer.
         """
         self.renderer = self.get_renderer(cleared=True)
-        # acquire a lock on the shared font cache
-        RendererAgg.lock.acquire()
-
-        try:
+        with RendererAgg.lock:
             self.figure.draw(self.renderer)
             # A GUI class may be need to update a window using this draw, so
             # don't forget to call the superclass.
             super().draw()
-        finally:
-            RendererAgg.lock.release()
 
     def get_renderer(self, cleared=False):
         l, b, w, h = self.figure.bbox.bounds

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -293,11 +293,8 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         pass
 
     def draw(self):
-        if self.get_visible() and self.get_mapped():
+        if self.is_drawable():
             self.queue_draw()
-            # do a synchronous draw (its less efficient than an async draw,
-            # but is required if/when animation is used)
-            self.get_property("window").process_updates(False)
 
     def draw_idle(self):
         if self._idle_draw_id != 0:

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -1,5 +1,6 @@
 from . import backend_cairo, backend_gtk3
 from .backend_gtk3 import Gtk, _BackendGTK3
+from matplotlib import cbook
 from matplotlib.backend_bases import cursors
 
 
@@ -35,6 +36,7 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
         return False  # finish event propagation?
 
 
+@cbook.deprecated("3.1", alternative="backend_gtk3.FigureManagerGTK3")
 class FigureManagerGTK3Cairo(backend_gtk3.FigureManagerGTK3):
     pass
 
@@ -42,4 +44,3 @@ class FigureManagerGTK3Cairo(backend_gtk3.FigureManagerGTK3):
 @_BackendGTK3.export
 class _BackendGTK3Cairo(_BackendGTK3):
     FigureCanvas = FigureCanvasGTK3Cairo
-    FigureManager = FigureManagerGTK3Cairo

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -1,5 +1,5 @@
 """
-Render to qt from agg
+Render to qt from agg.
 """
 
 import ctypes
@@ -31,8 +31,8 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
             return
         self._draw_idle()  # Only does something if a draw is pending.
 
-        # if the canvas does not have a renderer, then give up and wait for
-        # FigureCanvasAgg.draw(self) to be called
+        # If the canvas does not have a renderer, then give up and wait for
+        # FigureCanvasAgg.draw(self) to be called.
         if not hasattr(self, 'renderer'):
             return
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -20,13 +20,13 @@ from matplotlib.backend_bases import (
     StatusbarBase)
 from matplotlib.backend_bases import _has_pil
 
+from matplotlib import cbook, rcParams, backend_tools
 from matplotlib._pylab_helpers import Gcf
+from matplotlib.backend_managers import ToolManager
 from matplotlib.figure import Figure
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
 from matplotlib.widgets import SubplotTool
-from matplotlib.backend_managers import ToolManager
-from matplotlib import cbook, rcParams, backend_tools
 
 import wx
 
@@ -38,30 +38,25 @@ _log = logging.getLogger(__name__)
 # traceback is performed, and pdb activated, for all uncaught exceptions in
 # this case
 _DEBUG = 5
-if _DEBUG < 5:
-    import traceback
-    import pdb
 _DEBUG_lvls = {1: 'Low ', 2: 'Med ', 3: 'High', 4: 'Error'}
 
 
 def DEBUG_MSG(string, lvl=3, o=None):
     if lvl >= _DEBUG:
-        cls = o.__class__
-        # Jeremy, often times the commented line won't print but the
-        # one below does.  I think WX is redefining stderr, damned
-        # beast
-        # print("%s- %s in %s" % (_DEBUG_lvls[lvl], string, cls),
-        #       file=sys.stderr)
-        print("%s- %s in %s" % (_DEBUG_lvls[lvl], string, cls))
+        print(f"{_DEBUG_lvls[lvl]}- {string} in {type(o)}")
 
 
+@cbook.deprecated("3.1")
 def debug_on_error(type, value, tb):
     """Code due to Thomas Heller - published in Python Cookbook (O'Reilley)"""
+    import pdb
+    import traceback
     traceback.print_exception(type, value, tb)
     print()
-    pdb.pm()  # jdh uncomment
+    pdb.pm()
 
 
+@cbook.deprecated("3.1")
 class fake_stderr(object):
     """
     Wx does strange things with stderr, as it makes the assumption that
@@ -96,6 +91,7 @@ def error_msg_wx(msg, parent=None):
     return None
 
 
+@cbook.deprecated("3.1")
 def raise_msg_to_str(msg):
     """msg is a return arg from a raise.  Join with new lines."""
     if not isinstance(msg, str):
@@ -1091,22 +1087,16 @@ class FigureCanvasWx(_FigureCanvasWxBase):
             image = self.bitmap.ConvertToImage()
             image.SetOption(wx.IMAGE_OPTION_QUALITY, str(jpeg_quality))
 
-        # Now that we have rendered into the bitmap, save it
-        # to the appropriate file type and clean up
+        # Now that we have rendered into the bitmap, save it to the appropriate
+        # file type and clean up.
         if isinstance(filename, str):
             if not image.SaveFile(filename, filetype):
-                DEBUG_MSG('print_figure() file save error', 4, self)
-                raise RuntimeError(
-                    'Could not save figure to %s\n' %
-                    (filename))
+                raise RuntimeError(f'Could not save figure to {filename}')
         elif cbook.is_writable_file_like(filename):
             if not isinstance(image, wx.Image):
                 image = image.ConvertToImage()
             if not image.SaveStream(filename, filetype):
-                DEBUG_MSG('print_figure() file save error', 4, self)
-                raise RuntimeError(
-                    'Could not save figure to %s\n' %
-                    (filename))
+                raise RuntimeError(f'Could not save figure to {filename}')
 
         # Restore everything to normal
         self.bitmap = origBitmap
@@ -1316,6 +1306,7 @@ def _set_frame_icon(frame):
     frame.SetIcons(bundle)
 
 
+@cbook.deprecated("3.1")
 class MenuButtonWx(wx.Button):
     """
     wxPython does not permit a menu to be incorporated directly into a toolbar.
@@ -1393,7 +1384,7 @@ class MenuButtonWx(wx.Button):
         """Ensures that there are entries for max_axis axes in the menu
         (selected by default)."""
         if maxAxis > len(self._axisId):
-            for i in range(len(self._axisId) + 1, maxAxis + 1, 1):
+            for i in range(len(self._axisId) + 1, maxAxis + 1):
                 menuId = wx.NewId()
                 self._axisId.append(menuId)
                 self._menu.Append(menuId, "Axis %d" % i,
@@ -1638,15 +1629,9 @@ class StatusBarWx(wx.StatusBar):
     def __init__(self, parent, *args, **kwargs):
         wx.StatusBar.__init__(self, parent, -1)
         self.SetFieldsCount(2)
-        self.SetStatusText("None", 1)
-        # self.SetStatusText("Measurement: None", 2)
-        # self.Reposition()
 
     def set_function(self, string):
         self.SetStatusText("%s" % string, 1)
-
-    # def set_measurement(self, string):
-    #    self.SetStatusText("Measurement: %s" % string, 2)
 
 
 # tools for matplotlib.backend_managers.ToolManager:
@@ -1956,6 +1941,7 @@ backend_tools.ToolCopyToClipboard = ToolCopyToClipboardWx
 
 # < Additions for printing support: Matt Newville
 
+@cbook.deprecated("3.1")
 class PrintoutWx(wx.Printout):
     """
     Simple wrapper around wx Printout class -- all the real work
@@ -2037,7 +2023,6 @@ class PrintoutWx(wx.Printout):
         self.canvas.figure.dpi = fig_dpi
         self.canvas.draw()
         return True
-# >
 
 
 @_Backend.export


### PR DESCRIPTION
Split out from the qt5cairo and wxcairo PRs.

- GTK3: is_drawable is the same as mapped & visible
  (https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-is-drawable)
- Synchronous draw appears unnecessary on GTK3 based on tests (probably
  was only needed in early animation code).
- Most of the Wx printout code has been removed in 84ffb60; this PR just
  deprecates some remnants of it.  MenuButtonWx is likewise unused since
  the removal of "classic" toolbars in 4243470; this PR deprecates it.
- _convert_agg_to_wx_image is unused; _WX28_clipped_agg_as_bitmap can
  reasonably be inlined into _convert_agg_to_wx_bitmap.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
