### PR TITLE
Simplify rst cross references by omitting the shortener ~ when not needed

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -306,8 +306,8 @@ class Artist(object):
 
         Parameters
         ----------
-        t : `~.Transform`
-            .. ACCEPTS: `~.Transform`
+        t : `.Transform`
+            .. ACCEPTS: `.Transform`
         """
         self._transform = t
         self._transformSet = True
@@ -469,7 +469,7 @@ class Artist(object):
 
     @cbook.deprecated("2.2", "artist.figure is not None")
     def is_figure_set(self):
-        """Returns whether the artist is assigned to a `~.Figure`."""
+        """Returns whether the artist is assigned to a `.Figure`."""
         return self.figure is not None
 
     def get_url(self):
@@ -596,8 +596,8 @@ class Artist(object):
 
         Parameters
         ----------
-        path_effects : `~.AbstractPathEffect`
-            .. ACCEPTS: `~.AbstractPathEffect`
+        path_effects : `.AbstractPathEffect`
+            .. ACCEPTS: `.AbstractPathEffect`
         """
         self._path_effects = path_effects
         self.stale = True
@@ -606,17 +606,17 @@ class Artist(object):
         return self._path_effects
 
     def get_figure(self):
-        """Return the `~.Figure` instance the artist belongs to."""
+        """Return the `.Figure` instance the artist belongs to."""
         return self.figure
 
     def set_figure(self, fig):
         """
-        Set the `~.Figure` instance the artist belongs to.
+        Set the `.Figure` instance the artist belongs to.
 
         Parameters
         ----------
-        fig : `~.Figure`
-            .. ACCEPTS: a `~.Figure` instance
+        fig : `.Figure`
+            .. ACCEPTS: a `.Figure` instance
         """
         # if this is a no-op just return
         if self.figure is fig:
@@ -636,12 +636,12 @@ class Artist(object):
 
     def set_clip_box(self, clipbox):
         """
-        Set the artist's clip `~.Bbox`.
+        Set the artist's clip `.Bbox`.
 
         Parameters
         ----------
-        clipbox : `~.Bbox`
-            .. ACCEPTS: a `~.Bbox` instance
+        clipbox : `.Bbox`
+            .. ACCEPTS: a `.Bbox` instance
         """
         self.clipbox = clipbox
         self.pchanged()
@@ -662,7 +662,7 @@ class Artist(object):
         this method will set the clipping box to the corresponding rectangle
         and set the clipping path to ``None``.
 
