### PR TITLE
Deprecate two-args for cycler() and set_prop_cycle()

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -23,3 +23,7 @@ The following classes, methods, functions, and attributes are deprecated:
 
 The following rcParams are deprecated:
 - ``pgf.debug`` (the pgf backend relies on logging),
+
+The the two-argument forms of ``cycler(label, values)`` and
+``Axes.set_prop_cycle(label, values)`` are deprecated. Please use the keyword
+syntax ``cycler(label=values)``, ``set_prop_cycle(label=values)`` instead.

--- a/examples/api/filled_step.py
+++ b/examples/api/filled_step.py
@@ -180,8 +180,8 @@ hist_func = partial(np.histogram, bins=edges)
 
 # set up style cycles
 color_cycle = cycler(facecolor=plt.rcParams['axes.prop_cycle'][:4])
-label_cycle = cycler('label', ['set {n}'.format(n=n) for n in range(4)])
-hatch_cycle = cycler('hatch', ['/', '*', '+', '|'])
+label_cycle = cycler(label=['set {n}'.format(n=n) for n in range(4)])
+hatch_cycle = cycler(hatch=['/', '*', '+', '|'])
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)

--- a/examples/color/color_cycler.py
+++ b/examples/color/color_cycler.py
@@ -24,15 +24,15 @@ yy = np.transpose([np.sin(x + phi) for phi in offsets])
 
 # 1. Setting prop cycle on default rc parameter
 plt.rc('lines', linewidth=4)
-plt.rc('axes', prop_cycle=(cycler('color', ['r', 'g', 'b', 'y']) +
-                           cycler('linestyle', ['-', '--', ':', '-.'])))
+plt.rc('axes', prop_cycle=(cycler(color=['r', 'g', 'b', 'y']) +
+                           cycler(linestyle=['-', '--', ':', '-.'])))
 fig, (ax0, ax1) = plt.subplots(nrows=2)
 ax0.plot(yy)
 ax0.set_title('Set default color cycle to rgby')
 
 # 2. Define prop cycle for single set of axes
-ax1.set_prop_cycle(cycler('color', ['c', 'm', 'y', 'k']) +
-                   cycler('lw', [1, 2, 3, 4]))
+ax1.set_prop_cycle(cycler(color=['c', 'm', 'y', 'k']) +
+                   cycler(lw=[1, 2, 3, 4]))
 ax1.plot(yy)
 ax1.set_title('Set axes color cycle to cmyk')
 

--- a/examples/lines_bars_and_markers/markevery_prop_cycle.py
+++ b/examples/lines_bars_and_markers/markevery_prop_cycle.py
@@ -43,7 +43,7 @@ colors = ['#1f77b4',
 
 # Create two different cyclers to use with axes.prop_cycle
 markevery_cycler = cycler(markevery=cases)
-color_cycler = cycler('color', colors)
+color_cycler = cycler(color=colors)
 
 # Configure rcParams axes.prop_cycle with custom cycler
 custom_cycler = color_cycler + markevery_cycler

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1164,6 +1164,7 @@ class _AxesBase(martist.Artist):
         Form 1 simply sets given `Cycler` object.
 
         Form 2 creates and sets a `Cycler` from a label and an iterable.
+        *Note*: This API is deprecated. Please use keywords instead.
 
         Form 3 composes and sets a `Cycler` as an inner product of the
         pairs of keyword arguments. In other words, all of the
@@ -1189,7 +1190,7 @@ class _AxesBase(martist.Artist):
         Setting the property cycle for a single property:
 
         >>> ax.set_prop_cycle(color=['red', 'green', 'blue'])  # or
-        >>> ax.set_prop_cycle('color', ['red', 'green', 'blue'])
+        >>> ax.set_prop_cycle('color', ['red', 'green', 'blue'])  # deprecated
 
         Setting the property cycle for simultaneously cycling over multiple
         properties (e.g. red circle, green plus, blue cross):
@@ -1208,6 +1209,12 @@ class _AxesBase(martist.Artist):
                             "arguments to this method.")
         if len(args) == 1 and args[0] is None:
             prop_cycle = None
