### PR TITLE
Use rcParams to control default "raise window" behavior 

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -188,7 +188,8 @@ class _Backend(object):
         if not managers:
             return
         for manager in managers:
-            manager.show()
+            if rcParams['figure.show']:
+                manager.show()
         if block is None:
             # Hack: Are we in IPython's pylab mode?
             from matplotlib import pyplot

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1289,6 +1289,8 @@ defaultParams = {
     # This is a buffer around the axes in inches.  This is 3pts.
     'figure.constrained_layout.h_pad': [0.04167, validate_float],
     'figure.constrained_layout.w_pad': [0.04167, validate_float],
+    # Show the figure on the GUI
+    'figure.show': [True, validate_bool],
 
     ## Saving figure's properties
     'savefig.dpi':         ['figure', validate_dpi],  # DPI

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -455,6 +455,7 @@ backend      : $TEMPLATE_BACKEND
 #figure.constrained_layout.w_pad : 0.04167 ##  inches. Default is 3./72. inches (3 pts)
 #figure.constrained_layout.hspace : 0.02   ## Space between subplot groups. Float representing 
 #figure.constrained_layout.wspace : 0.02   ##  a fraction of the subplot widths being separated. 
+#figure.show       : True    ## Show the figure on the GUI
 
 #### IMAGES
 #image.aspect : equal             ## equal | auto | a number


### PR DESCRIPTION
## PR Summary
PR  for issue #8692. The solution currently creates a new rcParam 'figure.show' which is used to suppress the raise window behavior backend_bases.py depending on rcParams.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
