### PR TITLE
Fixes #10501.  python3 support and pep8 in jpl_units

### DIFF
--- a/lib/matplotlib/testing/jpl_units/Duration.py
+++ b/lib/matplotlib/testing/jpl_units/Duration.py
@@ -1,211 +1,229 @@
-#===========================================================================
+# ==========================================================================
 #
 # Duration
 #
-#===========================================================================
+# ==========================================================================
 
 
 """Duration module."""
 
-#===========================================================================
+# ==========================================================================
 # Place all imports after here.
 #
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
+import operator
 #
 # Place all imports before here.
-#===========================================================================
+# ==========================================================================
 
-#===========================================================================
+
+# ==========================================================================
 class Duration(object):
-   """Class Duration in development.
-   """
-   allowed = [ "ET", "UTC" ]
+    """Class Duration in development.
+    """
+    allowed = ["ET", "UTC"]
 
-   #-----------------------------------------------------------------------
-   def __init__( self, frame, seconds ):
-      """Create a new Duration object.
+    # ----------------------------------------------------------------------
+    def __init__(self, frame, seconds):
+        """Create a new Duration object.
 
-      = ERROR CONDITIONS
-      - If the input frame is not in the allowed list, an error is thrown.
+        = ERROR CONDITIONS
+        - If the input frame is not in the allowed list, an error is thrown.
 
-      = INPUT VARIABLES
-      - frame    The frame of the duration.  Must be 'ET' or 'UTC'
-      - seconds  The number of seconds in the Duration.
-      """
-      if frame not in self.allowed:
-         msg = "Input frame '%s' is not one of the supported frames of %s" \
-               % ( frame, str( self.allowed ) )
-         raise ValueError( msg )
+        = INPUT VARIABLES
+        - frame     The frame of the duration.  Must be 'ET' or 'UTC'
+        - seconds  The number of seconds in the Duration.
+        """
+        if frame not in self.allowed:
+            msg = "Input frame '%s' is not one of the supported frames of %s" \
+                    % (frame, str(self.allowed))
+            raise ValueError(msg)
 
-      self._frame = frame
-      self._seconds = seconds
+        self._frame = frame
+        self._seconds = seconds
 
-   #-----------------------------------------------------------------------
-   def frame( self ):
-      """Return the frame the duration is in."""
-      return self._frame
+    # ----------------------------------------------------------------------
+    def frame(self):
+        """Return the frame the duration is in."""
+        return self._frame
 
-   #-----------------------------------------------------------------------
-   def __abs__( self ):
-      """Return the absolute value of the duration."""
-      return Duration( self._frame, abs( self._seconds ) )
+    # ----------------------------------------------------------------------
+    def __abs__(self):
+        """Return the absolute value of the duration."""
+        return Duration(self._frame, abs(self._seconds))
 
-   #-----------------------------------------------------------------------
-   def __neg__( self ):
-      """Return the negative value of this Duration."""
-      return Duration( self._frame, -self._seconds )
+    # ----------------------------------------------------------------------
+    def __neg__(self):
+        """Return the negative value of this Duration."""
+        return Duration(self._frame, -self._seconds)
 
-   #-----------------------------------------------------------------------
-   def seconds( self ):
-      """Return the number of seconds in the Duration."""
-      return self._seconds
+    # ----------------------------------------------------------------------
+    def seconds(self):
+        """Return the number of seconds in the Duration."""
+        return self._seconds
 
-   #-----------------------------------------------------------------------
-   def __nonzero__( self ):
-      """Compare two Durations.
+    # ----------------------------------------------------------------------
+    def __nonzero__(self):
+        """Compare two Durations.
 
-      = INPUT VARIABLES
-      - rhs    The Duration to compare against.
+        = INPUT VARIABLES
+        - rhs     The Duration to compare against.
 
-      = RETURN VALUE
-      - Returns -1 if self < rhs, 0 if self == rhs, +1 if self > rhs.
-      """
-      return self._seconds != 0
+        = RETURN VALUE
+        - Returns -1 if self < rhs, 0 if self == rhs, +1 if self > rhs.
+        """
+        return self._seconds != 0
 
-   if six.PY3:
-      __bool__ = __nonzero__
+    if six.PY3:
+        __bool__ = __nonzero__
 
-   #-----------------------------------------------------------------------
-   def __cmp__( self, rhs ):
-      """Compare two Durations.
+    # ----------------------------------------------------------------------
+    def __eq__(self, rhs):
+        return self._cmp(rhs, operator.eq)
 
-      = ERROR CONDITIONS
-      - If the input rhs is not in the same frame, an error is thrown.
+    def __ne__(self, rhs):
+        return self._cmp(rhs, operator.ne)
 
-      = INPUT VARIABLES
-      - rhs    The Duration to compare against.
+    def __lt__(self, rhs):
+        return self._cmp(rhs, operator.lt)
 
-      = RETURN VALUE
-      - Returns -1 if self < rhs, 0 if self == rhs, +1 if self > rhs.
-      """
-      self.checkSameFrame( rhs, "compare" )
-      return cmp( self._seconds, rhs._seconds )
+    def __le__(self, rhs):
+        return self._cmp(rhs, operator.le)
 
-   #-----------------------------------------------------------------------
-   def __add__( self, rhs ):
-      """Add two Durations.
+    def __gt__(self, rhs):
+        return self._cmp(rhs, operator.gt)
 
-      = ERROR CONDITIONS
-      - If the input rhs is not in the same frame, an error is thrown.
+    def __ge__(self, rhs):
+        return self._cmp(rhs, operator.ge)
 
-      = INPUT VARIABLES
-      - rhs    The Duration to add.
+    def _cmp(self, rhs, op):
+        """Compare two Durations.
 
-      = RETURN VALUE
-      - Returns the sum of ourselves and the input Duration.
-      """
-      # Delay-load due to circular dependencies.
-      import matplotlib.testing.jpl_units as U
+        = INPUT VARIABLES
+        - rhs     The Duration to compare against.
+        - op      The function to do the comparison
 
-      if isinstance( rhs, U.Epoch ):
-         return rhs + self
+        = RETURN VALUE
+        - Returns op(self, rhs)
+        """
+        self.checkSameFrame(rhs, "compare")
+        return op(self._seconds, rhs._seconds)
 
-      self.checkSameFrame( rhs, "add" )
-      return Duration( self._frame, self._seconds + rhs._seconds )
+    # ----------------------------------------------------------------------
+    def __add__(self, rhs):
+        """Add two Durations.
 
-   #-----------------------------------------------------------------------
-   def __sub__( self, rhs ):
-      """Subtract two Durations.
+        = ERROR CONDITIONS
+        - If the input rhs is not in the same frame, an error is thrown.
 
-      = ERROR CONDITIONS
-      - If the input rhs is not in the same frame, an error is thrown.
+        = INPUT VARIABLES
+        - rhs     The Duration to add.
 
-      = INPUT VARIABLES
-      - rhs    The Duration to subtract.
+        = RETURN VALUE
+        - Returns the sum of ourselves and the input Duration.
+        """
+        # Delay-load due to circular dependencies.
+        import matplotlib.testing.jpl_units as U
 
-      = RETURN VALUE
-      - Returns the difference of ourselves and the input Duration.
-      """
-      self.checkSameFrame( rhs, "sub" )
-      return Duration( self._frame, self._seconds - rhs._seconds )
+        if isinstance(rhs, U.Epoch):
+            return rhs + self
 
-   #-----------------------------------------------------------------------
-   def __mul__( self, rhs ):
-      """Scale a UnitDbl by a value.
+        self.checkSameFrame(rhs, "add")
+        return Duration(self._frame, self._seconds + rhs._seconds)
 
-      = INPUT VARIABLES
-      - rhs    The scalar to multiply by.
+    # ----------------------------------------------------------------------
+    def __sub__(self, rhs):
+        """Subtract two Durations.
 
-      = RETURN VALUE
-      - Returns the scaled Duration.
-      """
-      return Duration( self._frame, self._seconds * float( rhs ) )
+        = ERROR CONDITIONS
+        - If the input rhs is not in the same frame, an error is thrown.
 
-   #-----------------------------------------------------------------------
-   def __rmul__( self, lhs ):
-      """Scale a Duration by a value.
+        = INPUT VARIABLES
+        - rhs     The Duration to subtract.
 
-      = INPUT VARIABLES
-      - lhs    The scalar to multiply by.
+        = RETURN VALUE
+        - Returns the difference of ourselves and the input Duration.
+        """
+        self.checkSameFrame(rhs, "sub")
+        return Duration(self._frame, self._seconds - rhs._seconds)
 
-      = RETURN VALUE
-      - Returns the scaled Duration.
-      """
-      return Duration( self._frame, self._seconds * float( lhs ) )
+    # ----------------------------------------------------------------------
+    def __mul__(self, rhs):
+        """Scale a UnitDbl by a value.
 
-   #-----------------------------------------------------------------------
-   def __div__( self, rhs ):
-      """Divide a Duration by a value.
+        = INPUT VARIABLES
+        - rhs     The scalar to multiply by.
 
-      = INPUT VARIABLES
-      - rhs    The scalar to divide by.
+        = RETURN VALUE
+        - Returns the scaled Duration.
+        """
+        return Duration(self._frame, self._seconds * float(rhs))
 
-      = RETURN VALUE
-      - Returns the scaled Duration.
-      """
-      return Duration( self._frame, self._seconds / rhs )
+    # ----------------------------------------------------------------------
+    def __rmul__(self, lhs):
+        """Scale a Duration by a value.
 
-   #-----------------------------------------------------------------------
-   def __rdiv__( self, rhs ):
-      """Divide a Duration by a value.
+        = INPUT VARIABLES
+        - lhs     The scalar to multiply by.
 
