### PR TITLE
[wip] Replace _remove_method by _on_remove list of callbacks

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -378,7 +378,7 @@ class Axes(_AxesBase):
         if len(extra_args):
             raise TypeError('legend only accepts two non-keyword arguments')
         self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
-        self.legend_._remove_method = self._remove_legend
+        self.legend_._on_remove = [self._remove_legend]
         return self.legend_
 
     def _remove_legend(self, legend):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1860,7 +1860,7 @@ class _AxesBase(martist.Artist):
         """
         a.axes = self
         self.artists.append(a)
-        a._remove_method = self.artists.remove
+        a._on_remove = [self.artists.remove]
         self._set_artist_props(a)
         a.set_clip_path(self.patch)
         self.stale = True
@@ -1877,7 +1877,7 @@ class _AxesBase(martist.Artist):
         if not label:
             collection.set_label('_collection%d' % len(self.collections))
         self.collections.append(collection)
-        collection._remove_method = self.collections.remove
+        collection._on_remove = [self.collections.remove]
         self._set_artist_props(collection)
 
         if collection.get_clip_path() is None:
@@ -1899,7 +1899,7 @@ class _AxesBase(martist.Artist):
         if not image.get_label():
             image.set_label('_image%d' % len(self.images))
         self.images.append(image)
-        image._remove_method = self.images.remove
+        image._on_remove = [self.images.remove]
         self.stale = True
         return image
 
@@ -1922,7 +1922,7 @@ class _AxesBase(martist.Artist):
         if not line.get_label():
             line.set_label('_line%d' % len(self.lines))
         self.lines.append(line)
-        line._remove_method = self.lines.remove
+        line._on_remove = [self.lines.remove]
         self.stale = True
         return line
 
@@ -1932,7 +1932,7 @@ class _AxesBase(martist.Artist):
         """
         self._set_artist_props(txt)
         self.texts.append(txt)
-        txt._remove_method = self.texts.remove
+        txt._on_remove = [self.texts.remove]
         self.stale = True
         return txt
 
@@ -1995,7 +1995,7 @@ class _AxesBase(martist.Artist):
             p.set_clip_path(self.patch)
         self._update_patch_limits(p)
         self.patches.append(p)
-        p._remove_method = self.patches.remove
+        p._on_remove = [self.patches.remove]
         return p
 
     def _update_patch_limits(self, patch):
@@ -2041,7 +2041,7 @@ class _AxesBase(martist.Artist):
         self._set_artist_props(tab)
         self.tables.append(tab)
         tab.set_clip_path(self.patch)
-        tab._remove_method = self.tables.remove
+        tab._on_remove = [self.tables.remove]
         return tab
 
     def add_container(self, container):
@@ -2055,7 +2055,7 @@ class _AxesBase(martist.Artist):
         if not label:
             container.set_label('_container%d' % len(self.containers))
         self.containers.append(container)
-        container._remove_method = self.containers.remove
+        container._on_remove = [self.containers.remove]
         return container
 
     def _on_units_changed(self, scalex=False, scaley=False):

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -22,23 +22,21 @@ class Container(tuple):
         self.eventson = False  # fire events only if eventson
         self._oid = 0  # an observer id
         self._propobservers = {}  # a dict from oids to funcs
-
-        self._remove_method = None
+        self._on_remove = []
 
         self.set_label(label)
 
     @cbook.deprecated("3.0")
     def set_remove_method(self, f):
-        self._remove_method = f
+        self._on_remove = [f]
 
     def remove(self):
         for c in cbook.flatten(
                 self, scalarp=lambda x: isinstance(x, martist.Artist)):
             if c is not None:
                 c.remove()
-
-        if self._remove_method:
-            self._remove_method(self)
+        for cb in self._on_remove:
+            cb(self)
 
     def get_label(self):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -885,7 +885,7 @@ default: 'top'
         if norm is None:
             im.set_clim(vmin, vmax)
         self.images.append(im)
-        im._remove_method = self.images.remove
+        im._on_remove = [self.images.remove]
         self.stale = True
         return im
 
@@ -1157,7 +1157,7 @@ default: 'top'
 
         self._axstack.add(key, a)
         self.sca(a)
-        a._remove_method = self._remove_ax
+        a._on_remove = [self._remove_ax]
         self.stale = True
         a.stale_callback = _stale_figure_callback
         return a
@@ -1264,7 +1264,7 @@ default: 'top'
             a = subplot_class_factory(projection_class)(self, *args, **kwargs)
         self._axstack.add(key, a)
         self.sca(a)
-        a._remove_method = self._remove_ax
+        a._on_remove = [self._remove_ax]
         self.stale = True
         a.stale_callback = _stale_figure_callback
         return a
@@ -1598,7 +1598,7 @@ default: 'top'
             pass
         l = mlegend.Legend(self, handles, labels, *extra_args, **kwargs)
         self.legends.append(l)
-        l._remove_method = self.legends.remove
+        l._on_remove = [self.legends.remove]
         self.stale = True
         return l
 
@@ -1626,7 +1626,7 @@ default: 'top'
         t.update(override)
         self._set_artist_props(t)
         self.texts.append(t)
-        t._remove_method = self.texts.remove
+        t._on_remove = [self.texts.remove]
         self.stale = True
         return t
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1115,9 +1115,8 @@ class Legend(Artist):
 
         if state:
             if self._draggable is None:
