### PR TITLE
Fix offsetbox expand mode

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -77,16 +77,16 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
         return total, offsets
 
     elif mode == "expand":
+        # This is a bit of a hack to avoid a TypeError when *total*
+        # is None and used in conjugation with tight layout.
+        if total is None:
+            total = 1
         if len(w_list) > 1:
-            sep = (total - sum(w_list)) / (len(w_list) - 1.)
+            sep = (total - sum(w_list)) / (len(w_list) - 1)
         else:
             sep = 0
         offsets_ = np.cumsum([0] + [w + sep for w in w_list])
         offsets = offsets_[:-1]
-        # this is a bit of a hack to avoid a TypeError when used
-        # in conjugation with tight layout
-        if total is None:
-            total = 1
         return total, offsets
 
     elif mode == "equal":


### PR DESCRIPTION
## PR Summary

Fixes #10784.

Small fix of a the “hacky” fix (b177c85) about issues when calling tight_layout with a legend in "expand" mode.

My understanding of the “new” issue is that when passing `ncol=2  # or more` to `Axes.legend`, it calls "_get_packed_offsets" (from the module `offsetbox`) with an argument `wd_list` that is longer than 1, which triggers a code path where `total` is used in arithmetic operations *before* that the processing of the case `total is None` introduced by b177c85 is actually performed. The core idea of this PR is simply to move that special-case processing before the arithmetic operation causing the issue.

Being there I simplified a bit the original test. I also added a test of the private function that triggered all those errors, with sets of parameters that should cover at least the edge-cases that have been recently found (`mode = "expand"`), and hopefully check that other corner cases do not raise exceptions. For the record, this multi-test (240 subtests) adds about 1.1 s to the testing time on my machine.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

**Edit:** The PEP 8 checking was successful :). And added more details on the PR. 
