### PR TITLE
TST: Replace assert_equal with plain asserts.

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt5.py
+++ b/lib/matplotlib/tests/test_backend_qt5.py
@@ -6,8 +6,6 @@ import matplotlib
 from matplotlib import pyplot as plt
 from matplotlib._pylab_helpers import Gcf
 
-from numpy.testing import assert_equal
-
 import pytest
 try:
     # mock in python 3.3+
@@ -135,8 +133,8 @@ def test_dpi_ratio_change():
         # The actual widget size and figure physical size don't change
         assert size.width() == 600
         assert size.height() == 240
-        assert_equal(qt_canvas.get_width_height(), (600, 240))
-        assert_equal(fig.get_size_inches(), (5, 2))
+        assert qt_canvas.get_width_height() == (600, 240)
+        assert (fig.get_size_inches() == (5, 2)).all()
 
         p.return_value = 2
 
@@ -158,8 +156,8 @@ def test_dpi_ratio_change():
         # The actual widget size and figure physical size don't change
         assert size.width() == 600
         assert size.height() == 240
-        assert_equal(qt_canvas.get_width_height(), (600, 240))
-        assert_equal(fig.get_size_inches(), (5, 2))
+        assert qt_canvas.get_width_height() == (600, 240)
+        assert (fig.get_size_inches() == (5, 2)).all()
 
 
 @pytest.mark.backend('Qt5Agg')

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, print_function
 import io
 
 import numpy as np
-from numpy.testing import (
-    assert_array_equal, assert_array_almost_equal, assert_equal)
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pytest
 
 import matplotlib.pyplot as plt
@@ -87,7 +86,7 @@ def test__EventCollection__get_orientation():
     orientation
     '''
     _, coll, props = generate_EventCollection_plot()
-    assert_equal(props['orientation'], coll.get_orientation())
+    assert props['orientation'] == coll.get_orientation()
 
 
 def test__EventCollection__is_horizontal():
@@ -96,7 +95,7 @@ def test__EventCollection__is_horizontal():
     orientation
     '''
     _, coll, _ = generate_EventCollection_plot()
-    assert_equal(True, coll.is_horizontal())
+    assert coll.is_horizontal()
 
 
 def test__EventCollection__get_linelength():
@@ -104,7 +103,7 @@ def test__EventCollection__get_linelength():
     check to make sure the default linelength matches the input linelength
     '''
     _, coll, props = generate_EventCollection_plot()
-    assert_equal(props['linelength'], coll.get_linelength())
+    assert props['linelength'] == coll.get_linelength()
 
 
 def test__EventCollection__get_lineoffset():
@@ -112,7 +111,7 @@ def test__EventCollection__get_lineoffset():
     check to make sure the default lineoffset matches the input lineoffset
     '''
     _, coll, props = generate_EventCollection_plot()
-    assert_equal(props['lineoffset'], coll.get_lineoffset())
+    assert props['lineoffset'] == coll.get_lineoffset()
 
 
 def test__EventCollection__get_linestyle():
