### PR TITLE
FIX/ENH CL: Allow single parent colorbar w/ gridspec layout

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1124,6 +1124,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     anchor = kw.pop('anchor', loc_settings['anchor'])
     parent_anchor = kw.pop('panchor', loc_settings['panchor'])
 
+    parents_iterable = cbook.iterable(parents)
     # turn parents into a list if it is not already. We do this w/ np
     # because `plt.subplots` can return an ndarray and is natural to
     # pass to `colorbar`.
@@ -1191,7 +1192,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
         # and we need to set the aspect ratio by hand...
         cax.set_aspect(aspect, anchor=anchor, adjustable='box')
     else:
-        if len(parents) == 1:
+        if not parents_iterable:
             # this is a single axis...
             ax = parents[0]
             lb, lbpos = constrained_layout.layoutcolorbarsingle(

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -105,14 +105,38 @@ im = ax.pcolormesh(arr, rasterized=True)
 fig.colorbar(im, ax=ax, shrink=0.6)
 
 ############################################################################
-# If you specify multiple axes to the ``ax`` argument of ``colorbar``,
-# constrained_layout will take space from all axes that share the same
-# gridspec.
+# If you specify a list of axes (or other iterable container) to the
+# ``ax`` argument of ``colorbar``, constrained_layout will take space from all # axes that share the same gridspec.
 
 fig, axs = plt.subplots(2, 2, figsize=(4, 4), constrained_layout=True)
 for ax in axs.flatten():
     im = ax.pcolormesh(arr, rasterized=True)
 fig.colorbar(im, ax=axs, shrink=0.6)
+
+############################################################################
+# Note that there is a bit of a subtlety when specifying a single axes
+# as the parent.  In the following, it might be desirable and expected
+# for the colorbars to line up, but they don't because the colorbar paired
+# with the bottom axes is tied to the subplotspec of the axes, and hence
+# shrinks when the gridspec-level colorbar is added.
+
+fig, axs = plt.subplots(3, 1, figsize=(4, 4), constrained_layout=True)
+for ax in axs[:2]:
+    im = ax.pcolormesh(arr, rasterized=True)
+fig.colorbar(im, ax=axs[:2], shrink=0.6)
+im = axs[2].pcolormesh(arr, rasterized=True)
+fig.colorbar(im, ax=axs[2], shrink=0.6)
+
+############################################################################
+# The API to make a single-axes behave like a list of axes is to specify
+# it as a list (or other iterable container), as below:
+
+fig, axs = plt.subplots(3, 1, figsize=(4, 4), constrained_layout=True)
+for ax in axs[:2]:
+    im = ax.pcolormesh(arr, rasterized=True)
+fig.colorbar(im, ax=axs[:2], shrink=0.6)
+im = axs[2].pcolormesh(arr, rasterized=True)
+fig.colorbar(im, ax=[axs[2]], shrink=0.6)
 
 ####################################################
 # Suptitle


### PR DESCRIPTION
## PR Summary

In the master version of constrained_layout (CL), a colorbar associated with a single parent axes (i.e. `fig.colorbar(im, ax=axs[2])`) is associated with the subplotspec layout box. If there is more than one parent, it is associated with the gridspec layout box that contains the subplotspecs (i.e. `fig.colorbar(im, ax=axs[:2])`).  

As noted in #10627 by @afvincent this leads to a surprising result for a layout like:

```python
import matplotlib.pyplot as plt
import numpy as np

def example_pcolor(ax, cmap='RdBu_r'):
    dx, dy = 0.6, 0.6
    y, x = np.mgrid[slice(-3, 3 + dy, dy),
                    slice(-3, 3 + dx, dx)]
    z = (1 - x / 2. + x ** 5 + y ** 3) * np.exp(-x ** 2 - y ** 2)
    pcm = ax.pcolormesh(x, y, z, cmap=cmap, vmin=-1., vmax=1.,
                        rasterized=True)
    return pcm

fig, axs = plt.subplots(3, 1, figsize=(4, 4), constrained_layout=True)
for ax in axs[:2]:
    pc = example_pcolor(ax)
pc2 = example_pcolor(axs[2], cmap='viridis')

fig.colorbar(pc, ax=axs[:2])
fig.colorbar(pc, ax=axs[2])

plt.show()
```

yields:

![figure1](https://user-images.githubusercontent.com/1562854/36801167-25653fba-1c66-11e8-979b-81a9a1e88471.png)

This is technically correct.  We *want* to be able to have a single colorbar follow a single axes:

![figure3](https://user-images.githubusercontent.com/1562854/36801092-f30c67d2-1c65-11e8-851d-a779025e0e7b.png)

However, for this case it is undesirable.  This PR changes the argument of `ax` in `fig.colorbar` so that if it is an iterable, even with just one element, it will be treated as a gridspec level colorbar.  i.e. if instead of `fig.colorbar(pc, ax=axs[2])` we make the axes a list:
```python
fig.colorbar(pc, ax=[axs[2]])
```
we get:

![figure2](https://user-images.githubusercontent.com/1562854/36801246-6651ca48-1c66-11e8-9e83-f558bac08c69.png)

(the user will still have to futz around w/ the colorbar aspect ratios to make that look nice).  

This doesn't break `constrained_layout=False` (default), which both yeild identical layouts:

![figure4](https://user-images.githubusercontent.com/1562854/36801314-9cd536c2-1c66-11e8-840c-a0976ed5a1e4.png)

so this is a non-breaking change...

~The todo list below is still active.  I'll add a test and update the tutorial if this approach is OK.~

Decided against a dedicated test. The underlying functionality works, so a test is a bit superfluous.  Did update the tutorial.


## PR Checklist

- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->