### PR TITLE
When latex fails, make sure it does not write a dvi.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -361,7 +361,8 @@ class TexManager(object):
             texfile = self.make_tex(tex, fontsize)
             with Locked(self.texcache):
                 self._run_checked_subprocess(
-                    ["latex", "-interaction=nonstopmode", texfile], tex)
+                    ["latex", "-interaction=nonstopmode", "--halt-on-error",
+                     texfile], tex)
             for fname in glob.glob(basefile + '*'):
                 if not fname.endswith(('dvi', 'tex')):
                     try:
@@ -387,7 +388,8 @@ class TexManager(object):
         if not os.path.exists(dvifile) or not os.path.exists(baselinefile):
             texfile = self.make_tex_preview(tex, fontsize)
             report = self._run_checked_subprocess(
-                ["latex", "-interaction=nonstopmode", texfile], tex)
+                ["latex", "-interaction=nonstopmode", "--halt-on-error",
+                 texfile], tex)
 
             # find the box extent information in the latex output
             # file and store them in ".baseline" file


### PR DESCRIPTION
PR #10180 added some tests checking that when the latex subprocess used
by usetex fails, a RuntimeError does propagate up to the Python process.
It originally passed the CI, but since its merge, various CIs have been
failing on the test that a text with `$22_2_2$` (an invalid tex
construct) fails when usetex is set.

This is because while `latex --interaction=nonstopmode` does exit with
error code 1 when processing a file with that construct, the error is
"benign" enough that it still writes a dvi before exiting (the contents
are simply as if the input was `$22_{22}$`).  The dvi goes into the tex
cache and later CI runs pick up the cached dvi instead of running the
subprocess, thus failing the test.

The solution is to use --halt-on-error on top of nonstopmode, see e.g.
https://tex.stackexchange.com/questions/258814/what-is-the-difference-between-interaction-nonstopmode-and-halt-on-error (and to clear your tex cache).

Note that before the PR, there would similarly be the weird behavior
(for the user) that the first attempt to use a "benignly" invalid tex
construct would trigger an exception, but latter attempts would not (for
the same reason as above).

attn @efiring 
labeling as rc as it's a CI issue.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
