### PR TITLE
Backport of PR #10581

### DIFF
--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -230,7 +230,7 @@ fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,
 # or in the `matplotlibrc` file.  They all have the prefix
 # `figure.constrained_layout`:
 #
-#  - `do`: Whether to do constrained_layout. Default is False
+#  - `use`: Whether to use constrained_layout. Default is False
 #  - `w_pad`, `h_pad`    Padding around axes objects.
 #     Float representing inches.  Default is 3./72. inches (3 pts)
 #  - `wspace`, `hspace`  Space between subplot groups.

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -226,7 +226,7 @@ fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,
 # rcParams:
 # -----------
 #
-# There are four `rcParams` that can be set, either in a script
+# There are five `rcParams` that can be set, either in a script
 # or in the `matplotlibrc` file.  They all have the prefix
 # `figure.constrained_layout`:
 #


### PR DESCRIPTION
## PR Summary

Backported fixes for minor documentation problems in the constrained-layout tutorial.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