-      = INPUT VARIABLES
-      - rhs    The scalar to divide by.
+        = RETURN VALUE
+        - Returns the scaled Duration.
+        """
+        return Duration(self._frame, self._seconds * float(lhs))
 
-      = RETURN VALUE
-      - Returns the scaled Duration.
-      """
-      return Duration( self._frame, rhs / self._seconds )
+    # ----------------------------------------------------------------------
+    def __div__(self, rhs):
+        """Divide a Duration by a value.
 
-   #-----------------------------------------------------------------------
-   def __str__( self ):
-      """Print the Duration."""
-      return "%g %s" % ( self._seconds, self._frame )
+        = INPUT VARIABLES
+        - rhs     The scalar to divide by.
 
-   #-----------------------------------------------------------------------
-   def __repr__( self ):
-      """Print the Duration."""
-      return "Duration( '%s', %g )" % ( self._frame, self._seconds )
+        = RETURN VALUE
+        - Returns the scaled Duration.
+        """
+        return Duration(self._frame, self._seconds / rhs)
 
-   #-----------------------------------------------------------------------
-   def checkSameFrame( self, rhs, func ):
-      """Check to see if frames are the same.
+    # ----------------------------------------------------------------------
+    def __rdiv__(self, rhs):
+        """Divide a Duration by a value.
 
-      = ERROR CONDITIONS
-      - If the frame of the rhs Duration is not the same as our frame,
-        an error is thrown.
+        = INPUT VARIABLES
+        - rhs     The scalar to divide by.
 
-      = INPUT VARIABLES
-      - rhs    The Duration to check for the same frame
-      - func   The name of the function doing the check.
-      """
-      if self._frame != rhs._frame:
-         msg = "Cannot %s Duration's with different frames.\n" \
-               "LHS: %s\n" \
-               "RHS: %s" % ( func, self._frame, rhs._frame )
-         raise ValueError( msg )
+        = RETURN VALUE
+        - Returns the scaled Duration.
+        """
+        return Duration(self._frame, rhs / self._seconds)
 
-#===========================================================================
+    # ----------------------------------------------------------------------
+    def __str__(self):
+        """Print the Duration."""
+        return "%g %s" % (self._seconds, self._frame)
+
+    # ----------------------------------------------------------------------
+    def __repr__(self):
+        """Print the Duration."""
+        return "Duration('%s', %g)" % (self._frame, self._seconds)
+
+    # ----------------------------------------------------------------------
+    def checkSameFrame(self, rhs, func):
+        """Check to see if frames are the same.
+
+        = ERROR CONDITIONS
+        - If the frame of the rhs Duration is not the same as our frame,
+          an error is thrown.
+
+        = INPUT VARIABLES
+        - rhs     The Duration to check for the same frame
+        - func    The name of the function doing the check.
+        """
+        if self._frame != rhs._frame:
+            msg = "Cannot %s Duration's with different frames.\n" \
+                    "LHS: %s\n" \
+                    "RHS: %s" % (func, self._frame, rhs._frame)
+            raise ValueError(msg)
+
+# ==========================================================================

--- a/lib/matplotlib/testing/jpl_units/Epoch.py
+++ b/lib/matplotlib/testing/jpl_units/Epoch.py
@@ -1,238 +1,260 @@
-#===========================================================================
+# ===========================================================================
 #
 # Epoch
 #
-#===========================================================================
+# ===========================================================================
 
 
 """Epoch module."""
 
-#===========================================================================
+# ===========================================================================
 # Place all imports after here.
 #
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-
+import operator
 import math
 import datetime as DT
 from matplotlib.dates import date2num
 #
 # Place all imports before here.
-#===========================================================================
+# ===========================================================================
 
-#===========================================================================
+
+# ===========================================================================
 class Epoch(object):
-   # Frame conversion offsets in seconds
-   # t(TO) = t(FROM) + allowed[ FROM ][ TO ]
-   allowed = {
-      "ET" : {
-         "UTC" : +64.1839,
-         },
-      "UTC" : {
-         "ET" : -64.1839,
-         },
-      }
+    # Frame conversion offsets in seconds
+    # t(TO) = t(FROM) + allowed[ FROM ][ TO ]
+    allowed = {
+        "ET": {
+            "UTC": +64.1839,
+            },
+        "UTC": {
+            "ET": -64.1839,
+            },
+        }
 
-   #-----------------------------------------------------------------------
-   def __init__( self, frame, sec=None, jd=None, daynum=None, dt=None ):
-      """Create a new Epoch object.
+    # -----------------------------------------------------------------------
+    def __init__(self, frame, sec=None, jd=None, daynum=None, dt=None):
+        """Create a new Epoch object.
 
-      Build an epoch 1 of 2 ways:
+        Build an epoch 1 of 2 ways:
 
-      Using seconds past a Julian date:
-      #   Epoch( 'ET', sec=1e8, jd=2451545 )
+        Using seconds past a Julian date:
+        #   Epoch('ET', sec=1e8, jd=2451545)
 
-      or using a matplotlib day number
-      #   Epoch( 'ET', daynum=730119.5 )
+        or using a matplotlib day number
+        #   Epoch('ET', daynum=730119.5)
 
 
-      = ERROR CONDITIONS
-      - If the input units are not in the allowed list, an error is thrown.
+        = ERROR CONDITIONS
+        - If the input units are not in the allowed list, an error is thrown.
 
-      = INPUT VARIABLES
-      - frame    The frame of the epoch.  Must be 'ET' or 'UTC'
-      - sec      The number of seconds past the input JD.
-      - jd       The Julian date of the epoch.
-      - daynum   The matplotlib day number of the epoch.
-      - dt       A python datetime instance.
-      """
-      if ( ( sec is None and jd is not None ) or
-           ( sec is not None and jd is None ) or
-           ( daynum is not None and ( sec is not None or jd is not None ) ) or
-           ( daynum is None and dt is None and ( sec is None or jd is None ) ) or
-           ( daynum is not None and dt is not None ) or
-           ( dt is not None and ( sec is not None or jd is not None ) ) or
-           ( (dt is not None) and not isinstance(dt, DT.datetime) ) ):
-         msg = "Invalid inputs.  Must enter sec and jd together, " \
-               "daynum by itself, or dt (must be a python datetime).\n" \
-               "Sec = %s\nJD  = %s\ndnum= %s\ndt  = %s" \
-               % ( str( sec ), str( jd ), str( daynum ), str( dt ) )
-         raise ValueError( msg )
+        = INPUT VARIABLES
+        - frame     The frame of the epoch.  Must be 'ET' or 'UTC'
+        - sec        The number of seconds past the input JD.
+        - jd         The Julian date of the epoch.
+        - daynum    The matplotlib day number of the epoch.
+        - dt         A python datetime instance.
+        """
+        if ((sec is None and jd is not None) or
+                (sec is not None and jd is None) or
+                (daynum is not None and
+                 (sec is not None or jd is not None)) or
+                (daynum is None and dt is None and
+                 (sec is None or jd is None)) or
+                (daynum is not None and dt is not None) or
+                (dt is not None and (sec is not None or jd is not None)) or
+                ((dt is not None) and not isinstance(dt, DT.datetime))):
+            msg = "Invalid inputs.  Must enter sec and jd together, " \
+                    "daynum by itself, or dt (must be a python datetime).\n" \
+                    "Sec = %s\nJD  = %s\ndnum= %s\ndt  = %s" \
+                    % (str(sec), str(jd), str(daynum), str(dt))
+            raise ValueError(msg)
 
-      if frame not in self.allowed:
-         msg = "Input frame '%s' is not one of the supported frames of %s" \
-               % ( frame, str( list(six.iterkeys(self.allowed) ) ) )
-         raise ValueError(msg)
+        if frame not in self.allowed:
+            msg = "Input frame '%s' is not one of the supported frames of %s" \
+                    % (frame, str(list(six.iterkeys(self.allowed))))
+            raise ValueError(msg)
 
-      self._frame = frame
+        self._frame = frame
 
-      if dt is not None:
-         daynum = date2num( dt )
+        if dt is not None:
+            daynum = date2num(dt)
 
-      if daynum is not None:
-         # 1-JAN-0001 in JD = 1721425.5
-         jd = float( daynum ) + 1721425.5
-         self._jd = math.floor( jd )
-         self._seconds = ( jd - self._jd ) * 86400.0
+        if daynum is not None:
+            # 1-JAN-0001 in JD = 1721425.5
+            jd = float(daynum) + 1721425.5
+            self._jd = math.floor(jd)
+            self._seconds = (jd - self._jd) * 86400.0
 
-      else:
-         self._seconds = float( sec )
-         self._jd = float( jd )
+        else:
+            self._seconds = float(sec)
+            self._jd = float(jd)
 
-         # Resolve seconds down to [ 0, 86400 )
-         deltaDays = int( math.floor( self._seconds / 86400.0 ) )
-         self._jd += deltaDays
-         self._seconds -= deltaDays * 86400.0
+            # Resolve seconds down to [ 0, 86400)
+            deltaDays = int(math.floor(self._seconds / 86400.0))
+            self._jd += deltaDays
+            self._seconds -= deltaDays * 86400.0
 
-   #-----------------------------------------------------------------------
-   def convert( self, frame ):
-      if self._frame == frame:
-         return self
+    # -----------------------------------------------------------------------
+    def convert(self, frame):
+        if self._frame == frame:
+            return self
 
-      offset = self.allowed[ self._frame ][ frame ]
+        offset = self.allowed[self._frame][frame]
 
