### PR TITLE
Highlight deprecations in the docs

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -373,14 +373,24 @@ div.warning {
     border: 1px solid #eed3d7;
 }
 
+div.deprecated {
+    color: #606060;
+    background-color: #f0f0f0;
+    border: 1px solid #404040;
+}
+
+div.deprecated span.versionmodified {
+    color: #606060;
+    font-weight: bold;
+}
+
 div.green {
     color: #468847;
     background-color: #dff0d8;
     border: 1px solid #d6e9c6;
 }
 
-
-div.admonition p, div.warning p {
+div.admonition p, div.warning p, div.deprecated p {
     margin: 0.5em 1em 0.5em 1em;
     padding: 0;
 }
@@ -401,14 +411,13 @@ div.warning p.admonition-title {
     font-size: 14px;
 }
 
-div.admonition {
+div.admonition, div.deprecated {
     margin-bottom: 10px;
     margin-top: 10px;
     padding: 7px;
     border-radius: 4px;
     -moz-border-radius: 4px;
   }
-
 
 div.note {
     background-color: #eee;

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1219,16 +1219,16 @@ class _AxesBase(martist.Artist):
         self._get_lines.set_prop_cycle(prop_cycle)
         self._get_patches_for_fill.set_prop_cycle(prop_cycle)
 
+    @cbook.deprecated('1.5', alternative='`.set_prop_cycle`')
     def set_color_cycle(self, clist):
         """
         Set the color cycle for any future plot commands on this Axes.
 
-        *clist* is a list of mpl color specifiers.
-
-        .. deprecated:: 1.5
+        Parameters
+        ----------
+        clist
+            A list of mpl color specifiers.
         """
-        cbook.warn_deprecated(
-            '1.5', name='set_color_cycle', alternative='set_prop_cycle')
         if clist is None:
             # Calling set_color_cycle() or set_prop_cycle() with None
             # effectively resets the cycle, but you can't do


### PR DESCRIPTION
## PR Summary

This adds css to highlight deprecation messages in the docs.

**Before**:
The deprecation message was just regular text.

![grafik](https://user-images.githubusercontent.com/2836374/36939759-16368d40-1f37-11e8-95ba-42ef577f01d2.png)


**Now**:
There's a box around the message to make it more visible and set it apart from the regular text.

![grafik](https://user-images.githubusercontent.com/2836374/36939771-4089b324-1f37-11e8-88fc-6081226459d9.png)
