### PR TITLE
Update layout of sidebar in documentation

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -232,9 +232,6 @@ div.sphinxsidebar {
     text-align: left;
 /*    margin-left: -100%; */
 }
-div.sphinxsidebarwrapper {
-    padding-top: 28px
-}
 
 div.sphinxsidebar h4, div.sphinxsidebar h3 {
     margin: 1em 0 0.5em 0;
@@ -243,6 +240,11 @@ div.sphinxsidebar h4, div.sphinxsidebar h3 {
     color: white;
     border: 1px solid #86989B;
     background-color: #AFC1C4;
+}
+
+div.sphinxsidebar h3 a {
+    /* workaround for table of contents heading, which is a link */
+    color: white !important;
 }
 
 div.sphinxsidebar ul {
@@ -256,6 +258,11 @@ div.sphinxsidebar ul {
 div.sphinxsidebar ul ul {
     list-style: square;
     margin-left: 20px;
+}
+
+#searchbox input[type=text] {
+    width: 100%;
+    box-sizing: border-box;
 }
 
 p {
@@ -811,6 +818,10 @@ figcaption {
     -o-transform:rotate(45deg);
     box-shadow:4px 4px 10px rgba(0,0,0,0.8);
   }
+}
+
+#sidebar-donations {
+    margin-top: 28px;
 }
 
 .donate_button {

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -260,9 +260,34 @@ div.sphinxsidebar ul ul {
     margin-left: 20px;
 }
 
-#searchbox input[type=text] {
-    width: 100%;
+div.sphinxsidebar #searchbox input {
+    border: 1px solid #aaa;
+    padding: 0.25em;
     box-sizing: border-box;
+}
+
+div.sphinxsidebar #searchbox form {
+    display: inline-block;
+    width: 100%
+}
+
+div.sphinxsidebar #searchbox input[type="text"] {
+    float: left;
+    width: 80%;
+}
+
+div.sphinxsidebar #searchbox input[type="submit"] {
+    float: left;
+    width: 20%;
+    border-left: none;
+}
+
+div.sphinxsidebar #searchbox input[type="submit"]:hover {
+    background: #ddd;
+}
+
+div.sphinxsidebar .searchformwrapper {
+    display: block;
 }
 
 p {

--- a/doc/_templates/donate_sidebar.html
+++ b/doc/_templates/donate_sidebar.html
@@ -1,5 +1,5 @@
 
-<div>
+<div id="sidebar-donations">
   <a href="https://www.flipcause.com/secure/cause_pdetails/MjI1OA==" target="_blank"> <div class="donate_button" >Support Matplotlib</div></a>
   <a href="https://www.flipcause.com/secure/cause_pdetails/MTY3NTU=" target="_blank"> <div class="donate_button" >Support NumFOCUS</div></a>
 </div>

--- a/doc/_templates/pagesource.html
+++ b/doc/_templates/pagesource.html
@@ -1,0 +1,7 @@
+{%- if show_source and has_source and sourcename %}
+  <div id="sidebar-pagesource" role="note" aria-label="source link"
+    style="margin-top: 1.5em; padding-top: 0.1em; border-top: 1px solid #86989b">
+  <a href="{{ pathto('_sources/' + sourcename, true)|e }}"
+     style="color: #c0c0c0" rel="nofollow">{{ _('Show Page Source') }}</a>
+  </div>
+{%- endif %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -241,7 +241,8 @@ html_index = 'index.html'
 # Custom sidebar templates, maps page names to templates.
 html_sidebars = {
     'index': ['searchbox.html', 'donate_sidebar.html'],
-    '**': ['searchbox.html', 'localtoc.html', 'relations.html']
+    '**': ['searchbox.html', 'localtoc.html', 'relations.html',
+           'pagesource.html']
 }
 
 # If false, no module index is generated.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -240,9 +240,8 @@ html_index = 'index.html'
 
 # Custom sidebar templates, maps page names to templates.
 html_sidebars = {
-    'index': ['donate_sidebar.html', 'searchbox.html'],
-    '**': ['localtoc.html', 'relations.html',
-           'sourcelink.html', 'searchbox.html']
+    'index': ['searchbox.html', 'donate_sidebar.html'],
+    '**': ['searchbox.html', 'localtoc.html', 'relations.html']
 }
 
 # If false, no module index is generated.


### PR DESCRIPTION
## PR Summary

This PR contains some changes to the sidebar in the html documentation:

- Move the search bar to the top. IMO it's one of the most important side bar items and it has a small fixed height. Therefore it's good to have it at the top.
- Remove the section "This Page / Show Source". This was probably inherited from the sphinx defaults. However, it's rather useless if not confusing for the user to view the .rst source.
- Make the search field use the full width. (Note: I've add recently sent a PR to sphinx that joins the search field and button https://github.com/sphinx-doc/sphinx/pull/4377. This will be available from Sphinx 1.7 on. Until then it's at least visually more appealing to have the search field span the whole width).
- Force the "Table of Contents" heading to be white as well. - It's a link and therefore was rendered black.

Index page before / after:

![grafik](https://user-images.githubusercontent.com/2836374/35768800-fe79f43a-0901-11e8-917e-1a3fc7844f73.png)  ![grafik](https://user-images.githubusercontent.com/2836374/35768824-390284be-0902-11e8-8a20-02a636a77679.png)

Other pages before / after:

![grafik](https://user-images.githubusercontent.com/2836374/35768851-74c12776-0902-11e8-89db-cb1bf5c2a75b.png)  ![grafik](https://user-images.githubusercontent.com/2836374/35769114-771a3400-0906-11e8-8cd3-84a107c9a089.png)

