### PR TITLE
Define RecursionError for Python versions < 3.5

### DIFF
--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -12,6 +12,11 @@ from matplotlib.dates import rrulewrapper
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 
+try:  # https://docs.python.org/3/library/exceptions.html#RecursionError
+    RecursionError                 # Python 3.5+
+except NameError:
+    RecursionError = RuntimeError  # Python < 3.5
+
 
 def test_simple():
     fig = plt.figure()


### PR DESCRIPTION
__RecursionError__ is used on line 189.  https://docs.python.org/3/library/exceptions.html#RecursionError

## PR Summary
Fixes undefined name __RecursionError__ in Python versions < 3.5.

## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is PEP 8 compliant
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [X] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [X] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
