### PR TITLE
Rely a bit more on rc_context.

### DIFF
--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -136,14 +136,11 @@ def context(style, after_reset=False):
         If True, apply style after resetting settings to their defaults;
         otherwise, apply style on top of the current settings.
     """
-    initial_settings = mpl.rcParams.copy()
-    if after_reset:
-        mpl.rcdefaults()
-    try:
+    with mpl.rc_context():
+        if after_reset:
+            mpl.rcdefaults()
         use(style)
         yield
-    finally:
-        mpl.rcParams.update(initial_settings)
 
 
 def load_base_library():

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -117,30 +117,26 @@ def test_pdflatex():
 @pytest.mark.style('default')
 @pytest.mark.backend('pgf')
 def test_rcupdate():
-    rc_sets = []
-    rc_sets.append({'font.family': 'sans-serif',
-                    'font.size': 30,
-                    'figure.subplot.left': .2,
-                    'lines.markersize': 10,
-                    'pgf.rcfonts': False,
-                    'pgf.texsystem': 'xelatex'})
-    rc_sets.append({'font.family': 'monospace',
-                    'font.size': 10,
-                    'figure.subplot.left': .1,
-                    'lines.markersize': 20,
-                    'pgf.rcfonts': False,
-                    'pgf.texsystem': 'pdflatex',
-                    'pgf.preamble': ['\\usepackage[utf8x]{inputenc}',
-                                     '\\usepackage[T1]{fontenc}',
-                                     '\\usepackage{sfmath}']})
-    tol = (6, 0)
-    original_params = mpl.rcParams.copy()
+    rc_sets = [{'font.family': 'sans-serif',
+                'font.size': 30,
+                'figure.subplot.left': .2,
+                'lines.markersize': 10,
+                'pgf.rcfonts': False,
+                'pgf.texsystem': 'xelatex'},
+               {'font.family': 'monospace',
+                'font.size': 10,
+                'figure.subplot.left': .1,
+                'lines.markersize': 20,
+                'pgf.rcfonts': False,
+                'pgf.texsystem': 'pdflatex',
+                'pgf.preamble': ['\\usepackage[utf8x]{inputenc}',
+                                 '\\usepackage[T1]{fontenc}',
+                                 '\\usepackage{sfmath}']}]
+    tol = [6, 0]
     for i, rc_set in enumerate(rc_sets):
-        mpl.rcParams.clear()
-        mpl.rcParams.update(original_params)
-        mpl.rcParams.update(rc_set)
-        create_figure()
-        compare_figure('pgf_rcupdate%d.pdf' % (i + 1), tol=tol[i])
+        with mpl.rc_context(rc_set):
+            create_figure()
+            compare_figure('pgf_rcupdate%d.pdf' % (i + 1), tol=tol[i])
 
 
 # test backend-side clipping, since large numbers are not supported by TeX


### PR DESCRIPTION
## PR Summary

Not really an argument for the PR, but note that (unusually), the contextmanager form is much faster:
```
In [5]: %timeit _orig = plt.rcParams.copy(); pass; plt.rcParams.update(_orig)
633 µs ± 3.87 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [6]: %timeit with plt.rc_context(): pass
14.6 µs ± 578 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
I believe (haven't profiled it) that's because plt.rc_context() intentionally *doesn't* revalidate the original rcs when restoring them.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
