### PR TITLE
Fix InvertedLog10Transform.inverted() 

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -93,7 +93,7 @@ class LogTransformBase(Transform):
     is_separable = True
     has_inverse = True
 
-    def __init__(self, nonpos='mask'):
+    def __init__(self, nonpos='clip'):
         Transform.__init__(self)
         self._clip = {"clip": True, "mask": False}[nonpos]
 
@@ -115,7 +115,9 @@ class LogTransformBase(Transform):
         return out
 
     def __str__(self):
-        return "{}({!r})".format(type(self).__name__, "clip" if self._clip else "mask")
+        return "{}({!r})".format(type(self).__name__,
+            "clip" if self._clip else "mask")
+
 
 class InvertedLogTransformBase(Transform):
     input_dims = 1
@@ -173,7 +175,7 @@ class InvertedNaturalLogTransform(InvertedLogTransformBase):
 
 
 class LogTransform(LogTransformBase):
-    def __init__(self, base, nonpos='mask'):
+    def __init__(self, base, nonpos='clip'):
         LogTransformBase.__init__(self, nonpos)
         self.base = base
 
@@ -471,7 +473,8 @@ class LogitTransform(Transform):
         return LogisticTransform(self._nonpos)
 
     def __str__(self):
-        return "{}({!r})".format(type(self).__name__, "clip" if self._clip else "mask")
+        return "{}({!r})".format(type(self).__name__,
+            "clip" if self._clip else "mask")
 
 
 class LogisticTransform(Transform):

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -93,7 +93,7 @@ class LogTransformBase(Transform):
     is_separable = True
     has_inverse = True
 
-    def __init__(self, nonpos):
+    def __init__(self, nonpos='mask'):
         Transform.__init__(self)
         self._clip = {"clip": True, "mask": False}[nonpos]
 
@@ -114,6 +114,8 @@ class LogTransformBase(Transform):
             out[a <= 0] = -1000
         return out
 
+    def __str__(self):
+        return "{}({!r})".format(type(self).__name__, "clip" if self._clip else "mask")
 
 class InvertedLogTransformBase(Transform):
     input_dims = 1
@@ -123,6 +125,9 @@ class InvertedLogTransformBase(Transform):
 
     def transform_non_affine(self, a):
         return ma.power(self.base, a)
+
+    def __str__(self):
+        return "{}()".format(type(self).__name__)
 
 
 class Log10Transform(LogTransformBase):
@@ -168,7 +173,7 @@ class InvertedNaturalLogTransform(InvertedLogTransformBase):
 
 
 class LogTransform(LogTransformBase):
-    def __init__(self, base, nonpos):
+    def __init__(self, base, nonpos='mask'):
         LogTransformBase.__init__(self, nonpos)
         self.base = base
 
@@ -448,7 +453,7 @@ class LogitTransform(Transform):
     is_separable = True
     has_inverse = True
 
-    def __init__(self, nonpos):
+    def __init__(self, nonpos='mask'):
         Transform.__init__(self)
         self._nonpos = nonpos
         self._clip = {"clip": True, "mask": False}[nonpos]
@@ -464,6 +469,9 @@ class LogitTransform(Transform):
 
     def inverted(self):
         return LogisticTransform(self._nonpos)
+
+    def __str__(self):
+        return "{}({!r})".format(type(self).__name__, "clip" if self._clip else "mask")
 
 
 class LogisticTransform(Transform):
@@ -482,6 +490,9 @@ class LogisticTransform(Transform):
 
     def inverted(self):
         return LogitTransform(self._nonpos)
+
+    def __str__(self):
+        return "{}({!r})".format(type(self).__name__, self._nonpos)
 
 
 class LogitScale(ScaleBase):

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -80,6 +80,7 @@ def test_logscale_invert_transform():
     # get transformation from data to axes
     tform = (ax.transAxes + ax.transData.inverted()).inverted()
 
+
 def test_logscale_transform_repr():
     fig, ax = plt.subplots()
     ax.set_yscale('log')

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -77,7 +77,8 @@ def test_extra_kwargs_raise():
 def test_logscale_invert_transform():
     fig, ax = plt.subplots()
     ax.set_yscale('log')
-    tform = ax.transData.inverted()
+    # get transformation from data to axes
+    tform = (ax.transAxes + ax.transData.inverted()).inverted()
 
 def test_logscale_transform_repr():
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
+from matplotlib.scale import Log10Transform, InvertedLog10Transform
 import numpy as np
 import io
 import pytest
@@ -80,11 +81,18 @@ def test_logscale_invert_transform():
     # get transformation from data to axes
     tform = (ax.transAxes + ax.transData.inverted()).inverted()
 
+    # direct test of log transform inversion
+    assert isinstance(Log10Transform().inverted(), InvertedLog10Transform)
 
 def test_logscale_transform_repr():
+    # check that repr of log transform succeeds
     fig, ax = plt.subplots()
     ax.set_yscale('log')
     s = repr(ax.transData)
+
+    # check that repr of log transform returns correct string
+    s = repr(Log10Transform(nonpos='clip'))
+    assert s == "Log10Transform('clip')"
 
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -84,6 +84,7 @@ def test_logscale_invert_transform():
     # direct test of log transform inversion
     assert isinstance(Log10Transform().inverted(), InvertedLog10Transform)
 
+
 def test_logscale_transform_repr():
     # check that repr of log transform succeeds
     fig, ax = plt.subplots()
@@ -92,7 +93,7 @@ def test_logscale_transform_repr():
 
     # check that repr of log transform returns correct string
     s = repr(Log10Transform(nonpos='clip'))
-    assert s == "Log10Transform('clip')"
+    assert s == "Log10Transform({!r})".format('clip')
 
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -74,6 +74,17 @@ def test_extra_kwargs_raise():
         ax.set_yscale('log', nonpos='mask')
 
 
+def test_logscale_invert_transform():
+    fig, ax = plt.subplots()
+    ax.set_yscale('log')
+    tform = ax.transData.inverted()
+
+def test_logscale_transform_repr():
+    fig, ax = plt.subplots()
+    ax.set_yscale('log')
+    s = repr(ax.transData)
+
+
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,
                   extensions=['png'], style='mpl20')
 def test_logscale_nonpos_values():


### PR DESCRIPTION
## PR Summary

Closes issue #10202 

InvertedLog10Transform.inverted() method fails because position argument `nonpos` is missing. To fix this, a default value for the `nonpos` argument is added in constructor of `LogTransformBase` base class (and to be consistent, also to `LogitTransform` and `LogisticTransform` constructors). While testing it was noted that repr of Log/Logit/LogisticTransform objects results in max recursion error, because the `Transform` base class implements `__repr__` with a call to `str(self)` and no `__str__` methods are implemented for the Log/Logit/LogisticTransform classes. This was fixed as well.

## PR Checklist

- [x] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