-        ACCEPTS: [(`~matplotlib.path.Path`, `~.Transform`) | `~.Patch` | None]
+        ACCEPTS: [(`~matplotlib.path.Path`, `.Transform`) | `.Patch` | None]
         """
         from matplotlib.patches import Patch, Rectangle
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -345,7 +345,7 @@ class Axes(_AxesBase):
         Parameters
         ----------
 
-        handles : sequence of `~.Artist`, optional
+        handles : sequence of `.Artist`, optional
             A list of Artists (lines, patches) to be added to the legend.
             Use this together with *labels*, if you need full control on what
             is shown in the legend and the automatic mechanism described above
@@ -387,7 +387,7 @@ class Axes(_AxesBase):
             corner of the legend in axes coordinates (in which case
             ``bbox_to_anchor`` will be ignored).
 
-        bbox_to_anchor : `~.BboxBase` or pair of floats
+        bbox_to_anchor : `.BboxBase` or pair of floats
             Specify any arbitrary location for the legend in `bbox_transform`
             coordinates (default Axes coordinates).
 
@@ -412,13 +412,13 @@ class Axes(_AxesBase):
 
         numpoints : None or int
             The number of marker points in the legend when creating a legend
-            entry for a `~.Line2D` (line).
+            entry for a `.Line2D` (line).
             Default is ``None``, which will take the value from
             :rc:`legend.numpoints`.
 
         scatterpoints : None or int
             The number of marker points in the legend when creating
-            a legend entry for a `~.PathCollection` (scatter plot).
+            a legend entry for a `.PathCollection` (scatter plot).
             Default is ``None``, which will take the value from
             :rc:`legend.scatterpoints`.
 
@@ -1306,7 +1306,7 @@ class Axes(_AxesBase):
         >>> plot(y)           # plot y using x as index array 0..N-1
         >>> plot(y, 'r+')     # ditto, but with red plusses
 
-        You can use `~.Line2D` properties as keyword arguments for more
+        You can use `.Line2D` properties as keyword arguments for more
         control on the  appearance. Line properties and *fmt* can be mixed.
         The following two calls yield identical results:
 
@@ -1404,7 +1404,7 @@ class Axes(_AxesBase):
             These parameters determined if the view limits are adapted to
             the data limits. The values are passed on to `autoscale_view`.
 
-        **kwargs : `~.Line2D` properties, optional
+        **kwargs : `.Line2D` properties, optional
             *kwargs* are used to specify properties like a line label (for
             auto legends), linewidth, antialiasing, marker face color.
             Example::
@@ -1415,14 +1415,14 @@ class Axes(_AxesBase):
             If you make multiple lines with one plot command, the kwargs
             apply to all those lines.
 
-            Here is a list of available `~.Line2D` properties:
+            Here is a list of available `.Line2D` properties:
 
             %(Line2D)s
 
         Returns
         -------
         lines
-            A list of `~.Line2D` objects that were added.
+            A list of `.Line2D` objects that were added.
 
 
         See Also
@@ -1801,12 +1801,12 @@ class Axes(_AxesBase):
             lag vector.
         c : array  (length ``2*maxlags+1``)
             auto correlation vector.
-        line : `~.LineCollection` or `~.Line2D`
-            `~.Artist` added to the axes of the correlation.
+        line : `.LineCollection` or `.Line2D`
+            `.Artist` added to the axes of the correlation.
 
-             `~.LineCollection` if *usevlines* is True
-             `~.Line2D` if *usevlines* is False
-        b : `~.Line2D` or None
+             `.LineCollection` if *usevlines* is True
+             `.Line2D` if *usevlines* is False
+        b : `.Line2D` or None
             Horizontal line at 0 if *usevlines* is True
             None *usevlines* is False
 
@@ -1863,12 +1863,12 @@ class Axes(_AxesBase):
             lag vector.
         c : array  (length ``2*maxlags+1``)
             auto correlation vector.
-        line : `~.LineCollection` or `~.Line2D`
-            `~.Artist` added to the axes of the correlation
+        line : `.LineCollection` or `.Line2D`
+            `.Artist` added to the axes of the correlation
 
-             `~.LineCollection` if *usevlines* is True
-             `~.Line2D` if *usevlines* is False
-        b : `~.Line2D` or None
+             `.LineCollection` if *usevlines* is True
+             `.Line2D` if *usevlines* is False
+        b : `.Line2D` or None
             Horizontal line at 0 if *usevlines* is True
             None *usevlines* is False
 
@@ -2050,7 +2050,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        `~.BarContainer`
+        `.BarContainer`
             Container with all the bars and optionally errorbars.
 
         Other Parameters
@@ -2368,7 +2368,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        `~.BarContainer`
+        `.BarContainer`
             Container with all the bars and optionally errorbars.
 
         Other Parameters
@@ -2486,7 +2486,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs : :class:`~.BrokenBarHCollection` properties
+        **kwargs : :class:`.BrokenBarHCollection` properties
 
             Each *kwarg* can be either a single argument applying to all
             rectangles, e.g.::
@@ -2980,7 +2980,7 @@ class Axes(_AxesBase):
             - *None*: No errorbar.
 
         fmt : plot format string, optional, default: ''
-            The format for the data points / data lines. See `~.plot` for
+            The format for the data points / data lines. See `.plot` for
             details.
 
             Use 'none' (case insensitive) to plot errorbars without any data
@@ -3050,7 +3050,7 @@ class Axes(_AxesBase):
             property names, *markerfacecolor*, *markeredgecolor*, *markersize*
             and *markeredgewidth*.
 
-            Valid kwargs for the marker properties are `~.Lines2D` properties:
+            Valid kwargs for the marker properties are `.Lines2D` properties:
 
             %(Line2D)s
 
@@ -4104,7 +4104,7 @@ class Axes(_AxesBase):
             ``image.cmap``.
 
         norm : `~matplotlib.colors.Normalize`, optional, default: None
-            A `~.Normalize` instance is used to scale luminance data to 0, 1.
+            A `.Normalize` instance is used to scale luminance data to 0, 1.
             *norm* is only used if *c* is an array of floats. If *None*, use
             the default `.colors.Normalize`.
 
@@ -5028,15 +5028,15 @@ class Axes(_AxesBase):
         Other Parameters
         ----------------
         **kwargs
-            All other keyword arguments are passed on to `~.PolyCollection`.
-            They control the `~.Polygon` properties:
+            All other keyword arguments are passed on to `.PolyCollection`.
+            They control the `.Polygon` properties:
 
             %(PolyCollection)s
 
         Returns
         -------
-        `~.PolyCollection`
-            A `~.PolyCollection` containing the plotted polygons.
+        `.PolyCollection`
+            A `.PolyCollection` containing the plotted polygons.
 
         See Also
         --------
@@ -5212,15 +5212,15 @@ class Axes(_AxesBase):
         Other Parameters
         ----------------
         **kwargs
-            All other keyword arguments are passed on to `~.PolyCollection`.
-            They control the `~.Polygon` properties:
+            All other keyword arguments are passed on to `.PolyCollection`.
+            They control the `.Polygon` properties:
 
             %(PolyCollection)s
 
         Returns
         -------
-        `~.PolyCollection`
-            A `~.PolyCollection` containing the plotted polygons.
+        `.PolyCollection`
+            A `.PolyCollection` containing the plotted polygons.
 
         See Also
         --------

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -625,13 +625,13 @@ class _AxesBase(martist.Artist):
 
     def set_figure(self, fig):
         """
