### PR TITLE
remove string escapes from matplotlibrc.template

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -122,36 +122,36 @@ backend      : $TEMPLATE_BACKEND
 #boxplot.showfliers  : True
 #boxplot.meanline    : False
 
-#boxplot.flierprops.color           : 'k'
-#boxplot.flierprops.marker          : 'o'
-#boxplot.flierprops.markerfacecolor : 'none'
-#boxplot.flierprops.markeredgecolor : 'k'
+#boxplot.flierprops.color           : k
+#boxplot.flierprops.marker          : o
+#boxplot.flierprops.markerfacecolor : none
+#boxplot.flierprops.markeredgecolor : k
 #boxplot.flierprops.markersize      : 6
-#boxplot.flierprops.linestyle       : 'none'
+#boxplot.flierprops.linestyle       : none
 #boxplot.flierprops.linewidth       : 1.0
 
-#boxplot.boxprops.color     : 'k'
+#boxplot.boxprops.color     : k
 #boxplot.boxprops.linewidth : 1.0
-#boxplot.boxprops.linestyle : '-'
+#boxplot.boxprops.linestyle : -
 
-#boxplot.whiskerprops.color     : 'k'
+#boxplot.whiskerprops.color     : k
 #boxplot.whiskerprops.linewidth : 1.0
-#boxplot.whiskerprops.linestyle : '-'
+#boxplot.whiskerprops.linestyle : -
 
-#boxplot.capprops.color     : 'k'
+#boxplot.capprops.color     : k
 #boxplot.capprops.linewidth : 1.0
-#boxplot.capprops.linestyle : '-'
+#boxplot.capprops.linestyle : -
 
-#boxplot.medianprops.color     : 'C1'
+#boxplot.medianprops.color     : C1
 #boxplot.medianprops.linewidth : 1.0
-#boxplot.medianprops.linestyle : '-'
+#boxplot.medianprops.linestyle : -
 
-#boxplot.meanprops.color           : 'C2'
-#boxplot.meanprops.marker          : '^'
-#boxplot.meanprops.markerfacecolor : 'C2'
-#boxplot.meanprops.markeredgecolor : 'C2'
+#boxplot.meanprops.color           : C2
+#boxplot.meanprops.marker          : ^
+#boxplot.meanprops.markerfacecolor : C2
+#boxplot.meanprops.markeredgecolor : C2
 #boxplot.meanprops.markersize      :  6
-#boxplot.meanprops.linestyle       : 'none'
+#boxplot.meanprops.linestyle       : none
 #boxplot.meanprops.linewidth       : 1.0
 
 ### FONT
@@ -291,7 +291,7 @@ backend      : $TEMPLATE_BACKEND
 #axes.labelpad       : 4.0     # space between label and axis
 #axes.labelweight    : normal  # weight of the x and y labels
 #axes.labelcolor     : black
-#axes.axisbelow      : 'line'  # draw axis gridlines and ticks below
+#axes.axisbelow      : line    # draw axis gridlines and ticks below
                                # patches (True); above patches but below
                                # lines ('line'); or above all (False)
 
@@ -538,14 +538,14 @@ backend      : $TEMPLATE_BACKEND
 #ps.distiller.res  : 6000      # dpi
 #ps.fonttype       : 3         # Output Type 3 (Type3) or Type 42 (TrueType)
 
-# pdf backend params
+## pdf backend params
 #pdf.compression   : 6 # integer from 0 to 9
                        # 0 disables compression (good for debugging)
 #pdf.fonttype       : 3         # Output Type 3 (Type3) or Type 42 (TrueType)
 
-# svg backend params
+## svg backend params
 #svg.image_inline : True       # write raster image data directly into the svg file
-#svg.fonttype : 'path'         # How to handle SVG fonts:
+#svg.fonttype :   path         # How to handle SVG fonts:
 #    'none': Assume fonts are installed on the machine where the SVG will be viewed.
 #    'path': Embed characters as paths -- supported by most SVG renderers
 #    'svgfont': Embed characters as SVG fonts -- supported only by Chrome,
@@ -578,14 +578,15 @@ backend      : $TEMPLATE_BACKEND
 #examples.directory : ''   # directory to look in for custom installation
 
 ###ANIMATION settings
-#animation.html : 'none'           # How to display the animation as HTML in
+#animation.html :  none            # How to display the animation as HTML in
                                    # the IPython notebook. 'html5' uses
-                                   # HTML5 video tag.
+                                   # HTML5 video tag; 'jshtml' creates a 
+								   # Javascript animation
 #animation.writer : ffmpeg         # MovieWriter 'backend' to use
 #animation.codec : h264            # Codec to use for writing movie
 #animation.bitrate: -1             # Controls size/quality tradeoff for movie.
                                    # -1 implies let utility auto-determine
-#animation.frame_format: 'png'     # Controls frame format used by temp files
+#animation.frame_format:  png      # Controls frame format used by temp files
 #animation.html_args: ''           # Additional arguments to pass to html writer
 #animation.ffmpeg_path: 'ffmpeg'   # Path to ffmpeg binary. Without full path
                                    # $PATH is searched


### PR DESCRIPTION
Remove string escapes from `matplotlibrc.template`.
This fixes #10406.  Since the matplotlib rc file is not a python file, the rc arguments should not contain string escape characters. E.g. instead of formerly
```
boxplot.medianprops.color : 'C1'
```
it should read
```
boxplot.medianprops.color : C1
```
This change makes it easier to just uncomment the lines in the template file for use in a real rc file.

Note that I left some of the arguments in the "animations" section unchanged, because it is not clear what to put there instead. In any case, the fixed version of the template allows to uncomment any rc line (including those from the animations section) and not get a warning, so I suppose the animation parameters are correct, although they contain string escapes.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
