### PR TITLE
Proof of concept for deprecation of global non-callables.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -143,6 +143,7 @@ import warnings
 from . import cbook
 from matplotlib.cbook import (
     mplDeprecation, dedent, get_label, sanitize_sequence)
+from matplotlib.cbook.deprecation import _deprecated_global
 from matplotlib.rcsetup import defaultParams, validate_backend, cycler
 
 import numpy
@@ -389,6 +390,11 @@ class Verbose(object):
     def ge(self, level):
         'return true if self.level is >= level'
         return self.vald[self.level] >= self.vald[level]
+
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    _deprecated_global("verbose", Verbose(), "2.2")
 
 
 def _wrap(fmt, func, level='DEBUG', always=True):


### PR DESCRIPTION
Triggered by the recent discussion on deprecating matplotlib.verbose.

This ensures that a deprecation warning is triggered just by trying to
access matplotlib.verbose (or importing it).  The implementation idea is
based on njsmith's metamodule, but without the hacks needed to support
Py<3.5.

Py3.7+ will provide instance-`__getattr__` on all classes by default,
making the `_DeprecatorModuleType` patching unnecessary (but the warning
emitter would still need to be implemented, so there is actually fairly
limited improvement from that).

Just putting this here to show that it can be done... attn @jklymak

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
