### PR TITLE
WIP: add separate IsoDateFormatter to existing DateFormatter (lib/matplotlib/dates.py)

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -132,6 +132,8 @@ Here all all the date formatters:
 
     * :class:`DateFormatter`: use :func:`strftime` format strings
 
+    * :class:`IsoDateFormatter`: like :class:`DateFormatter`, but use :meth:`datetime.datetime.isoformat`.
+
     * :class:`IndexDateFormatter`: date plots with implicit *x*
       indexing.
 """
@@ -167,7 +169,7 @@ import matplotlib.ticker as ticker
 _log = logging.getLogger(__name__)
 
 __all__ = ('date2num', 'num2date', 'num2timedelta', 'drange', 'epoch2num',
-           'num2epoch', 'mx2num', 'DateFormatter',
+           'num2epoch', 'mx2num', 'DateFormatter', 'IsoDateFormatter',
            'IndexDateFormatter', 'AutoDateFormatter', 'DateLocator',
            'RRuleLocator', 'AutoDateLocator', 'YearLocator',
            'MonthLocator', 'WeekdayLocator',
@@ -601,6 +603,51 @@ def drange(dstart, dend, delta):
     return np.linspace(f1, f2, num + 1)
 
 ### date tickers and formatters ###
+
+
+class IsoDateFormatter(ticker.Formatter):
+    """
+    WRITEME
+    """
+
+    def __init__(self, tz=None):
+        """
+        *tz* is the :class:`tzinfo` instance.
+        """
+        if tz is None:
+            tz = _get_rc_timezone()
+        self.tz = tz
+
+    def __call__(self, x, pos=0):
+        if x == 0:
+            raise ValueError('IsoDateFormatter found a value of x=0, which is '
+                             'an illegal date.  This usually occurs because '
+                             'you have not informed the axis that it is '
+                             'plotting dates, e.g., with ax.xaxis_date()')
+        dt = num2date(x, self.tz)
+        return self.isoformat(dt)
+
+    def set_tzinfo(self, tz):
+        self.tz = tz
+
+
+    def isoformat(self, dt):
+        """
+        Refer to documentation for :meth:`datetime.datetime.isoformat`
+        """
+        if dt.year < 1900:
+            """
+            No idea if this needs special treatment
+            """
+            pass
+
+        return cbook.unicode_safe(dt.isoformat())
+
+    def strftime(self, dt):
+        """
+        WRITEME
+        """
+        return self.isoformat(dt)
 
 
 class DateFormatter(ticker.Formatter):

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -132,7 +132,8 @@ Here all all the date formatters:
 
     * :class:`DateFormatter`: use :func:`strftime` format strings
 
-    * :class:`IsoDateFormatter`: like :class:`DateFormatter`, but use :meth:`datetime.datetime.isoformat`.
+    * :class:`IsoDateFormatter`: like :class:`DateFormatter`,
+      but use :meth:`datetime.datetime.isoformat`.
 
     * :class:`IndexDateFormatter`: date plots with implicit *x*
       indexing.
@@ -629,7 +630,6 @@ class IsoDateFormatter(ticker.Formatter):
 
     def set_tzinfo(self, tz):
         self.tz = tz
-
 
     def isoformat(self, dt):
         """

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -608,12 +608,13 @@ def drange(dstart, dend, delta):
 
 class IsoDateFormatter(ticker.Formatter):
     """
-    WRITEME
+    Use ISO 8601 format for tick format.
     """
 
-    def __init__(self, tz=None):
+    def __init__(self, fmt=None, tz=None):
         """
         *tz* is the :class:`tzinfo` instance.
+        *fmt* is ignored and kept for compatibility with `DateFormatter`.
         """
         if tz is None:
             tz = _get_rc_timezone()
@@ -633,19 +634,20 @@ class IsoDateFormatter(ticker.Formatter):
 
     def isoformat(self, dt):
         """
+        Return the isoformat() of a datetime object.
         Refer to documentation for :meth:`datetime.datetime.isoformat`
         """
-        if dt.year < 1900:
-            """
-            No idea if this needs special treatment
-            """
-            pass
+        # no special treatment for years before 1900 because isoformat appears
+        # to "just work" for datetimes before 1900.
 
         return cbook.unicode_safe(dt.isoformat())
 
