### PR TITLE
make centre_baseline legal for Text.set_verticalalignment

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1147,9 +1147,10 @@ class Text(Artist):
         """
         Set the vertical alignment
 
-        ACCEPTS: [ 'center' | 'top' | 'bottom' | 'baseline' ]
+        ACCEPTS: [ 'center' | 'top' | 'bottom' | 'baseline' |
+                   'center_baseline' ]
         """
-        legal = ('top', 'bottom', 'center', 'baseline')
+        legal = ('top', 'bottom', 'center', 'baseline', 'centre_baseline')
         if align not in legal:
             raise ValueError('Vertical alignment must be one of %s' %
                              str(legal))


### PR DESCRIPTION
## PR Summary

At some point in the past code was added to text.py to allow vertical alignment of text by centering on the baseline.

However, 'centre_baseline'  is not a legal value for the set_verticalalignment() method.

This does not stop text using centre_baseline:  you can supply the value as an argument when a Text object is created.

My guess is the option was added but the set_verticalalignment() method was overloooked.

If there is some other reason for hiding this option then the reason should be documented.

Perhaps the real fix here is to do something with type annotations rather than have the list of legal values in the code.
 