-        Set the `~.Figure` for this `~.Axes`.
+        Set the `.Figure` for this `.Axes`.
 
-        .. ACCEPTS: `~.Figure`
+        .. ACCEPTS: `.Figure`
 
         Parameters
         ----------
-        fig : `~.Figure`
+        fig : `.Figure`
         """
         martist.Artist.set_figure(self, fig)
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -614,7 +614,7 @@ def to_filehandle(fname, flag='rU', return_opened=False, encoding=None):
 
 @contextlib.contextmanager
 def open_file_cm(path_or_file, mode="r", encoding=None):
-    r"""Pass through file objects and context-manage `~.PathLike`\s."""
+    r"""Pass through file objects and context-manage `.PathLike`\s."""
     fh, opened = to_filehandle(path_or_file, mode, True, encoding)
     if opened:
         with fh:

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -332,11 +332,11 @@ class ScalarMappable(object):
     def set_norm(self, norm):
         """Set the normalization instance.
 
-        .. ACCEPTS: `~.Normalize`
+        .. ACCEPTS: `.Normalize`
 
         Parameters
         ----------
-        norm : `~.Normalize`
+        norm : `.Normalize`
         """
         if norm is None:
             norm = colors.Normalize()

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -297,10 +297,10 @@ def _dt64_to_ordinalf(d):
 def _from_ordinalf(x, tz=None):
     """
     Convert Gregorian float of the date, preserving hours, minutes,
-    seconds and microseconds.  Return value is a `~.datetime`.
+    seconds and microseconds.  Return value is a `.datetime`.
 
     The input date *x* is a float in ordinal days at UTC, and the output will
-    be the specified `~.datetime` object corresponding to that time in
+    be the specified `.datetime` object corresponding to that time in
     timezone *tz*, or if *tz* is ``None``, in the timezone specified in
     :rc:`timezone`.
     """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -258,14 +258,14 @@ class Figure(Artist):
 
     """
     The Figure instance supports callbacks through a *callbacks* attribute
-    which is a `~.CallbackRegistry` instance.  The events you can connect to
+    which is a `.CallbackRegistry` instance.  The events you can connect to
     are 'dpi_changed', and the callback will be called with ``func(fig)`` where
     fig is the `Figure` instance.
 
     Attributes
     ----------
     patch
-        The `~.Rectangle` instance representing the figure patch.
+        The `.Rectangle` instance representing the figure patch.
 
     suppressComposite
         For multiple figure images, the figure will make composite images
