### PR TITLE
DOC: Expending a bit about the "tableau-colorblind10" entry in What's new

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -161,7 +161,14 @@ New style colorblind-friendly color cycle
 
 A new style defining a color cycle has been added,
 tableau-colorblind10, to provide another option for
-colorblind-friendly plots.
+colorblind-friendly plots.  A demonstration of this new
+style can be found in the reference_ of style sheets. To
+load this color cycle in place of the default one::
+
+  import matplotlib.pyplot as plt
+  plt.style.use('tableau-colorblind10')
+
+.. _reference: https://matplotlib.org/gallery/style_sheets/style_sheets_reference.html
 
 
 Support for numpy.datetime64


### PR DESCRIPTION
## PR Summary

As it took me several readings to understand how to load the new “tableau-colorblind10” color cycle, I would suggest slightly expanding the entry about it in the What's new section, to be more explicit. I guess it cannot really hurt if we want to promote that new color cycle.

On a technical note, I was originally planning to use a versionned URL, but it seems that “https://matplotlib.org/2.2.0/*“ does not exist yet :/, does it?

*Disclaimer*: Hopefully I got the RST syntax right. I simply followed patterns found in other places of the file, and did **not** build the full documentation locally.

@tacaswell I apologize in advance if it would have been better not to edit the `whats_new.rst` file, but instead to create a new separate entry file that you would have used to update the relevant entry. My genuine reasoning was that it is more a fix than a new entry.
