### PR TITLE
ENH: Stop mangling default figure file name if file exists

### DIFF
--- a/doc/users/next_whats_new/default_filename_suffix.rst
+++ b/doc/users/next_whats_new/default_filename_suffix.rst
@@ -1,0 +1,13 @@
+Stop adding a suffix to suggest unique file name
+------------------------------------------------
+
+Previously, when saving a figure to a file using the GUI's
+save dialog box, if the default filename (based on the
+figure window title) already existed on disk, Matplotlib
+would append a suffix (e.g. `Figure_1-1.png`), preventing
+the dialog from prompting to overwrite the file. This
+behaviour has been removed. Now if the file name exists on
+disk, the user is prompted whether or not to overwrite it.
+This eliminates guesswork, and allows intentional
+overwriting, especially when the figure name has been
+manually set using `fig.canvas.set_window_title()`.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2275,17 +2275,6 @@ class FigureCanvasBase(object):
         default_basename = default_basename.replace(' ', '_')
         default_filetype = self.get_default_filetype()
         default_filename = default_basename + '.' + default_filetype
-
-        save_dir = os.path.expanduser(rcParams['savefig.directory'])
-
-        # ensure non-existing filename in save dir
-        i = 1
-        while os.path.isfile(os.path.join(save_dir, default_filename)):
-            # attach numerical count to basename
-            default_filename = (
-                '{}-{}.{}'.format(default_basename, i, default_filetype))
-            i += 1
-
         return default_filename
 
     def switch_backends(self, FigureCanvasClass):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -592,6 +592,7 @@ class FileChooserDialog(Gtk.FileChooserDialog):
                 ):
         super().__init__(title, parent, action, buttons)
         self.set_default_response(Gtk.ResponseType.OK)
+        self.set_do_overwrite_confirmation(True)
 
         if not path:
             path = os.getcwd()

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -60,20 +60,3 @@ def test_get_default_filename():
         assert filename == 'image.png'
     finally:
         shutil.rmtree(test_dir)
-
-
-def test_get_default_filename_already_exists():
-    # From #3068: Suggest non-existing default filename
-    try:
-        test_dir = tempfile.mkdtemp()
-        plt.rcParams['savefig.directory'] = test_dir
-        fig = plt.figure()
-        canvas = FigureCanvasBase(fig)
-
-        # create 'image.png' in figure's save dir
-        open(os.path.join(test_dir, 'image.png'), 'w').close()
-
-        filename = canvas.get_default_filename()
-        assert filename == 'image-1.png'
-    finally:
-        shutil.rmtree(test_dir)


### PR DESCRIPTION
Back in 2012, I added the feature that takes the title of the figure window and uses that as the default file name. Fairly recently, I noticed that the behaviour has changed. Now the default file name is prevented from ever possibly being identical to the name on disk, by appending a `-1`, `-2`, etc to the end of the base file name. This is absolutely daft in my opinion, and a bug, not a feature. There is no risk of accidentally overwriting an existing file, because the save dialog box, like any other, always first asks if you want to overwrite. I almost without fail *do* want to overwrite, which is why I hit save in the first place, but I have to constantly remove the useless `-1` from the file name field every time I want to update my saved figures on disk.

This code restores the original behaviour.

I couldn't find any issues discussing the change from the original behaviour, and I don't know when it was introduced.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.
FIX
- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