+        elif len(args) == 2:
+            cbook.warn_deprecated(
+                "3.0", "The two-argument form set_prop_cycle(name, values) is "
+                "deprecated. Please use the keyword form "
+                "set_prop_cycle(name=values) instead.")
+            prop_cycle = cycler(**{args[0]: args[1]})
         else:
             prop_cycle = cycler(*args, **kwargs)
         self._get_lines.set_prop_cycle(prop_cycle)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1236,7 +1236,7 @@ class _AxesBase(martist.Artist):
             # set_prop_cycle('color', None). So we are special-casing this.
             self.set_prop_cycle(None)
         else:
-            self.set_prop_cycle('color', clist)
+            self.set_prop_cycle(color=clist)
 
     @cbook.deprecated("2.0")
     def ishold(self):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -756,6 +756,7 @@ def cycler(*args, **kwargs):
     Form 1 simply copies a given `Cycler` object.
 
     Form 2 creates a `Cycler` from a label and an iterable.
+    *Note*: This API is deprecated. Please use keywords instead.
 
     Form 3 composes a `Cycler` as an inner product of the
     pairs of keyword arguments. In other words, all of the
@@ -785,7 +786,7 @@ def cycler(*args, **kwargs):
     Creating a cycler for a single property:
 
     >>> c = cycler(color=['red', 'green', 'blue'])  # or
-    >>> c = cycler('color', ['red', 'green', 'blue'])
+    >>> c = cycler('color', ['red', 'green', 'blue'])  # deprecated
 
     Creating a cycler for simultaneously cycling over multiple properties
     (e.g. red circle, green plus, blue cross):
@@ -806,6 +807,9 @@ def cycler(*args, **kwargs):
                             " be a Cycler instance.")
         return validate_cycler(args[0])
     elif len(args) == 2:
+        cbook.warn_deprecated(
+            "3.0", "The two-argument form cycler(name, values) is deprecated. "
+            "Please use the keyword form cycler(name=values) instead.")
         pairs = [(args[0], args[1])]
     elif len(args) > 2:
         raise TypeError("No more than 2 positional arguments allowed")

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -786,7 +786,7 @@ def cycler(*args, **kwargs):
     Creating a cycler for a single property:
 
     >>> c = cycler(color=['red', 'green', 'blue'])  # or
-    >>> c = cycler('color', ['red', 'green', 'blue'])  # deprecated
+    >>> c = cycler(color=['red', 'green', 'blue'])  # deprecated
 
     Creating a cycler for simultaneously cycling over multiple properties
     (e.g. red circle, green plus, blue cross):

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -66,7 +66,7 @@ def stackplot(axes, x, *args, **kwargs):
 
     colors = kwargs.pop('colors', None)
     if colors is not None:
-        axes.set_prop_cycle(cycler('color', colors))
+        axes.set_prop_cycle(cycler(color=colors))
 
     baseline = kwargs.pop('baseline', 'zero')
     # Assume data passed has not been 'stacked', so stack it here.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4951,8 +4951,8 @@ def test_violin_point_mass():
 
 
 def generate_errorbar_inputs():
