### PR TITLE
Corrected mistitling on the annotation tutorial page

### DIFF
--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -516,11 +516,11 @@ more control, it supports a few other options.
     You may take a look at this example
     :ref:`sphx_glr_gallery_text_labels_and_annotations_annotation_demo.py`.
 
-Using ConnectorPatch
+Using ConnectionPatch
 --------------------
 
-The ConnectorPatch is like an annotation without text. While the annotate
-function is recommended in most situations, the ConnectorPatch is useful when
+The ConnectionPatch is like an annotation without text. While the annotate
+function is recommended in most situations, the ConnectionPatch is useful when
 you want to connect points in different axes. ::
 
   from matplotlib.patches import ConnectionPatch
@@ -540,7 +540,7 @@ point xy in the data coordinates of ``ax2``. Here is a simple example.
    Connect Simple01
 
 
-While the ConnectorPatch instance can be added to any axes, you may want to add
+While the ConnectionPatch instance can be added to any axes, you may want to add
 it to the axes that is latest in drawing order to prevent overlap by other
 axes.
 

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -517,7 +517,7 @@ more control, it supports a few other options.
     :ref:`sphx_glr_gallery_text_labels_and_annotations_annotation_demo.py`.
 
 Using ConnectionPatch
---------------------
+---------------------
 
 The ConnectionPatch is like an annotation without text. While the annotate
 function is recommended in most situations, the ConnectionPatch is useful when


### PR DESCRIPTION
## PR Summary

Corrects the mistitled ConnectorPatch -> ConnectionPatch on the tutorial page for annotation addressed in #10727. 


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
