### PR TITLE
GTK backend deprecations

### DIFF
--- a/doc/api/api_changes/2018-02-10-ES.rst
+++ b/doc/api/api_changes/2018-02-10-ES.rst
@@ -1,0 +1,7 @@
+GTKAgg and GTKCairo backends deprecated
+```````````````````````````````````````
+The GTKAgg and GTKCairo backends have been deprecated. These obsolete backends
+allow figures to be rendered via the GTK+ 2 toolkit. They are untested, known
+to be broken, will not work with Python 3, and their use has been discouraged
+for some time. Instead, use the `GTK3Agg` and `GTK3Cairo` backends for
+rendering to GTK+ 3 windows.

--- a/lib/matplotlib/backends/backend_gdk.py
+++ b/lib/matplotlib/backends/backend_gdk.py
@@ -384,7 +384,7 @@ class FigureCanvasGDK (FigureCanvasBase):
         if self.__class__ == matplotlib.backends.backend_gdk.FigureCanvasGDK:
             warn_deprecated('2.0', message="The GDK backend is "
                             "deprecated. It is untested, known to be "
-                            "broken and will be removed in Matplotlib 2.2. "
+                            "broken and will be removed in Matplotlib 3.0. "
                             "Use the Agg backend instead. "
                             "See Matplotlib usage FAQ for"
                             " more info on backends.",

--- a/lib/matplotlib/backends/backend_gtk.py
+++ b/lib/matplotlib/backends/backend_gtk.py
@@ -186,7 +186,7 @@ class FigureCanvasGTK (gtk.DrawingArea, FigureCanvasBase):
         if self.__class__ == matplotlib.backends.backend_gtk.FigureCanvasGTK:
             warn_deprecated('2.0', message="The GTK backend is "
                             "deprecated. It is untested, known to be "
-                            "broken and will be removed in Matplotlib 2.2. "
+                            "broken and will be removed in Matplotlib 3.0. "
                             "Use the GTKAgg backend instead. "
                             "See Matplotlib usage FAQ for"
                             " more info on backends.",

--- a/lib/matplotlib/backends/backend_gtkagg.py
+++ b/lib/matplotlib/backends/backend_gtkagg.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import matplotlib
+from matplotlib.cbook import warn_deprecated
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.backends.backend_gtk import (
     gtk, _BackendGTK, FigureCanvasGTK, FigureManagerGTK, NavigationToolbar2GTK,
@@ -33,6 +34,16 @@ class FigureManagerGTKAgg(FigureManagerGTK):
 class FigureCanvasGTKAgg(FigureCanvasGTK, FigureCanvasAgg):
     filetypes = FigureCanvasGTK.filetypes.copy()
     filetypes.update(FigureCanvasAgg.filetypes)
+
+    def __init__(self, *args, **kwargs):
+        warn_deprecated('2.2',
+                        message=('The GTKAgg backend is deprecated. It is '
+                                 'untested and will be removed in Matplotlib '
+                                 '3.0. Use the GTK3Agg backend instead. See '
+                                 'Matplotlib usage FAQ for more info on '
+                                 'backends.'),
+                        alternative='GTK3Agg')
+        super(FigureCanvasGTKAgg, self).__init__(*args, **kwargs)
 
     def configure_event(self, widget, event=None):
 

--- a/lib/matplotlib/backends/backend_gtkcairo.py
+++ b/lib/matplotlib/backends/backend_gtkcairo.py
@@ -33,6 +33,16 @@ class FigureCanvasGTKCairo(backend_cairo.FigureCanvasCairo, FigureCanvasGTK):
     filetypes = FigureCanvasGTK.filetypes.copy()
     filetypes.update(backend_cairo.FigureCanvasCairo.filetypes)
 
+    def __init__(self, *args, **kwargs):
+        warn_deprecated('2.2',
+                        message=('The GTKCairo backend is deprecated. It is '
+                                 'untested and will be removed in Matplotlib '
+                                 '3.0. Use the GTK3Cairo backend instead. See '
+                                 'Matplotlib usage FAQ for more info on '
+                                 'backends.'),
+                        alternative='GTK3Cairo')
+        super(FigureCanvasGTKCairo, self).__init__(*args, **kwargs)
+
     def _renderer_init(self):
         """Override to use cairo (rather than GDK) renderer"""
         self._renderer = RendererGTKCairo(self.figure.dpi)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -192,7 +192,7 @@ class RendererWx(RendererBase):
         """
         warn_deprecated('2.0', message="The WX backend is "
                         "deprecated. It's untested "
-                        "and will be removed in Matplotlib 2.2. "
+                        "and will be removed in Matplotlib 3.0. "
                         "Use the WXAgg backend instead. "
                         "See Matplotlib usage FAQ for more info on backends.",
                         alternative='WXAgg')


### PR DESCRIPTION
## PR Summary

This deprecates the GTKAgg and GTKCairo backends. They require pygtk which doesn't build on Python 3 anymore, and GTK2, which hasn't seen a major release in 7 years.

Also, bump the removal version for the GDK, GTK, and WX backends, as I think it makes more sense to remove them in a major release like 3.0 than 2.2 which is happening imminently.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way