### PR TITLE
Axes doc datanotes

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6370,6 +6370,10 @@ linewidth=2, markersize=12)
         --------
         hist2d : 2D histograms
 
+        Notes
+        -----
+        .. [Notes section required for data comment. See #10189.]
+
         """
         # Avoid shadowing the builtin.
         bin_range = range
@@ -7094,6 +7098,11 @@ linewidth=2, markersize=12)
         :func:`specgram`
             :func:`specgram` can plot the magnitude spectrum of segments within
             the signal in a colormap.
+
+        Notes
+        -----
+        .. [Notes section required for data comment. See #10189.]
+
         """
         if not self._hold:
             self.cla()
@@ -7186,6 +7195,11 @@ linewidth=2, markersize=12)
         :func:`specgram`
             :func:`specgram` can plot the angle spectrum of segments within the
             signal in a colormap.
+
+        Notes
+        -----
+        .. [Notes section required for data comment. See #10189.]
+
         """
         if not self._hold:
             self.cla()
@@ -7265,6 +7279,11 @@ linewidth=2, markersize=12)
         :func:`specgram`
             :func:`specgram` can plot the phase spectrum of segments within the
             signal in a colormap.
+
+        Notes
+        -----
+        .. [Notes section required for data comment. See #10189.]
+
         """
         if not self._hold:
             self.cla()
@@ -7753,6 +7772,11 @@ linewidth=2, markersize=12)
               :class:`matplotlib.collections.LineCollection` instance
               created to identify the median values of each of the
               violin's distribution.
+
+        Notes
+        -----
+        .. [Notes section required for data comment. See #10189.]
+
         """
 
         def _kde_method(X, coords):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -676,6 +676,11 @@ class Axes(_AxesBase):
 
             %(Line2D)s
 
+        See also
+        --------
+        hlines : add horizontal lines in data coordinates
+        axhspan : add a horizontal span (rectangle) across the axis
+
         Notes
         -----
         kwargs are passed to :class:`~matplotlib.lines.Line2D` and can be used
@@ -697,12 +702,7 @@ class Axes(_AxesBase):
 
             >>> axhline(y=.5, xmin=0.25, xmax=0.75)
 
-        See also
-        --------
-        hlines : add horizontal lines in data coordinates
-        axhspan : add a horizontal span (rectangle) across the axis
         """
-
         if "transform" in kwargs:
             raise ValueError(
                 "'transform' is not allowed as a kwarg;"
@@ -2800,10 +2800,7 @@ linewidth=2, markersize=12)
         -----
         The pie chart will probably look best if the figure and axes are
         square, or the Axes aspect is equal.
-
-
         """
-
         x = np.array(x, np.float32)
 
         sx = x.sum()
@@ -4431,7 +4428,7 @@ linewidth=2, markersize=12)
             to the return collection as attributes *hbar* and *vbar*.
 
         Notes
-        --------
+        -----
         The standard descriptions of all the
         :class:`~matplotlib.collections.Collection` parameters:
 
@@ -6853,17 +6850,6 @@ linewidth=2, markersize=12)
 
             %(Line2D)s
 
-        Notes
-        -----
-        For plotting, the power is plotted as
-        :math:`10\log_{10}(P_{xx})` for decibels, though *Pxx* itself
-        is returned.
-
-        References
-        ----------
-        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
-        John Wiley & Sons (1986)
-
         See Also
         --------
         :func:`specgram`
@@ -6876,6 +6862,17 @@ linewidth=2, markersize=12)
 
         :func:`csd`
             :func:`csd` plots the spectral density between two signals.
+
+        Notes
+        -----
+        For plotting, the power is plotted as
+        :math:`10\log_{10}(P_{xx})` for decibels, though *Pxx* itself
+        is returned.
+
+        References
+        ----------
+        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
+        John Wiley & Sons (1986)
         """
         if not self._hold:
             self.cla()
@@ -6981,6 +6978,11 @@ linewidth=2, markersize=12)
 
             %(Line2D)s
 
+        See Also
+        --------
+        :func:`psd`
+            :func:`psd` is the equivalent to setting y=x.
+
         Notes
         -----
         For plotting, the power is plotted as
@@ -6991,11 +6993,6 @@ linewidth=2, markersize=12)
         ----------
         Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
         John Wiley & Sons (1986)
-
-        See Also
-        --------
-        :func:`psd`
-            :func:`psd` is the equivalent to setting y=x.
         """
         if not self._hold:
             self.cla()
@@ -7440,11 +7437,6 @@ linewidth=2, markersize=12)
             Additional kwargs are passed on to imshow which makes the
             specgram image
 
-        Notes
-        -----
-            *detrend* and *scale_by_freq* only apply when *mode* is set to
-            'psd'
-
         Returns
         -------
         spectrum : 2-D array
@@ -7478,6 +7470,11 @@ linewidth=2, markersize=12)
         :func:`phase_spectrum`
             A single spectrum, similar to having a single segment when *mode*
             is 'phase'. Plots a line instead of a colormap.
+
+        Notes
+        -----
+        The parameters *detrend* and *scale_by_freq* do only apply when *mode*
+        is set to 'psd'.
         """
         if not self._hold:
             self.cla()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -507,7 +507,6 @@ class Figure(Artist):
 
         Parameters
         ----------
-
         bottom : scalar
             The bottom of the subplots for :meth:`subplots_adjust`
 
@@ -543,7 +542,7 @@ class Figure(Artist):
         self.stale = True
 
     def get_children(self):
-        'get a list of artists contained in the figure'
+        """Get a list of artists contained in the figure."""
         children = [self.patch]
         children.extend(self.artists)
         children.extend(self.axes)
@@ -566,9 +565,9 @@ class Figure(Artist):
         return inside, {}
 
     def get_window_extent(self, *args, **kwargs):
