### PR TITLE
Avoid narrowing conversion in image_wrapper on 32-bit.

### DIFF
--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -352,13 +352,12 @@ static PyObject *image_pcolor(PyObject *self, PyObject *args, PyObject *kwds)
     numpy::array_view<const float, 1> x;
     numpy::array_view<const float, 1> y;
     numpy::array_view<const agg::int8u, 3> d;
-    unsigned int rows;
-    unsigned int cols;
+    npy_intp rows, cols;
     float bounds[4];
     int interpolation;
 
     if (!PyArg_ParseTuple(args,
-                          "O&O&O&II(ffff)i:pcolor",
+                          "O&O&O&nn(ffff)i:pcolor",
                           &x.converter,
                           &x,
                           &y.converter,
@@ -396,13 +395,12 @@ static PyObject *image_pcolor2(PyObject *self, PyObject *args, PyObject *kwds)
     numpy::array_view<const double, 1> x;
     numpy::array_view<const double, 1> y;
     numpy::array_view<const agg::int8u, 3> d;
-    unsigned int rows;
-    unsigned int cols;
+    npy_intp rows, cols;
     float bounds[4];
     numpy::array_view<const agg::int8u, 1> bg;
 
     if (!PyArg_ParseTuple(args,
-                          "O&O&O&II(ffff)O&:pcolor2",
+                          "O&O&O&nn(ffff)O&:pcolor2",
                           &x.converter_contiguous,
                           &x,
                           &y.converter_contiguous,


### PR DESCRIPTION
## PR Summary

@yurivict can you check whether that fixes #10698?

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
