### PR TITLE
Added feature (Make pie charts circular by default #10789)

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2672,8 +2672,6 @@ class Axes(_AxesBase):
         The pie chart will probably look best if the figure and axes are
         square, or the Axes aspect is equal.
         """
-        self.set_aspect('equal')
-
         x = np.array(x, np.float32)
 
         sx = x.sum()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2672,6 +2672,8 @@ class Axes(_AxesBase):
         The pie chart will probably look best if the figure and axes are
         square, or the Axes aspect is equal.
         """
+        self.set_aspect('equal')
+
         x = np.array(x, np.float32)
 
         sx = x.sum()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2672,6 +2672,7 @@ class Axes(_AxesBase):
         The pie chart will probably look best if the figure and axes are
         square, or the Axes aspect is equal.
         """
+        self.set_aspect('equal')
         x = np.array(x, np.float32)
 
         sx = x.sum()


### PR DESCRIPTION
## PR Summary
github.com/matplotlib/matplotlib/issues/10789
As seen in the issue link above, a simple way to generate a pie graph is using plt.pie, and the second method to generate a pie graph is by using plt.subplots. Both of these approaches creates the pie graph through _axes.py by using an Axes instance which calls its pie method; the additional line to add calls the set_aspect function, which sets the aspect of the axis scaling, with ‘equals’ as parameters and this results in a default circular pie graph with an equal aspect ratio as wanted.

Here is the travis test: https://travis-ci.org/jerrylui803/matplotlib/builds/358696515

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
