### PR TITLE
Ability to scale axis by a fixed factor

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2672,6 +2672,7 @@ class _AxesBase(martist.Artist):
                            be used for numbers outside the range
                            10`m`:sup: to 10`n`:sup:.
                            Use (0,0) to include all numbers.
+                           Use (m,m) to fix scaling to 10`m`:sup:.
           *useOffset*      [ bool | offset ]; if True,
                            the offset will be calculated as needed;
                            if False, no offset will be used; if a

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -727,7 +727,10 @@ class ScalarFormatter(Formatter):
                 oom = 0
             else:
                 oom = math.floor(math.log10(val))
-        if oom <= self._powerlimits[0]:
+        if self._powerlimits[0]==self._powerlimits[1] and self._powerlimits[0] != 0:
+            # fixed scaling when lower power limit = upper <> 0.
+            self.orderOfMagnitude = self._powerlimits[0]
+        elif oom <= self._powerlimits[0]:
             self.orderOfMagnitude = oom
         elif oom >= self._powerlimits[1]:
             self.orderOfMagnitude = oom


### PR DESCRIPTION
Often we would like to scale the axis by a certain fixed factor (1e6), and we do not want to adjust the values prior to plotting in matplotlib. Here's an example of the behavior:

![image](https://user-images.githubusercontent.com/3169669/35380509-beaaf736-01b9-11e8-96b2-e34a7bb2dfec.png)

We can turn on scaling by ```ax.ticklabel_format(style='sci', scilimits=(6, 6), axis='y')```; however, matplotlib would adjust the scaling factor such that the largest label would be greater than one. In other words, the scaling is on, but it is not fixed.

![image](https://user-images.githubusercontent.com/3169669/35380484-a5673190-01b9-11e8-8cb2-a26a84b8c7d2.png)

This PR implements the fixed-scaling feature via a small change to ticker.py