@@ -321,10 +321,10 @@ class Figure(Artist):
 
         tight_layout : bool
             If ``False`` use *subplotpars*; if ``True`` adjust subplot
-            parameters using `~.tight_layout` with default padding.
+            parameters using `.tight_layout` with default padding.
             When providing a dict containing the keys
             ``pad``, ``w_pad``, ``h_pad``, and ``rect``, the default
-            `~.tight_layout` paddings will be overridden.
+            `.tight_layout` paddings will be overridden.
             Defaults to rc ``figure.autolayout``.
 
         constrained_layout : bool
@@ -486,20 +486,20 @@ class Figure(Artist):
 
     def get_tight_layout(self):
         """
-        Return whether and how `~.tight_layout` is called when drawing.
+        Return whether and how `.tight_layout` is called when drawing.
         """
         return self._tight
 
     def set_tight_layout(self, tight):
         """
-        Set whether and how `~.tight_layout` is called when drawing.
+        Set whether and how `.tight_layout` is called when drawing.
 
         Parameters
         ----------
         tight : bool or dict with keys "pad", "w_pad", "h_pad", "rect" or None
-            If a bool, sets whether to call `~.tight_layout` upon drawing.
+            If a bool, sets whether to call `.tight_layout` upon drawing.
             If ``None``, use the ``figure.autolayout`` rcparam instead.
-            If a dict, pass it as kwargs to `~.tight_layout`, overriding the
+            If a dict, pass it as kwargs to `.tight_layout`, overriding the
             default paddings.
 
             ..
@@ -1002,7 +1002,7 @@ class Figure(Artist):
 
     def delaxes(self, ax):
         """
