### PR TITLE
Fix bug "Setting an alpha value to a Poly3DCollection #10237"

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -686,6 +686,7 @@ class Poly3DCollection(PolyCollection):
         try:
             self._facecolors = mcolors.to_rgba_array(
                 self._facecolors3d, self._alpha)
+            self._facecolors3d = self._facecolors
         except (AttributeError, TypeError, IndexError):
             pass
         try:


### PR DESCRIPTION
## PR Summary
In order to set alpha successfully. In Poly3DCollection's set_alpha, facecolors3d should equal to facecolors.
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

Snippet of code:
In latest version these two cases can not show the transparency of the graph. In my feature branch it has been fixed.
Case 1 (Setting facecolor and alpha individually, facecolor first):

from mpl_toolkits.mplot3d import Axes3D
from mpl_toolkits.mplot3d.art3d import Poly3DCollection
import matplotlib.pyplot as plt

fig = plt.figure()
ax = Axes3D(fig)
x = [1, 0.9, 1, 0]
y = [0, 0.7, 0, 1]
z = [0, 0.8, 1, 0]
verts = [list(zip(x, y, z))]

alpha=0.4
fc = "C0"

pc = Poly3DCollection(verts, linewidths=1)
pc.set_facecolor(fc)
pc.set_alpha(alpha)
ax.add_collection3d(pc)
plt.show()

Case 2 (Setting facecolors and alpha at instantiation):

from mpl_toolkits.mplot3d import Axes3D
from mpl_toolkits.mplot3d.art3d import Poly3DCollection
import matplotlib.pyplot as plt

fig = plt.figure()
ax = Axes3D(fig)
x = [1, 0.9, 1, 0]
y = [0, 0.7, 0, 1]
z = [0, 0.8, 1, 0]
verts = [list(zip(x, y, z))]

alpha=0.4
fc = "C0"
pc = Poly3DCollection(verts, alpha = alpha, facecolors=fc,
linewidths=1)
ax.add_collection3d(pc)
plt.show()

