### PR TITLE
Switch to per-file locking.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -10,6 +10,7 @@ The following functions and classes are deprecated:
 
 - ``cbook.GetRealpathAndStat`` (which is only a helper for
   ``get_realpath_and_stat``),
+- ``cbook.Locked``,
 - ``cbook.is_numlike`` (use ``isinstance(..., numbers.Number)`` instead),
 - ``mathtext.unichr_safe`` (use ``chr`` instead),
 - ``texmanager.dvipng_hack_alpha``,

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1446,7 +1446,7 @@ else:
         fontManager = FontManager()
 
         if _fmcache:
-            with cbook.Locked(cachedir):
+            with cbook._lock_path(_fmcache):
                 json_dump(fontManager, _fmcache)
         _log.info("generated new fontManager")
 
@@ -1459,9 +1459,9 @@ else:
             else:
                 fontManager.default_size = None
                 _log.debug("Using fontManager instance from %s", _fmcache)
-        except cbook.Locked.TimeoutError:
+        except TimeoutError:
             raise
-        except:
+        except Exception:
             _rebuild()
     else:
         _rebuild()

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -33,29 +33,25 @@ your script::
 
 """
 
-from __future__ import absolute_import, division, print_function
-
 import six
 
 import copy
+import distutils.version
 import glob
 import hashlib
 import logging
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
 import warnings
 
-import distutils.version
 import numpy as np
+
 import matplotlib as mpl
-from matplotlib import rcParams
-from matplotlib._png import read_png
-from matplotlib.cbook import Locked
-import matplotlib.dviread as dviread
-import re
+from matplotlib import _png, cbook, dviread, rcParams
 
 _log = logging.getLogger(__name__)
 
@@ -340,7 +336,7 @@ class TexManager(object):
         dvifile = '%s.dvi' % basefile
         if not os.path.exists(dvifile):
             texfile = self.make_tex(tex, fontsize)
-            with Locked(self.texcache):
+            with cbook._lock_path(texfile):
                 self._run_checked_subprocess(
                     ["latex", "-interaction=nonstopmode", "--halt-on-error",
                      texfile], tex)
@@ -436,7 +432,7 @@ class TexManager(object):
         alpha = self.grey_arrayd.get(key)
         if alpha is None:
             pngfile = self.make_png(tex, fontsize, dpi)
-            X = read_png(os.path.join(self.texcache, pngfile))
+            X = _png.read_png(os.path.join(self.texcache, pngfile))
             self.grey_arrayd[key] = alpha = X[:, :, -1]
         return alpha
 


### PR DESCRIPTION
Replace the Locked contextmanager (which locks a directory, preventing
other (cooperative) processes to access it) by a private _lock_path
contextmanager, which locks a single file (or directory).

- The finer grained lock avoids locking out the entire tex cache when
  handling usetex, which is useful when running multiple processes at
  once.

- Python3 implements the `"x"` ("exclusive") mode to open, which we can
  use instead of relying on `makedirs` to achieve a race-free operation
  on the filesystem.

- The previous implementation allowed multiple threads of a single
  process to acquire the same lock, but (for the use cases here, e.g.
  running a tex subprocess) this is actually undesirable.  Removing this
  behavior also simplifies the implementation.

- As far as I can tell, the previous implementation was actually racy:
  in

  ```
    retries = 50
    sleeptime = 0.1
    while retries:
        files = glob.glob(self.pattern)
        if files and not files[0].endswith(self.end):
            time.sleep(sleeptime)
            retries -= 1
        else:
            break
    else:
        err_str = _lockstr.format(self.pattern)
        raise self.TimeoutError(err_str)

    # <----- HERE

    if not files:
        try:
            os.makedirs(self.lock_path)
        except OSError:
            pass
    else:  # PID lock already here --- someone else will remove it.
        self.remove = False
  ```

  multiple processes can reach "HERE" at the same time and each
  successfully create their own lock.

This should mostly mitigate out #7776.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
