### PR TITLE
Inline knownfailureif.

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -27,27 +27,6 @@ from . import _copy_metadata, is_called_from_pytest
 from .exceptions import ImageComparisonFailure
 
 
-def _knownfailureif(fail_condition, msg=None, known_exception_class=None):
-    """
-
-    Assume a will fail if *fail_condition* is True. *fail_condition*
-    may also be False or the string 'indeterminate'.
-
-    *msg* is the error message displayed for the test.
-
-    If *known_exception_class* is not None, the failure is only known
-    if the exception is an instance of this class. (Default = None)
-
-    """
-    import pytest
-    if fail_condition == 'indeterminate':
-        fail_condition, strict = True, False
-    else:
-        fail_condition, strict = bool(fail_condition), True
-    return pytest.mark.xfail(condition=fail_condition, reason=msg,
-                             raises=known_exception_class, strict=strict)
-
-
 def _do_cleanup(original_units_registry, original_settings):
     plt.close('all')
 
@@ -152,14 +131,13 @@ def check_freetype_version(ver):
 
 
 def _checked_on_freetype_version(required_freetype_version):
-    if check_freetype_version(required_freetype_version):
-        return lambda f: f
-
+    import pytest
     reason = ("Mismatched version of freetype. "
               "Test requires '%s', you have '%s'" %
               (required_freetype_version, ft2font.__freetype_version__))
-    return _knownfailureif('indeterminate', msg=reason,
-                           known_exception_class=ImageComparisonFailure)
+    return pytest.mark.xfail(
+        not check_freetype_version(required_freetype_version),
+        reason=reason, raises=ImageComparisonFailure, strict=False)
 
 
 def remove_ticks_and_titles(figure):
@@ -195,14 +173,11 @@ def _raise_on_image_difference(expected, actual, tol):
 
 
 def _xfail_if_format_is_uncomparable(extension):
-    will_fail = extension not in comparable_formats()
-    if will_fail:
-        fail_msg = 'Cannot compare %s files on this system' % extension
-    else:
-        fail_msg = 'No failure expected'
-
-    return _knownfailureif(will_fail, fail_msg,
-                           known_exception_class=ImageComparisonFailure)
+    import pytest
+    return pytest.mark.xfail(
+        extension not in comparable_formats(),
+        reason='Cannot compare {} files on this system'.format(extension),
+        raises=ImageComparisonFailure, strict=True)
 
 
 def _mark_xfail_if_format_is_uncomparable(extension):


### PR DESCRIPTION
Now that nose support has been dropped, knownfailureif is just a thin
wrapper around pytest.mark.xfail that's more obfuscating the purpose of
the code than anything else.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
