### PR TITLE
Rewrite the tk C blitting code

### DIFF
--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -1,4 +1,4 @@
-from . import tkagg  # Paint image to Tk photo blitter extension.
+from . import _backend_tk
 from .backend_agg import FigureCanvasAgg
 from ._backend_tk import (
     _BackendTk, FigureCanvasTk, FigureManagerTk, NavigationToolbar2Tk)
@@ -7,12 +7,12 @@ from ._backend_tk import (
 class FigureCanvasTkAgg(FigureCanvasAgg, FigureCanvasTk):
     def draw(self):
         super(FigureCanvasTkAgg, self).draw()
-        tkagg.blit(self._tkphoto, self.renderer._renderer, colormode=2)
+        _backend_tk.blit(self._tkphoto, self.renderer._renderer, (0, 1, 2, 3))
         self._master.update_idletasks()
 
     def blit(self, bbox=None):
-        tkagg.blit(
-            self._tkphoto, self.renderer._renderer, bbox=bbox, colormode=2)
+        _backend_tk.blit(
+            self._tkphoto, self.renderer._renderer, (0, 1, 2, 3), bbox=bbox)
         self._master.update_idletasks()
 
 

--- a/lib/matplotlib/backends/backend_tkcairo.py
+++ b/lib/matplotlib/backends/backend_tkcairo.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-from . import tkagg  # Paint image to Tk photo blitter extension.
+from . import _backend_tk
 from .backend_cairo import cairo, FigureCanvasCairo, RendererCairo
 from ._backend_tk import _BackendTk, FigureCanvasTk
 
@@ -20,13 +20,9 @@ class FigureCanvasTkCairo(FigureCanvasCairo, FigureCanvasTk):
         self._renderer.set_width_height(width, height)
         self.figure.draw(self._renderer)
         buf = np.reshape(surface.get_data(), (height, width, 4))
-        # Convert from ARGB32 to RGBA8888.  Using .take() instead of directly
-        # indexing ensures C-contiguity of the result, which is needed by
-        # tkagg.
-        buf = buf.take(
-            [2, 1, 0, 3] if sys.byteorder == "little" else [1, 2, 3, 0],
-            axis=2)
-        tkagg.blit(self._tkphoto, buf, colormode=2)
+        _backend_tk.blit(
+            self._tkphoto, buf,
+            (2, 1, 0, 3) if sys.byteorder == "little" else (1, 2, 3, 0))
         self._master.update_idletasks()
 
 

--- a/lib/matplotlib/backends/tkagg.py
+++ b/lib/matplotlib/backends/tkagg.py
@@ -2,7 +2,13 @@ import tkinter as Tk
 
 import numpy as np
 
+from matplotlib import cbook
 from matplotlib.backends import _tkagg
+
+
+cbook.warn_deprecated(
+    "3.0", "The matplotlib.backends.tkagg module is deprecated.")
+
 
 def blit(photoimage, aggimage, bbox=None, colormode=1):
     tk = photoimage.tk


### PR DESCRIPTION
... to use the standard Python C-API rather than the tk API.

We do not need to support colormodes other than 2 (i.e. RGBA)
(previously there was 0 = grayscale, 1 = RGB) so it was simpler to just
deprecate the previous function and move everything to a new private one
(matplotlib.backends._backend_tk.blit).

Followup to https://github.com/matplotlib/matplotlib/pull/10486#issuecomment-366104200.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
