### PR TITLE
Quick and dirty revert of busy cursor for 2.1.2.

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -427,12 +427,12 @@ class FigureCanvasAgg(FigureCanvasBase):
 
         toolbar = self.toolbar
         try:
-            if toolbar:
-                toolbar.set_cursor(cursors.WAIT)
+            # if toolbar:
+            #     toolbar.set_cursor(cursors.WAIT)
             self.figure.draw(self.renderer)
         finally:
-            if toolbar:
-                toolbar.set_cursor(toolbar._lastCursor)
+            # if toolbar:
+            #     toolbar.set_cursor(toolbar._lastCursor)
             RendererAgg.lock.release()
 
     def get_renderer(self, cleared=False):

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -393,8 +393,8 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         """Expose_event for all GTK backends. Should not be overridden.
         """
         toolbar = self.toolbar
-        if toolbar:
-            toolbar.set_cursor(cursors.WAIT)
+        # if toolbar:
+        #     toolbar.set_cursor(cursors.WAIT)
         if GTK_WIDGET_DRAWABLE(self):
             if self._need_redraw:
                 x, y, w, h = self.allocation
@@ -404,8 +404,8 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
             x, y, w, h = event.area
             self.window.draw_drawable (self.style.fg_gc[self.state],
                                        self._pixmap, x, y, x, y, w, h)
-        if toolbar:
-            toolbar.set_cursor(toolbar._lastCursor)
+        # if toolbar:
+        #     toolbar.set_cursor(toolbar._lastCursor)
         return False  # finish event propagation?
 
     filetypes = FigureCanvasBase.filetypes.copy()
@@ -484,7 +484,6 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
             gtk.main_iteration(True)
         gtk.gdk.flush()
         gtk.gdk.threads_leave()
-
 
 
 class FigureManagerGTK(FigureManagerBase):

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -35,13 +35,13 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
     def on_draw_event(self, widget, ctx):
         """GtkDrawable draw event."""
         toolbar = self.toolbar
-        if toolbar:
-            toolbar.set_cursor(cursors.WAIT)
+        # if toolbar:
+        #     toolbar.set_cursor(cursors.WAIT)
         self._renderer.set_context(ctx)
         allocation = self.get_allocation()
         self._render_figure(allocation.width, allocation.height)
-        if toolbar:
-            toolbar.set_cursor(toolbar._lastCursor)
+        # if toolbar:
+        #     toolbar.set_cursor(toolbar._lastCursor)
         return False  # finish event propagation?
 
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
