### PR TITLE
Replace "matplotlibrc" by "rcParams" in the docs where applicable.

### DIFF
--- a/doc/matplotlibrc
+++ b/doc/matplotlibrc
@@ -1,16 +1,4 @@
-backend      : Agg
-
-figure.figsize   : 5.5, 4.5    # figure size in inches
-savefig.dpi       : 80      # figure dots per inch
-docstring.hardcopy : True  # set this when you want to generate hardcopy docstring
-
-# these parameters are useful for packagers who want to build the docs
-# w/o invoking file downloads for the sampledata (see
-# matplotlib.cbook.get_sample_data.  Unpack
-# mpl_sampledata-VERSION.tar.gz and point examples.directory to it.
-# You can use a relative path for examples.directory and it must be
-# relative to this matplotlibrc file
-
-#examples.download : False  # False to bypass downloading mechanism
-#examples.directory : /your/path/to/sample_data/   # directory to look in if download is false
-
+backend            : Agg
+figure.figsize     : 5.5, 4.5 # figure size in inches
+savefig.dpi        : 80       # figure dots per inch
+docstring.hardcopy : True     # set this when you want to generate hardcopy docstring

--- a/examples/api/sankey_basics.py
+++ b/examples/api/sankey_basics.py
@@ -67,10 +67,9 @@ diagrams[0].text.set_fontweight('bold')
 # Notice:
 #
 # 1. Since the sum of the flows is nonzero, the width of the trunk isn't
-#    uniform.  If verbose.level is helpful (in matplotlibrc), a message is
-#    given in the terminal window.
-# 2. The second flow doesn't appear because its value is zero.  Again, if
-#    verbose.level is helpful, a message is given in the terminal window.
+#    uniform.  The matplotlib logging system logs this at the DEBUG level.
+# 2. The second flow doesn't appear because its value is zero.  Again, this is
+#    logged at the DEBUG level.
 
 
 ###############################################################################

--- a/examples/api/unicode_minus.py
+++ b/examples/api/unicode_minus.py
@@ -3,13 +3,15 @@
 Unicode minus
 =============
 
