### PR TITLE
FIX: (re-allow) legend OrderedDict handles and labels...

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -599,7 +599,7 @@ class Legend(Artist):
             else:
                 _lab.append(label)
                 _hand.append(handle)
-        label, handle = _lab, _hand
+        labels, handles = _lab, _hand
 
         handles = list(handles)
         if len(handles) < 2:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -589,14 +589,17 @@ class Legend(Artist):
             setattr(self, name, value)
         del locals_view
         # trim handles and labels if illegal label...
-        for label, handle in zip(labels[:], handles[:]):
-                if (isinstance(label, six.string_types) and
-                        label.startswith('_')):
-                    warnings.warn('The handle {!r} has a label of {!r} which '
-                                  'cannot be automatically added to the '
-                                  'legend.'.format(handle, label))
-                    labels.remove(label)
-                    handles.remove(handle)
+        _lab, _hand = [], []
+        for label, handle in zip(labels, handles):
+            if (isinstance(label, six.string_types) and
+                    label.startswith('_')):
+                warnings.warn('The handle {!r} has a label of {!r} which '
+                              'cannot be automatically added to the '
+                              'legend.'.format(handle, label))
+            else:
+                _lab.append(label)
+                _hand.append(handle)
+        label, handle = _lab, _hand
 
         handles = list(handles)
         if len(handles) < 2:

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -5,6 +5,7 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+import collections
 import numpy as np
 import pytest
 
@@ -51,6 +52,23 @@ def test_legend_kwdocstrings():
     assert stleg == stax
     assert stfig == stax
     assert stleg == stfig
+
+
+def test_legend_ordereddict():
+    # smoketest that ordereddict inputs work...
+
+    X = np.random.randn(10)
+    Y = np.random.randn(10)
+    labels = ['a'] * 5 + ['b'] * 5
+    colors = ['r'] * 5 + ['g'] * 5
+
+    fig, ax = plt.subplots()
+    for x, y, label, color in zip(X, Y, labels, colors):
+        ax.scatter(x, y, label=label, c=color)
+
+    handles, labels = ax.get_legend_handles_labels()
+    legend = collections.OrderedDict(zip(labels, handles))
+    ax.legend(legend.values(), legend.keys(), loc=6, bbox_to_anchor=(1, .5))
 
 
 @image_comparison(baseline_images=['legend_auto1'], remove_text=True)


### PR DESCRIPTION
## PR Summary

As reported in #10262, OrderedDict input no longer works in 2.1.1.  i.e. 

```python
import collections
import matplotlib.pyplot as plt
import numpy as np

X = np.random.randn(10)
Y = np.random.randn(10)
labels = ['a'] * 5 + ['b'] * 5
colors = ['r'] * 5 + ['g'] * 5

fig, ax = plt.subplots()
for x, y, label, color in zip(X, Y, labels, colors):
    ax.scatter(x, y, label=label, c=color)

handles, labels = ax.get_legend_handles_labels()
legend = collections.OrderedDict(zip(labels, handles))
ax.legend(legend.values(), legend.keys(), loc=6, bbox_to_anchor=(1, .5))
```

This PR fixes that (thanks @anntzer) and adds a small test...


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->