### PR TITLE
Convert six.moves.xrange() to range() for Python 3

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -21,7 +21,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange, zip
+from six.moves import zip
 
 import abc
 import contextlib
@@ -1680,7 +1680,7 @@ class FuncAnimation(TimedAnimation):
             if hasattr(frames, '__len__'):
                 self.save_count = len(frames)
         else:
-            self._iter_gen = lambda: iter(xrange(frames))
+            self._iter_gen = lambda: iter(range(frames))
             self.save_count = frames
 
         if self.save_count is None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange, zip, zip_longest
+from six.moves import zip, zip_longest
 
 import functools
 import itertools
@@ -3923,7 +3923,7 @@ class Axes(_AxesBase):
         else:
             def doplot(*args, **kwargs):
                 shuffled = []
-                for i in xrange(0, len(args), 2):
+                for i in range(0, len(args), 2):
                     shuffled.extend([args[i + 1], args[i]])
                 return self.plot(*shuffled, **kwargs)
 
@@ -3937,7 +3937,7 @@ class Axes(_AxesBase):
                              "values must have same the length")
         # check position
         if positions is None:
-            positions = list(xrange(1, N + 1))
+            positions = list(range(1, N + 1))
         elif len(positions) != N:
             raise ValueError(datashape_message.format("positions"))
 
@@ -4558,15 +4558,15 @@ class Axes(_AxesBase):
 
             # create accumulation arrays
             lattice1 = np.empty((nx1, ny1), dtype=object)
-            for i in xrange(nx1):
-                for j in xrange(ny1):
+            for i in range(nx1):
+                for j in range(ny1):
                     lattice1[i, j] = []
             lattice2 = np.empty((nx2, ny2), dtype=object)
-            for i in xrange(nx2):
-                for j in xrange(ny2):
+            for i in range(nx2):
+                for j in range(ny2):
                     lattice2[i, j] = []
 
-            for i in xrange(len(x)):
+            for i in range(len(x)):
                 if bdist[i]:
                     if 0 <= ix1[i] < nx1 and 0 <= iy1[i] < ny1:
                         lattice1[ix1[i], iy1[i]].append(C[i])
@@ -4574,15 +4574,15 @@ class Axes(_AxesBase):
                     if 0 <= ix2[i] < nx2 and 0 <= iy2[i] < ny2:
                         lattice2[ix2[i], iy2[i]].append(C[i])
 
-            for i in xrange(nx1):
-                for j in xrange(ny1):
+            for i in range(nx1):
+                for j in range(ny1):
                     vals = lattice1[i, j]
                     if len(vals) > mincnt:
                         lattice1[i, j] = reduce_C_function(vals)
                     else:
                         lattice1[i, j] = np.nan
-            for i in xrange(nx2):
-                for j in xrange(ny2):
+            for i in range(nx2):
+                for j in range(ny2):
                     vals = lattice2[i, j]
                     if len(vals) > mincnt:
                         lattice2[i, j] = reduce_C_function(vals)
