### PR TITLE
FIX: deprecate qt4/5 rcparams

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -267,31 +267,26 @@ def validate_backend(s):
 
 
 def validate_qt4(s):
-    # Don't spam the test suite with warnings every time the rcparams are
-    # reset.  While it may seem better to use filterwarnings from within the
-    # test suite, pytest 3.1+ explicitly disregards warnings filters (pytest
-    # issue #2430).
     if s is None:
+        # return a reasonable default for deprecation period
         return 'PyQt4'
-    if not testing.is_called_from_pytest():
-        cbook.warn_deprecated(
-            "2.2",
-            "The backend.qt4 rcParam was deprecated in version 2.2.  In order "
-            "to force the use of a specific Qt4 binding, either import that "
-            "binding first, or set the QT_API environment variable.")
+    cbook.warn_deprecated(
+        "2.2",
+        "The backend.qt4 rcParam was deprecated in version 2.2.  In order "
+        "to force the use of a specific Qt4 binding, either import that "
+        "binding first, or set the QT_API environment variable.")
     return ValidateInStrings("backend.qt4", ['PyQt4', 'PySide', 'PyQt4v2'])(s)
 
 
 def validate_qt5(s):
-    # See comment re: validate_qt4.
     if s is None:
+        # return a reasonable default for deprecation period
         return 'PyQt5'
-    if not testing.is_called_from_pytest():
-        cbook.warn_deprecated(
-            "2.2",
-            "The backend.qt5 rcParam was deprecated in version 2.2.  In order "
-            "to force the use of a specific Qt5 binding, either import that "
-            "binding first, or set the QT_API environment variable.")
+    cbook.warn_deprecated(
+        "2.2",
+        "The backend.qt5 rcParam was deprecated in version 2.2.  In order "
+        "to force the use of a specific Qt5 binding, either import that "
+        "binding first, or set the QT_API environment variable.")
     return ValidateInStrings("backend.qt5", ['PyQt5', 'PySide2'])(s)
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -271,6 +271,8 @@ def validate_qt4(s):
     # reset.  While it may seem better to use filterwarnings from within the
     # test suite, pytest 3.1+ explicitly disregards warnings filters (pytest
     # issue #2430).
+    if s is None:
+        return 'PyQt4'
     if not testing.is_called_from_pytest():
         cbook.warn_deprecated(
             "2.2",
@@ -282,6 +284,8 @@ def validate_qt4(s):
 
 def validate_qt5(s):
     # See comment re: validate_qt4.
+    if s is None:
+        return 'PyQt5'
     if not testing.is_called_from_pytest():
         cbook.warn_deprecated(
             "2.2",
@@ -958,8 +962,8 @@ defaultParams = {
     'backend':           ['Agg', validate_backend],  # agg is certainly
                                                       # present
     'backend_fallback':  [True, validate_bool],  # agg is certainly present
-    'backend.qt4':       ['PyQt4', validate_qt4],
-    'backend.qt5':       ['PyQt5', validate_qt5],
+    'backend.qt4':       [None, validate_qt4],
+    'backend.qt5':       [None, validate_qt5],
     'webagg.port':       [8988, validate_int],
     'webagg.address':    ['127.0.0.1', validate_webagg_address],
     'webagg.open_in_browser': [True, validate_bool],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -40,11 +40,6 @@
 # non-interactive backend.
 backend      : $TEMPLATE_BACKEND
 
-# If you are using the Qt4Agg backend, you can choose here
-# to use the PyQt4 bindings or the newer PySide bindings to
-# the underlying Qt4 toolkit.
-#backend.qt4 : PyQt4        # PyQt4 | PySide
-
 # Note that this can be overridden by the environment variable
 # QT_API used by Enthought Tool Suite (ETS); valid values are
 # "pyqt" and "pyside".  The "pyqt" setting has the side effect of

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -495,13 +495,8 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # How do I select PyQt4 or PySide?
 # --------------------------------
 #
-# You can choose either PyQt4 or PySide when using the `qt4` backend by setting
-# the appropriate value for `backend.qt4` in your :file:`matplotlibrc` file. The
-# default value is `PyQt4`.
-#
-# The setting in your :file:`matplotlibrc` file can be overridden by setting the
-# `QT_API` environment variable to either `pyqt` or `pyside` to use `PyQt4` or
-# `PySide`, respectively.
+# The `QT_API` environment variable can be set to either `pyqt` or `pyside`
+# to use `PyQt4` or `PySide`, respectively.
 #
 # Since the default value for the bindings to be used is `PyQt4`,
 # :mod:`matplotlib` first tries to import it, if the import fails, it tries to


### PR DESCRIPTION
## PR Summary

#10282 deprecated rcparams `backend.qt4` and `backend.qt5` but left the defaults active so the deprecation warning came on, even if the user did not have these rcparams in the `matplotlibrc`.  This PR makes the defaults `None`, and adds a check for `None` in the validator (that returns the old defaults).  Hence the deprecation now only displays if these rcParams are still in the `matplotlibrc`.



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->