### PR TITLE
Filter out invalid value warnings in log scaling

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -98,25 +98,26 @@ class LogTransformBase(Transform):
         self._clip = {"clip": True, "mask": False}[nonpos]
 
     def transform_non_affine(self, a):
+        # Ignore invalid values due to nans being passed to the transform
         with np.errstate(divide="ignore", invalid="ignore"):
             out = np.log(a)
-        out /= np.log(self.base)
-        if self._clip:
-            # SVG spec says that conforming viewers must support values up
-            # to 3.4e38 (C float); however experiments suggest that Inkscape
-            # (which uses cairo for rendering) runs into cairo's 24-bit limit
-            # (which is apparently shared by Agg).
-            # Ghostscript (used for pdf rendering appears to overflow even
-            # earlier, with the max value around 2 ** 15 for the tests to pass.
-            # On the other hand, in practice, we want to clip beyond
-            #     np.log10(np.nextafter(0, 1)) ~ -323
-            # so 1000 seems safe.
-            out[a <= 0] = -1000
+            out /= np.log(self.base)
+            if self._clip:
+                # SVG spec says that conforming viewers must support values up
+                # to 3.4e38 (C float); however experiments suggest that
+                # Inkscape (which uses cairo for rendering) runs into cairo's
+                # 24-bit limit (which is apparently shared by Agg).
+                # Ghostscript (used for pdf rendering appears to overflow even
+                # earlier, with the max value around 2 ** 15 for the tests to
+                # pass. On the other hand, in practice, we want to clip beyond
+                #     np.log10(np.nextafter(0, 1)) ~ -323
+                # so 1000 seems safe.
+                    out[a <= 0] = -1000
         return out
 
     def __str__(self):
-        return "{}({!r})".format(type(self).__name__,
-            "clip" if self._clip else "mask")
+        return "{}({!r})".format(
+            type(self).__name__, "clip" if self._clip else "mask")
 
 
 class InvertedLogTransformBase(Transform):


### PR DESCRIPTION
Currently in `LogTransformBase` the line `out[a <= 0] = -1000` will raise a numpy warning if a contains nans. This PR filters out this warning, which seems reasonable since it's also done a few lines earlier, and log-scaling with data that includes nans should probably work without errors or warnings.