### PR TITLE
Avoid double draw in qt5cairo.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -7,22 +7,30 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
     def __init__(self, figure):
         super(FigureCanvasQTCairo, self).__init__(figure=figure)
         self._renderer = RendererCairo(self.figure.dpi)
+        self._renderer.set_width_height(-1, -1)  # Invalid values.
+
+    def draw(self):
+        if hasattr(self._renderer.gc, "ctx"):
+            self.figure.draw(self._renderer)
+        super(FigureCanvasQTCairo, self).draw()
 
     def paintEvent(self, event):
         self._update_dpi()
         dpi_ratio = self._dpi_ratio
         width = dpi_ratio * self.width()
         height = dpi_ratio * self.height()
-        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
-        self._renderer.set_ctx_from_surface(surface)
-        self._renderer.set_width_height(width, height)
-        self.figure.draw(self._renderer)
-        buf = surface.get_data()
+        if (width, height) != self._renderer.get_canvas_width_height():
+            surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
+            self._renderer.set_ctx_from_surface(surface)
+            self._renderer.set_width_height(width, height)
+            self.figure.draw(self._renderer)
+        buf = self._renderer.gc.ctx.get_target().get_data()
         qimage = QtGui.QImage(buf, width, height,
                               QtGui.QImage.Format_ARGB32_Premultiplied)
         # Adjust the buf reference count to work around a memory leak bug in
         # QImage under PySide on Python 3.
         if QT_API == 'PySide' and six.PY3:
+            import ctypes
             ctypes.c_long.from_address(id(buf)).value = 1
         if hasattr(qimage, 'setDevicePixelRatio'):
             # Not available on Qt4 or some older Qt5.


### PR DESCRIPTION
## PR Summary

Fix the double draw mentioned in https://github.com/matplotlib/matplotlib/pull/10210#discussion_r165855897.  Better solution is likely to move this to the backend_cairo base class (as done by mplcairo) but that's a bit more surgery, for the next time...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
