### PR TITLE
FIX/TST constrained_layout remove test8 duplication

### DIFF
--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -123,40 +123,6 @@ def test_constrained_layout6():
                  ticks=ticker.MaxNLocator(nbins=5))
 
 
-@image_comparison(baseline_images=['constrained_layout8'],
-        extensions=['png'])
-def test_constrained_layout8():
-    'Test for gridspecs that are not completely full'
-    fig = plt.figure(figsize=(7, 4), constrained_layout=True)
-    gs = gridspec.GridSpec(3, 5, figure=fig)
-    axs = []
-    j = 1
-    for i in [0, 1]:
-        ax = fig.add_subplot(gs[j, i])
-        axs += [ax]
-        pcm = example_pcolor(ax, fontsize=10)
-        if i > 0:
-            ax.set_ylabel('')
-        if j < 1:
-            ax.set_xlabel('')
-        ax.set_title('')
-    j = 0
-    for i in [2, 4]:
-        ax = fig.add_subplot(gs[j, i])
-        axs += [ax]
-        pcm = example_pcolor(ax, fontsize=10)
-        if i > 0:
-            ax.set_ylabel('')
-        if j < 1:
-            ax.set_xlabel('')
-        ax.set_title('')
-    ax = fig.add_subplot(gs[2, :])
-    axs += [ax]
-    pcm = example_pcolor(ax, fontsize=10)
-
-    fig.colorbar(pcm, ax=axs, pad=0.01, shrink=0.6)
-
-
 def test_constrained_layout7():
     'Test for proper warning if fig not set in GridSpec'
     with pytest.warns(UserWarning, match='Calling figure.constrained_layout, '
@@ -179,26 +145,20 @@ def test_constrained_layout8():
     fig = plt.figure(figsize=(10, 5), constrained_layout=True)
     gs = gridspec.GridSpec(3, 5, figure=fig)
     axs = []
-    j = 1
-    for i in [0, 4]:
-        ax = fig.add_subplot(gs[j, i])
-        axs += [ax]
-        pcm = example_pcolor(ax, fontsize=9)
-        if i > 0:
-            ax.set_ylabel('')
-        if j < 1:
-            ax.set_xlabel('')
-        ax.set_title('')
-    j = 0
-    for i in [1]:
-        ax = fig.add_subplot(gs[j, i])
-        axs += [ax]
-        pcm = example_pcolor(ax, fontsize=9)
-        if i > 0:
-            ax.set_ylabel('')
-        if j < 1:
-            ax.set_xlabel('')
-        ax.set_title('')
+    for j in [0, 1]:
+        if j == 0:
+            ilist = [1]
+        else:
+            ilist = [0, 4]
+        for i in ilist:
+            ax = fig.add_subplot(gs[j, i])
+            axs += [ax]
+            pcm = example_pcolor(ax, fontsize=9)
+            if i > 0:
+                ax.set_ylabel('')
+            if j < 1:
+                ax.set_xlabel('')
+            ax.set_title('')
     ax = fig.add_subplot(gs[2, :])
     axs += [ax]
     pcm = example_pcolor(ax, fontsize=9)


### PR DESCRIPTION
## PR Summary

closes #10722

Had an extra copy of a test in `test_constrainedlayout`.  Removed, and refactored the test a bit while there.  


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->