### PR TITLE
Wx Toolbar for ToolManager

### DIFF
--- a/doc/sphinxext/mock_gui_toolkits.py
+++ b/doc/sphinxext/mock_gui_toolkits.py
@@ -118,6 +118,9 @@ class MyWX(MagicMock):
     class Frame(object):
         pass
 
+    class StatusBar(object):
+        pass
+
 
 def setup(app):
     sys.modules.update(

--- a/examples/user_interfaces/toolmanager_sgskip.py
+++ b/examples/user_interfaces/toolmanager_sgskip.py
@@ -19,6 +19,7 @@ import matplotlib
 matplotlib.use('GTK3Cairo')
 # matplotlib.use('TkAgg')
 # matplotlib.use('QT5Agg')
+# matplotlib.use('WxAgg')
 matplotlib.rcParams['toolbar'] = 'toolmanager'
 import matplotlib.pyplot as plt
 from matplotlib.backend_tools import ToolBase, ToolToggleBase

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1284,7 +1284,7 @@ class FigureManagerWx(FigureManagerBase):
         self.frame = frame
         self.window = frame
 
-        self.toolmanager = frame.toolmanager
+        self.toolmanager = getattr(frame, "toolmanager", None)
         self.toolbar = frame.GetToolBar()
 
     def show(self):
@@ -1552,6 +1552,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def configure_subplots(self, evt):
         global FigureManager  # placates pyflakes: created by @_Backend.export
         frame = wx.Frame(None, -1, "Configure subplots")
+        _set_frame_icon(frame)
 
         toolfig = Figure((6, 3))
         canvas = self.get_canvas(frame, toolfig)
@@ -1811,7 +1812,6 @@ class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):
     def configure_subplots(self):
         frame = wx.Frame(None, -1, "Configure subplots")
         _set_frame_icon(frame)
-        frame.toolmanager = None
 
         toolfig = Figure((6, 3))
         canvas = self.get_canvas(frame, toolfig)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1350,6 +1350,8 @@ def _load_bitmap(filename):
 
 
 _FRAME_ICON = None
+
+
 def _set_frame_icon(frame):
     # set frame icon
     global _FRAME_ICON
@@ -1358,9 +1360,11 @@ def _set_frame_icon(frame):
         for image in ('matplotlib.png', 'matplotlib_large.png'):
             image = os.path.join(matplotlib.rcParams['datapath'], 'images',
                                  image)
-            if not os.path.exists(image): continue
+            if not os.path.exists(image):
+                continue
             icon = wx.Icon(_load_bitmap(image))
-            if not icon.IsOk(): return
+            if not icon.IsOk():
+                return
             bundle.AddIcon(icon)
     frame.SetIcons(_FRAME_ICON)
 
@@ -1748,7 +1752,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
             tool = self.InsertTool(idx, -1, name, bmp, wx.NullBitmap, kind,
                                    description or "")
         else:
-            size = (self.GetTextExtent(name)[0]+10,-1)
+            size = (self.GetTextExtent(name)[0]+10, -1)
             if toggle:
                 control = wx.ToggleButton(self, -1, name, size=size)
             else:
@@ -1787,6 +1791,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
             else:
                 tool.GetControl().SetValue(toggled)
         self.Refresh()
+
     def remove_toolitem(self, name):
         for tool, handler in self._toolitems[name]:
             self.DeleteTool(tool.Id)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1349,24 +1349,18 @@ def _load_bitmap(filename):
     return bmp
 
 
-_FRAME_ICON = None
-
-
 def _set_frame_icon(frame):
     # set frame icon
-    global _FRAME_ICON
-    if not _FRAME_ICON:
-        _FRAME_ICON = bundle = wx.IconBundle()
-        for image in ('matplotlib.png', 'matplotlib_large.png'):
-            image = os.path.join(matplotlib.rcParams['datapath'], 'images',
-                                 image)
-            if not os.path.exists(image):
-                continue
-            icon = wx.Icon(_load_bitmap(image))
-            if not icon.IsOk():
-                return
-            bundle.AddIcon(icon)
-    frame.SetIcons(_FRAME_ICON)
+    bundle = wx.IconBundle()
+    for image in ('matplotlib.png', 'matplotlib_large.png'):
+        image = os.path.join(matplotlib.rcParams['datapath'], 'images', image)
+        if not os.path.exists(image):
+            continue
+        icon = wx.Icon(_load_bitmap(image))
+        if not icon.IsOk():
+            return
+        bundle.AddIcon(icon)
+    frame.SetIcons(bundle)
 
 
 class MenuButtonWx(wx.Button):


### PR DESCRIPTION
## PR Summary
This adds a first implementation of the ToolbarWx for use with ToolManager, including StatusbarWx, and ConfigureSubplotsWx.
The other tools were there already.
The ToolManager example is updated.

Additionally, an icon will be set also for FigureFrameWx.


I will also prepare an additional PR to replace the toolbar with a standard wx toolbar at the top of the frame. This will fix issue 2716 and make the FigureFrameWx initialization code more straightforward.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