-    base_xy = cycler('x', [np.arange(5)]) + cycler('y', [np.ones((5, ))])
-    err_cycler = cycler('err', [1,
+    base_xy = cycler(x=[np.arange(5)]) + cycler(y=[np.ones((5, ))])
+    err_cycler = cycler(err=[1,
                                 [1, 1, 1, 1, 1],
                                 [[1, 1, 1, 1, 1],
                                  [1, 1, 1, 1, 1]],
@@ -4962,11 +4962,11 @@ def generate_errorbar_inputs():
                                 np.ones((5, 1)),
                                 None
                                 ])
-    xerr_cy = cycler('xerr', err_cycler)
-    yerr_cy = cycler('yerr', err_cycler)
+    xerr_cy = cycler(xerr=err_cycler)
+    yerr_cy = cycler(yerr=err_cycler)
 
-    empty = ((cycler('x', [[]]) + cycler('y', [[]])) *
-             cycler('xerr', [[], None]) * cycler('yerr', [[], None]))
+    empty = ((cycler(x=[[]]) + cycler(y=[[]])) *
+             cycler(xerr=[[], None]) * cycler(yerr=[[], None]))
     xerr_only = base_xy * xerr_cy
     yerr_only = base_xy * yerr_cy
     both_err = base_xy * yerr_cy * xerr_cy

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -631,7 +631,7 @@ def test_cn():
     assert mcolors.to_hex("C0") == '#0343df'
     assert mcolors.to_hex("C1") == '#ff0000'
 
-    matplotlib.rcParams['axes.prop_cycle'] = cycler('color', ['8e4585', 'r'])
+    matplotlib.rcParams['axes.prop_cycle'] = cycler(color=['8e4585', 'r'])
 
     assert mcolors.to_hex("C0") == '#8e4585'
     # if '8e4585' gets parsed as a float before it gets detected as a hex

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -14,7 +14,7 @@ from cycler import cycler
 def test_colorcycle_basic():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('color', ['r', 'g', 'y']))
+    ax.set_prop_cycle(cycler(color=['r', 'g', 'y']))
     xs = np.arange(10)
     ys = 0.25 * xs + 2
     ax.plot(xs, ys, label='red', lw=4)
@@ -32,8 +32,8 @@ def test_colorcycle_basic():
 def test_marker_cycle():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('c', ['r', 'g', 'y']) +
-                      cycler('marker', ['.', '*', 'x']))
+    ax.set_prop_cycle(cycler(c=['r', 'g', 'y']) +
+                      cycler(marker=['.', '*', 'x']))
     xs = np.arange(10)
     ys = 0.25 * xs + 2
     ax.plot(xs, ys, label='red dot', lw=4, ms=16)
@@ -67,7 +67,7 @@ def test_marker_cycle():
 def test_linestylecycle_basic():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('ls', ['-', '--', ':']))
+    ax.set_prop_cycle(cycler(ls=['-', '--', ':']))
     xs = np.arange(10)
     ys = 0.25 * xs + 2
     ax.plot(xs, ys, label='solid', lw=4, color='k')
@@ -85,9 +85,9 @@ def test_linestylecycle_basic():
 def test_fillcycle_basic():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('c',  ['r', 'g', 'y']) +
-                      cycler('hatch', ['xx', 'O', '|-']) +
-                      cycler('linestyle', ['-', '--', ':']))
+    ax.set_prop_cycle(cycler(c=['r', 'g', 'y']) +
+                      cycler(hatch=['xx', 'O', '|-']) +
+                      cycler(linestyle=['-', '--', ':']))
     xs = np.arange(10)
     ys = 0.25 * xs**.5 + 2
     ax.fill(xs, ys, label='red, xx', linewidth=3)
@@ -105,9 +105,9 @@ def test_fillcycle_basic():
 def test_fillcycle_ignore():
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.set_prop_cycle(cycler('color',  ['r', 'g', 'y']) +
-                      cycler('hatch', ['xx', 'O', '|-']) +
-                      cycler('marker', ['.', '*', 'D']))
+    ax.set_prop_cycle(cycler(color=['r', 'g', 'y']) +
+                      cycler(hatch=['xx', 'O', '|-']) +
+                      cycler(marker=['.', '*', 'D']))
     xs = np.arange(10)
     ys = 0.25 * xs**.5 + 2
     # Should not advance the cycler, even though there is an
@@ -128,7 +128,7 @@ def test_fillcycle_ignore():
                   remove_text=True, extensions=['png'])
 def test_property_collision_plot():
     fig, ax = plt.subplots()
-    ax.set_prop_cycle('linewidth', [2, 4])
+    ax.set_prop_cycle(linewidth=[2, 4])
     for c in range(1, 4):
         ax.plot(np.arange(10), c * np.arange(10), lw=0.1, color='k')
     ax.plot(np.arange(10), 4 * np.arange(10), color='k')
