### PR TITLE
Unset the canvas manager when saving the figure.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2149,6 +2149,15 @@ class FigureCanvasBase(object):
 
         """
         self._is_saving = True
+        # Remove the figure manager, if any, to avoid resizing the GUI widget.
+        # Having *no* manager and a *None* manager are currently different (see
+        # Figure.show); should probably be normalized to None at some point.
+        _no_manager = object()
+        if hasattr(self, 'manager'):
+            manager = self.manager
+            del self.manager
+        else:
+            manager = _no_manager
 
         if format is None:
             # get format from filename, or from backend's default filetype
@@ -2267,8 +2276,9 @@ class FigureCanvasBase(object):
             self.figure.set_facecolor(origfacecolor)
             self.figure.set_edgecolor(origedgecolor)
             self.figure.set_canvas(self)
+            if manager is not _no_manager:
+                self.manager = manager
             self._is_saving = False
-            #self.figure.canvas.draw() ## seems superfluous
         return result
 
     @classmethod


### PR DESCRIPTION
Saving a figure may involve temporarily resizing the canvas (e.g. due to
different dpi), but we don't want that resize to be propagated to the
actual GUI widget.  Ensure this by temporarily unsetting the manager as
well.

Closes #8736, #10287, and (I believe) #8852.  #9131 still remains valid though I believe.
Milestoning as 2.2 only to match the above mentioned issues.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