-        ''''
+        """
         Return figure bounding box in display space; arguments are ignored.
-        '''
+        """
         return self.bbox
 
     def suptitle(self, t, **kwargs):
@@ -757,7 +756,6 @@ class Figure(Artist):
 
         See Also
         --------
-
         matplotlib.Figure.get_size_inches
         """
 
@@ -794,33 +792,32 @@ class Figure(Artist):
 
         See Also
         --------
-
         matplotlib.Figure.set_size_inches
         """
         return np.array(self.bbox_inches.p1)
 
     def get_edgecolor(self):
-        'Get the edge color of the Figure rectangle'
+        """Get the edge color of the Figure rectangle."""
         return self.patch.get_edgecolor()
 
     def get_facecolor(self):
-        'Get the face color of the Figure rectangle'
+        """Get the face color of the Figure rectangle."""
         return self.patch.get_facecolor()
 
     def get_figwidth(self):
-        'Return the figwidth as a float'
+        """Return the figwidth as a float."""
         return self.bbox_inches.width
 
     def get_figheight(self):
-        'Return the figheight as a float'
+        """Return the figheight as a float."""
         return self.bbox_inches.height
 
     def get_dpi(self):
-        'Return the dpi as a float'
+        """Return the dpi as a float."""
         return self.dpi
 
     def get_frameon(self):
-        'get the boolean indicating frameon'
+        """Get the boolean indicating frameon."""
         return self.frameon
 
     def set_edgecolor(self, color):
@@ -883,7 +880,7 @@ class Figure(Artist):
         self.stale = True
 
     def _make_key(self, *args, **kwargs):
-        'make a hashable key out of args and kwargs'
+        """Make a hashable key out of args and kwargs."""
 
         def fixitems(items):
             #items may have arrays and lists in them, so convert them
@@ -1345,8 +1342,8 @@ class Figure(Artist):
 
     def draw_artist(self, a):
         """
-        draw :class:`matplotlib.artist.Artist` instance *a* only --
-        this is available only after the figure is drawn
+        Draw :class:`matplotlib.artist.Artist` instance *a* only.
+        This is available only after the figure is drawn.
         """
         if self._cachedRenderer is None:
             raise AttributeError("draw_artist can only be used after an "
@@ -1679,7 +1676,7 @@ class Figure(Artist):
         return self.add_subplot(1, 1, 1, **kwargs)
 
     def sca(self, a):
-        'Set the current axes to be a and return a'
+        """Set the current axes to be a and return a."""
         self._axstack.bubble(a)
         for func in self._axobservers:
             func(self)
@@ -1687,8 +1684,7 @@ class Figure(Artist):
 
     def _gci(self):
         """
-        helper for :func:`~matplotlib.pyplot.gci`;
-        do not use elsewhere.
+        Helper for :func:`~matplotlib.pyplot.gci`. Do not use elsewhere.
         """
         # Look first for an image in the current Axes:
         cax = self._axstack.current_key_axes()[1]
@@ -1775,7 +1771,7 @@ class Figure(Artist):
         self.stale = True
 
     def add_axobserver(self, func):
-        'whenever the axes state change, ``func(self)`` will be called'
+        """Whenever the axes state change, ``func(self)`` will be called."""
         self._axobservers.append(func)
 
     def savefig(self, fname, **kwargs):
@@ -1933,7 +1929,7 @@ class Figure(Artist):
                               wspace=None, hspace=None)
 
         Update the :class:`SubplotParams` with *kwargs* (defaulting to rc when
-        *None*) and update the subplot locations
+        *None*) and update the subplot locations.
 
         """
         self.subplotpars.update(*args, **kwargs)
@@ -2057,7 +2053,6 @@ class Figure(Artist):
 
         Parameters
         ----------
-
         pad : float
             padding between the figure edge and the edges of subplots,
             as a fraction of the font-size.
@@ -2107,19 +2102,19 @@ class Figure(Artist):
             Optional list of (or ndarray) `~matplotlib.axes.Axes` to align
             the xlabels.  Default is to align all axes on the figure.
 
-        Note
-        ----
-        This assumes that ``axs`` are from the same `~.GridSpec`, so that
-        their `~.SubplotSpec` positions correspond to figure positions.
-
         See Also
         --------
         matplotlib.figure.Figure.align_ylabels
 
         matplotlib.figure.Figure.align_labels
 
-        Example
-        -------
+        Notes
+        -----
+        This assumes that ``axs`` are from the same `~.GridSpec`, so that
+        their `~.SubplotSpec` positions correspond to figure positions.
+
+        Examples
+        --------
         Example with rotated xtick labels::
 
             fig, axs = plt.subplots(1, 2)
@@ -2175,19 +2170,19 @@ class Figure(Artist):
             Optional list (or ndarray) of `~matplotlib.axes.Axes` to align
             the ylabels. Default is to align all axes on the figure.
 
-        Note
-        ----
-        This assumes that ``axs`` are from the same `~.GridSpec`, so that
-        their `~.SubplotSpec` positions correspond to figure positions.
-
         See Also
         --------
         matplotlib.figure.Figure.align_xlabels
 
         matplotlib.figure.Figure.align_labels
 
-        Example
-        -------
+        Notes
+        -----
+        This assumes that ``axs`` are from the same `~.GridSpec`, so that
+        their `~.SubplotSpec` positions correspond to figure positions.
+
+        Examples
+        --------
         Example with large yticks labels::
 
             fig, axs = plt.subplots(2, 1)


### PR DESCRIPTION
## PR Summary

Some minor docstring cleanups in Axes:

- Added some empty notes sections to catch injected notes on the data argument.
- Reordered sections to the order required from numpydoc https://github.com/numpy/numpydoc/pull/121

