### PR TITLE
Move down logging levels in mpl/__init__ to DEBUG.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -382,7 +382,7 @@ class Verbose(object):
         return self.vald[self.level] >= self.vald[level]
 
 
-def _wrap(fmt, func, level='INFO', always=True):
+def _wrap(fmt, func, level='DEBUG', always=True):
     """
     return a callable function that wraps func and reports its
     output through logger
@@ -1131,7 +1131,7 @@ You have the following UNSUPPORTED LaTeX preamble customizations:
 Please do not ask for support with these customizations active.
 *****************************************************************
 """, '\n'.join(config['text.latex.preamble']))
-    _log.info('loaded rc file %s', fname)
+    _log.debug('loaded rc file %s', fname)
 
     return config
 
@@ -1839,7 +1839,7 @@ def _preprocess_data(replace_names=None, replace_all_args=False,
 
     return param
 
-_log.info('matplotlib version %s', __version__)
-_log.info('interactive is %s', is_interactive())
-_log.info('platform is %s', sys.platform)
+_log.debug('matplotlib version %s', __version__)
+_log.debug('interactive is %s', is_interactive())
+_log.debug('platform is %s', sys.platform)
 _log.debug('loaded modules: %s', list(sys.modules))


### PR DESCRIPTION
Most "info" level logs in the codebase are either reporting "mildly"
invalid conditions that mpl can easily work around, or initializations
that occur relatively rarely.  On the contrary, `mpl/__init__` is run
every time mpl is imported and reports on completely normal stuff.

Moving the levels of the logs in `mpl/__init__` down to DEBUG makes it
possible to have a globally activated logger at the INFO level (see e.g.
https://coloredlogs.readthedocs.io/en/latest/ specifically
https://coloredlogs.readthedocs.io/en/latest/#environment-variables)
without it being spammed by matplotlib.

Would be nice to have this for 2.2 as that's the version that introduces use of logging.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
