### PR TITLE
Use some new Python3 types

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-ES.rst
+++ b/doc/api/next_api_changes/2018-02-15-ES.rst
@@ -1,0 +1,5 @@
+matplotlib.cbook.Bunch deprecated
+`````````````````````````````````
+The ``matplotlib.cbook.Bunch`` class has been deprecated. Instead, use
+`types.SimpleNamespace` from the standard library which provides the same
+functionality.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -10,6 +10,7 @@ import itertools
 import warnings
 import math
 from operator import attrgetter
+import types
 
 import numpy as np
 
@@ -3954,7 +3955,7 @@ class _AxesBase(martist.Artist):
             Intended to be overridden by new projection types.
 
         """
-        self._pan_start = cbook.Bunch(
+        self._pan_start = types.SimpleNamespace(
             lim=self.viewLim.frozen(),
             trans=self.transData.frozen(),
             trans_inverse=self.transData.inverted().frozen(),

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -17,6 +17,7 @@ import re
 import struct
 import sys
 import time
+import types
 import warnings
 import zlib
 
@@ -28,7 +29,7 @@ from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
     RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
-from matplotlib.cbook import (Bunch, get_realpath_and_stat,
+from matplotlib.cbook import (get_realpath_and_stat,
                               is_writable_file_like, maxdict)
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, is_opentype_cff_font, get_font
@@ -320,7 +321,8 @@ _pdfops = dict(
     grestore=b'Q', textpos=b'Td', selectfont=b'Tf', textmatrix=b'Tm',
     show=b'Tj', showkern=b'TJ', setlinewidth=b'w', clip=b'W', shading=b'sh')
 
-Op = Bunch(**{name: Operator(value) for name, value in _pdfops.items()})
+Op = types.SimpleNamespace(**{name: Operator(value)
+                              for name, value in _pdfops.items()})
 
 
 def _paint_path(fill, stroke):
@@ -685,7 +687,7 @@ class PdfFile(object):
         pdfname = Name('F%d' % self.nextFont)
         self.nextFont += 1
         _log.debug('Assigning font %s = %s (dvi)', pdfname, dvifont.texname)
-        self.dviFontInfo[dvifont.texname] = Bunch(
+        self.dviFontInfo[dvifont.texname] = types.SimpleNamespace(
             dvifont=dvifont,
             pdfname=pdfname,
             fontfile=psfont.filename,

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -488,7 +488,8 @@ def strip_math(s):
     return s
 
 
-class Bunch(object):
+@deprecated('3.0', alternative='types.SimpleNamespace')
+class Bunch(types.SimpleNamespace):
     """
     Often we want to just collect a bunch of stuff together, naming each
     item of the bunch; a dictionary's OK for that, but a small do- nothing
@@ -497,16 +498,8 @@ class Bunch(object):
 
       >>> point = Bunch(datum=2, squared=4, coord=12)
       >>> point.datum
-
-      By: Alex Martelli
-      From: https://code.activestate.com/recipes/121294/
     """
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-    def __repr__(self):
-        return 'Bunch(%s)' % ', '.join(
-            '%s=%s' % kv for kv in six.iteritems(vars(self)))
+    pass
 
 
 @deprecated('2.1')

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -22,6 +22,7 @@ from six import unichr
 
 import os
 from math import ceil
+import types
 import unicodedata
 from warnings import warn
 from functools import lru_cache
@@ -37,7 +38,7 @@ ParserElement.enablePackrat()
 
 from matplotlib import _png, colors as mcolors, get_data_path, rcParams
 from matplotlib.afm import AFM
-from matplotlib.cbook import Bunch, get_realpath_and_stat
+from matplotlib.cbook import get_realpath_and_stat
 from matplotlib.ft2font import FT2Image, KERNING_DEFAULT, LOAD_NO_HINTING
 from matplotlib.font_manager import findfont, FontProperties, get_font
 from matplotlib._mathtext_data import (latex_to_bakoma, latex_to_standard,
@@ -312,8 +313,8 @@ class MathtextBackendSvg(MathtextBackend):
 
     def get_results(self, box, used_characters):
         ship(0, 0, box)
-        svg_elements = Bunch(svg_glyphs = self.svg_glyphs,
-                             svg_rects = self.svg_rects)
+        svg_elements = types.SimpleNamespace(svg_glyphs=self.svg_glyphs,
+                                             svg_rects=self.svg_rects)
         return (self.width,
                 self.height + self.depth,
                 self.depth,
@@ -587,7 +588,7 @@ class TruetypeFonts(Fonts):
 
         xmin, ymin, xmax, ymax = [val/64.0 for val in glyph.bbox]
         offset = self._get_offset(font, glyph, fontsize, dpi)
-        metrics = Bunch(
+        metrics = types.SimpleNamespace(
             advance = glyph.linearHoriAdvance/65536.0,
             height  = glyph.height/64.0,
             width   = glyph.width/64.0,
@@ -600,7 +601,7 @@ class TruetypeFonts(Fonts):
             slanted = slanted
             )
 
-        result = self.glyphd[key] = Bunch(
+        result = self.glyphd[key] = types.SimpleNamespace(
             font            = font,
             fontsize        = fontsize,
             postscript_name = font.postscript_name,
@@ -1167,7 +1168,7 @@ class StandardPsFonts(Fonts):
 
         xmin, ymin, xmax, ymax = [val * scale
                                   for val in font.get_bbox_char(glyph)]
-        metrics = Bunch(
+        metrics = types.SimpleNamespace(
             advance  = font.get_width_char(glyph) * scale,
             width    = font.get_width_char(glyph) * scale,
             height   = font.get_height_char(glyph) * scale,
@@ -1180,7 +1181,7 @@ class StandardPsFonts(Fonts):
             slanted = slanted
             )
 
-        self.glyphd[key] = Bunch(
+        self.glyphd[key] = types.SimpleNamespace(
             font            = font,
             fontsize        = fontsize,
             postscript_name = font.get_fontname(),
@@ -2290,7 +2291,7 @@ class Parser(object):
     _right_delim = set(r") ] \} > \rfloor \rangle \rceil".split())
 
     def __init__(self):
-        p = Bunch()
+        p = types.SimpleNamespace()
         # All forward declarations are here
         p.accent           = Forward()
         p.ambi_delim       = Forward()

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 from collections import OrderedDict
+import types
 
 import numpy as np
 
@@ -1362,7 +1363,7 @@ class PolarAxes(Axes):
         elif button == 3:
             mode = 'zoom'
 
-        self._pan_start = cbook.Bunch(
+        self._pan_start = types.SimpleNamespace(
             rmax=self.get_rmax(),
             trans=self.transData.frozen(),
             trans_inverse=self.transData.inverted().frozen(),

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -6,10 +6,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 import logging
+from types import SimpleNamespace
 from six.moves import zip
 import numpy as np
 
-from matplotlib.cbook import iterable, Bunch
+from matplotlib.cbook import iterable
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 from matplotlib.transforms import Affine2D
@@ -780,8 +781,9 @@ class Sankey(object):
         # where either could determine the margins (e.g., arrow shoulders).
 
         # Add this diagram as a subdiagram.
-        self.diagrams.append(Bunch(patch=patch, flows=flows, angles=angles,
-                                   tips=tips, text=text, texts=texts))
+        self.diagrams.append(
+            SimpleNamespace(patch=patch, flows=flows, angles=angles, tips=tips,
+                            text=text, texts=texts))
 
         # Allow a daisy-chained call structure (see docstring for the class).
         return self

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -28,6 +28,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import binascii
+import enum
 import io
 import itertools
 import re
@@ -38,6 +39,11 @@ import numpy as np
 if six.PY3:
     def ord(x):
         return x
+
+
+# token types
+_TokenType = enum.Enum('_TokenType',
+                       'whitespace name string delimiter number')
 
 
 class Type1Font(object):
@@ -143,25 +149,18 @@ class Type1Font(object):
     _comment_re = re.compile(br'%[^\r\n\v]*')
     _instring_re = re.compile(br'[()\\]')
 
-    # token types, compared via object identity (poor man's enum)
-    _whitespace = object()
-    _name = object()
-    _string = object()
-    _delimiter = object()
-    _number = object()
-
     @classmethod
     def _tokens(cls, text):
         """
         A PostScript tokenizer. Yield (token, value) pairs such as
-        (cls._whitespace, '   ') or (cls._name, '/Foobar').
+        (_TokenType.whitespace, '   ') or (_TokenType.name, '/Foobar').
         """
         pos = 0
         while pos < len(text):
             match = (cls._comment_re.match(text[pos:]) or
                      cls._whitespace_re.match(text[pos:]))
             if match:
-                yield (cls._whitespace, match.group())
+                yield (_TokenType.whitespace, match.group())
                 pos += match.end()
             elif text[pos] == b'(':
                 start = pos
@@ -178,25 +177,25 @@ class Type1Font(object):
                         depth -= 1
                     else:  # a backslash - skip the next character
                         pos += 1
-                yield (cls._string, text[start:pos])
+                yield (_TokenType.string, text[start:pos])
             elif text[pos:pos + 2] in (b'<<', b'>>'):
-                yield (cls._delimiter, text[pos:pos + 2])
+                yield (_TokenType.delimiter, text[pos:pos + 2])
                 pos += 2
             elif text[pos] == b'<':
                 start = pos
                 pos += text[pos:].index(b'>')
-                yield (cls._string, text[start:pos])
+                yield (_TokenType.string, text[start:pos])
             else:
                 match = cls._token_re.match(text[pos:])
                 if match:
                     try:
                         float(match.group())
-                        yield (cls._number, match.group())
+                        yield (_TokenType.number, match.group())
                     except ValueError:
-                        yield (cls._name, match.group())
+                        yield (_TokenType.name, match.group())
                     pos += match.end()
                 else:
-                    yield (cls._delimiter, text[pos:pos + 1])
+                    yield (_TokenType.delimiter, text[pos:pos + 1])
                     pos += 1
 
     def _parse(self):
@@ -210,23 +209,23 @@ class Type1Font(object):
                 'UnderlinePosition': -100, 'UnderlineThickness': 50}
         filtered = ((token, value)
                     for token, value in self._tokens(self.parts[0])
-                    if token is not self._whitespace)
+                    if token is not _TokenType.whitespace)
         # The spec calls this an ASCII format; in Python 2.x we could
         # just treat the strings and names as opaque bytes but let's
         # turn them into proper Unicode, and be lenient in case of high bytes.
         convert = lambda x: x.decode('ascii', 'replace')
         for token, value in filtered:
-            if token is self._name and value.startswith(b'/'):
+            if token is _TokenType.name and value.startswith(b'/'):
                 key = convert(value[1:])
                 token, value = next(filtered)
-                if token is self._name:
+                if token is _TokenType.name:
                     if value in (b'true', b'false'):
                         value = value == b'true'
                     else:
                         value = convert(value.lstrip(b'/'))
-                elif token is self._string:
+                elif token is _TokenType.string:
                     value = convert(value.lstrip(b'(').rstrip(b')'))
-                elif token is self._number:
+                elif token is _TokenType.number:
                     if b'.' in value:
                         value = float(value)
                     else:
@@ -284,7 +283,7 @@ class Type1Font(object):
                 token, value = next(tokens)      # name, e.g., /FontMatrix
                 yield bytes(value)
                 token, value = next(tokens)      # possible whitespace
-                while token is cls._whitespace:
+                while token is _TokenType.whitespace:
                     yield bytes(value)
                     token, value = next(tokens)
                 if value != b'[':                # name/number/etc.
@@ -309,7 +308,7 @@ class Type1Font(object):
                  b'/UniqueID': suppress}
 
         for token, value in tokens:
-            if token is cls._name and value in table:
+            if token is _TokenType.name and value in table:
                 for value in table[value](itertools.chain([(token, value)],
                                                           tokens)):
                     yield value


### PR DESCRIPTION
## PR Summary

This is a PoC of using some new Python 3 types: `enum.Enum` in a couple places, and replace `cbook.Bunch` by `types.SimpleNamespace`. ~~This will fail CI right now.~~

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way