### PR TITLE
Implemented support for 'markevery' in prop_cycle

### DIFF
--- a/doc/users/next_whats_new/markevery_prop_cycle.rst
+++ b/doc/users/next_whats_new/markevery_prop_cycle.rst
@@ -1,0 +1,7 @@
+Implemented support for axes.prop_cycle property markevery in rcParams
+----------------------------------------------------------------------
+
+The Matplotlib ``rcParams`` settings object now supports configuration
+of the attribute `axes.prop_cycle` with cyclers using the `markevery`
+Line2D object property. An example of this feature is provided at 
+`~matplotlib/examples/lines_bars_and_markers/markevery_prop_cycle.py`

--- a/examples/lines_bars_and_markers/markevery_prop_cycle.py
+++ b/examples/lines_bars_and_markers/markevery_prop_cycle.py
@@ -1,0 +1,69 @@
+"""
+=================================================================
+Implemented support for prop_cycle property markevery in rcParams
+=================================================================
+
+This example demonstrates a working solution to issue #8576, providing full
+support of the markevery property for axes.prop_cycle assignments through
+rcParams. Makes use of the same list of markevery cases from
+https://matplotlib.org/examples/pylab_examples/markevery_demo.html
+
+Renders a plot with shifted-sine curves along each column with
+a unique markevery value for each sine curve.
+"""
+from __future__ import division
+from cycler import cycler
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+
+# Define a list of markevery cases and color cases to plot
+cases = [None,
+         8,
+         (30, 8),
+         [16, 24, 30],
+         [0, -1],
+         slice(100, 200, 3),
+         0.1,
+         0.3,
+         1.5,
+         (0.0, 0.1),
+         (0.45, 0.1)]
+
+colors = ['#1f77b4',
+          '#ff7f0e',
+          '#2ca02c',
+          '#d62728',
+          '#9467bd',
+          '#8c564b',
+          '#e377c2',
+          '#7f7f7f',
+          '#bcbd22',
+          '#17becf',
+          '#1a55FF']
+
+# Create two different cyclers to use with axes.prop_cycle
+markevery_cycler = cycler(markevery=cases)
+color_cycler = cycler('color', colors)
+
+# Configure rcParams axes.prop_cycle with custom cycler
+custom_cycler = color_cycler + markevery_cycler
+mpl.rcParams['axes.prop_cycle'] = custom_cycler
+
+# Create data points and offsets
+x = np.linspace(0, 2 * np.pi)
+offsets = np.linspace(0, 2 * np.pi, 11, endpoint=False)
+yy = np.transpose([np.sin(x + phi) for phi in offsets])
+
+# Set the plot curve with markers and a title
+fig = plt.figure()
+ax = fig.add_axes([0.1, 0.1, 0.6, 0.75])
+
+for i in range(len(cases)):
+    ax.plot(yy[:, i], marker='o', label=str(cases[i]))
+    ax.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
+
+plt.title('Support for axes.prop_cycle cycler with markevery')
+
+plt.show()

--- a/examples/lines_bars_and_markers/markevery_prop_cycle.py
+++ b/examples/lines_bars_and_markers/markevery_prop_cycle.py
@@ -11,12 +11,10 @@ https://matplotlib.org/examples/pylab_examples/markevery_demo.html
 Renders a plot with shifted-sine curves along each column with
 a unique markevery value for each sine curve.
 """
-from __future__ import division
 from cycler import cycler
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
 
 # Define a list of markevery cases and color cases to plot
 cases = [None,

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -568,6 +568,8 @@ def validate_markevery(s):
                 raise ValueError("'markevery' tuple with first element of "
                                  "type float must have all elements of type "
                                  "float")
+            if not instance(tupType, (float, int)):
+                raise TypeError("'markevery' tuple is of an invalid type")
         if isinstance(s, list):
             if not all(isinstance(e, int) for e in s):
                 raise ValueError("'markevery' list must have all elements "

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -568,7 +568,7 @@ def validate_markevery(s):
                 raise ValueError("'markevery' tuple with first element of "
                                  "type float must have all elements of type "
                                  "float")
-            if not instance(tupType, (float, int)):
+            if not isinstance(tupType, (float, int)):
                 raise TypeError("'markevery' tuple is of an invalid type")
         if isinstance(s, list):
             if not all(isinstance(e, int) for e in s):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -541,27 +541,43 @@ def validate_markevery(s):
     Parameters
     ----------
     s : None, int, float, slice, length-2 tuple of ints,
-        length-2 tuple of floats, list
+        length-2 tuple of floats, list of ints
 
     Returns
     -------
     s : None, int, float, slice, length-2 tuple of ints,
-        length-2 tuple of floats, list, ValueError
+        length-2 tuple of floats, list of ints
 
     """
