### PR TITLE
ENH have ax.get_tightbbox have a bbox around all artists attached to axes.

### DIFF
--- a/doc/api/next_api_changes/2018-04-29-JMK.rst
+++ b/doc/api/next_api_changes/2018-04-29-JMK.rst
@@ -1,0 +1,20 @@
+`.matplotlib.Axes.get_tightbbox` now includes all artists
+---------------------------------------------------------
+
+Layout tools like `.Figure.tight_layout`, ``constrained_layout``,
+and ``fig.savefig('fname.png', bbox_inches="tight")`` use
+`.matplotlib.Axes.get_tightbbox` to determine the bounds of each axes on
+a figure and adjust spacing between axes.
+
+In Matplotlib 2.2 ``get_tightbbox`` started to include legends made on the
+axes, but still excluded some other artists, like text that may overspill an
+axes.  For Matplotlib 3.0, *all* artists are now included in the bounding box.
+
+This new default may be overridden in either of two ways:
+
+1. Make the artist to be excluded a child of the figure, not the axes. E.g., 
+   call ``fig.legend()`` instead of ``ax.legend()`` (perhaps using
+   `~.matplotlib.Axes.get_legend_handles_labels` to gather handles and labels
+   from the parent axes).
+2. If the artist is a child of the axes, set the artist property
+   ``artist.set_in_layout(False)``.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4110,19 +4110,47 @@ class _AxesBase(martist.Artist):
         martist.Artist.pick(self, args[0])
 
     def get_default_bbox_extra_artists(self):
-        return [artist for artist in self.get_children()
-                if artist.get_visible()]
-
-    def get_tightbbox(self, renderer, call_axes_locator=True):
         """
-        Return the tight bounding box of the axes.
-        The dimension of the Bbox in canvas coordinate.
+        Return a default list of artists that are used for the bounding box
+        calculation.
 
-        If *call_axes_locator* is *False*, it does not call the
-        _axes_locator attribute, which is necessary to get the correct
-        bounding box. ``call_axes_locator==False`` can be used if the
-        caller is only intereted in the relative size of the tightbbox
-        compared to the axes bbox.
+        Artists are excluded either by not being visible or
+        ``artist.set_in_layout(False)``.
+        """
+        return [artist for artist in self.get_children()
+                if (artist.get_visible() and artist.get_in_layout())]
+
+    def get_tightbbox(self, renderer, call_axes_locator=True,
+            bbox_extra_artists=None):
+        """
+        Return the tight bounding box of the axes, including axis and their
+        decorators (xlabel, title, etc).
+
+        Artists that have ``artist.set_in_layout(False)`` are not included
+        in the bbox.
+
+        Parameters
+        ----------
+        renderer : `.RendererBase` instance
+            renderer that will be used to draw the figures (i.e.
+            ``fig.canvas.get_renderer()``)
+
+        bbox_extra_artists : list of `.Artist` or ``None``
+            List of artists to include in the tight bounding box.  If
+            ``None`` (default), then all artist children of the axes are
+            included in the tight bounding box.
+
+        call_axes_locator : boolean (default ``True``)
+            If *call_axes_locator* is ``False``, it does not call the
+            ``_axes_locator`` attribute, which is necessary to get the correct
+            bounding box. ``call_axes_locator=False`` can be used if the
+            caller is only interested in the relative size of the tightbbox
+            compared to the axes bbox.
+
+        Returns
+        -------
+        bbox : `.BboxBase`
+            bounding box in figure pixel coordinates.
         """
 
         bb = []
@@ -4155,11 +4183,14 @@ class _AxesBase(martist.Artist):
         if bb_yaxis:
             bb.append(bb_yaxis)
 
