### PR TITLE
TST/FIX twinx and twiny w/ constrainedlayout

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4192,25 +4192,9 @@ class _AxesBase(martist.Artist):
         if 'sharex' in kwargs and 'sharey' in kwargs:
             raise ValueError("Twinned Axes may share only one axis.")
         ax2 = self.figure.add_axes(self.get_position(True), *kl, **kwargs)
-
         self.set_adjustable('datalim')
         ax2.set_adjustable('datalim')
         self._twinned_axes.join(self, ax2)
-        # check if we have a layoutbox.  If so, then set this axis
-        # gets the same poslayoutbox and layoutbox...
-        if self._layoutbox is not None:
-            name = self._layoutbox.name + 'twin' + layoutbox.seq_id()
-            ax2._layoutbox = layoutbox.LayoutBox(
-                    parent=self._subplotspec._layoutbox,
-                    name=name,
-                    artist=ax2)
-            ax2._poslayoutbox = layoutbox.LayoutBox(
-                    parent=ax2._layoutbox,
-                    name=ax2._layoutbox.name+'.pos',
-                    pos=True, subplot=True, artist=ax2)
-            # make the layout boxes be the same
-            ax2._layoutbox.constrain_same(self._layoutbox)
-            ax2._poslayoutbox.constrain_same(self._poslayoutbox)
         return ax2
 
     def twinx(self):
@@ -4263,6 +4247,7 @@ class _AxesBase(martist.Artist):
         For those who are 'picking' artists while using twiny, pick
         events are only called for the artists in the top-most axes.
         """
+
         ax2 = self._make_twin_axes(sharey=self)
         ax2.xaxis.tick_top()
         ax2.xaxis.set_label_position('top')

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -183,6 +183,12 @@ class SubplotBase(object):
         self.figure.add_subplot(ax2)
         self.set_adjustable('datalim')
         ax2.set_adjustable('datalim')
+
+        if self._layoutbox is not None and ax2._layoutbox is not None:
+            # make the layout boxes be explicitly the same
+            ax2._layoutbox.constrain_same(self._layoutbox)
+            ax2._poslayoutbox.constrain_same(self._poslayoutbox)
+
         self._twinned_axes.join(self, ax2)
         return ax2
 

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -206,8 +206,6 @@ class GridSpec(GridSpecBase):
                               height_ratios=height_ratios)
 
         if (self.figure is None) or not self.figure.get_constrained_layout():
-            _log.info("GridSpec must be called with the fig keyword if "
-                    "constrained_layout is used")
             self._layoutbox = None
         else:
             self.figure.init_layoutbox()

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -355,3 +355,25 @@ def test_constrained_layout17():
     example_plot(ax2)
     example_plot(ax3)
     example_plot(ax4)
+
+
+def test_constrained_layout18():
+    'Test twinx'
+    fig, ax = plt.subplots(constrained_layout=True)
+    ax2 = ax.twinx()
+    example_plot(ax)
+    example_plot(ax2, fontsize=24)
+    fig.canvas.draw()
+    assert all(ax.get_position().extents == ax2.get_position().extents)
+
+
+def test_constrained_layout19():
+    'Test twiny'
+    fig, ax = plt.subplots(constrained_layout=True)
+    ax2 = ax.twiny()
+    example_plot(ax)
+    example_plot(ax2, fontsize=24)
+    ax2.set_title('')
+    ax.set_title('')
+    fig.canvas.draw()
+    assert all(ax.get_position().extents == ax2.get_position().extents)


### PR DESCRIPTION
## PR Summary

As per #10404, the `twinx/y` code in `_base.py` for constrainedlayout was not being called in any of the tests, and hence an import was inadvertently erased.  This adds the import and two tests.  I also tested interactively, and everything works as it should to window resizing. 


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
