### PR TITLE
fix bug #3690: don't call evt.Skip() when window has just been destroyed

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1007,14 +1007,16 @@ class FigureCanvasWx(FigureCanvasBase, wx.Panel):
     def _onKeyDown(self, evt):
         """Capture key press."""
         key = self._get_key(evt)
-        evt.Skip()
         FigureCanvasBase.key_press_event(self, key, guiEvent=evt)
+        if self:
+            evt.Skip()
 
     def _onKeyUp(self, evt):
         """Release key."""
         key = self._get_key(evt)
-        evt.Skip()
         FigureCanvasBase.key_release_event(self, key, guiEvent=evt)
+        if self:
+            evt.Skip()
 
     def _set_capture(self, capture=True):
         """control wx mouse capture """


### PR DESCRIPTION
## PR Summary
Fixes https://github.com/matplotlib/matplotlib/issues/3690
Forwarding the event to a destroyed window caused the crash.

It would be best not to call  `evt.Skip()` at all if a key was handled by `FigureCanvasBase.key_press_event()` but that's probably more difficult to implement.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