-You can use the proper typesetting Unicode minus (see
-https://en.wikipedia.org/wiki/Plus_sign#Plus_sign) or the ASCII hyphen
-for minus, which some people prefer.  The matplotlibrc param
-axes.unicode_minus controls the default behavior.
+You can use the proper typesetting `Unicode minus`__ or the ASCII hyphen for
+minus, which some people prefer.  :rc:`axes.unicode_minus` controls the default
+behavior.
+
+__ https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
 
 The default is to use the Unicode minus.
 """
+
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt

--- a/examples/ticks_and_spines/tick_xlabel_top.py
+++ b/examples/ticks_and_spines/tick_xlabel_top.py
@@ -7,9 +7,10 @@ We can use :rc:`xtick.labeltop` (default False) and :rc:`xtick.top`
 (default False) and :rc:`xtick.labelbottom` (default True) and
 :rc:`xtick.bottom` (default True) to control where on the axes ticks and
 their labels appear.
-These properties can also be set in the ``.matplotlib/matplotlibrc``.
 
+These properties can also be set in ``.matplotlib/matplotlibrc``.
 """
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3369,8 +3369,7 @@ class Axes(_AxesBase):
 
         """
 
-        # If defined in matplotlibrc, apply the value from rc file
-        # Overridden if argument is passed
+        # Missing arguments default to rcParams.
         if whis is None:
             whis = rcParams['boxplot.whiskers']
         if bootstrap is None:

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2454,7 +2454,7 @@ def key_press_handler(event, canvas, toolbar=None):
     if event.key is None:
         return
 
-    # Load key-mappings from your matplotlibrc file.
+    # Load key-mappings from rcParams.
     fullscreen_keys = rcParams['keymap.fullscreen']
     home_keys = rcParams['keymap.home']
     back_keys = rcParams['keymap.back']

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -521,11 +521,10 @@ class FigureCanvasAgg(FigureCanvasBase):
             Other Parameters
             ----------------
             quality : int
-                The image quality, on a scale from 1 (worst) to
-                95 (best). The default is 95, if not given in the
-                matplotlibrc file in the savefig.jpeg_quality parameter.
-                Values above 95 should be avoided; 100 completely
-                disables the JPEG quantization stage.
+                The image quality, on a scale from 1 (worst) to 100 (best).
+                The default is :rc:`savefig.jpeg_quality`.  Values above
+                95 should be avoided; 100 completely disables the JPEG
+                quantization stage.
 
             optimize : bool
                 If present, indicates that the encoder should
@@ -543,7 +542,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             # handle any transparency
             image = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
             rgba = mcolors.to_rgba(rcParams['savefig.facecolor'])
-            color = tuple([int(x * 255.0) for x in rgba[:3]])
+            color = tuple([int(x * 255) for x in rgba[:3]])
             background = Image.new('RGB', size, color)
             background.paste(image, image)
             options = {k: kwargs[k]

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1743,8 +1743,7 @@ class QuadContourSet(ContourSet):
         contour-only keyword arguments:
 
           *linewidths*: [ *None* | number | tuple of numbers ]
-            If *linewidths* is *None*, the default width in
-            ``lines.linewidth`` in ``matplotlibrc`` is used.
+            If *None*, defaults to :rc:`lines.linewidth`.
 
             If a number, all levels will be plotted with this linewidth.
 
@@ -1752,10 +1751,9 @@ class QuadContourSet(ContourSet):
             linewidths in the order specified.
 
           *linestyles*: [ *None* | 'solid' | 'dashed' | 'dashdot' | 'dotted' ]
-            If *linestyles* is *None*, the default is 'solid' unless
-            the lines are monochrome.  In that case, negative
-            contours will take their linestyle from the ``matplotlibrc``
-            ``contour.negative_linestyle`` setting.
+            If *linestyles* is *None*, the default is 'solid' unless the lines
+            are monochrome.  In that case, negative contours will take their
+            linestyle from :rc:`contour.negative_linestyle` setting.
 
             *linestyles* can also be an iterable of the above strings
             specifying a set of linestyles to be used. If this

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1809,8 +1809,7 @@ default: 'top'
 
             If *format* is *None* and *fname* is a string, the output
             format is deduced from the extension of the filename. If
-            the filename has no extension, the value of the rc parameter
-            ``savefig.format`` is used.
+            the filename has no extension, :rc:`savefig.format` is used.
 
             If *fname* is not a string, remember to specify *format* to
             ensure that the correct backend is used.
@@ -1818,19 +1817,20 @@ default: 'top'
         Other Parameters
         ----------------
 
-        dpi : [ *None* | scalar > 0 | 'figure']
-            The resolution in dots per inch.  If *None* it will default to
-            the value ``savefig.dpi`` in the matplotlibrc file. If 'figure'
-            it will set the dpi to be the value of the figure.
+        dpi : [ *None* | scalar > 0 | 'figure' ]
+            The resolution in dots per inch.  If *None*, defaults to
+            :rc:`savefig.dpi`.  If 'figure', uses the figure's dpi value.
 
         facecolor : color spec or None, optional
-            the facecolor of the figure; if None, defaults to savefig.facecolor
+            The facecolor of the figure; if *None*, defaults to
+            :rc:`savefig.facecolor`.
 
         edgecolor : color spec or None, optional
-            the edgecolor of the figure; if None, defaults to savefig.edgecolor
+            The edgecolor of the figure; if *None*, defaults to
+            :rc:`savefig.edgecolor`
 
         orientation : {'landscape', 'portrait'}
-            not supported on all backends; currently only on postscript output
+            Currently only supported by the postscript backend.
 
         papertype : str
             One of 'letter', 'legal', 'executive', 'ledger', 'a0' through

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -556,7 +556,7 @@ class FontProperties(object):
         The items may include a generic font family name, either
         'serif', 'sans-serif', 'cursive', 'fantasy', or 'monospace'.
         In that case, the actual font to be used will be looked up
-        from the associated rcParam in :file:`matplotlibrc`.
+        from the associated rcParam.
 
       - style: Either 'normal', 'italic' or 'oblique'.
 
@@ -577,7 +577,7 @@ class FontProperties(object):
         absolute font size, e.g., 12
 
     The default font property for TrueType fonts (as specified in the
-    default :file:`matplotlibrc` file) is::
+    default rcParams) is::
 
       sans-serif, normal, normal, normal, normal, scalable.
 
@@ -596,9 +596,9 @@ class FontProperties(object):
     This support does not require fontconfig to be installed.  We are merely
     borrowing its pattern syntax for use here.
 
-    Note that matplotlib's internal font manager and fontconfig use a
+    Note that Matplotlib's internal font manager and fontconfig use a
     different algorithm to lookup fonts, so the results of the same pattern
-    may be different in matplotlib than in other applications that use
+    may be different in Matplotlib than in other applications that use
     fontconfig.
     """
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -467,8 +467,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
     to properly clean up the memory.
 
     rcParams defines the default values, which can be modified in the
-    matplotlibrc file
-
+    matplotlibrc file.
     """
 
     if figsize is None:

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -25,12 +25,7 @@ as follows::
   Z = texmanager.get_rgba(s, fontsize=12, dpi=80, rgb=(1,0,0))
 
 To enable tex rendering of all text in your matplotlib figure, set
-text.usetex in your matplotlibrc file or include these two lines in
-your script::
-
-  from matplotlib import rc
-  rc('text', usetex=True)
-
+:rc:`text.usetex` to True.
 """
 
 import copy

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -969,11 +969,10 @@ class Text(Artist):
 
     def set_family(self, fontname):
         """
-        Set the font family.  May be either a single string, or a list
-        of strings in decreasing priority.  Each string may be either
-        a real font name or a generic font class name.  If the latter,
-        the specific font names will be looked up in the
-        :file:`matplotlibrc` file.
+        Set the font family.  May be either a single string, or a list of
+        strings in decreasing priority.  Each string may be either a real font
+        name or a generic font class name.  If the latter, the specific font
+        names will be looked up in the corresponding rcParams.
 
         ACCEPTS: [FONTNAME | 'serif' | 'sans-serif' | 'cursive' | 'fantasy' |
                   'monospace' ]

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -230,8 +230,7 @@ def tricontour(ax, *args, **kwargs):
     tricontour-only keyword arguments:
 
         *linewidths*: [ *None* | number | tuple of numbers ]
-        If *linewidths* is *None*, the default width in
-        ``lines.linewidth`` in ``matplotlibrc`` is used.
+        If *linewidths* is *None*, defaults to rc:`lines.linewidth`.
 
         If a number, all levels will be plotted with this linewidth.
 
@@ -248,8 +247,7 @@ def tricontour(ax, *args, **kwargs):
 
         If contour is using a monochrome colormap and the contour
         level is less than 0, then the linestyle specified
-        in ``contour.negative_linestyle`` in ``matplotlibrc``
-        will be used.
+        in :rc:`contour.negative_linestyle` will be used.
 
     tricontourf-only keyword arguments:
 


### PR DESCRIPTION
In preparation for the possible switch to the new rcsystem.

This doesn't touch any place actually documenting the rcsystem, just
places where "the foo param in the matplotlibrc" can reasonably be
replaced by "the foo rcParam".

The `examples.download` and `examples.directory` rcParams removed from
doc/matplotlibrc have been removed in 6c5e961 (2012).  The
verbose.level rcParam is deprecated, update the docs accordingly.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