-      return Epoch( frame, self._seconds + offset, self._jd )
+        return Epoch(frame, self._seconds + offset, self._jd)
 
-   #-----------------------------------------------------------------------
-   def frame( self ):
-      return self._frame
+    # -----------------------------------------------------------------------
+    def frame(self):
+        return self._frame
 
-   #-----------------------------------------------------------------------
-   def julianDate( self, frame ):
-      t = self
-      if frame != self._frame:
-         t = self.convert( frame )
+    # -----------------------------------------------------------------------
+    def julianDate(self, frame):
+        t = self
+        if frame != self._frame:
+            t = self.convert(frame)
 
-      return t._jd + t._seconds / 86400.0
+        return t._jd + t._seconds / 86400.0
 
-   #-----------------------------------------------------------------------
-   def secondsPast( self, frame, jd ):
-      t = self
-      if frame != self._frame:
-         t = self.convert( frame )
+    # -----------------------------------------------------------------------
+    def secondsPast(self, frame, jd):
+        t = self
+        if frame != self._frame:
+            t = self.convert(frame)
 
-      delta = t._jd - jd
-      return t._seconds + delta * 86400
+        delta = t._jd - jd
+        return t._seconds + delta * 86400
 
-   #-----------------------------------------------------------------------
-   def __cmp__( self, rhs ):
-      """Compare two Epoch's.
+    # -----------------------------------------------------------------------
+    def __eq__(self, rhs):
+        return self._cmp(rhs, operator.eq)
 
-      = INPUT VARIABLES
-      - rhs    The Epoch to compare against.
+    def __ne__(self, rhs):
+        return self._cmp(rhs, operator.ne)
 
-      = RETURN VALUE
-      - Returns -1 if self < rhs, 0 if self == rhs, +1 if self > rhs.
-      """
-      t = self
-      if self._frame != rhs._frame:
-         t = self.convert( rhs._frame )
+    def __lt__(self, rhs):
+        return self._cmp(rhs, operator.lt)
 
-      if t._jd != rhs._jd:
-         return cmp( t._jd, rhs._jd )
+    def __le__(self, rhs):
+        return self._cmp(rhs, operator.le)
 
-      return cmp( t._seconds, rhs._seconds )
+    def __gt__(self, rhs):
+        return self._cmp(rhs, operator.gt)
 
-   #-----------------------------------------------------------------------
-   def __add__( self, rhs ):
-      """Add a duration to an Epoch.
+    def __ge__(self, rhs):
+        return self._cmp(rhs, operator.ge)
 
-      = INPUT VARIABLES
-      - rhs    The Epoch to subtract.
+    def _cmp(self, rhs, op):
+        """Compare two Epoch's.
 
-      = RETURN VALUE
-      - Returns the difference of ourselves and the input Epoch.
-      """
-      t = self
-      if self._frame != rhs.frame():
-         t = self.convert( rhs._frame )
+        = INPUT VARIABLES
+        - rhs     The Epoch to compare against.
+        - op      The function to do the comparison
 
-      sec = t._seconds + rhs.seconds()
+        = RETURN VALUE
+        - Returns op(self, rhs)
+        """
+        t = self
+        if self._frame != rhs._frame:
+            t = self.convert(rhs._frame)
 
-      return Epoch( t._frame, sec, t._jd )
+        if t._jd != rhs._jd:
+            return op(t._jd, rhs._jd)
 
-   #-----------------------------------------------------------------------
-   def __sub__( self, rhs ):
-      """Subtract two Epoch's or a Duration from an Epoch.
+        return op(t._seconds, rhs._seconds)
 
-      Valid:
-      Duration = Epoch - Epoch
-      Epoch = Epoch - Duration
+    # -----------------------------------------------------------------------
+    def __add__(self, rhs):
+        """Add a duration to an Epoch.
 
-      = INPUT VARIABLES
-      - rhs    The Epoch to subtract.
+        = INPUT VARIABLES
+        - rhs     The Epoch to subtract.
 
-      = RETURN VALUE
-      - Returns either the duration between to Epoch's or the a new
-        Epoch that is the result of subtracting a duration from an epoch.
-      """
-      # Delay-load due to circular dependencies.
-      import matplotlib.testing.jpl_units as U
+        = RETURN VALUE
+        - Returns the difference of ourselves and the input Epoch.
+        """
+        t = self
+        if self._frame != rhs.frame():
+            t = self.convert(rhs._frame)
 
-      # Handle Epoch - Duration
-      if isinstance( rhs, U.Duration ):
-         return self + -rhs
+        sec = t._seconds + rhs.seconds()
 
-      t = self
-      if self._frame != rhs._frame:
-         t = self.convert( rhs._frame )
+        return Epoch(t._frame, sec, t._jd)
 
-      days = t._jd - rhs._jd
-      sec = t._seconds - rhs._seconds
+    # -----------------------------------------------------------------------
+    def __sub__(self, rhs):
+        """Subtract two Epoch's or a Duration from an Epoch.
 
-      return U.Duration( rhs._frame, days*86400 + sec )
+        Valid:
+        Duration = Epoch - Epoch
+        Epoch = Epoch - Duration
 
-   #-----------------------------------------------------------------------
-   def __str__( self ):
-      """Print the Epoch."""
-      return "%22.15e %s" % ( self.julianDate( self._frame ), self._frame )
+        = INPUT VARIABLES
+        - rhs     The Epoch to subtract.
 
-   #-----------------------------------------------------------------------
-   def __repr__( self ):
-      """Print the Epoch."""
-      return str( self )
+        = RETURN VALUE
+        - Returns either the duration between to Epoch's or the a new
+          Epoch that is the result of subtracting a duration from an epoch.
+        """
+        # Delay-load due to circular dependencies.
+        import matplotlib.testing.jpl_units as U
 
-   #-----------------------------------------------------------------------
-   def range( start, stop, step ):
-      """Generate a range of Epoch objects.
+        # Handle Epoch - Duration
+        if isinstance(rhs, U.Duration):
+            return self + -rhs
 
-      Similar to the Python range() method.  Returns the range [
-      start, stop ) at the requested step.  Each element will be a
-      Epoch object.
+        t = self
+        if self._frame != rhs._frame:
+            t = self.convert(rhs._frame)
 
-      = INPUT VARIABLES
-      - start    The starting value of the range.
-      - stop     The stop value of the range.
-      - step     Step to use.
+        days = t._jd - rhs._jd
+        sec = t._seconds - rhs._seconds
 
-      = RETURN VALUE
-      - Returns a list contianing the requested Epoch values.
-      """
-      elems = []
+        return U.Duration(rhs._frame, days*86400 + sec)
 
-      i = 0
-      while True:
-         d = start + i * step
-         if d >= stop:
-            break
+    # -----------------------------------------------------------------------
+    def __str__(self):
+        """Print the Epoch."""
+        return "%22.15e %s" % (self.julianDate(self._frame), self._frame)
 
-         elems.append( d )
-         i += 1
+    # -----------------------------------------------------------------------
+    def __repr__(self):
+        """Print the Epoch."""
+        return str(self)
 
-      return elems
+    # -----------------------------------------------------------------------
+    def range(start, stop, step):
+        """Generate a range of Epoch objects.
 
-   range = staticmethod( range )
+        Similar to the Python range() method.  Returns the range [
+        start, stop) at the requested step.  Each element will be a
+        Epoch object.
 
-#===========================================================================
+        = INPUT VARIABLES
+        - start     The starting value of the range.
+        - stop      The stop value of the range.
+        - step      Step to use.
+
+        = RETURN VALUE
+        - Returns a list contianing the requested Epoch values.
+        """
+        elems = []
+
+        i = 0
+        while True:
+            d = start + i * step
+            if d >= stop:
+                break
+
+            elems.append(d)
+            i += 1
+
+        return elems
+
+    range = staticmethod(range)
+
+# ===========================================================================

--- a/lib/matplotlib/testing/jpl_units/EpochConverter.py
+++ b/lib/matplotlib/testing/jpl_units/EpochConverter.py
@@ -1,13 +1,13 @@
-#===========================================================================
+# ==========================================================================
 #
 # EpochConverter
 #
-#===========================================================================
+# ==========================================================================
 
 
 """EpochConverter module containing class EpochConverter."""
 
