### PR TITLE
Remove some APIs deprecated in mpl2.1.

### DIFF
--- a/doc/api/next_api_changes/2018-02-26-AL-removals.rst
+++ b/doc/api/next_api_changes/2018-02-26-AL-removals.rst
@@ -26,8 +26,12 @@ The following deprecated API elements have been removed:
 - ``_AxesBase.axesPatch``, ``_AxesBase.get_cursor_props``,
   ``_AxesBase.set_cursor_props``,
 - ``_ImageBase.iterpnames``,
+- ``FigureCanvasBase.start_event_loop_default``;
+- ``FigureCanvasBase.stop_event_loop_default``;
 - ``Figure.figurePatch``,
 - ``FigureCanvasBase.dynamic_update``, ``FigureCanvasBase.idle_event``,
   ``FigureCanvasBase.get_linestyle``, ``FigureCanvasBase.set_linestyle``,
 - ``FigureCanvasQTAgg.blitbox``,
+- passing non-numbers to ``EngFormatter.format_eng``,
 - passing ``frac`` to ``PolarAxes.set_theta_grids``,
+- any mention of idle events,

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2337,13 +2337,7 @@ class FigureCanvasBase(object):
                 print('you pressed', event.button, event.xdata, event.ydata)
 
             cid = canvas.mpl_connect('button_press_event', on_press)
-
         """
-        if s == 'idle_event':
-            cbook.warn_deprecated(1.5,
-                "idle_event is only implemented for the wx backend, and will "
-                "be removed in matplotlib 2.1. Use the animations module "
-                "instead.")
 
         return self.callbacks.connect(s, func)
 
@@ -2427,11 +2421,6 @@ class FigureCanvasBase(object):
         `start_event_loop`
         """
         self._looping = False
-
-    start_event_loop_default = cbook.deprecated(
-        "2.1", name="start_event_loop_default")(start_event_loop)
-    stop_event_loop_default = cbook.deprecated(
-        "2.1", name="stop_event_loop_default")(stop_event_loop)
 
 
 def key_press_handler(event, canvas, toolbar=None):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1253,43 +1253,31 @@ class EngFormatter(Formatter):
         '1.0 M'
 
         >>> format_eng("-1e-6") # for self.places = 2
-        u'-1.00 \N{GREEK SMALL LETTER MU}'
-
-        `num` may be a numeric value or a string that can be converted
-        to a numeric value with ``float(num)``.
+        '-1.00 \N{GREEK SMALL LETTER MU}'
         """
-        if isinstance(num, six.string_types):
-            warnings.warn(
-                "Passing a string as *num* argument is deprecated since"
-                "Matplotlib 2.1, and is expected to be removed in 2.3.",
-                mplDeprecation)
-
-        dnum = float(num)
         sign = 1
         fmt = "g" if self.places is None else ".{:d}f".format(self.places)
 
-        if dnum < 0:
+        if num < 0:
             sign = -1
-            dnum = -dnum
+            num = -num
 
-        if dnum != 0:
-            pow10 = int(math.floor(math.log10(dnum) / 3) * 3)
+        if num != 0:
+            pow10 = int(math.floor(math.log10(num) / 3) * 3)
         else:
             pow10 = 0
-            # Force dnum to zero, to avoid inconsistencies like
+            # Force num to zero, to avoid inconsistencies like
             # format_eng(-0) = "0" and format_eng(0.0) = "0"
             # but format_eng(-0.0) = "-0.0"
-            dnum = 0.0
+            num = 0.0
 
         pow10 = np.clip(pow10, min(self.ENG_PREFIXES), max(self.ENG_PREFIXES))
 
-        mant = sign * dnum / (10.0 ** pow10)
-        # Taking care of the cases like 999.9..., which
-        # may be rounded to 1000 instead of 1 k.  Beware
-        # of the corner case of values that are beyond
+        mant = sign * num / (10.0 ** pow10)
+        # Taking care of the cases like 999.9..., which may be rounded to 1000
+        # instead of 1 k.  Beware of the corner case of values that are beyond
         # the range of SI prefixes (i.e. > 'Y').
-        _fmant = float("{mant:{fmt}}".format(mant=mant, fmt=fmt))
-        if _fmant >= 1000 and pow10 != max(self.ENG_PREFIXES):
+        if float(format(mant, fmt)) >= 1000 and pow10 < max(self.ENG_PREFIXES):
             mant /= 1000
             pow10 += 3
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
