### PR TITLE
ENH: new date formatter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -240,6 +240,7 @@ per-file-ignores =
     examples/text_labels_and_annotations/tex_demo.py: E402
     examples/text_labels_and_annotations/watermark_text.py: E402
     examples/ticks_and_spines/auto_ticks.py: E501
+    examples/ticks_and_spines/date_concise_formatter.py: E402 
     examples/user_interfaces/canvasagg.py: E402
     examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py: E402
     examples/user_interfaces/embedding_in_gtk3_sgskip.py: E402

--- a/doc/users/next_whats_new/concise_date_formatter.rst
+++ b/doc/users/next_whats_new/concise_date_formatter.rst
@@ -1,0 +1,40 @@
+:orphan:
+
+New date formatter: `~.dates.ConciseDateFormatter`
+--------------------------------------------------
+
+The automatic date formatter used by default can be quite verbose.  A new
+formatter can be accessed that tries to make the tick labels appropriately
+concise.
+
+  .. plot::
+
+    import datetime
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    import numpy as np
+
+    # make a timeseries...
+    base = datetime.datetime(2005, 2, 1)
+    dates = np.array([base + datetime.timedelta(hours= 2 * i)
+                      for i in range(732)])
+    N = len(dates)
+    np.random.seed(19680801)
+    y = np.cumsum(np.random.randn(N))
+
+    lims = [(np.datetime64('2005-02'), np.datetime64('2005-04')),
+            (np.datetime64('2005-02-03'), np.datetime64('2005-02-15')),
+            (np.datetime64('2005-02-03 11:00'), np.datetime64('2005-02-04 13:20'))]
+    fig, axs = plt.subplots(3, 1, constrained_layout=True)
+    for nn, ax in enumerate(axs):
+        # activate the formatter here.
+        locator = mdates.AutoDateLocator()
+        formatter = mdates.ConciseDateFormatter(locator)
+        ax.xaxis.set_major_locator(locator)
+        ax.xaxis.set_major_formatter(formatter)
+
+        ax.plot(dates, y)
+        ax.set_xlim(lims[nn])
+    axs[0].set_title('Concise Date Formatter')
+
+    plt.show()

