### PR TITLE
BUG: Fix UnboundLocalError in contour labelling

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -440,7 +440,7 @@ class ContourLabeler(object):
             # Actually break contours
             if closed:
                 # This will remove contour if shorter than label
-                if np.all(I != -1):
+                if all(i != -1 for i in I):
                     nlc.append(np.row_stack([xy2, lc[I[1]:I[0]+1], xy1]))
             else:
                 # These will remove pieces of contour if they have length zero


### PR DESCRIPTION
This fixes hitting the following traceback with 2.2.0 (problem also exists on master):
```pytb
  File "/home/travis/miniconda/envs/gallery/lib/python3.5/site-packages/matplotlib/pyplot.py", line 2790, in clabel
    ret = ax.clabel(CS, *args, **kwargs)
  File "/home/travis/miniconda/envs/gallery/lib/python3.5/site-packages/matplotlib/axes/_axes.py", line 6173, in clabel
    return CS.clabel(*args, **kwargs)
  File "/home/travis/miniconda/envs/gallery/lib/python3.5/site-packages/matplotlib/contour.py", line 213, in clabel
    self.labels(inline, inline_spacing)
  File "/home/travis/miniconda/envs/gallery/lib/python3.5/site-packages/matplotlib/contour.py", line 646, in labels
    inline_spacing)
  File "/home/travis/miniconda/envs/gallery/lib/python3.5/site-packages/matplotlib/contour.py", line 445, in calc_label_rot_and_inline
    nlc.append(np.row_stack([xy2, lc[I[1]:I[0]+1], xy1]))
UnboundLocalError: local variable 'xy2' referenced before assignment
```

That traces back to this block:
https://github.com/matplotlib/matplotlib/blob/d2f7bb1d5b7c9de3498741276c4dd0ef57848ba5/lib/matplotlib/contour.py#L433-L444

The code was trying to protect the access of xy1 and xy2 to valid cases, using `np.all()`. Unfortunately, in this case `I` is a list, so `I != -1` doesn't do element-by-element or
return an error--it just always returns `True`. That caused the if to not actually guard anything. Replaced with `all` and a generator expression.

I tried making a test, but I couldn't find any sensible set of data to reproduce. We hit this in an example of ours that was using cartopy incorrectly (fixing that problem makes the error disappear). It appears to only trigger when you have a really tiny contour (in display coords) that can't be properly interpolated to create a spot for the contour label.

cc @anntzer since you introduced this code according to git.