### PR TITLE
Deprecate truncating saved unsized anims to 100 frames.

### DIFF
--- a/examples/animation/simple_anim.py
+++ b/examples/animation/simple_anim.py
@@ -26,7 +26,7 @@ def animate(i):
 
 
 ani = animation.FuncAnimation(
-    fig, animate, init_func=init, interval=2, blit=True)
+    fig, animate, init_func=init, interval=2, blit=True, save_count=50)
 
 # To save the animation, use e.g.
 #

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -38,9 +38,8 @@ import numpy as np
 
 from matplotlib._animation_data import (DISPLAY_TEMPLATE, INCLUDED_FRAMES,
                                         JS_INCLUDE)
-from matplotlib.cbook import iterable, deprecated
 from matplotlib.compat import subprocess
-from matplotlib import rcParams, rcParamsDefault, rc_context
+from matplotlib import cbook, rcParams, rcParamsDefault, rc_context
 
 if six.PY2:
     from base64 import encodestring as encodebytes
@@ -1681,7 +1680,7 @@ class FuncAnimation(TimedAnimation):
             self._iter_gen = itertools.count
         elif callable(frames):
             self._iter_gen = frames
-        elif iterable(frames):
+        elif cbook.iterable(frames):
             self._iter_gen = lambda: iter(frames)
             if hasattr(frames, '__len__'):
                 self.save_count = len(frames)
@@ -1723,7 +1722,26 @@ class FuncAnimation(TimedAnimation):
             self._old_saved_seq = list(self._save_seq)
             return iter(self._old_saved_seq)
         else:
-            return itertools.islice(self.new_frame_seq(), self.save_count)
+            if self.save_count is not None:
+                return itertools.islice(self.new_frame_seq(), self.save_count)
+
+            else:
+                frame_seq = self.new_frame_seq()
+
+                def gen():
+                    try:
+                        for _ in range(100):
+                            yield next(frame_seq)
+                    except StopIteration:
+                        pass
+                    else:
+                        cbook.warn_deprecated(
+                            "2.2", "FuncAnimation.save has truncated your "
+                            "animation to 100 frames.  In the future, no such "
+                            "truncation will occur; please pass 'save_count' "
+                            "accordingly.")
+
+                return gen()
 
     def _init_draw(self):
         # Initialize the drawing either using the given init_func or by


### PR DESCRIPTION
To test that the deprecation is working, uncomment the `ani.save(...)`
line in the simple_anim.py example and modify the anim's save_count.

Animations that happened to generate exactly 100 frames without
truncation will incorrectly trigger a warning; not sure we can do much
about it (because after the 100th frame is generated there is no way to
know whether another frame is coming except by actually calling next()
on the generator, which we do not want to do).

cf discussion in #8278.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
