### PR TITLE
Fix gtk3agg alpha channel.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -1,5 +1,7 @@
-import numpy as np
+import sys
 import warnings
+
+import numpy as np
 
 from . import backend_agg, backend_cairo, backend_gtk3
 from ._gtk3_compat import gi
@@ -31,7 +33,7 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         backend_agg.FigureCanvasAgg.draw(self)
 
     def on_draw_event(self, widget, ctx):
-        """ GtkDrawable draw event, like expose_event in GTK 2.X
+        """GtkDrawable draw event, like expose_event in GTK 2.X.
         """
         allocation = self.get_allocation()
         w, h = allocation.width, allocation.height
@@ -45,17 +47,29 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         ctx = backend_cairo._to_context(ctx)
 
         for bbox in bbox_queue:
-            area = self.copy_from_bbox(bbox)
-            buf = np.fromstring(area.to_string_argb(), dtype='uint8')
-
             x = int(bbox.x0)
             y = h - int(bbox.y1)
             width = int(bbox.x1) - int(bbox.x0)
             height = int(bbox.y1) - int(bbox.y0)
 
+            buf = (np.fromstring(self.copy_from_bbox(bbox).to_string_argb(),
+                                 dtype='uint8')
+                   .reshape((width, height, 4)))
+            # cairo wants premultiplied alpha.  Only bother doing the
+            # conversion when the alpha channel is not fully opaque, as the
+            # cost is not negligible.  (The unsafe cast is needed to do the
+            # multiplication in-place in an integer buffer.)
+            if sys.byteorder == "little":
+                rgb24 = buf[..., :-1]
+                alpha8 = buf[..., -1:]
+            else:
+                alpha8 = buf[..., :1]
+                rgb24 = buf[..., 1:]
+            if alpha8.min() != 0xff:
+                np.multiply(rgb24, alpha8 / 0xff, out=rgb24, casting="unsafe")
+
             image = cairo.ImageSurface.create_for_data(
-                buf.ravel().data, cairo.FORMAT_ARGB32,
-                width, height, width * 4)
+                buf.ravel().data, cairo.FORMAT_ARGB32, width, height)
             ctx.set_source_surface(image, x, y)
             ctx.paint()
 


### PR DESCRIPTION
The gtk3agg backend works by drawing the ARGB32 buffer (from Agg) onto a
cairo context (passed by gtk3).  However, cairo wants a *premultiplied*
ARGB32 buffer (i.e., where 100% blue with 50% transparency is
represented by (r=0%, g=0%, b=50%, a=50%) instead of (r=0%, g=0%,
b=100%, a=50%), which we didn't do before.

This is only apparent if the entire buffer contains some transparency,
e.g. if the figure background is transparent.  Consider e.g. under
gtk3agg:

    from pylab import *
    rcParams["figure.facecolor"] = (0, 0, 0, 0)
    gca()
    show()

Without the patch, the area surrounding the axes is white (because of
the misinterpretation of premultiplied alpha).  With the patch, it is
(correctly) gray, which is the background color of the gtk widget.
(Note that when running the example under qt5agg or tkagg, the situation
is complicated by the fact that these backends themselves set the widget
background color to white rather than gray.)

As a comparison point, qt5agg builds the QImage using Format_ARGB32,
instead of Format_ARB32_Premultiplied; i.e. Qt provides its own
conversion from non-premultiplied to premultiplied.

The premultiplication step involves allocating a full new buffer, so
check whether there is actually any transparency before doing it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
