### PR TITLE
Workaround property list indent

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1253,7 +1253,7 @@ class ArtistInspector(object):
             lines.append('%s%s: %s' % (pad, name, accepts))
         return lines
 
-    def pprint_setters_rest(self, prop=None, leadingspace=2):
+    def pprint_setters_rest(self, prop=None, leadingspace=4):
         """
         If *prop* is *None*, return a list of strings of all settable
         properties and their valid values.  Format the output for ReST
@@ -1470,7 +1470,7 @@ def kwdoc(a):
     hardcopy = matplotlib.rcParams['docstring.hardcopy']
     if hardcopy:
         return '\n'.join(ArtistInspector(a).pprint_setters_rest(
-                         leadingspace=2))
+                         leadingspace=4))
     else:
         return '\n'.join(ArtistInspector(a).pprint_setters(leadingspace=2))
 


### PR DESCRIPTION
## PR Summary

This is a simple workaround for an incorrect indentation of auto-generated property tables (#10161).

The current code had a fixed indent of 2. This PR simply increases it to 4. Of course, this is not the technically elegant solution, but it should do the trick.

- Within parameter lists, the parameters are usually indented by 4 spaces. The two spaces resulted in a unexpected dedent of the table with respect to the parameter description (#10161). The 4 spaces will now result in a table on the same level as the text.

- If the table was used in a regular paragraph, changing the indent from 2 to 4 should not have an effect for ReST either. (Not sure if this case happens at all.

This PR should do as a workaround to fix this for 2.2. Still, a proper indentation handling is desirable and should be pursued in the above issue. 
