### PR TITLE
FIX: restore verbose attribute at top level

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -388,6 +388,11 @@ class Verbose(object):
         return self.vald[self.level] >= self.vald[level]
 
 
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    verbose = Verbose()
+
+
 def _wrap(fmt, func, level=logging.DEBUG, always=True):
     """
     return a callable function that wraps func and reports its

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import six
 import sys
 
+import matplotlib
+
 
 def test_simple():
     assert 1 + 1 == 2
@@ -39,3 +41,7 @@ def test_override_builtins():
                 overridden = True
 
     assert not overridden
+
+
+def test_verbose():
+    assert isinstance(matplotlib.verbose, matplotlib.Verbose)


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
