### PR TITLE
Restore axes sharedness when unpickling.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -395,14 +395,15 @@ class _process_plot_var_args(object):
             yield from self._plot_args(this, kwargs)
 
 
+_shared_x_axes = cbook.Grouper()
+_shared_y_axes = cbook.Grouper()
+_twinned_axes = cbook.Grouper()
+
+
 class _AxesBase(martist.Artist):
     """
     """
     name = "rectilinear"
-
-    _shared_x_axes = cbook.Grouper()
-    _shared_y_axes = cbook.Grouper()
-    _twinned_axes = cbook.Grouper()
 
     def __str__(self):
         return "{0}({1[0]:g},{1[1]:g};{1[2]:g}x{1[3]:g})".format(
@@ -468,6 +469,13 @@ class _AxesBase(martist.Artist):
         """ % {'scale': ' | '.join(
             [repr(x) for x in mscale.get_scale_names()])}
         martist.Artist.__init__(self)
+
+        # Reference the global instances in the instance dict to support
+        # pickling.
+        self._shared_x_axes = _shared_x_axes
+        self._shared_y_axes = _shared_y_axes
+        self._twinned_axes = _twinned_axes
+
         if isinstance(rect, mtransforms.Bbox):
             self._position = rect
         else:

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -981,6 +981,25 @@ class Grouper(object):
     def __init__(self, init=()):
         self._mapping = {ref(x): [ref(x)] for x in init}
 
+    def __getstate__(self):
+        mapping = {}
+        for k, vs in self._mapping.items():
+            k = k()
+            if k is None:
+                continue
+            mapping[k] = l = []
+            for v in vs:
+                v = v()
+                if v is None:
+                    continue
+                l.append(v)
+        return {"_mapping": mapping}
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._mapping = {ref(k): [ref(v) for v in vs]
+                         for k, vs in self._mapping.items()}
+
     def __contains__(self, item):
         return ref(item) in self._mapping
 

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -187,3 +187,10 @@ def test_rrulewrapper():
     except RecursionError:
         print('rrulewrapper pickling test failed')
         raise
+
+
+def test_shared():
+    fig, axs = plt.subplots(2, sharex=True)
+    fig = pickle.loads(pickle.dumps(fig))
+    fig.axes[0].set_xlim(10, 20)
+    assert fig.axes[1].get_xlim() == (10, 20)


### PR DESCRIPTION
Previously, pickling and unpickling shared axes would result in
axes sharing a ticker instance (because that's how shared axes
are set up), but without changes of one's xlims propagated to the
other.  The reason is that that sharedness information is stored in
AxesBase._shared_x_axes, which does *not* get pickled together with the
Axes instance: the latter only has a textual reference "I am an instance
of AxesBase", so the Grouper information is lost.

To keep the Grouper information valid, instead move the Groupers to the
instance dictionaries (as references to global groupers).  Also make
Groupers picklable following a similar strategy as Transforms, i.e. by
transforming weakrefs into real refs when pickling and transforming them
back into weakref when unpickling.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
