### PR TITLE
FIX: DPI inconsistency of draggable legend

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -731,6 +731,7 @@ class Legend(Artist):
         # value of the find_offset.
         self._loc_real = loc
         self.stale = True
+        self._legend_box.set_offset(self._findoffset)
 
     def _get_loc(self):
         return self._loc_real
@@ -1002,7 +1003,6 @@ class Legend(Artist):
                                    children=[self._legend_title_box,
                                              self._legend_handle_box])
         self._legend_box.set_figure(self.figure)
-        self._legend_box.set_offset(self._findoffset)
         self.texts = text_list
         self.legendHandles = handle_list
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1611,14 +1611,14 @@ class DraggableBase(object):
     helper code for a draggable artist (legend, offsetbox)
     The derived class must override following two method.
 
-      def saveoffset(self):
+      def save_offset(self):
           pass
 
       def update_offset(self, dx, dy):
           pass
 
-    *saveoffset* is called when the object is picked for dragging and it is
-    meant to save reference position of the artist.
+    *save_offset* is called when the object is picked for dragging and it
+    is meant to save reference position of the artist.
 
     *update_offset* is called during the dragging. dx and dy is the pixel
      offset from the point where the mouse drag started.


### PR DESCRIPTION
## PR Summary

Fix for #10458 : draggable legend has an inconsistent offset behavior between the DPI value used for display and the DPI value used for saving. This was introduced in 199a87a due to some refactoring that was just a bit too eager. This PR simply reverts the one line that is causing the issue, and fixes some typos in a related docstring. Please see #10458 for more details about the issue (bisect, manual test script, etc.).

As the side remark, this issue was silently introduced because it affects an interactive part of Matplotlib, thus that it is not exercised by the test suite (if I a remember correctly).

## PR Checklist

- [ ] Has Pytest style unit tests: no, as this is related to interactive behavior.
- [ ] Code is PEP 8 compliant: fingers crossed 🐑 
