### PR TITLE
Update install instructions for win

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -294,14 +294,14 @@ without fiddling with environment variables::
   conda install -c conda-forge msinttypes
 
   # copy the libs which have "wrong" names
-  set LIBRARY_LIB=%CONDA_DEFAULT_ENV%\Library\lib
+  set LIBRARY_LIB=%CONDA_PREFIX%\Library\lib
   mkdir lib || cmd /c "exit /b 0"
   copy %LIBRARY_LIB%\zlibstatic.lib lib\z.lib
   copy %LIBRARY_LIB%\libpng_static.lib lib\png.lib
 
   # Make the header files and the rest of the static libs available during the build
   # CONDA_DEFAULT_ENV is a env variable which is set to the currently active environment path
-  set MPLBASEDIRLIST=%CONDA_DEFAULT_ENV%\Library\;.
+  set MPLBASEDIRLIST=%CONDA_PREFIX%\Library\;.
 
   # build the wheel
   python setup.py bdist_wheel


### PR DESCRIPTION
## PR Summary

This is a small update on the install instructions for Windows.

For newer versions of conda the environment variable `%CONDA_DEFAULT_ENV%` points to the *name*  of the environment, not the *path*. Instead `%CONDA_PREFIX%` points to the path which has to be used for copying the files during the build. 

This change is correctly reflected in the `build_alllocal.cmd`

https://github.com/matplotlib/matplotlib/blob/c29d9b21ccdd97d3727d979a02376906a52c3ca1/build_alllocal.cmd#L24

but the documentation needs to be updated as well; at least if we do not want people to spend an hour trying to figure out what's wrong with their built like I just did.

