### PR TITLE
API: check locator and formatter args when passed

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1568,7 +1568,7 @@ class Axis(artist.Artist):
 
         ACCEPTS: A :class:`~matplotlib.ticker.Formatter` instance
         """
-        if not hasattr(formatter, 'format_data'):
+        if not isinstance(formatter, mticker.Formatter):
             raise TypeError("formatter argument should be instance of "
                     "matplotlib.ticker.Formatter")
         self.isDefault_majfmt = False
@@ -1582,7 +1582,7 @@ class Axis(artist.Artist):
 
         ACCEPTS: A :class:`~matplotlib.ticker.Formatter` instance
         """
-        if not hasattr(formatter, 'format_data'):
+        if not isinstance(formatter, mticker.Formatter):
             raise TypeError("formatter argument should be instance of "
                     "matplotlib.ticker.Formatter")
         self.isDefault_minfmt = False
@@ -1596,7 +1596,7 @@ class Axis(artist.Artist):
 
         ACCEPTS: a :class:`~matplotlib.ticker.Locator` instance
         """
-        if not hasattr(locator, 'tick_values'):
+        if not isinstance(locator, mticker.Locator):
             raise TypeError("formatter argument should be instance of "
                     "matplotlib.ticker.Locator")
         self.isDefault_majloc = False
@@ -1610,7 +1610,7 @@ class Axis(artist.Artist):
 
         ACCEPTS: a :class:`~matplotlib.ticker.Locator` instance
         """
-        if not hasattr(locator, 'tick_values'):
+        if not isinstance(locator, mticker.Locator):
             raise TypeError("formatter argument should be instance of "
                     "matplotlib.ticker.Locator")
         self.isDefault_minloc = False

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1568,6 +1568,9 @@ class Axis(artist.Artist):
 
         ACCEPTS: A :class:`~matplotlib.ticker.Formatter` instance
         """
+        if not hasattr(formatter, 'format_data'):
+            raise TypeError("formatter argument should be instance of "
+                    "matplotlib.ticker.Formatter")
         self.isDefault_majfmt = False
         self.major.formatter = formatter
         formatter.set_axis(self)
@@ -1579,6 +1582,9 @@ class Axis(artist.Artist):
 
         ACCEPTS: A :class:`~matplotlib.ticker.Formatter` instance
         """
+        if not hasattr(formatter, 'format_data'):
+            raise TypeError("formatter argument should be instance of "
+                    "matplotlib.ticker.Formatter")
         self.isDefault_minfmt = False
         self.minor.formatter = formatter
         formatter.set_axis(self)
@@ -1590,6 +1596,9 @@ class Axis(artist.Artist):
 
         ACCEPTS: a :class:`~matplotlib.ticker.Locator` instance
         """
+        if not hasattr(locator, 'tick_values'):
+            raise TypeError("formatter argument should be instance of "
+                    "matplotlib.ticker.Locator")
         self.isDefault_majloc = False
         self.major.locator = locator
         locator.set_axis(self)
@@ -1601,6 +1610,9 @@ class Axis(artist.Artist):
 
         ACCEPTS: a :class:`~matplotlib.ticker.Locator` instance
         """
+        if not hasattr(locator, 'tick_values'):
+            raise TypeError("formatter argument should be instance of "
+                    "matplotlib.ticker.Locator")
         self.isDefault_minloc = False
         self.minor.locator = locator
         locator.set_axis(self)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -728,3 +728,27 @@ class TestPercentFormatter(object):
         fmt = mticker.PercentFormatter(symbol='\\{t}%', is_latex=is_latex)
         with matplotlib.rc_context(rc={'text.usetex': usetex}):
             assert fmt.format_pct(50, 100) == expected
+
+
+def test_majformatter_type():
+    fig, ax = plt.subplots()
+    with pytest.raises(TypeError):
+        ax.xaxis.set_major_formatter(matplotlib.ticker.LogLocator())
+
+
+def test_minformatter_type():
+    fig, ax = plt.subplots()
+    with pytest.raises(TypeError):
+        ax.xaxis.set_minor_formatter(matplotlib.ticker.LogLocator())
+
+
+def test_majlocator_type():
+    fig, ax = plt.subplots()
+    with pytest.raises(TypeError):
+        ax.xaxis.set_major_locator(matplotlib.ticker.LogFormatter())
+
+
+def test_minlocator_type():
+    fig, ax = plt.subplots()
+    with pytest.raises(TypeError):
+        ax.xaxis.set_minor_locator(matplotlib.ticker.LogFormatter())


### PR DESCRIPTION
## PR Summary

Right now, `ax.set_major_formatter` and `ax.set_major_locator` throw pretty deep error messages if the wrong type of data is passed to them.  This catches at entry. 

Closes #10769

```python
import matplotlib
import matplotlib.pyplot as plt

f, ax = plt.subplots(1, 1, figsize=(15, 10))
plt.plot([10**4, 11*10**4], [100, 150])
ax.xaxis.set_major_formatter(matplotlib.ticker.LogLocator())
plt.show()
```
Now returns:
```
Traceback (most recent call last):
  File "testEngTicker.py", line 6, in <module>
    ax.xaxis.set_major_formatter(matplotlib.ticker.LogLocator())
  File "/Users/jklymak/matplotlib/lib/matplotlib/axis.py", line 1573, in set_major_formatter
    "formatter argument must be matplotlib.ticker.Formatter")
ValueError: formatter argument must be matplotlib.ticker.Formatter
```
instead of something down in the bowels of drawing the ticker...

## PR Checklist

- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->