### PR TITLE
Deprecation fixes.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -142,7 +142,6 @@ import warnings
 from . import cbook
 from matplotlib.cbook import (
     mplDeprecation, dedent, get_label, sanitize_sequence)
-from matplotlib.compat import subprocess
 from matplotlib.rcsetup import defaultParams, validate_backend, cycler
 
 import numpy

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -589,8 +589,7 @@ class FigureCanvasAgg(FigureCanvasBase):
                 return
             image = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
             dpi = (self.figure.dpi, self.figure.dpi)
-            return image.save(filename_or_obj, format='tiff',
-                              dpi=dpi)
+            return image.save(filename_or_obj, format='tiff', dpi=dpi)
         print_tiff = print_tif
 
 

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -103,8 +103,7 @@ def warn_deprecated(
     """
     message = _generate_deprecation_message(
                 since, message, name, alternative, pending, obj_type)
-
-    warnings.warn(message, mplDeprecation, stacklevel=1)
+    warnings.warn(message, mplDeprecation, stacklevel=2)
 
 
 def deprecated(since, message='', name='', alternative='', pending=False,


### PR DESCRIPTION
1) don't import matplotlib.compat.subprocess in `__init__` (as that
triggers a deprecation warning).
2) using stacklevel=2 for warn_deprecated as default is not necessarily
always sufficient, but will definitely be better than stacklevel=1 as
default... (see https://docs.python.org/3/library/warnings.html#warnings.warn).
xref #10643.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
