### PR TITLE
Add test to imread from url.

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1,11 +1,8 @@
-from __future__ import absolute_import, division, print_function
-
-import six
-
 from copy import copy
 import io
 import os
 import sys
+import urllib.request
 import warnings
 
 import numpy as np
@@ -630,9 +627,9 @@ def test_minimized_rasterized():
 
 @pytest.mark.network
 def test_load_from_url():
-    req = six.moves.urllib.request.urlopen(
-        "http://matplotlib.org/_static/logo_sidebar_horiz.png")
-    plt.imread(req)
+    url = "http://matplotlib.org/_static/logo_sidebar_horiz.png"
+    plt.imread(url)
+    plt.imread(urllib.request.urlopen(url))
 
 
 @image_comparison(baseline_images=['log_scale_image'],


### PR DESCRIPTION
## PR Summary

Replaces #4485.  Note that we *already* have a test there that requires internet access (but reading from the filelike object returned by urllib.request) so adding another test requiring internet request can't change our status wrt debian policies (discussed in the previous thread).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
