### PR TITLE
Bugfix in axes3d not raising an exception

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2633,7 +2633,7 @@ class Axes3D(Axes):
         argi = 6
         if len(args) < argi:
             raise ValueError('Wrong number of arguments. Expected %d got %d' %
-                       (argi, len(args)))
+                             (argi, len(args)))
 
         # first 6 arguments are X, Y, Z, U, V, W
         input_args = args[:argi]

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2632,7 +2632,7 @@ class Axes3D(Axes):
         # handle args
         argi = 6
         if len(args) < argi:
-            ValueError('Wrong number of arguments. Expected %d got %d' %
+            raise ValueError('Wrong number of arguments. Expected %d got %d' %
                        (argi, len(args)))
 
         # first 6 arguments are X, Y, Z, U, V, W


### PR DESCRIPTION
## PR Summary

Instantiating an exception, but not raising it, has no effect. 
Found using [lgtm.com](https://lgtm.com/projects/g/matplotlib/matplotlib/alerts/?mode=tree&severity=error&rule=1505923886371).