### PR TITLE
BUG: sscanf did not parse arguments in _tkagg.cpp

### DIFF
--- a/lib/matplotlib/backends/tkagg.py
+++ b/lib/matplotlib/backends/tkagg.py
@@ -19,7 +19,7 @@ def blit(photoimage, aggimage, bbox=None, colormode=1):
     else:
         bboxptr = 0
     data = np.asarray(aggimage)
-    dataptr = (data.ctypes.data, data.shape[0], data.shape[1])
+    dataptr = (data.shape[0], data.shape[1], data.ctypes.data)
     try:
         tk.call(
             "PyAggImagePhoto", photoimage,

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -41,6 +41,8 @@ import sys
 from matplotlib import pyplot as plt
 
 fig = plt.figure()
+ax = fig.add_subplot(111)
+ax.plot([1,2,3], [1,3,1])
 fig.canvas.mpl_connect("draw_event", lambda event: sys.exit())
 plt.show()
 """

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -73,7 +73,7 @@ static int PyAggImagePhoto(ClientData clientdata, Tcl_Interp *interp, int
         TCL_APPEND_RESULT(interp, "destination photo must exist", (char *)NULL);
         return TCL_ERROR;
     }
-    /* get buffer from str which is "ptr height width" */
+    /* get buffer from str which is "height width ptr" */
     if (sscanf(argv[2], IMG_FORMAT, &hdata, &wdata, &pdata) != 3) {
         TCL_APPEND_RESULT(interp, 
                           "error reading data, expected height width ptr",

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -19,9 +19,9 @@
 #include "_tkmini.h"
 
 #if defined(_MSC_VER)
-#  define IMG_FORMAT "%Iu %d %d"
+#  define IMG_FORMAT "%d %d %Iu"
 #else
-#  define IMG_FORMAT "%zu %d %d"
+#  define IMG_FORMAT "%d %d %zu"
 #endif
 #define BBOX_FORMAT "%f %f %f %f"
 
@@ -74,9 +74,9 @@ static int PyAggImagePhoto(ClientData clientdata, Tcl_Interp *interp, int
         return TCL_ERROR;
     }
     /* get buffer from str which is "ptr height width" */
-    if (sscanf(argv[2], IMG_FORMAT, &pdata, &hdata, &wdata) != 3) {
+    if (sscanf(argv[2], IMG_FORMAT, &hdata, &wdata, &pdata) != 3) {
         TCL_APPEND_RESULT(interp, 
-                          "error reading data, expected ptr height width",
+                          "error reading data, expected height width ptr",
                           (char *)NULL);
         return TCL_ERROR;
     }


### PR DESCRIPTION
## PR Summary

Fix issue #10479 which was caused by a quirk (bug?) in the way sscanf works on MSVC (windows). It seems that additional values cannot be used after "%Iu" which scans into size_t

Also added line drawing in an interactive test