### PR TITLE
Pass options to ps2pdf using `-foo#bar` instead of `-foo=bar`.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1546,26 +1546,16 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
     pdffile = tmpfile + '.pdf'
     psfile = tmpfile + '.ps'
 
-    if eps:
-        paper_option = "-dEPSCrop"
-    else:
-        if sys.platform == "win32":
-            paper_option = "-sPAPERSIZE#%s" % ptype
-        else:
-            paper_option = "-sPAPERSIZE=%s" % ptype
-
-    if sys.platform == "win32":
-        command = [str("ps2pdf"), "-dAutoFilterColorImages#false",
-                   "-dAutoFilterGrayImages#false",
-                   "-sGrayImageFilter#FlateEncode",
-                   "-sColorImageFilter#FlateEncode", paper_option, tmpfile,
-                   pdffile]
-    else:
-        command = [str("ps2pdf"), "-dAutoFilterColorImages=false",
-                   "-dAutoFilterGrayImages=false",
-                   "-sGrayImageFilter=FlateEncode",
-                   "-sColorImageFilter=FlateEncode", paper_option, tmpfile,
-                   pdffile]
+    # Pass options as `-foo#bar` instead of `-foo=bar` to keep Windows happy
+    # (https://www.ghostscript.com/doc/9.22/Use.htm#MS_Windows).
+    command = [str("ps2pdf"),
+               "-dAutoFilterColorImages#false",
+               "-dAutoFilterGrayImages#false",
+               "-dAutoRotatePages#false",
+               "-sGrayImageFilter#FlateEncode",
+               "-sColorImageFilter#FlateEncode",
+               "-dEPSCrop" if eps else "-sPAPERSIZE#%s" % ptype,
+               tmpfile, pdffile]
     _log.debug(command)
 
     try:
@@ -1624,7 +1614,7 @@ def get_bbox(tmpfile, bbox):
     """
 
     gs_exe = ps_backend_helper.gs_exe
-    command = [gs_exe, "-dBATCH", "-dNOPAUSE", "-sDEVICE=bbox" "%s" % tmpfile]
+    command = [gs_exe, "-dBATCH", "-dNOPAUSE", "-sDEVICE=bbox", "%s" % tmpfile]
     _log.debug(command)
     p = subprocess.Popen(command, stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,


### PR DESCRIPTION
The former works both on Windows and Linux (so we can stick to it)
whereas the later only works on Linux (so we had to use a switch
depending on the OS).

Will conflict #10294, but easy to resolve either...

Closes  #10290 

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->