### PR TITLE
FIX: re-jigger deprecation of rcParams using machinery in __init__

### DIFF
--- a/doc/api/api_changes/2018-02-04-AL.rst
+++ b/doc/api/api_changes/2018-02-04-AL.rst
@@ -1,0 +1,7 @@
+Deprecation of qt binding rcparams
+``````````````````````````````````
+
+The :rc:`backend.qt4` and :rc:`backend.qt5` rcParams were deprecated
+in version 2.2.  In order to force the use of a specific Qt binding,
+either import that binding first, or set the ``QT_API`` environment
+variable.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -848,7 +848,10 @@ _deprecated_ignore_map = {'nbagg.transparent': 'figure.facecolor'}
 _obsolete_set = {'plugins.directory', 'text.dvipnghack'}
 
 # The following may use a value of None to suppress the warning.
-_deprecated_set = {'axes.hold'}  # do NOT include in _all_deprecated
+# do NOT include in _all_deprecated
+_deprecated_set = {'axes.hold',
+                   'backend.qt4',
+                   'backend.qt5'}
 
 _all_deprecated = set(itertools.chain(
     _deprecated_ignore_map, _deprecated_map, _obsolete_set))
@@ -872,6 +875,10 @@ class RcParams(MutableMapping, dict):
     msg_depr_ignore = "%s is deprecated and ignored. Use %s instead."
     msg_obsolete = ("%s is obsolete. Please remove it from your matplotlibrc "
                     "and/or style files.")
+    msg_backend_obsolete = ("The {} rcParam was deprecated in version 2.2.  In"
+                            " order to force the use of a specific Qt binding,"
+                            " either import that binding first, or set the "
+                            "QT_API environment variable.")
 
     # validate values on the way in
     def __init__(self, *args, **kwargs):
@@ -886,8 +893,12 @@ class RcParams(MutableMapping, dict):
                 key = alt_key
                 val = alt_val(val)
             elif key in _deprecated_set and val is not None:
-                warnings.warn(self.msg_depr_set % key,
-                              mplDeprecation)
+                if key.startswith('backend'):
+                    warnings.warn(self.msg_backend_obsolete.format(key),
+                                  mplDeprecation)
+                else:
+                    warnings.warn(self.msg_depr_set % key,
+                                  mplDeprecation)
             elif key in _deprecated_ignore_map:
                 alt = _deprecated_ignore_map[key]
                 warnings.warn(self.msg_depr_ignore % (key, alt),

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -83,16 +83,16 @@ _fallback_to_qt4 = False
 if QT_API is None:
     # No ETS environment or incompatible so use rcParams.
     if rcParams['backend'] == 'Qt5Agg':
-        QT_API = rcParams['backend.qt5']
+        QT_API = QT_API_PYQT5
     elif rcParams['backend'] == 'Qt4Agg':
-        QT_API = rcParams['backend.qt4']
+        QT_API = QT_API_PYQT
     else:
         # A non-Qt backend was specified, no version of the Qt
         # bindings is imported, but we still got here because a Qt
         # related file was imported. This is allowed, fall back to Qt5
         # using which ever binding the rparams ask for.
         _fallback_to_qt4 = True
-        QT_API = rcParams['backend.qt5']
+        QT_API = QT_API_PYQT5
 
 # We will define an appropriate wrapper for the differing versions
 # of file dialog.
@@ -142,7 +142,7 @@ if _sip_imported:
         except ImportError:
             if _fallback_to_qt4:
                 # fell through, tried PyQt5, failed fall back to PyQt4
-                QT_API = rcParams['backend.qt4']
+                QT_API = QT_API_PYQT
                 QT_RC_MAJOR_VERSION = 4
             else:
                 raise

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -268,25 +268,13 @@ def validate_backend(s):
 
 def validate_qt4(s):
     if s is None:
-        # return a reasonable default for deprecation period
-        return 'PyQt4'
-    cbook.warn_deprecated(
-        "2.2",
-        "The backend.qt4 rcParam was deprecated in version 2.2.  In order "
-        "to force the use of a specific Qt4 binding, either import that "
-        "binding first, or set the QT_API environment variable.")
+        return None
     return ValidateInStrings("backend.qt4", ['PyQt4', 'PySide', 'PyQt4v2'])(s)
 
 
 def validate_qt5(s):
     if s is None:
-        # return a reasonable default for deprecation period
-        return 'PyQt5'
-    cbook.warn_deprecated(
-        "2.2",
-        "The backend.qt5 rcParam was deprecated in version 2.2.  In order "
-        "to force the use of a specific Qt5 binding, either import that "
-        "binding first, or set the QT_API environment variable.")
+        return None
     return ValidateInStrings("backend.qt5", ['PyQt5', 'PySide2'])(s)
 
 


### PR DESCRIPTION
## PR Summary

This suppresses the warnings in the test suite and removes 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

