### PR TITLE
Switch to using StrictVersion in wx_compat.py

### DIFF
--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -11,7 +11,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from distutils.version import LooseVersion
+from distutils.version import StrictVersion
 
 missingwx = "Matplotlib backend_wx and backend_wxagg require wxPython>=2.9"
 
@@ -24,7 +24,7 @@ except ImportError:
     raise ImportError(missingwx)
 
 # Ensure we have the correct version imported
-if LooseVersion(wx.VERSION_STRING) < LooseVersion("2.9"):
+if StrictVersion(wx.VERSION_STRING) < StrictVersion("2.9"):
     raise ImportError(missingwx)
 
 if is_phoenix:
@@ -152,7 +152,7 @@ def _AddTool(parent, wx_ids, text, bmp, tooltip_text):
     else:
         add_tool = parent.DoAddTool
 
-    if not is_phoenix or LooseVersion(wx.VERSION_STRING) >= str("4.0.0b2"):
+    if not is_phoenix or StrictVersion(wx.VERSION_STRING) >= str("4.0.0b2"):
         # NOTE: when support for Phoenix prior to 4.0.0b2 is dropped then
         # all that is needed is this clause, and the if and else clause can
         # be removed.


### PR DESCRIPTION
## PR Summary
Under LooseVersion, the new version of wxPython (4.0.0) is judged to come before the previous beta release (4.0.0b2) which breaks the AddTool function in the same way that #9187 was designed to address.

As far as I can tell, wxPython now adheres to the StrictVersion [principles](http://epydoc.sourceforge.net/stdlib/distutils.version.StrictVersion-class.html) so it seems like a good fix here.

For the moment, this is blocking our upgrade to Phoenix 4.0.0 so hopefully this can make it in to the next release.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
