### PR TITLE
FIX: axes limits reverting to automatic when sharing

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1015,7 +1015,8 @@ class _AxesBase(martist.Artist):
             self.xaxis.major = self._sharex.xaxis.major
             self.xaxis.minor = self._sharex.xaxis.minor
             x0, x1 = self._sharex.get_xlim()
-            self.set_xlim(x0, x1, emit=False, auto=None)
+            self.set_xlim(x0, x1, emit=False,
+                          auto=self._sharex.get_autoscalex_on())
             self.xaxis._scale = mscale.scale_factory(
                     self._sharex.xaxis.get_scale(), self.xaxis)
         else:
@@ -1029,7 +1030,8 @@ class _AxesBase(martist.Artist):
             self.yaxis.major = self._sharey.yaxis.major
             self.yaxis.minor = self._sharey.yaxis.minor
             y0, y1 = self._sharey.get_ylim()
-            self.set_ylim(y0, y1, emit=False, auto=None)
+            self.set_ylim(y0, y1, emit=False,
+                          auto=self._sharey.get_autoscaley_on())
             self.yaxis._scale = mscale.scale_factory(
                     self._sharey.yaxis.get_scale(), self.yaxis)
         else:
@@ -1045,8 +1047,10 @@ class _AxesBase(martist.Artist):
         if (rcParams['ytick.minor.visible']):
             self.yaxis.set_minor_locator(mticker.AutoMinorLocator())
 
-        self._autoscaleXon = True
-        self._autoscaleYon = True
+        if self._sharex is None:
+            self._autoscaleXon = True
+        if self._sharey is None:
+            self._autoscaleYon = True
         self._xmargin = rcParams['axes.xmargin']
         self._ymargin = rcParams['axes.ymargin']
         self._tight = None

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5128,16 +5128,16 @@ def test_remove_shared_axes_relim():
 
 
 def test_shared_axes_autoscale():
-    l = np.arange(-80,90,40)
-    t = np.random.random_sample((l.size,l.size))
+    l = np.arange(-80, 90, 40)
+    t = np.random.random_sample((l.size, l.size))
 
     ax1 = plt.subplot(211)
-    ax1.set_xlim(-1000,1000)
-    ax1.set_ylim(-1000,1000)
-    ax1.contour(l,l,t)
+    ax1.set_xlim(-1000, 1000)
+    ax1.set_ylim(-1000, 1000)
+    ax1.contour(l, l, t)
 
-    ax2 = plt.subplot(212,sharex=ax1,sharey=ax1)
-    ax2.contour(l,l,t)
+    ax2 = plt.subplot(212, sharex=ax1, sharey=ax1)
+    ax2.contour(l, l, t)
     assert not ax1.get_autoscalex_on() and not ax2.get_autoscalex_on()
     assert not ax1.get_autoscaley_on() and not ax2.get_autoscaley_on()
     assert ax1.get_xlim() == ax2.get_xlim() == (-1000, 1000)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5127,6 +5127,23 @@ def test_remove_shared_axes_relim():
     assert_array_equal(ax_lst[0][1].get_xlim(), orig_xlim)
 
 
+def test_shared_axes_autoscale():
+    l = np.arange(-80,90,40)
+    t = np.random.random_sample((l.size,l.size))
+
+    ax1 = plt.subplot(211)
+    ax1.set_xlim(-1000,1000)
+    ax1.set_ylim(-1000,1000)
+    ax1.contour(l,l,t)
+
+    ax2 = plt.subplot(212,sharex=ax1,sharey=ax1)
+    ax2.contour(l,l,t)
+    assert not ax1.get_autoscalex_on() and not ax2.get_autoscalex_on()
+    assert not ax1.get_autoscaley_on() and not ax2.get_autoscaley_on()
+    assert ax1.get_xlim() == ax2.get_xlim() == (-1000, 1000)
+    assert ax1.get_ylim() == ax2.get_ylim() == (-1000, 1000)
+
+
 def test_adjust_numtick_aspect():
     fig, ax = plt.subplots()
     ax.yaxis.get_major_locator().set_params(nbins='auto')


### PR DESCRIPTION
## PR Summary

This fixes issue #10062.
The script there initially has manual limits on the first subplot. After adding a shared axis, the manual limits are lost on both subplots. This is evident for contour plots which make use of autoscale_view().

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
