### PR TITLE
Support markers from Paths that consist of one line segment

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -251,6 +251,11 @@ class MarkerStyle(object):
         if (isinstance(marker, np.ndarray) and marker.ndim == 2 and
                 marker.shape[1] == 2):
             self._marker_function = self._set_vertices
+        elif (isinstance(marker, six.string_types)
+              and cbook.is_math_text(marker)):
+            self._marker_function = self._set_mathtext_path
+        elif isinstance(marker, Path):
+            self._marker_function = self._set_path_marker
         elif (isinstance(marker, Sized) and len(marker) in (2, 3) and
                 marker[1] in (0, 1, 2, 3)):
             self._marker_function = self._set_tuple_marker
@@ -258,11 +263,6 @@ class MarkerStyle(object):
               marker in self.markers):
             self._marker_function = getattr(
                 self, '_set_' + self.markers[marker])
-        elif (isinstance(marker, six.string_types)
-              and cbook.is_math_text(marker)):
-            self._marker_function = self._set_mathtext_path
-        elif isinstance(marker, Path):
-            self._marker_function = self._set_path_marker
         else:
             try:
                 Path(marker)

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -1,5 +1,6 @@
 import numpy as np
 from matplotlib import markers
+from matplotlib.path import Path
 
 import pytest
 
@@ -18,3 +19,10 @@ def test_markers_invalid():
     # Checking this does fail.
     with pytest.raises(ValueError):
         marker_style.set_marker(mrk_array)
+
+
+def test_marker_path():
+    marker_style = markers.MarkerStyle()
+    path = Path([[0, 0], [1, 0]], [Path.MOVETO, Path.LINETO])
+    # Checking this doesn't fail.
+    marker_style.set_marker(path)


### PR DESCRIPTION
The `elif` clauses in `Marker.set_marker` needed to be reordered because any Python object that has a `__len__` method is an instance of `collections.Sized`.

Before this change, the new unit test `test_marker_path()` would fail with this exception:

```
TypeError: 'Path' object does not support indexing
```