### PR TITLE
Add some basic smoketesting for webagg (and wx).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ install:
         codecov \
         coverage \
         $CYCLER \
+        $DATEUTIL \
         $NOSE \
         $NUMPY \
         $PANDAS \
@@ -138,8 +139,8 @@ install:
         coverage \
         pillow \
         $PYPARSING \
-        $DATEUTIL \
-        $SPHINX
+        $SPHINX \
+        tornado
     # GUI toolkits are pip-installable only for some versions of Python so
     # don't fail if we can't install them.  Make it easier to check whether the
     # install was successful by trying to import the toolkit (sometimes, the

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -1,9 +1,14 @@
 import importlib
 import os
-from subprocess import Popen
+import signal
+import subprocess
 import sys
+import time
+import urllib.request
 
 import pytest
+
+import matplotlib as mpl
 
 
 # Minimal smoke-testing of the backends for which the dependencies are
@@ -17,6 +22,7 @@ def _get_testable_interactive_backends():
                           (["PyQt5"], "qt5agg"),
                           (["cairocffi", "PyQt5"], "qt5cairo"),
                           (["tkinter"], "tkagg"),
+                          (["wx"], "wx"),
                           (["wx"], "wxagg")]:
         reason = None
         if not os.environ.get("DISPLAY"):
@@ -30,20 +36,47 @@ def _get_testable_interactive_backends():
 
 _test_script = """\
 import sys
-from matplotlib import pyplot as plt
+from matplotlib import pyplot as plt, rcParams
+rcParams.update({
+    "webagg.open_in_browser": False,
+    "webagg.port_retries": 1,
+})
 
 fig = plt.figure()
 ax = fig.add_subplot(111)
-ax.plot([1,2,3], [1,3,1])
+ax.plot([1, 2], [2, 3])
 fig.canvas.mpl_connect("draw_event", lambda event: sys.exit())
 plt.show()
 """
+_test_timeout = 10  # Empirically, 1s is not enough on Travis.
 
 
 @pytest.mark.parametrize("backend", _get_testable_interactive_backends())
 @pytest.mark.flaky(reruns=3)
-def test_backend(backend):
-    proc = Popen([sys.executable, "-c", _test_script],
-                 env={**os.environ, "MPLBACKEND": backend})
-    # Empirically, 1s is not enough on Travis.
-    assert proc.wait(timeout=10) == 0
+def test_interactive_backend(backend):
+    subprocess.run([sys.executable, "-c", _test_script],
+                   env={**os.environ, "MPLBACKEND": backend},
+                   check=True,  # Throw on failure.
+                   timeout=_test_timeout)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Cannot send SIGINT on Windows.")
+def test_webagg():
+    pytest.importorskip("tornado")
+    proc = subprocess.Popen([sys.executable, "-c", _test_script],
+                            env={**os.environ, "MPLBACKEND": "webagg"})
+    url = "http://{}:{}".format(
+        mpl.rcParams["webagg.address"], mpl.rcParams["webagg.port"])
+    timeout = time.perf_counter() + _test_timeout
+    while True:
+        try:
+            conn = urllib.request.urlopen(url)
+            break
+        except urllib.error.URLError:
+            if time.perf_counter() > timeout:
+                pytest.fail("Failed to connect to the webagg server.")
+            else:
+                continue
+    conn.close()
+    proc.send_signal(signal.SIGINT)
+    assert proc.wait(timeout=_test_timeout) == 0


### PR DESCRIPTION
## PR Summary

Adds some (smoke)testing for #10708.  This basically just checks that the server sets up correctly and closes cleanly on ctrl-c.
If you know how to actually trigger a draw on the websocket (and thus trigger the draw_event handler of the other backends), feel free to push a better method to this PR...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
