### PR TITLE
Add canonical link to webpages

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -153,7 +153,9 @@ parents[-1].link|e }}" />
 }}" />
     {%- endif %}
 {%- endblock %}
-{%- block extrahead %} {% endblock %}
+{%- block extrahead %}
+  <link rel="canonical" href="https://matplotlib.org/{{pagename}}.html" />
+{% endblock %}
 
 
   </head>


### PR DESCRIPTION
This should stop google indexing devdocs or old versions of the docs. Fixes #9065.