### PR TITLE
Fix to allow both old and new style wx versions

### DIFF
--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -22,7 +22,7 @@ try:
     is_phoenix = 'phoenix' in wx.PlatformInfo
 except ImportError:
     raise ImportError(missingwx)
-    
+
 try:
     wx_version = StrictVersion(wx.VERSION_STRING)
 except ValueError:

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -11,7 +11,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion, LooseVersion
 
 missingwx = "Matplotlib backend_wx and backend_wxagg require wxPython>=2.9"
 
@@ -22,9 +22,14 @@ try:
     is_phoenix = 'phoenix' in wx.PlatformInfo
 except ImportError:
     raise ImportError(missingwx)
+    
+try:
+    wx_version = StrictVersion(wx.VERSIONSTRING)
+except ValueError:
+    wx_version = LooseVersion(wx.VERSIONSTRING)
 
 # Ensure we have the correct version imported
-if StrictVersion(wx.VERSION_STRING) < StrictVersion("2.9"):
+if wx_version < str("2.9"):
     raise ImportError(missingwx)
 
 if is_phoenix:
@@ -152,7 +157,7 @@ def _AddTool(parent, wx_ids, text, bmp, tooltip_text):
     else:
         add_tool = parent.DoAddTool
 
-    if not is_phoenix or StrictVersion(wx.VERSION_STRING) >= str("4.0.0b2"):
+    if not is_phoenix or wx_version >= str("4.0.0b2"):
         # NOTE: when support for Phoenix prior to 4.0.0b2 is dropped then
         # all that is needed is this clause, and the if and else clause can
         # be removed.

--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -24,9 +24,9 @@ except ImportError:
     raise ImportError(missingwx)
     
 try:
-    wx_version = StrictVersion(wx.VERSIONSTRING)
+    wx_version = StrictVersion(wx.VERSION_STRING)
 except ValueError:
-    wx_version = LooseVersion(wx.VERSIONSTRING)
+    wx_version = LooseVersion(wx.VERSION_STRING)
 
 # Ensure we have the correct version imported
 if wx_version < str("2.9"):


### PR DESCRIPTION
## PR Summary
Apologies, I made a mistake in my previous PR #10362 and it got merged in just as I realised.
StrictVersion will fail with a value error on the old style versions like '2.8.12.0'.

This can be resolved by attempting to call StrictVersion and on failure, use a LooseVersion.
Both can be compared correctly with str("x.x.x") and the conditionals do not overlap.

I have now tested this functionality locally but am not entirely sure how I would go about writing a test to cover it in the library

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
