### PR TITLE
DOC: Make colorbar tutorial examples look like colorbars.

### DIFF
--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -10,8 +10,8 @@ Customized Colorbars
 
 :class:`~matplotlib.colorbar.ColorbarBase` derives from
 :mod:`~matplotlib.cm.ScalarMappable` and puts a colorbar in a specified axes,
-so it has everything needed for a standalone colorbar. It can be used as is to
-make a colorbar for a given colormap and does not need a mappable object like
+so it has everything needed for a standalone colorbar. It can be used as-is to
+make a colorbar for a given colormap; it does not need a mappable object like
 an image. In this tutorial we will explore what can be done with standalone
 colorbar.
 
@@ -22,14 +22,15 @@ Set the colormap and norm to correspond to the data for which the colorbar
 will be used. Then create the colorbar by calling
 :class:`~matplotlib.colorbar.ColorbarBase` and specify axis, colormap, norm
 and orientation as parameters. Here we create a basic continuous colorbar
-with ticks and labels. More information on colorbar api can be found
-`here <https://matplotlib.org/api/colorbar_api.html>`.
+with ticks and labels. More information on the colorbar API can be found
+`here <https://matplotlib.org/api/colorbar_api.html>`_.
 """
 
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(figsize=(6, 1))
+fig.subplots_adjust(bottom=0.5)
 
 cmap = mpl.cm.cool
 norm = mpl.colors.Normalize(vmin=5, vmax=10)
@@ -62,7 +63,8 @@ fig.show()
 # *extend*, you must specify two extra boundaries. Finally spacing argument
 # ensures that intervals are shown on colorbar proportionally.
 
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(figsize=(6, 1))
+fig.subplots_adjust(bottom=0.5)
 
 cmap = mpl.colors.ListedColormap(['red', 'green', 'blue', 'cyan'])
 cmap.set_over('0.25')
@@ -88,7 +90,8 @@ fig.show()
 # colorbar with discrete intervals. To make the length of each extension same
 # as the length of the interior colors, use ``extendfrac='auto'``.
 
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(figsize=(6, 1))
+fig.subplots_adjust(bottom=0.5)
 
 cmap = mpl.colors.ListedColormap(['royalblue', 'cyan',
                                   'yellow', 'orange'])

--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -87,8 +87,8 @@ fig.show()
 # --------------------------------------
 #
 # Here we illustrate the use of custom length colorbar extensions, used on a
-# colorbar with discrete intervals. To make the length of each extension same
-# as the length of the interior colors, use ``extendfrac='auto'``.
+# colorbar with discrete intervals. To make the length of each extension the
+# same as the length of the interior colors, use ``extendfrac='auto'``.
 
 fig, ax = plt.subplots(figsize=(6, 1))
 fig.subplots_adjust(bottom=0.5)


### PR DESCRIPTION
- Give the colorbars a reasonable aspect ratio.
- Fix a link.
- Other minor edits.

Here are the revised plots:
![cb1](https://user-images.githubusercontent.com/85125/37577112-1163fcc8-2ad4-11e8-85e7-85024cbb22f5.png)
![cb2](https://user-images.githubusercontent.com/85125/37577113-1181c186-2ad4-11e8-90eb-df19a439602d.png)
![cb3](https://user-images.githubusercontent.com/85125/37577114-1207cc0e-2ad4-11e8-9a95-eff2e448d985.png)
The original versions can be seen here: https://matplotlib.org/tutorials/colors/colorbar_only.html#sphx-glr-tutorials-colors-colorbar-only-py