### PR TITLE
Correctly display error when running setup.py test.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,9 +125,9 @@ classifiers = [
 
 
 class NoopTestCommand(TestCommand):
-    def run(self):
+    def __init__(self, dist):
         print("Matplotlib does not support running tests with "
-              "'python setup.py test'. Please run 'python tests.py'")
+              "'python setup.py test'. Please run 'python tests.py'.")
 
 
 class BuildExtraLibraries(BuildExtCommand):


### PR DESCRIPTION
We display an error if someone tries to run setup.py test (saying that
one should run tests.py instead), but that doesn't get displayed if
test.local_freetype is set in setup.cfg -- because the test command
considers that equivalent to passing a (non-existent) local_freetype
option to it, and fails first during argument parsing.

As a solution, display the error in the constructor of the command
instead.

Closes #8874.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
