### PR TITLE
fix broken link in lib/matplotlib/dates.py comment

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -726,7 +726,7 @@ class DateFormatter(ticker.Formatter):
         fmt = fmt.replace("%s", "s")
         if dt.year >= 1900:
             # Note: in python 3.3 this is okay for years >= 1000,
-            # refer to http://bugs.python.org/issue177742
+            # refer to http://bugs.python.org/issue1777412
             return cbook.unicode_safe(dt.strftime(fmt))
 
         return self.strftime_pre_1900(dt, fmt)


### PR DESCRIPTION
This closes #10453

## PR Summary

One missing digit in a comment

```python
        fmt = fmt.replace("%s", "s")
        if dt.year >= 1900:
            # Note: in python 3.3 this is okay for years >= 1000,
            # refer to http://bugs.python.org/issue177742
            return cbook.unicode_safe(dt.strftime(fmt))
```

should be http://bugs.python.org/issue1777412

(Suggested by @jenshnielsen and confirmed in https://github.com/matplotlib/matplotlib/pull/3242#issuecomment-62784225)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

(no new feature, no major change, no API change, didn't check the others but
given how minor the change is I expect what was PEP8, shinx and numpydoc
compliant should stay so)
