### PR TITLE
New "accepts units" decorator

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -33,6 +33,7 @@ import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
+import matplotlib.units as munits
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
 from matplotlib.axes._base import _AxesBase, _process_plot_format
 
@@ -4006,6 +4007,7 @@ class Axes(_AxesBase):
         return dict(whiskers=whiskers, caps=caps, boxes=boxes,
                     medians=medians, fliers=fliers, means=means)
 
+    @munits._accepts_units(convert_x=['x'], convert_y=['y'])
     @_preprocess_data(replace_names=["x", "y", "s", "linewidths",
                                      "edgecolors", "c", "facecolor",
                                      "facecolors", "color"],
@@ -4148,10 +4150,6 @@ class Axes(_AxesBase):
 
         if edgecolors is None and not rcParams['_internal.classic_mode']:
             edgecolors = 'face'
-
-        self._process_unit_info(xdata=x, ydata=y, kwargs=kwargs)
-        x = self.convert_xunits(x)
-        y = self.convert_yunits(y)
 
         # np.ma.ravel yields an ndarray, not a masked array,
         # unless its argument is a masked array.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -637,6 +637,7 @@ class Axes(_AxesBase):
 
         return rectpatch, connects
 
+    @munits._accepts_units(convert_x=['x'], convert_y=['y'])
     def text(self, x, y, s, fontdict=None, withdash=False, **kwargs):
         """
         Add text to the axes.
@@ -732,6 +733,7 @@ class Axes(_AxesBase):
     annotate.__doc__ = mtext.Annotation.__init__.__doc__
     #### Lines and spans
 
+    @munits._accepts_units(convert_y=['y'])
     @docstring.dedent_interpd
     def axhline(self, y=0, xmin=0, xmax=1, **kwargs):
         """
@@ -787,14 +789,9 @@ class Axes(_AxesBase):
         if "transform" in kwargs:
             raise ValueError(
                 "'transform' is not allowed as a kwarg;"
-                + "axhline generates its own transform.")
+                "axhline generates its own transform.")
         ymin, ymax = self.get_ybound()
-
-        # We need to strip away the units for comparison with
-        # non-unitized bounds
-        self._process_unit_info(ydata=y, kwargs=kwargs)
-        yy = self.convert_yunits(y)
-        scaley = (yy < ymin) or (yy > ymax)
+        scaley = (y < ymin) or (y > ymax)
 
         trans = self.get_yaxis_transform(which='grid')
         l = mlines.Line2D([xmin, xmax], [y, y], transform=trans, **kwargs)
@@ -802,6 +799,7 @@ class Axes(_AxesBase):
         self.autoscale_view(scalex=False, scaley=scaley)
         return l
 
+    @munits._accepts_units(convert_x=['x'])
     @docstring.dedent_interpd
     def axvline(self, x=0, ymin=0, ymax=1, **kwargs):
         """
@@ -856,14 +854,9 @@ class Axes(_AxesBase):
         if "transform" in kwargs:
             raise ValueError(
                 "'transform' is not allowed as a kwarg;"
-                + "axvline generates its own transform.")
+                "axvline generates its own transform.")
         xmin, xmax = self.get_xbound()
-
-        # We need to strip away the units for comparison with
-        # non-unitized bounds
-        self._process_unit_info(xdata=x, kwargs=kwargs)
-        xx = self.convert_xunits(x)
-        scalex = (xx < xmin) or (xx > xmax)
+        scalex = (x < xmin) or (x > xmax)
 
         trans = self.get_xaxis_transform(which='grid')
         l = mlines.Line2D([x, x], [ymin, ymax], transform=trans, **kwargs)
@@ -1952,6 +1945,7 @@ class Axes(_AxesBase):
 
     #### Specialized plotting
 
+    @munits._accepts_units(convert_x=['x'], convert_y=['y'])
     @_preprocess_data(replace_names=["x", "y"], label_namer="y")
     def step(self, x, y, *args, where='pre', **kwargs):
         """
@@ -2421,6 +2415,7 @@ class Axes(_AxesBase):
                            align=align, **kwargs)
         return patches
 
