### PR TITLE
Fix for plt.plot() does not support structured arrays as data= kwarg

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -55,22 +55,24 @@ def _plot_args_replacer(args, data):
         return ["y"]
     elif len(args) == 2:
         # this can be two cases: x,y or y,c
-        if not args[1] in data:
-            # this is not in data, so just assume that it is something which
-            # will not get replaced (color spec or array like).
-            return ["y", "c"]
         # it's data, but could be a color code like 'ro' or 'b--'
         # -> warn the user in that case...
+
         try:
             _process_plot_format(args[1])
         except ValueError:
             pass
         else:
-            warnings.warn(
-                "Second argument {!r} is ambiguous: could be a color spec but "
-                "is in data; using as data.  Either rename the entry in data "
-                "or use three arguments to plot.".format(args[1]),
-                RuntimeWarning, stacklevel=3)
+            # arg can be parsed into colour; verify arg is not data
+            if not args[1] in data:
+                return ["y", "c"]
+            else:
+                warnings.warn(
+                    "Second argument {!r} is ambiguous: could be a color spec "
+                    "but is in data; using as data.  Either rename the entry "
+                    "in data or use three arguments to plot.".format(args[1]),
+                    RuntimeWarning, stacklevel=3)
+
         return ["x", "y"]
     elif len(args) == 3:
         return ["x", "y", "c"]

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -55,24 +55,26 @@ def _plot_args_replacer(args, data):
         return ["y"]
     elif len(args) == 2:
         # this can be two cases: x,y or y,c
+        if (not args[1] in data and
+            not (hasattr(data, 'dtype') and
+                 hasattr(data.dtype, 'names') and
+                 data.dtype.names is not None and
+                 args[1] in data.dtype.names)):
+            # this is not in data, so just assume that it is something which
+            # will not get replaced (color spec or array like).
+            return ["y", "c"]
         # it's data, but could be a color code like 'ro' or 'b--'
         # -> warn the user in that case...
-
         try:
             _process_plot_format(args[1])
         except ValueError:
             pass
         else:
-            # arg can be parsed into colour; verify arg is not data
-            if not args[1] in data:
-                return ["y", "c"]
-            else:
-                warnings.warn(
-                    "Second argument {!r} is ambiguous: could be a color spec "
-                    "but is in data; using as data.  Either rename the entry "
-                    "in data or use three arguments to plot.".format(args[1]),
-                    RuntimeWarning, stacklevel=3)
-
+            warnings.warn(
+                "Second argument {!r} is ambiguous: could be a color spec but "
+                "is in data; using as data.  Either rename the entry in data "
+                "or use three arguments to plot.".format(args[1]),
+                RuntimeWarning, stacklevel=3)
         return ["x", "y"]
     elif len(args) == 3:
         return ["x", "y", "c"]

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -588,6 +588,7 @@ def test_structured_data():
     # support for stuctured data
     pts = np.array([(1, 1), (2, 2)], dtype=[("ones", float), ("twos", float)])
 
+    # this should not read second name as a format and raise ValueError
     fig, ax = plt.subplots(2)
     ax[0].plot("ones", "twos", data=pts)
     ax[1].plot("ones", "twos", "r", data=pts)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -584,6 +584,15 @@ def test_shaped_data():
     plt.plot(xdata[:, 1], xdata[1, :], 'o')
 
 
+def test_structured_data():
+    # support for stuctured data
+    pts = np.array([(1, 1), (2, 2)], dtype=[("ones", float), ("twos", float)])
+
+    fig, ax = plt.subplots(2)
+    ax[0].plot("ones", "twos", data=pts)
+    ax[1].plot("ones", "twos", "r", data=pts)
+
+
 @image_comparison(baseline_images=['const_xy'])
 def test_const_xy():
     fig = plt.figure()


### PR DESCRIPTION
## PR Summary
Fix for issue #8818 - plot() is now be able to plot structured arrays passed in as data=... kwarg without incorrectly interpreting the data as a format string. 

A small simple test case is included with this PR to check that plotting a structured array will not cause and exception (without the use of image comparison since it felt unneeded). 

If any changes/modifications are needed, please let me know. Thank you!