+    # Validate s against type slice
+    if isinstance(s, slice):
+        return s
+    # Validate s against type tuple and list
+    if isinstance(s, Iterable):
+        if isinstance(s, tuple):
+            tupMaxLength = 2
+            tupType = type(s[0])
+            if len(s) != tupMaxLength:
+                raise ValueError("'markevery' tuple must have a length "
+                                 "of %d" % (tupMaxLength))
+            if tupType is int and not all(isinstance(e, int) for e in s):
+                raise ValueError("'markevery' tuple with first element of "
+                                 "type int must have all elements of type "
+                                 "int")
+            if tupType is float and not all(isinstance(e, float) for e in s):
+                raise ValueError("'markevery' tuple with first element of "
+                                 "type float must have all elements of type "
+                                 "float")
+        if isinstance(s, list):
+            if not all(isinstance(e, int) for e in s):
+                raise ValueError("'markevery' list must have all elements "
+                                 "of type int")
+    # Validate s against type float int and None
+    elif not isinstance(s, (float, int)):
+        if s is not None:
+            raise TypeError("'markevery' is of an invalid type")
 
-    if isinstance(s, tuple):
-        # Ensure correct length of 2
-        if len(s) != 2:
-            raise ValueError("'markevery' tuple must be a length of 2")
-        # Ensure that all elements in the tuple are of type int
-        if not all(isinstance(x, int) for x in s):
-            raise ValueError("'markevery' tuple ")
-        # Ensure that all elements in the tuple are of type float
-        elif not all(isinstance(x, float) for x in s):
-            raise ValueError("'markevery' tuple ")
-
-    return s;
+    return s
 
 validate_markeverylist = _listify_validator(validate_markevery)
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -552,28 +552,28 @@ def validate_markevery(s):
     # Validate s against type slice
     if isinstance(s, slice):
         return s
-    # Validate s against type tuple and list
-    if isinstance(s, Iterable):
-        if isinstance(s, tuple):
-            tupMaxLength = 2
-            tupType = type(s[0])
-            if len(s) != tupMaxLength:
-                raise ValueError("'markevery' tuple must have a length "
-                                 "of %d" % (tupMaxLength))
-            if tupType is int and not all(isinstance(e, int) for e in s):
-                raise ValueError("'markevery' tuple with first element of "
-                                 "type int must have all elements of type "
-                                 "int")
-            if tupType is float and not all(isinstance(e, float) for e in s):
-                raise ValueError("'markevery' tuple with first element of "
-                                 "type float must have all elements of type "
-                                 "float")
-            if tupType is not float and tupType is not int:
-                raise TypeError("'markevery' tuple is of an invalid type")
-        if isinstance(s, list):
-            if not all(isinstance(e, int) for e in s):
-                raise ValueError("'markevery' list must have all elements "
-                                 "of type int")
+    # Validate s against type tuple
+    if isinstance(s, tuple):
+        tupMaxLength = 2
+        tupType = type(s[0])
+        if len(s) != tupMaxLength:
+            raise TypeError("'markevery' tuple must have a length of "
+                            "%d" % (tupMaxLength))
+        if tupType is int and not all(isinstance(e, int) for e in s):
+            raise TypeError("'markevery' tuple with first element of "
+                            "type int must have all elements of type "
+                            "int")
+        if tupType is float and not all(isinstance(e, float) for e in s):
+            raise TypeError("'markevery' tuple with first element of "
+                            "type float must have all elements of type "
+                            "float")
+        if tupType is not float and tupType is not int:
+            raise TypeError("'markevery' tuple contains an invalid type")
+    # Validate s against type list
+    elif isinstance(s, list):
+        if not all(isinstance(e, int) for e in s):
+            raise TypeError("'markevery' list must have all elements of "
+                            "type int")
     # Validate s against type float int and None
     elif not isinstance(s, (float, int)):
         if s is not None:

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -568,7 +568,7 @@ def validate_markevery(s):
                 raise ValueError("'markevery' tuple with first element of "
                                  "type float must have all elements of type "
                                  "float")
