### PR TITLE
Move unrendered docstrings to private attributes.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6032,7 +6032,7 @@ linewidth=2, markersize=12)
         contours = mcontour.QuadContourSet(self, *args, **kwargs)
         self.autoscale_view()
         return contours
-    contour.__doc__ = mcontour.QuadContourSet.contour_doc
+    contour.__doc__ = mcontour.QuadContourSet._contour_doc
 
     @_preprocess_data()
     def contourf(self, *args, **kwargs):
@@ -6042,7 +6042,7 @@ linewidth=2, markersize=12)
         contours = mcontour.QuadContourSet(self, *args, **kwargs)
         self.autoscale_view()
         return contours
-    contourf.__doc__ = mcontour.QuadContourSet.contour_doc
+    contourf.__doc__ = mcontour.QuadContourSet._contour_doc
 
     def clabel(self, CS, *args, **kwargs):
         return CS.clabel(*args, **kwargs)
@@ -7856,11 +7856,11 @@ linewidth=2, markersize=12)
 
     def tricontour(self, *args, **kwargs):
         return mtri.tricontour(self, *args, **kwargs)
-    tricontour.__doc__ = mtri.TriContourSet.tricontour_doc
+    tricontour.__doc__ = mtri.tricontour.__doc__
 
     def tricontourf(self, *args, **kwargs):
         return mtri.tricontourf(self, *args, **kwargs)
-    tricontourf.__doc__ = mtri.TriContourSet.tricontour_doc
+    tricontourf.__doc__ = mtri.tricontour.__doc__
 
     def tripcolor(self, *args, **kwargs):
         return mtri.tripcolor(self, *args, **kwargs)

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -779,8 +779,8 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             particular contour level are grouped together so that
             ``level0segs = [polygon0]`` and ``level0kinds = [polygon0kinds]``.
 
-        Keyword arguments are as described in
-        :attr:`matplotlib.contour.QuadContourSet.contour_doc`.
+        Keyword arguments are as described in the docstring of
+        `~.Axes.contour`.
         """
         self.ax = ax
         self.levels = kwargs.pop('levels', None)
@@ -1571,7 +1571,7 @@ class QuadContourSet(ContourSet):
             y = y[::-1]
         return np.meshgrid(x, y)
 
-    contour_doc = """
+    _contour_doc = """
         Plot contours.
 
         :func:`~matplotlib.pyplot.contour` and

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -195,7 +195,7 @@ class Dvi(object):
     """
     # dispatch table
     _dtable = [None for _ in xrange(256)]