-#===========================================================================
+# ==========================================================================
 # Place all imports after here.
 #
 from __future__ import (absolute_import, division, print_function,
@@ -20,146 +20,145 @@ import matplotlib.dates as date_ticker
 from matplotlib.cbook import iterable
 #
 # Place all imports before here.
-#===========================================================================
+# ==========================================================================
 
-__all__ = [ 'EpochConverter' ]
+__all__ = ['EpochConverter']
 
-#===========================================================================
-class EpochConverter( units.ConversionInterface ):
-   """: A matplotlib converter class.  Provides matplotlib conversion
-        functionality for Monte Epoch and Duration classes.
-   """
 
-   # julian date reference for "Jan 1, 0001" minus 1 day because
-   # matplotlib really wants "Jan 0, 0001"
-   jdRef = 1721425.5 - 1
+# ==========================================================================
+class EpochConverter(units.ConversionInterface):
+    """: A matplotlib converter class.  Provides matplotlib conversion
+          functionality for Monte Epoch and Duration classes.
+    """
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def axisinfo( unit, axis ):
-      """: Returns information on how to handle an axis that has Epoch data.
+    # julian date reference for "Jan 1, 0001" minus 1 day because
+    # matplotlib really wants "Jan 0, 0001"
+    jdRef = 1721425.5 - 1
 
-      = INPUT VARIABLES
-      - unit    The units to use for a axis with Epoch data.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def axisinfo(unit, axis):
+        """: Returns information on how to handle an axis that has Epoch data.
 
-      = RETURN VALUE
-      - Returns a matplotlib AxisInfo data structure that contains
-        minor/major formatters, major/minor locators, and default
-        label information.
-      """
+        = INPUT VARIABLES
+        - unit     The units to use for a axis with Epoch data.
 
-      majloc = date_ticker.AutoDateLocator()
-      majfmt = date_ticker.AutoDateFormatter( majloc )
+        = RETURN VALUE
+        - Returns a matplotlib AxisInfo data structure that contains
+          minor/major formatters, major/minor locators, and default
+          label information.
+        """
 
-      return units.AxisInfo( majloc = majloc,
-                             majfmt = majfmt,
-                             label = unit )
+        majloc = date_ticker.AutoDateLocator()
+        majfmt = date_ticker.AutoDateFormatter(majloc)
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def float2epoch( value, unit ):
-      """: Convert a matplotlib floating-point date into an Epoch of the
-           specified units.
+        return units.AxisInfo(majloc=majloc, majfmt=majfmt, label=unit)
 
-      = INPUT VARIABLES
-      - value    The matplotlib floating-point date.
-      - unit     The unit system to use for the Epoch.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def float2epoch(value, unit):
+        """: Convert a matplotlib floating-point date into an Epoch of the
+              specified units.
 
-      = RETURN VALUE
-      - Returns the value converted to an Epoch in the specified time system.
-      """
-      # Delay-load due to circular dependencies.
-      import matplotlib.testing.jpl_units as U
+        = INPUT VARIABLES
+        - value     The matplotlib floating-point date.
+        - unit      The unit system to use for the Epoch.
 
-      secPastRef = value * 86400.0 * U.UnitDbl( 1.0, 'sec' )
-      return U.Epoch( unit, secPastRef, EpochConverter.jdRef )
+        = RETURN VALUE
+        - Returns the value converted to an Epoch in the specified time system.
+        """
+        # Delay-load due to circular dependencies.
+        import matplotlib.testing.jpl_units as U
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def epoch2float( value, unit ):
-      """: Convert an Epoch value to a float suitible for plotting as a
-           python datetime object.
+        secPastRef = value * 86400.0 * U.UnitDbl(1.0, 'sec')
+        return U.Epoch(unit, secPastRef, EpochConverter.jdRef)
 
-      = INPUT VARIABLES
-      - value   An Epoch or list of Epochs that need to be converted.
-      - unit    The units to use for an axis with Epoch data.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def epoch2float(value, unit):
+        """: Convert an Epoch value to a float suitible for plotting as a
+              python datetime object.
 
-      = RETURN VALUE
-      - Returns the value parameter converted to floats.
-      """
-      return value.julianDate( unit ) - EpochConverter.jdRef
+        = INPUT VARIABLES
+        - value    An Epoch or list of Epochs that need to be converted.
+        - unit     The units to use for an axis with Epoch data.
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def duration2float( value ):
-      """: Convert a Duration value to a float suitible for plotting as a
-           python datetime object.
+        = RETURN VALUE
+        - Returns the value parameter converted to floats.
+        """
+        return value.julianDate(unit) - EpochConverter.jdRef
 
-      = INPUT VARIABLES
-      - value   A Duration or list of Durations that need to be converted.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def duration2float(value):
+        """: Convert a Duration value to a float suitible for plotting as a
+              python datetime object.
 
-      = RETURN VALUE
-      - Returns the value parameter converted to floats.
-      """
-      return value.seconds() / 86400.0
+        = INPUT VARIABLES
+        - value    A Duration or list of Durations that need to be converted.
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def convert( value, unit, axis ):
-      """: Convert value using unit to a float.  If value is a sequence, return
-      the converted sequence.
+        = RETURN VALUE
+        - Returns the value parameter converted to floats.
+        """
+        return value.seconds() / 86400.0
 
-      = INPUT VARIABLES
-      - value   The value or list of values that need to be converted.
-      - unit    The units to use for an axis with Epoch data.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def convert(value, unit, axis):
+        """: Convert value using unit to a float.  If value is a sequence, return
+        the converted sequence.
 
-      = RETURN VALUE
-      - Returns the value parameter converted to floats.
-      """
-      # Delay-load due to circular dependencies.
-      import matplotlib.testing.jpl_units as U
+        = INPUT VARIABLES
+        - value    The value or list of values that need to be converted.
+        - unit     The units to use for an axis with Epoch data.
 
-      isNotEpoch = True
-      isDuration = False
+        = RETURN VALUE
+        - Returns the value parameter converted to floats.
+        """
+        # Delay-load due to circular dependencies.
+        import matplotlib.testing.jpl_units as U
 
-      if ( iterable(value) and not isinstance(value, six.string_types) ):
-         if ( len(value) == 0 ):
-            return []
-         else:
-            return [ EpochConverter.convert( x, unit, axis ) for x in value ]
+        isNotEpoch = True
+        isDuration = False
 
-      if ( isinstance(value, U.Epoch) ):
-         isNotEpoch = False
-      elif ( isinstance(value, U.Duration) ):
-         isDuration = True
+        if iterable(value) and not isinstance(value, six.string_types):
+            if (len(value) == 0):
+                return []
+            else:
+                return [EpochConverter.convert(x, unit, axis) for x in value]
 
-      if ( isNotEpoch and not isDuration and
-           units.ConversionInterface.is_numlike( value ) ):
-         return value
+        if isinstance(value, U.Epoch):
+            isNotEpoch = False
+        elif isinstance(value, U.Duration):
+            isDuration = True
 
-      if ( unit == None ):
-         unit = EpochConverter.default_units( value, axis )
+        if (isNotEpoch and not isDuration and
+           units.ConversionInterface.is_numlike(value)):
+            return value
 
-      if ( isDuration ):
-         return EpochConverter.duration2float( value )
-      else:
-         return EpochConverter.epoch2float( value, unit )
+        if unit is None:
+            unit = EpochConverter.default_units(value, axis)
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def default_units( value, axis ):
-      """: Return the default unit for value, or None.
+        if isDuration:
+            return EpochConverter.duration2float(value)
+        else:
+            return EpochConverter.epoch2float(value, unit)
 
-      = INPUT VARIABLES
-      - value   The value or list of values that need units.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def default_units(value, axis):
+        """: Return the default unit for value, or None.
 
-      = RETURN VALUE
-      - Returns the default units to use for value.
-      """
-      frame = None
-      if ( iterable(value) and not isinstance(value, six.string_types) ):
-         return EpochConverter.default_units( value[0], axis )
-      else:
-         frame = value.frame()
+        = INPUT VARIABLES
+        - value    The value or list of values that need units.
 
-      return frame
+        = RETURN VALUE
+        - Returns the default units to use for value.
+        """
+        frame = None
+        if iterable(value) and not isinstance(value, six.string_types):
+            return EpochConverter.default_units(value[0], axis)
+        else:
+            frame = value.frame()
+
+        return frame

--- a/lib/matplotlib/testing/jpl_units/StrConverter.py
+++ b/lib/matplotlib/testing/jpl_units/StrConverter.py
@@ -1,163 +1,161 @@
-#===========================================================================
+# ==========================================================================
 #
 # StrConverter
 #
-#===========================================================================
+# ==========================================================================
 
 
 """StrConverter module containing class StrConverter."""
 
-#===========================================================================
+# ==========================================================================
 # Place all imports after here.
 #
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
-
 import matplotlib.units as units
 from matplotlib.cbook import iterable
 
 # Place all imports before here.
-#===========================================================================
+# ==========================================================================
 
-__all__ = [ 'StrConverter' ]
-
-#===========================================================================
-class StrConverter( units.ConversionInterface ):
-   """: A matplotlib converter class.  Provides matplotlib conversion
-        functionality for string data values.
-
-   Valid units for string are:
-   - 'indexed' : Values are indexed as they are specified for plotting.
-   - 'sorted'  : Values are sorted alphanumerically.
-   - 'inverted' : Values are inverted so that the first value is on top.
-   - 'sorted-inverted' :  A combination of 'sorted' and 'inverted'
-   """
-
-   #------------------------------------------------------------------------
-   @staticmethod
-   def axisinfo( unit, axis ):
-      """: Returns information on how to handle an axis that has string data.
-
-      = INPUT VARIABLES
-      - axis    The axis using this converter.
-      - unit    The units to use for a axis with string data.
-
-      = RETURN VALUE
-      - Returns a matplotlib AxisInfo data structure that contains
-        minor/major formatters, major/minor locators, and default
-        label information.
-      """
-
-      return None
-
-   #------------------------------------------------------------------------
-   @staticmethod
-   def convert( value, unit, axis ):
-      """: Convert value using unit to a float.  If value is a sequence, return
-      the converted sequence.
-
-      = INPUT VARIABLES
-      - axis    The axis using this converter.
-      - value   The value or list of values that need to be converted.
-      - unit    The units to use for a axis with Epoch data.
-
-      = RETURN VALUE
-      - Returns the value parameter converted to floats.
-      """
-
-      if ( units.ConversionInterface.is_numlike( value ) ):
-         return value
-
-      if ( value == [] ):
-         return []
-
-      # we delay loading to make matplotlib happy
-      ax = axis.axes
-      if axis is ax.get_xaxis():
-         isXAxis = True
-      else:
-         isXAxis = False
-
-      axis.get_major_ticks()
-      ticks = axis.get_ticklocs()
-      labels = axis.get_ticklabels()
-
-      labels = [ l.get_text() for l in labels if l.get_text() ]
-
-      if ( not labels ):
-         ticks = []
-         labels = []
+__all__ = ['StrConverter']
 
 
-      if ( not iterable( value ) ):
-         value = [ value ]
+# ==========================================================================
+class StrConverter(units.ConversionInterface):
+    """: A matplotlib converter class.  Provides matplotlib conversion
+          functionality for string data values.
 
-      newValues = []
-      for v in value:
-         if ( (v not in labels) and (v not in newValues) ):
-            newValues.append( v )
+    Valid units for string are:
+    - 'indexed' : Values are indexed as they are specified for plotting.
+    - 'sorted'  : Values are sorted alphanumerically.
+    - 'inverted' : Values are inverted so that the first value is on top.
+    - 'sorted-inverted' :  A combination of 'sorted' and 'inverted'
+    """
 
-      for v in newValues:
-         if ( labels ):
-            labels.append( v )
-         else:
-            labels = [ v ]
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def axisinfo(unit, axis):
+        """: Returns information on how to handle an axis that has string data.
 
-      #DISABLED: This is disabled because matplotlib bar plots do not
-      #DISABLED: recalculate the unit conversion of the data values
-      #DISABLED: this is due to design and is not really a bug.
-      #DISABLED: If this gets changed, then we can activate the following
-      #DISABLED: block of code.  Note that this works for line plots.
-      #DISABLED if ( unit ):
-      #DISABLED    if ( unit.find( "sorted" ) > -1 ):
-      #DISABLED       labels.sort()
-      #DISABLED    if ( unit.find( "inverted" ) > -1 ):
-      #DISABLED       labels = labels[ ::-1 ]
+        = INPUT VARIABLES
+        - axis     The axis using this converter.
+        - unit     The units to use for a axis with string data.
 
-      # add padding (so they do not appear on the axes themselves)
-      labels = [ '' ] + labels + [ '' ]
-      ticks = list(range( len(labels) ))
-      ticks[0] = 0.5
-      ticks[-1] = ticks[-1] - 0.5
+        = RETURN VALUE
+        - Returns a matplotlib AxisInfo data structure that contains
+          minor/major formatters, major/minor locators, and default
+          label information.
+        """
 
-      axis.set_ticks( ticks )
-      axis.set_ticklabels( labels )
-      # we have to do the following lines to make ax.autoscale_view work
-      loc = axis.get_major_locator()
-      loc.set_bounds( ticks[0], ticks[-1] )
+        return None
 
-      if ( isXAxis ):
-         ax.set_xlim( ticks[0], ticks[-1] )
-      else:
-         ax.set_ylim( ticks[0], ticks[-1] )
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def convert(value, unit, axis):
+        """: Convert value using unit to a float.  If value is a sequence, return
+        the converted sequence.
 
-      result = []
-      for v in value:
-         # If v is not in labels then something went wrong with adding new
-         # labels to the list of old labels.
-         errmsg  = "This is due to a logic error in the StrConverter class.  "
-         errmsg += "Please report this error and its message in bugzilla."
-         assert ( v in labels ), errmsg
-         result.append( ticks[ labels.index(v) ] )
+        = INPUT VARIABLES
+        - axis     The axis using this converter.
+        - value    The value or list of values that need to be converted.
+        - unit     The units to use for a axis with Epoch data.
 
-      ax.viewLim.ignore(-1)
-      return result
+        = RETURN VALUE
+        - Returns the value parameter converted to floats.
+        """
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def default_units( value, axis ):
-      """: Return the default unit for value, or None.
+        if units.ConversionInterface.is_numlike(value):
+            return value
 
-      = INPUT VARIABLES
-      - axis    The axis using this converter.
-      - value   The value or list of values that need units.
+        if value == []:
+            return []
 
-      = RETURN VALUE
-      - Returns the default units to use for value.
-      Return the default unit for value, or None.
-      """
+        # we delay loading to make matplotlib happy
+        ax = axis.axes
+        if axis is ax.get_xaxis():
+            isXAxis = True
+        else:
+            isXAxis = False
 
-      # The default behavior for string indexing.
-      return "indexed"
+        axis.get_major_ticks()
+        ticks = axis.get_ticklocs()
+        labels = axis.get_ticklabels()
+
+        labels = [l.get_text() for l in labels if l.get_text()]
+
+        if not labels:
+            ticks = []
+            labels = []
+
+        if not iterable(value):
+            value = [value]
+
+        newValues = []
+        for v in value:
+            if v not in labels and v not in newValues:
+                newValues.append(v)
+
+        for v in newValues:
+            if labels:
+                labels.append(v)
+            else:
+                labels = [v]
+
+        # DISABLED: This is disabled because matplotlib bar plots do not
+        # DISABLED: recalculate the unit conversion of the data values
+        # DISABLED: this is due to design and is not really a bug.
+        # DISABLED: If this gets changed, then we can activate the following
+        # DISABLED: block of code.  Note that this works for line plots.
+        # DISABLED if (unit):
+        # DISABLED     if (unit.find("sorted") > -1):
+        # DISABLED         labels.sort()
+        # DISABLED     if (unit.find("inverted") > -1):
+        # DISABLED         labels = labels[::-1]
+
+        # add padding (so they do not appear on the axes themselves)
+        labels = [''] + labels + ['']
+        ticks = list(range(len(labels)))
+        ticks[0] = 0.5
+        ticks[-1] = ticks[-1] - 0.5
+
+        axis.set_ticks(ticks)
+        axis.set_ticklabels(labels)
+        # we have to do the following lines to make ax.autoscale_view work
+        loc = axis.get_major_locator()
+        loc.set_bounds(ticks[0], ticks[-1])
+
+        if isXAxis:
+            ax.set_xlim(ticks[0], ticks[-1])
+        else:
+            ax.set_ylim(ticks[0], ticks[-1])
+
+        result = []
+        for v in value:
+            # If v is not in labels then something went wrong with adding new
+            # labels to the list of old labels.
+            errmsg = "This is due to a logic error in the StrConverter class."
+            errmsg += " Please report this error and its message in bugzilla."
+            assert v in labels, errmsg
+            result.append(ticks[labels.index(v)])
+
+        ax.viewLim.ignore(-1)
+        return result
+
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def default_units(value, axis):
+        """: Return the default unit for value, or None.
+
+        = INPUT VARIABLES
+        - axis     The axis using this converter.
+        - value    The value or list of values that need units.
+
+        = RETURN VALUE
+        - Returns the default units to use for value.
+        Return the default unit for value, or None.
+        """
+
+        # The default behavior for string indexing.
+        return "indexed"

--- a/lib/matplotlib/testing/jpl_units/UnitDbl.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDbl.py
@@ -1,297 +1,317 @@
-#===========================================================================
+# ==========================================================================
 #
 # UnitDbl
 #
-#===========================================================================
+# ==========================================================================
 
 
 """UnitDbl module."""
 
-#===========================================================================
+# ==========================================================================
 # Place all imports after here.
 #
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
+import operator
 #
 # Place all imports before here.
-#===========================================================================
+# ==========================================================================
 
 
-#===========================================================================
+# ==========================================================================
 class UnitDbl(object):
-   """Class UnitDbl in development.
-   """
-   #-----------------------------------------------------------------------
-   # Unit conversion table.  Small subset of the full one but enough
-   # to test the required functions.  First field is a scale factor to
-   # convert the input units to the units of the second field.  Only
-   # units in this table are allowed.
-   allowed = {
-               "m" : ( 0.001, "km" ),
-               "km" : ( 1, "km" ),
-               "mile" : ( 1.609344, "km" ),
+    """Class UnitDbl in development.
+    """
+    # ----------------------------------------------------------------------
+    # Unit conversion table.  Small subset of the full one but enough
+    # to test the required functions.  First field is a scale factor to
+    # convert the input units to the units of the second field.  Only
+    # units in this table are allowed.
+    allowed = {
+        "m": (0.001, "km"),
+        "km": (1, "km"),
+        "mile": (1.609344, "km"),
 
-               "rad" : ( 1, "rad" ),
-               "deg" : ( 1.745329251994330e-02, "rad" ),
+        "rad": (1, "rad"),
+        "deg": (1.745329251994330e-02, "rad"),
 
-               "sec" : ( 1, "sec" ),
-               "min" : ( 60.0, "sec" ),
-               "hour" : ( 3600, "sec" ),
-             }
+        "sec": (1, "sec"),
+        "min": (60.0, "sec"),
+        "hour": (3600, "sec"),
+        }
 
-   _types = {
-              "km" : "distance",
-              "rad" : "angle",
-              "sec" : "time",
-            }
+    _types = {
+        "km": "distance",
+        "rad": "angle",
+        "sec": "time",
+        }
 
-   #-----------------------------------------------------------------------
-   def __init__( self, value, units ):
-      """Create a new UnitDbl object.
+    # ----------------------------------------------------------------------
+    def __init__(self, value, units):
+        """Create a new UnitDbl object.
 
-      Units are internally converted to km, rad, and sec.  The only
-      valid inputs for units are [ m, km, mile, rad, deg, sec, min, hour ].
+        Units are internally converted to km, rad, and sec.  The only
+        valid inputs for units are [m, km, mile, rad, deg, sec, min, hour].
 
-      The field UnitDbl.value will contain the converted value.  Use
-      the convert() method to get a specific type of units back.
+        The field UnitDbl.value will contain the converted value.  Use
+        the convert() method to get a specific type of units back.
 
-      = ERROR CONDITIONS
-      - If the input units are not in the allowed list, an error is thrown.
+        = ERROR CONDITIONS
+        - If the input units are not in the allowed list, an error is thrown.
 
-      = INPUT VARIABLES
-      - value    The numeric value of the UnitDbl.
-      - units    The string name of the units the value is in.
-      """
-      self.checkUnits( units )
+        = INPUT VARIABLES
+        - value     The numeric value of the UnitDbl.
+        - units     The string name of the units the value is in.
+        """
+        self.checkUnits(units)
 
-      data = self.allowed[ units ]
-      self._value = float( value * data[0] )
-      self._units = data[1]
+        data = self.allowed[units]
+        self._value = float(value * data[0])
+        self._units = data[1]
 
-   #-----------------------------------------------------------------------
-   def convert( self, units ):
-      """Convert the UnitDbl to a specific set of units.
+    # ----------------------------------------------------------------------
+    def convert(self, units):
+        """Convert the UnitDbl to a specific set of units.
 
-      = ERROR CONDITIONS
-      - If the input units are not in the allowed list, an error is thrown.
+        = ERROR CONDITIONS
+        - If the input units are not in the allowed list, an error is thrown.
 
-      = INPUT VARIABLES
-      - units    The string name of the units to convert to.
+        = INPUT VARIABLES
+        - units     The string name of the units to convert to.
 
-      = RETURN VALUE
-      - Returns the value of the UnitDbl in the requested units as a floating
-        point number.
-      """
-      if self._units == units:
-         return self._value
+        = RETURN VALUE
+        - Returns the value of the UnitDbl in the requested units as a floating
+          point number.
+        """
+        if self._units == units:
+            return self._value
 
-      self.checkUnits( units )
+        self.checkUnits(units)
 
-      data = self.allowed[ units ]
-      if self._units != data[1]:
-         msg = "Error trying to convert to different units.\n" \
-               "   Invalid conversion requested.\n" \
-               "   UnitDbl: %s\n" \
-               "   Units:   %s\n" % ( str( self ), units )
-         raise ValueError( msg )
+        data = self.allowed[units]
+        if self._units != data[1]:
+            msg = "Error trying to convert to different units.\n" \
+                    "    Invalid conversion requested.\n" \
+                    "    UnitDbl: %s\n" \
+                    "    Units:    %s\n" % (str(self), units)
+            raise ValueError(msg)
 
-      return self._value / data[0]
+        return self._value / data[0]
 
-   #-----------------------------------------------------------------------
-   def __abs__( self ):
-      """Return the absolute value of this UnitDbl."""
-      return UnitDbl( abs( self._value ), self._units )
+    # ----------------------------------------------------------------------
+    def __abs__(self):
+        """Return the absolute value of this UnitDbl."""
+        return UnitDbl(abs(self._value), self._units)
 
-   #-----------------------------------------------------------------------
-   def __neg__( self ):
-      """Return the negative value of this UnitDbl."""
-      return UnitDbl( -self._value, self._units )
+    # ----------------------------------------------------------------------
+    def __neg__(self):
+        """Return the negative value of this UnitDbl."""
+        return UnitDbl(-self._value, self._units)
 
-   #-----------------------------------------------------------------------
-   def __nonzero__( self ):
-      """Test a UnitDbl for a non-zero value.
+    # ----------------------------------------------------------------------
+    def __nonzero__(self):
+        """Test a UnitDbl for a non-zero value.
 
-      = RETURN VALUE
-      - Returns true if the value is non-zero.
-      """
-      if six.PY3:
-          return self._value.__bool__()
-      else:
-          return self._value.__nonzero__()
+        = RETURN VALUE
+        - Returns true if the value is non-zero.
+        """
+        if six.PY3:
+            return self._value.__bool__()
+        else:
+            return self._value.__nonzero__()
 
-   if six.PY3:
-      __bool__ = __nonzero__
+    if six.PY3:
+        __bool__ = __nonzero__
 
-   #-----------------------------------------------------------------------
-   def __cmp__( self, rhs ):
-      """Compare two UnitDbl's.
+    # ----------------------------------------------------------------------
+    def __eq__(self, rhs):
+        return self._cmp(rhs, operator.eq)
 
-      = ERROR CONDITIONS
-      - If the input rhs units are not the same as our units,
-        an error is thrown.
+    def __ne__(self, rhs):
+        return self._cmp(rhs, operator.ne)
 
-      = INPUT VARIABLES
-      - rhs    The UnitDbl to compare against.
+    def __lt__(self, rhs):
+        return self._cmp(rhs, operator.lt)
 
-      = RETURN VALUE
-      - Returns -1 if self < rhs, 0 if self == rhs, +1 if self > rhs.
-      """
-      self.checkSameUnits( rhs, "compare" )
-      return cmp( self._value, rhs._value )
+    def __le__(self, rhs):
+        return self._cmp(rhs, operator.le)
 
-   #-----------------------------------------------------------------------
-   def __add__( self, rhs ):
-      """Add two UnitDbl's.
+    def __gt__(self, rhs):
+        return self._cmp(rhs, operator.gt)
 
-      = ERROR CONDITIONS
-      - If the input rhs units are not the same as our units,
-        an error is thrown.
+    def __ge__(self, rhs):
+        return self._cmp(rhs, operator.ge)
 
-      = INPUT VARIABLES
-      - rhs    The UnitDbl to add.
+    def _cmp(self, rhs, op):
+        """Compare two UnitDbl's.
 
-      = RETURN VALUE
-      - Returns the sum of ourselves and the input UnitDbl.
-      """
-      self.checkSameUnits( rhs, "add" )
-      return UnitDbl( self._value + rhs._value, self._units )
+        = ERROR CONDITIONS
+        - If the input rhs units are not the same as our units,
+          an error is thrown.
 
-   #-----------------------------------------------------------------------
-   def __sub__( self, rhs ):
-      """Subtract two UnitDbl's.
+        = INPUT VARIABLES
+        - rhs     The UnitDbl to compare against.
+        - op      The function to do the comparison
 
-      = ERROR CONDITIONS
-      - If the input rhs units are not the same as our units,
-        an error is thrown.
+        = RETURN VALUE
+        - Returns op(self, rhs)
+        """
+        self.checkSameUnits(rhs, "compare")
+        return op(self._value, rhs._value)
 
-      = INPUT VARIABLES
-      - rhs    The UnitDbl to subtract.
+    # ----------------------------------------------------------------------
+    def __add__(self, rhs):
+        """Add two UnitDbl's.
 
-      = RETURN VALUE
-      - Returns the difference of ourselves and the input UnitDbl.
-      """
-      self.checkSameUnits( rhs, "subtract" )
-      return UnitDbl( self._value - rhs._value, self._units )
+        = ERROR CONDITIONS
+        - If the input rhs units are not the same as our units,
+          an error is thrown.
 
-   #-----------------------------------------------------------------------
-   def __mul__( self, rhs ):
-      """Scale a UnitDbl by a value.
+        = INPUT VARIABLES
+        - rhs     The UnitDbl to add.
 
-      = INPUT VARIABLES
-      - rhs    The scalar to multiply by.
+        = RETURN VALUE
+        - Returns the sum of ourselves and the input UnitDbl.
+        """
+        self.checkSameUnits(rhs, "add")
+        return UnitDbl(self._value + rhs._value, self._units)
 
-      = RETURN VALUE
-      - Returns the scaled UnitDbl.
-      """
-      return UnitDbl( self._value * rhs, self._units )
+    # ----------------------------------------------------------------------
+    def __sub__(self, rhs):
+        """Subtract two UnitDbl's.
 
-   #-----------------------------------------------------------------------
-   def __rmul__( self, lhs ):
-      """Scale a UnitDbl by a value.
+        = ERROR CONDITIONS
+        - If the input rhs units are not the same as our units,
+          an error is thrown.
 
-      = INPUT VARIABLES
-      - lhs    The scalar to multiply by.
+        = INPUT VARIABLES
+        - rhs     The UnitDbl to subtract.
 
-      = RETURN VALUE
-      - Returns the scaled UnitDbl.
-      """
-      return UnitDbl( self._value * lhs, self._units )
+        = RETURN VALUE
+        - Returns the difference of ourselves and the input UnitDbl.
+        """
+        self.checkSameUnits(rhs, "subtract")
+        return UnitDbl(self._value - rhs._value, self._units)
 
-   #-----------------------------------------------------------------------
-   def __div__( self, rhs ):
-      """Divide a UnitDbl by a value.
+    # ----------------------------------------------------------------------
+    def __mul__(self, rhs):
+        """Scale a UnitDbl by a value.
 
-      = INPUT VARIABLES
-      - rhs    The scalar to divide by.
+        = INPUT VARIABLES
+        - rhs     The scalar to multiply by.
 
-      = RETURN VALUE
-      - Returns the scaled UnitDbl.
-      """
-      return UnitDbl( self._value / rhs, self._units )
+        = RETURN VALUE
+        - Returns the scaled UnitDbl.
+        """
+        return UnitDbl(self._value * rhs, self._units)
 
-   #-----------------------------------------------------------------------
-   def __str__( self ):
-      """Print the UnitDbl."""
-      return "%g *%s" % ( self._value, self._units )
+    # ----------------------------------------------------------------------
+    def __rmul__(self, lhs):
+        """Scale a UnitDbl by a value.
 
-   #-----------------------------------------------------------------------
-   def __repr__( self ):
-      """Print the UnitDbl."""
-      return "UnitDbl( %g, '%s' )" % ( self._value, self._units )
+        = INPUT VARIABLES
+        - lhs     The scalar to multiply by.
 
-   #-----------------------------------------------------------------------
-   def type( self ):
-      """Return the type of UnitDbl data."""
-      return self._types[ self._units ]
+        = RETURN VALUE
+        - Returns the scaled UnitDbl.
+        """
+        return UnitDbl(self._value * lhs, self._units)
 
-   #-----------------------------------------------------------------------
-   def range( start, stop, step=None ):
-      """Generate a range of UnitDbl objects.
+    # ----------------------------------------------------------------------
+    def __div__(self, rhs):
+        """Divide a UnitDbl by a value.
 
-      Similar to the Python range() method.  Returns the range [
-      start, stop ) at the requested step.  Each element will be a
-      UnitDbl object.
+        = INPUT VARIABLES
+        - rhs     The scalar to divide by.
 
-      = INPUT VARIABLES
-      - start    The starting value of the range.
-      - stop     The stop value of the range.
-      - step     Optional step to use.  If set to None, then a UnitDbl of
-                 value 1 w/ the units of the start is used.
+        = RETURN VALUE
+        - Returns the scaled UnitDbl.
+        """
+        return UnitDbl(self._value / rhs, self._units)
 
-      = RETURN VALUE
-      - Returns a list contianing the requested UnitDbl values.
-      """
-      if step is None:
-         step = UnitDbl( 1, start._units )
+    # ----------------------------------------------------------------------
+    def __str__(self):
+        """Print the UnitDbl."""
+        return "%g *%s" % (self._value, self._units)
 
-      elems = []
+    # ----------------------------------------------------------------------
+    def __repr__(self):
+        """Print the UnitDbl."""
+        return "UnitDbl(%g, '%s')" % (self._value, self._units)
 
-      i = 0
-      while True:
-         d = start + i * step
-         if d >= stop:
-            break
+    # ----------------------------------------------------------------------
+    def type(self):
+        """Return the type of UnitDbl data."""
+        return self._types[self._units]
 
-         elems.append( d )
-         i += 1
+    # ----------------------------------------------------------------------
+    def range(start, stop, step=None):
+        """Generate a range of UnitDbl objects.
 
-      return elems
+        Similar to the Python range() method.  Returns the range [
+        start, stop) at the requested step.  Each element will be a
+        UnitDbl object.
 
-   range = staticmethod( range )
+        = INPUT VARIABLES
+        - start     The starting value of the range.
+        - stop      The stop value of the range.
+        - step      Optional step to use.  If set to None, then a UnitDbl of
+                      value 1 w/ the units of the start is used.
 
-   #-----------------------------------------------------------------------
-   def checkUnits( self, units ):
-      """Check to see if some units are valid.
+        = RETURN VALUE
+        - Returns a list contianing the requested UnitDbl values.
+        """
+        if step is None:
+            step = UnitDbl(1, start._units)
 
-      = ERROR CONDITIONS
-      - If the input units are not in the allowed list, an error is thrown.
+        elems = []
 
-      = INPUT VARIABLES
-      - units    The string name of the units to check.
-      """
-      if units not in self.allowed:
-         msg = "Input units '%s' are not one of the supported types of %s" \
-               % ( units, str( list(six.iterkeys(self.allowed)) ) )
-         raise ValueError( msg )
+        i = 0
+        while True:
+            d = start + i * step
+            if d >= stop:
+                break
 
-   #-----------------------------------------------------------------------
-   def checkSameUnits( self, rhs, func ):
-      """Check to see if units are the same.
+            elems.append(d)
+            i += 1
 
-      = ERROR CONDITIONS
-      - If the units of the rhs UnitDbl are not the same as our units,
-        an error is thrown.
+        return elems
 
-      = INPUT VARIABLES
-      - rhs    The UnitDbl to check for the same units
-      - func   The name of the function doing the check.
-      """
-      if self._units != rhs._units:
-         msg = "Cannot %s units of different types.\n" \
-               "LHS: %s\n" \
-               "RHS: %s" % ( func, self._units, rhs._units )
-         raise ValueError( msg )
+    range = staticmethod(range)
 
-#===========================================================================
+    # ----------------------------------------------------------------------
+    def checkUnits(self, units):
+        """Check to see if some units are valid.
+
+        = ERROR CONDITIONS
+        - If the input units are not in the allowed list, an error is thrown.
+
+        = INPUT VARIABLES
+        - units     The string name of the units to check.
+        """
+        if units not in self.allowed:
+            msg = "Input units '%s' are not one of the supported types of %s" \
+                    % (units, str(list(six.iterkeys(self.allowed))))
+            raise ValueError(msg)
+
+    # ----------------------------------------------------------------------
+    def checkSameUnits(self, rhs, func):
+        """Check to see if units are the same.
+
+        = ERROR CONDITIONS
+        - If the units of the rhs UnitDbl are not the same as our units,
+          an error is thrown.
+
+        = INPUT VARIABLES
+        - rhs     The UnitDbl to check for the same units
+        - func    The name of the function doing the check.
+        """
+        if self._units != rhs._units:
+            msg = "Cannot %s units of different types.\n" \
+                    "LHS: %s\n" \
+                    "RHS: %s" % (func, self._units, rhs._units)
+            raise ValueError(msg)
+
+# ==========================================================================

--- a/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
@@ -1,13 +1,12 @@
-#===========================================================================
+# ==========================================================================
 #
 # UnitDblConverter
 #
-#===========================================================================
-
+# ==========================================================================
 
 """UnitDblConverter module containing class UnitDblConverter."""
 
-#===========================================================================
+# ==========================================================================
 # Place all imports after here.
 #
 from __future__ import (absolute_import, division, print_function,
@@ -21,139 +20,140 @@ import matplotlib.projections.polar as polar
 from matplotlib.cbook import iterable
 #
 # Place all imports before here.
-#===========================================================================
+# ==========================================================================
 
-__all__ = [ 'UnitDblConverter' ]
+__all__ = ['UnitDblConverter']
 
-#===========================================================================
 
+# ==========================================================================
 # A special function for use with the matplotlib FuncFormatter class
 # for formatting axes with radian units.
 # This was copied from matplotlib example code.
-def rad_fn(x, pos = None ):
-   """Radian function formatter."""
-   n = int((x / np.pi) * 2.0 + 0.25)
-   if n == 0:
-      return str(x)
-   elif n == 1:
-      return r'$\pi/2$'
-   elif n == 2:
-      return r'$\pi$'
-   elif n % 2 == 0:
-      return r'$%s\pi$' % (n/2,)
-   else:
-      return r'$%s\pi/2$' % (n,)
+def rad_fn(x, pos=None):
+    """Radian function formatter."""
+    n = int((x / np.pi) * 2.0 + 0.25)
+    if n == 0:
+        return str(x)
+    elif n == 1:
+        return r'$\pi/2$'
+    elif n == 2:
+        return r'$\pi$'
+    elif n % 2 == 0:
+        return r'$%s\pi$' % (n/2,)
+    else:
+        return r'$%s\pi/2$' % (n,)
 
-#===========================================================================
-class UnitDblConverter( units.ConversionInterface ):
-   """: A matplotlib converter class.  Provides matplotlib conversion
-        functionality for the Monte UnitDbl class.
-   """
 
-   # default for plotting
-   defaults = {
-                 "distance" : 'km',
-                 "angle" : 'deg',
-                 "time" : 'sec',
-              }
+# ==========================================================================
+class UnitDblConverter(units.ConversionInterface):
+    """: A matplotlib converter class.  Provides matplotlib conversion
+          functionality for the Monte UnitDbl class.
+    """
+    # default for plotting
+    defaults = {
+       "distance": 'km',
+       "angle": 'deg',
+       "time": 'sec',
+       }
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def axisinfo( unit, axis ):
-      """: Returns information on how to handle an axis that has Epoch data.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def axisinfo(unit, axis):
+        """: Returns information on how to handle an axis that has Epoch data.
 
-      = INPUT VARIABLES
-      - unit    The units to use for a axis with Epoch data.
+        = INPUT VARIABLES
+        - unit     The units to use for a axis with Epoch data.
 
-      = RETURN VALUE
-      - Returns a matplotlib AxisInfo data structure that contains
-        minor/major formatters, major/minor locators, and default
-        label information.
-      """
-      # Delay-load due to circular dependencies.
-      import matplotlib.testing.jpl_units as U
+        = RETURN VALUE
+        - Returns a matplotlib AxisInfo data structure that contains
+          minor/major formatters, major/minor locators, and default
+          label information.
+        """
+        # Delay-load due to circular dependencies.
+        import matplotlib.testing.jpl_units as U
 
-      # Check to see if the value used for units is a string unit value
-      # or an actual instance of a UnitDbl so that we can use the unit
-      # value for the default axis label value.
-      if ( unit ):
-         if ( isinstance( unit, six.string_types ) ):
-            label = unit
-         else:
-            label = unit.label()
-      else:
-         label = None
+        # Check to see if the value used for units is a string unit value
+        # or an actual instance of a UnitDbl so that we can use the unit
+        # value for the default axis label value.
+        if (unit):
+            if (isinstance(unit, six.string_types)):
+                label = unit
+            else:
+                label = unit.label()
+        else:
+            label = None
 
-      if ( label == "deg" ) and isinstance( axis.axes, polar.PolarAxes ):
-         # If we want degrees for a polar plot, use the PolarPlotFormatter
-         majfmt = polar.PolarAxes.ThetaFormatter()
-      else:
-         majfmt = U.UnitDblFormatter( useOffset = False )
+        if (label == "deg") and isinstance(axis.axes, polar.PolarAxes):
+            # If we want degrees for a polar plot, use the PolarPlotFormatter
+            majfmt = polar.PolarAxes.ThetaFormatter()
+        else:
+            majfmt = U.UnitDblFormatter(useOffset=False)
 
-      return units.AxisInfo( majfmt = majfmt, label = label )
+        return units.AxisInfo(majfmt=majfmt, label=label)
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def convert( value, unit, axis ):
-      """: Convert value using unit to a float.  If value is a sequence, return
-      the converted sequence.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def convert(value, unit, axis):
+        """: Convert value using unit to a float.  If value is a sequence, return
+        the converted sequence.
 
-      = INPUT VARIABLES
-      - value   The value or list of values that need to be converted.
-      - unit    The units to use for a axis with Epoch data.
+        = INPUT VARIABLES
+        - value    The value or list of values that need to be converted.
+        - unit     The units to use for a axis with Epoch data.
 
-      = RETURN VALUE
-      - Returns the value parameter converted to floats.
-      """
-      # Delay-load due to circular dependencies.
-      import matplotlib.testing.jpl_units as U
+        = RETURN VALUE
+        - Returns the value parameter converted to floats.
+        """
+        # Delay-load due to circular dependencies.
+        import matplotlib.testing.jpl_units as U
 
-      isNotUnitDbl = True
+        isNotUnitDbl = True
 
-      if ( iterable(value) and not isinstance(value, six.string_types) ):
-         if ( len(value) == 0 ):
-            return []
-         else:
-            return [ UnitDblConverter.convert( x, unit, axis ) for x in value ]
+        if (iterable(value) and not isinstance(value, six.string_types)):
+            if (len(value) == 0):
+                return []
+            else:
+                return [UnitDblConverter.convert(x, unit, axis) for x in value]
 
-      # We need to check to see if the incoming value is actually a UnitDbl and
-      # set a flag.  If we get an empty list, then just return an empty list.
-      if ( isinstance(value, U.UnitDbl) ):
-         isNotUnitDbl = False
+        # We need to check to see if the incoming value is actually a
+        # UnitDbl and set a flag.  If we get an empty list, then just
+        # return an empty list.
+        if (isinstance(value, U.UnitDbl)):
+            isNotUnitDbl = False
 
-      # If the incoming value behaves like a number, but is not a UnitDbl,
-      # then just return it because we don't know how to convert it
-      # (or it is already converted)
-      if ( isNotUnitDbl and units.ConversionInterface.is_numlike( value ) ):
-         return value
+        # If the incoming value behaves like a number, but is not a UnitDbl,
+        # then just return it because we don't know how to convert it
+        # (or it is already converted)
+        if (isNotUnitDbl and units.ConversionInterface.is_numlike(value)):
+            return value
 
-      # If no units were specified, then get the default units to use.
-      if ( unit == None ):
-         unit = UnitDblConverter.default_units( value, axis )
+        # If no units were specified, then get the default units to use.
+        if unit is None:
+            unit = UnitDblConverter.default_units(value, axis)
 
-      # Convert the incoming UnitDbl value/values to float/floats
-      if isinstance( axis.axes, polar.PolarAxes ) and value.type() == "angle":
-         # Guarantee that units are radians for polar plots.
-         return value.convert( "rad" )
+        # Convert the incoming UnitDbl value/values to float/floats
+        if isinstance(axis.axes, polar.PolarAxes) and value.type() == "angle":
+            # Guarantee that units are radians for polar plots.
+            return value.convert("rad")
 
-      return value.convert( unit )
+        return value.convert(unit)
 
-   #------------------------------------------------------------------------
-   @staticmethod
-   def default_units( value, axis ):
-      """: Return the default unit for value, or None.
+    # -----------------------------------------------------------------------
+    @staticmethod
+    def default_units(value, axis):
+        """: Return the default unit for value, or None.
 
-      = INPUT VARIABLES
-      - value   The value or list of values that need units.
+        = INPUT VARIABLES
+        - value    The value or list of values that need units.
 
-      = RETURN VALUE
-      - Returns the default units to use for value.
-      Return the default unit for value, or None.
-      """
+        = RETURN VALUE
+        - Returns the default units to use for value.
+        Return the default unit for value, or None.
+        """
 
-      # Determine the default units based on the user preferences set for
-      # default units when printing a UnitDbl.
-      if ( iterable(value) and not isinstance(value, six.string_types) ):
-         return UnitDblConverter.default_units( value[0], axis )
-      else:
-         return UnitDblConverter.defaults[ value.type() ]
+        # Determine the default units based on the user preferences set for
+        # default units when printing a UnitDbl.
+        if (iterable(value) and not isinstance(value, six.string_types)):
+            return UnitDblConverter.default_units(value[0], axis)
+        else:
+            return UnitDblConverter.defaults[value.type()]

--- a/lib/matplotlib/testing/jpl_units/UnitDblFormatter.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDblFormatter.py
@@ -1,47 +1,46 @@
-#===========================================================================
+# ==========================================================================
 #
 # UnitDblFormatter
 #
-#===========================================================================
+# ==========================================================================
 
 
 """UnitDblFormatter module containing class UnitDblFormatter."""
 
-#===========================================================================
+# ==========================================================================
 # Place all imports after here.
 #
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import six
-
 import matplotlib.ticker as ticker
 #
 # Place all imports before here.
-#===========================================================================
+# ==========================================================================
 
-__all__ = [ 'UnitDblFormatter' ]
+__all__ = ['UnitDblFormatter']
 
-#===========================================================================
-class UnitDblFormatter( ticker.ScalarFormatter ):
-   """The formatter for UnitDbl data types.  This allows for formatting
-      with the unit string.
-   """
-   def __init__( self, *args, **kwargs ):
-      'The arguments are identical to matplotlib.ticker.ScalarFormatter.'
-      ticker.ScalarFormatter.__init__( self, *args, **kwargs )
 
-   def __call__( self, x, pos = None ):
-      'Return the format for tick val x at position pos'
-      if len(self.locs) == 0:
-         return ''
-      else:
-         return '{:.12}'.format(x)
+# ==========================================================================
+class UnitDblFormatter(ticker.ScalarFormatter):
+    """The formatter for UnitDbl data types.  This allows for formatting
+        with the unit string.
+    """
+    def __init__(self, *args, **kwargs):
+        'The arguments are identical to matplotlib.ticker.ScalarFormatter.'
+        ticker.ScalarFormatter.__init__(self, *args, **kwargs)
 
-   def format_data_short( self, value ):
-      "Return the value formatted in 'short' format."
-      return '{:.12}'.format(value)
+    def __call__(self, x, pos=None):
+        'Return the format for tick val x at position pos'
+        if len(self.locs) == 0:
+            return ''
+        else:
+            return '{:.12}'.format(x)
 
-   def format_data( self, value ):
-      "Return the value formatted into a string."
-      return '{:.12}'.format(value)
+    def format_data_short(self, value):
+        "Return the value formatted in 'short' format."
+        return '{:.12}'.format(value)
+
+    def format_data(self, value):
+        "Return the value formatted into a string."
+        return '{:.12}'.format(value)

--- a/lib/matplotlib/testing/jpl_units/__init__.py
+++ b/lib/matplotlib/testing/jpl_units/__init__.py
@@ -1,4 +1,4 @@
-#=======================================================================
+# ======================================================================
 
 """
 This is a sample set of units for use with testing unit conversion
@@ -30,11 +30,9 @@ to be called out as different that a simple measurement of time since a delta-t
 in one frame may not be the same in another.
 """
 
-#=======================================================================
+# ======================================================================
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
-import six
 
 from .Duration import Duration
 from .Epoch import Epoch
@@ -46,7 +44,7 @@ from .UnitDblConverter import UnitDblConverter
 
 from .UnitDblFormatter import UnitDblFormatter
 
-#=======================================================================
+# ======================================================================
 
 __version__ = "1.0"
 
@@ -58,31 +56,33 @@ __all__ = [
             'UnitDblFormatter',
           ]
 
-#=======================================================================
+
+# ======================================================================
 def register():
-   """Register the unit conversion classes with matplotlib."""
-   import matplotlib.units as mplU
+    """Register the unit conversion classes with matplotlib."""
+    import matplotlib.units as mplU
 
-   mplU.registry[ str ] = StrConverter()
-   mplU.registry[ Epoch ] = EpochConverter()
-   mplU.registry[ Duration ] = EpochConverter()
-   mplU.registry[ UnitDbl ] = UnitDblConverter()
+    mplU.registry[str] = StrConverter()
+    mplU.registry[Epoch] = EpochConverter()
+    mplU.registry[Duration] = EpochConverter()
+    mplU.registry[UnitDbl] = UnitDblConverter()
 
-#=======================================================================
+# ======================================================================
 # Some default unit instances
 
+
 # Distances
-m = UnitDbl( 1.0, "m" )
-km = UnitDbl( 1.0, "km" )
-mile = UnitDbl( 1.0, "mile" )
+m = UnitDbl(1.0, "m")
+km = UnitDbl(1.0, "km")
+mile = UnitDbl(1.0, "mile")
 
 # Angles
-deg = UnitDbl( 1.0, "deg" )
-rad = UnitDbl( 1.0, "rad" )
+deg = UnitDbl(1.0, "deg")
+rad = UnitDbl(1.0, "rad")
 
 # Time
-sec = UnitDbl( 1.0, "sec" )
-min = UnitDbl( 1.0, "min" )
-hr = UnitDbl( 1.0, "hour" )
-day = UnitDbl( 24.0, "hour" )
-sec = UnitDbl( 1.0, "sec" )
+sec = UnitDbl(1.0, "sec")
+min = UnitDbl(1.0, "min")
+hr = UnitDbl(1.0, "hour")
+day = UnitDbl(24.0, "hour")
+sec = UnitDbl(1.0, "sec")


### PR DESCRIPTION
Fix for #10501 - adds rich comparison methods to all classes for python3 support.  Also updated all the code to be pep8/flake8 compliant (so the diff looks enormous because of indentation updates on virtually every line).  

Tests cases that use jpl_units were run function normally.