### PR TITLE
FIX: don't autorotate xpdf images

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1544,7 +1544,7 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
     """
     pdffile = tmpfile + '.pdf'
     psfile = tmpfile + '.ps'
-
+    
     if eps:
         paper_option = "-dEPSCrop"
     else:
@@ -1557,12 +1557,14 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
         command = [str("ps2pdf"), "-dAutoFilterColorImages#false",
                    "-dAutoFilterGrayImages#false",
                    "-sGrayImageFilter#FlateEncode",
+                   "-dAutoRotatePages=false",
                    "-sColorImageFilter#FlateEncode", paper_option, tmpfile,
                    pdffile]
     else:
         command = [str("ps2pdf"), "-dAutoFilterColorImages=false",
                    "-dAutoFilterGrayImages=false",
                    "-sGrayImageFilter=FlateEncode",
+                   "-dAutoRotatePages=false",
                    "-sColorImageFilter=FlateEncode", paper_option, tmpfile,
                    pdffile]
     _log.debug(command)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1544,7 +1544,7 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
     """
     pdffile = tmpfile + '.pdf'
     psfile = tmpfile + '.ps'
-    
+
     if eps:
         paper_option = "-dEPSCrop"
     else:
@@ -1557,7 +1557,7 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
         command = [str("ps2pdf"), "-dAutoFilterColorImages#false",
                    "-dAutoFilterGrayImages#false",
                    "-sGrayImageFilter#FlateEncode",
-                   "-dAutoRotatePages=false",
+                   "-dAutoRotatePages#false",
                    "-sColorImageFilter#FlateEncode", paper_option, tmpfile,
                    pdffile]
     else:


### PR DESCRIPTION
## PR Summary

As per #10290, ghostscript auto-rotates during `ps2pdf`, so if a figure has a *lot* of roated text it gets unexpectedly rotated if the user has `rcParams['ps.usedistiller'] = "xpdf"` set.

This passes the flag "-dAutoRotatePages=false" to `ps2pdf`.

See also 

https://www.ghostscript.com/doc/current/Ps2pdf.htm

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->