### PR TITLE
Use TemporaryDirectory instead of mkdtemp in a few places.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -311,12 +311,12 @@ class LatexManager:
             self.latex.communicate()
             self.latex_stdin_utf8.close()
             self.latex.stdout.close()
-        except:
+        except Exception:
             pass
         try:
             self._shutil.rmtree(self.tmpdir)
             LatexManager._unclean_instances.discard(self)
-        except:
+        except Exception:
             sys.stderr.write("error deleting tmp directory %s\n" % self.tmpdir)
 
     def __del__(self):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -13,7 +13,7 @@ import re
 import shutil
 import subprocess
 import sys
-from tempfile import mkstemp
+from tempfile import TemporaryDirectory
 import time
 
 import numpy as np
@@ -1150,19 +1150,15 @@ class FigureCanvasPS(FigureCanvasBase):
         if rcParams['ps.usedistiller']:
             # We are going to use an external program to process the output.
             # Write to a temporary file.
-            fd, tmpfile = mkstemp()
-            try:
-                with open(fd, 'w', encoding='latin-1') as fh:
+            with TemporaryDirectory() as tmpdir:
+                tmpfile = os.path.join(tmpdir, "tmp.ps")
+                with open(tmpfile, 'w', encoding='latin-1') as fh:
                     print_figure_impl(fh)
                 if rcParams['ps.usedistiller'] == 'ghostscript':
                     gs_distill(tmpfile, isEPSF, ptype=papertype, bbox=bbox)
                 elif rcParams['ps.usedistiller'] == 'xpdf':
                     xpdf_distill(tmpfile, isEPSF, ptype=papertype, bbox=bbox)
-
                 _move_path_to_path_or_stream(tmpfile, outfile)
-            finally:
-                if os.path.isfile(tmpfile):
-                    os.unlink(tmpfile)
 
         else:
             # Write directly to outfile.
@@ -1255,9 +1251,9 @@ class FigureCanvasPS(FigureCanvasBase):
 
         # write to a temp file, we'll move it to outfile when done
 
-        fd, tmpfile = mkstemp()
-        try:
-            with open(fd, 'w', encoding='latin-1') as fh:
+        with TemporaryDirectory() as tmpdir:
+            tmpfile = os.path.join(tmpdir, "tmp.ps")
+            with open(tmpfile, 'w', encoding='latin-1') as fh:
                 # write the Encapsulated PostScript headers
                 print("%!PS-Adobe-3.0 EPSF-3.0", file=fh)
                 if title:
@@ -1344,9 +1340,6 @@ class FigureCanvasPS(FigureCanvasBase):
                              rotated=psfrag_rotated)
 
             _move_path_to_path_or_stream(tmpfile, outfile)
-        finally:
-            if os.path.isfile(tmpfile):
-                os.unlink(tmpfile)
 
 
 def convert_psfrags(tmpfile, psfrags, font_preamble, custom_preamble,

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 import sys
-import tempfile
 
 import numpy as np
 import pytest

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -1,15 +1,10 @@
-from matplotlib.backend_bases import FigureCanvasBase
-from matplotlib.backend_bases import RendererBase
-from matplotlib.backend_bases import LocationEvent
-
+from matplotlib.backend_bases import (
+    FigureCanvasBase, LocationEvent, RendererBase)
 import matplotlib.pyplot as plt
 import matplotlib.transforms as transforms
 import matplotlib.path as path
 
 import numpy as np
-import os
-import shutil
-import tempfile
 import pytest
 
 
@@ -52,16 +47,12 @@ def test_uses_per_path():
     check(id, paths, tforms, offsets, facecolors[0:1], edgecolors)
 
 
-def test_get_default_filename():
-    try:
-        test_dir = tempfile.mkdtemp()
-        plt.rcParams['savefig.directory'] = test_dir
-        fig = plt.figure()
-        canvas = FigureCanvasBase(fig)
-        filename = canvas.get_default_filename()
-        assert filename == 'image.png'
-    finally:
-        shutil.rmtree(test_dir)
+def test_get_default_filename(tmpdir):
+    plt.rcParams['savefig.directory'] = str(tmpdir)
+    fig = plt.figure()
+    canvas = FigureCanvasBase(fig)
+    filename = canvas.get_default_filename()
+    assert filename == 'image.png'
 
 
 @pytest.mark.backend('pdf')

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -2,8 +2,9 @@ from collections import OrderedDict
 from contextlib import contextmanager
 import gc
 import os
+from pathlib import Path
 import shutil
-import tempfile
+from tempfile import TemporaryDirectory
 import warnings
 
 import pytest
@@ -11,6 +12,7 @@ import pytest
 import matplotlib as mpl
 from matplotlib import pyplot as plt, style
 from matplotlib.style.core import USER_LIBRARY_PATHS, STYLE_EXTENSION
+
 
 PARAM = 'image.cmap'
 VALUE = 'pink'
@@ -23,21 +25,16 @@ def temp_style(style_name, settings=None):
     if not settings:
         settings = DUMMY_SETTINGS
     temp_file = '%s.%s' % (style_name, STYLE_EXTENSION)
-
-    # Write style settings to file in the temp directory.
-    tempdir = tempfile.mkdtemp()
-    with open(os.path.join(tempdir, temp_file), 'w') as f:
-        for k, v in settings.items():
-            f.write('%s: %s' % (k, v))
-
-    # Add temp directory to style path and reload so we can access this style.
-    USER_LIBRARY_PATHS.append(tempdir)
-    style.reload_library()
-
     try:
-        yield
+        with TemporaryDirectory() as tmpdir:
+            # Write style settings to file in the tmpdir.
+            Path(tmpdir, temp_file).write_text(
+                "\n".join(map("{0[0]}: {0[1]}".format, settings.items())))
+            # Add tmpdir to style path and reload so we can access this style.
+            USER_LIBRARY_PATHS.append(tmpdir)
+            style.reload_library()
+            yield
     finally:
-        shutil.rmtree(tempdir)
         style.reload_library()
 
 

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -29,7 +29,7 @@ def temp_style(style_name, settings=None):
         with TemporaryDirectory() as tmpdir:
             # Write style settings to file in the tmpdir.
             Path(tmpdir, temp_file).write_text(
-                "\n".join(map("{0[0]}: {0[1]}".format, settings.items())))
+                "\n".join("{}: {}".format(k, v) for k, v in settings.items()))
             # Add tmpdir to style path and reload so we can access this style.
             USER_LIBRARY_PATHS.append(tmpdir)
             style.reload_library()


### PR DESCRIPTION
## PR Summary

(main remaining place is backend_pgf which has a rather intricate way to set up the tempdir cleanup that'll need to be unwound at some point)

Edit: Also use TemporaryDirectory instead of mkstemp in backend_ps.py; the reason to use that instead of (Named)TemporaryFile is to make it easy to have a closable temporary file on Windows (where a temporary file cannot be opened both by python and by an external process (gs) at the same time).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