@@ -152,16 +152,16 @@ def test_valid_input_forms():
     fig, ax = plt.subplots()
     # These should not raise an error.
     ax.set_prop_cycle(None)
-    ax.set_prop_cycle(cycler('linewidth', [1, 2]))
-    ax.set_prop_cycle('color', 'rgywkbcm')
-    ax.set_prop_cycle('lw', (1, 2))
-    ax.set_prop_cycle('linewidth', [1, 2])
-    ax.set_prop_cycle('linewidth', iter([1, 2]))
-    ax.set_prop_cycle('linewidth', np.array([1, 2]))
-    ax.set_prop_cycle('color', np.array([[1, 0, 0],
-                                         [0, 1, 0],
-                                         [0, 0, 1]]))
-    ax.set_prop_cycle('dashes', [[], [13, 2], [8, 3, 1, 3], [None, None]])
+    ax.set_prop_cycle(cycler(linewidth=[1, 2]))
+    ax.set_prop_cycle(color='rgywkbcm')
+    ax.set_prop_cycle(lw=(1, 2))
+    ax.set_prop_cycle(linewidth=[1, 2])
+    ax.set_prop_cycle(linewidth=iter([1, 2]))
+    ax.set_prop_cycle(linewidth=np.array([1, 2]))
+    ax.set_prop_cycle(color=np.array([[1, 0, 0],
+                                      [0, 1, 0],
+                                      [0, 0, 1]]))
+    ax.set_prop_cycle(dashes=[[], [13, 2], [8, 3, 1, 3], [None, None]])
     ax.set_prop_cycle(lw=[1, 2], color=['k', 'w'], ls=['-', '--'])
     ax.set_prop_cycle(lw=np.array([1, 2]),
                       color=np.array(['k', 'w']),
@@ -202,17 +202,17 @@ def test_invalid_input_forms():
         ax.set_prop_cycle([1, 2])
 
     with pytest.raises((TypeError, ValueError)):
-        ax.set_prop_cycle('color', 'fish')
+        ax.set_prop_cycle(color='fish')
 
     with pytest.raises((TypeError, ValueError)):
-        ax.set_prop_cycle('linewidth', 1)
+        ax.set_prop_cycle(linewidth=1)
     with pytest.raises((TypeError, ValueError)):
-        ax.set_prop_cycle('linewidth', {'1': 1, '2': 2})
+        ax.set_prop_cycle(linewidth={'1': 1, '2': 2})
     with pytest.raises((TypeError, ValueError)):
         ax.set_prop_cycle(linewidth=1, color='r')
 
     with pytest.raises((TypeError, ValueError)):
-        ax.set_prop_cycle('foobar', [1, 2])
+        ax.set_prop_cycle(foobar=[1, 2])
     with pytest.raises((TypeError, ValueError)):
         ax.set_prop_cycle(foobar=[1, 2])
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -237,21 +237,21 @@ def generate_validator_testcases(valid):
         {'validator': validate_cycler,
          'success': (('cycler("color", "rgb")',
                       cycler("color", 'rgb')),
-                     (cycler('linestyle', ['-', '--']),
-                      cycler('linestyle', ['-', '--'])),
+                     (cycler(linestyle=['-', '--']),
+                      cycler(linestyle=['-', '--'])),
                      ("""(cycler("color", ["r", "g", "b"]) +
                           cycler("mew", [2, 3, 5]))""",
                       (cycler("color", 'rgb') +
                           cycler("markeredgewidth", [2, 3, 5]))),
                      ("cycler(c='rgb', lw=[1, 2, 3])",
-                      cycler('color', 'rgb') + cycler('linewidth', [1, 2, 3])),
-                     ("cycler('c', 'rgb') * cycler('linestyle', ['-', '--'])",
-                      (cycler('color', 'rgb') *
-                          cycler('linestyle', ['-', '--']))),
-                     (cycler('ls', ['-', '--']),
-                      cycler('linestyle', ['-', '--'])),
+                      cycler(color='rgb') + cycler(linewidth=[1, 2, 3])),
+                     ("cycler(c='rgb') * cycler(linestyle=['-', '--'])",
+                      (cycler(color='rgb') *
+                          cycler(linestyle=['-', '--']))),
+                     (cycler(ls=['-', '--']),
+                      cycler(linestyle=['-', '--'])),
                      (cycler(mew=[2, 5]),
-                      cycler('markeredgewidth', [2, 5])),
+                      cycler(markeredgewidth=[2, 5])),
                     ),
          # This is *so* incredibly important: validate_cycler() eval's
          # an arbitrary string! I think I have it locked down enough,