-                self._draggable = DraggableLegend(self,
-                                                  use_blit,
-                                                  update=update)
+                self._draggable = DraggableLegend(
+                    self, use_blit, update=update)
         else:
             if self._draggable is not None:
                 self._draggable.disconnect()

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1107,22 +1107,25 @@ class Legend(Artist):
         when dragged. If update is "loc", the *loc* parameter of the legend
         is changed. If "bbox", the *bbox_to_anchor* parameter is changed.
         """
-        is_draggable = self._draggable is not None
-
         # if state is None we'll toggle
         if state is None:
-            state = not is_draggable
+            state = self._draggable is None
 
         if state:
             if self._draggable is None:
                 self._draggable = DraggableLegend(
                     self, use_blit, update=update)
+                self._on_remove.append(self._set_undraggable)
         else:
-            if self._draggable is not None:
-                self._draggable.disconnect()
-            self._draggable = None
+            self._set_undraggable()
 
         return self._draggable
+
+    def _set_undraggable(self, _=None):
+        if self._draggable is not None:
+            self._on_remove.remove(self._set_undraggable)
+            self._draggable.disconnect()
+            self._draggable = None
 
 
 # Helper functions to parse legend arguments for both `figure.legend` and

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1837,21 +1837,25 @@ class _AnnotationBase(object):
         draggable is on.
         """
         from matplotlib.offsetbox import DraggableAnnotation
-        is_draggable = self._draggable is not None
 
         # if state is None we'll toggle
         if state is None:
-            state = not is_draggable
+            state = self._draggable is None
 
         if state:
             if self._draggable is None:
                 self._draggable = DraggableAnnotation(self, use_blit)
+                self._on_remove.append(self._set_undraggable)
         else:
-            if self._draggable is not None:
-                self._draggable.disconnect()
-            self._draggable = None
+            self._set_undraggable()
 
         return self._draggable
+
+    def _set_undraggable(self, _=None):
+        if self._draggable is not None:
+            self._on_remove.remove(self._set_undraggable)
+            self._draggable.disconnect()
+            self._draggable = None
 
 
 class Annotation(Text, _AnnotationBase):

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -242,7 +242,7 @@ class HostAxesBase(object):
         # note that ax2.transData == tr + ax1.transData
         # Anthing you draw in ax2 will match the ticks and grids of ax1.
         self.parasites.append(ax2)
-        ax2._remove_method = self.parasites.remove
+        ax2._on_remove = [self.parasites.remove]
         return ax2
 
     def _get_legend_handles(self, legend_handler_map=None):
@@ -303,7 +303,7 @@ class HostAxesBase(object):
 
         ax2 = parasite_axes_class(self, sharex=self, frameon=False)
         self.parasites.append(ax2)
-        ax2._remove_method = self._remove_twinx
+        ax2._on_remove = [self._remove_twinx]
 
         self.axis["right"].set_visible(False)
 
@@ -332,7 +332,7 @@ class HostAxesBase(object):
 
         ax2 = parasite_axes_class(self, sharey=self, frameon=False)
         self.parasites.append(ax2)
-        ax2._remove_method = self._remove_twiny
+        ax2._on_remove = [self._remove_twiny]
 
         self.axis["top"].set_visible(False)
 
@@ -367,7 +367,6 @@ class HostAxesBase(object):
             ax2 = parasite_axes_auxtrans_class(
                 self, aux_trans, viewlim_mode="transform")
         self.parasites.append(ax2)
-        ax2._remove_method = self.parasites.remove
 
         self.axis["top", "right"].set_visible(False)
 
@@ -378,7 +377,7 @@ class HostAxesBase(object):
             self.parasites.remove(h)
             self.axis["top", "right"].set_visible(True)
             self.axis["top", "right"].toggle(ticklabels=False, label=False)
-        ax2._remove_method = _remove_method
+        ax2._on_remove = [_remove_method]
 
         return ax2
 


### PR DESCRIPTION
## PR Summary

First commit replaces Artist._remove_method (called by Artist.remove) by a list of callbacks (with the same signature), Artist._on_remove.

Second commit shows the use case of such a change: it allows us to disconnect the dragging handlers when an artist is removed from an axes.  An minimal example is the following:

```
from pylab import *
rcdefaults()

ann = gca().annotate(
    "hello", xy=(.4, .4), xytext=(.6, .6), arrowprops={"arrowstyle": "->"})
ann.draggable(True, use_blit=True)

def handler(event):
    ann.remove()
    gcf().canvas.draw()

gcf().canvas.mpl_connect("pick_event", handler)

plt.show()
```

and click on the annotation and try to drag it.  As of master, this cause the following exception to be printed:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/matplotlib/cbook/__init__.py", line 388, in process
    proxy(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/matplotlib/cbook/__init__.py", line 228, in __call__
    return mtd(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/matplotlib/offsetbox.py", line 1672, in on_motion_blit
    self.ref_artist.draw(self.ref_artist.figure._cachedRenderer)
AttributeError: 'NoneType' object has no attribute '_cachedRenderer'
```
and this is fixed by the PR.  (Note that clicking a second time would cause a different exception, independently of this PR, due to the fact that an artist cannot be removed twice.)

This may seem to be a slightly obscure case, but I have a real use case in https://github.com/anntzer/mplcursors: there, clicking on an artist will create an annotation on that artist, *removing a previously created annotation* (on another artist); then, moving the mouse would try to drag the now deleted annotation.

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is PEP 8 compliant

Only touches private API.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
