### PR TITLE
Fix some C++ warnings

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -412,7 +412,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                                 t,
                                 _interpd_[self.get_interpolation()],
                                 self.get_resample(), 1.0,
-                                self.get_filternorm() or 0.0,
+                                self.get_filternorm(),
                                 self.get_filterrad() or 0.0)
 
                 # we are done with A_scaled now, remove from namespace
@@ -447,7 +447,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                                 t,
                                 _interpd_[self.get_interpolation()],
                                 True, 1,
-                                self.get_filternorm() or 0.0,
+                                self.get_filternorm(),
                                 self.get_filterrad() or 0.0)
                 # we are done with the mask, delete from namespace to be sure!
                 del mask
@@ -481,7 +481,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 _image.resample(
                     A, output, t, _interpd_[self.get_interpolation()],
                     self.get_resample(), alpha,
-                    self.get_filternorm() or 0.0, self.get_filterrad() or 0.0)
+                    self.get_filternorm(), self.get_filterrad() or 0.0)
 
             # at this point output is either a 2D array of normed data
             # (of int or float)

--- a/lib/matplotlib/tri/_tri.cpp
+++ b/lib/matplotlib/tri/_tri.cpp
@@ -629,9 +629,9 @@ PyObject* TriContourGenerator::contour_to_segs_and_kinds(const Contour& contour)
     ContourLine::const_iterator point;
 
     // Find total number of points in all contour lines.
-    int n_points = 0;
+    npy_intp n_points = 0;
     for (line = contour.begin(); line != contour.end(); ++line)
-        n_points += line->size();
+        n_points += (npy_intp)line->size();
 
     // Create segs array for point coordinates.
     npy_intp segs_dims[2] = {n_points, 2};
@@ -1021,8 +1021,8 @@ TrapezoidMapTriFinder::add_edge_to_tree(const Edge& edge)
     // Iterate through trapezoids intersecting edge from left to right.
     // Replace each old trapezoid with 2+ new trapezoids, and replace its
     // corresponding nodes in the search tree with new nodes.
-    unsigned int ntraps = trapezoids.size();
-    for (unsigned int i = 0; i < ntraps; ++i) {
+    size_t ntraps = trapezoids.size();
+    for (size_t i = 0; i < ntraps; ++i) {
         Trapezoid* old = trapezoids[i];  // old trapezoid to replace.
         bool start_trap = (i == 0);
         bool end_trap = (i == ntraps-1);
@@ -1397,8 +1397,8 @@ TrapezoidMapTriFinder::initialize()
     std::random_shuffle(_edges.begin()+2, _edges.end(), rng);
 
     // Add edges, one at a time, to tree.
-    unsigned int nedges = _edges.size();
-    for (unsigned int index = 2; index < nedges; ++index) {
+    size_t nedges = _edges.size();
+    for (size_t index = 2; index < nedges; ++index) {
         if (!add_edge_to_tree(_edges[index]))
             throw std::runtime_error("Triangulation is invalid");
         _tree->assert_valid(index == nedges-1);

--- a/setupext.py
+++ b/setupext.py
@@ -1265,11 +1265,13 @@ class FT2Font(SetupPackage):
         sources = [
             'src/ft2font.cpp',
             'src/ft2font_wrapper.cpp',
-            'src/mplutils.cpp'
+            'src/mplutils.cpp',
+            'src/py_converters.cpp',
             ]
         ext = make_extension('matplotlib.ft2font', sources)
         FreeType().add_flags(ext)
         Numpy().add_flags(ext)
+        LibAgg().add_flags(ext, add_sources=False)
         return ext
 
 
@@ -1394,9 +1396,11 @@ class Contour(SetupPackage):
         sources = [
             "src/_contour.cpp",
             "src/_contour_wrapper.cpp",
+            'src/py_converters.cpp',
             ]
         ext = make_extension('matplotlib._contour', sources)
         Numpy().add_flags(ext)
+        LibAgg().add_flags(ext, add_sources=False)
         return ext
 
 

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -281,8 +281,8 @@ class RendererAgg
                                        DashesVector &linestyles,
                                        AntialiasedArray &antialiaseds,
                                        e_offset_position offset_position,
-                                       int check_snap,
-                                       int has_curves);
+                                       bool check_snap,
+                                       bool has_curves);
 
     template <class PointArray, class ColorArray>
     void _draw_gouraud_triangle(PointArray &points,
@@ -915,8 +915,8 @@ inline void RendererAgg::_draw_path_collection_generic(GCAgg &gc,
                                                        DashesVector &linestyles,
                                                        AntialiasedArray &antialiaseds,
                                                        e_offset_position offset_position,
-                                                       int check_snap,
-                                                       int has_curves)
+                                                       bool check_snap,
+                                                       bool has_curves)
 {
     typedef agg::conv_transform<typename PathGenerator::path_iterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removed_t;
@@ -1068,8 +1068,8 @@ inline void RendererAgg::draw_path_collection(GCAgg &gc,
                                   linestyles,
                                   antialiaseds,
                                   offset_position,
-                                  1,
-                                  1);
+                                  true,
+                                  true);
 }
 
 template <class CoordinateArray>
@@ -1186,8 +1186,8 @@ inline void RendererAgg::draw_quad_mesh(GCAgg &gc,
                                   linestyles,
                                   antialiaseds,
                                   OFFSET_POSITION_FIGURE,
-                                  0,
-                                  0);
+                                  false,
+                                  false);
 }
 
 template <class PointArray, class ColorArray>