-            if not isinstance(tupType, (float, int)):
+            if tupType is not float and tupType is not int:
                 raise TypeError("'markevery' tuple is of an invalid type")
         if isinstance(s, list):
             if not all(isinstance(e, int) for e in s):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -534,7 +534,36 @@ validate_fillstylelist = _listify_validator(validate_fillstyle)
 _validate_negative_linestyle = ValidateInStrings('negative_linestyle',
                                                  ['solid', 'dashed'],
                                                  ignorecase=True)
+def validate_markevery(s):
+    """
+    Validate the markevery property of a Line2D object.
 
+    Parameters
+    ----------
+    s : None, int, float, slice, length-2 tuple of ints,
+        length-2 tuple of floats, list
+
+    Returns
+    -------
+    s : None, int, float, slice, length-2 tuple of ints,
+        length-2 tuple of floats, list, ValueError
+
+    """
+
+    if isinstance(s, tuple):
+        # Ensure correct length of 2
+        if len(s) != 2:
+            raise ValueError("'markevery' tuple must be a length of 2")
+        # Ensure that all elements in the tuple are of type int
+        if not all(isinstance(x, int) for x in s):
+            raise ValueError("'markevery' tuple ")
+        # Ensure that all elements in the tuple are of type float
+        elif not all(isinstance(x, float) for x in s):
+            raise ValueError("'markevery' tuple ")
+
+    return s;
+
+validate_markeverylist = _listify_validator(validate_markevery)
 
 validate_legend_loc = ValidateInStrings(
     'legend_loc',
@@ -676,6 +705,7 @@ _prop_validators = {
         'markersize': validate_floatlist,
         'markeredgewidth': validate_floatlist,
         'markeredgecolor': validate_colorlist,
+        'markevery': validate_markeverylist,
         'alpha': validate_floatlist,
         'marker': validate_stringlist,
         'hatch': validate_hatchlist,

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -338,22 +338,23 @@ def generate_validator_testcases(valid):
                       (slice(2), slice(None, 2, None)),
                       (slice(1, 2, 3), slice(1, 2, 3))
                       ),
-          'fail': (((1, 2, 3), ValueError),
-                   ([1, 2, 0.3], ValueError),
-                   (['a', 2, 3], ValueError),
-                   ([1, 2, 'a'], ValueError),
-                   ((0.1, 0.2, 0.3), ValueError),
-                   ((0.1, 2, 3), ValueError),
-                   ((1, 0.2, 0.3), ValueError),
-                   ((1, 0.1), ValueError),
-                   ((0.1, 1), ValueError),
-                   (('abc'), ValueError),
-                   ((1, 'a'), ValueError),
-                   ((0.1, 'b'), ValueError),
-                   (('a', 1), ValueError),
-                   (('a', 0.1), ValueError),
+          'fail': (((1, 2, 3), TypeError),
+                   ([1, 2, 0.3], TypeError),
+                   (['a', 2, 3], TypeError),
+                   ([1, 2, 'a'], TypeError),
+                   ((0.1, 0.2, 0.3), TypeError),
+                   ((0.1, 2, 3), TypeError),
+                   ((1, 0.2, 0.3), TypeError),
+                   ((1, 0.1), TypeError),
+                   ((0.1, 1), TypeError),
+                   (('abc'), TypeError),
+                   ((1, 'a'), TypeError),
+                   ((0.1, 'b'), TypeError),
+                   (('a', 1), TypeError),
+                   (('a', 0.1), TypeError),
                    ('abc', TypeError),
-                   ('a', TypeError)
+                   ('a', TypeError),
+                   (object(), TypeError)
                    )
          }
     )

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -332,22 +332,28 @@ def generate_validator_testcases(valid):
           'success': ((None, None),
                       (1, 1),
                       (0.1, 0.1),
-                      ((1,1), (1,1)),
-                      ((0.1,0.1), (0.1,0.1)),
-                      ([1,2,3], [1,2,3]),
-                      (slice(2), slice(None,2,None)),
-                      (slice(1,2,3), slice(1,2,3))
+                      ((1, 1), (1, 1)),
+                      ((0.1, 0.1), (0.1, 0.1)),
+                      ([1, 2, 3], [1, 2, 3]),
+                      (slice(2), slice(None, 2, None)),
+                      (slice(1, 2, 3), slice(1, 2, 3))
                       ),
