### PR TITLE
API: shift deprecation of TempCache class to 3.0

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -15,6 +15,7 @@ The following classes, methods, and functions are deprecated:
 - ``container.Container.set_remove_method``,
 - ``mathtext.unichr_safe`` (use ``chr`` instead),
 - ``texmanager.dvipng_hack_alpha``,
+- ``font_manager.TempCache``,
 
 The following rcParams are deprecated:
 - ``pgf.debug`` (the pgf backend relies on logging),

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -926,7 +926,7 @@ def _normalize_font_family(family):
     return family
 
 
-@cbook.deprecated("2.2")
+@cbook.deprecated("3.0")
 class TempCache(object):
     """
     A class to store temporary caches that are (a) not saved to disk


### PR DESCRIPTION
The changes to not use this were reverted on the 2.2.x branch.
