### PR TITLE
Remove some manual manipulation of whatsnew when releasing.

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -10,14 +10,13 @@ out what caused the breakage and how to fix it by updating your code.
 For new features that were added to Matplotlib, please see
 :ref:`whats-new`.
 
-.. for a release comment out the toctree below
+.. ifconfig:: __import__('pkg_resources').parse_version(version).local
 
+   .. toctree::
+      :glob:
+      :maxdepth: 1
 
-.. toctree::
-   :glob:
-   :maxdepth: 1
-
-   next_api_changes/*
+      next_api_changes/*
 
 
 API Changes in 2.2.0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,6 +31,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
+    'sphinx.ext.ifconfig',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'IPython.sphinxext.ipython_console_highlighting',

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -48,10 +48,10 @@ Review and commit changes.  Some issue/PR titles may not be valid rst (the most 
 Check Docs
 ----------
 
-Before tagging, update the what's new listing in :file:`doc/users/whats_new.rst`
-by merging all files in :file:`doc/users/next_whats_new/` coherently. Also,
-temporarily comment out the include and toctree glob; re-instate these after a
-release. Finally, make sure that the docs build cleanly ::
+Before tagging, update the what's new listing in
+:file:`doc/users/whats_new.rst` by merging all files in
+:file:`doc/users/next_whats_new/` coherently.  Then, make sure that the docs
+build cleanly::
 
   make -Cdoc O=-n$(nproc) html latexpdf
 

--- a/doc/users/next_whats_new/README.rst
+++ b/doc/users/next_whats_new/README.rst
@@ -9,7 +9,9 @@ When adding an entry please look at the currently existing files to
 see if you can extend any of them.  If you create a file, name it
 something like :file:`cool_new_feature.rst` if you have added a brand new
 feature or something like :file:`updated_feature.rst` for extensions of
-existing features.  Include contents of the form: ::
+existing features.  Include contents of the form:
+
+.. code-block:: rst
 
     Section Title for Feature
     -------------------------

--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -10,16 +10,14 @@ revision, see the :ref:`github-stats`.
 .. contents:: Table of Contents
    :depth: 4
 
+.. ifconfig:: __import__('pkg_resources').parse_version(version).local
 
-..
-   For a release, add a new section after this, then comment out the include
-   and toctree below by indenting them. Uncomment them after the release.
-.. include:: next_whats_new/README.rst
-.. toctree::
-   :glob:
-   :maxdepth: 1
+   .. include:: next_whats_new/README.rst
+   .. toctree::
+      :glob:
+      :maxdepth: 1
 
-   next_whats_new/*
+      next_whats_new/*
 
 
 New in Matplotlib 2.2


### PR DESCRIPTION
This PR ensures that the "unmerged" whatsnew entries get included in the
docs if and only if we're building the docs for a "local release", i.e.
when the version number includes a git tag, but not a tagged release.
This previously required manual manipulation.

Noted while reviewing #10548.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