-    dispatch = partial(_dispatch, _dtable)
+    _dispatch = partial(_dispatch, _dtable)
 
     def __init__(self, filename, dpi):
         """
@@ -332,22 +332,22 @@ class Dvi(object):
             value = 0x100*value + ord(str[i])
         return value
 
-    @dispatch(min=0, max=127, state=_dvistate.inpage)
+    @_dispatch(min=0, max=127, state=_dvistate.inpage)
     def _set_char_immediate(self, char):
         self._put_char_real(char)
         self.h += self.fonts[self.f]._width_of(char)
 
-    @dispatch(min=128, max=131, state=_dvistate.inpage, args=('olen1',))
+    @_dispatch(min=128, max=131, state=_dvistate.inpage, args=('olen1',))
     def _set_char(self, char):
         self._put_char_real(char)
         self.h += self.fonts[self.f]._width_of(char)
 
-    @dispatch(132, state=_dvistate.inpage, args=('s4', 's4'))
+    @_dispatch(132, state=_dvistate.inpage, args=('s4', 's4'))
     def _set_rule(self, a, b):
         self._put_rule_real(a, b)
         self.h += b
 
-    @dispatch(min=133, max=136, state=_dvistate.inpage, args=('olen1',))
+    @_dispatch(min=133, max=136, state=_dvistate.inpage, args=('olen1',))
     def _put_char(self, char):
         self._put_char_real(char)
 
@@ -369,7 +369,7 @@ class Dvi(object):
                                    _mul2012(a, scale), _mul2012(b, scale))
                                for x, y, a, b in font._vf[char].boxes])
 
-    @dispatch(137, state=_dvistate.inpage, args=('s4', 's4'))
+    @_dispatch(137, state=_dvistate.inpage, args=('s4', 's4'))
     def _put_rule(self, a, b):
         self._put_rule_real(a, b)
 
@@ -377,11 +377,11 @@ class Dvi(object):
         if a > 0 and b > 0:
             self.boxes.append(Box(self.h, self.v, a, b))
 
-    @dispatch(138)
+    @_dispatch(138)
     def _nop(self, _):
         pass
 
-    @dispatch(139, state=_dvistate.outer, args=('s4',)*11)
+    @_dispatch(139, state=_dvistate.outer, args=('s4',)*11)
     def _bop(self, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, p):
         self.state = _dvistate.inpage
         self.h, self.v, self.w, self.x, self.y, self.z = 0, 0, 0, 0, 0, 0
@@ -389,60 +389,60 @@ class Dvi(object):
         self.text = []          # list of Text objects
         self.boxes = []         # list of Box objects
 
-    @dispatch(140, state=_dvistate.inpage)
+    @_dispatch(140, state=_dvistate.inpage)
     def _eop(self, _):
         self.state = _dvistate.outer
         del self.h, self.v, self.w, self.x, self.y, self.z, self.stack
 
-    @dispatch(141, state=_dvistate.inpage)
+    @_dispatch(141, state=_dvistate.inpage)
     def _push(self, _):
         self.stack.append((self.h, self.v, self.w, self.x, self.y, self.z))
 
-    @dispatch(142, state=_dvistate.inpage)
+    @_dispatch(142, state=_dvistate.inpage)
     def _pop(self, _):
         self.h, self.v, self.w, self.x, self.y, self.z = self.stack.pop()
 
-    @dispatch(min=143, max=146, state=_dvistate.inpage, args=('slen1',))
+    @_dispatch(min=143, max=146, state=_dvistate.inpage, args=('slen1',))
     def _right(self, b):
         self.h += b
 
-    @dispatch(min=147, max=151, state=_dvistate.inpage, args=('slen',))
+    @_dispatch(min=147, max=151, state=_dvistate.inpage, args=('slen',))
     def _right_w(self, new_w):
         if new_w is not None:
             self.w = new_w
         self.h += self.w
 
-    @dispatch(min=152, max=156, state=_dvistate.inpage, args=('slen',))
+    @_dispatch(min=152, max=156, state=_dvistate.inpage, args=('slen',))
     def _right_x(self, new_x):
         if new_x is not None:
             self.x = new_x
         self.h += self.x
 
-    @dispatch(min=157, max=160, state=_dvistate.inpage, args=('slen1',))
+    @_dispatch(min=157, max=160, state=_dvistate.inpage, args=('slen1',))
     def _down(self, a):
         self.v += a
 
-    @dispatch(min=161, max=165, state=_dvistate.inpage, args=('slen',))
+    @_dispatch(min=161, max=165, state=_dvistate.inpage, args=('slen',))
     def _down_y(self, new_y):
         if new_y is not None:
             self.y = new_y
         self.v += self.y
 
-    @dispatch(min=166, max=170, state=_dvistate.inpage, args=('slen',))
+    @_dispatch(min=166, max=170, state=_dvistate.inpage, args=('slen',))
     def _down_z(self, new_z):
         if new_z is not None:
             self.z = new_z
         self.v += self.z
 
-    @dispatch(min=171, max=234, state=_dvistate.inpage)
+    @_dispatch(min=171, max=234, state=_dvistate.inpage)
     def _fnt_num_immediate(self, k):
         self.f = k
 
-    @dispatch(min=235, max=238, state=_dvistate.inpage, args=('olen1',))
+    @_dispatch(min=235, max=238, state=_dvistate.inpage, args=('olen1',))
     def _fnt_num(self, new_f):
         self.f = new_f
 
-    @dispatch(min=239, max=242, args=('ulen1',))
+    @_dispatch(min=239, max=242, args=('ulen1',))
     def _xxx(self, datalen):
         special = self.file.read(datalen)
         if six.PY3:
@@ -455,7 +455,7 @@ class Dvi(object):
             ''.join([chr_(ch) if 32 <= ord(ch) < 127 else '<%02x>' % ord(ch)
                      for ch in special]))
 
-    @dispatch(min=243, max=246, args=('olen1', 'u4', 'u4', 'u4', 'u1', 'u1'))
+    @_dispatch(min=243, max=246, args=('olen1', 'u4', 'u4', 'u4', 'u1', 'u1'))
     def _fnt_def(self, k, c, s, d, a, l):
         self._fnt_def_real(k, c, s, d, a, l)
 
@@ -476,7 +476,7 @@ class Dvi(object):
 
         self.fonts[k] = DviFont(scale=s, tfm=tfm, texname=n, vf=vf)
 
-    @dispatch(247, state=_dvistate.pre, args=('u1', 'u4', 'u4', 'u4', 'u1'))
+    @_dispatch(247, state=_dvistate.pre, args=('u1', 'u4', 'u4', 'u4', 'u1'))
     def _pre(self, i, num, den, mag, k):
         comment = self.file.read(k)
         if i != 2:
@@ -494,17 +494,17 @@ class Dvi(object):
             # I think we can assume this is constant
         self.state = _dvistate.outer
 
-    @dispatch(248, state=_dvistate.outer)
+    @_dispatch(248, state=_dvistate.outer)
     def _post(self, _):
         self.state = _dvistate.post_post
         # TODO: actually read the postamble and finale?
         # currently post_post just triggers closing the file
 
-    @dispatch(249)
+    @_dispatch(249)
     def _post_post(self, _):
         raise NotImplementedError
 
-    @dispatch(min=250, max=255)
+    @_dispatch(min=250, max=255)
     def _malformed(self, offset):
         raise ValueError("unknown command: byte %d", 250 + offset)
 

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -35,7 +35,7 @@ class TriContourSet(ContourSet):
 
         The first argument of the initializer must be an axes
         object.  The remaining arguments and keyword arguments
-        are described in TriContourSet.tricontour_doc.
+        are described in the docstring of `tricontour`.
         """
         ContourSet.__init__(self, ax, *args, **kwargs)
 
