### PR TITLE
Clean up example section titles

### DIFF
--- a/examples/animation/README.txt
+++ b/examples/animation/README.txt
@@ -2,5 +2,5 @@
 
 .. _animation-examples-index:
 
-Animation Examples
-==================
+Animation
+=========

--- a/examples/misc/README.txt
+++ b/examples/misc/README.txt
@@ -1,4 +1,4 @@
 .. _misc-examples-index:
 
-Miscellaneous Examples
-======================
+Miscellaneous
+=============

--- a/examples/mplot3d/README.txt
+++ b/examples/mplot3d/README.txt
@@ -2,5 +2,5 @@
 
 .. _mplot3d-examples-index:
 
-mplot3d toolkit
-===============
+3D plotting
+===========

--- a/examples/pyplots/README.txt
+++ b/examples/pyplots/README.txt
@@ -1,4 +1,4 @@
 .. _pyplots_examples:
 
-Pyplot Examples
-===============
+Pyplot
+======

--- a/examples/scales/README.txt
+++ b/examples/scales/README.txt
@@ -1,6 +1,6 @@
 .. _scales_examples:
 
-Scales in Matplotlib
-====================
+Scales
+======
 
 These examples cover how different scales are handled in Matplotlib.

--- a/examples/units/README.txt
+++ b/examples/units/README.txt
@@ -2,8 +2,8 @@
 
 .. _units-examples-index:
 
-Units in Matplotlib
-===================
+Units
+=====
 
 These examples cover the many representations of units
 in Matplotlib.

--- a/examples/user_interfaces/README.txt
+++ b/examples/user_interfaces/README.txt
@@ -1,13 +1,13 @@
 .. _user_interfaces:
 
-Embedding matplotlib in graphical user interfaces
+Embedding Matplotlib in graphical user interfaces
 =================================================
 
-You can embed matplotlib directly into a user interface application by
-following the embedding_in_SOMEGUI.py examples here.  Currently
+You can embed Matplotlib directly into a user interface application by
+following the embedding_in_SOMEGUI.py examples here. Currently
 matplotlib supports wxpython, pygtk, tkinter and pyqt4/5.
 
-When embedding matplotlib in a GUI, you must use the matplotlib API
+When embedding Matplotlib in a GUI, you must use the Matplotlib API
 directly rather than the pylab/pyplot proceedural interface, so take a
 look at the examples/api directory for some example code working with
 the API.


### PR DESCRIPTION
Remove "Matplotlib" and "Examples"  from section titles, since it should be obvious that these are examples for Matplotlib.