### PR TITLE
import six

### DIFF
--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -1,3 +1,6 @@
+
+import six
+
 from .backend_cairo import cairo, FigureCanvasCairo, RendererCairo
 from .backend_qt5 import QtCore, QtGui, _BackendQT5, FigureCanvasQT
 from .qt_compat import QT_API

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -16,6 +16,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import six
 from six.moves import xrange
 
 import sys

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import functools
 import warnings
 
+import six
 import matplotlib as mpl
 from matplotlib import cbook
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

These four Python files use the __six__ module but do not import it so this PR adds __import six__.  Also:
* Removed unused imports
* Added __import ctypes__ where required
* Ran isort on imports
* Changed __file()__ to __open()__ because __file()__ was removed in Python 3.