### PR TITLE
FigureCanvasWx/Agg fixed size

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -948,16 +948,18 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
 
         DEBUG_MSG("_onSize()", 2, self)
         sz = self.GetParent().GetSizer()
-        if sz: si = sz.GetItem(self)
+        if sz:
+            si = sz.GetItem(self)
         if sz and si and not si.Proportion and not si.Flag & wx.EXPAND:
             # managed by a sizer, but with a fixed size
             size = self.GetMinSize()
         else:
             # variable size
             size = self.GetClientSize()
-        if getattr(self, "_width", None) and size==(self._width,self._height):
-            # no change in size
-            return
+        if getattr(self, "_width", None):
+            if size == (self._width, self._height):
+                # no change in size
+                return
         self._width, self._height = size
         # Create a new, correctly sized bitmap
         self.bitmap = wxc.EmptyBitmap(self._width, self._height)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -947,8 +947,19 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
         """
 
         DEBUG_MSG("_onSize()", 2, self)
+        sz = self.GetParent().GetSizer()
+        if sz: si = sz.GetItem(self)
+        if sz and si and not si.Proportion and not si.Flag & wx.EXPAND:
+            # managed by a sizer, but with a fixed size
+            size = self.GetMinSize()
+        else:
+            # variable size
+            size = self.GetClientSize()
+        if getattr(self, "_width", None) and size==(self._width,self._height):
+            # no change in size
+            return
+        self._width, self._height = size
         # Create a new, correctly sized bitmap
-        self._width, self._height = self.GetClientSize()
         self.bitmap = wxc.EmptyBitmap(self._width, self._height)
 
         self._isDrawn = False


### PR DESCRIPTION
## PR Summary
(replacement for PR #10153)

The embedded FigureCanvasWx currently can't be set to a fixed size.
When it is added to a sizer with `proportion=0` and `wx.EXPAND` not set, then it will not expand over it's defined size, as expected. But when the visible area is reduced below the defined size, it will re-scale itself to fit the visible area because 'self.GetClientSize()' is used to read the size.
This could happen if the window size is reduced or a splitter is used.
When placed on a scrolled window, the problem does not occur, as then the VirtualSize will not change, even when the widget is not 100% visible.

This is not a big issue as the behaviour can easily be modified in a derived class. It would be nice though, to have the correct behaviour by default.


See attached file `embedding_in_wx4_fixed.py` for an example. With the modification from the pull request the size will stay fixed.
The only change is the `sizer.Add` call with `proportion=0` and without `EXPAND`:
```
self.figure = Figure(figsize=(5, 4), dpi=100)
...
self.canvas = FigureCanvas(self, -1, self.figure)
self.sizer = wx.BoxSizer(wx.VERTICAL)
#self.sizer.Add(self.canvas, 1, wx.TOP | wx.LEFT | wx.EXPAND)
self.sizer.Add(self.canvas, 0, wx.TOP | wx.LEFT)
```
[embedding_in_wx4_fixed.py.txt](https://github.com/matplotlib/matplotlib/files/1602044/embedding_in_wx4_fixed.py.txt)


I could commit the example file, but that's probably not worth it.


If the canvas is directly used as single child of a frame (i.e. instead of a panel), the behaviour is not modified by the pull request. This could be changed, but I don't see a use case for this.


Btw.: I just noticed that the `embedding_in_wx4.py` example includes an `EVT_PAINT` handler. I don't think that this is required, as the plot is static. Instead, it causes unnecessary renderings.

Also, the structure of `fourier_demo_wx.py` is a bit unusual. The usual hierarchy would be `Frame->Panel->Sizer->Canvas`. Actually it's now `Frame->Sizer->Window->Canvas` where the `Window` does not have any function and the sliders are drawn on the plain frame background.

I could submit a PR to update the demos, if desired.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

