### PR TITLE
Remove backports.functools_lru_cache

### DIFF
--- a/build_alllocal.cmd
+++ b/build_alllocal.cmd
@@ -6,8 +6,6 @@
 :: conda install pyqt
 :: # this package is only available in the conda-forge channel
 :: conda install -c conda-forge msinttypes
-:: if you build on py2.7:
-:: conda install -c conda-forge backports.functools_lru_cache
 
 set TARGET=bdist_wheel
 IF [%1]==[] (

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -23,7 +23,7 @@ import six
 from six.moves import xrange
 
 from collections import namedtuple
-from functools import partial, wraps
+from functools import lru_cache, partial, wraps
 import logging
 import numpy as np
 import os
@@ -34,11 +34,6 @@ import textwrap
 
 from matplotlib import cbook, rcParams
 from matplotlib.compat import subprocess
-
-try:
-    from functools import lru_cache
-except ImportError:  # Py2
-    from backports.functools_lru_cache import lru_cache
 
 if six.PY3:
     def ord(x):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -45,6 +45,7 @@ License   : matplotlib license (PSF compatible)
 """
 
 from collections import Iterable
+from functools import lru_cache
 import json
 import os
 import sys
@@ -56,11 +57,6 @@ from matplotlib import afm, cbook, ft2font, rcParams, get_cachedir
 from matplotlib.compat import subprocess
 from matplotlib.fontconfig_pattern import (
     parse_fontconfig_pattern, generate_fontconfig_pattern)
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache
 
 _log = logging.getLogger(__name__)
 

--- a/lib/matplotlib/fontconfig_pattern.py
+++ b/lib/matplotlib/fontconfig_pattern.py
@@ -22,10 +22,7 @@ import re
 from pyparsing import (Literal, ZeroOrMore, Optional, Regex, StringEnd,
                        ParseException, Suppress)
 
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache
+from functools import lru_cache
 
 family_punc = r'\\\-:,'
 family_unescape = re.compile(r'\\([%s])' % family_punc).sub

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -24,11 +24,7 @@ import os
 from math import ceil
 import unicodedata
 from warnings import warn
-
-try:
-    from functools import lru_cache
-except ImportError:  # Py2
-    from backports.functools_lru_cache import lru_cache
+from functools import lru_cache
 
 import numpy as np
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -16,10 +16,7 @@ import six
 
 from weakref import WeakValueDictionary
 
-try:
-    from functools import lru_cache
-except ImportError:  # Py2
-    from backports.functools_lru_cache import lru_cache
+from functools import lru_cache
 
 import numpy as np
 

--- a/setupext.py
+++ b/setupext.py
@@ -1441,8 +1441,6 @@ class InstallRequires(SetupPackage):
             "six>=1.10",
             "kiwisolver>=1.0.1",
         ]
-        if sys.version_info < (3,):
-            install_requires += ["backports.functools_lru_cache"]
         if sys.version_info < (3,) and os.name == "posix":
             install_requires += ["subprocess32"]
         return install_requires


### PR DESCRIPTION
## PR Summary

lru_cache was introduced in Python 3.3 so the backport is no longer necessary.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
