### PR TITLE
Deprecate the backend.qt{4,5} rcParams.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1116,8 +1116,10 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
         return config_from_file
 
     iter_params = six.iteritems(defaultParams)
-    config = RcParams([(key, default) for key, (default, _) in iter_params
-                                      if key not in _all_deprecated])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", mplDeprecation)
+        config = RcParams([(key, default) for key, (default, _) in iter_params
+                           if key not in _all_deprecated])
     config.update(config_from_file)
 
     if config['datapath'] is None:
@@ -1155,9 +1157,11 @@ if rcParams['examples.directory']:
 
 rcParamsOrig = rcParams.copy()
 
-rcParamsDefault = RcParams([(key, default) for key, (default, converter) in
-                            six.iteritems(defaultParams)
-                            if key not in _all_deprecated])
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", mplDeprecation)
+    rcParamsDefault = RcParams([(key, default) for key, (default, converter) in
+                                six.iteritems(defaultParams)
+                                if key not in _all_deprecated])
 
 rcParams['ps.usedistiller'] = checkdep_ps_distiller(
                       rcParams['ps.usedistiller'])

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -266,8 +266,20 @@ def validate_backend(s):
         return _validate_standard_backends(s)
 
 
-validate_qt4 = ValidateInStrings('backend.qt4', ['PyQt4', 'PySide', 'PyQt4v2'])
-validate_qt5 = ValidateInStrings('backend.qt5', ['PyQt5', 'PySide2'])
+@deprecated("2.2",
+            "The backend.qt4 rcParam was deprecated in version 2.2.  In order "
+            "to force the use of a specific Qt4 binding, either import that "
+            "binding first, or set the QT_API environment variable.")
+def validate_qt4(s):
+    return ValidateInStrings("backend.qt4", ['PyQt4', 'PySide', 'PyQt4v2'])(s)
+
+
+@deprecated("2.2",
+            "The backend.qt5 rcParam was deprecated in version 2.2.  In order "
+            "to force the use of a specific Qt5 binding, either import that "
+            "binding first, or set the QT_API environment variable.")
+def validate_qt5(s):
+    return ValidateInStrings("backend.qt5", ['PyQt5', 'PySide2'])(s)
 
 
 def validate_toolbar(s):


### PR DESCRIPTION
1) For the rcParams rewrite (MEP32), they may make it tricky to
transform rcParams into a nested dictionary type of object, as "backend"
is already the name of another (more important) rcParam.
(I haven't decided on a nested dict design yet, just keeping options open.)
This specific issue could be solved with deprecation + renaming, but also...

2) The use of these rcParams can easily be replaced by a) first
importing one of the bindings (qt_compat will ensure that the already
imported binding gets used, as importing multiple bindings in the same
process is a bad idea anyways), or b) setting the QT_API environment
variable appropriately.

Milestoning as 2.2 so that the rcparams may actually get removed when (if) MEP32 makes it in 3.0, but feel free to push back too.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
