### PR TITLE
FIX: tight_layout having negative width axes

### DIFF
--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -171,25 +171,40 @@ def auto_adjust_subplotpars(
         margin_bottom = max([sum(s) for s in vspaces[-cols:]] + [0])
         margin_bottom += pad_inches / fig_height_inch
 
+    if margin_left + margin_right >= 1:
+        margin_left = 0.4999
+        margin_right = 0.4999
+        warnings.warn('The left and right margins cannot be made large '
+                      'enough to accomodate all axes decorations. ')
     kwargs = dict(left=margin_left,
                   right=1 - margin_right,
                   bottom=margin_bottom,
                   top=1 - margin_top)
-
     if cols > 1:
         hspace = (
             max(sum(s)
                 for i in range(rows)
                 for s in hspaces[i * (cols + 1) + 1:(i + 1) * (cols + 1) - 1])
             + hpad_inches / fig_width_inch)
+        # axes widths:
         h_axes = (1 - margin_right - margin_left - hspace * (cols - 1)) / cols
-        kwargs["wspace"] = hspace / h_axes
+        if h_axes < 0.:
+            warnings.warn('tight_layout cannot make axes width small enough '
+                          'to accomodate all axes decorations')
+            kwargs["wspace"] = 0.5
+        else:
+            kwargs["wspace"] = hspace / h_axes
 
     if rows > 1:
         vspace = (max(sum(s) for s in vspaces[cols:-cols])
                   + vpad_inches / fig_height_inch)
         v_axes = (1 - margin_top - margin_bottom - vspace * (rows - 1)) / rows
-        kwargs["hspace"] = vspace / v_axes
+        if v_axes < 0:
+            warnings.warn('tight_layout cannot make axes height small enough '
+                          'to accomodate all axes decorations')
+            kwargs["hspace"] = 0.5
+        else:
+            kwargs["hspace"] = vspace / v_axes
 
     return kwargs
 


### PR DESCRIPTION
## PR Summary

Closes #4413

`fig.tight_layout()` could cause axes to flip sign if the title was too big, and cause the whole thing to Error if the title was really big.  This PR adds a check that the axes width and height is still greater than zero after the margins have been set.  

It would be nice to just collapse the axes when this happens, but thats actually a bit of work to fake because subplots_adjust 's space parameter is specified as a fraction of average axes width (not the way I'd have expressed this parameter, but...)

Discussion in #4413 suggested that something could be done to ignore the title, but otherwise compute the tight_layout.  I think that's theoretically possible, but if someone has a really long title they should probably shorten it or adjust the spacing manually rather than trying to make `tight_layout` do something magical.

```python
import matplotlib.pyplot as plt

fig, axs = plt.subplots(1, 2, figsize=(6,2))
leng = 95
axs[0].set_title('A'+('a' * leng))
axs[0].set_yticks([])
axs[1].set_title('B' +('b' * leng))
axs[1].set_yticks([])
axs[0].set_xlabel('title length %d' % leng)
fig.tight_layout()
plt.show()
```

![t45](https://user-images.githubusercontent.com/1562854/38069500-98e40950-32cb-11e8-804e-82c66b576f44.png)
![t46](https://user-images.githubusercontent.com/1562854/38069504-9b7865c6-32cb-11e8-9ef7-89c682a3a14e.png)
![t95](https://user-images.githubusercontent.com/1562854/38069505-9e177ed4-32cb-11e8-9c22-c6a3c32710f7.png)

For the second and third plots, a warning is emitted...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->