### PR TITLE
Add 'val' attribute to slider doc

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -262,10 +262,14 @@ class Slider(AxesWidget):
     """
     A slider representing a floating point range.
 
-    Create a slider from `valmin` to `valmax` in axes `ax`. For the slider to
-    remain responsive you must maintain a reference to it.
+    Create a slider from *valmin* to *valmax* in axes *ax*. For the slider to
+    remain responsive you must maintain a reference to it. Call
+    :meth:`on_changed` to connect to the slider event.
 
-    Call :meth:`on_changed` to connect to the slider event
+    Attributes
+    ----------
+    val : float
+        Slider value.
     """
     def __init__(self, ax, label, valmin, valmax, valinit=0.5, valfmt='%1.2f',
                  closedmin=True, closedmax=True, slidermin=None,


### PR DESCRIPTION
Quite a useful attribute to be able to get - might be worth adding it as a proper class property at some point without breaking `get_val()` that currently exists.