### PR TITLE
Deprecate ImageComparisonTest.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -11,7 +11,7 @@ The following modules are deprecated:
 The following classes, methods, functions, and attributes are deprecated:
 
 - ``afm.parse_afm``,
-- ``Annotation.arrow``,
+- ``backend_wx.FigureCanvasWx.macros``,
 - ``cbook.GetRealpathAndStat``, ``cbook.Locked``,
 - ``cbook.is_numlike`` (use ``isinstance(..., numbers.Number)`` instead),
   ``cbook.listFiles``, ``cbook.unicode_safe``
@@ -19,8 +19,9 @@ The following classes, methods, functions, and attributes are deprecated:
 - ``dates.DateFormatter.strftime_pre_1900``, ``dates.DateFormatter.strftime``,
 - ``font_manager.TempCache``,
 - ``mathtext.unichr_safe`` (use ``chr`` instead),
-- ``FigureCanvasWx.macros``,
+- ``testing.ImageComparisonTest``,
 - ``texmanager.dvipng_hack_alpha``,
+- ``text.Annotation.arrow``,
 
 The following rcParams are deprecated:
 - ``pgf.debug`` (the pgf backend relies on logging),

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -251,6 +251,7 @@ class _ImageComparisonBase(object):
         _raise_on_image_difference(expected_fname, actual_fname, self.tol)
 
 
+@cbook.deprecated("3.0")
 class ImageComparisonTest(CleanupTest, _ImageComparisonBase):
     """
     Nose-based image comparison class


### PR DESCRIPTION
It's a weird leftover at that point that tries to set up a nose test
class but uses pytest markers (via e.g. _checked_on_freetype_version,
which uses _knownfailureif, which itself unconditionally relies on
pytest) -- basically, it can't actually be used for nose-based testing
unless nose somehow learns to interpret pytest markers.

A (fairly trivial...) PR has been opened on pytest-mpl to fix their use:
https://github.com/matplotlib/pytest-mpl/pull/70

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
