### PR TITLE
Add libm when building Qhull.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1337,6 +1337,8 @@ class Qhull(SetupPackage):
         else:
             ext.include_dirs.insert(0, 'extern')
             ext.sources.extend(sorted(glob.glob('extern/libqhull/*.c')))
+            if sysconfig.get_config_var('LIBM') == '-lm':
+                ext.libraries.extend('m')
 
 
 class TTConv(SetupPackage):


### PR DESCRIPTION
## PR Summary

If you build with `LDFLAGS=-Wl,--no-undefined` and no system Qhull, you will get a bunch of errors due to missing math functions. This conditionally adds `libm` to the linker based on [this post](https://mail.python.org/pipermail/distutils-sig/2011-November/018165.html).

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way