### PR TITLE
Remove reference to ignored rcParam, nbagg.transparent

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -234,8 +234,6 @@ class _BackendNbAgg(_Backend):
     @staticmethod
     def new_figure_manager_given_figure(num, figure):
         canvas = FigureCanvasNbAgg(figure)
-        if rcParams['nbagg.transparent']:
-            figure.patch.set_alpha(0)
         manager = FigureManagerNbAgg(canvas, num)
         if is_interactive():
             manager.show()


### PR DESCRIPTION
In #10024, rcParams['nbagg.transparent'] was marked as deprecated
and ignored, but it was not removed from backend_nbagg.  As a
result, every plot made with backend_nbagg was raising a
warning.  This PR finishes #10024 by removing the reference and
the line that depends on it.
