### PR TITLE
Fix issue with clf not clearing constrainedlayout

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1425,6 +1425,8 @@ class Figure(Artist):
         if not keep_observers:
             self._axobservers = []
         self._suptitle = None
+        if self.get_constrained_layout():
+            layoutbox.nonetree(self._layoutbox)
         self.stale = True
 
     def clear(self, keep_observers=False):


### PR DESCRIPTION
## PR Summary

As noted by @afvincent  (on gitter)

```python

import matplotlib.pyplot as plt

#import matplotlib as mpl
#print(mpl.__version__)  #  --> 2.2.0rc1

plt.ion()  # --> no warning without it

fig = plt.figure(num=1,
                clear=True, #--> no effect on the warnin
                constrained_layout=True)
ax = fig.subplots()
ax.plot([1, 2])
```

if called twice in an interactive session doesn't work on master.  

The new axis is still being constrained by the presence of the old (cleared) one and gets shrunk to nothing.

This change properly resets the constrained_layout mechanism when `figure.clf()` is called.


