### PR TITLE
Fix new warnings with gcc8

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,8 @@
 include INSTALL.rst README.rst
-include CONTRIBUTING.md
 include pytest.ini
-include Makefile MANIFEST.in
+include MANIFEST.in
 include matplotlibrc.template setup.cfg.template
-include setupext.py setup.py distribute_setup.py
+include setupext.py setup.py
 include lib/matplotlib/mpl-data/lineprops.glade
 include lib/matplotlib/mpl-data/matplotlibrc
 include lib/matplotlib/mpl-data/images/*

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -441,7 +441,7 @@ static PyObject *Py_affine_transform(PyObject *self, PyObject *args, PyObject *k
         numpy::array_view<double, 2> result(dims);
         CALL_CPP("affine_transform", (affine_transform_2d(vertices, trans, result)));
         return result.pyobj();
-    } catch (py::exception) {
+    } catch (py::exception &) {
         PyErr_Clear();
         try {
             numpy::array_view<double, 1> vertices(vertices_obj);
@@ -449,7 +449,7 @@ static PyObject *Py_affine_transform(PyObject *self, PyObject *args, PyObject *k
             numpy::array_view<double, 1> result(dims);
             CALL_CPP("affine_transform", (affine_transform_1d(vertices, trans, result)));
             return result.pyobj();
-        } catch (py::exception) {
+        } catch (py::exception &) {
             return NULL;
         }
     }

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -167,7 +167,7 @@ int convert_rect(PyObject *rectobj, void *rectp)
             rect->x2 = rect_arr(1, 0);
             rect->y2 = rect_arr(1, 1);
         }
-        catch (py::exception)
+        catch (py::exception &)
         {
             PyErr_Clear();
 
@@ -185,7 +185,7 @@ int convert_rect(PyObject *rectobj, void *rectp)
                 rect->x2 = rect_arr(2);
                 rect->y2 = rect_arr(3);
             }
-            catch (py::exception)
+            catch (py::exception &)
             {
                 return 0;
             }
@@ -347,7 +347,7 @@ int convert_trans_affine(PyObject *obj, void *transp)
             return 1;
         }
     }
-    catch (py::exception)
+    catch (py::exception &)
     {
         return 0;
     }

--- a/src/py_exceptions.h
+++ b/src/py_exceptions.h
@@ -30,7 +30,7 @@ class exception : public std::exception
         }                                                                    \
         return (errorcode);                                                  \
     }                                                                        \
-    catch (const std::bad_alloc)                                             \
+    catch (const std::bad_alloc &)                                           \
     {                                                                        \
         PyErr_Format(PyExc_MemoryError, "In %s: Out of memory", (name));     \
         {                                                                    \


### PR DESCRIPTION
## PR Summary

Don't catch polymorphic exceptions by value. We don't use the variable anyway, so the exact type is not a big deal for us.

Also, cleanup the manifest which had some stale entries.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way