### PR TITLE
Cleanup old print statements

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -62,7 +62,8 @@ def DEBUG_MSG(string, lvl=3, o=None):
         # Jeremy, often times the commented line won't print but the
         # one below does.  I think WX is redefining stderr, damned
         # beast
-        # print >>sys.stderr, "%s- %s in %s" % (_DEBUG_lvls[lvl], string, cls)
+        # print("%s- %s in %s" % (_DEBUG_lvls[lvl], string, cls),
+        #       file=sys.stderr)
         print("%s- %s in %s" % (_DEBUG_lvls[lvl], string, cls))
 
 

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -191,7 +191,7 @@ class Dvi(object):
 
     >>> with matplotlib.dviread.Dvi('input.dvi', 72) as dvi:
     >>>     for page in dvi:
-    >>>         print ''.join(unichr(t.glyph) for t in page.text)
+    >>>         print(''.join(unichr(t.glyph) for t in page.text))
     """
     # dispatch table
     _dtable = [None for _ in xrange(256)]

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -93,25 +93,21 @@ def segment_hits(cx, cy, x, y, radius):
     Lnorm_sq = dx ** 2 + dy ** 2  # Possibly want to eliminate Lnorm==0
     u = ((cx - xr) * dx + (cy - yr) * dy) / Lnorm_sq
     candidates = (u >= 0) & (u <= 1)
-    #if any(candidates): print "candidates",xr[candidates]
 
     # Note that there is a little area near one side of each point
     # which will be near neither segment, and another which will
     # be near both, depending on the angle of the lines.  The
     # following radius test eliminates these ambiguities.
     point_hits = (cx - x) ** 2 + (cy - y) ** 2 <= radius ** 2
-    #if any(point_hits): print "points",xr[candidates]
     candidates = candidates & ~(point_hits[:-1] | point_hits[1:])
 
     # For those candidates which remain, determine how far they lie away
     # from the line.
     px, py = xr + u * dx, yr + u * dy
     line_hits = (cx - px) ** 2 + (cy - py) ** 2 <= radius ** 2
-    #if any(line_hits): print "lines",xr[candidates]
     line_hits = line_hits & candidates
     points, = point_hits.ravel().nonzero()
     lines, = line_hits.ravel().nonzero()
-    #print points,lines
     return np.concatenate((points, lines))
 
 

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -114,11 +114,9 @@ def select_step(v1, v2, nv, hour=False, include_last=True,
 
     # for degree
     if dv > 1./threshold_factor:
-        #print "degree"
         step, factor = _select_step(dv)
     else:
         step, factor = select_step_sub(dv*threshold_factor)
-        #print "feac", step, factor
 
         factor = factor * threshold_factor
 

--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -304,7 +304,7 @@ plt.show()
 #     In [159]: ax1
 #     Out[159]: <matplotlib.axes.Subplot instance at 0xd54b26c>
 #
-#     In [160]: print fig.axes
+#     In [160]: print(fig.axes)
 #     [<matplotlib.axes.Subplot instance at 0xd54b26c>, <matplotlib.axes.Axes instance at 0xd3f0b2c>]
 #
 # Because the figure maintains the concept of the "current axes" (see
@@ -404,7 +404,7 @@ plt.show()
 #
 # .. sourcecode:: ipython
 #
-#     In [229]: print ax.lines
+#     In [229]: print(ax.lines)
 #     [<matplotlib.lines.Line2D instance at 0xd378b0c>]
 #
 # Similarly, methods that create patches, like
@@ -419,7 +419,7 @@ plt.show()
 #     In [234]: rectangles
 #     Out[234]: <a list of 50 Patch objects>
 #
-#     In [235]: print len(ax.patches)
+#     In [235]: print(len(ax.patches))
 #
 # You should not add objects directly to the ``Axes.lines`` or
 # ``Axes.patches`` lists unless you know exactly what you are doing,
@@ -445,11 +445,11 @@ plt.show()
 #     In [263]: rect = matplotlib.patches.Rectangle( (1,1), width=5, height=12)
 #
 #     # by default the axes instance is None
-#     In [264]: print rect.get_axes()
+#     In [264]: print(rect.get_axes())
 #     None
 #
 #     # and the transformation instance is set to the "identity transform"
-#     In [265]: print rect.get_transform()
+#     In [265]: print(rect.get_transform())
 #     <Affine object at 0x13695544>
 #
 #     # now we add the Rectangle to the Axes
@@ -457,30 +457,30 @@ plt.show()
 #
 #     # and notice that the ax.add_patch method has set the axes
 #     # instance
-#     In [267]: print rect.get_axes()
+#     In [267]: print(rect.get_axes())
 #     Axes(0.125,0.1;0.775x0.8)
 #
 #     # and the transformation has been set too
-#     In [268]: print rect.get_transform()
+#     In [268]: print(rect.get_transform())
 #     <Affine object at 0x15009ca4>
 #
 #     # the default axes transformation is ax.transData
-#     In [269]: print ax.transData
+#     In [269]: print(ax.transData)
 #     <Affine object at 0x15009ca4>
 #
 #     # notice that the xlimits of the Axes have not been changed
-#     In [270]: print ax.get_xlim()
+#     In [270]: print(ax.get_xlim())
 #     (0.0, 1.0)
 #
 #     # but the data limits have been updated to encompass the rectangle
-#     In [271]: print ax.dataLim.bounds
+#     In [271]: print(ax.dataLim.bounds)
 #     (1.0, 1.0, 5.0, 12.0)
 #
 #     # we can manually invoke the auto-scaling machinery
 #     In [272]: ax.autoscale_view()
 #
 #     # and now the xlim are updated to encompass the rectangle
-#     In [273]: print ax.get_xlim()
+#     In [273]: print(ax.get_xlim())
 #     (1.0, 6.0)
 #
 #     # we have to manually force a figure draw


### PR DESCRIPTION
## PR Summary

Update comments and docstrings that use old print statements, either with functions or just removing the comments entirely.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
