### PR TITLE
Remove special-casing of _remove_method when pickling.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -2,16 +2,17 @@ Deprecations
 ````````````
 The following modules are deprecated:
 
-- :mod:`matplotlib.compat.subprocess`. This was a python 2 workaround, but all the
-  functionality can now be found in the python 3 standard library
+- :mod:`matplotlib.compat.subprocess`. This was a python 2 workaround, but all
+  the functionality can now be found in the python 3 standard library
   :mod:`subprocess`.
 
-The following functions and classes are deprecated:
+The following classes, methods, and functions are deprecated:
 
 - ``cbook.GetRealpathAndStat`` (which is only a helper for
   ``get_realpath_and_stat``),
 - ``cbook.Locked``,
 - ``cbook.is_numlike`` (use ``isinstance(..., numbers.Number)`` instead),
+- ``container.Container.set_remove_method``,
 - ``mathtext.unichr_safe`` (use ``chr`` instead),
 - ``texmanager.dvipng_hack_alpha``,
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -124,7 +124,6 @@ class Artist(object):
         d = self.__dict__.copy()
         # remove the unpicklable remove method, this will get re-added on load
         # (by the axes) if the artist lives on an axes.
-        d['_remove_method'] = None
         d['stale_callback'] = None
         return d
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -554,8 +554,11 @@ class Axes(_AxesBase):
         if len(extra_args):
             raise TypeError('legend only accepts two non-keyword arguments')
         self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
-        self.legend_._remove_method = lambda h: setattr(self, 'legend_', None)
+        self.legend_._remove_method = self._remove_legend
         return self.legend_
+
+    def _remove_legend(self, legend):
+        self.legend_ = None
 
     def text(self, x, y, s, fontdict=None, withdash=False, **kwargs):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -586,12 +586,6 @@ class _AxesBase(martist.Artist):
 
     def __setstate__(self, state):
         self.__dict__ = state
-        # put the _remove_method back on all artists contained within the axes
-        for container_name in ['lines', 'collections', 'tables', 'patches',
-                               'texts', 'images']:
-            container = getattr(self, container_name)
-            for artist in container:
-                artist._remove_method = container.remove
         self._stale = True
         self._layoutbox = None
         self._poslayoutbox = None
@@ -1858,9 +1852,9 @@ class _AxesBase(martist.Artist):
         """
         a.axes = self
         self.artists.append(a)
+        a._remove_method = self.artists.remove
         self._set_artist_props(a)
         a.set_clip_path(self.patch)
-        a._remove_method = lambda h: self.artists.remove(h)
         self.stale = True
         return a
 
@@ -1875,6 +1869,7 @@ class _AxesBase(martist.Artist):
         if not label:
             collection.set_label('_collection%d' % len(self.collections))
         self.collections.append(collection)
+        collection._remove_method = self.collections.remove
         self._set_artist_props(collection)
 
         if collection.get_clip_path() is None:
@@ -1883,7 +1878,6 @@ class _AxesBase(martist.Artist):
         if autolim:
             self.update_datalim(collection.get_datalim(self.transData))
 
-        collection._remove_method = lambda h: self.collections.remove(h)
         self.stale = True
         return collection
 
@@ -1897,7 +1891,7 @@ class _AxesBase(martist.Artist):
         if not image.get_label():
             image.set_label('_image%d' % len(self.images))
         self.images.append(image)
-        image._remove_method = lambda h: self.images.remove(h)
+        image._remove_method = self.images.remove
         self.stale = True
         return image
 
@@ -1920,7 +1914,7 @@ class _AxesBase(martist.Artist):
         if not line.get_label():
             line.set_label('_line%d' % len(self.lines))
         self.lines.append(line)
-        line._remove_method = lambda h: self.lines.remove(h)
+        line._remove_method = self.lines.remove
         self.stale = True
         return line
 
@@ -1930,7 +1924,7 @@ class _AxesBase(martist.Artist):
         """
         self._set_artist_props(txt)
         self.texts.append(txt)
-        txt._remove_method = lambda h: self.texts.remove(h)
+        txt._remove_method = self.texts.remove
         self.stale = True
         return txt
 
@@ -1993,7 +1987,7 @@ class _AxesBase(martist.Artist):
             p.set_clip_path(self.patch)
         self._update_patch_limits(p)
         self.patches.append(p)
-        p._remove_method = lambda h: self.patches.remove(h)
+        p._remove_method = self.patches.remove
         return p
 
     def _update_patch_limits(self, patch):
@@ -2039,7 +2033,7 @@ class _AxesBase(martist.Artist):
         self._set_artist_props(tab)
         self.tables.append(tab)
         tab.set_clip_path(self.patch)
-        tab._remove_method = lambda h: self.tables.remove(h)
+        tab._remove_method = self.tables.remove
         return tab
 
     def add_container(self, container):
@@ -2053,7 +2047,7 @@ class _AxesBase(martist.Artist):
         if not label:
             container.set_label('_container%d' % len(self.containers))
         self.containers.append(container)
-        container.set_remove_method(lambda h: self.containers.remove(h))
+        container._remove_method = self.containers.remove
         return container
 
     def _on_units_changed(self, scalex=False, scaley=False):

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import six
 
 import matplotlib.cbook as cbook
@@ -32,6 +29,7 @@ class Container(tuple):
 
         self.set_label(label)
 
+    @cbook.deprecated("3.0")
     def set_remove_method(self, f):
         self._remove_method = f
 
