### PR TITLE
Fix syntax highlighting of sample bash and bibtex in rst markup.

### DIFF
--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -7,7 +7,7 @@ If Matplotlib contributes to a project that leads to a scientific
 publication, please acknowledge this fact by citing `Hunter et al (2007)
 <http://doi.org/10.1109/MCSE.2007.55>`_ using this ready-made BibTeX entry:
 
-.. code:: bibtex
+.. code-block:: bibtex
 
    @Article{Hunter:2007,
      Author    = {Hunter, J. D.},

--- a/doc/faq/osx_framework.rst
+++ b/doc/faq/osx_framework.rst
@@ -7,6 +7,7 @@ Working with Matplotlib on OSX
 .. contents::
    :backlinks: none
 
+.. highlight:: bash
 
 .. _osxframework_introduction:
 
@@ -77,9 +78,7 @@ Until this is fixed, one of the following workarounds can be used:
 
 The best known work around is to use the non
 virtualenv python along with the PYTHONHOME environment variable.
-This can be done by defining a function in your ``.bashrc`` using
-
-.. code:: bash
+This can be done by defining a function in your ``.bashrc`` using ::
 
   function frameworkpython {
       if [[ ! -z "$VIRTUAL_ENV" ]]; then
@@ -115,9 +114,7 @@ An alternative work around borrowed from the `WX wiki
 virtualenv python along with the PYTHONHOME environment variable.  This can be
 implemented in a script as below. To use this modify ``PYVER`` and
 ``PATHTOPYTHON`` and put the script in the virtualenv bin directory i.e.
-``PATHTOVENV/bin/frameworkpython``
-
-.. code:: bash
+``PATHTOVENV/bin/frameworkpython`` ::
 
   #!/bin/bash
 


### PR DESCRIPTION
## PR Summary

Current
https://matplotlib.org/devdocs/citing.html#citing-matplotlib
https://matplotlib.org/devdocs/faq/osx_framework.html#short-version

After PR:
https://1543-7439715-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/citing.html#citing-matplotlib
https://1543-7439715-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/faq/osx_framework.html#short-version

See https://github.com/sphinx-doc/sphinx/issues/2155 for (likely) why `.. code:: foo` is not working.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