@@ -273,8 +273,8 @@ def generate_validator_testcases(valid):
                   ('cycler("waka", [1, 2, 3])', ValueError),  # not a property
                   ('cycler(c=[1, 2, 3])', ValueError),  # invalid values
                   ("cycler(lw=['a', 'b', 'c'])", ValueError),  # invalid values
-                  (cycler('waka', [1, 3, 5]), ValueError),  # not a property
-                  (cycler('color', ['C1', 'r', 'g']), ValueError)  # no CN
+                  (cycler(waka=[1, 3, 5]), ValueError),  # not a property
+                  (cycler(color=['C1', 'r', 'g']), ValueError)  # no CN
                  )
         },
         {'validator': validate_hatch,

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -322,7 +322,7 @@ backend      : $TEMPLATE_BACKEND
 #axes.unicode_minus  : True    ## use unicode for the minus symbol
                                ## rather than hyphen.  See
                                ## http://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
-#axes.prop_cycle    : cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
+#axes.prop_cycle    : cycler(color=['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
                       ## color cycle for plot lines  as list of string
                       ## colorspecs: single letter, long name, or web-style hex
 					  ## Note the use of string escapes here ('1f77b4', instead of 1f77b4)

--- a/tutorials/intermediate/color_cycle.py
+++ b/tutorials/intermediate/color_cycle.py
@@ -39,8 +39,8 @@ print(yy.shape)
 # cycler and a linestyle cycler by adding (``+``) two ``cycler``'s together.
 # See the bottom of this tutorial for more information about combining
 # different cyclers.
-default_cycler = cycler('color', ['r', 'g', 'b', 'y']) \
-                    + cycler('linestyle', ['-', '--', ':', '-.'])
+default_cycler = cycler(color=['r', 'g', 'b', 'y']) \
+                    + cycler(linestyle=['-', '--', ':', '-.'])
 
 plt.rc('lines', linewidth=4)
 plt.rc('axes', prop_cycle=default_cycler)
@@ -52,8 +52,8 @@ plt.rc('axes', prop_cycle=default_cycler)
 # which will only set the ``prop_cycle`` for this :mod:`matplotlib.axes.Axes`
 # instance. We'll use a second ``cycler`` that combines a color cycler and a
 # linewidth cycler.
-custom_cycler = cycler('color', ['c', 'm', 'y', 'k']) \
-    + cycler('lw', [1, 2, 3, 4])
+custom_cycler = cycler(color=['c', 'm', 'y', 'k']) \
+    + cycler(lw=[1, 2, 3, 4])
 
 fig, (ax0, ax1) = plt.subplots(nrows=2)
 ax0.plot(yy)
@@ -76,7 +76,7 @@ plt.show()
 #
 # ..code-block:: python
 #
-#    axes.prop_cycle    : cycler('color', 'bgrcmyk')
+#    axes.prop_cycle    : cycler(color='bgrcmyk')
 #
 # Cycling through multiple properties
 # -----------------------------------


### PR DESCRIPTION
## PR Summary

Following a discussion in #10662, this deprecates the two-arg forms
- ``rcsetup.cycler(label, values)``
- ``Axes.set_prop_cycle(label, values)``
in favor of their keyword equivalents
- ``rcsetup.cycler(label=values)``
- ``Axes.set_prop_cycle(label=values)``


## PR Checklist

- [x] Code is PEP 8 compliant
- [x] Documentation is sphinx and numpydoc compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