-        for child in self.get_children():
-            if isinstance(child, OffsetBox) and child.get_visible():
-                bb.append(child.get_window_extent(renderer))
-            elif isinstance(child, Legend) and child.get_visible():
-                bb.append(child._legend_box.get_window_extent(renderer))
+        bbox_artists = bbox_extra_artists
+        if bbox_artists is None:
+            bbox_artists = self.get_default_bbox_extra_artists()
+
+        for a in bbox_artists:
+            bbox = a.get_tightbbox(renderer)
+            if bbox is not None and (bbox.width != 0 or bbox.height != 0):
+                bb.append(bbox)
 
         _bbox = mtransforms.Bbox.union(
             [b for b in bb if b.width != 0 or b.height != 0])

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2048,36 +2048,9 @@ class FigureCanvasBase(object):
                         dryrun=True,
                         **kwargs)
                     renderer = self.figure._cachedRenderer
-                    bbox_inches = self.figure.get_tightbbox(renderer)
-
                     bbox_artists = kwargs.pop("bbox_extra_artists", None)
-                    if bbox_artists is None:
-                        bbox_artists = \
-                            self.figure.get_default_bbox_extra_artists()
-
-                    bbox_filtered = []
-                    for a in bbox_artists:
-                        bbox = a.get_window_extent(renderer)
-                        if a.get_clip_on():
-                            clip_box = a.get_clip_box()
-                            if clip_box is not None:
-                                bbox = Bbox.intersection(bbox, clip_box)
-                            clip_path = a.get_clip_path()
-                            if clip_path is not None and bbox is not None:
-                                clip_path = \
-                                    clip_path.get_fully_transformed_path()
-                                bbox = Bbox.intersection(
-                                    bbox, clip_path.get_extents())
-                        if bbox is not None and (
-                                bbox.width != 0 or bbox.height != 0):
-                            bbox_filtered.append(bbox)
-
-                    if bbox_filtered:
-                        _bbox = Bbox.union(bbox_filtered)
-                        trans = Affine2D().scale(1.0 / self.figure.dpi)
-                        bbox_extra = TransformedBbox(_bbox, trans)
-                        bbox_inches = Bbox.union([bbox_inches, bbox_extra])
-
+                    bbox_inches = self.figure.get_tightbbox(renderer,
+                            bbox_extra_artists=bbox_artists)
                     pad = kwargs.pop("pad_inches", None)
                     if pad is None:
                         pad = rcParams['savefig.pad_inches']

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -981,6 +981,22 @@ class Legend(Artist):
         'Return extent of the legend.'
         return self._legend_box.get_window_extent(*args, **kwargs)
 
+    def get_tightbbox(self, renderer):
+        """
+        Like `.Legend.get_window_extent`, but uses the box for the legend.
+
+        Parameters
+        ----------
+        renderer : `.RendererBase` instance
+            renderer that will be used to draw the figures (i.e.
+            ``fig.canvas.get_renderer()``)
+
+        Returns
+        -------
+        `.BboxBase` : containing the bounding box in figure pixel co-ordinates.
+        """
+        return self._legend_box.get_window_extent(renderer)
+
     def get_frame_on(self):
         """Get whether the legend box patch is drawn."""
         return self._drawFrame

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -391,3 +391,28 @@ def test_fspath(fmt, tmpdir):
         # All the supported formats include the format name (case-insensitive)
         # in the first 100 bytes.
         assert fmt.encode("ascii") in file.read(100).lower()
