### PR TITLE
Fix getting polar axes in plt.polar()

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1822,11 +1822,12 @@ class Figure(Artist):
                         "3.0",
                         "Calling `gca()` using the same arguments as a "
                         "previous axes currently reuses the earlier "
-                        "instance.  In a future version, a new instance will "
-                        "always be created and returned.  Meanwhile, this "
-                        "warning can be suppressed, and the future behavior "
-                        "ensured, by passing a unique label to each axes "
-                        "instance.")
+                        "instance.\n"
+                        "In a future version, a new instance will "
+                        "always be created and returned.\n"
+                        "Meanwhile, this warning can be suppressed, and the "
+                        "future behavior ensured, by passing a unique label "
+                        "to each axes instance.")
                     return cax
                 else:
                     warnings.warn('Requested projection is different from '

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2283,12 +2283,15 @@ def polar(*args, **kwargs):
     strings, as in :func:`~matplotlib.pyplot.plot`.
 
     """
-    # If an axis already exists, check if it has a polar projection
+    # If an axes already exists, check if it has a polar projection
     if gcf().get_axes():
         if not isinstance(gca(), PolarAxes):
             warnings.warn('Trying to create polar plot on an axis that does '
                           'not have a polar projection.')
-    ax = gca(polar=True)
+        ax = gca()
+    else:
+        ax = gcf().add_subplot(1, 1, 1, polar=True)
+
     ret = ax.plot(*args, **kwargs)
     return ret
 


### PR DESCRIPTION
Currently `ax = gca(polar=True)` raises a warning, because in future version it will return a new subplot instead of returning an existing one.

This PR removes this warning, and ensures `plt.polar` will behave well into the future by calling `gca()` without arguments. This means that if no axes are present, a new polar axes is manually created in `plt.polar`.