### PR TITLE
Wrong explanation in docstring for add_subplot fixed

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1153,8 +1153,8 @@ class Figure(Artist):
         *args
             Either a 3-digit integer or three separate integers
             describing the position of the subplot. If the three
-            integers are I, J, and K, the subplot is the Ith plot on a
-            grid with J rows and K columns.
+            integers are I, J, and K in order, the subplot is the
+            Kth plot on a grid with I rows and J columns.
 
         projection : ['aitoff' | 'hammer' | 'lambert' | \
 'mollweide' | 'polar' | 'rectilinear'], optional


### PR DESCRIPTION
## PR Summary

Docstring for method add_subplot of Figure class have wrong information

## PR Checklist

- [N/A] Has Pytest style unit tests
- [N/A] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