+
+
+def test_tightbbox():
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 1)
+    t = ax.text(1., 0.5, 'This dangles over end')
+    renderer = fig.canvas.get_renderer()
+    x1Nom0 = 9.035  # inches
+    assert np.abs(t.get_tightbbox(renderer).x1 - x1Nom0 * fig.dpi) < 2
+    assert np.abs(ax.get_tightbbox(renderer).x1 - x1Nom0 * fig.dpi) < 2
+    assert np.abs(fig.get_tightbbox(renderer).x1 - x1Nom0) < 0.05
+    assert np.abs(fig.get_tightbbox(renderer).x0 - 0.679) < 0.05
+    # now exclude t from the tight bbox so now the bbox is quite a bit
+    # smaller
+    t.set_in_layout(False)
+    x1Nom = 7.333
+    assert np.abs(ax.get_tightbbox(renderer).x1 - x1Nom * fig.dpi) < 2
+    assert np.abs(fig.get_tightbbox(renderer).x1 - x1Nom) < 0.05
+
+    t.set_in_layout(True)
+    x1Nom = 7.333
+    assert np.abs(ax.get_tightbbox(renderer).x1 - x1Nom0 * fig.dpi) < 2
+    # test bbox_extra_artists method...
+    assert np.abs(ax.get_tightbbox(renderer,
+                        bbox_extra_artists=[]).x1 - x1Nom * fig.dpi) < 2

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -189,7 +189,7 @@ fig.suptitle('Big Suptitle')
 
 fig, ax = plt.subplots(constrained_layout=True)
 ax.plot(np.arange(10), label='This is a plot')
-ax.legend(loc='center left', bbox_to_anchor=(0.9, 0.5))
+ax.legend(loc='center left', bbox_to_anchor=(0.8, 0.5))
 
 #############################################
 # However, this will steal space from a subplot layout:
@@ -198,7 +198,39 @@ fig, axs = plt.subplots(2, 2, constrained_layout=True)
 for ax in axs.flatten()[:-1]:
     ax.plot(np.arange(10))
 axs[1, 1].plot(np.arange(10), label='This is a plot')
