### PR TITLE
Remove Python 2 code from C extensions

### DIFF
--- a/lib/matplotlib/tri/_tri.h
+++ b/lib/matplotlib/tri/_tri.h
@@ -60,8 +60,8 @@
  * points below or above (including the same as) the contour level) and 6 that
  * do.  See the function get_exit_edge for details.
  */
-#ifndef _TRI_H
-#define _TRI_H
+#ifndef MPL_TRI_H
+#define MPL_TRI_H
 
 #include "src/numpy_cpp.h"
 

--- a/lib/matplotlib/tri/_tri_wrapper.cpp
+++ b/lib/matplotlib/tri/_tri_wrapper.cpp
@@ -494,7 +494,6 @@ static PyTypeObject* PyTrapezoidMapTriFinder_init_type(PyObject* m, PyTypeObject
 
 extern "C" {
 
-#if PY3K
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_tri",
@@ -507,44 +506,29 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC PyInit__tri(void)
-
-#else
-#define INITERROR return
-
-PyMODINIT_FUNC init_tri(void)
-#endif
-
 {
     PyObject *m;
 
-#if PY3K
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("_tri", NULL, NULL);
-#endif
 
     if (m == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     if (!PyTriangulation_init_type(m, &PyTriangulationType)) {
-        INITERROR;
+        return NULL;
     }
     if (!PyTriContourGenerator_init_type(m, &PyTriContourGeneratorType)) {
-        INITERROR;
+        return NULL;
     }
     if (!PyTrapezoidMapTriFinder_init_type(m, &PyTrapezoidMapTriFinderType)) {
-        INITERROR;
+        return NULL;
     }
 
     import_array();
 
-#if PY3K
     return m;
-#endif
 }
 
 } // extern "C"

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -3,8 +3,8 @@
 /* _backend_agg.h
 */
 
-#ifndef __BACKEND_AGG_H__
-#define __BACKEND_AGG_H__
+#ifndef MPL_BACKEND_AGG_H
+#define MPL_BACKEND_AGG_H
 
 #include <cmath>
 #include <vector>

--- a/src/_backend_agg_basic_types.h
+++ b/src/_backend_agg_basic_types.h
@@ -1,5 +1,5 @@
-#ifndef __BACKEND_AGG_BASIC_TYPES_H__
-#define __BACKEND_AGG_BASIC_TYPES_H__
+#ifndef MPL_BACKEND_AGG_BASIC_TYPES_H
+#define MPL_BACKEND_AGG_BASIC_TYPES_H
 
 /* Contains some simple types from the Agg backend that are also used
    by other modules */

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -586,13 +586,8 @@ PyRendererAgg_get_content_extents(PyRendererAgg *self, PyObject *args, PyObject 
 
 static PyObject *PyRendererAgg_buffer_rgba(PyRendererAgg *self, PyObject *args, PyObject *kwds)
 {
-#if PY3K
     return PyBytes_FromStringAndSize((const char *)self->x->pixBuffer,
                                      self->x->get_width() * self->x->get_height() * 4);
-#else
-    return PyBuffer_FromReadWriteMemory(self->x->pixBuffer,
-                                        self->x->get_width() * self->x->get_height() * 4);
-#endif
 }
 
 int PyRendererAgg_get_buffer(PyRendererAgg *self, Py_buffer *buf, int flags)
@@ -724,7 +719,6 @@ static PyTypeObject *PyRendererAgg_init_type(PyObject *m, PyTypeObject *type)
 
 extern "C" {
 
-#if PY3K
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_backend_agg",
@@ -737,42 +731,27 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC PyInit__backend_agg(void)
-
-#else
-#define INITERROR return
-
-PyMODINIT_FUNC init_backend_agg(void)
-#endif
-
 {
     PyObject *m;
 
-#if PY3K
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("_backend_agg", NULL, NULL);
-#endif
 
     if (m == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     import_array();
 
     if (!PyRendererAgg_init_type(m, &PyRendererAggType)) {
-        INITERROR;
+        return NULL;
     }
 
     if (!PyBufferRegion_init_type(m, &PyBufferRegionType)) {
-        INITERROR;
+        return NULL;
     }
 
-#if PY3K
     return m;
-#endif
 }
 
 } // extern "C"

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -134,7 +134,7 @@ static PyTypeObject *PyBufferRegion_init_type(PyObject *m, PyTypeObject *type)
     type->tp_name = "matplotlib.backends._backend_agg.BufferRegion";
     type->tp_basicsize = sizeof(PyBufferRegion);
     type->tp_dealloc = (destructor)PyBufferRegion_dealloc;
-    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_NEWBUFFER;
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     type->tp_methods = methods;
     type->tp_new = PyBufferRegion_new;
     type->tp_as_buffer = &buffer_procs;
@@ -700,7 +700,7 @@ static PyTypeObject *PyRendererAgg_init_type(PyObject *m, PyTypeObject *type)
     type->tp_name = "matplotlib.backends._backend_agg.RendererAgg";
     type->tp_basicsize = sizeof(PyRendererAgg);
     type->tp_dealloc = (destructor)PyRendererAgg_dealloc;
-    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_NEWBUFFER;
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     type->tp_methods = methods;
     type->tp_init = (initproc)PyRendererAgg_init;
     type->tp_new = PyRendererAgg_new;

--- a/src/_contour.h
+++ b/src/_contour.h
@@ -139,8 +139,8 @@
  * different polygons.  The S-most polygon must be started first, then the next
  * S-most and so on until the N-most polygon is started in that quad.
  */
-#ifndef _CONTOUR_H
-#define _CONTOUR_H
+#ifndef MPL_CONTOUR_H
+#define MPL_CONTOUR_H
 
 #include "src/numpy_cpp.h"
 #include <stdint.h>

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -154,7 +154,6 @@ static PyTypeObject* PyQuadContourGenerator_init_type(PyObject* m, PyTypeObject*
 
 extern "C" {
 
-#if PY3K
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_contour",
@@ -167,38 +166,23 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC PyInit__contour(void)
-
-#else
-#define INITERROR return
-
-PyMODINIT_FUNC init_contour(void)
-#endif
-
 {
     PyObject *m;
 
-#if PY3K
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("_contour", NULL, NULL);
-#endif
 
     if (m == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     if (!PyQuadContourGenerator_init_type(m, &PyQuadContourGeneratorType)) {
-        INITERROR;
+        return NULL;
     }
 
     import_array();
 
-#if PY3K
     return m;
-#endif
 }
 
 } // extern "C"

--- a/src/_image.h
+++ b/src/_image.h
@@ -4,8 +4,8 @@
  *
  */
 
-#ifndef _IMAGE_H
-#define _IMAGE_H
+#ifndef MPL_IMAGE_H
+#define MPL_IMAGE_H
 
 #include <vector>
 

--- a/src/_image_resample.h
+++ b/src/_image_resample.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef RESAMPLE_H
-#define RESAMPLE_H
+#ifndef MPL_RESAMPLE_H
+#define MPL_RESAMPLE_H
 
 #include "agg_image_accessors.h"
 #include "agg_path_storage.h"
@@ -1010,4 +1010,4 @@ void resample(
     }
 }
 
-#endif /* RESAMPLE_H */
+#endif /* MPL_RESAMPLE_H */

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -4,11 +4,6 @@
 #include "py_converters.h"
 
 
-#ifndef NPY_1_7_API_VERSION
-#define NPY_ARRAY_C_CONTIGUOUS NPY_C_CONTIGUOUS
-#endif
-
-
 /**********************************************************************
  * Free functions
  * */

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -437,7 +437,6 @@ static PyMethodDef module_functions[] = {
 
 extern "C" {
 
-#if PY3K
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_image",
@@ -450,27 +449,14 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC PyInit__image(void)
-
-#else
-#define INITERROR return
-
-PyMODINIT_FUNC init_image(void)
-#endif
-
 {
     PyObject *m;
 
-#if PY3K
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("_image", module_functions, NULL);
-#endif
 
     if (m == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     if (PyModule_AddIntConstant(m, "NEAREST", NEAREST) ||
@@ -491,14 +477,12 @@ PyMODINIT_FUNC init_image(void)
         PyModule_AddIntConstant(m, "LANCZOS", LANCZOS) ||
         PyModule_AddIntConstant(m, "BLACKMAN", BLACKMAN) ||
         PyModule_AddIntConstant(m, "_n_interpolation", _n_interpolation)) {
-        INITERROR;
+        return NULL;
     }
 
     import_array();
 
-#if PY3K
     return m;
-#endif
 }
 
 } // extern "C"

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -3,7 +3,8 @@
 #include <sys/socket.h>
 #include <Python.h>
 
-#define PYOSINPUTHOOK_REPETITIVE 1 /* Remove this once Python is fixed */
+/* Remove this once Python is fixed: https://bugs.python.org/issue23237 */
+#define PYOSINPUTHOOK_REPETITIVE 1
 
 /* Proper way to check for the OS X version we are compiling for, from
    http://developer.apple.com/documentation/DeveloperTools/Conceptual/cross_development */

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -5,12 +5,6 @@
 
 #define PYOSINPUTHOOK_REPETITIVE 1 /* Remove this once Python is fixed */
 
-#if PY_MAJOR_VERSION >= 3
-#define PY3K 1
-#else
-#define PY3K 0
-#endif
-
 /* Proper way to check for the OS X version we are compiling for, from
    http://developer.apple.com/documentation/DeveloperTools/Conceptual/cross_development */
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
@@ -325,13 +319,8 @@ FigureCanvas_dealloc(FigureCanvas* self)
 static PyObject*
 FigureCanvas_repr(FigureCanvas* self)
 {
-#if PY3K
     return PyUnicode_FromFormat("FigureCanvas object %p wrapping NSView %p",
                                (void*)self, (void*)(self->view));
-#else
-    return PyString_FromFormat("FigureCanvas object %p wrapping NSView %p",
-                               (void*)self, (void*)(self->view));
-#endif
 }
 
 static PyObject*
@@ -730,13 +719,8 @@ FigureManager_init(FigureManager *self, PyObject *args, PyObject *kwds)
 static PyObject*
 FigureManager_repr(FigureManager* self)
 {
-#if PY3K
     return PyUnicode_FromFormat("FigureManager object %p wrapping NSWindow %p",
                                (void*) self, (void*)(self->window));
-#else
-    return PyString_FromFormat("FigureManager object %p wrapping NSWindow %p",
-                               (void*) self, (void*)(self->window));
-#endif
 }
 
 static void
@@ -1197,11 +1181,7 @@ NavigationToolbar_dealloc(NavigationToolbar *self)
 static PyObject*
 NavigationToolbar_repr(NavigationToolbar* self)
 {
-#if PY3K
     return PyUnicode_FromFormat("NavigationToolbar object %p", (void*)self);
-#else
-    return PyString_FromFormat("NavigationToolbar object %p", (void*)self);
-#endif
 }
 
 static char NavigationToolbar_doc[] =
@@ -1743,11 +1723,7 @@ NavigationToolbar2_dealloc(NavigationToolbar2 *self)
 static PyObject*
 NavigationToolbar2_repr(NavigationToolbar2* self)
 {
-#if PY3K
     return PyUnicode_FromFormat("NavigationToolbar2 object %p", (void*)self);
-#else
-    return PyString_FromFormat("NavigationToolbar2 object %p", (void*)self);
-#endif
 }
 
 static char NavigationToolbar2_doc[] =
@@ -1758,11 +1734,7 @@ NavigationToolbar2_set_message(NavigationToolbar2 *self, PyObject* args)
 {
     const char* message;
 
-#if PY3K
     if(!PyArg_ParseTuple(args, "y", &message)) return NULL;
-#else
-    if(!PyArg_ParseTuple(args, "s", &message)) return NULL;
-#endif
 
     NSText* messagebox = self->messagebox;
 
@@ -1869,11 +1841,7 @@ choose_save_file(PyObject* unused, PyObject* args)
         unsigned int n = [filename length];
         unichar* buffer = malloc(n*sizeof(unichar));
         [filename getCharacters: buffer];
-#if PY3K
-        PyObject* string =  PyUnicode_FromKindAndData(PyUnicode_2BYTE_KIND, buffer, n);
-#else
-        PyObject* string =  PyUnicode_FromUnicode(buffer, n);
-#endif
+        PyObject* string = PyUnicode_FromKindAndData(PyUnicode_2BYTE_KIND, buffer, n);
         free(buffer);
         return string;
     }
@@ -2855,13 +2823,8 @@ Timer_new(PyTypeObject* type, PyObject *args, PyObject *kwds)
 static PyObject*
 Timer_repr(Timer* self)
 {
-#if PY3K
     return PyUnicode_FromFormat("Timer object %p wrapping CFRunLoopTimerRef %p",
                                (void*) self, (void*)(self->timer));
-#else
-    return PyString_FromFormat("Timer object %p wrapping CFRunLoopTimerRef %p",
-                               (void*) self, (void*)(self->timer));
-#endif
 }
 
 static char Timer_doc[] =
@@ -3092,8 +3055,6 @@ static struct PyMethodDef methods[] = {
    {NULL,          NULL, 0, NULL}/* sentinel */
 };
 
-#if PY3K
-
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_macosx",
@@ -3107,11 +3068,6 @@ static struct PyModuleDef moduledef = {
 };
 
 PyObject* PyInit__macosx(void)
-
-#else
-
-void init_macosx(void)
-#endif
 {
     PyObject *module;
 
@@ -3120,31 +3076,15 @@ void init_macosx(void)
      || PyType_Ready(&NavigationToolbarType) < 0
      || PyType_Ready(&NavigationToolbar2Type) < 0
      || PyType_Ready(&TimerType) < 0)
-#if PY3K
         return NULL;
-#else
-        return;
-#endif
 
     NSApp = [NSApplication sharedApplication];
 
     if (!verify_framework())
-#if PY3K
         return NULL;
-#else
-        return;
-#endif
 
-#if PY3K
     module = PyModule_Create(&moduledef);
     if (module==NULL) return NULL;
-#else
-    module = Py_InitModule4("_macosx",
-                            methods,
-                            "Mac OS X native backend",
-                            NULL,
-                            PYTHON_API_VERSION);
-#endif
 
     Py_INCREF(&FigureCanvasType);
     Py_INCREF(&FigureManagerType);
@@ -3168,7 +3108,5 @@ void init_macosx(void)
                                name: NSWorkspaceDidLaunchApplicationNotification
                              object: nil];
     [pool release];
-#if PY3K
     return module;
-#endif
 }

--- a/src/_path.h
+++ b/src/_path.h
@@ -1076,13 +1076,8 @@ char *__add_number(double val, const char *format, int precision,
 {
     char *result;
 
-#if PY_VERSION_HEX >= 0x02070000
     char *str;
     str = PyOS_double_to_string(val, format[0], precision, 0, NULL);
-#else
-    char str[64];
-    PyOS_ascii_formatd(str, 64, format, val);
-#endif
 
     // Delete trailing zeros and decimal point
     char *q = str;
@@ -1104,17 +1099,11 @@ char *__add_number(double val, const char *format, int precision,
     ++q;
     *q = 0;
 
-#if PY_VERSION_HEX >= 0x02070000
     if ((result = __append_to_string(p, buffer, buffersize, str)) == NULL) {
         PyMem_Free(str);
         return NULL;
     }
     PyMem_Free(str);
-#else
-    if ((result = __append_to_string(p, buffer, buffersize, str)) == NULL) {
-        return NULL;
-    }
-#endif
 
     return result;
 }
@@ -1128,12 +1117,7 @@ int __convert_to_string(PathIterator &path,
                         char **buffer,
                         size_t *buffersize)
 {
-#if PY_VERSION_HEX >= 0x02070000
     const char *format = "f";
-#else
-    char format[64];
-    snprintf(format, 64, "%s.%df", "%", precision);
-#endif
 
     char *p = *buffer;
     double x[3];

--- a/src/_path.h
+++ b/src/_path.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef __PATH_H__
-#define __PATH_H__
+#ifndef MPL_PATH_H
+#define MPL_PATH_H
 
 #include <limits>
 #include <math.h>

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -866,7 +866,6 @@ extern "C" {
         {NULL}
     };
 
-#if PY3K
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "_path",
@@ -879,28 +878,17 @@ extern "C" {
         NULL
     };
 
-#define INITERROR return NULL
     PyMODINIT_FUNC PyInit__path(void)
-#else
-#define INITERROR return
-    PyMODINIT_FUNC init_path(void)
-#endif
     {
         PyObject *m;
-#if PY3K
         m = PyModule_Create(&moduledef);
-#else
-        m = Py_InitModule3("_path", module_functions, NULL);
-#endif
 
         if (m == NULL) {
-            INITERROR;
+            return NULL;
         }
 
         import_array();
 
-#if PY3K
         return m;
-#endif
     }
 }

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -61,11 +61,7 @@ static void write_png_data(png_structp png_ptr, png_bytep data, png_size_t lengt
     PyObject *write_method = PyObject_GetAttrString(py_file_obj, "write");
     PyObject *result = NULL;
     if (write_method) {
-#if PY3K
         result = PyObject_CallFunction(write_method, (char *)"y#", data, length);
-#else
-        result = PyObject_CallFunction(write_method, (char *)"s#", data, length);
-#endif
     }
     Py_XDECREF(write_method);
     Py_XDECREF(result);
@@ -232,11 +228,7 @@ static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
         }
         buff.cursor = 0;
     } else {
-        #if PY3K
         if (close_file) {
-        #else
-        if (close_file || PyFile_Check(py_file)) {
-        #endif
             fp = mpl_PyFile_Dup(py_file, (char *)"wb", &offset);
         }
 
@@ -309,7 +301,6 @@ static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
 
         while (PyDict_Next(metadata, &pos, &meta_key, &meta_val)) {
             text[meta_pos].compression = PNG_TEXT_COMPRESSION_NONE;
-#if PY3K
             if (PyUnicode_Check(meta_key)) {
                 PyObject *temp_key = PyUnicode_AsEncodedString(meta_key, "latin_1", "strict");
                 if (temp_key != NULL) {
@@ -332,10 +323,6 @@ static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
             } else {
                 text[meta_pos].text = (char *)"Invalid value in metadata";
             }
-#else
-            text[meta_pos].key = PyString_AsString(meta_key);
-            text[meta_pos].text = PyString_AsString(meta_val);
-#endif
 #ifdef PNG_iTXt_SUPPORTED
             text[meta_pos].lang = NULL;
 #endif
@@ -466,11 +453,7 @@ static PyObject *_read_png(PyObject *filein, bool float_result)
         py_file = filein;
     }
 
-    #if PY3K
     if (close_file) {
-    #else
-    if (close_file || PyFile_Check(py_file)) {
-    #endif
         fp = mpl_PyFile_Dup(py_file, (char *)"rb", &offset);
     }
 
@@ -738,7 +721,6 @@ static PyMethodDef module_methods[] = {
 
 extern "C" {
 
-#if PY3K
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "_png",
@@ -751,27 +733,14 @@ extern "C" {
         NULL
     };
 
-#define INITERROR return NULL
-
     PyMODINIT_FUNC PyInit__png(void)
-
-#else
-#define INITERROR return
-
-    PyMODINIT_FUNC init_png(void)
-#endif
-
     {
         PyObject *m;
 
-#if PY3K
         m = PyModule_Create(&moduledef);
-#else
-        m = Py_InitModule3("_png", module_methods, NULL);
-#endif
 
         if (m == NULL) {
-            INITERROR;
+            return NULL;
         }
 
         import_array();
@@ -781,12 +750,10 @@ extern "C" {
             PyModule_AddIntConstant(m, "PNG_FILTER_UP", PNG_FILTER_UP) ||
             PyModule_AddIntConstant(m, "PNG_FILTER_AVG", PNG_FILTER_AVG) ||
             PyModule_AddIntConstant(m, "PNG_FILTER_PAETH", PNG_FILTER_PAETH)) {
-            INITERROR;
+            return NULL;
         }
 
 
-#if PY3K
         return m;
-#endif
     }
 }

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -322,13 +322,10 @@ int load_tkinter_funcs(void)
 #else  // not Windows
 
 /*
- * On Unix, we can get the TCL and Tk synbols from the tkinter module, because
+ * On Unix, we can get the TCL and Tk symbols from the tkinter module, because
  * tkinter uses these symbols, and the symbols are therefore visible in the
  * tkinter dynamic library (module).
  */
-#if PY_MAJOR_VERSION >= 3
-#define TKINTER_PKG "tkinter"
-#define TKINTER_MOD "_tkinter"
 // From module __file__ attribute to char *string for dlopen.
 char *fname2char(PyObject *fname)
 {
@@ -339,12 +336,6 @@ char *fname2char(PyObject *fname)
     }
     return PyBytes_AsString(bytes);
 }
-#else
-#define TKINTER_PKG "Tkinter"
-#define TKINTER_MOD "tkinter"
-// From module __file__ attribute to char *string for dlopen
-#define fname2char(s) (PyString_AsString(s))
-#endif
 
 #include <dlfcn.h>
 
@@ -402,11 +393,11 @@ int load_tkinter_funcs(void)
     PyErr_Clear();
 
     // Now try finding the tkinter compiled module
-    pModule = PyImport_ImportModule(TKINTER_PKG);
+    pModule = PyImport_ImportModule("tkinter");
     if (pModule == NULL) {
         goto exit;
     }
-    pSubmodule = PyObject_GetAttrString(pModule, TKINTER_MOD);
+    pSubmodule = PyObject_GetAttrString(pModule, "_tkinter");
     if (pSubmodule == NULL) {
         goto exit;
     }
@@ -453,7 +444,6 @@ exit:
 }
 #endif // end not Windows
 
-#if PY_MAJOR_VERSION >= 3
 static PyModuleDef _tkagg_module = { PyModuleDef_HEAD_INIT, "_tkagg", "",   -1,  functions,
                                      NULL,                  NULL,     NULL, NULL };
 
@@ -465,11 +455,3 @@ PyMODINIT_FUNC PyInit__tkagg(void)
 
     return (load_tkinter_funcs() == 0) ? m : NULL;
 }
-#else
-PyMODINIT_FUNC init_tkagg(void)
-{
-    Py_InitModule("_tkagg", functions);
-
-    load_tkinter_funcs();
-}
-#endif

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -109,11 +109,7 @@ static PyObject *convert_ttf_to_ps(PyObject *self, PyObject *args, PyObject *kwd
     static const char *kwlist[] = { "filename", "output", "fonttype", "glyph_ids", NULL };
     if (!PyArg_ParseTupleAndKeywords(args,
                                      kwds,
-#if PY_MAJOR_VERSION == 3
                                      "yO&i|O&:convert_ttf_to_ps",
-#else
-                                     "sO&i|O&:convert_ttf_to_ps",
-#endif
                                      (char **)kwlist,
                                      &filename,
                                      fileobject_to_PythonFileWriter,
@@ -189,11 +185,7 @@ static PyObject *py_get_pdf_charprocs(PyObject *self, PyObject *args, PyObject *
     static const char *kwlist[] = { "filename", "glyph_ids", NULL };
     if (!PyArg_ParseTupleAndKeywords(args,
                                      kwds,
-#if PY_MAJOR_VERSION == 3
                                      "y|O&:get_pdf_charprocs",
-#else
-                                     "s|O&:get_pdf_charprocs",
-#endif
                                      (char **)kwlist,
                                      &filename,
                                      pyiterable_to_vector_int,

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -86,11 +86,7 @@ int pyiterable_to_vector_int(PyObject *object, void *address)
 
     PyObject *item;
     while ((item = PyIter_Next(iterator))) {
-#if PY3K
         long value = PyLong_AsLong(item);
-#else
-        long value = PyInt_AsLong(item);
-#endif
         Py_DECREF(item);
         if (value == -1 && PyErr_Occurred()) {
             return 0;
@@ -279,7 +275,6 @@ static const char *module_docstring =
     "fonts to Postscript Type 3, Postscript Type 42 and "
     "Pdf Type 3 fonts.";
 
-#if PY3K
 static PyModuleDef ttconv_module = {
     PyModuleDef_HEAD_INIT,
     "ttconv",
@@ -298,10 +293,3 @@ PyInit_ttconv(void)
 
     return m;
 }
-#else
-PyMODINIT_FUNC
-initttconv(void)
-{
-    Py_InitModule3("ttconv", ttconv_methods, module_docstring);
-}
-#endif

--- a/src/_windowing.cpp
+++ b/src/_windowing.cpp
@@ -36,8 +36,6 @@ static PyMethodDef _windowing_methods[] =
     {NULL, NULL}
 };
 
-#if PY_MAJOR_VERSION >= 3
-
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "_windowing",
@@ -55,10 +53,3 @@ PyMODINIT_FUNC PyInit__windowing(void)
     PyObject *module = PyModule_Create(&moduledef);
     return module;
 }
-
-#else
-PyMODINIT_FUNC init_windowing()
-{
-    Py_InitModule("_windowing", _windowing_methods);
-}
-#endif

--- a/src/agg_workaround.h
+++ b/src/agg_workaround.h
@@ -1,5 +1,5 @@
-#ifndef __AGG_WORKAROUND_H__
-#define __AGG_WORKAROUND_H__
+#ifndef MPL_AGG_WORKAROUND_H
+#define MPL_AGG_WORKAROUND_H
 
 #include "agg_pixfmt_rgba.h"
 

--- a/src/array.h
+++ b/src/array.h
@@ -3,8 +3,8 @@
 /* Utilities to create scalars and empty arrays that behave like the
    Numpy array wrappers in numpy_cpp.h */
 
-#ifndef _SCALAR_H_
-#define _SCALAR_H_
+#ifndef MPL_SCALAR_H
+#define MPL_SCALAR_H
 
 namespace array
 {

--- a/src/file_compat.h
+++ b/src/file_compat.h
@@ -1,5 +1,5 @@
-#ifndef __FILE_COMPAT_H__
-#define __FILE_COMPAT_H__
+#ifndef MPL_FILE_COMPAT_H
+#define MPL_FILE_COMPAT_H
 
 #include <Python.h>
 #include <stdio.h>
@@ -234,4 +234,4 @@ fail:
 }
 #endif
 
-#endif /* ifndef __FILE_COMPAT_H__ */
+#endif /* ifndef MPL_FILE_COMPAT_H */

--- a/src/file_compat.h
+++ b/src/file_compat.h
@@ -48,7 +48,6 @@ extern "C" {
 /*
  * PyFile_* compatibility
  */
-#if defined(PY3K) | defined(PYPY_VERSION)
 
 /*
  * Get a FILE* handle to the file represented by the Python object
@@ -178,26 +177,6 @@ static NPY_INLINE int mpl_PyFile_Check(PyObject *file)
     }
     return 1;
 }
-
-#else
-
-static NPY_INLINE FILE *mpl_PyFile_Dup(PyObject *file, const char *mode, mpl_off_t *orig_pos)
-{
-    return PyFile_AsFile(file);
-}
-
-static NPY_INLINE int mpl_PyFile_DupClose(PyObject *file, FILE *handle, mpl_off_t orig_pos)
-{
-    // deliberately nothing
-    return 0;
-}
-
-static NPY_INLINE int mpl_PyFile_Check(PyObject *file)
-{
-    return PyFile_Check(file);
-}
-
-#endif
 
 static NPY_INLINE PyObject *mpl_PyFile_OpenFile(PyObject *filename, const char *mode)
 {

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -1,8 +1,8 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
 /* A python interface to FreeType */
-#ifndef _FT2FONT_H
-#define _FT2FONT_H
+#ifndef MPL_FT2FONT_H
+#define MPL_FT2FONT_H
 #include <vector>
 #include <stdint.h>
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -207,7 +207,7 @@ static PyTypeObject *PyFT2Image_init_type(PyObject *m, PyTypeObject *type)
     type->tp_name = "matplotlib.ft2font.FT2Image";
     type->tp_basicsize = sizeof(PyFT2Image);
     type->tp_dealloc = (destructor)PyFT2Image_dealloc;
-    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_NEWBUFFER;
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     type->tp_methods = methods;
     type->tp_new = PyFT2Image_new;
     type->tp_init = (initproc)PyFT2Image_init;
@@ -1656,7 +1656,7 @@ static PyTypeObject *PyFT2Font_init_type(PyObject *m, PyTypeObject *type)
     type->tp_doc = PyFT2Font_init__doc__;
     type->tp_basicsize = sizeof(PyFT2Font);
     type->tp_dealloc = (destructor)PyFT2Font_dealloc;
-    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_NEWBUFFER;
+    type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     type->tp_methods = methods;
     type->tp_getset = getset;
     type->tp_new = PyFT2Font_new;

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1220,17 +1220,10 @@ static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args, PyObj
                              t->maxComponentDepth);
     }
     case 2: {
-#if PY3K
         char os_2_dict[] =
             "{s:H, s:h, s:H, s:H, s:H, s:h, s:h, s:h,"
             "s:h, s:h, s:h, s:h, s:h, s:h, s:h, s:h, s:y#, s:(kkkk),"
             "s:y#, s:H, s:H, s:H}";
-#else
-        char os_2_dict[] =
-            "{s:H, s:h, s:H, s:H, s:H, s:h, s:h, s:h,"
-            "s:h, s:h, s:h, s:h, s:h, s:h, s:h, s:h, s:s#, s:(kkkk),"
-            "s:s#, s:H, s:H, s:H}";
-#endif
         TT_OS2 *t = (TT_OS2 *)table;
         return Py_BuildValue(os_2_dict,
                              "version",
@@ -1377,15 +1370,9 @@ static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args, PyObj
                              t->maxMemType1);
     }
     case 6: {
-        #if PY3K
         char pclt_dict[] =
             "{s:(h,H), s:k, s:H, s:H, s:H, s:H, s:H, s:H, s:y#, s:y#, s:b, "
             "s:b, s:b}";
-        #else
-        char pclt_dict[] =
-            "{s:(h,H), s:k, s:H, s:H, s:H, s:H, s:H, s:H, s:s#, s:s#, s:b, "
-            "s:b, s:b}";
-        #endif
         TT_PCLT *t = (TT_PCLT *)table;
         return Py_BuildValue(pclt_dict,
                              "version",
@@ -1689,7 +1676,6 @@ static PyTypeObject *PyFT2Font_init_type(PyObject *m, PyTypeObject *type)
 
 extern "C" {
 
-#if PY3K
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "ft2font",
@@ -1702,39 +1688,26 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC PyInit_ft2font(void)
-
-#else
-#define INITERROR return
-
-PyMODINIT_FUNC initft2font(void)
-#endif
-
 {
     PyObject *m;
 
-#if PY3K
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("ft2font", NULL, NULL);
-#endif
 
     if (m == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     if (!PyFT2Image_init_type(m, &PyFT2ImageType)) {
-        INITERROR;
+        return NULL;
     }
 
     if (!PyGlyph_init_type(m, &PyGlyphType)) {
-        INITERROR;
+        return NULL;
     }
 
     if (!PyFT2Font_init_type(m, &PyFT2FontType)) {
-        INITERROR;
+        return NULL;
     }
 
     PyObject *d = PyModule_GetDict(m);
@@ -1775,7 +1748,7 @@ PyMODINIT_FUNC initft2font(void)
         add_dict_int(d, "LOAD_TARGET_MONO", (unsigned long)FT_LOAD_TARGET_MONO) ||
         add_dict_int(d, "LOAD_TARGET_LCD", (unsigned long)FT_LOAD_TARGET_LCD) ||
         add_dict_int(d, "LOAD_TARGET_LCD_V", (unsigned long)FT_LOAD_TARGET_LCD_V)) {
-        INITERROR;
+        return NULL;
     }
 
     // initialize library
@@ -1783,7 +1756,7 @@ PyMODINIT_FUNC initft2font(void)
 
     if (error) {
         PyErr_SetString(PyExc_RuntimeError, "Could not initialize the freetype2 library");
-        INITERROR;
+        return NULL;
     }
 
     {
@@ -1793,19 +1766,17 @@ PyMODINIT_FUNC initft2font(void)
         FT_Library_Version(_ft2Library, &major, &minor, &patch);
         sprintf(version_string, "%d.%d.%d", major, minor, patch);
         if (PyModule_AddStringConstant(m, "__freetype_version__", version_string)) {
-            INITERROR;
+            return NULL;
         }
     }
 
     if (PyModule_AddStringConstant(m, "__freetype_build_type__", STRINGIFY(FREETYPE_BUILD_TYPE))) {
-        INITERROR;
+        return NULL;
     }
 
     import_array();
 
-#if PY3K
     return m;
-#endif
 }
 
 } // extern "C"

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -30,9 +30,7 @@ typedef unsigned __int8   uint8_t;
 
 #include <Python.h>
 
-#if PY_MAJOR_VERSION >= 3
 #define Py_TPFLAGS_HAVE_NEWBUFFER 0
-#endif
 
 #undef CLAMP
 #define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -30,8 +30,6 @@ typedef unsigned __int8   uint8_t;
 
 #include <Python.h>
 
-#define Py_TPFLAGS_HAVE_NEWBUFFER 0
-
 #undef CLAMP
 #define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -31,10 +31,7 @@ typedef unsigned __int8   uint8_t;
 #include <Python.h>
 
 #if PY_MAJOR_VERSION >= 3
-#define PY3K 1
 #define Py_TPFLAGS_HAVE_NEWBUFFER 0
-#else
-#define PY3K 0
 #endif
 
 #undef CLAMP

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -2,8 +2,8 @@
 
 /* Small utilities that are shared by most extension modules. */
 
-#ifndef _MPLUTILS_H
-#define _MPLUTILS_H
+#ifndef MPLUTILS_H
+#define MPLUTILS_H
 
 #if defined(_MSC_VER) && _MSC_VER <= 1600
 typedef unsigned __int8   uint8_t;

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef _NUMPY_CPP_H_
-#define _NUMPY_CPP_H_
+#ifndef MPL_NUMPY_CPP_H
+#define MPL_NUMPY_CPP_H
 
 /***************************************************************************
  * This file is based on original work by Mark Wiebe, available at:

--- a/src/path_cleanup.h
+++ b/src/path_cleanup.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef PATH_CLEANUP_H
-#define PATH_CLEANUP_H
+#ifndef MPL_PATH_CLEANUP_H
+#define MPL_PATH_CLEANUP_H
 
 #include <Python.h>
 
@@ -24,4 +24,4 @@ unsigned get_vertex(void *pipeline, double *x, double *y);
 
 void free_path_iterator(void *pipeline);
 
-#endif /* PATH_CLEANUP_H */
+#endif /* MPL_PATH_CLEANUP_H */

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef __PATH_CONVERTERS_H__
-#define __PATH_CONVERTERS_H__
+#ifndef MPL_PATH_CONVERTERS_H
+#define MPL_PATH_CONVERTERS_H
 
 #include <cmath>
 #include <stdint.h>
@@ -1008,4 +1008,4 @@ class Sketch
     RandomNumberGenerator m_rand;
 };
 
-#endif // __PATH_CONVERTERS_H__
+#endif // MPL_PATH_CONVERTERS_H

--- a/src/py_adaptors.h
+++ b/src/py_adaptors.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef __PY_ADAPTORS_H__
-#define __PY_ADAPTORS_H__
+#ifndef MPL_PY_ADAPTORS_H
+#define MPL_PY_ADAPTORS_H
 
 /***************************************************************************
  * This module contains a number of C++ classes that adapt Python data

--- a/src/py_converters.h
+++ b/src/py_converters.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef __PY_CONVERTERS_H__
-#define __PY_CONVERTERS_H__
+#ifndef MPL_PY_CONVERTERS_H
+#define MPL_PY_CONVERTERS_H
 
 /***************************************************************************
  * This module contains a number of conversion functions from Python types

--- a/src/py_exceptions.h
+++ b/src/py_exceptions.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-#ifndef __PY_EXCEPTIONS_H__
-#define __PY_EXCEPTIONS_H__
+#ifndef MPL_PY_EXCEPTIONS_H
+#define MPL_PY_EXCEPTIONS_H
 
 #include <exception>
 #include <stdexcept>

--- a/src/qhull_wrap.c
+++ b/src/qhull_wrap.c
@@ -11,12 +11,6 @@
 #include <stdio.h>
 
 
-#if PY_MAJOR_VERSION >= 3
-#define PY3K 1
-#else
-#define PY3K 0
-#endif
-
 #ifndef MPL_DEVNULL
 #error "MPL_DEVNULL must be defined as the OS-equivalent of /dev/null"
 #endif
@@ -333,7 +327,6 @@ static PyMethodDef qhull_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-#if PY3K
 static struct PyModuleDef qhull_module = {
     PyModuleDef_HEAD_INIT,
     "qhull",
@@ -343,33 +336,18 @@ static struct PyModuleDef qhull_module = {
     NULL, NULL, NULL, NULL
 };
 
-#define ERROR_RETURN return NULL
-
 PyMODINIT_FUNC
 PyInit__qhull(void)
-#else
-#define ERROR_RETURN return
-
-PyMODINIT_FUNC
-init_qhull(void)
-#endif
 {
     PyObject* m;
 
-    #if PY3K
-        m = PyModule_Create(&qhull_module);
-    #else
-        m = Py_InitModule3("_qhull", qhull_methods,
-                           "Computing Delaunay triangulations.\n");
-    #endif
+    m = PyModule_Create(&qhull_module);
 
     if (m == NULL) {
-        ERROR_RETURN;
+        return NULL;
     }
 
     import_array();
 
-    #if PY3K
-        return m;
-    #endif
+    return m;
 }


### PR DESCRIPTION
## PR Summary

Remove a bunch of fallback code and macros that provided Python 2 compatibility in the C extensions. ~~Note, this is based on #7853, #10426 and #10383 because I did not want to work out the conflicts later.~~ I'm putting this out there to prevent duplicate work later.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way