-          'fail': (((1,2,3), ValueError),
-                   ((0.1,0.2,0.3), ValueError),
-                   ((0.1,2,3), ValueError),
-                   ((1,0.2,0.3), ValueError),
-                   ((1,0.1), ValueError),
-                   ((0.1,1), ValueError),
+          'fail': (((1, 2, 3), ValueError),
+                   ([1, 2, 0.3], ValueError),
+                   (['a', 2, 3], ValueError),
+                   ([1, 2, 'a'], ValueError),
+                   ((0.1, 0.2, 0.3), ValueError),
+                   ((0.1, 2, 3), ValueError),
+                   ((1, 0.2, 0.3), ValueError),
+                   ((1, 0.1), ValueError),
+                   ((0.1, 1), ValueError),
                    (('abc'), ValueError),
-                   (('a'), ValueError),
-                   ('abc', ValueError),
-                   ('a', ValueError)
+                   ((1, 'a'), ValueError),
+                   ((0.1, 'b'), ValueError),
+                   (('a', 1), ValueError),
+                   (('a', 0.1), ValueError),
+                   ('abc', TypeError),
+                   ('a', TypeError)
                    )
          }
     )

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -23,6 +23,7 @@ from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_cycler,
                                 validate_hatch,
                                 validate_hist_bins,
+                                validate_markevery,
                                 _validate_linestyle)
 
 
@@ -326,6 +327,17 @@ def generate_validator_testcases(valid):
                      ),
          'fail': (('aardvark', ValueError),
                   )
+         },
+         {'validator': validate_markevery,
+          'success': ((None,None),
+                      (1,1),
+                      (0.1,0.1)
+                      ),
+          'fail': (((1,2,3), ValueError),
+                   ((0.1,0.2,0.3), ValueError),
+                   ((1,0.1), ValueError),
+                   (('abc'), ValueError)
+                   )
          }
     )
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -329,14 +329,25 @@ def generate_validator_testcases(valid):
                   )
          },
          {'validator': validate_markevery,
-          'success': ((None,None),
-                      (1,1),
-                      (0.1,0.1)
+          'success': ((None, None),
+                      (1, 1),
+                      (0.1, 0.1),
+                      ((1,1), (1,1)),
+                      ((0.1,0.1), (0.1,0.1)),
+                      ([1,2,3], [1,2,3]),
+                      (slice(2), slice(None,2,None)),
+                      (slice(1,2,3), slice(1,2,3))
                       ),
           'fail': (((1,2,3), ValueError),
                    ((0.1,0.2,0.3), ValueError),
+                   ((0.1,2,3), ValueError),
+                   ((1,0.2,0.3), ValueError),
                    ((1,0.1), ValueError),
-                   (('abc'), ValueError)
+                   ((0.1,1), ValueError),
+                   (('abc'), ValueError),
+                   (('a'), ValueError),
+                   ('abc', ValueError),
+                   ('a', ValueError)
                    )
          }
     )


### PR DESCRIPTION
## PR Summary
Closes issue #8576 

This PR resolves a ValueError caused by assigning the axes.prop_cycle attribute, through rcParams, a cycler composed using a markevery value. Markevery is Line2D object property that is used to show a marker at actual data points along a plot. e.g., if markevery=[5], every 5-th marker will be plotted. Additional details about markevery and it's type constraints can be found here https://matplotlib.org/api/_as_gen/matplotlib.lines.Line2D.html#matplotlib.lines.Line2D.set_markevery

The following code replicates the ValueError mentioned above.

```python
from cycler import cycler
import numpy as np
import matplotlib as mpl
import matplotlib.pyplot as plt

mpl.rcParams['axes.prop_cycle'] = cycler(markevery=[5])
t = np.arange(0.0, 1.0, 0.01)
plt.plot(t, np.sin(2*np.pi*t), marker='o')
plt.show()
```
```bash
ValueError: Key axes.prop_cycle: Unknown artist properties: {'markevery'}
```

The following picture shows the above code functioning correctly, every 5th data point on the sine curve is marked.
![figure_1](https://user-images.githubusercontent.com/12175684/37138714-2ebf42f4-2279-11e8-9495-048faea74ae2.png)
I have extended rcsetup.py to include a markevery validator and the test cases for the markevery validator in test_rcparams.py. I have added the what's new entry for this fix and example code showcasing axes.prop_cycle configured through rcParams with valid use cases of markevery.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
