### PR TITLE
Don't call np.identity() in transforms.

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1928,7 +1928,8 @@ class Affine2D(Affine2DBase):
         """
         Affine2DBase.__init__(self, **kwargs)
         if matrix is None:
-            matrix = np.identity(3)
+            # A bit faster than np.identity(3).
+            matrix = IdentityTransform._mtx.copy()
         self._mtx = matrix
         self._invalid = 0
 
@@ -1999,13 +2000,14 @@ class Affine2D(Affine2DBase):
         Unless this transform will be mutated later on, consider using
         the faster :class:`IdentityTransform` class instead.
         """
-        return Affine2D(np.identity(3))
+        return Affine2D()
 
     def clear(self):
         """
         Reset the underlying matrix to the identity transform.
         """
-        self._mtx = np.identity(3)
+        # A bit faster than np.identity(3).
+        self._mtx = IdentityTransform._mtx.copy()
         self.invalidate()
         return self
 


### PR DESCRIPTION
EDIT: see below.

Speeds up setting up of subplots by ~3% and their drawing by ~2% at a
reasonably limited cost in legibility.

The difference is actually not easy to observe because variation in
timings are much greater than 3% from run to run.

In a call like `subplots(10, 10)`, just setting up the figure calls
`np.identity(3)` 1801 times and actually drawing the figure another 1705
times (measured by manually instrumenting the calls to identity() in the
old version.  At the same time,

```
%timeit np.identity(3)
```
and
```
%%timeit t = np.identity(3)
t.copy()
```
show that on my machine, a call to np.identity(3) is approximately 16us
slower than copying a preexisting matrix; multiplying this by 1801 shows
that the calls to identity correspond to an excess time of ~27ms.

Finally, setting up the axes and drawing it can be timed using
```
from time import perf_counter
import matplotlib; matplotlib.use("agg")
from matplotlib import pyplot as plt

N = 10
 # First draw always seems slower, so skip it.
figure = plt.figure()
figure.subplots(N, N)
figure.canvas.draw()
plt.close("all")

for _ in range(5):
    figure = plt.figure()
    start = perf_counter()
    figure.subplots(N, N)
    print("{: 4}".format(int(1000 * (perf_counter() - start))), end=" ")
    start = perf_counter()
    figure.canvas.draw()
    print("{: 4}".format(int(1000 * (perf_counter() - start))))
    plt.close("all")
```
which shows that (on my machine) setting up the subplots takes ~850ms
and drawing them ~1300ms (but again, with a lot of jitter).

Hence, the gain from the patch should be ~3% for the setup and ~2% for
the draw.

----

Edit: I realized that my timings were invalid because I had https://pypi.org/project/ipython-autoimport/ active which, while reasonably fast, still messed up the timings a bit.
The real gain is probably ~5x less than what advertised above, so ~0.5%.  Feel free to close if you think this is not worth it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
