### PR TITLE
Fix overflow when resizing path-to-string buffer.

### DIFF
--- a/src/_path.h
+++ b/src/_path.h
@@ -1047,15 +1047,13 @@ void quad2cubic(double x0, double y0,
 char *__append_to_string(char *p, char **buffer, size_t *buffersize,
                          const char *content)
 {
-    int buffersize_int = (int)*buffersize;
-
     for (const char *i = content; *i; ++i) {
         if (p < *buffer) {
             /* This is just an internal error */
             return NULL;
         }
-        if (p - *buffer >= buffersize_int) {
-            int diff = p - *buffer;
+        if ((size_t)(p - *buffer) >= *buffersize) {
+            ptrdiff_t diff = p - *buffer;
             *buffersize *= 2;
             *buffer = (char *)realloc(*buffer, *buffersize);
             if (*buffer == NULL) {


### PR DESCRIPTION
The int version of the buffer size was not updated when the buffer was
resized. It's there to prevent a signed/unsigned comparison warning, but
it's simpler just to cast the other side of the comparison. There's no
problem with the signed-to-unsigned cast since we already know that the
result is positive due to the previous check.

Fixes #10889.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
