### PR TITLE
Fix extra and missing spaces in constrainedlayout warning.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2195,7 +2195,7 @@ class Figure(Artist):
 
     def init_layoutbox(self):
         """
-        initilaize the layoutbox for use in constrained_layout.
+        Initialize the layoutbox for use in constrained_layout.
         """
         if self._layoutbox is None:
             self._layoutbox = layoutbox.LayoutBox(parent=None,
@@ -2207,23 +2207,21 @@ class Figure(Artist):
         """
         Use ``layoutbox`` to determine pos positions within axes.
 
-        See also set_constrained_layout_pads
+        See also set_constrained_layout_pads.
         """
 
-        from matplotlib._constrained_layout import (do_constrained_layout)
+        from matplotlib._constrained_layout import do_constrained_layout
 
         _log.debug('Executing constrainedlayout')
         if self._layoutbox is None:
-            warnings.warn("Calling figure.constrained_layout, but figure "
-                          "not setup to do constrained layout.  "
-                          "   You either called GridSpec without the "
-                          "fig keyword, you are using plt.subplot, "
-                          "or you need to call figure or subplots"
-                          "with the constrained_layout=True kwarg.")
+            warnings.warn("Calling figure.constrained_layout, but figure not "
+                          "setup to do constrained layout.  You either called "
+                          "GridSpec without the fig keyword, you are using "
+                          "plt.subplot, or you need to call figure or "
+                          "subplots with the constrained_layout=True kwarg.")
             return
         w_pad, h_pad, wspace, hspace = self.get_constrained_layout_pads()
         # convert to unit-relative lengths
-
         fig = self
         width, height = fig.get_size_inches()
         w_pad = w_pad / width


### PR DESCRIPTION
(Too many spaces between "layout." and "You", missing betwen "subplots"
and "with".)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
