### PR TITLE
cbook: Fix undefined name __Full

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ install:
     ccache -s
     git describe
     # Upgrade pip and setuptools and wheel to get as clean an install as possible
-    python -mpip install --upgrade pip setuptools wheel
+    python -m pip install --upgrade pip setuptools wheel
   - |
     # Install dependencies from PyPI
     python -mpip install --upgrade $PRE \

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -924,7 +924,7 @@ class RingBuffer(object):
         if len(self.data) == self.max:
             self.cur = 0
             # Permanently change self's class from non-full to full
-            self.__class__ = __Full
+            self.__class__ = RingBuffer.__Full
 
     def get(self):
         """ Return a list of elements from the oldest to the newest. """


### PR DESCRIPTION
```
@deprecated('2.1')
class RingBuffer(object):
```
contains an undefined name that probably means that when the buffer is full, a NameError is raised instead of executing the expected code path.  Given the deprecation, this might not be worth fixing but at least it can be documented. 

### Method of discovery:
$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/matplotlib/cbook/__init__.py:927:30: F821 undefined name '__Full'
            self.__class__ = __Full
                             ^
```

### Proof (same on both Python 2 and Python 3):
```python
class Outer(object):
    def __init__(self):
        self.inner = self.Inner()

    class Inner(object):
        def __init__(self):
            print(Outer.Inner)  # This works but...
            print(Inner)        # This raises NameError

Outer()
```