@@ -94,187 +94,185 @@ class TriContourSet(ContourSet):
         self._contour_level_args(z, args[1:])
         return (tri, z)
 
-    tricontour_doc = """
-        Draw contours on an unstructured triangular grid.
-        :func:`~matplotlib.pyplot.tricontour` and
-        :func:`~matplotlib.pyplot.tricontourf` draw contour lines and
-        filled contours, respectively.  Except as noted, function
-        signatures and return values are the same for both versions.
-
-        The triangulation can be specified in one of two ways; either::
-
-          tricontour(triangulation, ...)
-
-        where triangulation is a :class:`matplotlib.tri.Triangulation`
-        object, or
-
-        ::
-
-          tricontour(x, y, ...)
-          tricontour(x, y, triangles, ...)
-          tricontour(x, y, triangles=triangles, ...)
-          tricontour(x, y, mask=mask, ...)
-          tricontour(x, y, triangles, mask=mask, ...)
-
-        in which case a Triangulation object will be created.  See
-        :class:`~matplotlib.tri.Triangulation` for a explanation of
-        these possibilities.
-
-        The remaining arguments may be::
-
-          tricontour(..., Z)
-
-        where *Z* is the array of values to contour, one per point
-        in the triangulation.  The level values are chosen
-        automatically.
-
-        ::
-
-          tricontour(..., Z, N)
-
-        contour up to *N+1* automatically chosen contour levels
-        (*N* intervals).
-
-        ::
-
-          tricontour(..., Z, V)
-
-        draw contour lines at the values specified in sequence *V*,
-        which must be in increasing order.
-
-        ::
-
-          tricontourf(..., Z, V)
-
-        fill the (len(*V*)-1) regions between the values in *V*,
-        which must be in increasing order.
-
-        ::
-
-          tricontour(Z, **kwargs)
-
-        Use keyword args to control colors, linewidth, origin, cmap ... see
-        below for more details.
-
-        ``C = tricontour(...)`` returns a
-        :class:`~matplotlib.contour.TriContourSet` object.
-
-        Optional keyword arguments:
-
-          *colors*: [ *None* | string | (mpl_colors) ]
-            If *None*, the colormap specified by cmap will be used.
-
-            If a string, like 'r' or 'red', all levels will be plotted in this
-            color.
-
-            If a tuple of matplotlib color args (string, float, rgb, etc),
-            different levels will be plotted in different colors in the order
-            specified.
-
-          *alpha*: float
-            The alpha blending value
-
-          *cmap*: [ *None* | Colormap ]
-            A cm :class:`~matplotlib.colors.Colormap` instance or
-            *None*. If *cmap* is *None* and *colors* is *None*, a
-            default Colormap is used.
-
-          *norm*: [ *None* | Normalize ]
-            A :class:`matplotlib.colors.Normalize` instance for
-            scaling data values to colors. If *norm* is *None* and
-            *colors* is *None*, the default linear scaling is used.
-
-          *levels* [level0, level1, ..., leveln]
-            A list of floating point numbers indicating the level
-            curves to draw, in increasing order; e.g., to draw just
-            the zero contour pass ``levels=[0]``
-
-          *origin*: [ *None* | 'upper' | 'lower' | 'image' ]
-            If *None*, the first value of *Z* will correspond to the
-            lower left corner, location (0,0). If 'image', the rc
-            value for ``image.origin`` will be used.
-
-            This keyword is not active if *X* and *Y* are specified in
-            the call to contour.
-
-          *extent*: [ *None* | (x0,x1,y0,y1) ]
-
-            If *origin* is not *None*, then *extent* is interpreted as
-            in :func:`matplotlib.pyplot.imshow`: it gives the outer
-            pixel boundaries. In this case, the position of Z[0,0]
-            is the center of the pixel, not a corner. If *origin* is
-            *None*, then (*x0*, *y0*) is the position of Z[0,0], and
-            (*x1*, *y1*) is the position of Z[-1,-1].
-
-            This keyword is not active if *X* and *Y* are specified in
-            the call to contour.
-
-          *locator*: [ *None* | ticker.Locator subclass ]
-            If *locator* is None, the default
-            :class:`~matplotlib.ticker.MaxNLocator` is used. The
-            locator is used to determine the contour levels if they
-            are not given explicitly via the *V* argument.
-
-          *extend*: [ 'neither' | 'both' | 'min' | 'max' ]
-            Unless this is 'neither', contour levels are automatically
-            added to one or both ends of the range so that all data
-            are included. These added ranges are then mapped to the
-            special colormap values which default to the ends of the
-            colormap range, but can be set via
-            :meth:`matplotlib.colors.Colormap.set_under` and
-            :meth:`matplotlib.colors.Colormap.set_over` methods.
-
-          *xunits*, *yunits*: [ *None* | registered units ]
-            Override axis units by specifying an instance of a
-            :class:`matplotlib.units.ConversionInterface`.
-
-
-        tricontour-only keyword arguments:
-
-          *linewidths*: [ *None* | number | tuple of numbers ]
-            If *linewidths* is *None*, the default width in
-            ``lines.linewidth`` in ``matplotlibrc`` is used.
-
-            If a number, all levels will be plotted with this linewidth.
-
-            If a tuple, different levels will be plotted with different
-            linewidths in the order specified
-
-          *linestyles*: [ *None* | 'solid' | 'dashed' | 'dashdot' | 'dotted' ]
-            If *linestyles* is *None*, the 'solid' is used.
-
-            *linestyles* can also be an iterable of the above strings
-            specifying a set of linestyles to be used. If this
-            iterable is shorter than the number of contour levels
-            it will be repeated as necessary.
-
-            If contour is using a monochrome colormap and the contour
-            level is less than 0, then the linestyle specified
-            in ``contour.negative_linestyle`` in ``matplotlibrc``
-            will be used.
-
-        tricontourf-only keyword arguments:
-
-          *antialiased*: bool
-            enable antialiasing
-
-        Note: tricontourf fills intervals that are closed at the top; that
-        is, for boundaries *z1* and *z2*, the filled region is::
-
-            z1 < z <= z2
-
-        There is one exception: if the lowest boundary coincides with
-        the minimum value of the *z* array, then that minimum value
-        will be included in the lowest interval.
-        """
-
 
 def tricontour(ax, *args, **kwargs):
