### PR TITLE
Unify "blank space" and "white space" to "space".

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -171,10 +171,10 @@ The other parameters you can configure are, with their defaults
 *top* = 0.9
     the top of the subplots of the figure
 *wspace* = 0.2
-    the amount of width reserved for blank space between subplots,
+    the amount of width reserved for space between subplots,
     expressed as a fraction of the average axis width
 *hspace* = 0.2
-    the amount of height reserved for white space between subplots,
+    the amount of height reserved for space between subplots,
     expressed as a fraction of the average axis height
 
 If you want additional control, you can create an

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -193,11 +193,11 @@ class SubplotParams(object):
             The top of the subplots of the figure
 
         wspace : 0.2
-            The amount of width reserved for blank space between subplots,
+            The amount of width reserved for space between subplots,
             expressed as a fraction of the average axis width
 
         hspace : 0.2
-            The amount of height reserved for white space between subplots,
+            The amount of height reserved for space between subplots,
             expressed as a fraction of the average axis height
         """
 

--- a/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
@@ -313,9 +313,9 @@ figure.subplot.left    : 0.125  # the left side of the subplots of the figure
 figure.subplot.right   : 0.9    # the right side of the subplots of the figure
 figure.subplot.bottom  : 0.1    # the bottom of the subplots of the figure
 figure.subplot.top     : 0.9    # the top of the subplots of the figure
-figure.subplot.wspace  : 0.2    # the amount of width reserved for blank space between subplots,
+figure.subplot.wspace  : 0.2    # the amount of width reserved for space between subplots,
                                 # expressed as a fraction of the average axis width
-figure.subplot.hspace  : 0.2    # the amount of height reserved for white space between subplots,
+figure.subplot.hspace  : 0.2    # the amount of height reserved for space between subplots,
                                 # expressed as a fraction of the average axis height
 
 ### IMAGES

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -315,9 +315,9 @@ figure.subplot.left    : 0.125  # the left side of the subplots of the figure
 figure.subplot.right   : 0.9    # the right side of the subplots of the figure
 figure.subplot.bottom  : 0.1    # the bottom of the subplots of the figure
 figure.subplot.top     : 0.9    # the top of the subplots of the figure
-figure.subplot.wspace  : 0.2    # the amount of width reserved for blank space between subplots,
+figure.subplot.wspace  : 0.2    # the amount of width reserved for space between subplots,
                                 # expressed as a fraction of the average axis width
-figure.subplot.hspace  : 0.2    # the amount of height reserved for white space between subplots,
+figure.subplot.hspace  : 0.2    # the amount of height reserved for space between subplots,
                                 # expressed as a fraction of the average axis height
 
 ### IMAGES

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1309,9 +1309,9 @@ def subplots_adjust(*args, **kwargs):
       right = 0.9    # the right side of the subplots of the figure
       bottom = 0.1   # the bottom of the subplots of the figure
       top = 0.9      # the top of the subplots of the figure
-      wspace = 0.2   # the amount of width reserved for blank space between subplots,
+      wspace = 0.2   # the amount of width reserved for space between subplots,
                      # expressed as a fraction of the average axis width
-      hspace = 0.2   # the amount of height reserved for white space between subplots,
+      hspace = 0.2   # the amount of height reserved for space between subplots,
                      # expressed as a fraction of the average axis height
 
     The actual defaults are controlled by the rc file

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -442,9 +442,9 @@ backend      : $TEMPLATE_BACKEND
 #figure.subplot.right   : 0.9    # the right side of the subplots of the figure
 #figure.subplot.bottom  : 0.11    # the bottom of the subplots of the figure
 #figure.subplot.top     : 0.88    # the top of the subplots of the figure
-#figure.subplot.wspace  : 0.2    # the amount of width reserved for blank space between subplots,
+#figure.subplot.wspace  : 0.2    # the amount of width reserved for space between subplots,
                                  # expressed as a fraction of the average axis width
-#figure.subplot.hspace  : 0.2    # the amount of height reserved for white space between subplots,
+#figure.subplot.hspace  : 0.2    # the amount of height reserved for space between subplots,
                                  # expressed as a fraction of the average axis height
 
 


### PR DESCRIPTION
Note that there are many usages of "whitespace" elsewhere that are left
unchanged, as I believe they generally make sentences clearer.

Closes #9160.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
