### PR TITLE
Fix check_shared in test_subplots.

### DIFF
--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import, division, print_function
-
+import itertools
 import warnings
 
 import numpy
@@ -14,14 +13,15 @@ def check_shared(axs, x_shared, y_shared):
     x_shared and y_shared are n x n boolean matrices; entry (i, j) indicates
     whether the x (or y) axes of subplots i and j should be shared.
     """
-    shared = [axs[0]._shared_x_axes, axs[0]._shared_y_axes]
-    for (i1, ax1), (i2, ax2), (i3, (name, shared)) in zip(
+    for (i1, ax1), (i2, ax2), (i3, (name, shared)) in itertools.product(
             enumerate(axs),
             enumerate(axs),
             enumerate(zip("xy", [x_shared, y_shared]))):
         if i2 <= i1:
             continue
-        assert shared[i3].joined(ax1, ax2) == shared[i1, i2], \
+        assert \
+            (getattr(axs[0], "_shared_{}_axes".format(name)).joined(ax1, ax2)
+             == shared[i1, i2]), \
             "axes %i and %i incorrectly %ssharing %s axis" % (
                 i1, i2, "not " if shared[i1, i2] else "", name)
 
@@ -30,7 +30,7 @@ def check_visible(axs, x_visible, y_visible):
     def tostr(v):
         return "invisible" if v else "visible"
 
-    for (ax, vx, vy) in zip(axs, x_visible, y_visible):
+    for ax, vx, vy in zip(axs, x_visible, y_visible):
         for l in ax.get_xticklabels() + [ax.get_xaxis().offsetText]:
             assert l.get_visible() == vx, \
                     "X axis was incorrectly %s" % (tostr(vx))


### PR DESCRIPTION
The previous version of check_shared did not test anything because of
the use of `zip` instead of `product` (so `i2 <= i1` was always true).
Moreover, the `shared` variable defined outside the loop would get
shadowed by the one defined in the loop.

Fix both issues.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
