### PR TITLE
DOC: remove sphinx markup that confsed SG

### DIFF
--- a/examples/recipes/create_subplots.py
+++ b/examples/recipes/create_subplots.py
@@ -24,7 +24,7 @@ ax3 = fig.add_subplot(224, sharex=ax1, sharey=ax1)
 # Fernando Perez has provided a nice top level method to create in
 # :func:`~matplotlib.pyplots.subplots` (note the "s" at the end)
 # everything at once, and turn on x and y sharing for the whole bunch.
-# You can either unpack the axes individually::
+# You can either unpack the axes individually...
 
 # new style method 1; unpack the axes
 fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, sharex=True, sharey=True)


### PR DESCRIPTION
Some vestiges of an old RST file in the doc gallery confused sphinx-gallery.

See
https://matplotlib.org/gallery/recipes/create_subplots.html#sphx-glr-gallery-recipes-create-subplots-py
and 
https://matplotlib.org/devdocs/gallery/recipes/create_subplots.html#sphx-glr-gallery-recipes-create-subplots-py

This should fix that.
