### PR TITLE
Prevent ZeroDivisionError when devicePixelRatio() returns 0

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -269,11 +269,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     def _dpi_ratio(self):
         # Not available on Qt4 or some older Qt5.
         try:
-            ratio = self.devicePixelRatio()
-            if ratio == 0:
-                return 1
-            else:
-                return ratio
+            return self.devicePixelRatio() or 1 # can be 0 in rare cases
         except AttributeError:
             return 1
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -268,8 +268,9 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     @property
     def _dpi_ratio(self):
         # Not available on Qt4 or some older Qt5.
-        try:
-            return self.devicePixelRatio() or 1 # can be 0 in rare cases
+            try:
+            # self.devicePixelRatio() returns 0 in rare cases
+            return self.devicePixelRatio() or 1
         except AttributeError:
             return 1
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -269,7 +269,11 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     def _dpi_ratio(self):
         # Not available on Qt4 or some older Qt5.
         try:
-            return self.devicePixelRatio()
+            ratio = self.devicePixelRatio()
+            if ratio == 0:
+                return 1
+            else:
+                return ratio
         except AttributeError:
             return 1
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -268,7 +268,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     @property
     def _dpi_ratio(self):
         # Not available on Qt4 or some older Qt5.
-            try:
+        try:
             # self.devicePixelRatio() returns 0 in rare cases
             return self.devicePixelRatio() or 1
         except AttributeError:


### PR DESCRIPTION
This bug only occurs under very special circumstances. For some reason when using Screen Scaling in KDE while also downscaling the terminal emulator Konsole, in which matplotlib is run, devicePixelRatio() returns 0 and causes a ZeroDevisionError. I do not know other circumstances under which this bug occurs. It is also probably not really a bug in matplotlib, but this fixes the issue for me.

You may ask why this setup is necessary to begin with, the answer can be found [here](https://www.reddit.com/r/kde/comments/5u44r3/konsole_screen_tearing_workaround/). Essentially it is a workaround necessary to prevent screen tearing in Konsole for some very few people including myself.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
