### PR TITLE
Hide the backend.qt4/5 rcparam deprecation warning in test suite.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -24,7 +24,7 @@ import os
 import warnings
 import re
 
-from matplotlib import cbook
+from matplotlib import cbook, testing
 from matplotlib.cbook import mplDeprecation, deprecated, ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
 from matplotlib.colors import is_color_like
@@ -266,19 +266,28 @@ def validate_backend(s):
         return _validate_standard_backends(s)
 
 
-@deprecated("2.2",
+def validate_qt4(s):
+    # Don't spam the test suite with warnings every time the rcparams are
+    # reset.  While it may seem better to use filterwarnings from within the
+    # test suite, pytest 3.1+ explicitly disregards warnings filters (pytest
+    # issue #2430).
+    if not testing.is_called_from_pytest():
+        cbook.warn_deprecated(
+            "2.2",
             "The backend.qt4 rcParam was deprecated in version 2.2.  In order "
             "to force the use of a specific Qt4 binding, either import that "
             "binding first, or set the QT_API environment variable.")
-def validate_qt4(s):
     return ValidateInStrings("backend.qt4", ['PyQt4', 'PySide', 'PyQt4v2'])(s)
 
 
-@deprecated("2.2",
-            "The backend.qt5 rcParam was deprecated in version 2.2.  In order "
-            "to force the use of a specific Qt5 binding, either import that "
-            "binding first, or set the QT_API environment variable.")
 def validate_qt5(s):
+    # See comment re: validate_qt4.
+    if not testing.is_called_from_pytest():
+        cbook.warn_deprecated(
+            "2.2",
+            "The backend.qt5 rcParam was deprecated in version 2.2.  In order "
+            "to force the use of a specific Qt4 binding, either import that "
+            "binding first, or set the QT_API environment variable.")
     return ValidateInStrings("backend.qt5", ['PyQt5', 'PySide2'])(s)
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -286,7 +286,7 @@ def validate_qt5(s):
         cbook.warn_deprecated(
             "2.2",
             "The backend.qt5 rcParam was deprecated in version 2.2.  In order "
-            "to force the use of a specific Qt4 binding, either import that "
+            "to force the use of a specific Qt5 binding, either import that "
             "binding first, or set the QT_API environment variable.")
     return ValidateInStrings("backend.qt5", ['PyQt5', 'PySide2'])(s)
 

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -4,8 +4,8 @@ from __future__ import (absolute_import, division, print_function,
 import functools
 import warnings
 
-import matplotlib
-from matplotlib import cbook, rcParams, rcdefaults, use
+import matplotlib as mpl
+from matplotlib import cbook
 
 
 def _is_list_like(obj):
@@ -15,7 +15,7 @@ def _is_list_like(obj):
 
 def is_called_from_pytest():
     """Returns whether the call was done from pytest"""
-    return getattr(matplotlib, '_called_from_pytest', False)
+    return getattr(mpl, '_called_from_pytest', False)
 
 
 def _copy_metadata(src_func, tgt_func):
@@ -26,13 +26,13 @@ def _copy_metadata(src_func, tgt_func):
 
 
 def set_font_settings_for_testing():
-    rcParams['font.family'] = 'DejaVu Sans'
-    rcParams['text.hinting'] = False
-    rcParams['text.hinting_factor'] = 8
+    mpl.rcParams['font.family'] = 'DejaVu Sans'
+    mpl.rcParams['text.hinting'] = False
+    mpl.rcParams['text.hinting_factor'] = 8
 
 
 def set_reproducibility_for_testing():
-    rcParams['svg.hashsalt'] = 'matplotlib'
+    mpl.rcParams['svg.hashsalt'] = 'matplotlib'
 
 
 def setup():
@@ -51,12 +51,12 @@ def setup():
                 "Could not set locale to English/United States. "
                 "Some date-related tests may fail")
 
-    use('Agg', warn=False)  # use Agg backend for these tests
+    mpl.use('Agg', warn=False)  # use Agg backend for these tests
 
     # These settings *must* be hardcoded for running the comparison
     # tests and are not necessarily the default values as specified in
     # rcsetup.py
-    rcdefaults()  # Start with all defaults
+    mpl.rcdefaults()  # Start with all defaults
 
     set_font_settings_for_testing()
     set_reproducibility_for_testing()


### PR DESCRIPTION
Otherwise, the test suite is spammed by warnings.  Note that pytest
explicitly disregards warnings filters (pytest issue 2430) so we can't
just set a filter when resetting the rcparams are reset in the test
suite.

The changes in matplotlib.testing are just there to allow it to be
imported relatively early in the matplotlib import process.

labeling as release critical given the amount of spam on the test suite (if this, or another similar fix, cannot be merged, then we should revert #10282 until a better solution is found).
attn @efiring who first mentioned the issue to me.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