+    """
+    Draw contours on an unstructured triangular grid.
+    :func:`~matplotlib.pyplot.tricontour` and
+    :func:`~matplotlib.pyplot.tricontourf` draw contour lines and
+    filled contours, respectively.  Except as noted, function
+    signatures and return values are the same for both versions.
+
+    The triangulation can be specified in one of two ways; either::
+
+        tricontour(triangulation, ...)
+
+    where triangulation is a :class:`matplotlib.tri.Triangulation`
+    object, or
+
+    ::
+
+        tricontour(x, y, ...)
+        tricontour(x, y, triangles, ...)
+        tricontour(x, y, triangles=triangles, ...)
+        tricontour(x, y, mask=mask, ...)
+        tricontour(x, y, triangles, mask=mask, ...)
+
+    in which case a Triangulation object will be created.  See
+    :class:`~matplotlib.tri.Triangulation` for a explanation of
+    these possibilities.
+
+    The remaining arguments may be::
+
+        tricontour(..., Z)
+
+    where *Z* is the array of values to contour, one per point
+    in the triangulation.  The level values are chosen
+    automatically.
+
+    ::
+
+        tricontour(..., Z, N)
+
+    contour up to *N+1* automatically chosen contour levels
+    (*N* intervals).
+
+    ::
+
+        tricontour(..., Z, V)
+
+    draw contour lines at the values specified in sequence *V*,
+    which must be in increasing order.
+
+    ::
+
+        tricontourf(..., Z, V)
+
+    fill the (len(*V*)-1) regions between the values in *V*,
+    which must be in increasing order.
+
+    ::
+
+        tricontour(Z, **kwargs)
+
+    Use keyword args to control colors, linewidth, origin, cmap ... see
+    below for more details.
+
+    ``C = tricontour(...)`` returns a
+    :class:`~matplotlib.contour.TriContourSet` object.
+
+    Optional keyword arguments:
+
+        *colors*: [ *None* | string | (mpl_colors) ]
+        If *None*, the colormap specified by cmap will be used.
+
+        If a string, like 'r' or 'red', all levels will be plotted in this
+        color.
+
+        If a tuple of matplotlib color args (string, float, rgb, etc),
+        different levels will be plotted in different colors in the order
+        specified.
+
+        *alpha*: float
+        The alpha blending value
+
+        *cmap*: [ *None* | Colormap ]
+        A cm :class:`~matplotlib.colors.Colormap` instance or
+        *None*. If *cmap* is *None* and *colors* is *None*, a
+        default Colormap is used.
+
+        *norm*: [ *None* | Normalize ]
+        A :class:`matplotlib.colors.Normalize` instance for
+        scaling data values to colors. If *norm* is *None* and
+        *colors* is *None*, the default linear scaling is used.
+
+        *levels* [level0, level1, ..., leveln]
+        A list of floating point numbers indicating the level
+        curves to draw, in increasing order; e.g., to draw just
+        the zero contour pass ``levels=[0]``
+
+        *origin*: [ *None* | 'upper' | 'lower' | 'image' ]
+        If *None*, the first value of *Z* will correspond to the
+        lower left corner, location (0,0). If 'image', the rc
+        value for ``image.origin`` will be used.
+
+        This keyword is not active if *X* and *Y* are specified in
+        the call to contour.
+
+        *extent*: [ *None* | (x0,x1,y0,y1) ]
+
+        If *origin* is not *None*, then *extent* is interpreted as
+        in :func:`matplotlib.pyplot.imshow`: it gives the outer
+        pixel boundaries. In this case, the position of Z[0,0]
+        is the center of the pixel, not a corner. If *origin* is
+        *None*, then (*x0*, *y0*) is the position of Z[0,0], and
+        (*x1*, *y1*) is the position of Z[-1,-1].
+
+        This keyword is not active if *X* and *Y* are specified in
+        the call to contour.
+
+        *locator*: [ *None* | ticker.Locator subclass ]
+        If *locator* is None, the default
+        :class:`~matplotlib.ticker.MaxNLocator` is used. The
+        locator is used to determine the contour levels if they
+        are not given explicitly via the *V* argument.
+
+        *extend*: [ 'neither' | 'both' | 'min' | 'max' ]
+        Unless this is 'neither', contour levels are automatically
+        added to one or both ends of the range so that all data
+        are included. These added ranges are then mapped to the
+        special colormap values which default to the ends of the
+        colormap range, but can be set via
+        :meth:`matplotlib.colors.Colormap.set_under` and
+        :meth:`matplotlib.colors.Colormap.set_over` methods.
+
+        *xunits*, *yunits*: [ *None* | registered units ]
+        Override axis units by specifying an instance of a
+        :class:`matplotlib.units.ConversionInterface`.
+
+
+    tricontour-only keyword arguments:
+
+        *linewidths*: [ *None* | number | tuple of numbers ]
+        If *linewidths* is *None*, the default width in
+        ``lines.linewidth`` in ``matplotlibrc`` is used.
+
+        If a number, all levels will be plotted with this linewidth.
+
+        If a tuple, different levels will be plotted with different
+        linewidths in the order specified
+
+        *linestyles*: [ *None* | 'solid' | 'dashed' | 'dashdot' | 'dotted' ]
+        If *linestyles* is *None*, the 'solid' is used.
+
+        *linestyles* can also be an iterable of the above strings
+        specifying a set of linestyles to be used. If this
+        iterable is shorter than the number of contour levels
+        it will be repeated as necessary.
+
+        If contour is using a monochrome colormap and the contour
+        level is less than 0, then the linestyle specified
+        in ``contour.negative_linestyle`` in ``matplotlibrc``
+        will be used.
+
+    tricontourf-only keyword arguments:
+
+        *antialiased*: bool
+        enable antialiasing
+
+    Note: tricontourf fills intervals that are closed at the top; that
+    is, for boundaries *z1* and *z2*, the filled region is::
+
+        z1 < z <= z2
+
+    There is one exception: if the lowest boundary coincides with
+    the minimum value of the *z* array, then that minimum value
+    will be included in the lowest interval.
+    """
     if not ax._hold:
         ax.cla()
     kwargs['filled'] = False
     return TriContourSet(ax, *args, **kwargs)