--- a/src/_backend_agg_basic_types.h
+++ b/src/_backend_agg_basic_types.h
@@ -115,7 +115,7 @@ class GCAgg
 
     bool has_hatchpath()
     {
-        return hatchpath.total_vertices();
+        return hatchpath.total_vertices() != 0;
     }
 
   private:

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -396,11 +396,11 @@ static PyObject *PyRendererAgg_draw_quad_mesh(PyRendererAgg *self, PyObject *arg
     numpy::array_view<const double, 2> offsets;
     agg::trans_affine offset_trans;
     numpy::array_view<const double, 2> facecolors;
-    int antialiased;
+    bool antialiased;
     numpy::array_view<const double, 2> edgecolors;
 
     if (!PyArg_ParseTuple(args,
-                          "O&O&IIO&O&O&O&iO&:draw_quad_mesh",
+                          "O&O&IIO&O&O&O&O&O&:draw_quad_mesh",
                           &convert_gcagg,
                           &gc,
                           &convert_trans_affine,
@@ -415,6 +415,7 @@ static PyObject *PyRendererAgg_draw_quad_mesh(PyRendererAgg *self, PyObject *arg
                           &offset_trans,
                           &convert_colors,
                           &facecolors,
+                          &convert_bool,
                           &antialiased,
                           &convert_colors,
                           &edgecolors)) {

--- a/src/_contour.cpp
+++ b/src/_contour.cpp
@@ -60,15 +60,15 @@
 #define Z_NW                     Z_LEVEL(POINT_NW)
 #define Z_SE                     Z_LEVEL(POINT_SE)
 #define Z_SW                     Z_LEVEL(POINT_SW)
-#define VISITED(quad,li)         (_cache[quad] & (li==1 ? MASK_VISITED_1 : MASK_VISITED_2))
-#define VISITED_S(quad)          (_cache[quad] & MASK_VISITED_S)
-#define VISITED_W(quad)          (_cache[quad] & MASK_VISITED_W)
-#define VISITED_CORNER(quad)     (_cache[quad] & MASK_VISITED_CORNER)
-#define SADDLE(quad,li)          (_cache[quad] & (li==1 ? MASK_SADDLE_1 : MASK_SADDLE_2))
-#define SADDLE_LEFT(quad,li)     (_cache[quad] & (li==1 ? MASK_SADDLE_LEFT_1 : MASK_SADDLE_LEFT_2))
-#define SADDLE_START_SW(quad,li) (_cache[quad] & (li==1 ? MASK_SADDLE_START_SW_1 : MASK_SADDLE_START_SW_2))
-#define BOUNDARY_S(quad)         (_cache[quad] & MASK_BOUNDARY_S)
-#define BOUNDARY_W(quad)         (_cache[quad] & MASK_BOUNDARY_W)
+#define VISITED(quad,li)         ((_cache[quad] & (li==1 ? MASK_VISITED_1 : MASK_VISITED_2)) != 0)
+#define VISITED_S(quad)          ((_cache[quad] & MASK_VISITED_S) != 0)
+#define VISITED_W(quad)          ((_cache[quad] & MASK_VISITED_W) != 0)
+#define VISITED_CORNER(quad)     ((_cache[quad] & MASK_VISITED_CORNER) != 0)
+#define SADDLE(quad,li)          ((_cache[quad] & (li==1 ? MASK_SADDLE_1 : MASK_SADDLE_2)) != 0)
+#define SADDLE_LEFT(quad,li)     ((_cache[quad] & (li==1 ? MASK_SADDLE_LEFT_1 : MASK_SADDLE_LEFT_2)) != 0)
+#define SADDLE_START_SW(quad,li) ((_cache[quad] & (li==1 ? MASK_SADDLE_START_SW_1 : MASK_SADDLE_START_SW_2)) != 0)
+#define BOUNDARY_S(quad)         ((_cache[quad] & MASK_BOUNDARY_S) != 0)
+#define BOUNDARY_W(quad)         ((_cache[quad] & MASK_BOUNDARY_W) != 0)
 #define BOUNDARY_N(quad)         BOUNDARY_S(quad+_nx)
 #define BOUNDARY_E(quad)         BOUNDARY_W(quad+1)
 #define EXISTS_QUAD(quad)        ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_QUAD)
@@ -1773,12 +1773,12 @@ void QuadContourGenerator::write_cache_quad(long quad, bool grid_only) const
     std::cout << " BNDY=" << (BOUNDARY_S(quad)>0) << (BOUNDARY_W(quad)>0);
     if (!grid_only) {
         std::cout << " Z=" << Z_LEVEL(quad)
-            << " SAD=" << (SADDLE(quad,1)>0) << (SADDLE(quad,2)>0)
-            << " LEFT=" << (SADDLE_LEFT(quad,1)>0) << (SADDLE_LEFT(quad,2)>0)
-            << " NW=" << (SADDLE_START_SW(quad,1)>0) << (SADDLE_START_SW(quad,2)>0)
-            << " VIS=" << (VISITED(quad,1)>0) << (VISITED(quad,2)>0)
-            << (VISITED_S(quad)>0) << (VISITED_W(quad)>0)
-            << (VISITED_CORNER(quad)>0);
+            << " SAD=" << SADDLE(quad,1) << SADDLE(quad,2)
+            << " LEFT=" << SADDLE_LEFT(quad,1) << SADDLE_LEFT(quad,2)
+            << " NW=" << SADDLE_START_SW(quad,1) << SADDLE_START_SW(quad,2)
+            << " VIS=" << VISITED(quad,1) << VISITED(quad,2)
+            << VISITED_S(quad) << VISITED_W(quad)
+            << VISITED_CORNER(quad);
     }
     std::cout << std::endl;
 }

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -1,5 +1,6 @@
 #include "src/_contour.h"
 #include "src/mplutils.h"
+#include "src/py_converters.h"
 #include "src/py_exceptions.h"
 
 /* QuadContourGenerator */
@@ -29,15 +30,15 @@ static int PyQuadContourGenerator_init(PyQuadContourGenerator* self, PyObject* a
 {
     QuadContourGenerator::CoordinateArray x, y, z;
     QuadContourGenerator::MaskArray mask;
-    int corner_mask;
+    bool corner_mask;
     long chunk_size;
 
-    if (!PyArg_ParseTuple(args, "O&O&O&O&il",
+    if (!PyArg_ParseTuple(args, "O&O&O&O&O&l",
                           &x.converter_contiguous, &x,
                           &y.converter_contiguous, &y,
                           &z.converter_contiguous, &z,
                           &mask.converter_contiguous, &mask,
-                          &corner_mask,
+                          &convert_bool, &corner_mask,
                           &chunk_size)) {
         return -1;
     }

--- a/src/_image.cpp
+++ b/src/_image.cpp
@@ -12,7 +12,7 @@ void _bin_indices_middle(
     unsigned int *rowstart = irows;
     const float *ys2 = ys1 + 1;
     const float *yl = ys1 + ny;
-    float yo = y_min + dy / 2.0;
+    float yo = y_min + dy / 2.0f;
     float ym = 0.5f * (*ys1 + *ys2);
     // y/rows
     j = 0;
@@ -126,7 +126,7 @@ void _bin_indices_linear(
         int iilast = (int)ny - 1;
         int iy0 = (int)floor(sc * (y[ii] - offs));
         int iy1 = (int)floor(sc * (y[ii + 1] - offs));
-        float invgap = 1.0 / (iy1 - iy0);
+        float invgap = 1.0f / (iy1 - iy0);
         for (i = 0; i < nrows && i < iy0; i++) {
             irows[i] = -1;
         }
@@ -135,7 +135,7 @@ void _bin_indices_linear(
                 ii++;
                 iy0 = iy1;
                 iy1 = (int)floor(sc * (y[ii + 1] - offs));
-                invgap = 1.0 / (iy1 - iy0);
+                invgap = 1.0f / (iy1 - iy0);
             }
             if (i >= iy0 && i <= iy1) {
                 irows[i] = ii;
@@ -151,7 +151,7 @@ void _bin_indices_linear(
         int ii = iilast;
         int iy0 = (int)floor(sc * (y[ii] - offs));
         int iy1 = (int)floor(sc * (y[ii - 1] - offs));
-        float invgap = 1.0 / (iy1 - iy0);
+        float invgap = 1.0f / (iy1 - iy0);
         for (i = 0; i < nrows && i < iy0; i++) {
             irows[i] = -1;
         }
@@ -160,7 +160,7 @@ void _bin_indices_linear(
                 ii--;
                 iy0 = iy1;
                 iy1 = (int)floor(sc * (y[ii - 1] - offs));
-                invgap = 1.0 / (iy1 - iy0);
+                invgap = 1.0f / (iy1 - iy0);
             }
             if (i >= iy0 && i <= iy1) {
                 irows[i] = ii - 1;

--- a/src/_image_resample.h
+++ b/src/_image_resample.h
@@ -800,7 +800,7 @@ struct resample_params_t {
     agg::trans_affine affine;
     const double *transform_mesh;
     bool resample;
-    double norm;
+    bool norm;
     double radius;
     double alpha;
 };

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -14,7 +14,7 @@
  * */
 
 const char* image_resample__doc__ =
-"resample(input_array, output_array, matrix, interpolation=NEAREST, alpha=1.0, norm=0, radius=1)\n\n"
+"resample(input_array, output_array, matrix, interpolation=NEAREST, alpha=1.0, norm=False, radius=1)\n\n"
 
 "Resample input_array, blending it in-place into output_array, using an\n"
 "affine transformation.\n\n"
@@ -48,8 +48,8 @@ const char* image_resample__doc__ =
 "    The level of transparency to apply.  1.0 is completely opaque.\n"
 "    0.0 is completely transparent.\n\n"
 
-"norm : float, optional\n"
-"    The norm for the interpolation function.  Default is 0.\n\n"
+"norm : bool, optional\n"
+"    Whether to norm the interpolation function.  Default is `False`.\n\n"
 
 "radius: float, optional\n"
 "    The radius of the kernel, if method is SINC, LANCZOS or BLACKMAN.\n"
@@ -120,6 +120,7 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
     PyObject *py_transform = NULL;
     resample_params_t params;
     int resample_;
+    int norm_;
 
     PyArrayObject *input_array = NULL;
     PyArrayObject *output_array = NULL;
@@ -132,9 +133,9 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         "resample", "alpha", "norm", "radius", NULL };
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "OOO|iiddd:resample", (char **)kwlist,
+            args, kwargs, "OOO|iidid:resample", (char **)kwlist,
             &py_input_array, &py_output_array, &py_transform,
-            &params.interpolation, &resample_, &params.alpha, &params.norm,
+            &params.interpolation, &resample_, &params.alpha, &norm_,
             &params.radius)) {
         return NULL;
     }
@@ -146,6 +147,7 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
     }
 
     params.resample = (resample_ != 0);
+    params.norm = (norm_ != 0);
 
     input_array = (PyArrayObject *)PyArray_FromAny(
         py_input_array, NULL, 2, 3, NPY_ARRAY_C_CONTIGUOUS, NULL);

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -119,8 +119,6 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
     PyObject *py_output_array = NULL;
     PyObject *py_transform = NULL;
     resample_params_t params;
-    int resample_;
-    int norm_;
 
     PyArrayObject *input_array = NULL;
     PyArrayObject *output_array = NULL;
@@ -133,10 +131,10 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         "resample", "alpha", "norm", "radius", NULL };
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "OOO|iidid:resample", (char **)kwlist,
+            args, kwargs, "OOO|iO&dO&d:resample", (char **)kwlist,
             &py_input_array, &py_output_array, &py_transform,
-            &params.interpolation, &resample_, &params.alpha, &norm_,
-            &params.radius)) {
+            &params.interpolation, &convert_bool, &params.resample,
+            &params.alpha, &convert_bool, &params.norm, &params.radius)) {
         return NULL;
     }
 
@@ -145,9 +143,6 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
                      params.interpolation);
         goto error;
     }
-
-    params.resample = (resample_ != 0);
-    params.norm = (norm_ != 0);
 
     input_array = (PyArrayObject *)PyArray_FromAny(
         py_input_array, NULL, 2, 3, NPY_ARRAY_C_CONTIGUOUS, NULL);

--- a/src/_path.h
+++ b/src/_path.h
@@ -278,7 +278,7 @@ inline bool point_in_path(
 
     points_in_path(points, r, path, trans, result);
 
-    return (bool)result[0];
+    return result[0] != 0;
 }
 
 template <class PathIterator, class PointArray, class ResultArray>
@@ -320,7 +320,7 @@ inline bool point_on_path(
 
     points_on_path(points, r, path, trans, result);
 
-    return (bool)result[0];
+    return result[0] != 0;
 }
 
 struct extent_limits

--- a/src/_path.h
+++ b/src/_path.h
@@ -1229,7 +1229,7 @@ int convert_to_string(PathIterator &path,
     }
 
     if (sketch_params.scale != 0.0) {
-        *buffersize *= 10.0;
+        *buffersize *= 10;
     }
 
     *buffer = (char *)malloc(*buffersize);

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -310,12 +310,12 @@ static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args, PyO
     numpy::array_view<const double, 3> transforms;
     numpy::array_view<const double, 2> offsets;
     agg::trans_affine offset_trans;
-    int filled;
+    bool filled;
     e_offset_position offset_position;
     std::vector<int> result;
 
     if (!PyArg_ParseTuple(args,
-                          "dddO&OO&O&O&iO&:point_in_path_collection",
+                          "dddO&OO&O&O&O&O&:point_in_path_collection",
                           &x,
                           &y,
                           &radius,
@@ -328,6 +328,7 @@ static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args, PyO
                           &offsets,
                           &convert_trans_affine,
                           &offset_trans,
+                          &convert_bool,
                           &filled,
                           &convert_offset_position,
                           &offset_position)) {
@@ -402,15 +403,16 @@ static PyObject *Py_clip_path_to_rect(PyObject *self, PyObject *args, PyObject *
 {
     py::PathIterator path;
     agg::rect_d rect;
-    int inside;
+    bool inside;
     std::vector<Polygon> result;
 
     if (!PyArg_ParseTuple(args,
-                          "O&O&i:clip_path_to_rect",
+                          "O&O&O&:clip_path_to_rect",
                           &convert_path,
                           &path,
                           &convert_rect,
                           &rect,
+                          &convert_bool,
                           &inside)) {
         return NULL;
     }
@@ -527,13 +529,13 @@ static PyObject *Py_path_intersects_rectangle(PyObject *self, PyObject *args, Py
 {
     py::PathIterator path;
     double rect_x1, rect_y1, rect_x2, rect_y2;
-    int filled = 0;
+    bool filled = false;
     const char *names[] = { "path", "rect_x1", "rect_y1", "rect_x2", "rect_y2", "filled", NULL };
     bool result;
 
     if (!PyArg_ParseTupleAndKeywords(args,
                                      kwds,
-                                     "O&dddd|i:path_intersects_rectangle",
+                                     "O&dddd|O&:path_intersects_rectangle",
                                      (char **)names,
                                      &convert_path,
                                      &path,
@@ -541,6 +543,7 @@ static PyObject *Py_path_intersects_rectangle(PyObject *self, PyObject *args, Py
                                      &rect_y1,
                                      &rect_x2,
                                      &rect_y2,
+                                     &convert_bool,
                                      &filled)) {
         return NULL;
     }
@@ -594,21 +597,22 @@ static PyObject *Py_cleanup_path(PyObject *self, PyObject *args, PyObject *kwds)
 {
     py::PathIterator path;
     agg::trans_affine trans;
-    int remove_nans;
+    bool remove_nans;
     agg::rect_d clip_rect;
     e_snap_mode snap_mode;
     double stroke_width;
     PyObject *simplifyobj;
     bool simplify = false;
-    int return_curves;
+    bool return_curves;
     SketchParams sketch;
 
     if (!PyArg_ParseTuple(args,
-                          "O&O&iO&O&dOiO&:cleanup_path",
+                          "O&O&O&O&O&dOO&O&:cleanup_path",
                           &convert_path,
                           &path,
                           &convert_trans_affine,
                           &trans,
+                          &convert_bool,
                           &remove_nans,
                           &convert_rect,
                           &clip_rect,
@@ -616,6 +620,7 @@ static PyObject *Py_cleanup_path(PyObject *self, PyObject *args, PyObject *kwds)
                           &snap_mode,
                           &stroke_width,
                           &simplifyobj,
+                          &convert_bool,
                           &return_curves,
                           &convert_sketch_params,
                           &sketch)) {
@@ -675,14 +680,14 @@ static PyObject *Py_convert_to_string(PyObject *self, PyObject *args, PyObject *
     int precision;
     PyObject *codesobj;
     char *codes[5];
-    int postfix;
+    bool postfix;
     char *buffer = NULL;
     size_t buffersize;
     PyObject *result;
     int status;
 
     if (!PyArg_ParseTuple(args,
-                          "O&O&O&OO&iOi:convert_to_string",
+                          "O&O&O&OO&iOO&:convert_to_string",
                           &convert_path,
                           &path,
                           &convert_trans_affine,
@@ -694,6 +699,7 @@ static PyObject *Py_convert_to_string(PyObject *self, PyObject *args, PyObject *
                           &sketch,
                           &precision,
                           &codesobj,
+                          &convert_bool,
                           &postfix)) {
         return NULL;
     }
@@ -727,7 +733,7 @@ static PyObject *Py_convert_to_string(PyObject *self, PyObject *args, PyObject *
     CALL_CPP("convert_to_string",
              (status = convert_to_string(
                  path, trans, cliprect, simplify, sketch,
-                 precision, codes, (bool)postfix, &buffer,
+                 precision, codes, postfix, &buffer,
                  &buffersize)));
 
     if (status) {

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -173,7 +173,7 @@ static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
 
     png_uint_32 width = (png_uint_32)buffer.dim(1);
     png_uint_32 height = (png_uint_32)buffer.dim(0);
-    int channels = buffer.dim(2);
+    npy_intp channels = buffer.dim(2);
     std::vector<png_bytep> row_pointers(height);
     for (png_uint_32 row = 0; row < (png_uint_32)height; ++row) {
         row_pointers[row] = (png_bytep)&buffer(row, 0, 0);

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -599,12 +599,12 @@ static PyObject *_read_png(PyObject *filein, bool float_result)
                 if (bit_depth == 16) {
                     png_uint_16 *ptr = &reinterpret_cast<png_uint_16 *>(row)[x * dimensions[2]];
                     for (png_uint_32 p = 0; p < (png_uint_32)dimensions[2]; p++) {
-                        A(y, x, p) = (float)(ptr[p]) / max_value;
+                        A(y, x, p) = (float)(ptr[p] / max_value);
                     }
                 } else {
                     png_byte *ptr = &(row[x * dimensions[2]]);
                     for (png_uint_32 p = 0; p < (png_uint_32)dimensions[2]; p++) {
-                        A(y, x, p) = (float)(ptr[p]) / max_value;
+                        A(y, x, p) = (float)(ptr[p] / max_value);
                     }
                 }
             }

--- a/src/file_compat.h
+++ b/src/file_compat.h
@@ -82,7 +82,7 @@ static NPY_INLINE FILE *mpl_PyFile_Dup(PyObject *file, char *mode, mpl_off_t *or
     if (ret == NULL) {
         return NULL;
     }
-    fd2 = PyNumber_AsSsize_t(ret, NULL);
+    fd2 = (int)PyNumber_AsSsize_t(ret, NULL);
     Py_DECREF(ret);
 
 /* Convert to FILE* handle */

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -532,8 +532,6 @@ FT2Font::~FT2Font()
 
 void FT2Font::clear()
 {
-    angle = 0.0;
-
     pen.x = 0;
     pen.y = 0;
 

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -124,7 +124,6 @@ class FT2Font
     std::vector<FT_Vector> pos;
     FT_BBox bbox;
     FT_Pos advance;
-    double angle;
     double ptsize;
     double dpi;
     long hinting_factor;

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1,6 +1,7 @@
 #include "mplutils.h"
 #include "ft2font.h"
 #include "file_compat.h"
+#include "py_converters.h"
 #include "py_exceptions.h"
 #include "numpy_cpp.h"
 
@@ -829,11 +830,11 @@ const char *PyFT2Font_draw_glyphs_to_bitmap__doc__ =
 
 static PyObject *PyFT2Font_draw_glyphs_to_bitmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
-    int antialiased = 1;
+    bool antialiased = true;
     const char *names[] = { "antialiased", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(
-             args, kwds, "|i:draw_glyphs_to_bitmap", (char **)names, &antialiased)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:draw_glyphs_to_bitmap",
+                                     (char **)names, &convert_bool, &antialiased)) {
         return NULL;
     }
 
@@ -849,11 +850,12 @@ const char *PyFT2Font_get_xys__doc__ =
 
 static PyObject *PyFT2Font_get_xys(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
-    int antialiased = 1;
+    bool antialiased = true;
     std::vector<double> xys;
     const char *names[] = { "antialiased", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|i:get_xys", (char **)names, &antialiased)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:get_xys",
+                                     (char **)names, &convert_bool, &antialiased)) {
         return NULL;
     }
 
@@ -879,12 +881,12 @@ static PyObject *PyFT2Font_draw_glyph_to_bitmap(PyFT2Font *self, PyObject *args,
     PyFT2Image *image;
     double xd, yd;
     PyGlyph *glyph;
-    int antialiased = 1;
+    bool antialiased = true;
     const char *names[] = { "image", "x", "y", "glyph", "antialiased", NULL };
 
     if (!PyArg_ParseTupleAndKeywords(args,
                                      kwds,
-                                     "O!ddO!|i:draw_glyph_to_bitmap",
+                                     "O!ddO!|O&:draw_glyph_to_bitmap",
                                      (char **)names,
                                      &PyFT2ImageType,
                                      &image,
@@ -892,6 +894,7 @@ static PyObject *PyFT2Font_draw_glyph_to_bitmap(PyFT2Font *self, PyObject *args,
                                      &yd,
                                      &PyGlyphType,
                                      &glyph,
+                                     &convert_bool,
                                      &antialiased)) {
         return NULL;
     }

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -63,7 +63,7 @@ extern "C" int add_dict_int(PyObject *dict, const char *key, long val);
 
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
 namespace std {
-  inline bool isfinite(double num) { return _finite(num); }
+  inline bool isfinite(double num) { return _finite(num) != 0; }
 }
 #endif
 

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -109,8 +109,13 @@ int convert_double(PyObject *obj, void *p)
 int convert_bool(PyObject *obj, void *p)
 {
     bool *val = (bool *)p;
+    int ret;
 
-    *val = PyObject_IsTrue(obj);
+    ret = PyObject_IsTrue(obj);
+    if (ret == -1) {
+        return 0;
+    }
+    *val = ret != 0;
 
     return 1;
 }
@@ -387,7 +392,7 @@ int convert_path(PyObject *obj, void *pathp)
     if (should_simplify_obj == NULL) {
         goto exit;
     }
-    should_simplify = PyObject_IsTrue(should_simplify_obj);
+    should_simplify = PyObject_IsTrue(should_simplify_obj) != 0;
 
     simplify_threshold_obj = PyObject_GetAttrString(obj, "simplify_threshold");
     if (simplify_threshold_obj == NULL) {


### PR DESCRIPTION
## PR Summary

This fixes various minor type conversion and other casting warnings. It is not completely clean now, but saves about 100 lines of warnings in every AppVeyor build.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way