### PR TITLE
FIX: TypeError when using offset box in expand mode with tightlayout

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -83,6 +83,10 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
             sep = 0
         offsets_ = np.cumsum([0] + [w + sep for w in w_list])
         offsets = offsets_[:-1]
+        # this is a bit of a hack to avoid a TypeError when used
+        # in conjugation with tight layout
+        if total is None:
+            total = 1
         return total, offsets
 
     elif mode == "equal":

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -98,3 +98,19 @@ def test_offsetbox_loc_codes():
         anchored_box = AnchoredOffsetbox(loc=code, child=da)
         ax.add_artist(anchored_box)
     fig.canvas.draw()
+
+
+def test_expand_with_tight_layout():
+    fig = plt.figure()
+    axes = fig.add_subplot(111)
+
+    d1 = [29388871, 12448, 40, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0]
+    d2 = [28396236, 981940, 22171, 537, 123, 88, 41, 42, 40, 26, 26,
+          84, 6, 2, 0, 0, 0, 0, 0]
+    axes.plot(d1, label='series 1')
+    axes.plot(d2, label='series 2')
+    axes.legend(mode='expand')
+
+    # ### THIS IS WHERE THE CRASH HAPPENS
+    plt.tight_layout(rect=[0, 0.08, 1, 0.92])


### PR DESCRIPTION
Perfect minimal example from @ewels
suggested fix from @afvincent

Fixes #10476

## PR Summary

## PR Checklist

- [x] as Pytest style unit tests
- [x] Code is PEP 8 compliant
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
