### PR TITLE
Cleanup _plot_args_replacer logic

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1529,8 +1529,8 @@ _DATA_DOC_APPENDIX = """
     following arguments are replaced by **data[<arg>]**:
 
     {replaced}
-    
-    Objects passed as **data** must support item access (``data[<arg>]``) and 
+
+    Objects passed as **data** must support item access (``data[<arg>]``) and
     membership test (``<arg> in data``).
 """
 
@@ -1557,7 +1557,7 @@ def _add_data_doc(docstring, replace_names, replace_all_args):
     if docstring is None:
         docstring = ''
     else:
-        docstring = dedent(docstring)git
+        docstring = dedent(docstring)
     _repl = ""
     if replace_names is None:
         _repl = "* All positional and all keyword arguments."

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1529,6 +1529,9 @@ _DATA_DOC_APPENDIX = """
     following arguments are replaced by **data[<arg>]**:
 
     {replaced}
+    
+    Objects passed as **data** must support item access (``data[<arg>]``) and 
+    membership test (``<arg> in data``).
 """
 
 
@@ -1554,7 +1557,7 @@ def _add_data_doc(docstring, replace_names, replace_all_args):
     if docstring is None:
         docstring = ''
     else:
-        docstring = dedent(docstring)
+        docstring = dedent(docstring)git
     _repl = ""
     if replace_names is None:
         _repl = "* All positional and all keyword arguments."

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -44,18 +44,24 @@ _log = logging.getLogger(__name__)
 rcParams = matplotlib.rcParams
 
 
+def _has_item(data, name):
+    """Return whether *data* can be item-accessed with *name*.
+
+    This supports data with a dict-like interface (`in` checks item
+    availability) and with numpy.arrays.
+    """
+    try:
+        return name in data or name in data.dtype.names
+    except (AttributeError, TypeError):
+        return False
+
+
 def _plot_args_replacer(args, data):
     if len(args) == 1:
         return ["y"]
     elif len(args) == 2:
         # this can be two cases: x,y or y,c
-        if (not args[1] in data and
-            not (hasattr(data, 'dtype') and
-                 hasattr(data.dtype, 'names') and
-                 data.dtype.names is not None and
-                 args[1] in data.dtype.names)):
-            # this is not in data, so just assume that it is something which
-            # will not get replaced (color spec or array like).
+        if not _has_item(data, args[1]):
             return ["y", "c"]
         # it's data, but could be a color code like 'ro' or 'b--'
         # -> warn the user in that case...

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -51,9 +51,9 @@ def _has_item(data, name):
     availability) and with numpy.arrays.
     """
     try:
-        return name in data or name in data.dtype.names
-    except (AttributeError, TypeError):
-        return False
+        return data.dtype.names is not None and name in data.dtype.names
+    except AttributeError:  # not a numpy array
+        return name in data
 
 
 def _plot_args_replacer(args, data):


### PR DESCRIPTION
## PR Summary

This is a follow-up to #10810. Basically it cleans up the code structure. The logic in the PR is the same, just rewritten to be more clear.

### Additional follow up question

As part of the cleanup, I realized that we are not exactly checking what we want to know:
- *Want to know* whether *data* as an item named *name*.
- *Check* `name in data or name in data.dtype.names`.

That works for usual data (dict like and numpy.array), but may fail e.g. if a user would use a string-list for data. I assume that's ok-ish.

I think there is no real "has_item()" function and the only exact way of finding out if `data[name]` works is really trying and catching a possible exception. I assume we don't want to really pull data as part of this check.

So in total the present check is still the check we want to do. Please correct me if I'm wrong here.