### PR TITLE
file() was removed in Python 3

### DIFF
--- a/examples/misc/rc_traits_sgskip.py
+++ b/examples/misc/rc_traits_sgskip.py
@@ -107,7 +107,7 @@ Color = traits.Trait(RGBA(), float_to_rgba, colorname_to_rgba, RGBA,
 
 
 def file_exists(ob, name, val):
-    fh = file(val, 'r')
+    fh = open(val, 'r')
     return val
 
 linestyles = ('-', '--', '-.', ':', 'steps', 'None')

--- a/tools/subset.py
+++ b/tools/subset.py
@@ -59,7 +59,7 @@ def subset_font_raw(font_in, font_out, unicodes, opts):
         # and invert comments on following 2 lines
         # nam_fn = opts['--namelist']
         nam_fn = font_out + '.nam'
-        nam = opentype(nam_fn, 'w')
+        nam = open(nam_fn, 'w')
     else:
         nam = None
     if '--script' in opts:

--- a/tools/subset.py
+++ b/tools/subset.py
@@ -24,12 +24,15 @@
 # TODO 2013-04-08 ensure the menu files are as compact as possible by default, similar to subset.pl
 # TODO 2013-05-22 in Arimo, the latin subset doesn't include ; but the greek does. why on earth is this happening?
 from __future__ import print_function
-import fontforge
-import sys
+
 import getopt
 import os
-import subprocess
 import struct
+import subprocess
+import sys
+
+import fontforge
+
 
 def log_namelist(nam, unicode):
     if nam and isinstance(unicode, int):
@@ -46,7 +49,7 @@ def select_with_refs(font, unicode, newfont, pe = None, nam = None):
             log_namelist(nam, ref[0])
             if pe:
                 print('SelectMore("%s")' % ref[0], file=pe)
-    except:
+    except Exception:
         print('Resolving references on u+%04x failed' % unicode)
 
 def subset_font_raw(font_in, font_out, unicodes, opts):
@@ -56,18 +59,18 @@ def subset_font_raw(font_in, font_out, unicodes, opts):
         # and invert comments on following 2 lines
         # nam_fn = opts['--namelist']
         nam_fn = font_out + '.nam'
-        nam = file(nam_fn, 'w')
+        nam = opentype(nam_fn, 'w')
     else:
         nam = None
     if '--script' in opts:
         pe_fn = "/tmp/script.pe"
-        pe = file(pe_fn, 'w')
+        pe = open(pe_fn, 'w')
     else:
         pe = None
     font = fontforge.open(font_in)
     if pe:
-      print('Open("' + font_in + '")', file=pe)
-      extract_vert_to_script(font_in, pe)
+        print('Open("' + font_in + '")', file=pe)
+        extract_vert_to_script(font_in, pe)
     for i in unicodes:
         select_with_refs(font, i, font, pe, nam)
 
@@ -161,7 +164,7 @@ def subset_font_raw(font_in, font_out, unicodes, opts):
 def subset_font(font_in, font_out, unicodes, opts):
     font_out_raw = font_out
     if not font_out_raw.endswith('.ttf'):
-        font_out_raw += '.ttf';
+        font_out_raw += '.ttf'
     subset_font_raw(font_in, font_out_raw, unicodes, opts)
     if font_out != font_out_raw:
         os.rename(font_out_raw, font_out)
@@ -340,7 +343,8 @@ def set_os2_vert(pe, name, val):
 # http://sourceforge.net/mailarchive/forum.php?thread_name=20100906085718.GB1907%40khaled-laptop&forum_name=fontforge-users
 
 def extract_vert_to_script(font_in, pe):
-    data = file(font_in, 'rb').read()
+    with open(font_in, 'rb') as in_file:
+        data = in_file.read()
     sfnt = Sfnt(data)
     hhea = sfnt.hhea()
     os2 = sfnt.os2()


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

The builtin __file()__ was removed in Python 3 so this PR substitutes __open()__ or __with open() as__.  Also:
* Fixed indentation
* Ran isort on imports
* Cleaned up a bare exception