+    @munits._accepts_units(convert_x=['xranges'], convert_y=['yrange'])
     @_preprocess_data(label_namer=None)
     @docstring.dedent_interpd
     def broken_barh(self, xranges, yrange, **kwargs):
@@ -2480,11 +2475,6 @@ class Axes(_AxesBase):
             ydata = cbook.safe_first_element(yrange)
         else:
             ydata = None
-        self._process_unit_info(xdata=xdata,
-                                ydata=ydata,
-                                kwargs=kwargs)
-        xranges = self.convert_xunits(xranges)
-        yrange = self.convert_yunits(yrange)
 
         col = mcoll.BrokenBarHCollection(xranges, yrange, **kwargs)
         self.add_collection(col, autolim=True)
@@ -4268,6 +4258,7 @@ class Axes(_AxesBase):
 
         return collection
 
+    @munits._accepts_units(convert_x=['x'], convert_y=['y'])
     @_preprocess_data(replace_names=["x", "y"], label_namer="y")
     @docstring.dedent_interpd
     def hexbin(self, x, y, C=None, gridsize=100, bins=None,
@@ -4396,8 +4387,6 @@ class Axes(_AxesBase):
             %(Collection)s
 
         """
-        self._process_unit_info(xdata=x, ydata=y, kwargs=kwargs)
-
         x, y, C = cbook.delete_masked_points(x, y, C)
 
         # Set the size of the hexagon grid

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3046,11 +3046,6 @@ class _AxesBase(martist.Artist):
         Raise ValueError if converted limits are non-finite.
 
         Note that this function also accepts None as a limit argument.
-
-        Returns
-        -------
-        The limit value after call to convert(), or None if limit is None.
-
         """
         if limit is not None:
             converted_limit = convert(limit)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -27,6 +27,7 @@ import matplotlib.spines as mspines
 import matplotlib.font_manager as font_manager
 import matplotlib.text as mtext
 import matplotlib.image as mimage
+import matplotlib.units as munits
 
 from matplotlib.rcsetup import cycler, validate_axisbelow
 
@@ -3041,19 +3042,19 @@ class _AxesBase(martist.Artist):
         """
         return tuple(self.viewLim.intervalx)
 
-    def _validate_converted_limits(self, limit, convert):
+    def _validate_converted_limits(self, converted_limit):
         """
         Raise ValueError if converted limits are non-finite.
 
         Note that this function also accepts None as a limit argument.
         """
-        if limit is not None:
-            converted_limit = convert(limit)
-            if (isinstance(converted_limit, Real)
-                    and not np.isfinite(converted_limit)):
+        if converted_limit is not None:
+            if (isinstance(converted_limit, float) and
+                    (not np.isreal(converted_limit) or
+                        not np.isfinite(converted_limit))):
                 raise ValueError("Axis limits cannot be NaN or Inf")
-            return converted_limit
 
+    @munits._accepts_units(convert_x=['left', 'right'])
     def set_xlim(self, left=None, right=None, emit=True, auto=False,
                  *, xmin=None, xmax=None):
         """
@@ -3131,9 +3132,8 @@ class _AxesBase(martist.Artist):
                 raise TypeError('Cannot pass both `xmax` and `right`')
             right = xmax
 
-        self._process_unit_info(xdata=(left, right))
-        left = self._validate_converted_limits(left, self.convert_xunits)
-        right = self._validate_converted_limits(right, self.convert_xunits)
+        self._validate_converted_limits(left)
+        self._validate_converted_limits(right)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -3388,6 +3388,7 @@ class _AxesBase(martist.Artist):
         """
         return tuple(self.viewLim.intervaly)
 
+    @munits._accepts_units(convert_y=['bottom', 'top'])
     def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
                  *, ymin=None, ymax=None):
         """
@@ -3464,8 +3465,8 @@ class _AxesBase(martist.Artist):
                 raise TypeError('Cannot pass both `ymax` and `top`')
             top = ymax
 
-        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
-        top = self._validate_converted_limits(top, self.convert_yunits)
+        self._validate_converted_limits(bottom)
+        self._validate_converted_limits(top)
 
         old_bottom, old_top = self.get_ylim()
 

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -58,6 +58,8 @@ def _accepts_units(convert_x=[], convert_y=[]):
     unit information, are converted, and then handed on to the decorated
     function.
 
+    The first argument of the decorated function must be an Axes.
+
     Parameters
     ----------
     convert_x, convert_y : list
@@ -73,8 +75,7 @@ def _accepts_units(convert_x=[], convert_y=[]):
             # Get the original arguments - these will be modified later
             arguments = bound_args.arguments
             # Check for data kwarg
-            has_data = (('data' in arguments) and
-                        (arguments['data'] is not None))
+            has_data = arguments.get('data') is not None
             if has_data:
                 data = arguments['data']
 

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -51,7 +51,7 @@ import numpy as np
 from matplotlib import cbook
 
 
-def _accepts_units(convert_x, convert_y):
+def _accepts_units(convert_x=[], convert_y=[]):
     """
     A decorator for functions and methods that accept units. The parameters
     indicated in *convert_x* and *convert_y* are used to update the axis
@@ -69,6 +69,7 @@ def _accepts_units(convert_x, convert_y):
             axes = args[0]
             # Bind the incoming arguments to the function signature
             bound_args = inspect.signature(func).bind(*args, **kwargs)
+            bound_args.apply_defaults()
             # Get the original arguments - these will be modified later
             arguments = bound_args.arguments
             # Check for data kwarg

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -25,6 +25,7 @@ import matplotlib.docstring as docstring
 import matplotlib.projections as proj
 import matplotlib.scale as mscale
 import matplotlib.transforms as mtransforms
+import matplotlib.units as munits
 from matplotlib.axes import Axes, rcParams
 from matplotlib.colors import Normalize, LightSource
 from matplotlib.transforms import Bbox
@@ -595,6 +596,7 @@ class Axes3D(Axes):
             xmax += 0.05
         return (xmin, xmax)
 
+    @munits._accepts_units(convert_x=['left', 'right'])
     def set_xlim3d(self, left=None, right=None, emit=True, auto=False,
                    *, xmin=None, xmax=None):
         """
@@ -618,9 +620,8 @@ class Axes3D(Axes):
                 raise TypeError('Cannot pass both `xmax` and `right`')
             right = xmax
 
-        self._process_unit_info(xdata=(left, right))
-        left = self._validate_converted_limits(left, self.convert_xunits)
-        right = self._validate_converted_limits(right, self.convert_xunits)
+        self._validate_converted_limits(left)
+        self._validate_converted_limits(right)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -653,6 +654,7 @@ class Axes3D(Axes):
         return left, right
     set_xlim = set_xlim3d
 
+    @munits._accepts_units(convert_y=['bottom', 'top'])
     def set_ylim3d(self, bottom=None, top=None, emit=True, auto=False,
                    *, ymin=None, ymax=None):
         """
@@ -676,9 +678,8 @@ class Axes3D(Axes):
                 raise TypeError('Cannot pass both `ymax` and `top`')
             top = ymax
 
-        self._process_unit_info(ydata=(bottom, top))
-        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
-        top = self._validate_converted_limits(top, self.convert_yunits)
+        self._validate_converted_limits(bottom)
+        self._validate_converted_limits(top)
 
         old_bottom, old_top = self.get_ylim()
         if bottom is None:
@@ -735,8 +736,10 @@ class Axes3D(Axes):
             top = zmax
 
         self._process_unit_info(zdata=(bottom, top))
-        bottom = self._validate_converted_limits(bottom, self.convert_zunits)
-        top = self._validate_converted_limits(top, self.convert_zunits)
+        bottom = self.convert_zunits(bottom)
+        top = self.convert_zunits(top)
+        self._validate_converted_limits(bottom)
+        self._validate_converted_limits(top)
 
         old_bottom, old_top = self.get_zlim()
         if bottom is None:


### PR DESCRIPTION
This PR implements a decorator that marks a function as accepting units, and also does the unit conversion. The decorator takes a list of parameters that can accept unitised data, so for example both `x` and `xlim` could be converted as part of the same function.

The decorator itself is currently not very neat code, but it works as a proof of concept.

This would also make the creation of "methods that accept units" registry really easy, as anything that is decorated could be automatically added to it, and a page in the docs with methods that support units could be automatically generated.