-        Remove the `~.Axes` *ax* from the figure and update the current axes.
+        Remove the `.Axes` *ax* from the figure and update the current axes.
         """
         self._axstack.remove(ax)
         for func in self._axobservers:
@@ -1516,7 +1516,7 @@ class Figure(Artist):
         Parameters
         ----------
 
-        handles : sequence of `~.Artist`, optional
+        handles : sequence of `.Artist`, optional
             A list of Artists (lines, patches) to be added to the legend.
             Use this together with *labels*, if you need full control on what
             is shown in the legend and the automatic mechanism described above
@@ -1558,7 +1558,7 @@ class Figure(Artist):
             corner of the legend in axes coordinates (in which case
             ``bbox_to_anchor`` will be ignored).
 
-        bbox_to_anchor : `~.BboxBase` or pair of floats
+        bbox_to_anchor : `.BboxBase` or pair of floats
             Specify any arbitrary location for the legend in `bbox_transform`
             coordinates (default Axes coordinates).
 
@@ -1583,13 +1583,13 @@ class Figure(Artist):
 
         numpoints : None or int
             The number of marker points in the legend when creating a legend
-            entry for a `~.Line2D` (line).
+            entry for a `.Line2D` (line).
             Default is ``None``, which will take the value from
             :rc:`legend.numpoints`.
 
         scatterpoints : None or int
             The number of marker points in the legend when creating
-            a legend entry for a `~.PathCollection` (scatter plot).
+            a legend entry for a `.PathCollection` (scatter plot).
             Default is ``None``, which will take the value from
             :rc:`legend.scatterpoints`.
 
@@ -2298,8 +2298,8 @@ class Figure(Artist):
 
         Notes
         -----
-        This assumes that ``axs`` are from the same `~.GridSpec`, so that
-        their `~.SubplotSpec` positions correspond to figure positions.
+        This assumes that ``axs`` are from the same `.GridSpec`, so that
+        their `.SubplotSpec` positions correspond to figure positions.
 
         Examples
         --------
@@ -2366,8 +2366,8 @@ class Figure(Artist):
 
         Notes
         -----
-        This assumes that ``axs`` are from the same `~.GridSpec`, so that
-        their `~.SubplotSpec` positions correspond to figure positions.
+        This assumes that ``axs`` are from the same `.GridSpec`, so that
+        their `.SubplotSpec` positions correspond to figure positions.
 
         Examples
         --------

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -134,7 +134,7 @@ loc : int or string or pair of floats, default: 'upper right'
     corner of the legend in axes coordinates (in which case
     ``bbox_to_anchor`` will be ignored).
 
-bbox_to_anchor : `~.BboxBase` or pair of floats
+bbox_to_anchor : `.BboxBase` or pair of floats
     Specify any arbitrary location for the legend in `bbox_transform`
     coordinates (default Axes coordinates).
 
@@ -159,13 +159,13 @@ fontsize : int or float or {'xx-small', 'x-small', 'small', 'medium', \
 
 numpoints : None or int
     The number of marker points in the legend when creating a legend
-    entry for a `~.Line2D` (line).
+    entry for a `.Line2D` (line).
     Default is ``None``, which will take the value from
     :rc:`legend.numpoints`.
 
 scatterpoints : None or int
     The number of marker points in the legend when creating
-    a legend entry for a `~.PathCollection` (scatter plot).
+    a legend entry for a `.PathCollection` (scatter plot).
     Default is ``None``, which will take the value from
     :rc:`legend.scatterpoints`.
 
@@ -389,7 +389,7 @@ class Legend(Artist):
             corner of the legend in axes coordinates (in which case
             ``bbox_to_anchor`` will be ignored).
 
-        bbox_to_anchor : `~.BboxBase` or pair of floats
+        bbox_to_anchor : `.BboxBase` or pair of floats
             Specify any arbitrary location for the legend in `bbox_transform`
             coordinates (default Axes coordinates).
 
@@ -414,13 +414,13 @@ class Legend(Artist):
 
         numpoints : None or int
             The number of marker points in the legend when creating a legend
-            entry for a `~.Line2D` (line).
+            entry for a `.Line2D` (line).
             Default is ``None``, which will take the value from
             :rc:`legend.numpoints`.
 
         scatterpoints : None or int
             The number of marker points in the legend when creating
-            a legend entry for a `~.PathCollection` (scatter plot).
+            a legend entry for a `.PathCollection` (scatter plot).
             Default is ``None``, which will take the value from
             :rc:`legend.scatterpoints`.
 
@@ -1118,7 +1118,7 @@ class Legend(Artist):
         self.stale = True
 
     def get_title(self):
-        'Return the `~.Text` instance for the legend title.'
+        'Return the `.Text` instance for the legend title.'
         return self._legend_title_box._text
 
     def get_window_extent(self, *args, **kwargs):
@@ -1154,7 +1154,7 @@ class Legend(Artist):
 
         *bbox* can be
 
-        - A `~.BboxBase` instance
+        - A `.BboxBase` instance
         - A tuple of ``(left, bottom, width, height)`` in the given transform
           (normalized axes coordinate if None)
         - A tuple of ``(left, bottom)`` where the width and height will be
@@ -1271,7 +1271,7 @@ class Legend(Artist):
           * False : turn draggable off
 
         If draggable is on, you can drag the legend on the canvas with
-        the mouse. The `~.DraggableLegend` helper instance is returned if
+        the mouse. The `.DraggableLegend` helper instance is returned if
         draggable is on.
 
         The update parameter control which parameter of the legend changes

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -4,8 +4,8 @@ A module for dealing with the polylines used throughout Matplotlib.
 The primary class for polyline handling in Matplotlib is `Path`.  Almost all
 vector drawing makes use of `Path`\s somewhere in the drawing pipeline.
 
-Whilst a `Path` instance itself cannot be drawn, some `~.Artist` subclasses,
-such as `~.PathPatch` and `~.PathCollection`, can be used for convenient `Path`
+Whilst a `Path` instance itself cannot be drawn, some `.Artist` subclasses,
+such as `.PathPatch` and `.PathCollection`, can be used for convenient `Path`
 visualisation.
 """
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -641,7 +641,7 @@ def close(*args):
 
     ``close()`` by itself closes the current figure
 
-    ``close(fig)`` closes the `~.Figure` instance *fig*
+    ``close(fig)`` closes the `.Figure` instance *fig*
 
     ``close(num)`` closes the figure number *num*
 
@@ -878,7 +878,7 @@ def axes(arg=None, **kwargs):
         - 4-tuple of floats *rect* = ``[left, bottom, width, height]``.
           A new axes is added with dimensions *rect* in normalized
           (0, 1) units using `~.Figure.add_axes` on the current figure.