-axs[1, 1].legend(loc='center left', bbox_to_anchor=(0.9, 0.5))
+axs[1, 1].legend(loc='center left', bbox_to_anchor=(0.8, 0.5))
+
+#############################################
+# In order for a legend or other artist to *not* steal space
+# from the subplot layout, we can ``leg.set_in_layout(False)``.
+# Of course this can mean the legend ends up
+# cropped, but can be useful if the plot is subsequently called
+# with ``fig.savefig('outname.png', bbox_inches='tight')``.  Note,
+# however, that the legend's ``get_in_layout`` status will have to be
+# toggled again to make the saved file work:
+
+fig, axs = plt.subplots(2, 2, constrained_layout=True)
+for ax in axs.flatten()[:-1]:
+    ax.plot(np.arange(10))
+axs[1, 1].plot(np.arange(10), label='This is a plot')
+leg = axs[1, 1].legend(loc='center left', bbox_to_anchor=(0.8, 0.5))
+leg.set_in_layout(False)
+wanttoprint = False
+if wanttoprint:
+    leg.set_in_layout(True)
+    fig.do_constrained_layout(False)
+    fig.savefig('outname.png', bbox_inches='tight')
+
+#############################################
+# A better way to get around this awkwardness is to simply
+# use a legend for the figure:
+fig, axs = plt.subplots(2, 2, constrained_layout=True)
+for ax in axs.flatten()[:-1]:
+    ax.plot(np.arange(10))
+lines = axs[1, 1].plot(np.arange(10), label='This is a plot')
+labels = [l.get_label() for l in lines]
+leg = fig.legend(lines, labels, loc='center left',
+                 bbox_to_anchor=(0.8, 0.5), bbox_transform=axs[1, 1].transAxes)
 
 ###############################################################################
 # Padding and Spacing

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -284,6 +284,35 @@ gs2.tight_layout(fig, rect=[0.5, 0 + (bottom-gs2.bottom),
                  h_pad=0.5)
 
 ###############################################################################
+# Legends and Annotations
+# =======================
+#
+# Pre Matplotlih 2.2, legends and annotations were excluded from the bounding
+# box calculations that decide the layout.  Subsequently these artists were
+# added to the calculation, but sometimes it is undesirable to include them.
+# For instance in this case it might be good to have the axes shring a bit
+# to make room for the legend:
+
+fig, ax = plt.subplots(figsize=(4, 3))
+lines = ax.plot(range(10), label='A simple plot')
+ax.legend(bbox_to_anchor=(0.7, 0.5), loc='center left',)
+fig.tight_layout()
+plt.show()
+
+###############################################################################
+# However, sometimes this is not desired (quite often when using
+# ``fig.savefig('outname.png', bbox_inches='tight')``).  In order to
+# remove the legend from the bounding box calculation, we simply set its
+# bounding ``leg.set_in_layout(False)`` and the legend will be ignored.
+
+fig, ax = plt.subplots(figsize=(4, 3))
+lines = ax.plot(range(10), label='B simple plot')
+leg = ax.legend(bbox_to_anchor=(0.7, 0.5), loc='center left',)
+leg.set_in_layout(False)
+fig.tight_layout()
+plt.show()
+
+###############################################################################
 # Use with AxesGrid1
 # ==================
 #


### PR DESCRIPTION
## PR Summary

This PR takes the code that was in `backend_bases.py` in `savefig` for determining a figure bounding box, and puts it in `ax.get_tightbbox` and `fig.get_tightbbox`, via a refactoring into `Artists.get_tightbbox`.

Supercedes #10678 and extends already merged #9164

In previous PRs I was piecemeal adding new types of artists, but noted that `fig.savefig(bbox_inches='tight')` was actually doing the correct thing and putting the bbox around all the artists.  

To get the old behaviour back, a new kwarg has been added:

`ax.get_tightbbox(bbox_extra_artists=[])`

So now the following code

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots(figsize=(5,2))
ax.set_xlim([0, 1])
ax.text(1, 0.5, 'This is a long overflow')
print('before', ax.get_tightbbox(fig.canvas.get_renderer(),bbox_extra_artists=[]))
print('now   ', ax.get_tightbbox(fig.canvas.get_renderer()))
```

returns:

```
before Bbox(x0=61.2, y0=-3.4, x1=922.125, y1=363.0)
now    Bbox(x0=61.2, y0=-3.4, x1=1210.25, y1=363.0)
```

This *is* a breaking change, in that anyone who was expecting the bbox to not include artists, but just the axes axis elements and labels, will now get a different behaviour.  They can get the old behaviour as above (specifying the empty `bbox_extra_artists` kwarg.  OTOH, willing be told this is too big an API change. (it of course still needs an API change note, and likely a test or two somewhere).

### UPDATE 28 April:

This adds the artist property `artist.set/get_in_layout` (as discussed w/ @efiring et al on the weekly call) which specifies if an artist should be included in the tight_bbox calculation.  This allows toggling artists in the tight layout or constrained layout calculations.  

So, now we can also do:

```python
fig, ax = plt.subplots(figsize=(5,2))
ax.set_xlim([0, 1])
t = ax.text(1, 0.5, 'This is a long overflow')
t.inbbox = True  # default
print('inbbox true', ax.get_tightbbox(fig.canvas.get_renderer()))
t.set_in_layout(False)
print('inbbox false ', ax.get_tightbbox(fig.canvas.get_renderer()))
t.set_in_layout(True)
print('inbbox true ', ax.get_tightbbox(fig.canvas.get_renderer()))
```
and get 
```
in_layout  true  Bbox(x0=61.18055555555556, y0=-3.4444444444444535, x1=1210.25, y1=363.0)
in_layout false  Bbox(x0=61.18055555555556, y0=-3.4444444444444535, x1=922.125, y1=363.0)
in_layout  true  Bbox(x0=61.18055555555556, y0=-3.4444444444444535, x1=1210.25, y1=363.0)
```

Note that this also works for legends, which often get put outside axes and hence may not want to be part of the tight_layout machinery.

Discussion: Should artists that did not get included in the old `tight_layout` be set to `False` by default?  I'm somewhat against this because it means users have to guess or query what state the attribute is in...

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] Documentation is sphinx and numpydoc compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->