### PR TITLE
Simplify _get_xdg_cache_dir in setupext.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -23,43 +23,18 @@ import versioneer
 PY3min = (sys.version_info[0] >= 3)
 
 
-def _get_home():
-    """Find user's home directory if possible.
-    Otherwise, returns None.
-
-    :see:
-        http://mail.python.org/pipermail/python-list/2005-February/325395.html
-    """
-    try:
-        if not PY3min and sys.platform == 'win32':
-            path = os.path.expanduser(b"~").decode(sys.getfilesystemencoding())
-        else:
-            path = os.path.expanduser("~")
-    except ImportError:
-        # This happens on Google App Engine (pwd module is not present).
-        pass
-    else:
-        if os.path.isdir(path):
-            return path
-    for evar in ('HOME', 'USERPROFILE', 'TMP'):
-        path = os.environ.get(evar)
-        if path is not None and os.path.isdir(path):
-            return path
-    return None
-
-
 def _get_xdg_cache_dir():
     """
-    Returns the XDG cache directory, according to the `XDG
-    base directory spec
-    <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
+    Return the XDG cache directory.
+
+    See https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
     """
-    path = os.environ.get('XDG_CACHE_HOME')
-    if path is None:
-        path = _get_home()
-        if path is not None:
-            path = os.path.join(path, '.cache', 'matplotlib')
-    return path
+    cache_dir = os.environ.get('XDG_CACHE_HOME')
+    if not cache_dir:
+        cache_dir = os.path.expanduser('~/.cache')
+        if cache_dir.startswith('~/'):  # Expansion failed.
+            return None
+    return os.path.join(cache_dir, 'matplotlib')
 
 
 # SHA256 hashes of the FreeType tarballs


### PR DESCRIPTION
1. we don't support google app engine anymore (#8939).
2. in setupext, the cache dir is only used to cache the freetype
   tarball, so it's really not a huge deal if a cache dir cannot be
   located (this case is handled explicitly by the freetype build code).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