-        - `~.Axes`: This is equivalent to `.pyplot.sca`. It sets the current
+        - `.Axes`: This is equivalent to `.pyplot.sca`. It sets the current
           axes to *arg*. Note: This implicitly changes the current figure to
           the parent of *arg*.
 
@@ -994,7 +994,7 @@ def subplot(*args, **kwargs):
 
        subplot(nrows, ncols, index, **kwargs)
 
-    In the current figure, create and return an `~.Axes`, at position *index*
+    In the current figure, create and return an `.Axes`, at position *index*
     of a (virtual) grid of *nrows* by *ncols* axes.  Indexes go from 1 to
     ``nrows * ncols``, incrementing in row-major order.
 
@@ -1002,7 +1002,7 @@ def subplot(*args, **kwargs):
     given as a single, concatenated, three-digit number.
 
     For example, ``subplot(2, 3, 3)`` and ``subplot(233)`` both create an
-    `~.Axes` at the top right corner of the current figure, occupying half of
+    `.Axes` at the top right corner of the current figure, occupying half of
     the figure height and a third of the figure width.
 
     .. note::

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -58,8 +58,8 @@ def stackplot(axes, x, *args, **kwargs):
 
     Returns
     -------
-    list of `~.PolyCollection`
-        A list of `~.PolyCollection` instances, one for each element in the
+    list of `.PolyCollection`
+        A list of `.PolyCollection` instances, one for each element in the
         stacked area plot.
     """
 

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -253,7 +253,7 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
     ----------
     fig : Figure
     axes_list : list of Axes
-    subplotspec_list : list of `~.SubplotSpec`
+    subplotspec_list : list of `.SubplotSpec`
         The subplotspecs of each axes.
     renderer : renderer
     pad : float

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1623,7 +1623,7 @@ class Axes3D(Axes):
             Whether to shade the face colors.
 
         **kwargs :
-            Other arguments are forwarded to `~.Poly3DCollection`.
+            Other arguments are forwarded to `.Poly3DCollection`.
         """
 
         had_data = self.has_data()
@@ -1837,7 +1837,7 @@ class Axes3D(Axes):
             of the new default of ``rcount = ccount = 50``.
 
         **kwargs :
