### PR TITLE
Simplify Mac builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,6 @@ matrix:
     - python: "nightly"
       env: PRE=--pre
     - os: osx
-      osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       env: MOCK=mock
       only: master
@@ -109,8 +108,8 @@ before_install:
       export PATH=$PATH:/tmp/λ
       export PATH=/usr/lib/ccache:$PATH
     else
-      brew update
-      brew install python3 libpng ffmpeg imagemagick mplayer ccache
+      ci/travis/silence brew update
+      brew install python3 ffmpeg imagemagick mplayer ccache
       # make 'python' mean 'python3'
       ln -sf /usr/local/bin/python3 /usr/local/bin/python
       hash -r

--- a/ci/travis/silence
+++ b/ci/travis/silence
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Run a command, hiding its standard output and error if its exit
+# status is zero.
+
+stdout=$(mktemp -t stdout) || exit 1
+stderr=$(mktemp -t stderr) || exit 1
+"$@" >$stdout 2>$stderr
+code=$?
+if [[ $code != 0 ]]; then
+    cat $stdout
+    cat $stderr >&2
+    exit $code
+fi


### PR DESCRIPTION
- don't specify a fixed build environment version, use the default instead (https://docs.travis-ci.com/user/reference/osx#OS-X-Version)
- hide the `brew update` output unless there is an error (this is 1500+ lines in recent builds)
- remove an error message related to installing libpng, which is already a dependency of python3

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
