### PR TITLE
Switch the lasso selector to use mpl event handling, not input().

### DIFF
--- a/examples/widgets/lasso_selector_demo_sgskip.py
+++ b/examples/widgets/lasso_selector_demo_sgskip.py
@@ -9,9 +9,8 @@ This examples plots a scatter plot. You can then select a few points by drawing
 a lasso loop around the points on the graph. To draw, just click
 on the graph, hold, and drag it around the points you need to select.
 """
-from __future__ import print_function
 
-from six.moves import input
+from __future__ import print_function
 
 import numpy as np
 
@@ -79,7 +78,6 @@ class SelectFromCollection(object):
 if __name__ == '__main__':
     import matplotlib.pyplot as plt
 
-    plt.ion()
     # Fixing random state for reproducibility
     np.random.seed(19680801)
 
@@ -91,11 +89,15 @@ if __name__ == '__main__':
     pts = ax.scatter(data[:, 0], data[:, 1], s=80)
     selector = SelectFromCollection(ax, pts)
 
-    plt.draw()
-    input('Press Enter to accept selected points')
-    print("Selected points:")
-    print(selector.xys[selector.ind])
-    selector.disconnect()
+    def accept(event):
+        if event.key == "enter":
+            print("Selected points:")
+            print(selector.xys[selector.ind])
+            selector.disconnect()
+            ax.set_title("")
+            fig.canvas.draw()
 
-    # Block end of script so you can check that the lasso is disconnected.
-    input('Press Enter to quit')
+    fig.canvas.mpl_connect("key_press_event", accept)
+    ax.set_title("Press enter to accept selected points.")
+
+    plt.show()


### PR DESCRIPTION
Interaction between input() and the GUI event loop can be generously
described as... complex.

Fixes the mwe at #10269; although more documentation (suggesting to not mix `input` and the event loop) would be nice.  See also #10061.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
