### PR TITLE
MNT: catch more illegal '\'

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -51,7 +51,7 @@ else:
 
 
 _luatex_version_re = re.compile(
-    'This is LuaTeX, Version (?:beta-)?([0-9]+)\.([0-9]+)\.([0-9]+)'
+    r'This is LuaTeX, Version (?:beta-)?([0-9]+)\.([0-9]+)\.([0-9]+)'
 )
 
 
@@ -1199,7 +1199,7 @@ class PdfPages:
             figure.canvas = orig_canvas
 
     def _build_newpage_command(self, width, height):
-        '''LuaLaTeX from version 0.85 removed the `\pdf*` primitives,
+        r'''LuaLaTeX from version 0.85 removed the `\pdf*` primitives,
         so we need to check the lualatex version and use `\pagewidth` if
         the version is 0.85 or newer
         '''

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -209,18 +209,18 @@ class LocatorD(LocatorBase):
 
 
 class FormatterDMS(object):
-    deg_mark = "^{\circ}"
-    min_mark = "^{\prime}"
-    sec_mark = "^{\prime\prime}"
+    deg_mark = r"^{\circ}"
+    min_mark = r"^{\prime}"
+    sec_mark = r"^{\prime\prime}"
 
     fmt_d = "$%d" + deg_mark + "$"
     fmt_ds = r"$%d.%s" + deg_mark + "$"
 
     # %s for sign
-    fmt_d_m = r"$%s%d" + deg_mark + "\,%02d" + min_mark + "$"
-    fmt_d_ms = r"$%s%d" + deg_mark + "\,%02d.%s" + min_mark + "$"
+    fmt_d_m = r"$%s%d" + deg_mark + r"\,%02d" + min_mark + "$"
+    fmt_d_ms = r"$%s%d" + deg_mark + r"\,%02d.%s" + min_mark + "$"
 
-    fmt_d_m_partial = "$%s%d" + deg_mark + "\,%02d" + min_mark + "\,"
+    fmt_d_m_partial = "$%s%d" + deg_mark + r"\,%02d" + min_mark + r"\,"
     fmt_s_partial = "%02d" + sec_mark + "$"
     fmt_ss_partial = "%02d.%s" + sec_mark + "$"
 
@@ -315,18 +315,18 @@ class FormatterDMS(object):
 
 
 class FormatterHMS(FormatterDMS):
-    deg_mark = "^\mathrm{h}"
-    min_mark = "^\mathrm{m}"
-    sec_mark = "^\mathrm{s}"
+    deg_mark = r"^\mathrm{h}"
+    min_mark = r"^\mathrm{m}"
+    sec_mark = r"^\mathrm{s}"
 
     fmt_d = "$%d" + deg_mark + "$"
     fmt_ds = r"$%d.%s" + deg_mark + "$"
 
     # %s for sign
-    fmt_d_m = r"$%s%d" + deg_mark + "\,%02d" + min_mark+"$"
-    fmt_d_ms = r"$%s%d" + deg_mark + "\,%02d.%s" + min_mark+"$"
+    fmt_d_m = r"$%s%d" + deg_mark + r"\,%02d" + min_mark+"$"
+    fmt_d_ms = r"$%s%d" + deg_mark + r"\,%02d.%s" + min_mark+"$"
 
-    fmt_d_m_partial = "$%s%d" + deg_mark + "\,%02d" + min_mark + "\,"
+    fmt_d_m_partial = "$%s%d" + deg_mark + r"\,%02d" + min_mark + r"\,"
     fmt_s_partial = "%02d" + sec_mark + "$"
     fmt_ss_partial = "%02d.%s" + sec_mark + "$"
 


### PR DESCRIPTION
This is required to get the tests to run on close to cpython master and our master branch.  Looks like 'nightly' is passing on travis so I strongly suspect that this is a 3.8 related change.