### PR TITLE
Re-instate _path setting in Arc class

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1593,6 +1593,7 @@ class Arc(Ellipse):
 
         self.theta1 = theta1
         self.theta2 = theta2
+        self._path = Path.arc(self.theta1, self.theta2)
 
     @artist.allow_rasterization
     def draw(self, renderer):


### PR DESCRIPTION
Fixes #10654. We should probably work out a minimal test to make sure this doesn't break again, but I'm not sure what that would be yet.