### PR TITLE
FIX: make set_text(None) keep string empty instead of "None"

### DIFF
--- a/doc/api/next_api_changes/2018-02-07-JMK.rst
+++ b/doc/api/next_api_changes/2018-02-07-JMK.rst
@@ -1,0 +1,9 @@
+`Text.set_text` with string argument ``None`` sets string to empty
+------------------------------------------------------------------
+
+`Text.set_text` when passed a string value of ``None`` would set the
+string to ``"None"``, so subsequent calls to `Text.get_text` would return
+the ambiguous ``"None"`` string.
+
+This change sets text objects passed ``None`` to have empty strings, so that
+`Text.get_text` returns and an empty string.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1103,16 +1103,18 @@ class Legend(Artist):
         with *prop* parameter.
         """
         self._legend_title_box._text.set_text(title)
+        if title:
+            self._legend_title_box._text.set_visible(True)
+            self._legend_title_box.set_visible(True)
+        else:
+            self._legend_title_box._text.set_visible(False)
+            self._legend_title_box.set_visible(False)
 
         if prop is not None:
             if isinstance(prop, dict):
                 prop = FontProperties(**prop)
             self._legend_title_box._text.set_fontproperties(prop)
 
-        if title:
-            self._legend_title_box.set_visible(True)
-        else:
-            self._legend_title_box.set_visible(False)
         self.stale = True
 
     def get_title(self):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -517,3 +517,14 @@ def test_shadow_framealpha():
     ax.plot(range(100), label="test")
     leg = ax.legend(shadow=True, facecolor='w')
     assert leg.get_frame().get_alpha() == 1
+
+
+def test_legend_title_empty():
+    # test that if we don't set the legend title, that
+    # it comes back as an empty string, and that it is not
+    # visible:
+    fig, ax = plt.subplots()
+    ax.plot(range(10))
+    leg = ax.legend()
+    assert leg.get_title().get_text() == ""
+    assert leg.get_title().get_visible() is False

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1163,13 +1163,13 @@ class Text(Artist):
 
         It may contain newlines (``\\n``) or math in LaTeX syntax.
 
-        ACCEPTS: string or anything printable with '%s' conversion, except
+        ACCEPTS: string or object castable to string, except
         ``None``, which is set to an empty string.
         """
         if s is None:
             s = ''
         if s != self._text:
-            self._text = '%s' % (s,)
+            self._text = str(s)
             self.stale = True
 
     @staticmethod

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1164,7 +1164,7 @@ class Text(Artist):
         It may contain newlines (``\\n``) or math in LaTeX syntax.
 
         ACCEPTS: string or anything printable with '%s' conversion, except
-        ``None``, which leaves the text string empty:
+        ``None``, which is set to an empty string.
         """
         if s is None:
             s = ''

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1169,7 +1169,7 @@ class Text(Artist):
         if s is None:
             s = ''
         if s != self._text:
-            self._text = str(s)
+            self._text = '%s' % (s,)
             self.stale = True
 
     @staticmethod

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -158,6 +158,7 @@ class Text(Artist):
         elif isinstance(fontproperties, six.string_types):
             fontproperties = FontProperties(fontproperties)
 
+        self._text = ''
         self.set_text(text)
         self.set_color(color)
         self.set_usetex(usetex)
@@ -1158,14 +1159,18 @@ class Text(Artist):
 
     def set_text(self, s):
         """
-        Set the text string *s*
+        Set the text string *s*.
 
         It may contain newlines (``\\n``) or math in LaTeX syntax.
 
-        ACCEPTS: string or anything printable with '%s' conversion.
+        ACCEPTS: string or anything printable with '%s' conversion, except
+        ``None``, which leaves the text string empty:
         """
-        self._text = '%s' % (s,)
-        self.stale = True
+        if s is None:
+            s = ''
+        if s != self._text:
+            self._text = '%s' % (s,)
+            self.stale = True
 
     @staticmethod
     def is_math_text(s, usetex=None):


### PR DESCRIPTION
## PR Summary

As documented in #10391, `legend.set_title()` doesn't do sensible things with the default `title=None` (i.e it set the string of the legend title to the string "None").   

This is kind of an API change in that if anyone was checking for the string `"None"` to see if the legend title was empty will now fail, but lets hope no one was doing that.  

As pointed out below by @anntzer the problem is more wide spread: The updated PR now checks if `s` is `None` in `Text.set_text` and if it is does not do anything.  Before it would set the string to `"None"` which is silly.

One *could* go further and insist that `s` is a string (so the user knows what they are doing), but that'll likely break lots of people assuming the string cast happens.  
  

~This still needs a test....~

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] API change noted

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->