### PR TITLE
DOC: clarify that clim is not a valid kwarg if vmin/vmax are used

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -305,7 +305,8 @@ class ScalarMappable(object):
         sequence, interpret it as ``(vmin, vmax)`` which is used to
         support setp
 
-        ACCEPTS: a length 2 sequence of floats
+        ACCEPTS: a length 2 sequence of floats; may be overridden in methods
+        that have ``vmin`` and ``vmax`` kwargs.
         """
         if vmax is None:
             try:


### PR DESCRIPTION
## PR Summary

Closes #10346

@heath730 noted that `clim` is listed as a `QuadMesh` kwarg, but calling in `pcolormesh` is ignored in favour of `vmin`/`vmax`.  This just edits the `ScalarMappable.set_clim()` docstring, which is mapped downstream to methods that call `ScalarMappable` to make this clear. 

As discussed in #10346, its a bit strange to pass *all* the `set_blah` strings downstream; some of them make no sense, and some have no effect.  This is probably a bigger issue that will need some thought (after traitlets??)


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->