### PR TITLE
Fix eventplot exception due to uninitiliazed `_is_horizontal` attribute

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1271,10 +1271,11 @@ class Axes(_AxesBase):
                 minline = (lineoffsets - linelengths).min()
                 maxline = (lineoffsets + linelengths).max()
 
-                if colls[0].is_horizontal():
-                    corners = (minpos, minline), (maxpos, maxline)
-                else:
+                if (orientation is not None and
+                        orientation.lower() == "vertical"):
                     corners = (minline, minpos), (maxline, maxpos)
+                else:  # "horizontal", None or "none" (see EventCollection)
+                    corners = (minpos, minline), (maxpos, maxline)
                 self.update_datalim(corners)
                 self.autoscale_view()
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3236,6 +3236,17 @@ def test_empty_eventplot():
     plt.draw()
 
 
+@pytest.mark.parametrize('data, orientation', product(
+    ([[]], [[], [0, 1]], [[0, 1], []]),
+    ('_empty', 'vertical', 'horizontal', None, 'none')))
+def test_eventplot_orientation(data, orientation):
+    """Introduced when fixing issue #6412. """
+    opts = {} if orientation == "_empty" else {'orientation': orientation}
+    fig, ax = plt.subplots(1, 1)
+    ax.eventplot(data, **opts)
+    plt.draw()
+
+
 @image_comparison(baseline_images=['marker_styles'], extensions=['png'],
                   remove_text=True)
 def test_marker_styles():


### PR DESCRIPTION
## PR Summary

Fixes #6412 by using the orientation passed as a keyword argument to `ax.eventplot`, rather than trying to infer it from the (internally) instantiated EventCollection(s), which fails if the first one is empty. This is based on @tacaswell 's comment in #6412.

## PR Checklist

- [X] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant: let's see what is CI opinion

Milestoning it for 2.2, as I do not see an easy workaround to #6412 . Please feel free to re-milestone it if that is too optimistic.

**Edit:** English.