### PR TITLE
import matplotlib._layoutbox as layoutbox

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -19,6 +19,7 @@ from matplotlib import cbook
 from matplotlib.cbook import (_check_1d, _string_to_bool, iterable,
                               index_of, get_label)
 from matplotlib import docstring
+import matplotlib._layoutbox as layoutbox
 import matplotlib.colors as mcolors
 import matplotlib.lines as mlines
 import matplotlib.patches as mpatches


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

__layoutbox__ is an undefined name in three locations.  Using other files as an example, PR does an __import matplotlib.\_layoutbox as layoutbox__.

flake8 testing of https://github.com/matplotlib/matplotlib on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/matplotlib/axes/_base.py:4202:52: F821 undefined name 'layoutbox'
            name = self._layoutbox.name + 'twin' + layoutbox.seq_id()
                                                   ^
./lib/matplotlib/axes/_base.py:4203:30: F821 undefined name 'layoutbox'
            ax2._layoutbox = layoutbox.LayoutBox(
                             ^
./lib/matplotlib/axes/_base.py:4207:33: F821 undefined name 'layoutbox'
            ax2._poslayoutbox = layoutbox.LayoutBox(
                                ^
```