### PR TITLE
DOC: Add cividis to the tutorial about colormaps

### DIFF
--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -84,8 +84,8 @@ cmaps = OrderedDict()
 # amongst the colormaps: some are approximately linear in :math:`L^*` and others
 # are more curved.
 
-cmaps['Perceptually Uniform Sequential'] = ['viridis', 'plasma',
-                                            'inferno', 'magma']
+cmaps['Perceptually Uniform Sequential'] = [
+            'viridis', 'plasma', 'inferno', 'magma', 'cividis']
 
 cmaps['Sequential'] = [
             'Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
@@ -205,7 +205,7 @@ plt.show()
 mpl.rcParams.update({'font.size': 12})
 
 # Number of colormap per subplot for particular cmap categories
-_DSUBS = {'Perceptually Uniform Sequential': 4, 'Sequential': 6,
+_DSUBS = {'Perceptually Uniform Sequential': 5, 'Sequential': 6,
           'Sequential (2)': 6, 'Diverging': 6, 'Qualitative': 4,
           'Miscellaneous': 6}
 


### PR DESCRIPTION
## PR Summary

It seems like the existence of the [tutorial about colormaps](https://matplotlib.org/devdocs/tutorials/colors/colormaps.html) was forgotten by #9871 :).

Note that I used the same order as in #9871 (i.e. `['viridis', 'plasma', 'inferno', 'magma', 'cividis']`) for consistency sake, but I wonder if `['viridis', 'plasma', 'cividis', 'inferno', 'magma']` may actually be more “logical”: 'cividis' was designed to be similar to 'viridis' and 'plasma' rather than 'inferno' and 'magma', was it not?

## PR Checklist

- [ ] Code is PEP 8 compliant: hopefully
- [ ] Documentation is sphinx and numpydoc compliant: as well as PEP8
