### PR TITLE
update example docstring of afm.py

### DIFF
--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -19,7 +19,7 @@ It is pretty easy to use, and requires only built-in python libs:
     ...                         'fonts', 'afm', 'ptmr8a.afm')
     >>>
     >>> from matplotlib.afm import AFM
-    >>> with open(afm_fname) as fh:
+    >>> with open(afm_fname, 'rb') as fh:
     ...     afm = AFM(fh)
     >>> afm.string_width_height('What the heck?')
     (6220.0, 694)


### PR DESCRIPTION
In order for the example to work in python 3, the file needs to be read in binary mode: `open(afm_fname, 'rb')`

Issue description can be found here: https://stackoverflow.com/questions/48793711/calculating-the-width-height-of-strings-on-python


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
