### PR TITLE
Apply gtk3 background.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -4,7 +4,7 @@ import warnings
 from . import backend_agg, backend_cairo, backend_gtk3
 from ._gtk3_compat import gi
 from .backend_cairo import cairo
-from .backend_gtk3 import _BackendGTK3
+from .backend_gtk3 import Gtk, _BackendGTK3
 from matplotlib import transforms
 
 # The following combinations are allowed:
@@ -38,6 +38,10 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
 
         if not len(self._bbox_queue):
             self._render_figure(w, h)
+            Gtk.render_background(
+                self.get_style_context(), ctx,
+                allocation.x, allocation.y,
+                allocation.width, allocation.height)
             bbox_queue = [transforms.Bbox([[0, 0], [w, h]])]
         else:
             bbox_queue = self._bbox_queue

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -1,7 +1,7 @@
 from . import backend_cairo, backend_gtk3
 from ._gtk3_compat import gi
 from .backend_cairo import cairo
-from .backend_gtk3 import _BackendGTK3
+from .backend_gtk3 import Gtk, _BackendGTK3
 from matplotlib.backend_bases import cursors
 
 
@@ -39,6 +39,9 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
         #     toolbar.set_cursor(cursors.WAIT)
         self._renderer.set_context(ctx)
         allocation = self.get_allocation()
+        Gtk.render_background(
+            self.get_style_context(), ctx,
+            allocation.x, allocation.y, allocation.width, allocation.height)
         self._render_figure(allocation.width, allocation.height)
         # if toolbar:
         #     toolbar.set_cursor(toolbar._lastCursor)


### PR DESCRIPTION
Currently, gtk3 widget backgrounds are not being applied (which only
matters if the figure patch is partially transparent).  The lines added
by this PR are equivalent to the call to `painter.eraseRect(self.rect())`
in the qt5agg backend (compare http://doc.qt.io/qt-5/qpainter.html#eraseRect
and https://developer.gnome.org/gtk3/stable/GtkStyleContext.html#gtk-render-background).

As an example, run

    import os; os.environ["MPLBACKEND"] = "gtk3cairo"
    from pylab import *
    from gi.repository import Gtk
    rcParams["figure.facecolor"] = (0, 0, 0, 0)
    css = Gtk.CssProvider()
    css.load_from_data(b"* {background-color: red;}")
    gcf().canvas.get_style_context().add_provider(
        css, Gtk.STYLE_PROVIDER_PRIORITY_USER)
    gca()
    show()

Without this patch, the red background is not drawn. (gtk3agg behaves in the same way *after #10297 is applied*).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