--- a/examples/ticks_and_spines/date_concise_formatter.py
+++ b/examples/ticks_and_spines/date_concise_formatter.py
@@ -1,0 +1,183 @@
+"""
+================================================
+Formatting date ticks using ConciseDateFormatter
+================================================
+
+Finding good tick values and formatting the ticks for an axis that
+has date data is often a challenge.  `~.dates.ConciseDateFormatter` is
+meant to improve the strings chosen for the ticklabels, and to minimize
+the strings used in those tick labels as much as possible.
+
+.. note::
+
+    This formatter is a candidate to become the default date tick formatter
+    in future versions of Matplotlib.  Please report any issues or
+    suggestions for improvement to the github repository or mailing list.
+
+"""
+import datetime
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import numpy as np
+
+#############################################################################
+# First, the default formatter.
+
+base = datetime.datetime(2005, 2, 1)
+dates = np.array([base + datetime.timedelta(hours=(2 * i))
+                  for i in range(732)])
+N = len(dates)
+np.random.seed(19680801)
+y = np.cumsum(np.random.randn(N))
+
+fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+lims = [(np.datetime64('2005-02'), np.datetime64('2005-04')),
+        (np.datetime64('2005-02-03'), np.datetime64('2005-02-15')),
+        (np.datetime64('2005-02-03 11:00'), np.datetime64('2005-02-04 13:20'))]
+for nn, ax in enumerate(axs):
+    ax.plot(dates, y)
+    ax.set_xlim(lims[nn])
+    # rotate_labels...
+    for label in ax.get_xticklabels():
+        label.set_rotation(40)
+        label.set_horizontalalignment('right')
+axs[0].set_title('Default Date Formatter')
+plt.show()
+
+#############################################################################
+# The default date formater is quite verbose, so we have the option of
+# using `~.dates.ConciseDateFormatter`, as shown below.  Note that
+# for this example the labels do not need to be rotated as they do for the
+# default formatter because the labels are as small as possible.
+
+fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+for nn, ax in enumerate(axs):
+    locator = mdates.AutoDateLocator(minticks=3, maxticks=7)
+    formatter = mdates.ConciseDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+
+    ax.plot(dates, y)
+    ax.set_xlim(lims[nn])
+axs[0].set_title('Concise Date Formatter')
+
+plt.show()
+
+#############################################################################
+# If all calls to axes that have dates are to be made using this converter,
+# it is probably most convenient to use the units registry where you do
+# imports:
+
+import matplotlib.units as munits
+converter = mdates.ConciseDateConverter()
+munits.registry[np.datetime64] = converter
+munits.registry[datetime.date] = converter
+munits.registry[datetime.datetime] = converter
+
+fig, axs = plt.subplots(3, 1, figsize=(6, 6), constrained_layout=True)
+for nn, ax in enumerate(axs):
+    ax.plot(dates, y)
+    ax.set_xlim(lims[nn])
+axs[0].set_title('Concise Date Formatter')
+
+plt.show()
+
+#############################################################################
+# Localization of date formats
+# ============================
+#
+# Dates formats can be localized if the default formats are not desirable by
+# manipulating one of three lists of strings.
+#
+# The ``formatter.formats`` list of formats is for the normal tick labels,
+# There are six levels: years, months, days, hours, minutes, seconds.
+# The ``formatter.offset_formats`` is how the "offset" string on the right
+# of the axis is formatted.  This is usually much more verbose than the tick
+# labels. Finally, the ``formatter.zero_formats`` are the formats of the
+# ticks that are "zeros".  These are tick values that are either the first of
+# the year, month, or day of month, or the zeroth hour, minute, or second.
+# These are usually the same as the format of
+# the ticks a level above.  For example if the axis limts mean the ticks are
+# mostly days, then we label 1 Mar 2005 simply with a "Mar".  If the axis
+# limits are mostly hours, we label Feb 4 00:00 as simply "Feb-4".
+#
+# Note that these format lists can also be passed to `.ConciseDateFormatter`
+# as optional kwargs.
+#
+# Here we modify the labels to be "day month year", instead of the ISO
+# "year month day":
+
+fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+
+for nn, ax in enumerate(axs):
+    locator = mdates.AutoDateLocator()
+    formatter = mdates.ConciseDateFormatter(locator)
+    formatter.formats = ['%y',  # ticks are mostly years
+                         '%b',       # ticks are mostly months
+                         '%d',       # ticks are mostly days
+                         '%H:%M',    # hrs
+                         '%H:%M',    # min
+                         '%S.%f', ]  # secs
+    # these are mostly just the level above...
+    formatter.zero_formats = [''] + formatter.formats[:-1]
+    # ...except for ticks that are mostly hours, then it is nice to have
+    # month-day:
+    formatter.zero_formats[3] = '%d-%b'
+
+    formatter.offset_formats = ['',
+                                '%Y',
+                                '%b %Y',
+                                '%d %b %Y',
+                                '%d %b %Y',
+                                '%d %b %Y %H:%M', ]
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+
+    ax.plot(dates, y)
+    ax.set_xlim(lims[nn])
+axs[0].set_title('Concise Date Formatter')
+
+plt.show()
+
+#############################################################################
+# Registering a converter with localization
+# =========================================
+#
+# `.ConciseDateFormatter` doesn't have rcParams entries, but localization
+# can be accomplished by passing kwargs to `~.ConciseDateConverter` and
+# registering the datatypes you will use with the units registry:
+
+import datetime
+
+formats = ['%y',          # ticks are mostly years
+           '%b',     # ticks are mostly months
+           '%d',     # ticks are mostly days
+           '%H:%M',  # hrs
+           '%H:%M',  # min
+           '%S.%f', ]  # secs
+# these can be the same, except offset by one level....
+zero_formats = [''] + formats[:-1]
+# ...except for ticks that are mostly hours, then its nice to have month-day
+zero_formats[3] = '%d-%b'
+offset_formats = ['',
+                  '%Y',
+                  '%b %Y',
+                  '%d %b %Y',
+                  '%d %b %Y',
+                  '%d %b %Y %H:%M', ]
+
+converter = mdates.ConciseDateConverter(formats=formats,
+                                 zero_formats=zero_formats,
+                                 offset_formats=offset_formats)
+
+munits.registry[np.datetime64] = converter
+munits.registry[datetime.date] = converter
+munits.registry[datetime.datetime] = converter
+
+fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+for nn, ax in enumerate(axs):
+    ax.plot(dates, y)
+    ax.set_xlim(lims[nn])
+axs[0].set_title('Concise Date Formatter registered non-default')
+
+plt.show()

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -506,6 +506,57 @@ def test_auto_date_locator_intmult():
         assert list(map(str, mdates.num2date(locator()))) == expected
 
 
