### PR TITLE
Small fixes to gtk3 examples.

### DIFF
--- a/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
@@ -6,14 +6,14 @@ Embedding In GTK3 Panzoom
 Demonstrate NavigationToolbar with GTK3 accessed via pygobject.
 """
 
-from gi.repository import Gtk
-
 from matplotlib.backends.backend_gtk3 import (
     NavigationToolbar2GTK3 as NavigationToolbar)
 from matplotlib.backends.backend_gtk3agg import (
     FigureCanvasGTK3Agg as FigureCanvas)
 from matplotlib.figure import Figure
 import numpy as np
+from gi.repository import Gtk
+
 
 win = Gtk.Window()
 win.connect("delete-event", Gtk.main_quit)
@@ -29,11 +29,11 @@ a.plot(t, s)
 vbox = Gtk.VBox()
 win.add(vbox)
 
-# Add canvas to vbox
+# Add canvas to vbox.
 canvas = FigureCanvas(f)  # a Gtk.DrawingArea
 vbox.pack_start(canvas, True, True, 0)
 
-# Create toolbar
+# Create toolbar.
 toolbar = NavigationToolbar(canvas, win)
 vbox.pack_start(toolbar, False, False, 0)
 

--- a/examples/user_interfaces/embedding_in_gtk3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_sgskip.py
@@ -7,12 +7,12 @@ Demonstrate adding a FigureCanvasGTK3Agg widget to a Gtk.ScrolledWindow using
 GTK3 accessed via pygobject.
 """
 
-from gi.repository import Gtk
-
 from matplotlib.backends.backend_gtk3agg import (
     FigureCanvasGTK3Agg as FigureCanvas)
 from matplotlib.figure import Figure
 import numpy as np
+from gi.repository import Gtk
+
 
 win = Gtk.Window()
 win.connect("delete-event", Gtk.main_quit)
@@ -27,7 +27,7 @@ a.plot(t, s)
 
 sw = Gtk.ScrolledWindow()
 win.add(sw)
-# A scrolled window border goes outside the scrollbars and viewport
+# A scrolled window border goes outside the scrollbars and viewport.
 sw.set_border_width(10)
 
 canvas = FigureCanvas(f)  # a Gtk.DrawingArea

--- a/examples/user_interfaces/mpl_with_glade_316_sgskip.py
+++ b/examples/user_interfaces/mpl_with_glade_316_sgskip.py
@@ -5,13 +5,14 @@ Matplotlib With Glade 316
 
 """
 
-from gi.repository import Gtk
+from pathlib import Path
 
 from matplotlib.figure import Figure
 from matplotlib.axes import Subplot
 from matplotlib.backends.backend_gtk3agg import (
     FigureCanvasGTK3Agg as FigureCanvas)
 import numpy as np
+from gi.repository import Gtk
 
 
 class Window1Signals(object):
@@ -21,12 +22,14 @@ class Window1Signals(object):
 
 def main():
     builder = Gtk.Builder()
-    builder.add_objects_from_file("mpl_with_glade_316.glade", ("window1", ""))
+    builder.add_objects_from_file(
+        str(Path(__file__).with_name("mpl_with_glade_316.glade")),
+        ("window1", ""))
     builder.connect_signals(Window1Signals())
     window = builder.get_object("window1")
     sw = builder.get_object("scrolledwindow1")
 
-    # Start of Matplotlib specific code
+    # Start of Matplotlib specific code.
     figure = Figure(figsize=(8, 6), dpi=71)
     axis = figure.add_subplot(111)
     t = np.arange(0.0, 3.0, 0.01)
@@ -39,7 +42,7 @@ def main():
     canvas = FigureCanvas(figure)  # a Gtk.DrawingArea
     canvas.set_size_request(800, 600)
     sw.add_with_viewport(canvas)
-    # End of Matplotlib specific code
+    # End of Matplotlib specific code.
 
     window.show_all()
     Gtk.main()


### PR DESCRIPTION
- Move import of gi.repository.Gtk *after* matplotlib: this avoids the
warning "Gtk was imported without specifying a version first.", as
Matplotlib itself calls `gi.require_version("Gtk", "3.0")`.  The
examples could be modified to also include the call to require_version
but I'd rather decrease line noise as much as possible.

- Make mpl_with_glade_316_sgskip work even when the example is not run
from its folder (by looking for the glade file next to the source file).

Milestoning to 3.0 as these files were already modified during the py3fication.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