@@ -120,7 +119,7 @@ def test__EventCollection__get_linestyle():
     check to make sure the default linestyle matches the input linestyle
     '''
     _, coll, _ = generate_EventCollection_plot()
-    assert_equal(coll.get_linestyle(), [(None, None)])
+    assert coll.get_linestyle() == [(None, None)]
 
 
 def test__EventCollection__get_color():
@@ -214,8 +213,8 @@ def test__EventCollection__switch_orientation():
     splt, coll, props = generate_EventCollection_plot()
     new_orientation = 'vertical'
     coll.switch_orientation()
-    assert_equal(new_orientation, coll.get_orientation())
-    assert_equal(False, coll.is_horizontal())
+    assert new_orientation == coll.get_orientation()
+    assert not coll.is_horizontal()
     new_positions = coll.get_positions()
     check_segments(coll,
                    new_positions,
@@ -237,8 +236,8 @@ def test__EventCollection__switch_orientation_2x():
     coll.switch_orientation()
     coll.switch_orientation()
     new_positions = coll.get_positions()
-    assert_equal(props['orientation'], coll.get_orientation())
-    assert_equal(True, coll.is_horizontal())
+    assert props['orientation'] == coll.get_orientation()
+    assert coll.is_horizontal()
     np.testing.assert_array_equal(props['positions'], new_positions)
     check_segments(coll,
                    new_positions,
@@ -256,8 +255,8 @@ def test__EventCollection__set_orientation():
     splt, coll, props = generate_EventCollection_plot()
     new_orientation = 'vertical'
     coll.set_orientation(new_orientation)
-    assert_equal(new_orientation, coll.get_orientation())
-    assert_equal(False, coll.is_horizontal())
+    assert new_orientation == coll.get_orientation()
+    assert not coll.is_horizontal()
     check_segments(coll,
                    props['positions'],
                    props['linelength'],
@@ -276,7 +275,7 @@ def test__EventCollection__set_linelength():
     splt, coll, props = generate_EventCollection_plot()
     new_linelength = 15
     coll.set_linelength(new_linelength)
-    assert_equal(new_linelength, coll.get_linelength())
+    assert new_linelength == coll.get_linelength()
     check_segments(coll,
                    props['positions'],
                    new_linelength,
@@ -294,7 +293,7 @@ def test__EventCollection__set_lineoffset():
     splt, coll, props = generate_EventCollection_plot()
     new_lineoffset = -5.
     coll.set_lineoffset(new_lineoffset)
-    assert_equal(new_lineoffset, coll.get_lineoffset())
+    assert new_lineoffset == coll.get_lineoffset()
     check_segments(coll,
                    props['positions'],
                    props['linelength'],
@@ -312,7 +311,7 @@ def test__EventCollection__set_linestyle():
     splt, coll, _ = generate_EventCollection_plot()
     new_linestyle = 'dashed'
     coll.set_linestyle(new_linestyle)
-    assert_equal(coll.get_linestyle(), [(0, (6.0, 6.0))])
+    assert coll.get_linestyle() == [(0, (6.0, 6.0))]
     splt.set_title('EventCollection: set_linestyle')
 
 
@@ -325,7 +324,7 @@ def test__EventCollection__set_linestyle_single_dash():
     splt, coll, _ = generate_EventCollection_plot()
     new_linestyle = (0, (6., 6.))
     coll.set_linestyle(new_linestyle)
-    assert_equal(coll.get_linestyle(), [(0, (6.0, 6.0))])
+    assert coll.get_linestyle() == [(0, (6.0, 6.0))]
     splt.set_title('EventCollection: set_linestyle')
 
 
@@ -337,7 +336,7 @@ def test__EventCollection__set_linewidth():
     splt, coll, _ = generate_EventCollection_plot()
     new_linewidth = 5
     coll.set_linewidth(new_linewidth)
-    assert_equal(coll.get_linewidth(), new_linewidth)
+    assert coll.get_linewidth() == new_linewidth
     splt.set_title('EventCollection: set_linewidth')
 
 
@@ -376,10 +375,10 @@ def check_segments(coll, positions, linelength, lineoffset, orientation):
 
     # test to make sure each segment is correct
     for i, segment in enumerate(segments):
-        assert_equal(segment[0, pos1], lineoffset + linelength / 2.)
-        assert_equal(segment[1, pos1], lineoffset - linelength / 2.)
-        assert_equal(segment[0, pos2], positions[i])
-        assert_equal(segment[1, pos2], positions[i])
+        assert segment[0, pos1] == lineoffset + linelength / 2
+        assert segment[1, pos1] == lineoffset - linelength / 2
+        assert segment[0, pos2] == positions[i]
+        assert segment[1, pos2] == positions[i]
 
 
 def check_allprop_array(values, target):
@@ -408,7 +407,7 @@ def test_add_collection():
     ax.add_collection(coll)
     bounds = ax.dataLim.bounds
     coll = ax.scatter([], [])
-    assert_equal(ax.dataLim.bounds, bounds)
+    assert ax.dataLim.bounds == bounds
 
 
 def test_quiver_limits():
@@ -416,7 +415,7 @@ def test_quiver_limits():
     x, y = np.arange(8), np.arange(10)
     u = v = np.linspace(0, 10, 80).reshape(10, 8)
     q = plt.quiver(x, y, u, v)
-    assert_equal(q.get_datalim(ax.transData).bounds, (0., 0., 7., 9.))
+    assert q.get_datalim(ax.transData).bounds == (0., 0., 7., 9.)
 
     plt.figure()
     ax = plt.axes()
@@ -425,7 +424,7 @@ def test_quiver_limits():
     y, x = np.meshgrid(y, x)
     trans = mtransforms.Affine2D().translate(25, 32) + ax.transData
     plt.quiver(x, y, np.sin(x), np.cos(y), transform=trans)
-    assert_equal(ax.dataLim.bounds, (20.0, 30.0, 15.0, 6.0))
+    assert ax.dataLim.bounds == (20.0, 30.0, 15.0, 6.0)
 
 
 def test_barb_limits():
@@ -615,28 +614,28 @@ def test_lslw_bcast():
     col.set_linestyles(['-', '-'])
     col.set_linewidths([1, 2, 3])
 
-    assert_equal(col.get_linestyles(), [(None, None)] * 6)
-    assert_equal(col.get_linewidths(), [1, 2, 3] * 2)
+    assert col.get_linestyles() == [(None, None)] * 6
+    assert col.get_linewidths() == [1, 2, 3] * 2
 
     col.set_linestyles(['-', '-', '-'])
-    assert_equal(col.get_linestyles(), [(None, None)] * 3)
-    assert_equal(col.get_linewidths(), [1, 2, 3])
+    assert col.get_linestyles() == [(None, None)] * 3
+    assert (col.get_linewidths() == [1, 2, 3]).all()
 
 
 @pytest.mark.style('default')
 def test_capstyle():
     col = mcollections.PathCollection([], capstyle='round')
-    assert_equal(col.get_capstyle(), 'round')
+    assert col.get_capstyle() == 'round'
     col.set_capstyle('butt')
-    assert_equal(col.get_capstyle(), 'butt')
+    assert col.get_capstyle() == 'butt'
 
 
 @pytest.mark.style('default')
 def test_joinstyle():
     col = mcollections.PathCollection([], joinstyle='round')
-    assert_equal(col.get_joinstyle(), 'round')
+    assert col.get_joinstyle() == 'round'
     col.set_joinstyle('miter')
-    assert_equal(col.get_joinstyle(), 'miter')
+    assert col.get_joinstyle() == 'miter'
 
 
 @image_comparison(baseline_images=['cap_and_joinstyle'],


### PR DESCRIPTION
## PR Summary
Just found this lying around on my laptop and thought I should get it out there. No need for an external call when pytest rewrites this neatly already. 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way