### PR TITLE
Deprecate FigureCanvasQT.keyAutoRepeat.

### DIFF
--- a/doc/api/next_api_changes/2018-02-16-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-16-AL-deprecations.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+The `~.FigureCanvasQT.keyAutoRepeat` property is deprecated.  Directly check
+``event.guiEvent.isAutoRepeat()`` in the event handler to decide whether to
+handle autorepeated key presses.

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import six
 
 import functools
@@ -378,6 +376,8 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             FigureCanvasBase.key_release_event(self, key, guiEvent=event)
 
     @property
+    @cbook.deprecated("3.0", "Manually check `event.guiEvent.isAutoRepeat()` "
+                      "in the event handler.")
     def keyAutoRepeat(self):
         """
         If True, enable auto-repeat for key events.
@@ -385,6 +385,8 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         return self._keyautorepeat
 
     @keyAutoRepeat.setter
+    @cbook.deprecated("3.0", "Manually check `event.guiEvent.isAutoRepeat()` "
+                      "in the event handler.")
     def keyAutoRepeat(self, val):
         self._keyautorepeat = bool(val)
 


### PR DESCRIPTION
No other backend allows ignoring autorepeated keypresses.  Moreover,
such keypresses can easily be ignored in the key press handler by
directly checking on `event.isAutoRepeat()`.

(Some background info: Originally autorepeated keypresses where always ignored in the Qt backend (and only there); making this configurable was added in #6302.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