@@ -6410,7 +6410,7 @@ class Axes(_AxesBase):
         """
         # Avoid shadowing the builtin.
         bin_range = range
-        del range
+        from builtins import range
 
         if not self._hold:
             self.cla()
@@ -6480,7 +6480,7 @@ class Axes(_AxesBase):
                     'weights should have the same shape as x')
 
         if color is None:
-            color = [self._get_lines.get_next_color() for i in xrange(nx)]
+            color = [self._get_lines.get_next_color() for i in range(nx)]
         else:
             color = mcolors.to_rgba_array(color)
             if len(color) != nx:
@@ -6507,7 +6507,7 @@ class Axes(_AxesBase):
         tops = []
         mlast = None
         # Loop through datasets
-        for i in xrange(nx):
+        for i in range(nx):
             # this will automatically overwrite bins,
             # so that each histogram uses the same bins
             m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 from collections import OrderedDict
 
 import six
-from six.moves import xrange
 
 import itertools
 import warnings
@@ -393,7 +392,7 @@ class _process_plot_var_args(object):
         if ncx > 1 and ncy > 1 and ncx != ncy:
             cbook.warn_deprecated("2.2", "cycling among columns of inputs "
                                   "with non-matching shapes is deprecated.")
-        for j in xrange(max(ncx, ncy)):
+        for j in range(max(ncx, ncy)):
             seg = func(x[:, j % ncx], y[:, j % ncy], kw, kwargs)
             ret.append(seg)
         return ret

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -36,7 +36,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 from contextlib import contextmanager
 from functools import partial
@@ -440,7 +439,7 @@ class RendererBase(object):
             return
 
         transform = transforms.IdentityTransform()
-        for i in xrange(N):
+        for i in range(N):
             path = paths[i % Npaths]
             if Ntransforms:
                 transform = Affine2D(all_transforms[i % Ntransforms])
@@ -518,7 +517,7 @@ class RendererBase(object):
             gc0.set_linewidth(0.0)
 
         xo, yo = 0, 0
-        for i in xrange(N):
+        for i in range(N):
             path_id = path_ids[i % Npaths]
             if Noffsets:
                 xo, yo = toffsets[i % Noffsets]

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 
 import six
 from six import unichr
-from six.moves import xrange
 
 import base64
 import codecs
@@ -1112,7 +1111,7 @@ class RendererSVG(RendererBase):
                 same_y = True
                 if len(chars) > 1:
                     last_y = chars[0][1]
-                    for i in xrange(1, len(chars)):
+                    for i in range(1, len(chars)):
                         if chars[i][1] != last_y:
                             same_y = False
                             break

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -17,8 +17,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
-import six
 
 import sys
 import os
@@ -1448,7 +1446,7 @@ class MenuButtonWx(wx.Button):
             for menuId in self._axisId[maxAxis:]:
                 self._menu.Delete(menuId)
             self._axisId = self._axisId[:maxAxis]
-        self._toolbar.set_active(list(xrange(maxAxis)))
+        self._toolbar.set_active(list(range(maxAxis)))
 
     def getActiveAxes(self):
         """Return a list of the selected axes."""

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -498,9 +498,9 @@ class ColorbarBase(cm.ScalarMappable):
         # Using the non-array form of these line segments is much
         # simpler than making them into arrays.
         if self.orientation == 'vertical':
-            return [list(zip(X[i], Y[i])) for i in xrange(1, N - 1)]
+            return [list(zip(X[i], Y[i])) for i in range(1, N - 1)]
         else:
-            return [list(zip(Y[i], X[i])) for i in xrange(1, N - 1)]
+            return [list(zip(Y[i], X[i])) for i in range(1, N - 1)]
 
     def _add_solids(self, X, Y, C):
         '''
@@ -1337,7 +1337,7 @@ class ColorbarPatch(Colorbar):
         hatches = self.mappable.hatches * n_segments
 
         patches = []
-        for i in xrange(len(X) - 1):
+        for i in range(len(X) - 1):
             val = C[i][0]
             hatch = hatches[i]
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 import warnings
 import matplotlib as mpl
@@ -164,7 +163,7 @@ class ContourLabeler(object):
         self.rightside_up = kwargs.get('rightside_up', True)
         if len(args) == 0:
             levels = self.levels
-            indices = list(xrange(len(self.cvalues)))
+            indices = list(range(len(self.cvalues)))
         elif len(args) == 1:
             levlabs = list(args[0])
             indices, levels = [], []
@@ -190,7 +189,7 @@ class ContourLabeler(object):
             self.labelCValueList = np.take(self.cvalues, self.labelIndiceList)
         else:
             cmap = colors.ListedColormap(_colors, N=len(self.labelLevelList))
-            self.labelCValueList = list(xrange(len(self.labelLevelList)))
+            self.labelCValueList = list(range(len(self.labelLevelList)))
             self.labelMappable = cm.ScalarMappable(cmap=cmap,
                                                    norm=colors.NoNorm())
 
@@ -1340,7 +1339,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         # Nonetheless, improvements could probably be made.
 
         if indices is None:
-            indices = list(xrange(len(self.levels)))
+            indices = list(range(len(self.levels)))
 
         dmin = np.inf
         conmin = None

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 import numpy as np
 from matplotlib.path import Path
@@ -115,7 +114,7 @@ class Shapes(HatchPatternBase):
         shape_size = len(shape_vertices)
 
         cursor = 0
-        for row in xrange(self.num_rows + 1):
+        for row in range(self.num_rows + 1):
             if row % 2 == 0:
                 cols = np.linspace(0.0, 1.0, self.num_rows + 1, True)
             else:

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -87,7 +87,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 from collections import Sized
 from numbers import Number
@@ -101,7 +100,7 @@ from .transforms import IdentityTransform, Affine2D
 # special-purpose marker identifiers:
 (TICKLEFT, TICKRIGHT, TICKUP, TICKDOWN,
  CARETLEFT, CARETRIGHT, CARETUP, CARETDOWN,
- CARETLEFTBASE, CARETRIGHTBASE, CARETUPBASE, CARETDOWNBASE) = xrange(12)
+ CARETLEFTBASE, CARETRIGHTBASE, CARETUPBASE, CARETDOWNBASE) = range(12)
 
 _empty_path = Path(np.empty((0, 2)))
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -166,7 +166,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import map, xrange, zip
+from six.moves import map, zip
 
 import copy
 import csv
@@ -1453,7 +1453,7 @@ def cohere_pairs(X, ij, NFFT=256, Fs=2, detrend=detrend_none,
         windowVals = window
     else:
         windowVals = window(np.ones(NFFT, X.dtype))
-    ind = list(xrange(0, numRows-NFFT+1, NFFT-noverlap))
+    ind = list(range(0, numRows-NFFT+1, NFFT-noverlap))
     numSlices = len(ind)
     FFTSlices = {}
     FFTConjSlices = {}

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -18,7 +18,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange, zip
+from six.moves import zip
 
 import warnings
 import matplotlib.transforms as mtransforms
@@ -1194,7 +1194,7 @@ class AnchoredOffsetbox(OffsetBox):
         """
         assert loc in range(1, 11)  # called only internally
 
