### PR TITLE
Move some logging calls down to DEBUG level.

### DIFF
--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -87,7 +87,7 @@ or with matplotlib.use()""" %
     draw_if_interactive = getattr(backend_mod, 'draw_if_interactive',
                                   do_nothing)
 
-    _log.info('backend %s version %s' % (name, backend_version))
+    _log.debug('backend %s version %s', name, backend_version)
 
     # need to keep a global reference to the backend for compatibility
     # reasons. See https://github.com/matplotlib/matplotlib/issues/6092

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1458,7 +1458,7 @@ else:
                 _rebuild()
             else:
                 fontManager.default_size = None
-                _log.info("Using fontManager instance from %s", _fmcache)
+                _log.debug("Using fontManager instance from %s", _fmcache)
         except cbook.Locked.TimeoutError:
             raise
         except:


### PR DESCRIPTION
The idea is that a "normal" import of matplotlib should not trigger log
calls above the DEBUG level, see #10281 for rationale.

I'm allowing myself to tag this as release critical for 2.2 based on the same rationale as #10281, but feel free to disagree.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
