### PR TITLE
Explicitely destroy created wx PaintDC

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -937,6 +937,7 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
             self.draw(drawDC=drawDC)
         else:
             self.gui_repaint(drawDC=drawDC)
+        drawDC.Destroy()
 
     def _onSize(self, evt):
         """


### PR DESCRIPTION
## PR Summary

Fixes issue #10174: currently redraw errors occur on Mac OS X when a previous `PaintDC` is collected by the garbage collector during an ongoing `EVT_PAINT`.

wxPython Phoenix will have a context manager for this purpose, but for compatibility with previous versions, the explicit call is the only solution here.
( Pull request: https://github.com/wxWidgets/Phoenix/pull/713 )

In the example from issue #10174 there is an additional ref count created, maybe due to a handled exception. So it's a good idea to call `Destroy()` also on other platforms.


## PR Checklist
-> not applicable

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

