### PR TITLE
update set_drawstyle

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1002,6 +1002,8 @@ class Line2D(Artist):
             raise ValueError('Unrecognized drawstyle {!r}'.format(drawstyle))
         if self._drawstyle != drawstyle:
             self.stale = True
+            # invalidate to trigger a recache of the path
+            self._invalidx = True
         self._drawstyle = drawstyle
 
     def set_linewidth(self, w):

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -129,7 +129,7 @@ def test_valid_drawstyles():
     with pytest.raises(ValueError):
         line.set_drawstyle('foobar')
 
-        
+
 def test_set_drawstyle():
     x = np.linspace(0, 2*np.pi, 10)
     y = np.sin(x)
@@ -138,9 +138,10 @@ def test_set_drawstyle():
     line, = ax.plot(x, y)
     line.set_drawstyle("steps-pre")
     assert len(line.get_path().vertices) == 2*len(x)-1
-    
+
     line.set_drawstyle("default")
     assert len(line.get_path().vertices) == len(x)
+
 
 @image_comparison(baseline_images=['line_collection_dashes'], remove_text=True)
 def test_set_line_coll_dash_image():

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -129,6 +129,18 @@ def test_valid_drawstyles():
     with pytest.raises(ValueError):
         line.set_drawstyle('foobar')
 
+        
+def test_set_drawstyle():
+    x = np.linspace(0, 2*np.pi, 10)
+    y = np.sin(x)
+
+    fig, ax = plt.subplots()
+    line, = ax.plot(x, y)
+    line.set_drawstyle("steps-pre")
+    assert len(line.get_path().vertices) == 2*len(x)-1
+    
+    line.set_drawstyle("default")
+    assert len(line.get_path().vertices) == len(x)
 
 @image_comparison(baseline_images=['line_collection_dashes'], remove_text=True)
 def test_set_line_coll_dash_image():


### PR DESCRIPTION
Invalidate path on set_drawstyle to recache path, such that the new drawstyle is actually applied.
Fixes #10338


## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
