### PR TITLE
Bump a tolerance in test_axisartist_floating_axes.

### DIFF
--- a/lib/mpl_toolkits/tests/test_axisartist_floating_axes.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_floating_axes.py
@@ -80,7 +80,7 @@ def test_curvelinear3():
 
 
 @image_comparison(baseline_images=['curvelinear4'],
-                  extensions=['png'], style='default', tol=0.01)
+                  extensions=['png'], style='default', tol=0.015)
 def test_curvelinear4():
     fig = plt.figure(figsize=(5, 5))
     fig.clf()


### PR DESCRIPTION
This is to stop random test failures with test_curvelinear4.png.
It's original tolerance was 0.01; the mismatch is sometimes 0.011.

Closes #10602.