+def test_concise_formatter():
+    def _create_auto_date_locator(date1, date2):
+        fig, ax = plt.subplots()
+
+        locator = mdates.AutoDateLocator(interval_multiples=True)
+        formatter = mdates.ConciseDateFormatter(locator)
+        ax.yaxis.set_major_locator(locator)
+        ax.yaxis.set_major_formatter(formatter)
+        ax.set_ylim(date1, date2)
+        fig.canvas.draw()
+        sts = []
+        for st in ax.get_yticklabels():
+            sts += [st.get_text()]
+        return sts
+
+    d1 = datetime.datetime(1997, 1, 1)
+    results = ([datetime.timedelta(weeks=52 * 200),
+                [str(t) for t in range(1980, 2201, 20)]
+                ],
+               [datetime.timedelta(weeks=52),
+                ['1997', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
+                'Sep', 'Oct', 'Nov', 'Dec']
+                ],
+               [datetime.timedelta(days=141),
+                ['Jan', '22', 'Feb', '22', 'Mar', '22', 'Apr', '22',
+                 'May', '22']
+                ],
+               [datetime.timedelta(days=40),
+                ['Jan', '05', '09', '13', '17', '21', '25', '29', 'Feb',
+                 '05', '09']
+                ],
+               [datetime.timedelta(hours=40),
+                ['Jan-01', '04:00', '08:00', '12:00', '16:00', '20:00',
+                 'Jan-02', '04:00', '08:00', '12:00', '16:00']
+                ],
+               [datetime.timedelta(minutes=20),
+                ['00:00', '00:05', '00:10', '00:15', '00:20']
+                ],
+               [datetime.timedelta(seconds=40),
+                ['00:00', '05', '10', '15', '20', '25', '30', '35', '40']
+                ],
+               [datetime.timedelta(seconds=2),
+                ['59.5', '00:00', '00.5', '01.0', '01.5', '02.0', '02.5']
+                ],
+               )
+    for t_delta, expected in results:
+        d2 = d1 + t_delta
+        strings = _create_auto_date_locator(d1, d2)
+        assert strings == expected
+
+
 @image_comparison(baseline_images=['date_inverted_limit'],
                   extensions=['png'])
 def test_date_inverted_limit():

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -394,26 +394,15 @@ ax.plot(time, y1)
 ax.tick_params(axis='x', rotation=70)
 plt.show()
 
-##############################################################################
-# Maybe the format of the labels above is acceptable, but the choices is
-# rather idiosyncratic.  We can make the ticks fall on the start of the month
-# by modifying `matplotlib.dates.AutoDateLocator`
-import matplotlib.dates as mdates
-
-locator = mdates.AutoDateLocator(interval_multiples=True)
-
-fig, ax = plt.subplots(figsize=(5, 3), tight_layout=True)
-ax.xaxis.set_major_locator(locator)
-ax.plot(time, y1)
-ax.tick_params(axis='x', rotation=70)
-plt.show()
 
 ##############################################################################
-# However, this changes the tick labels. The easiest fix is to pass a format
+# We can pass a format
 # to `matplotlib.dates.DateFormatter`.  Also note that the 29th and the
 # next month are very close together.  We can fix this by using the
 # `dates.DayLocator` class, which allows us to specify a list of days of the
 # month to use. Similar formatters are listed in the `matplotlib.dates` module.
+
+import matplotlib.dates as mdates
 
 locator = mdates.DayLocator(bymonthday=[1, 15])
 formatter = mdates.DateFormatter('%b %d')


### PR DESCRIPTION
## PR Summary


### Update 22 Sep 2018: New localization mechanism.

This can now be localized.  Its a bit verbose because there are basically 3*7 = 21 formatting strings.  7 for the normal ticks, 7 for the ticks that are major time divisions (i.e. if ticks are 22 Mar, 1 Apr, 8 Apr, the tick labels will be "22", "Apr", "8". ).  I think the default is good, and ISO compliant.  The verbose lists of strings allow localization with a bit of work.  I include an example of how to create a trivial subclass to encapsulate that customization. Maybe someone more clever than me can come up with a better way to do this.  

