### PR TITLE
DOC: Tiny fixes, and possible overhaul, of the two scales example in the gallery

### DIFF
--- a/examples/api/two_scales.py
+++ b/examples/api/two_scales.py
@@ -22,13 +22,14 @@ t = np.arange(0.01, 10.0, 0.01)
 data1 = np.exp(t)
 data2 = np.sin(2 * np.pi * t)
 
-# Create twin axes and plot the mock data onto them
+# Create a pair of twin axes (ax1 and ax2) that share the same x-axis
 fig, ax1 = plt.subplots()
-ax2 = ax1.twinx()  # instantiate a second axes that shares the same x-axis
+ax2 = ax1.twinx()  # create the second `Axes` instance
 
+# Plot a different set of data on each axes
 for ax, data, c in ((ax1, data1, "red"), (ax2, data2, "blue")):
     ax.plot(t, data, color=c)
-    # Color the y-axis (both label and tick labels)
+    # Color the y-axis (both label and tick labels) accordingly to the data
     ax.yaxis.label.set_color(c)
     for tl in ax.get_yticklabels():
         tl.set_color(c)

--- a/examples/api/two_scales.py
+++ b/examples/api/two_scales.py
@@ -20,10 +20,9 @@ import matplotlib.pyplot as plt
 
 def two_scales(ax1, time, data1, data2, c1, c2):
     """
-
     Parameters
     ----------
-    ax : axis
+    ax1 : axis
         Axis to put two scales on
 
     time : array-like
@@ -43,10 +42,11 @@ def two_scales(ax1, time, data1, data2, c1, c2):
 
     Returns
     -------
-    ax : axis
+    ax1 : axis
         Original axis
     ax2 : axis
         New twin axis
+
     """
     ax2 = ax1.twinx()
 
@@ -56,8 +56,8 @@ def two_scales(ax1, time, data1, data2, c1, c2):
 
     ax2.plot(time, data2, color=c2)
     ax2.set_ylabel('sin')
-    return ax1, ax2
 
+    return ax1, ax2
 
 # Create some mock data
 t = np.arange(0.01, 10.0, 0.01)
@@ -68,7 +68,6 @@ s2 = np.sin(2 * np.pi * t)
 fig, ax = plt.subplots()
 ax1, ax2 = two_scales(ax, t, s1, s2, 'r', 'b')
 
-
 # Change color of each axis
 def color_y_axis(ax, color):
     """Color your axes."""
@@ -77,4 +76,6 @@ def color_y_axis(ax, color):
     return None
 color_y_axis(ax1, 'r')
 color_y_axis(ax2, 'b')
+
+fig.tight_layout()  # otherwise y-labels are slightly clipped
 plt.show()

--- a/examples/api/two_scales.py
+++ b/examples/api/two_scales.py
@@ -22,22 +22,20 @@ t = np.arange(0.01, 10.0, 0.01)
 data1 = np.exp(t)
 data2 = np.sin(2 * np.pi * t)
 
-# Create a pair of twin axes (ax1 and ax2) that share the same x-axis
 fig, ax1 = plt.subplots()
-ax2 = ax1.twinx()  # create the second `Axes` instance
 
-# Plot a different set of data on each axes
-for ax, data, c in ((ax1, data1, "red"), (ax2, data2, "blue")):
-    ax.plot(t, data, color=c)
-    # Color the y-axis (both label and tick labels) accordingly to the data
-    ax.yaxis.label.set_color(c)
-    for tl in ax.get_yticklabels():
-        tl.set_color(c)
-
-# Label both axes
+color = 'tab:red'
 ax1.set_xlabel('time (s)')
-ax1.set_ylabel('exp')
-ax2.set_ylabel('sin')  # NB: we already took care of the x-label with ax1
+ax1.set_ylabel('exp', color=color)
+ax1.plot(t, data1, color=color)
+ax1.tick_params(axis='y', labelcolor=color)
+
+ax2 = ax1.twinx()  # instantiate a second axes that shares the same x-axis
+
+color = 'tab:blue'
+ax2.set_ylabel('sin', color=color)  # we already handled the x-label with ax1
+ax2.plot(t, data2, color=color)
+ax2.tick_params(axis='y', labelcolor=color)
 
 fig.tight_layout()  # otherwise the right y-label is slightly clipped
 plt.show()

--- a/examples/api/two_scales.py
+++ b/examples/api/two_scales.py
@@ -17,53 +17,26 @@ have different top and bottom scales.
 import numpy as np
 import matplotlib.pyplot as plt
 
-
-def two_scales(ax1, time, data1, data2, c1, c2):
-    """
-    Parameters
-    ----------
-    ax1 : axis
-        Axis to share a second scale with.
-
-    time : array-like
-        x-axis values for both datasets.
-
-    data1, data2: array-like
-        Data for respectively the left and the right hand scale.
-
-    c1, c2 : color
-        Color for respectively the left and the right hand scale.
-
-    Returns
-    -------
-    ax1, ax2 : tuple of axis instances
-        Respectively the original axis and its new twin axis.
-
-    """
-    ax2 = ax1.twinx()  # create a second axes that shares the same x-axis
-
-    for ax, data, c in ((ax1, data1, c1), (ax2, data2, c2)):
-        ax.plot(time, data, color=c)
-        # Color the y-axis (both label and tick labels)
-        ax.yaxis.label.set_color(c)
-        for t in ax.get_yticklabels():
-            t.set_color(c)
-
-    return ax1, ax2
-
 # Create some mock data
 t = np.arange(0.01, 10.0, 0.01)
