### PR TITLE
Cache paths of fonts shipped with mpl relative to the mpl data path.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -42,7 +42,7 @@ per-file-ignores =
     matplotlib/backends/qt_editor/formlayout.py: E301, E501
     matplotlib/backends/tkagg.py: E231, E302, E701
     matplotlib/backends/windowing.py: E301, E302
-    matplotlib/font_manager.py: E203, E221, E225, E251, E261, E262, E302, E501
+    matplotlib/font_manager.py: E203, E221, E251, E261, E262, E302, E501
     matplotlib/fontconfig_pattern.py: E201, E203, E221, E222, E225, E302
     matplotlib/legend_handler.py: E201, E501
     matplotlib/mathtext.py: E201, E202, E203, E211, E221, E222, E225, E231, E251, E261, E301, E302, E303, E402, E501

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -945,7 +945,7 @@ class FontManager(object):
     # Increment this version number whenever the font cache data
     # format or behavior has changed and requires a existing font
     # cache files to be rebuilt.
-    __version__ = 201
+    __version__ = 300
 
     def __init__(self, size=None, weight='normal'):
         self._version = self.__version__
@@ -1333,7 +1333,8 @@ else:
 
     cachedir = get_cachedir()
     if cachedir is not None:
-        _fmcache = os.path.join(cachedir, 'fontList.json')
+        _fmcache = os.path.join(
+            cachedir, 'fontlist-v{}.json'.format(FontManager.__version__))
 
     fontManager = None
 

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -44,6 +44,7 @@ except ImportError:
     from dummy_threading import Timer
 import warnings
 
+import matplotlib as mpl
 from matplotlib import afm, cbook, ft2font, rcParams, get_cachedir
 from matplotlib.fontconfig_pattern import (
     parse_fontconfig_pattern, generate_fontconfig_pattern)
@@ -828,15 +829,23 @@ class FontProperties(object):
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, FontManager):
-            return dict(o.__dict__, _class='FontManager')
+            return dict(o.__dict__, __class__='FontManager')
         elif isinstance(o, FontEntry):
-            return dict(o.__dict__, _class='FontEntry')
+            d = dict(o.__dict__, __class__='FontEntry')
+            try:
+                # Cache paths of fonts shipped with mpl relative to the mpl
+                # data path, which helps in the presence of venvs.
+                d["fname"] = str(
+                    Path(d["fname"]).relative_to(mpl.get_data_path()))
+            except ValueError:
+                pass
+            return d
         else:
             return super().default(o)
 
 
 def _json_decode(o):
-    cls = o.pop('_class', None)
+    cls = o.pop('__class__', None)
     if cls is None:
         return o
     elif cls == 'FontManager':
@@ -846,15 +855,21 @@ def _json_decode(o):
     elif cls == 'FontEntry':
         r = FontEntry.__new__(FontEntry)
         r.__dict__.update(o)
+        if not os.path.isabs(r.fname):
+            r.fname = os.path.join(mpl.get_data_path(), r.fname)
         return r
     else:
-        raise ValueError("don't know how to deserialize _class=%s" % cls)
+        raise ValueError("don't know how to deserialize __class__=%s" % cls)
 
 
 def json_dump(data, filename):
-    """Dumps a data structure as JSON in the named file.
-    Handles FontManager and its fields."""
+    """
+    Dumps a data structure as JSON in the named file.
 
+    Handles FontManager and its fields.  File paths that are children of the
+    Matplotlib data path (typically, fonts shipped with Matplotlib) are stored
+    relative to that data path (to remain valid across virtualenvs).
+    """
     with open(filename, 'w') as fh:
         try:
             json.dump(data, fh, cls=JSONEncoder, indent=2)
@@ -863,9 +878,13 @@ def json_dump(data, filename):
 
 
 def json_load(filename):
-    """Loads a data structure as JSON from the named file.
-    Handles FontManager and its fields."""
+    """
+    Loads a data structure as JSON from the named file.
 
+    Handles FontManager and its fields.  Relative file paths are interpreted
+    as being relative to the Matplotlib data path, and transformed into
+    absolute paths.
+    """
     with open(filename, 'r') as fh:
         return json.load(fh, object_hook=_json_decode)
 
@@ -951,30 +970,32 @@ class FontManager(object):
         _log.debug('font search path %s', str(paths))
         #  Load TrueType fonts and create font dictionary.
 
-        self.ttffiles = findSystemFonts(paths) + findSystemFonts()
         self.defaultFamily = {
             'ttf': 'DejaVu Sans',
             'afm': 'Helvetica'}
         self.defaultFont = {}
 
-        for fname in self.ttffiles:
-            _log.debug('trying fontname %s', fname)
-            if fname.lower().find('DejaVuSans.ttf')>=0:
-                self.defaultFont['ttf'] = fname
-                break
-        else:
-            # use anything
-            self.defaultFont['ttf'] = self.ttffiles[0]
+        ttffiles = findSystemFonts(paths) + findSystemFonts()
+        self.defaultFont['ttf'] = next(
+            (fname for fname in ttffiles
+             if fname.lower().endswith("dejavusans.ttf")),
+            ttffiles[0])
+        self.ttflist = createFontList(ttffiles)
 
-        self.ttflist = createFontList(self.ttffiles)
+        afmfiles = (findSystemFonts(paths, fontext='afm')
+                    + findSystemFonts(fontext='afm'))
+        self.afmlist = createFontList(afmfiles, fontext='afm')
+        self.defaultFont['afm'] = afmfiles[0] if afmfiles else None
 
-        self.afmfiles = (findSystemFonts(paths, fontext='afm')
-                         + findSystemFonts(fontext='afm'))
-        self.afmlist = createFontList(self.afmfiles, fontext='afm')
-        if len(self.afmfiles):
-            self.defaultFont['afm'] = self.afmfiles[0]
-        else:
-            self.defaultFont['afm'] = None
+    @property
+    @cbook.deprecated("3.0")
+    def ttffiles(self):
+        return [font.fname for font in self.ttflist]
+
+    @property
+    @cbook.deprecated("3.0")
+    def afmfiles(self):
+        return [font.fname for font in self.afmlist]
 
     def get_default_weight(self):
         """


### PR DESCRIPTION
This lets the font cache stay valid across multiple virtualenvs (as long
as the list of fonts shipped by mpl does not change).

xref #10201.

As a side note note the previously buggy line `if fname.lower().find('DejaVuSans.ttf')>=0` which would always return False...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