-tricontour.__doc__ = TriContourSet.tricontour_doc
 
 
 def tricontourf(ax, *args, **kwargs):
@@ -282,4 +280,4 @@ def tricontourf(ax, *args, **kwargs):
         ax.cla()
     kwargs['filled'] = True
     return TriContourSet(ax, *args, **kwargs)
-tricontourf.__doc__ = TriContourSet.tricontour_doc
+tricontourf.__doc__ = tricontour.__doc__

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -66,7 +66,7 @@ class TriInterpolator(object):
     # (except, if needed, relevant additions).
     # However these methods are only implemented in subclasses to avoid
     # confusion in the documentation.
-    docstring__call__ = """
+    _docstring__call__ = """
         Returns a masked array containing interpolated values at the specified
         x,y points.
 
@@ -85,7 +85,7 @@ class TriInterpolator(object):
 
         """
 
-    docstringgradient = """
+    _docstringgradient = """
         Returns a list of 2 masked arrays containing interpolated derivatives
         at the specified x,y points.
 
@@ -274,12 +274,12 @@ class LinearTriInterpolator(TriInterpolator):
     def __call__(self, x, y):
         return self._interpolate_multikeys(x, y, tri_index=None,
                                            return_keys=('z',))[0]
-    __call__.__doc__ = TriInterpolator.docstring__call__
+    __call__.__doc__ = TriInterpolator._docstring__call__
 
     def gradient(self, x, y):
         return self._interpolate_multikeys(x, y, tri_index=None,
                                            return_keys=('dzdx', 'dzdy'))
-    gradient.__doc__ = TriInterpolator.docstringgradient
+    gradient.__doc__ = TriInterpolator._docstringgradient
 
     def _interpolate_single_key(self, return_key, tri_index, x, y):
         if return_key == 'z':
@@ -433,12 +433,12 @@ class CubicTriInterpolator(TriInterpolator):
     def __call__(self, x, y):
         return self._interpolate_multikeys(x, y, tri_index=None,
                                            return_keys=('z',))[0]
-    __call__.__doc__ = TriInterpolator.docstring__call__
+    __call__.__doc__ = TriInterpolator._docstring__call__
 
     def gradient(self, x, y):
         return self._interpolate_multikeys(x, y, tri_index=None,
                                            return_keys=('dzdx', 'dzdy'))
-    gradient.__doc__ = TriInterpolator.docstringgradient
+    gradient.__doc__ = TriInterpolator._docstringgradient
 
     def _interpolate_single_key(self, return_key, tri_index, x, y):
         tris_pts = self._tris_pts[tri_index]


### PR DESCRIPTION
Note that using `@property` to deprecate the attributes doesn't really
help as we'd want something that also returns the string value when
accessed from a class rather than from an instance; while it is
technically possible to write such a descriptor that seems a bit
overkill...

Closes #5873 and #9642.

Note that git thinks that the diff on QuadContourSet is code being moved around but actually I moved the *docstring* around, it's just that the docstring is longer than the code...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
