### PR TITLE
FIX: return proper legend window extent

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -952,7 +952,7 @@ class Legend(Artist):
 
     def get_window_extent(self, *args, **kwargs):
         'Return extent of the legend.'
-        return self.legendPatch.get_window_extent(*args, **kwargs)
+        return self._legend_box.get_window_extent(*args, **kwargs)
 
     def get_frame_on(self):
         """Get whether the legend box patch is drawn."""

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -495,11 +495,10 @@ def test_legend_proper_window_extent():
     fig, ax = plt.subplots(dpi=100)
     ax.plot(range(10), label='Aardvark')
     leg = ax.legend()
-    x0 = leg.get_window_extent(fig.canvas.get_renderer()).x0
-    assert pytest.approx(x0, 0.01) == 1094.375
+    x01 = leg.get_window_extent(fig.canvas.get_renderer()).x0
 
     fig, ax = plt.subplots(dpi=200)
     ax.plot(range(10), label='Aardvark')
     leg = ax.legend()
-    x0 = leg.get_window_extent(fig.canvas.get_renderer()).x0
-    assert pytest.approx(x0, 0.01) == 2189.015625
+    x02 = leg.get_window_extent(fig.canvas.get_renderer()).x0
+    assert pytest.approx(x01*2, 0.1) == x02

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -488,3 +488,18 @@ def test_legend_title_empty():
     leg = ax.legend()
     assert leg.get_title().get_text() == ""
     assert leg.get_title().get_visible() is False
+
+
+def test_legend_proper_window_extent():
+    # test that legend returns the expected extent under various dpi...
+    fig, ax = plt.subplots(dpi=100)
+    ax.plot(range(10), label='Aardvark')
+    leg = ax.legend()
+    x0 = leg.get_window_extent(fig.canvas.get_renderer()).x0
+    assert pytest.approx(x0, 0.01) == 1094.375
+
+    fig, ax = plt.subplots(dpi=200)
+    ax.plot(range(10), label='Aardvark')
+    leg = ax.legend()
+    x0 = leg.get_window_extent(fig.canvas.get_renderer()).x0
+    assert pytest.approx(x0, 0.01) == 2189.015625


### PR DESCRIPTION
## PR Summary

As per #10844, it was not possible to properly use `text.OffsetFrom` if the artist was a `legend`.  The issue was that `legend.get_window_extent` was calling the wrong patch object to get the patch location.  

The following code now returns properly placed text regardless of the savefig dpi:

```python
import matplotlib.pyplot as plt
import matplotlib.text

fig, ax = plt.subplots(dpi=200, figsize=(3,3))
ax.plot(range(10), label='Bah')
ax.set_xticks([])
ax.set_yticks([])
legend = ax.legend(loc="upper right")

offset = matplotlib.text.OffsetFrom(legend, (1.0, 0.0))
ax.annotate("info_string", xy=(0,0),size=14,
            xycoords='figure fraction', xytext=(0, 0), textcoords=offset,
            horizontalalignment='right', verticalalignment='top')
fig.savefig('plot1.png', dpi=100)
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->