-        BEST, UR, UL, LL, LR, R, CL, CR, LC, UC, C = xrange(11)
+        BEST, UR, UL, LL, LR, R, CL, CR, LC, UC, C = range(11)
 
         anchor_coefs = {UR: "NE",
                         UL: "NW",

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -9,9 +9,6 @@ http://stackoverflow.com/questions/2225995/how-can-i-create-stacked-line-graph-w
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
-from six.moves import xrange
-
 from cycler import cycler
 import numpy as np
 
@@ -120,7 +117,7 @@ def stackplot(axes, x, *args, **kwargs):
     r = [coll]
 
     # Color between array i-1 and array i
-    for i in xrange(len(y) - 1):
+    for i in range(len(y) - 1):
         color = axes._get_lines.get_next_color()
         r.append(axes.fill_between(x, stack[i, :], stack[i + 1, :],
                                    facecolor=color, label=next(labels, None),

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 import numpy as np
 import matplotlib
@@ -648,7 +647,7 @@ def _gen_starting_points(shape):
     x, y = 0, 0
     i = 0
     direction = 'right'
-    for i in xrange(nx * ny):
+    for i in range(nx * ny):
 
         yield x, y
 

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -23,7 +23,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 import warnings
 
@@ -551,7 +550,7 @@ class Table(Artist):
         else:
             # Position using loc
             (BEST, UR, UL, LL, LR, CL, CR, LC, UC, C,
-             TR, TL, BL, BR, R, L, T, B) = xrange(len(self.codes))
+             TR, TL, BL, BR, R, L, T, B) = range(len(self.codes))
             # defaults for center
             ox = (0.5 - w / 2) - l
             oy = (0.5 - h / 2) - b
@@ -670,8 +669,8 @@ def table(ax,
     height = table._approx_text_height()
 
     # Add the cells
-    for row in xrange(rows):
-        for col in xrange(cols):
+    for row in range(rows):
+        for col in range(cols):
             table.add_cell(row + offset, col,
                            width=colWidths[col], height=height,
                            text=cellText[row][col],
@@ -679,7 +678,7 @@ def table(ax,
                            loc=cellLoc)
     # Do column labels
     if colLabels is not None:
-        for col in xrange(cols):
+        for col in range(cols):
             table.add_cell(0, col,
                            width=colWidths[col], height=height,
                            text=colLabels[col], facecolor=colColours[col],
@@ -687,7 +686,7 @@ def table(ax,
 
     # Do row labels
     if rowLabels is not None:
-        for row in xrange(rows):
+        for row in range(rows):
             table.add_cell(row + offset, -1,
                            width=rowLabelWidth or 1e-15, height=height,
                            text=rowLabels[row], facecolor=rowColours[row],

--- a/lib/matplotlib/testing/jpl_units/StrConverter.py
+++ b/lib/matplotlib/testing/jpl_units/StrConverter.py
@@ -14,7 +14,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 import matplotlib.units as units
 from matplotlib.cbook import iterable
@@ -119,7 +118,7 @@ class StrConverter( units.ConversionInterface ):
 
       # add padding (so they do not appear on the axes themselves)
       labels = [ '' ] + labels + [ '' ]
-      ticks = list(xrange( len(labels) ))
+      ticks = list(range( len(labels) ))
       ticks[0] = 0.5
       ticks[-1] = ticks[-1] - 0.5
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import six
-from six.moves import xrange
 from itertools import chain, product
 from distutils.version import LooseVersion
 import io
@@ -283,7 +282,7 @@ def test_autoscale_tiny_range():
     # github pull #904
     fig, ax = plt.subplots(2, 2)
     ax = ax.flatten()
-    for i in xrange(4):
+    for i in range(4):
         y1 = 10**(-11 - i)
         ax[i].plot([0, 1], [1, 1 + y1])
 
@@ -2888,8 +2887,8 @@ def test_stem_args():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
 
-    x = list(xrange(10))
-    y = list(xrange(10))
+    x = list(range(10))
+    y = list(range(10))
 
     # Test the call signatures
     ax.stem(y)
@@ -3261,7 +3260,7 @@ def test_markers_fillstyle_rcparams():
 @image_comparison(baseline_images=['vertex_markers'], extensions=['png'],
                   remove_text=True)
 def test_vertex_markers():
-    data = list(xrange(10))
+    data = list(range(10))
     marker_as_tuple = ((-1, -1), (1, -1), (1, 1), (-1, 1))
     marker_as_list = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
     fig = plt.figure()
@@ -3275,7 +3274,7 @@ def test_vertex_markers():
 @image_comparison(baseline_images=['vline_hline_zorder',
                                    'errorbar_zorder'])
 def test_eb_line_zorder():
-    x = list(xrange(10))
+    x = list(range(10))
 
     # First illustrate basic pyplot interface, using defaults where possible.
     fig = plt.figure()
@@ -3291,9 +3290,9 @@ def test_eb_line_zorder():
     # Now switch to a more OO interface to exercise more features.
     fig = plt.figure()
     ax = fig.gca()
-    x = list(xrange(10))
+    x = list(range(10))
     y = np.zeros(10)
-    yerr = list(xrange(10))
+    yerr = list(range(10))
     ax.errorbar(x, y, yerr=yerr, zorder=5, lw=5, color='r')
     for j in range(10):
         ax.axhline(j, lw=5, color='k', zorder=j)
@@ -3422,7 +3421,7 @@ def test_mixed_collection():
     from matplotlib import patches
     from matplotlib import collections
 
-    x = list(xrange(10))
+    x = list(range(10))
 
     # First illustrate basic pyplot interface, using defaults where possible.
     fig = plt.figure()

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import xrange
 
 from matplotlib.tri import Triangulation
 from matplotlib.tri.trifinder import TriFinder
@@ -1533,7 +1532,7 @@ def _prod_vectorized(M1, M2):
     assert sh1[-1] == sh2[-2]
 
     ndim1 = len(sh1)
-    t1_index = list(xrange(ndim1-2)) + [ndim1-1, ndim1-2]
+    t1_index = list(range(ndim1-2)) + [ndim1-1, ndim1-2]
     return np.sum(np.transpose(M1, t1_index)[..., np.newaxis] *
                   M2[..., np.newaxis, :], -3)
 

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -583,9 +583,9 @@ class ColorbarBase(cm.ScalarMappable):
         x = np.array([1.0, 2.0])
         X, Y = np.meshgrid(x,levels)
         if self.orientation == 'vertical':
-            xy = [list(zip(X[i], Y[i])) for i in xrange(N)]
+            xy = [list(zip(X[i], Y[i])) for i in range(N)]
         else:
-            xy = [list(zip(Y[i], X[i])) for i in xrange(N)]
+            xy = [list(zip(Y[i], X[i])) for i in range(N)]
         col = collections.LineCollection(xy, linewidths=linewidths,
                                          )
         self.lines = col

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -13,7 +13,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from six.moves import map, xrange, zip, reduce
+from six.moves import map, zip, reduce
 
 import math
 import warnings
@@ -1693,8 +1693,8 @@ class Axes3D(Axes):
 
         #colset contains the data for coloring: either average z or the facecolor
         colset = []
-        for rs in xrange(0, rows-1, rstride):
-            for cs in xrange(0, cols-1, cstride):
+        for rs in range(0, rows-1, rstride):
+            for cs in range(0, cols-1, cstride):
                 ps = []
                 for a in (X, Y, Z):
                     ztop = a[rs,cs:min(cols, cs+cstride+1)]
@@ -1709,7 +1709,7 @@ class Axes3D(Axes):
                 # are removed here.
                 ps = list(zip(*ps))
                 lastp = np.array([])
-                ps2 = [ps[0]] + [ps[i] for i in xrange(1, len(ps)) if ps[i] != ps[i-1]]
+                ps2 = [ps[0]] + [ps[i] for i in range(1, len(ps)) if ps[i] != ps[i-1]]
                 avgzsum = sum(p[2] for p in ps2)
                 polys.append(ps2)
 
@@ -1878,14 +1878,14 @@ class Axes3D(Axes):
         tX, tY, tZ = np.transpose(X), np.transpose(Y), np.transpose(Z)
 
         if rstride:
-            rii = list(xrange(0, rows, rstride))
+            rii = list(range(0, rows, rstride))
             # Add the last index only if needed
             if rows > 0 and rii[-1] != (rows - 1):
                 rii += [rows-1]
         else:
             rii = []
         if cstride:
-            cii = list(xrange(0, cols, cstride))
+            cii = list(range(0, cols, cstride))
             # Add the last index only if needed
             if cols > 0 and cii[-1] != (cols - 1):
                 cii += [cols-1]


### PR DESCRIPTION
## PR Summary
As part of dropping support for Python 2, we can simplify the code by:
* removing all instances __from six.moves import xrange__ and
* converting all calls to __xrange()__ into calls to __range()__.