### PR TITLE
DOC: added bounds and more description to margins 

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2320,11 +2320,14 @@ class _AxesBase(martist.Artist):
 
         All three forms above set the xmargin and ymargin parameters.
         All keyword parameters are optional.  A single argument
-        specifies both xmargin and ymargin.  The *tight* parameter
-        is passed to :meth:`autoscale_view`, which is executed after
-        a margin is changed; the default here is *True*, on the
-        assumption that when margins are specified, no additional
-        padding to match tick marks is usually desired.  Setting
+        specifies both xmargin and ymargin. The padding added to the end of
+        each interval is *margin* times the data interval. The *margin* must
+        be a float in the range [0, 1].
+
+        The *tight* parameter is passed to :meth:`autoscale_view`
+        , which is executed after a margin is changed; the default here is
+        *True*, on the assumption that when margins are specified, no
+        additional padding to match tick marks is usually desired.  Setting
         *tight* to *None* will preserve the previous setting.
 
         Specifying any margin changes only the autoscaling; for example,


### PR DESCRIPTION
Added some language to [margins](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.margins.html?highlight=margins#matplotlib.axes.Axes.margins) documentation to try and clarify what the margins argument was and the expected range of values because it confused me earlier today. 

- [x] Code is PEP 8 compliant
- [x] Documentation is sphinx and numpydoc compliant