..its described in detail at https://13776-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/ticks_and_spines/date_concise_formatter.html#sphx-glr-gallery-ticks-and-spines-date-concise-formatter-py

   [x] still needs tests

ping @anntzer and @ImportanceOfBeingErnest who were both interested in how this would localize.  

### Update 4 July 2018

Renamed `ConciseDateFormatter` and included examples of how to use it.  

I think mechanisms or dicussion of whether it shoudl be the defautl can be deferred.  Certainly its nice to be able to set the date format manually as pointed out by @ImportanceOfBeingErnest below, and the current method allows this, whereas this Formatter has no localization like that.  



### ...
This is a proposed new date formatter.  I find the Automatic one less than useful, though I appreciate the functional flexibility of the default one. 

I'd argue the default should be something like this, but apprecaite we are conservative on such matters.

This isn't ready for serious review attention yet, but thoughts on the API or the result are welcome...

I'll note a couple fo flaws (in my opinion) of the default locator.  As per #9801, `interval_multiples=True` should be the default.  Secondly, it would be nice if the locator only located the first and 15th of the month rather than 1, 15, 29.  

EDIT: added extra info in the "offset" region of the axes.   



```python
import datetime
import numpy as np
import matplotlib
matplotlib.use('Qt5Agg')
import matplotlib.pyplot as plt
import matplotlib.dates as mdates


fig, axs = plt.subplots(2, 3, figsize=(8,8), constrained_layout=True)
axs = axs.flatten()
if False:
    for ax in axs:
        locator = mdates.AutoDateLocator(interval_multiples=True)
        formatter = mdates.ConciseDateFormatter(locator)
        ax.yaxis.set_major_locator(locator)
        ax.yaxis.set_major_formatter(formatter)
    fname = 'New.png'
else:
    for ax in axs:
        locator = mdates.AutoDateLocator(interval_multiples=True)
        formatter = mdates.AutoDateFormatter(locator)
        ax.yaxis.set_major_locator(locator)
        ax.yaxis.set_major_formatter(formatter)
    fname = 'Old.png'

ax = axs[0]

t0 = datetime.datetime(2009, 1, 20)
tf = datetime.datetime(2009, 1, 21)
ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
ax.set_ylim(t0 - datetime.timedelta(days=5),
            tf + datetime.timedelta(days=5))

ax.set_title('Days', loc='Right')

ax = axs[1]
t0 = datetime.datetime(2009, 1, 20)
tf = datetime.datetime(2009, 3, 21)
ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
ax.set_ylim(t0 - datetime.timedelta(days=15),
            tf + datetime.timedelta(days=15))

ax.set_title('2 Months', loc='Right')

ax = axs[2]
t0 = datetime.datetime(2008, 8, 20)
tf = datetime.datetime(2010, 3, 21)
ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
ax.set_ylim(t0 - datetime.timedelta(days=105),
            tf + datetime.timedelta(days=105))

ax.set_title(' Months/Y', loc='Right')


ax = axs[3]
t0 = datetime.datetime(2005, 8, 20)
tf = datetime.datetime(2015, 3, 21)
ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
ax.set_ylim(t0 - datetime.timedelta(days=1005),
            tf + datetime.timedelta(days=1005))

ax.set_title(' Years', loc='Right')

ax = axs[4]
t0 = datetime.datetime(2009, 8, 20)
tf = datetime.datetime(2009, 8, 21)
ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
ax.set_ylim(t0 - datetime.timedelta(hours=3),
            tf + datetime.timedelta(hours=3))

ax.set_title(' Hours', loc='Right')

ax = axs[5]
t0 = datetime.datetime(2009, 8, 20, 9)
tf = datetime.datetime(2009, 8, 20, 10)
ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
ax.set_ylim(t0 - datetime.timedelta(minutes=3),
            tf + datetime.timedelta(minutes=3))

ax.set_title(' Minutes', loc='Right')


fig.savefig(fname)
plt.show()
```

## Before:

![old](https://user-images.githubusercontent.com/1562854/37683856-2147f45a-2c4b-11e8-8670-b4e87ad3d845.png)


## After:

![new](https://user-images.githubusercontent.com/1562854/37712441-18fd92d8-2cd1-11e8-8a4b-50f1bfac33cf.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->