### PR TITLE
Rely on rglob support rather than os.walk.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -13,7 +13,7 @@ The following classes, methods, functions, and attributes are deprecated:
 - ``Annotation.arrow``,
 - ``cbook.GetRealpathAndStat``, ``cbook.Locked``,
 - ``cbook.is_numlike`` (use ``isinstance(..., numbers.Number)`` instead),
-  ``cbook.unicode_safe``
+  ``cbook.listFiles``, ``cbook.unicode_safe``
 - ``container.Container.set_remove_method``,
 - ``dates.DateFormatter.strftime_pre_1900``, ``dates.DateFormatter.strftime``,
 - ``font_manager.TempCache``,

--- a/doc/api/next_api_changes/2018-03-23-AL.rst
+++ b/doc/api/next_api_changes/2018-03-23-AL.rst
@@ -1,0 +1,4 @@
+``font_manager.list_fonts`` now follows the platform's casefolding semantics
+````````````````````````````````````````````````````````````````````````````
+
+i.e., it behaves case-insensitively on Windows only.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -743,14 +743,11 @@ get_data_path = _wrap('matplotlib data path %s', _get_data_path_cached,
 
 
 def get_py2exe_datafiles():
-    datapath = get_data_path()
-    _, tail = os.path.split(datapath)
+    data_path = Path(get_data_path())
     d = {}
-    for root, _, files in os.walk(datapath):
-        files = [os.path.join(root, filename) for filename in files]
-        root = root.replace(tail, 'mpl-data')
-        root = root[root.index('mpl-data'):]
-        d[root] = files
+    for path in filter(Path.is_file, data_path.glob("**/*")):
+        (d.setdefault(str(path.parent.relative_to(data_path.parent)), [])
+         .append(str(path)))
     return list(d.items())
 
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -676,6 +676,7 @@ def dedent(s):
     return result
 
 
+@deprecated("3.0")
 def listFiles(root, patterns='*', recurse=1, return_folders=0):
     """
     Recursively list files

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -35,6 +35,7 @@ from collections import Iterable
 from functools import lru_cache
 import json
 import os
+from pathlib import Path
 import subprocess
 import sys
 from threading import Timer
@@ -150,12 +151,13 @@ def get_fontext_synonyms(fontext):
 
 def list_fonts(directory, extensions):
     """
-    Return a list of all fonts matching any of the extensions,
-    possibly upper-cased, found recursively under the directory.
+    Return a list of all fonts matching any of the extensions, found
+    recursively under the directory.
     """
-    pattern = ';'.join(['*.%s;*.%s' % (ext, ext.upper())
-                        for ext in extensions])
-    return cbook.listFiles(directory, pattern)
+    extensions = ["." + ext for ext in extensions]
+    return [str(path)
+            for path in filter(Path.is_file, Path(directory).glob("**/*.*"))
+            if path.suffix in extensions]
 
 
 def win32FontDirectory():
@@ -231,21 +233,13 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
 
 
 def OSXInstalledFonts(directories=None, fontext='ttf'):
-    """
-    Get list of font files on OS X - ignores font suffix by default.
-    """
+    """Get list of font files on OS X."""
     if directories is None:
         directories = OSXFontDirectories
-
-    fontext = get_fontext_synonyms(fontext)
-
-    files = []
-    for path in directories:
-        if fontext is None:
-            files.extend(cbook.listFiles(path, '*'))
-        else:
-            files.extend(list_fonts(path, fontext))
-    return files
+    return [path
+            for directory in directories
+            for ext in get_fontext_synonyms(fontext)
+            for path in list_fonts(directory, ext)]
 
 
 @lru_cache()

--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -329,16 +329,10 @@ def find_failing_tests(result_images, source):
     Find all of the failing tests by looking for files with
     `-failed-diff` at the end of the basename.
     """
-    entries = []
-    for root, dirs, files in os.walk(result_images):
-        for fname in files:
-            basename, ext = os.path.splitext(fname)
-            if basename.endswith('-failed-diff'):
-                path = os.path.join(root, fname)
-                entry = Entry(path, result_images, source)
-                entries.append(entry)
-    entries.sort(key=lambda x: x.name)
-    return entries
+    return sorted(
+        (Entry(path, result_images, source)
+         for path in Path(result_images).glob("**/*-failed-diff.*")),
+        key=lambda x: x.name)
 
 
 def launch(result_images, source):


### PR DESCRIPTION
In OSXInstalledFonts, the `fontext is None` path could never be taken,
because `get_fontext_synonyms` never returns None.

(edit: I just realized this overlaps with #10435, but not completely so I'll resolve conflicts either way :-))

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
