### PR TITLE
WIP: ENH: autodecode pandas timestamps

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -430,6 +430,10 @@ def date2num(d):
     For details see the module docstring.
     """
 
+    if hasattr(d, "values"):
+        # this unpacks pandas series or dataframes...
+        d = d.values
+
     if ((isinstance(d, np.ndarray) and np.issubdtype(d.dtype, np.datetime64))
             or isinstance(d, np.datetime64)):
         return _dt64_to_ordinalf(d)

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -160,6 +160,10 @@ class Registry(dict):
         if classx is not None:
             converter = self.get(classx)
 
+        if converter is None and hasattr(x, "values"):
+            # this unpacks pandas series or dataframes...
+            x = x.values
+
         # If x is an array, look inside the array for data with units
         if isinstance(x, np.ndarray) and x.size:
             xravel = x.ravel()


### PR DESCRIPTION
## PR Summary

attempt at #10533 after @efiring 's suggestion. 

The following now works. (needs a recent pandas for the deregister step to work).  

ping @jorisvandenbossche   - if you have a more complete or canonical PR, feel free to push instead of this....

```python
import pandas as pd
import matplotlib.pyplot as plt
import numpy as np

pd.plotting.deregister_matplotlib_converters()

xticks = pd.date_range(start="10/10/2017", end="14/10/2017",
                       freq='D')
print(type(xticks))
print(xticks.to_pydatetime())
plt.plot(xticks, np.arange(len(xticks)))
plt.xticks(xticks, xticks.strftime("%a %m-%d"))
plt.show()
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->