### PR TITLE
doc: fix layout of tables within parameter lists

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -582,6 +582,20 @@ table.docutils {
     background-color: #eff3f4;
 }
 
+/* tables inside parameter descriptions */
+td.field-body table.docutils {
+    width: 100%;
+}
+
+td.field-body table.docutils th {
+    padding: 2px 10px;
+    border: 0;
+}
+
+td.field-body table.docutils td {
+    padding: 2px 10px;
+}
+
 /* function and class description */
 .descclassname {
     color: #aaa;

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -583,16 +583,16 @@ table.docutils {
 }
 
 /* tables inside parameter descriptions */
-td.field-body table.docutils {
+td.field-body table.property-table {
     width: 100%;
 }
 
-td.field-body table.docutils th {
+td.field-body table.property-table th {
     padding: 2px 10px;
     border: 0;
 }
 
-td.field-body table.docutils td {
+td.field-body table.property-table td {
     padding: 2px 10px;
 }
 

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -652,6 +652,9 @@ dl.class {
     font-family: monospace;
 }
 
+table.docutils.field-list {
+    width: 100%;
+}
 
 .docutils.field-list th {
     background-color: #eee;

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1281,6 +1281,12 @@ class ArtistInspector(object):
 
         col0_len = max(len(n) for n in names)
         col1_len = max(len(a) for a in accepts)
+
+        lines.append('')
+        lines.append(pad + '.. table::')
+        lines.append(pad + '   :class: property-table')
+        pad += '   '
+
         table_formatstr = pad + '=' * col0_len + '   ' + '=' * col1_len
 
         lines.append('')


### PR DESCRIPTION
## PR Summary

Since using numpydoc, it's quite common to insert the interpolated parameter list into the "Additional Parameters" section. The css layout was not specifically great for this, because it was assuming a top-level table.

This PR adds dedicated css for tables in numpydoc field descriptions.

Before:
![grafik](https://user-images.githubusercontent.com/2836374/35194629-96b4bd12-feb6-11e7-9395-d028adc8b1f5.png)

After:
![grafik](https://user-images.githubusercontent.com/2836374/35194647-c1d370ec-feb6-11e7-98ff-2fc1dacb2ab1.png)


Note: #10161 also targets the layout of interpolated parameter lists. However, the two issues are independent. The effect of #10161 is still visible in the above screenshots. Also, this PR does not influence a possible solution of #10161.