### PR TITLE
FIX: colorbar check for constrained layout

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1132,8 +1132,12 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     parents = np.atleast_1d(parents).ravel()
 
     # check if using constrained_layout:
-    gs = parents[0].get_subplotspec().get_gridspec()
-    using_constrained_layout = (gs._layoutbox is not None)
+    try:
+        gs = parents[0].get_subplotspec().get_gridspec()
+        using_constrained_layout = (gs._layoutbox is not None)
+    except AttributeError:
+        using_constrained_layout = False
+
     # defaults are not appropriate for constrained_layout:
     pad0 = loc_settings['pad']
     if using_constrained_layout:

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -377,3 +377,14 @@ def test_constrained_layout19():
     ax.set_title('')
     fig.canvas.draw()
     assert all(ax.get_position().extents == ax2.get_position().extents)
+
+
+def test_constrained_layout20():
+    'Smoke test cl does not mess up added axes'
+    gx = np.linspace(-5, 5, 4)
+    img = np.hypot(gx, gx[:, None])
+
+    fig = plt.figure()
+    ax = fig.add_axes([0, 0, 1, 1])
+    mesh = ax.pcolormesh(gx, gx, img)
+    fig.colorbar(mesh)


### PR DESCRIPTION
## PR Summary
Fixes #10582

```python
import matplotlib.pyplot as plt
import numpy as np

gx = np.linspace(-5, 5, 10)
img = np.hypot(gx, gx[:, None])

fig = plt.figure()
ax = fig.add_axes([0, 0, 1, 1])
mesh = ax.pcolormesh(gx, gx, img)
plt.colorbar(mesh)

plt.show()
```
failed with an attribute error.  This is the most straightforward way of checking for that. 

Not sure if this should have a test or not.  Seems that maybe pyplot-created colorbars are not tested if this one got through the test suite...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->