### PR TITLE
FIX: make un-used ticks not be visible

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1102,6 +1102,9 @@ class Axis(artist.Artist):
             tick.set_label1(label)
             tick.set_label2(label)
             if not mtransforms.interval_contains(interval_expanded, loc):
+                tick.set_visible(False)
+                tick.label1.set_visible(False)
+                tick.label2.set_visible(False)
                 continue
             ticks_to_draw.append(tick)
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1102,9 +1102,17 @@ class Axis(artist.Artist):
             tick.set_label1(label)
             tick.set_label2(label)
             if not mtransforms.interval_contains(interval_expanded, loc):
-                tick.set_visible(False)
                 tick.label1.set_visible(False)
                 tick.label2.set_visible(False)
+                tick.tick1line.set_visible(False)
+                try:
+                    self.tick2line.set_visible(False)
+                except AttributeError:
+                    pass
+                try:
+                    self.gridline.set_visible(False)
+                except AttributeError:
+                    pass
                 continue
             ticks_to_draw.append(tick)
 


### PR DESCRIPTION
## PR Summary

Addresses #10874 

This code fails master:

```python
import matplotlib
matplotlib.use('Agg')
import matplotlib.pyplot as plt

fig = plt.figure()
ax = fig.add_subplot(111, frameon=True)
ax.plot()

plt.get_current_fig_manager().canvas.draw()

for xtick in ax.get_xticklabels():
    xtick.get_window_extent()
```

This was originally caused by #9452 adding string data to the tick labels that were not seen.  Previously `get_window_extent` would bail on an empty string.  But after #9452 the labels were not empty.  But they were never drawn, so they never had `self._renderer` assigned.  This makes the labels to be visible if they are not visible, and that causes `get_window_extent` to ignore them.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->