### PR TITLE
sanitize norm extrema to be floats

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -314,9 +314,9 @@ class ScalarMappable(object):
             except (TypeError, ValueError):
                 pass
         if vmin is not None:
-            self.norm.vmin = vmin
+            self.norm.vmin = colors._sanitize_extrema(vmin)
         if vmax is not None:
-            self.norm.vmax = vmax
+            self.norm.vmax = colors._sanitize_extrema(vmax)
         self.changed()
 
     def set_cmap(self, cmap):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -94,6 +94,16 @@ def get_named_colors_mapping():
     return _colors_full_map
 
 
+def _sanitize_extrema(ex):
+    if ex is None:
+        return ex
+    try:
+        ret = np.asscalar(ex)
+    except AttributeError:
+        ret = float(ex)
+    return ret
+
+
 def _is_nth_color(c):
     """Return whether *c* can be interpreted as an item in the color cycle."""
     return isinstance(c, six.string_types) and re.match(r"\AC[0-9]\Z", c)
@@ -878,8 +888,8 @@ class Normalize(object):
         likely to lead to surprises; therefore the default is
         *clip* = *False*.
         """
-        self.vmin = vmin
-        self.vmax = vmax
+        self.vmin = _sanitize_extrema(vmin)
+        self.vmax = _sanitize_extrema(vmax)
         self.clip = clip
 
     @staticmethod

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -687,11 +687,18 @@ def test_ndarray_subclass_norm(recwarn):
             raise RuntimeError
 
     data = np.arange(-10, 10, 1, dtype=float)
+    data.shape = (10, 2)
+    mydata = data.view(MyArray)
 
     for norm in [mcolors.Normalize(), mcolors.LogNorm(),
                  mcolors.SymLogNorm(3, vmax=5, linscale=1),
+                 mcolors.Normalize(vmin=mydata.min(), vmax=mydata.max()),
+                 mcolors.SymLogNorm(3, vmin=mydata.min(), vmax=mydata.max()),
                  mcolors.PowerNorm(1)]:
-        assert_array_equal(norm(data.view(MyArray)), norm(data))
+        assert_array_equal(norm(mydata), norm(data))
+        fig, ax = plt.subplots()
+        ax.imshow(mydata, norm=norm)
+        fig.canvas.draw()
         if isinstance(norm, mcolors.PowerNorm):
             assert len(recwarn) == 1
             warn = recwarn.pop(UserWarning)


### PR DESCRIPTION
## PR Summary

Fix regression from 2.1.2 by ensuring norm extrema are always floats.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

## PR Description

We had a report from a yt user complaining about saving plots to disk raising errors in some cases:

https://mail.python.org/mm3/archives/list/yt-users@python.org/thread/24OJRJVPK47RMG7XLF7J7YP4JQH24MG7/

I was able to reproduce this issue on matplotlib 2.2.0 but not on matplotlib 2.1.2 and earlier, so this is a regression.

I believe this behavior was unintentionally introduced by @anntzer in #6700 to avoid rounding issues with `float128` on linux. As a side-effect that PR changed how matplotlib deals with data with units attached.

I've added a `_sanitize_extrema` helper so that we can use `np.asscalar` to avoid downcasting `float128` data while still converting data to a numpy scalar under the hood. I've also expanded the existing test in `test_colors.py` that handles ndarray subclass to also check this case as well.

It would be great if this could be backported to 2.2.