-            Other arguments are forwarded to `~.Line3DCollection`.
+            Other arguments are forwarded to `.Line3DCollection`.
         """
 
         had_data = self.has_data()

--- a/tutorials/advanced/transforms_tutorial.py
+++ b/tutorials/advanced/transforms_tutorial.py
@@ -25,12 +25,12 @@ description of that system. In the `Transformation Object` column,
 |           |                             |controlled by xlim and ylim.       |
 +-----------+-----------------------------+-----------------------------------+
 |"axes"     |``ax.transAxes``             |The coordinate system of the       |
-|           |                             |`~.Axes`; (0, 0) is bottom left of |
+|           |                             |`.Axes`; (0, 0) is bottom left of  |
 |           |                             |the axes, and (1, 1) is top right  |
 |           |                             |of the axes.                       |
 +-----------+-----------------------------+-----------------------------------+
 |"figure"   |``fig.transFigure``          |The coordinate system of the       |
-|           |                             |`~.Figure`; (0, 0) is bottom left  |
+|           |                             |`.Figure`; (0, 0) is bottom left   |
 |           |                             |of the figure, and (1, 1) is top   |
 |           |                             |right of the figure.               |
 +-----------+-----------------------------+-----------------------------------+

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -507,16 +507,16 @@ example_plot(ax4)
 #                - Axes: `axR1 = fig.add_subplot(ss)`
 #
 # Each item has a layoutbox associated with it. The nesting of gridspecs
-# created with `~.GridSpecFromSubplotSpec` can be arbitrarily deep.
+# created with `.GridSpecFromSubplotSpec` can be arbitrarily deep.
 #
-# Each `~.Axes` has *two* layoutboxes.  The first one ``ax._layoutbox``
+# Each `.Axes` has *two* layoutboxes.  The first one ``ax._layoutbox``
 # represents the outside of the Axes and all its decorations (i.e. ticklabels,
 # axis labels, etc.).  The second layoutbox corresponds to the Axes'
 # `ax.position`, which sets where in the figure the spines are placed.
 #
 # Why so many stacked containers?  Ideally, all that would be needed are the
 # Axes layout boxes. For the Gridspec case, a container is
-# needed if the Gridspec is nested via `~.GridSpecFromSubplotSpec`.  At the
+# needed if the Gridspec is nested via `.GridSpecFromSubplotSpec`.  At the
 # top level, it is desirable for symmetry, but it also makes room for
 # `~.Figure.suptitle`.
 #
@@ -534,7 +534,7 @@ example_plot(ax4)
 # the difference between the red ``pos`` box and the green ``ax`` box
 # is set by the size of the decorations around the Axes.
 #
-# In the code, this is accomplished by the entries in `~.do_constrained_layout`
+# In the code, this is accomplished by the entries in `.do_constrained_layout`
 # like::
 #
 #     ax._poslayoutbox.edit_left_margin_min(-bbox.x0 + pos.x0 + w_padt)
@@ -554,7 +554,7 @@ plot_children(fig, fig._layoutbox, printit=False)
 # much smaller than the left-hand, so the right-hand layoutboxes are smaller.
 #
 # The Subplotspec boxes are laid out in the code in the subroutine
-# `~.arange_subplotspecs`, which simply checks the subplotspecs in the code
+# `.arange_subplotspecs`, which simply checks the subplotspecs in the code
 # against one another and stacks them appropriately.
 #
 # The two ``pos`` axes are lined up.  Because they have the same

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -35,28 +35,28 @@ The following commands are used to create text in the pyplot
 interface and the object-oriented API:
 
 =================== =================== ======================================
-`~.pyplot` API      OO API              description
+`.pyplot` API       OO API              description
 =================== =================== ======================================
 `~.pyplot.text`     `~.Axes.text`       Add text at an arbitrary location of
-                                        the `~.Axes`.
+                                        the `.Axes`.
 
 `~.pyplot.annotate` `~.Axes.annotate`   Add an annotation, with an optional
                                         arrow, at an arbitrary location of the
-                                        `~.Axes`.
+                                        `.Axes`.
 
-`~.pyplot.xlabel`   `~.Axes.set_xlabel` Add a label to the `~.Axes`\\'s x-axis.
+`~.pyplot.xlabel`   `~.Axes.set_xlabel` Add a label to the `.Axes`\\'s x-axis.
 
-`~.pyplot.ylabel`   `~.Axes.set_ylabel` Add a label to the `~.Axes`\\'s y-axis.
+`~.pyplot.ylabel`   `~.Axes.set_ylabel` Add a label to the `.Axes`\\'s y-axis.
 
-`~.pyplot.title`    `~.Axes.set_title`  Add a title to the `~.Axes`.
+`~.pyplot.title`    `~.Axes.set_title`  Add a title to the `.Axes`.
 
 `~.pyplot.figtext`  `~.Figure.text`     Add text at an arbitrary location of
-                                        the `~.Figure`.
+                                        the `.Figure`.
 
-`~.pyplot.suptitle` `~.Figure.suptitle` Add a title to the `~.Figure`.
+`~.pyplot.suptitle` `~.Figure.suptitle` Add a title to the `.Figure`.
 =================== =================== ======================================
 
-All of these functions create and return a `~.Text` instance, which can be
+All of these functions create and return a `.Text` instance, which can be
 configured with a variety of font and other properties.  The example below
 shows all of these commands in action, and more detail is provided in the
 sections that follow.
@@ -145,7 +145,7 @@ ax.set_ylabel('Damped oscillation [V]', labelpad=18)
 plt.show()
 
 ###############################################################################
-# Or, the labels accept all the `~.Text` keyword arguments, including
+# Or, the labels accept all the `.Text` keyword arguments, including
 # *position*, via which we can manually specify the label positions.  Here we
 # put the xlabel to the far left of the axis.  Note, that the y-coordinate of
 # this position has no effect - to adjust the y-position we need to use the


### PR DESCRIPTION
## PR Summary

The use of the shortener character `~` is unneccesary for cases like `` `~.Axes` ``. `~` has no other function than limiting the display to the last component of the referenced entity.

This PR removes `~` from all references that have only one component anyway. It does not have any effect and leaving it out improves readability.
