### PR TITLE
Switch to @-matrix multiplication.

### DIFF
--- a/examples/text_labels_and_annotations/arrow_demo.py
+++ b/examples/text_labels_and_annotations/arrow_demo.py
@@ -210,7 +210,7 @@ def make_arrow_plot(data, size=4, display='length', shape='right',
             raise ValueError("Got unknown position parameter %s" % where)
 
         M = np.array([[cx, sx], [-sx, cx]])
-        coords = np.dot(orig_position, M) + [[x_pos, y_pos]]
+        coords = orig_position @ M + [[x_pos, y_pos]]
         x, y = np.ravel(coords)
         orig_label = rate_labels[pair]
         label = '$%s_{_{\mathrm{%s}}}$' % (orig_label[0], orig_label[1:])

--- a/examples/units/ellipse_with_units.py
+++ b/examples/units/ellipse_with_units.py
@@ -28,11 +28,7 @@ R = np.array([
     [np.cos(rtheta), -np.sin(rtheta)],
     [np.sin(rtheta),  np.cos(rtheta)],
     ])
-
-
-x, y = np.dot(R, np.array([x, y]))
-x += xcenter
-y += ycenter
+x, y = R @ [x, y] + [xcenter, ycenter]
 
 ###############################################################################
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1898,7 +1898,7 @@ class Axes(_AxesBase):
         correls = np.correlate(x, y, mode=2)
 
         if normed:
-            correls /= np.sqrt(np.dot(x, x) * np.dot(y, y))
+            correls /= np.linalg.norm(x) * np.linalg.norm(y)
 
         if maxlags is None:
             maxlags = Nx - 1

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1039,7 +1039,7 @@ class RendererSVG(RendererBase):
                 # to the anchor point manually for now.
                 angle_rad = np.deg2rad(angle)
                 dir_vert = np.array([np.sin(angle_rad), np.cos(angle_rad)])
-                v_offset = np.dot(dir_vert, [(x - ax), (y - ay)])
+                v_offset = dir_vert @ [x - ax, y - ay]
                 ax = ax + v_offset * dir_vert[0]
                 ay = ay + v_offset * dir_vert[1]
 

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -177,8 +177,8 @@ class BezierSegment(object):
     def point_at_t(self, t):
         "evaluate a point at t"
         tt = ((1 - t) ** self._orders)[::-1] * t ** self._orders
-        _x = np.dot(tt, self._px)
-        _y = np.dot(tt, self._py)
+        _x = tt @ self._px
+        _y = tt @ self._py
         return _x, _y
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1508,17 +1508,6 @@ def _vector_magnitude(arr):
     return np.sqrt(sum_sq)
 
 
-def _vector_dot(a, b):
-    # things that don't work here:
-    #   * a.dot(b) - fails on masked arrays until 1.10
-    #   * np.ma.dot(a, b) - doesn't mask enough things
-    #   * np.ma.dot(a, b, strict=True) - returns a maskedarray with no mask
-    dot = 0
-    for i in range(a.shape[-1]):
-        dot += a[..., i] * b[..., i]
-    return dot
-
-
 class LightSource(object):
     """
     Create a light source coming from the specified azimuth and elevation.
@@ -1655,7 +1644,7 @@ class LightSource(object):
             completely in shadow and 1 is completely illuminated.
         """
 
-        intensity = _vector_dot(normals, self.direction)
+        intensity = normals.dot(self.direction)
 
         # Apply contrast stretch
         imin, imax = intensity.min(), intensity.max()

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -675,15 +675,11 @@ def _find_closest_point_on_leg(p1, p2, p0):
     d01 = p0 - p1
 
     # project on to line segment to find closest point
-    proj = np.dot(d01, d21) / np.dot(d21, d21)
-    if proj < 0:
-        proj = 0
-    if proj > 1:
-        proj = 1
-    pc = p1 + proj * d21
+    proj = (d01 @ d21) / (d21 @ d21)
+    pc = p1 + np.clip(proj, 0, 1) * d21
 
     # find squared distance
-    d = np.sum((pc-p0)**2)
+    d = np.sum((pc - p0)**2)
 
     return d, pc
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1293,7 +1293,7 @@ class FancyArrow(Polygon):
                 # Account for division by zero
                 cx, sx = 0, 1
             M = [[cx, sx], [-sx, cx]]
-            verts = np.dot(coords, M) + (x + dx, y + dy)
+            verts = coords @ M + [x + dx, y + dy]
 
         Polygon.__init__(self, list(map(tuple, verts)), closed=True, **kwargs)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1255,10 +1255,7 @@ def test_arc_ellipse():
     R = np.array([
         [np.cos(rtheta), -np.sin(rtheta)],
         [np.sin(rtheta), np.cos(rtheta)]])
-
-    x, y = np.dot(R, np.array([x, y]))
-    x += xcenter
-    y += ycenter
+    x, y = R @ [x, y] + [xcenter, ycenter]
 
     fig = plt.figure()
     ax = fig.add_subplot(211, aspect='auto')

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -390,8 +390,7 @@ def test_triinterp():
     for interp in (cubic_min_E, cubic_geom):
         diff_cubic = np.abs(interp(xs, ys) - zs)
         assert np.max(diff_lin) >= 10 * np.max(diff_cubic)
-        assert (np.dot(diff_lin, diff_lin) >=
-                100 * np.dot(diff_cubic, diff_cubic))
+        assert diff_lin @ diff_lin >= 100 * diff_cubic @ diff_cubic
 
 
 def test_triinterpcubic_C1_continuity():
@@ -522,7 +521,7 @@ def test_triinterpcubic_cg_solver():
         b[itest] = 1.
         x, _ = mtri.triinterpolate._cg(A=mat, b=b, x0=np.zeros(n*m),
                                        tol=1.e-10)
-        assert_array_almost_equal(np.dot(mat_dense, x), b)
+        assert_array_almost_equal(mat_dense @ x, b)
 
     # 2) Same matrix with inserting 2 rows - cols with null diag terms
     # (but still linked with the rest of the matrix by extra-diag terms)
@@ -544,7 +543,7 @@ def test_triinterpcubic_cg_solver():
         b[itest] = 1.
         x, _ = mtri.triinterpolate._cg(A=mat, b=b, x0=np.ones(n*m + 2),
                                        tol=1.e-10)
-        assert_array_almost_equal(np.dot(mat_dense, x), b)
+        assert_array_almost_equal(mat_dense @ x, b)
 
     # 3) Now a simple test that summation of duplicate (i.e. with same rows,
     # same cols) entries occurs when compressed.

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1451,7 +1451,7 @@ class TextWithDash(Text):
                 dy = h
                 dx = h / tan_theta
         cwd = np.array([dx, dy]) / 2
-        cwd *= 1 + dashpad / np.sqrt(np.dot(cwd, cwd))
+        cwd *= 1 + dashpad / np.linalg.norm(cwd)
         cw = c2 + (dashdirection * 2 - 1) * cwd
 
         newx, newy = inverse.transform_point(tuple(cw))

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1779,14 +1779,6 @@ class AffineBase(Transform):
         # optimises the access of the transform matrix vs the superclass
         return self.get_matrix()
 
-    @staticmethod
-    def _concat(a, b):
-        """
-        Concatenates two transformation matrices (represented as numpy
-        arrays) together.
-        """
-        return np.dot(b, a)
-
     def __eq__(self, other):
         if getattr(other, "is_affine", False):
             return np.all(self.get_matrix() == other.get_matrix())
@@ -2021,9 +2013,8 @@ class Affine2D(Affine2DBase):
         """
         a = np.cos(theta)
         b = np.sin(theta)
-        rotate_mtx = np.array([[a, -b, 0.0], [b, a, 0.0], [0.0, 0.0, 1.0]],
-                              float)
-        self._mtx = np.dot(rotate_mtx, self._mtx)
+        rotate_mtx = np.array([[a, -b, 0.], [b, a, 0.], [0., 0., 1.]])
+        self._mtx = rotate_mtx @ self._mtx
         self.invalidate()
         return self
 
@@ -2045,6 +2036,8 @@ class Affine2D(Affine2DBase):
         calls to :meth:`rotate`, :meth:`rotate_deg`, :meth:`translate`
         and :meth:`scale`.
         """
+        # Cast to float to avoid wraparound issues with uint8's
+        x, y = float(x), float(y)
         return self.translate(-x, -y).rotate(theta).translate(x, y)
 
     def rotate_deg_around(self, x, y, degrees):
@@ -2067,9 +2060,8 @@ class Affine2D(Affine2DBase):
         calls to :meth:`rotate`, :meth:`rotate_deg`, :meth:`translate`
         and :meth:`scale`.
         """
-        translate_mtx = np.array(
-            [[1.0, 0.0, tx], [0.0, 1.0, ty], [0.0, 0.0, 1.0]], float)
-        self._mtx = np.dot(translate_mtx, self._mtx)
+        translate_mtx = np.array([[1., 0., tx], [0., 1., ty], [0., 0., 1.]])
+        self._mtx = translate_mtx @ self._mtx
         self.invalidate()
         return self
 
@@ -2086,9 +2078,8 @@ class Affine2D(Affine2DBase):
         """
         if sy is None:
             sy = sx
-        scale_mtx = np.array(
-            [[sx, 0.0, 0.0], [0.0, sy, 0.0], [0.0, 0.0, 1.0]], float)
-        self._mtx = np.dot(scale_mtx, self._mtx)
+        scale_mtx = np.array([[sx, 0., 0.], [0., sy, 0.], [0., 0., 1.]])
+        self._mtx = scale_mtx @ self._mtx
         self.invalidate()
         return self
 
@@ -2105,9 +2096,8 @@ class Affine2D(Affine2DBase):
         """
         rotX = np.tan(xShear)
         rotY = np.tan(yShear)
-        skew_mtx = np.array(
-            [[1.0, rotX, 0.0], [rotY, 1.0, 0.0], [0.0, 0.0, 1.0]], float)
-        self._mtx = np.dot(skew_mtx, self._mtx)
+        skew_mtx = np.array([[1., rotX, 0.], [rotY, 1., 0.], [0., 0., 1.]])
+        self._mtx = skew_mtx @ self._mtx
         self.invalidate()
         return self
 
@@ -2506,8 +2496,8 @@ class CompositeGenericTransform(Transform):
         if not self._b.is_affine:
             return self._b.get_affine()
         else:
-            return Affine2D(np.dot(self._b.get_affine().get_matrix(),
-                                self._a.get_affine().get_matrix()))
+            return Affine2D(self._b.get_affine().get_matrix()
+                            @ self._a.get_affine().get_matrix())
     get_affine.__doc__ = Transform.get_affine.__doc__
 
     def inverted(self):
@@ -2572,9 +2562,7 @@ class CompositeAffine2D(Affine2DBase):
 
     def get_matrix(self):
         if self._invalid:
-            self._mtx = np.dot(
-                self._b.get_matrix(),
-                self._a.get_matrix())
+            self._mtx = self._b.get_matrix() @ self._a.get_matrix()
             self._inverted = None
             self._invalid = 0
         return self._mtx

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -1217,7 +1217,7 @@ class _DOF_estimator_min_E(_DOF_estimator_geom):
         Uf, err = _cg(A=Kff_coo, b=Ff, x0=Uf0, tol=tol)
         # If the PCG did not converge, we return the best guess between Uf0
         # and Uf.
-        err0 = np.linalg.norm(Kff_coo.dot(Uf0) - Ff)
+        err0 = np.linalg.norm(Kff_coo @ Uf0 - Ff)
         if err0 < err:
             # Maybe a good occasion to raise a warning here ?
             warnings.warn("In TriCubicInterpolator initialization, PCG sparse"
@@ -1325,7 +1325,7 @@ def _cg(A, b, x0=None, tol=1.e-10, maxiter=1000):
     x: array.
         The converged solution.
     err: float
-        The absolute error np.linalg.norm(A.dot(x) - b)
+        The absolute error np.linalg.norm(A @ x - b)
 
     Other parameters
     ----------------
@@ -1355,28 +1355,28 @@ def _cg(A, b, x0=None, tol=1.e-10, maxiter=1000):
     else:
         x = x0
 
-    r = b - A.dot(x)
-    w = r/kvec
+    r = b - A @ x
+    w = r / kvec
 
     p = np.zeros(n)
     beta = 0.0
-    rho = np.dot(r, w)
+    rho = r @ w
     k = 0
 
     # Following C. T. Kelley
     while (np.sqrt(abs(rho)) > tol*b_norm) and (k < maxiter):
         p = w + beta*p
-        z = A.dot(p)
-        alpha = rho/np.dot(p, z)
+        z = A @ p
+        alpha = rho / (p @ z)
         r = r - alpha*z
         w = r/kvec
         rhoold = rho
-        rho = np.dot(r, w)
+        rho = r @ w
         x = x + alpha*p
         beta = rho/rhoold
-        #err = np.linalg.norm(A.dot(x) - b) # absolute accuracy - not used
+        #err = np.linalg.norm(A @ x - b) # absolute accuracy - not used
         k += 1
-    err = np.linalg.norm(A.dot(x) - b)
+    err = np.linalg.norm(A @ x - b)
     return x, err
 
 

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -270,9 +270,9 @@ class Type1Font(object):
             oldmatrix[0:3, 0] = array[::2]
             oldmatrix[0:3, 1] = array[1::2]
             modifier = np.array([[extend, 0, 0],
-                                 [slant, 1, 0],
-                                 [0, 0, 1]])
-            newmatrix = np.dot(modifier, oldmatrix)
+                                 [slant,  1, 0],
+                                 [0,      0, 1]])
+            newmatrix = modifier @ oldmatrix
             array[::2] = newmatrix[0:3, 0]
             array[1::2] = newmatrix[0:3, 1]
             as_string = u'[' + u' '.join(str(x) for x in array) + u']'

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1032,8 +1032,8 @@ class Axes3D(Axes):
 
         viewM = proj3d.view_transformation(E, R, V)
         projM = self._projection(zfront, zback)
-        M0 = np.dot(viewM, worldM)
-        M = np.dot(projM, M0)
+        M0 = viewM @ worldM
+        M = projM @ M0
         return M
 
     def mouse_init(self, rotate_btn=1, zoom_btn=3):
@@ -1775,7 +1775,7 @@ class Axes3D(Axes):
         *color* can also be an array of the same length as *normals*.
         '''
 
-        shade = np.array([np.dot(n / proj3d.mod(n), [-1, -1, 0.5])
+        shade = np.array([n / proj3d.mod(n) @ [-1, -1, 0.5]
                           if proj3d.mod(n) else np.nan
                           for n in normals])
         mask = ~np.isnan(shade)
@@ -2615,7 +2615,7 @@ class Axes3D(Axes):
             Rneg[[0,1,2,2],[2,2,0,1]] = -Rneg[[0,1,2,2],[2,2,0,1]]
 
             # multiply them to get the rotated vector
-            return Rpos.dot(uvw), Rneg.dot(uvw)
+            return Rpos @ uvw, Rneg @ uvw
 
         had_data = self.has_data()
 
@@ -2859,12 +2859,12 @@ class Axes3D(Axes):
         # render
         for permute in permutation_matrices(3):
             # find the set of ranges to iterate over
-            pc, qc, rc = permute.T.dot(size)
+            pc, qc, rc = permute.T @ size
             pinds = np.arange(pc)
             qinds = np.arange(qc)
             rinds = np.arange(rc)
 
-            square_rot = square.dot(permute.T)
+            square_rot = square @ permute.T
 
             # iterate within the current plane
             for p in pinds:
@@ -2874,15 +2874,15 @@ class Axes3D(Axes):
                     # empty space, to avoid drawing internal faces.
 
                     # draw lower faces
-                    p0 = permute.dot([p, q, 0])
+                    p0 = permute @ [p, q, 0]
                     i0 = tuple(p0)
                     if filled[i0]:
                         voxel_faces[i0].append(p0 + square_rot)
 
                     # draw middle faces
                     for r1, r2 in zip(rinds[:-1], rinds[1:]):
-                        p1 = permute.dot([p, q, r1])
-                        p2 = permute.dot([p, q, r2])
+                        p1 = permute @ [p, q, r1]
+                        p2 = permute @ [p, q, r2]
 
                         i1 = tuple(p1)
                         i2 = tuple(p2)
@@ -2893,8 +2893,8 @@ class Axes3D(Axes):
                             voxel_faces[i2].append(p2 + square_rot)
 
                     # draw upper faces
-                    pk = permute.dot([p, q, rc-1])
-                    pk2 = permute.dot([p, q, rc])
+                    pk = permute @ [p, q, rc-1]
+                    pk2 = permute @ [p, q, rc]
                     ik = tuple(pk)
                     if filled[ik]:
                         voxel_faces[ik].append(pk2 + square_rot)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -437,7 +437,7 @@ def _test_proj_make_M():
     V = np.array([0, 0, 1])
     viewM = proj3d.view_transformation(E, R, V)
     perspM = proj3d.persp_transformation(100, -100)
-    M = np.dot(perspM, viewM)
+    M = perspM @ viewM
     return M
 
 
@@ -504,7 +504,7 @@ def test_proj_axes_cube_ortho():
     V = np.array([0, 0, 1])
     viewM = proj3d.view_transformation(E, R, V)
     orthoM = proj3d.ortho_transformation(-1, 1)
-    M = np.dot(orthoM, viewM)
+    M = orthoM @ viewM
 
     ts = '0 1 2 3 0 4 5 6 7 4'.split()
     xs = np.array([0, 1, 1, 0, 0, 0, 1, 1, 0, 0]) * 100


### PR DESCRIPTION
1. it looks (a bit) nicer
2. it is (a bit, but reproducibly) faster:

    In [32]: %timeit t.dot(u)
    821 ns ± 1.04 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

    In [33]: %timeit t @ u
    797 ns ± 1.71 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

(where t and u are 3x3 float matrices)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
