### PR TITLE
Fix wxcairo byteorder.

### DIFF
--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -11,7 +11,7 @@ import wx
 from .backend_cairo import cairo, FigureCanvasCairo, RendererCairo
 from .backend_wx import (
     _BackendWx, _FigureCanvasWxBase, FigureFrameWx, NavigationToolbar2Wx)
-from . import wx_compat as wxc
+import wx.lib.wxcairo as wxcairo
 
 
 class FigureFrameWxCairo(FigureFrameWx):
@@ -44,13 +44,7 @@ class FigureCanvasWxCairo(_FigureCanvasWxBase, FigureCanvasCairo):
         self._renderer.set_ctx_from_surface(surface)
         self._renderer.set_width_height(width, height)
         self.figure.draw(self._renderer)
-        buf = np.frombuffer(surface.get_data(), dtype="uint8").reshape((height, width, 4))
-        if sys.byteorder == "little":
-            b, g, r, a = np.rollaxis(buf, -1)
-        else:
-            a, r, g, b = np.rollaxis(buf, -1)
-        rgba8888 = np.dstack([r, g, b, a])
-        self.bitmap = wxc.BitmapFromBuffer(width, height, rgba8888)
+        self.bitmap = wxcairo.BitmapFromImageSurface(surface)
         self._isDrawn = True
         self.gui_repaint(drawDC=drawDC, origin='WXCairo')
 

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -3,9 +3,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
-import sys
-
-import numpy as np
 import wx
 
 from .backend_cairo import cairo, FigureCanvasCairo, RendererCairo


### PR DESCRIPTION
## PR Summary

I'm still not sure what I'm supposed to do with premultiplication (https://wxpython.org/Phoenix/docs/html/wx.Bitmap.html#wx.Bitmap.FromBufferRGBA is not very clear...) but at least this should get the byteorders correct).
See https://github.com/matplotlib/matplotlib/pull/10395#issuecomment-364817853.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
