### PR TITLE
Mark the qt5 interactive test as xfail.

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -23,15 +23,16 @@ def _get_testable_interactive_backends():
                           (["PyQt5"], "qt5agg"),
                           (["tkinter"], "tkagg"),
                           (["wx"], "wxagg")]:
-        reason = None
+        mark = lambda backend: backend
         if sys.version_info < (3,):
-            reason = "Py3-only test"
+            mark = pytest.mark.skip(reason="Py3-only test")
         elif not os.environ.get("DISPLAY"):
-            reason = "No $DISPLAY"
+            mark = pytest.mark.skip(reason="No $DISPLAY")
         elif any(importlib.util.find_spec(dep) is None for dep in deps):
-            reason = "Missing dependency"
-        backends.append(pytest.mark.skip(reason=reason)(backend) if reason
-                        else backend)
+            mark = pytest.mark.skip(reason="Missing dependency")
+        elif backend == "qt5agg":
+            mark = pytest.mark.xfail(reason="Currently broken on Travis")
+        backends.append(mark(backend))
     return backends
 
 


### PR DESCRIPTION
## PR Summary

will selfmerge if passes to unbreak the build
probably worth using strict xfail later too

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
