### PR TITLE
Set packet_ends = None before using in dviread.py

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -640,7 +640,7 @@ class Vf(Dvi):
         Read one page from the file. Return True if successful,
         False if there were no more pages.
         """
-        packet_len, packet_char, packet_width = None, None, None
+        packet_char, packet_ends, packet_len, packet_width = None, None, None, None
         while True:
             byte = ord(self.file.read(1)[0])
             # If we are in a packet, execute the dvi instructions

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -640,7 +640,8 @@ class Vf(Dvi):
         Read one page from the file. Return True if successful,
         False if there were no more pages.
         """
-        packet_char, packet_ends, packet_len, packet_width = None, None, None, None
+        packet_char, packet_ends = None, None
+        packet_len, packet_width = None, None
         while True:
             byte = ord(self.file.read(1)[0])
             # If we are in a packet, execute the dvi instructions


### PR DESCRIPTION
__packed_ends__ is used on lines 649 and 653 but it is not defined/set until line 666.  This drives linters nuts because it is safer to set variables before using them.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
