### PR TITLE
Pass explicit font paths to fontspec in backend_pgf.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -11,6 +11,7 @@ The following modules are deprecated:
 The following classes, methods, functions, and attributes are deprecated:
 
 - ``afm.parse_afm``,
+- ``backend_pgf.get_texcommand``,
 - ``backend_qt5.error_msg_qt``, ``backend_qt5.exception_handler``,
 - ``backend_wx.FigureCanvasWx.macros``,
 - ``cbook.GetRealpathAndStat``, ``cbook.Locked``,

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -4,6 +4,7 @@ import errno
 import logging
 import math
 import os
+from pathlib import Path
 import re
 import shutil
 import subprocess
@@ -13,7 +14,7 @@ import warnings
 import weakref
 
 import matplotlib as mpl
-from matplotlib import _png, rcParams, __version__
+from matplotlib import _png, cbook, font_manager as fm, __version__, rcParams
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
     RendererBase)
@@ -28,33 +29,13 @@ _log = logging.getLogger(__name__)
 
 ###############################################################################
 
-# create a list of system fonts, all of these should work with xe/lua-latex
-system_fonts = []
-if sys.platform == 'win32':
-    from matplotlib import font_manager
-    for f in font_manager.win32InstalledFonts():
-        try:
-            system_fonts.append(font_manager.get_font(str(f)).family_name)
-        except:
-            pass # unknown error, skip this font
-else:
-    # assuming fontconfig is installed and the command 'fc-list' exists
-    try:
-        # list scalable (non-bitmap) fonts
-        fc_list = subprocess.check_output(
-            ['fc-list', ':outline,scalable', 'family'])
-        fc_list = fc_list.decode('utf8')
-        system_fonts = [f.split(',')[0] for f in fc_list.splitlines()]
-        system_fonts = list(set(system_fonts))
-    except:
-        warnings.warn('error getting fonts from fc-list', UserWarning)
-
 
 _luatex_version_re = re.compile(
     r'This is LuaTeX, Version (?:beta-)?([0-9]+)\.([0-9]+)\.([0-9]+)'
 )
 
 
+@cbook.deprecated("3.0")
 def get_texcommand():
     """Get chosen TeX system from rc."""
     texsystem_options = ["xelatex", "lualatex", "pdflatex"]
@@ -77,23 +58,20 @@ def _parse_lualatex_version(output):
 def get_fontspec():
     """Build fontspec preamble from rc."""
     latex_fontspec = []
-    texcommand = get_texcommand()
+    texcommand = rcParams["pgf.texsystem"]
 
     if texcommand != "pdflatex":
         latex_fontspec.append("\\usepackage{fontspec}")
 
     if texcommand != "pdflatex" and rcParams["pgf.rcfonts"]:
-        # try to find fonts from rc parameters
-        families = ["serif", "sans-serif", "monospace"]
-        fontspecs = [r"\setmainfont{%s}", r"\setsansfont{%s}",
-                     r"\setmonofont{%s}"]
-        for family, fontspec in zip(families, fontspecs):
-            matches = [f for f in rcParams["font." + family]
-                       if f in system_fonts]
-            if matches:
-                latex_fontspec.append(fontspec % matches[0])
-            else:
-                pass  # no fonts found, fallback to LaTeX defaule
+        families = ["serif", "sans\\-serif", "monospace"]
+        commands = ["setmainfont", "setsansfont", "setmonofont"]
+        for family, command in zip(families, commands):
+            # 1) Forward slashes also work on Windows, so don't mess with
+            # backslashes.  2) The dirname needs to include a separator.
+            path = Path(fm.findfont(family))
+            latex_fontspec.append(r"\%s{%s}[Path=%s]" % (
+                command, path.name, path.parent.as_posix() + "/"))
 
     return "\n".join(latex_fontspec)
 
@@ -163,7 +141,7 @@ def _font_properties_str(prop):
     family = prop.get_family()[0]
     if family in families:
         commands.append(families[family])
-    elif family in system_fonts and get_texcommand() != "pdflatex":
+    elif family in system_fonts and rcParams["pgf.texsystem"] != "pdflatex":
         commands.append(r"\setmainfont{%s}\rmfamily" % family)
     else:
         pass  # print warning?
@@ -232,7 +210,7 @@ class LatexManagerFactory:
 
     @staticmethod
     def get_latex_manager():
-        texcommand = get_texcommand()
+        texcommand = rcParams["pgf.texsystem"]
         latex_header = LatexManager._build_latex_header()
         prev = LatexManagerFactory.previous_instance
 
@@ -307,7 +285,7 @@ class LatexManager:
         LatexManager._unclean_instances.add(self)
 
         # test the LaTeX setup to ensure a clean startup of the subprocess
-        self.texcommand = get_texcommand()
+        self.texcommand = rcParams["pgf.texsystem"]
         self.latex_header = LatexManager._build_latex_header()
         latex_end = "\n\\makeatletter\n\\@@end\n"
         try:
@@ -909,7 +887,7 @@ class FigureCanvasPgf(FigureCanvasBase):
             with codecs.open(fname_tex, "w", "utf-8") as fh_tex:
                 fh_tex.write(latexcode)
 
-            texcommand = get_texcommand()
+            texcommand = rcParams["pgf.texsystem"]
             cmdargs = [texcommand, "-interaction=nonstopmode",
                        "-halt-on-error", "figure.tex"]
             try:


### PR DESCRIPTION
## PR Summary

xref #10307.  @laborleben Can you check whether this works for you?  Seems better than continuously posting patches :)

Basically
1. we already have a font fonding mechanism and should just reuse it in backend_pgf.
2. we sometimes find fonts in nonstandard locations and may need to tell tex exactly where to find them.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