-    def strftime(self, dt):
+    def strftime(self, dt, fmt=None):
         """
-        WRITEME
+        Print isoformat of datetime object
+        (for compatibility with `DateFormatter` interface)
+
+        *fmt* argument is ignored.
         """
         return self.isoformat(dt)
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -611,11 +611,17 @@ class IsoDateFormatter(ticker.Formatter):
     Use ISO 8601 format for tick format.
     """
 
-    def __init__(self, fmt=None, tz=None):
+    def __init__(self, fmt=None, tz=None, show_only=None):
         """
         *tz* is the :class:`tzinfo` instance.
         *fmt* is ignored and kept for compatibility with `DateFormatter`.
         """
+        if show_only is not None:
+            if show_only not in ['date', 'time']:
+                raise ValueError('show_only can only be "date", "time", or'
+                                 'None.')
+            if show_only:
+                self.fmt = show_only
         if tz is None:
             tz = _get_rc_timezone()
         self.tz = tz
@@ -640,7 +646,14 @@ class IsoDateFormatter(ticker.Formatter):
         # no special treatment for years before 1900 because isoformat appears
         # to "just work" for datetimes before 1900.
 
-        return cbook.unicode_safe(dt.isoformat())
+        if self.fmt == "date":
+            to_print = dt.date()
+        elif self.fmt == "time":
+            to_print = dt.time()
+        else:
+            to_print = dt
+
+        return cbook.unicode_safe(to_print.isoformat())
 
     def strftime(self, dt, fmt=None):
         """

--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -219,7 +219,7 @@ import matplotlib as mpl
 
 from matplotlib.dates import (
     date2num, num2date, datestr2num, strpdate2num, drange, epoch2num,
-    num2epoch, mx2num, DateFormatter, IndexDateFormatter, DateLocator,
+    num2epoch, mx2num, DateFormatter, IsoDateFormatter, IndexDateFormatter, DateLocator,
     RRuleLocator, YearLocator, MonthLocator, WeekdayLocator, DayLocator,
     HourLocator, MinuteLocator, SecondLocator, rrule, MO, TU, WE, TH, FR,
     SA, SU, YEARLY, MONTHLY, WEEKLY, DAILY, HOURLY, MINUTELY, SECONDLY,

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -211,6 +211,25 @@ def test_DateFormatter():
     fig.autofmt_xdate()
 
 
+def test_iso_date_formatter_strftime():
+    """
+    Tests that IsoDateFormatter matches datetime.isoformat,
+    CHECK:
+    check microseconds for years before 1900 for bug #3179
+    as well as a few related issues for years before 1900.
+    """
+    def test_strftime_fields(dt):
+        """WRITEME"""
+        formatter = mdates.IsoDateFormatter()
+        # TODO: confirm pre 1900
+        assert formatter.isoformat(dt) == dt.isoformat
+
+    for year in range(1, 3000, 71):
+        # Iterate through random set of years
+        test_strftime_fields(datetime.datetime(year, 1, 1))
+        test_strftime_fields(datetime.datetime(year, 2, 3, 4, 5, 6, 12345))
+
+
 def test_date_formatter_strftime():
     """
     Tests that DateFormatter matches datetime.strftime,

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -222,7 +222,7 @@ def test_iso_date_formatter_strftime():
         """WRITEME"""
         formatter = mdates.IsoDateFormatter()
         # TODO: confirm pre 1900
-        assert formatter.isoformat(dt) == dt.isoformat
+        assert formatter.isoformat(dt) == dt.isoformat()
 
     for year in range(1, 3000, 71):
         # Iterate through random set of years


### PR DESCRIPTION
## PR Summary

I want to print datetimes on matplotlib axes in isoformat.

I am under the impression that strftime cannot fully provide isoformat strings
[stackoverflow](https://stackoverflow.com/q/48745189/).

Also, since datetime has a separate `isoformat` method, rather than expecting
people to write ISO 8601 like strftime formats, I thought it might be nice to
have a dedicated formater in matplotlib as well.

ATM this PR is more a proof of principle. Do you think it is worth pursuing further?

## PR Checklist

(none attacked yet, will work on them if you want the PR)

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
