### PR TITLE
FIX/ENH: include text in ax.get_tightbbox

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -34,6 +34,7 @@ import matplotlib.image as mimage
 from matplotlib.offsetbox import OffsetBox
 from matplotlib.artist import allow_rasterization
 from matplotlib.legend import Legend
+from matplotlib.text import Text
 
 from matplotlib.rcsetup import cycler
 from matplotlib.rcsetup import validate_axisbelow
@@ -4178,6 +4179,8 @@ class _AxesBase(martist.Artist):
                 bb.append(child.get_window_extent(renderer))
             elif isinstance(child, Legend) and child.get_visible():
                 bb.append(child._legend_box.get_window_extent(renderer))
+            elif isinstance(child, Text) and child.get_visible():
+                bb.append(child.get_window_extent(renderer))
 
         _bbox = mtransforms.Bbox.union(
             [b for b in bb if b.width != 0 or b.height != 0])


### PR DESCRIPTION
## PR Summary

If text overflows an axes, `ax.get_tightbbox` doesn't include it.  

Note this doesn't require `constrained_layout` to be a problem.  ~Saving with `bbox_inches='tight'` will also cut the extra text off..~  EDIT: This wasn't true - `bbox_inches='tight'` renders the figure and then figures out the bbox.  But, I don't see why we wouldn't include over-spilling text in the tight bbox for an axes.

```python

import matplotlib.pyplot as plt

fig, ax = plt.subplots(constrained_layout=True)
ax.set_xlim([0, 1])
ax.text(1, 0.5, 'This is a long overflow')
plt.show()

```

## Before

![fig2](https://user-images.githubusercontent.com/1562854/36952257-3a549308-1fc2-11e8-954f-46d5fbba79ff.png)

## After

![fig1](https://user-images.githubusercontent.com/1562854/36952261-3f63e204-1fc2-11e8-9f08-ec2b1bcc5b36.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
