### PR TITLE
Use long color names for default rcParams

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1011,13 +1011,13 @@ defaultParams = {
 
     ## patch props
     'patch.linewidth':   [1.0, validate_float],     # line width in points
-    'patch.edgecolor':   ['k', validate_color],
+    'patch.edgecolor':   ['black', validate_color],
     'patch.force_edgecolor' : [False, validate_bool],
     'patch.facecolor':   ['C0', validate_color],    # first color in cycle
     'patch.antialiased': [True, validate_bool],     # antialiased (no jaggies)
 
     ## hatch props
-    'hatch.color': ['k', validate_color],
+    'hatch.color': ['black', validate_color],
     'hatch.linewidth': [1.0, validate_float],
 
     ## Histogram properties
@@ -1035,23 +1035,23 @@ defaultParams = {
     'boxplot.showfliers': [True, validate_bool],
     'boxplot.meanline': [False, validate_bool],
 
-    'boxplot.flierprops.color': ['k', validate_color],
+    'boxplot.flierprops.color': ['black', validate_color],
     'boxplot.flierprops.marker': ['o', validate_string],
     'boxplot.flierprops.markerfacecolor': ['none', validate_color_or_auto],
-    'boxplot.flierprops.markeredgecolor': ['k', validate_color],
+    'boxplot.flierprops.markeredgecolor': ['black', validate_color],
     'boxplot.flierprops.markersize': [6, validate_float],
     'boxplot.flierprops.linestyle': ['none', _validate_linestyle],
     'boxplot.flierprops.linewidth': [1.0, validate_float],
 
-    'boxplot.boxprops.color': ['k', validate_color],
+    'boxplot.boxprops.color': ['black', validate_color],
     'boxplot.boxprops.linewidth': [1.0, validate_float],
     'boxplot.boxprops.linestyle': ['-', _validate_linestyle],
 
-    'boxplot.whiskerprops.color': ['k', validate_color],
+    'boxplot.whiskerprops.color': ['black', validate_color],
     'boxplot.whiskerprops.linewidth': [1.0, validate_float],
     'boxplot.whiskerprops.linestyle': ['-', _validate_linestyle],
 
-    'boxplot.capprops.color': ['k', validate_color],
+    'boxplot.capprops.color': ['black', validate_color],
     'boxplot.capprops.linewidth': [1.0, validate_float],
     'boxplot.capprops.linestyle': ['-', _validate_linestyle],
 
@@ -1099,7 +1099,7 @@ defaultParams = {
                         validate_stringlist],
 
     # text props
-    'text.color':          ['k', validate_color],     # black
+    'text.color':          ['black', validate_color],
     'text.usetex':         [False, validate_bool],
     'text.latex.unicode':  [False, validate_bool],
     'text.latex.preamble': [[''], validate_stringlist],
@@ -1139,8 +1139,8 @@ defaultParams = {
     # axes props
     'axes.axisbelow':        ['line', validate_axisbelow],
     'axes.hold':             [None, deprecate_axes_hold],
-    'axes.facecolor':        ['w', validate_color],  # background color; white
-    'axes.edgecolor':        ['k', validate_color],  # edge color; black
+    'axes.facecolor':        ['white', validate_color],  # background color
+    'axes.edgecolor':        ['black', validate_color],  # edge color
     'axes.linewidth':        [0.8, validate_float],  # edge linewidth
 
     'axes.spines.left':      [True, validate_bool],  # Set visibility of axes
@@ -1163,7 +1163,7 @@ defaultParams = {
                                                              # x any y labels
     'axes.labelpad':         [4.0, validate_float], # space between label and axis
     'axes.labelweight':      ['normal', validate_string],  # fontsize of the x any y labels
-    'axes.labelcolor':       ['k', validate_color],    # color of axis label
+    'axes.labelcolor':       ['black', validate_color],    # color of axis label
     'axes.formatter.limits': [[-7, 7], validate_nseq_int(2)],
                                # use scientific notation if log10
                                # of the axis range is smaller than the
@@ -1256,7 +1256,7 @@ defaultParams = {
     'xtick.minor.width': [0.6, validate_float],  # minor xtick width in points
     'xtick.major.pad':   [3.5, validate_float],    # distance to label in points
     'xtick.minor.pad':   [3.4, validate_float],    # distance to label in points
-    'xtick.color':       ['k', validate_color],  # color of the xtick labels
+    'xtick.color':       ['black', validate_color],  # color of the xtick labels
     'xtick.minor.visible':   [False, validate_bool],    # visibility of the x axis minor ticks
     'xtick.minor.top':   [True, validate_bool],  # draw x axis top minor ticks
     'xtick.minor.bottom':    [True, validate_bool],    # draw x axis bottom minor ticks
@@ -1278,7 +1278,7 @@ defaultParams = {
     'ytick.minor.width': [0.6, validate_float],   # minor ytick width in points
     'ytick.major.pad':   [3.5, validate_float],     # distance to label in points
     'ytick.minor.pad':   [3.4, validate_float],     # distance to label in points
-    'ytick.color':       ['k', validate_color],   # color of the ytick labels
+    'ytick.color':       ['black', validate_color],   # color of the ytick labels
     'ytick.minor.visible':   [False, validate_bool],    # visibility of the y axis minor ticks
     'ytick.minor.left':   [True, validate_bool],  # draw y axis left minor ticks
     'ytick.minor.right':    [True, validate_bool],    # draw y axis right minor ticks
@@ -1305,8 +1305,8 @@ defaultParams = {
     # figure size in inches: width by height
     'figure.figsize':    [[6.4, 4.8], validate_nseq_float(2)],
     'figure.dpi':        [100, validate_float],  # DPI
-    'figure.facecolor':  ['w', validate_color],  # facecolor; white
-    'figure.edgecolor':  ['w', validate_color],  # edgecolor; white
+    'figure.facecolor':  ['white', validate_color],
+    'figure.edgecolor':  ['white', validate_color],
     'figure.frameon':    [True, validate_bool],
     'figure.autolayout': [False, validate_bool],
     'figure.max_open_warning': [20, validate_int],
@@ -1339,8 +1339,8 @@ defaultParams = {
 
     ## Saving figure's properties
     'savefig.dpi':         ['figure', validate_dpi],  # DPI
-    'savefig.facecolor':   ['w', validate_color],  # facecolor; white
-    'savefig.edgecolor':   ['w', validate_color],  # edgecolor; white
+    'savefig.facecolor':   ['white', validate_color],
+    'savefig.edgecolor':   ['white', validate_color],
     'savefig.frameon':     [True, validate_bool],
     'savefig.orientation': ['portrait', validate_orientation],  # edgecolor;
                                                                  #white

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -101,12 +101,12 @@ backend      : $TEMPLATE_BACKEND
 ## information on patch properties
 #patch.linewidth        : 1        ## edge width in points.
 #patch.facecolor        : C0
-#patch.edgecolor        : k       ## if forced, or patch is not filled
+#patch.edgecolor        : black   ## if forced, or patch is not filled
 #patch.force_edgecolor  : False   ## True to always use edgecolor
 #patch.antialiased      : True    ## render patches in antialiased (no jaggies)
 
 #### HATCHES
-#hatch.color     : k
+#hatch.color     : black
 #hatch.linewidth : 1.0
 
 #### Boxplot
@@ -121,23 +121,23 @@ backend      : $TEMPLATE_BACKEND
 #boxplot.showfliers  : True
 #boxplot.meanline    : False
 
-#boxplot.flierprops.color           : k
+#boxplot.flierprops.color           : black
 #boxplot.flierprops.marker          : o
 #boxplot.flierprops.markerfacecolor : none
-#boxplot.flierprops.markeredgecolor : k
+#boxplot.flierprops.markeredgecolor : black
 #boxplot.flierprops.markersize      : 6
 #boxplot.flierprops.linestyle       : none
 #boxplot.flierprops.linewidth       : 1.0
 
-#boxplot.boxprops.color     : k
+#boxplot.boxprops.color     : black
 #boxplot.boxprops.linewidth : 1.0
 #boxplot.boxprops.linestyle : -
 
-#boxplot.whiskerprops.color     : k
+#boxplot.whiskerprops.color     : black
 #boxplot.whiskerprops.linewidth : 1.0
 #boxplot.whiskerprops.linestyle : -
 
-#boxplot.capprops.color     : k
+#boxplot.capprops.color     : black
 #boxplot.capprops.linewidth : 1.0
 #boxplot.capprops.linestyle : -
 
@@ -211,7 +211,7 @@ backend      : $TEMPLATE_BACKEND
 ## text properties used by text.Text.  See
 ## http://matplotlib.org/api/artist_api.html#module-matplotlib.text for more
 ## information on text properties
-#text.color          : k
+#text.color          : black
 
 #### LaTeX customizations. See http://wiki.scipy.org/Cookbook/Matplotlib/UsingTex
 #text.usetex         : False  ## use latex for all text handling. The following fonts
@@ -280,8 +280,8 @@ backend      : $TEMPLATE_BACKEND
 ## default face and edge color, default tick sizes,
 ## default fontsizes for ticklabels, and so on.  See
 ## http://matplotlib.org/api/axes_api.html#module-matplotlib.axes
-#axes.facecolor      : w       ## axes background color
-#axes.edgecolor      : k       ## axes edge color
+#axes.facecolor      : white   ## axes background color
+#axes.edgecolor      : black   ## axes edge color
 #axes.linewidth      : 0.8     ## edge linewidth
 #axes.grid           : False   ## display grid or not
 #axes.grid.axis      : both    ## which axis the grid should apply to
@@ -292,7 +292,7 @@ backend      : $TEMPLATE_BACKEND
 #axes.labelsize      : medium  ## fontsize of the x any y labels
 #axes.labelpad       : 4.0     ## space between label and axis
 #axes.labelweight    : normal  ## weight of the x and y labels
-#axes.labelcolor     : k
+#axes.labelcolor     : black
 #axes.axisbelow      : line    ## draw axis gridlines and ticks below
                                ## patches (True); above patches but below
                                ## lines ('line'); or above all (False)
@@ -364,7 +364,7 @@ backend      : $TEMPLATE_BACKEND
 #xtick.minor.width    : 0.6    ## minor tick width in points
 #xtick.major.pad      : 3.5    ## distance to major tick label in points
 #xtick.minor.pad      : 3.4    ## distance to the minor tick label in points
-#xtick.color          : k      ## color of the tick labels
+#xtick.color          : black  ## color of the tick labels
 #xtick.labelsize      : medium ## fontsize of the tick labels
 #xtick.direction      : out    ## direction: in, out, or inout
 #xtick.minor.visible  : False  ## visibility of minor ticks on x-axis
@@ -384,7 +384,7 @@ backend      : $TEMPLATE_BACKEND
 #ytick.minor.width    : 0.6    ## minor tick width in points
 #ytick.major.pad      : 3.5    ## distance to major tick label in points
 #ytick.minor.pad      : 3.4    ## distance to the minor tick label in points
-#ytick.color          : k      ## color of the tick labels
+#ytick.color          : black  ## color of the tick labels
 #ytick.labelsize      : medium ## fontsize of the tick labels
 #ytick.direction      : out    ## direction: in, out, or inout
 #ytick.minor.visible  : False  ## visibility of minor ticks on y-axis
@@ -428,9 +428,9 @@ backend      : $TEMPLATE_BACKEND
 #figure.titleweight : normal   ## weight of the figure title
 #figure.figsize   : 6.4, 4.8   ## figure size in inches
 #figure.dpi       : 100        ## figure dots per inch
-#figure.facecolor : w      ## figure facecolor; 0.75 is scalar gray
-#figure.edgecolor : w      ## figure edgecolor
-#figure.frameon : True          ## enable figure frame
+#figure.facecolor : white      ## figure facecolor
+#figure.edgecolor : white      ## figure edgecolor
+#figure.frameon : True         ## enable figure frame
 #figure.max_open_warning : 20  ## The maximum number of figures to open through
                                ## the pyplot interface before emitting a warning.
                                ## If less than one this feature is disabled.
@@ -517,8 +517,8 @@ backend      : $TEMPLATE_BACKEND
 ## e.g., you may want a higher resolution, or to make the figure
 ## background white
 #savefig.dpi         : figure   ## figure dots per inch or 'figure'
-#savefig.facecolor   : w        ## figure facecolor when saving
-#savefig.edgecolor   : w        ## figure edgecolor when saving
+#savefig.facecolor   : white    ## figure facecolor when saving
+#savefig.edgecolor   : white    ## figure edgecolor when saving
 #savefig.format      : png      ## png, ps, pdf, svg
 #savefig.bbox        : standard ## 'tight' or 'standard'.
                                 ## 'tight' is incompatible with pipe-based animation


### PR DESCRIPTION
## PR Summary

As discussed in #10550, long color names improve the readability.
