### PR TITLE
Source typos

### DIFF
--- a/doc/devel/MEP/MEP28.rst
+++ b/doc/devel/MEP/MEP28.rst
@@ -254,13 +254,13 @@ This MEP can be divided into a few loosely coupled components:
 With this approach, #2 depends and #1, and #4 depends on #3.
 
 There are two possible approaches to #2. The first and most direct would
-be to mirror the new ``transform_in`` and ``tranform_out`` parameters of
+be to mirror the new ``transform_in`` and ``transform_out`` parameters of
 ``cbook.boxplot_stats`` in ``Axes.boxplot`` and pass them directly.
 
 The second approach would be to add ``statfxn`` and ``statfxn_args``
 parameters to ``Axes.boxplot``. Under this implementation, the default
 value of ``statfxn`` would be ``cbook.boxplot_stats``, but users could
-pass their own function. Then ``transform_in`` and ``tranform_out`` would
+pass their own function. Then ``transform_in`` and ``transform_out`` would
 then be passed as elements of the ``statfxn_args`` parameter.
 
 .. code:: python

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -99,7 +99,7 @@ Occasionally the internal documentation (python docstrings) will refer
 to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
 
 """
-# NOTE: This file must remain Python 2 compatible for the forseeable future,
+# NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for existing editable installs.
 from __future__ import absolute_import, division, print_function
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1797,7 +1797,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lags : array (lenth ``2*maxlags+1``)
+        lags : array (length ``2*maxlags+1``)
             lag vector.
         c : array  (length ``2*maxlags+1``)
             auto correlation vector.
@@ -1859,7 +1859,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lags : array (lenth ``2*maxlags+1``)
+        lags : array (length ``2*maxlags+1``)
             lag vector.
         c : array  (length ``2*maxlags+1``)
             auto correlation vector.

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -23,7 +23,7 @@ ETS = dict(pyqt=(QT_API_PYQTv2, 4), pyside=(QT_API_PYSIDE, 4),
            pyqt5=(QT_API_PYQT5, 5), pyside2=(QT_API_PYSIDE2, 5))
 # ETS is a dict of env variable to (QT_API, QT_MAJOR_VERSION)
 # If the ETS QT_API environment variable is set, use it, but only
-# if the varible if of the same major QT version.  Note that
+# if the variable if of the same major QT version.  Note that
 # ETS requires the version 2 of PyQt4, which is not the platform
 # default for Python 2.x.
 

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -23,7 +23,7 @@ ETS = dict(pyqt=(QT_API_PYQTv2, 4), pyside=(QT_API_PYSIDE, 4),
            pyqt5=(QT_API_PYQT5, 5), pyside2=(QT_API_PYSIDE2, 5))
 # ETS is a dict of env variable to (QT_API, QT_MAJOR_VERSION)
 # If the ETS QT_API environment variable is set, use it, but only
-# if the variable if of the same major QT version.  Note that
+# if the variable is of the same major QT version.  Note that
 # ETS requires the version 2 of PyQt4, which is not the platform
 # default for Python 2.x.
 

--- a/lib/matplotlib/backends/web_backend/jquery/js/jquery-1.11.3.js
+++ b/lib/matplotlib/backends/web_backend/jquery/js/jquery-1.11.3.js
@@ -6708,7 +6708,7 @@ jQuery.extend({
 				value += "px";
 			}
 
-			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
+			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 			// but it would mean to define eight (for every problematic property) identical functions
 			if ( !support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
 				style[ name ] = "inherit";

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -317,7 +317,7 @@ class Line2D(Artist):
 
         %(Line2D)s
 
-        See :meth:`set_linestyle` for a decription of the line styles,
+        See :meth:`set_linestyle` for a description of the line styles,
         :meth:`set_marker` for a description of the markers, and
         :meth:`set_drawstyle` for a description of the draw styles.
 

--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -131,7 +131,7 @@ _Matrix commands
   cumsum    - the cumulative sum along a dimension
   detrend   - remove the mean or besdt fit line from an array
   diag      - the k-th diagonal of matrix
-  diff      - the n-th differnce of an array
+  diff      - the n-th difference of an array
   eig       - the eigenvalues and eigen vectors of v
   eye       - a matrix where the k-th diagonal is ones, else zero
   find      - return the indices where a condition is nonzero

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -254,7 +254,7 @@ class BboxConnector(Patch):
             corner of *bbox2*.
         """
         if isinstance(bbox1, Rectangle):
-            transform = bbox1.get_transfrom()
+            transform = bbox1.get_transform()
             bbox1 = Bbox.from_bounds(0, 0, 1, 1)
             bbox1 = TransformedBbox(bbox1, transform)
 

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -348,8 +348,8 @@ class ExtremeFinderCycle(ExtremeFinderSimple):
                  lon_minmax = None,
                  lat_minmax = (-90, 90)
                  ):
-        #self.transfrom_xy = transform_xy
-        #self.inv_transfrom_xy = inv_transform_xy
+        #self.transform_xy = transform_xy
+        #self.inv_transform_xy = inv_transform_xy
         self.nx, self.ny = nx, ny
         self.lon_cycle, self.lat_cycle = lon_cycle, lat_cycle
         self.lon_minmax = lon_minmax

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ The matplotlib build options can be modified with a setup.cfg file. See
 setup.cfg.template for more information.
 """
 
-# NOTE: This file must remain Python 2 compatible for the forseeable future,
+# NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
 from __future__ import print_function, absolute_import


### PR DESCRIPTION
along with misc. source typos. Found via `codespell -q 3 -I ../matplotlib-whitelist.txt`