### PR TITLE
OOification of the new examples from #10306

### DIFF
--- a/examples/ticks_and_spines/tick_label_right.py
+++ b/examples/ticks_and_spines/tick_label_right.py
@@ -9,23 +9,20 @@ We can use :rc:`ytick.labelright` (default False) and :rc:`ytick.right`
 These properties can also be set in the ``.matplotlib/matplotlibrc``.
 
 """
-
-
 import matplotlib.pyplot as plt
 import numpy as np
 
 plt.rcParams['ytick.right'] = plt.rcParams['ytick.labelright'] = True
 plt.rcParams['ytick.left'] = plt.rcParams['ytick.labelleft'] = False
 
-
 x = np.arange(10)
 
-_, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
+fig, (ax0, ax1) = plt.subplots(2, 1, sharex=True, figsize=(6, 6))
 
-ax[0].plot(x)
-ax[0].yaxis.tick_left()
+ax0.plot(x)
+ax0.yaxis.tick_left()
 
 # use default parameter in rcParams, not calling tick_right()
-ax[1].plot(x)
+ax1.plot(x)
 
 plt.show()

--- a/examples/ticks_and_spines/tick_xlabel_top.py
+++ b/examples/ticks_and_spines/tick_xlabel_top.py
@@ -10,8 +10,6 @@ their labels appear.
 These properties can also be set in the ``.matplotlib/matplotlibrc``.
 
 """
-
-
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -21,6 +19,9 @@ plt.rcParams['xtick.top'] = plt.rcParams['xtick.labeltop'] = True
 
 x = np.arange(10)
 
-plt.plot(x)
-plt.title('xlabel top')
+fig, ax = plt.subplots()
+
+ax.plot(x)
+ax.set_title('xlabel top', pad=24)  # increase padding to make room for labels
+
 plt.show()


### PR DESCRIPTION
## PR Summary

This PR simply tries to make the examples added in #10306 a bit more consistent with the current trend of promoting the object-oriented API rather than the Pyplot one. I was planning to suggest the small changes in the original thread but the latter got merged while I was writing my post 🐑... 

Being there, this PR also slightly increase the title padding in `title_xlabel_top.py`, to make room for the tick labels and prevent a not very nice-looking overlap. _Please note that this change could (should) be removed if in the future a feature like #9498 was going to be introduced in Matplotlib._

Some questions that may still be open:
  - Should we merge the one examples into a single one? (I do not remember where we are about having very short and simple examples vs more complex/comprehensive ones)
  - If we prefer keeping two different files, should we make the names a bit more consistent? (e.g. `tick_label_right.py` <- `tick_ylabel_right.py`)

## PR Checklist

- [ ] Code is PEP 8 compliant: hopefully
- [ ] Documentation is sphinx and numpydoc compliant: CI will judge