-s1 = np.exp(t)
-s2 = np.sin(2 * np.pi * t)
+data1 = np.exp(t)
+data2 = np.sin(2 * np.pi * t)
 
-# Create axes and plot the mock data onto them
-fig, ax = plt.subplots()
-ax1, ax2 = two_scales(ax, t, s1, s2, 'r', 'b')
+# Create twin axes and plot the mock data onto them
+fig, ax1 = plt.subplots()
+ax2 = ax1.twinx()  # instantiate a second axes that shares the same x-axis
+
+for ax, data, c in ((ax1, data1, "red"), (ax2, data2, "blue")):
+    ax.plot(t, data, color=c)
+    # Color the y-axis (both label and tick labels)
+    ax.yaxis.label.set_color(c)
+    for tl in ax.get_yticklabels():
+        tl.set_color(c)
 
 # Label both axes
 ax1.set_xlabel('time (s)')
 ax1.set_ylabel('exp')
 ax2.set_ylabel('sin')  # NB: we already took care of the x-label with ax1
 
-fig.tight_layout()  # otherwise the y-labels are slightly clipped
+fig.tight_layout()  # otherwise the right y-label is slightly clipped
 plt.show()

--- a/examples/api/two_scales.py
+++ b/examples/api/two_scales.py
@@ -23,39 +23,31 @@ def two_scales(ax1, time, data1, data2, c1, c2):
     Parameters
     ----------
     ax1 : axis
-        Axis to put two scales on
+        Axis to share a second scale with.
 
     time : array-like
-        x-axis values for both datasets
+        x-axis values for both datasets.
 
-    data1: array-like
-        Data for left hand scale
+    data1, data2: array-like
+        Data for respectively the left and the right hand scale.
 
-    data2 : array-like
-        Data for right hand scale
-
-    c1 : color
-        Color for line 1
-
-    c2 : color
-        Color for line 2
+    c1, c2 : color
+        Color for respectively the left and the right hand scale.
 
     Returns
     -------
-    ax1 : axis
-        Original axis
-    ax2 : axis
-        New twin axis
+    ax1, ax2 : tuple of axis instances
+        Respectively the original axis and its new twin axis.
 
     """
-    ax2 = ax1.twinx()
+    ax2 = ax1.twinx()  # create a second axes that shares the same x-axis
 
-    ax1.plot(time, data1, color=c1)
-    ax1.set_xlabel('time (s)')
-    ax1.set_ylabel('exp')
-
-    ax2.plot(time, data2, color=c2)
-    ax2.set_ylabel('sin')
+    for ax, data, c in ((ax1, data1, c1), (ax2, data2, c2)):
+        ax.plot(time, data, color=c)
+        # Color the y-axis (both label and tick labels)
+        ax.yaxis.label.set_color(c)
+        for t in ax.get_yticklabels():
+            t.set_color(c)
 
     return ax1, ax2
 
@@ -64,18 +56,14 @@ t = np.arange(0.01, 10.0, 0.01)
 s1 = np.exp(t)
 s2 = np.sin(2 * np.pi * t)
 
-# Create axes
+# Create axes and plot the mock data onto them
 fig, ax = plt.subplots()
 ax1, ax2 = two_scales(ax, t, s1, s2, 'r', 'b')
 
-# Change color of each axis
-def color_y_axis(ax, color):
-    """Color your axes."""
-    for t in ax.get_yticklabels():
-        t.set_color(color)
-    return None
-color_y_axis(ax1, 'r')
-color_y_axis(ax2, 'b')
+# Label both axes
+ax1.set_xlabel('time (s)')
+ax1.set_ylabel('exp')
+ax2.set_ylabel('sin')  # NB: we already took care of the x-label with ax1
 
-fig.tight_layout()  # otherwise y-labels are slightly clipped
+fig.tight_layout()  # otherwise the y-labels are slightly clipped
 plt.show()


### PR DESCRIPTION
## PR Summary

Two-fold PR about the gallery example that shows how to use `ax.twinx` to display [two scales](https://matplotlib.org/devdocs/gallery/api/two_scales.html) on the same plot:
1. 367647e fixes a few typos and introduces a call to `fig.tight_layout` to prevent the y-labels from being clipped
2. fdb5900 is a significant style overhaul that:
    * compresses the docstring of the (main) helper function;
    * gets rid of the minor helper function used to color the y-tick labels, to simply include the relevant code into the main helper function (this avoids passing the desired colors a second time);
    * now colors the y-labels as well;
    * sets up the axes labels in a place that actually makes sense (beforehand, those labels were hard-coded into the main helper function, independently of whatever *data1* and *data2* could be...).

I agree that the value of the *2nd* commit may be subjective (although I personally think that the helper function is now quite more logical, and more suited to reusing outside of the gallery) and I would understand if it were discarded simply because of that. However, if it was the case, the *1st* commit fixes minor issues that, I think, are objective enough to still be this commit.

Here is what the example looks like with both commits:
![with_both_commits](https://user-images.githubusercontent.com/17270724/35372121-16bad1b6-014d-11e8-93d8-51f33b2532ce.png)


## PR Checklist

- [ ] Code is PEP 8 compliant: I think so, CI will decide
- [X] Documentation is sphinx and numpydoc compliant: AFAIU, it should be

NB: milestoned for 2.2 as it is only a small piece of documentation. Feel free to re-milestone for 3.0 if needed.