### PR TITLE
Ensure image scale factors are scalars

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -394,8 +394,10 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 A_scaled = np.empty(A.shape, dtype=scaled_dtype)
                 A_scaled[:] = A
                 A_scaled -= a_min
-                a_min = a_min.astype(scaled_dtype)
-                a_max = a_max.astype(scaled_dtype)
+                # a_min and a_max might be ndarray subclasses so use
+                # asscalar to ensure they are scalars to avoid errors
+                a_min = np.asscalar(a_min.astype(scaled_dtype))
+                a_max = np.asscalar(a_max.astype(scaled_dtype))
 
                 if a_min != a_max:
                     A_scaled /= ((a_max - a_min) / 0.8)


### PR DESCRIPTION
This avoids errors that get triggered by passing an ndarray subclass to imshow.

For example:

```python
import numpy as np
from yt.units import km
from matplotlib import pyplot as plt

data = np.random.random((100, 100))*km
plt.imshow(data)
plt.show()
```

Or similarly with `astropy`:

```python
import numpy as np
from astropy.units import km
from matplotlib import pyplot as plt

data = np.random.random((100, 100))*km
plt.imshow(data)
plt.show()
```

Before this patch, both of these commands raise an error because `a_min` and
`a_max` have units attached. By explicitly converting these to scalars we
avoid this failure mode.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
