### PR TITLE
Add closing quotes to embedded python in rst markup.

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -189,6 +189,9 @@ guide:
      'polar' | 'rectilinear'], optional
              The projection type of the axes.
 
+         ...
+         """
+
   Alternatively, you can describe the valid parameter values in a dedicated
   section of the docstring.
 
@@ -202,8 +205,6 @@ guide:
      Returns
      -------
      lines : `~matplotlib.collections.LineCollection`
-
-
 
 Linking to other code
 ---------------------
@@ -322,6 +323,7 @@ calls in `matplotlib.patches`.
 
 Adding figures
 ==============
+
 Figures in the documentation are automatically generated from scripts.
 It is not necessary to explicitly save the figure from the script; this will be
 done automatically when the docs are built to ensure that the code that is


### PR DESCRIPTION
Otherwise, this confuses vim's rst syntax highlighter, which actually
highlights embedded Python as, well, Python, but current thinks that the
multiline string extends all the way to the end of the file.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