@@ -43,13 +41,6 @@ class Container(tuple):
 
         if self._remove_method:
             self._remove_method(self)
-
-    def __getstate__(self):
-        d = self.__dict__.copy()
-        # remove the unpicklable remove method, this will get re-added on load
-        # (by the axes) if the artist lives on an axes.
-        d['_remove_method'] = None
-        return d
 
     def get_label(self):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -890,7 +890,7 @@ default: 'top'
         if norm is None:
             im.set_clim(vmin, vmax)
         self.images.append(im)
-        im._remove_method = lambda h: self.images.remove(h)
+        im._remove_method = self.images.remove
         self.stale = True
         return im
 
@@ -1162,7 +1162,7 @@ default: 'top'
 
         self._axstack.add(key, a)
         self.sca(a)
-        a._remove_method = self.__remove_ax
+        a._remove_method = self._remove_ax
         self.stale = True
         a.stale_callback = _stale_figure_callback
         return a
@@ -1269,7 +1269,7 @@ default: 'top'
             a = subplot_class_factory(projection_class)(self, *args, **kwargs)
         self._axstack.add(key, a)
         self.sca(a)
-        a._remove_method = self.__remove_ax
+        a._remove_method = self._remove_ax
         self.stale = True
         a.stale_callback = _stale_figure_callback
         return a
@@ -1402,7 +1402,7 @@ default: 'top'
             # Returned axis array will be always 2-d, even if nrows=ncols=1.
             return axarr
 
-    def __remove_ax(self, ax):
+    def _remove_ax(self, ax):
         def _reset_loc_form(axis):
             axis.set_major_formatter(axis.get_major_formatter())
             axis.set_major_locator(axis.get_major_locator())
@@ -1768,7 +1768,7 @@ default: 'top'
             pass
         l = mlegend.Legend(self, handles, labels, *extra_args, **kwargs)
         self.legends.append(l)
-        l._remove_method = lambda h: self.legends.remove(h)
+        l._remove_method = self.legends.remove
         self.stale = True
         return l
 
@@ -1796,7 +1796,7 @@ default: 'top'
         t.update(override)
         self._set_artist_props(t)
         self.texts.append(t)
-        t._remove_method = lambda h: self.texts.remove(h)
+        t._remove_method = self.texts.remove
         self.stale = True
         return t
 

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -243,7 +243,7 @@ class HostAxesBase(object):
         # note that ax2.transData == tr + ax1.transData
         # Anthing you draw in ax2 will match the ticks and grids of ax1.
         self.parasites.append(ax2)
-        ax2._remove_method = lambda h: self.parasites.remove(h)
+        ax2._remove_method = self.parasites.remove
         return ax2
 
     def _get_legend_handles(self, legend_handler_map=None):
@@ -304,19 +304,19 @@ class HostAxesBase(object):
 
         ax2 = parasite_axes_class(self, sharex=self, frameon=False)
         self.parasites.append(ax2)
+        ax2._remove_method = self._remove_twinx
 
         self.axis["right"].set_visible(False)
 
         ax2.axis["right"].set_visible(True)
         ax2.axis["left", "top", "bottom"].set_visible(False)
 
-        def _remove_method(h):
-            self.parasites.remove(h)
-            self.axis["right"].set_visible(True)
-            self.axis["right"].toggle(ticklabels=False, label=False)
-        ax2._remove_method = _remove_method
-
         return ax2
+
+    def _remove_twinx(self, ax):
+        self.parasites.remove(ax)
+        self.axis["right"].set_visible(True)
+        self.axis["right"].toggle(ticklabels=False, label=False)
 
     def twiny(self, axes_class=None):
         """
@@ -333,19 +333,19 @@ class HostAxesBase(object):
 
         ax2 = parasite_axes_class(self, sharey=self, frameon=False)
         self.parasites.append(ax2)
+        ax2._remove_method = self._remove_twiny
 
         self.axis["top"].set_visible(False)
 
         ax2.axis["top"].set_visible(True)
         ax2.axis["left", "right", "bottom"].set_visible(False)
 
-        def _remove_method(h):
-            self.parasites.remove(h)
-            self.axis["top"].set_visible(True)
-            self.axis["top"].toggle(ticklabels=False, label=False)
-        ax2._remove_method = _remove_method
-
         return ax2
+
+    def _remove_twiny(self, ax):
+        self.parasites.remove(ax)
+        self.axis["top"].set_visible(True)
+        self.axis["top"].toggle(ticklabels=False, label=False)
 
     def twin(self, aux_trans=None, axes_class=None):
         """
@@ -368,7 +368,7 @@ class HostAxesBase(object):
             ax2 = parasite_axes_auxtrans_class(
                 self, aux_trans, viewlim_mode="transform")
         self.parasites.append(ax2)
-        ax2._remove_method = lambda h: self.parasites.remove(h)
+        ax2._remove_method = self.parasites.remove
 
         self.axis["top", "right"].set_visible(False)
 


### PR DESCRIPTION
Now (in Py3) that instance methods are directly picklable, there's no
need to special-case _remove_method in pickling support.  The few cases
where _remove_method was not a bound method were handled by transforming
them, well, into bound methods.

_remove_method is clearly intended to be for private use (cf. comment
next to its definition in the Artist class), so deprecate
Container.set_remove_method (in any case, such a method, if we really
wanted it, should also live on the Artist class).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
