### PR TITLE
Make FigureCanvasWx ctor signature similar to FigureCanvasBase.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -5,4 +5,10 @@ The following functions and classes are deprecated:
 - ``cbook.GetRealpathAndStat`` (which is only a helper for
   ``get_realpath_and_stat``),
 - ``cbook.is_numlike`` (use ``isinstance(..., numbers.Number)`` instead),
+- ``FigureCanvasWx.frame`` and ``.tb`` (use ``.window`` and ``.toolbar``
+  respectively, which is consistent with other backends),
+- the ``FigureCanvasWx`` constructor should not be called with ``(parent, id,
+  figure)`` as arguments anymore, but just ``figure`` (like all other canvas
+  classes).  Call ``Reparent`` and ``SetId`` to set the parent and id of the
+  canvas.
 - ``mathtext.unichr_safe`` (use ``chr`` instead),

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -16,7 +16,9 @@ from .backend_wx import (
 
 class FigureFrameWxAgg(FigureFrameWx):
     def get_canvas(self, fig):
-        return FigureCanvasWxAgg(self, -1, fig)
+        canvas = FigureCanvasWxAgg(fig)
+        canvas.Reparent(self)
+        return canvas
 
 
 class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -4,17 +4,19 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import wx
+import wx.lib.wxcairo as wxcairo
 
 from .backend_cairo import cairo, FigureCanvasCairo, RendererCairo
 from .backend_wx import (
     _BackendWx, _FigureCanvasWxBase, FigureFrameWx,
     NavigationToolbar2Wx as NavigationToolbar2WxCairo)
-import wx.lib.wxcairo as wxcairo
 
 
 class FigureFrameWxCairo(FigureFrameWx):
     def get_canvas(self, fig):
-        return FigureCanvasWxCairo(self, -1, fig)
+        canvas = FigureCanvasWxCairo(fig)
+        canvas.Reparent(self)
+        return canvas
 
 
 class FigureCanvasWxCairo(_FigureCanvasWxBase, FigureCanvasCairo):
@@ -27,12 +29,13 @@ class FigureCanvasWxCairo(_FigureCanvasWxBase, FigureCanvasCairo):
     we give a hint as to our preferred minimum size.
     """
 
-    def __init__(self, parent, id, figure):
+    def __init__(self, *args):
         # _FigureCanvasWxBase should be fixed to have the same signature as
         # every other FigureCanvas and use cooperative inheritance, but in the
-        # meantime the following will make do.
-        _FigureCanvasWxBase.__init__(self, parent, id, figure)
-        FigureCanvasCairo.__init__(self, figure)
+        # meantime the following will make do.  (`args[-1]` is always the
+        # figure.)
+        _FigureCanvasWxBase.__init__(self, *args)
+        FigureCanvasCairo.__init__(self, args[-1])
         self._renderer = RendererCairo(self.figure.dpi)
 
     def draw(self, drawDC=None):


### PR DESCRIPTION
Currently, `FigureCanvasWx` has a signature of `(parent, id, figure)`,
unlike the Canvas classes of other backends, which only take `figure` as
argument.  Change `FigureCanvasWx` to be more similar to other backends.

A similar fix will later be applied to `FigureManagerWx` to bring it in
line with other Manager classes.

The ultimate goal is to get rid of `new_figure_manager` and
`new_figure_manager_given_figure` in the backend definitions, which can
be replaced by `return FigureManager(FigureCanvas(Figure(...)), num)` and
`return FigureManager(FigureCanvas(fig, num))` respectively.

Also deprecate the aliases `FigureCanvasWx.frame` and `.tb` (which are
named `.window` and `.toolbar` in all other backends).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
