### PR TITLE
Fix logging level type

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -391,7 +391,7 @@ class Verbose(object):
         return self.vald[self.level] >= self.vald[level]
 
 
-def _wrap(fmt, func, level='DEBUG', always=True):
+def _wrap(fmt, func, level=logging.DEBUG, always=True):
     """
     return a callable function that wraps func and reports its
     output through logger
@@ -405,8 +405,7 @@ def _wrap(fmt, func, level='DEBUG', always=True):
         ret = func(*args, **kwargs)
 
         if (always or not wrapper._spoke):
-            lvl = logging.getLevelName(level.upper())
-            _log.log(lvl, fmt % ret)
+            _log.log(level, fmt % ret)
             spoke = True
             if not wrapper._spoke:
                 wrapper._spoke = spoke


### PR DESCRIPTION
## PR Summary

When importing matplotlib version 2.2.0 a TypeError is raised (see trace below) upon initialization. This is caused by a string being passed as the `level` parameter to the standard python logger function `log()` when it should be an integer.

The fix was to change the contract of the `_wrap()` function so that the default value of the `level` parameter is `logger.debug` and not `'DEBUG'`.

```
Traceback (most recent call last):
  File "run.py", line 1, in <module>
    import matplotlib.pyplot as plt
  File "/dir/venv/lib/python3.4/site-packages/matplotlib/__init__.py", line 1153, in <module>
    rcParams = rc_params()
  File "/dir/venv/lib/python3.4/site-packages/matplotlib/__init__.py", line 987, in rc_params
    fname = matplotlib_fname()
  File "/dir/venv/lib/python3.4/site-packages/matplotlib/__init__.py", line 831, in matplotlib_fname
    for fname in gen_candidates():
  File "/dir/venv/lib/python3.4/site-packages/matplotlib/__init__.py", line 828, in gen_candidates
    yield os.path.join(_get_configdir(), 'matplotlibrc')
  File "/dir/venv/lib/python3.4/site-packages/matplotlib/__init__.py", line 696, in _get_configdir
    return _get_config_or_cache_dir(_get_xdg_config_dir())
  File "/dir/venv/lib/python3.4/site-packages/matplotlib/__init__.py", line 620, in _get_xdg_config_dir
    path = get_home()
  File "/dir/venv/lib/python3.4/site-packages/matplotlib/__init__.py", line 400, in wrapper
    _log.log(lvl, fmt % ret)
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/logging/__init__.py", line 1330, in log
    raise TypeError("level must be an integer")
TypeError: level must be an integer
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
