### PR TITLE
Don't let gridlines inherit the axis' clip path.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -234,13 +234,6 @@ class Tick(artist.Artist):
                     self.gridline, self.label1, self.label2]
         return children
 
-    def set_clip_path(self, clippath, transform=None):
-        artist.Artist.set_clip_path(self, clippath, transform)
-        self.gridline.set_clip_path(clippath, transform)
-        self.stale = True
-
-    set_clip_path.__doc__ = artist.Artist.set_clip_path.__doc__
-
     def get_pad_pixels(self):
         return self.figure.dpi * self._base_pad / 72.0
 
@@ -492,7 +485,6 @@ class XTick(Tick):
                           markersize=self._size,
                           markeredgewidth=self._width,
                           zorder=self._zorder)
-
         l.set_transform(self.axes.get_xaxis_transform(which='tick2'))
         self._set_artist_props(l)
         return l
@@ -510,7 +502,6 @@ class XTick(Tick):
         l.set_transform(self.axes.get_xaxis_transform(which='grid'))
         l.get_path()._interpolation_steps = GRIDLINE_INTERPOLATION_STEPS
         self._set_artist_props(l)
-
         return l
 
     def update_position(self, loc):
@@ -834,10 +825,6 @@ class Axis(artist.Artist):
             del self.minorTicks
         except AttributeError:
             pass
-        try:
-            self.set_clip_path(self.axes.patch)
-        except AttributeError:
-            pass
 
     def set_tick_params(self, which='major', reset=False, **kw):
         """
@@ -921,12 +908,6 @@ class Axis(artist.Artist):
         else:
             raise NotImplementedError("Inverse translation is deferred")
         return kwtrans
-
-    def set_clip_path(self, clippath, transform=None):
-        artist.Artist.set_clip_path(self, clippath, transform)
-        for child in self.majorTicks + self.minorTicks:
-            child.set_clip_path(clippath, transform)
-        self.stale = True
 
     def get_view_interval(self):
         'return the Interval instance for this axis view limits'


### PR DESCRIPTION
Currently, setting a clip path on an axis will also clip the grid lines
(but not the ticks or tick labels).  But grid lines don't need to be
clipped to be drawn correctly as they are actually drawn from 0 to 1 in
the relevant transform (basically, similarly to an ax{v,h}line).

This PR deletes the code that specifically implements this behavior,
gaining ~10% in speed when setting up figures with many subplots
(drawing itself, which is ~1.5x slower, is unaffected).  The gain in
speed is because when the axis is set up, its clip path is set from, and
it tries to propagate it to its ticks, which are thus instantiated, even
though they will later be recomputed based on the actual axis limits and
locator (and tick instantiation is surprisingly costly, cf recent PRs).
By suppressing the propagation, we suppress the need to instantiate
unused ticks.

This code came in with 633759b (October 2007), which clipped both the
gridlines and the ticks; then b39c2d (November 2007) removed clipping
for the ticks, only leaving clipping of the gridlines.  No reason is
given for the behavior.

Note also that e.g. setting a clip path on an Axes doesn't propagate to
the child Axis, nor (as mentioned above) does a clip path on an Axis
propagate to the child ticks and ticklabels; thus I believe not
propagating to the tick lines either is actually more consistent (or we
should just propagate all the time).

Example that shows the relevant behaviors:
```
from pylab import *
fig = plt.figure()
 # Set up some polar axes that just serves as an easy way to have a round clip
 # path for the "real" hero here, `ax`.
axp = fig.add_subplot(111, projection="polar", label="foo")
ax = fig.add_subplot(221, label="bar")
ax.xaxis.grid()
 # Currently, the following line will clip the gridlines to the round path (i.e.
 # the gridlines will inherit the round clip path).  Nothing else (ticks, tick
 # labels) will be clipped.
 # With the proposed patch, nothing will be clipped at all.
ax.xaxis.set_clip_path(axp.patch)
 # ax.set_clip_path(axp.patch)  # Doesn't clip *anything*.
show()
```

Previously:
![old](https://user-images.githubusercontent.com/1322974/35435436-959681cc-023f-11e8-8168-f2e40be62cd8.png)

With this PR:
![new](https://user-images.githubusercontent.com/1322974/35435437-9835183a-023f-11e8-8f06-5126ea5a6dc8.png)


Profiling script:
```
from time import perf_counter
import matplotlib; matplotlib.use("agg")
from matplotlib import pyplot as plt

N = 10
 # First draw always seems slower, so skip it.
figure = plt.figure()
figure.subplots(N, N)
figure.canvas.draw()
plt.close("all")

for _ in range(5):
    figure = plt.figure()
    start = perf_counter()
    figure.subplots(N, N)
    print("{: 4}".format(int(1000 * (perf_counter() - start))), end=" ")
    start = perf_counter()
    figure.canvas.draw()
    print("{: 4}".format(int(1000 * (perf_counter() - start))))
    plt.close("all")
```

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
