### PR TITLE
Fix rctemplate tests when user config file exists.

### DIFF
--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -430,12 +430,11 @@ def test_if_rctemplate_is_up_to_date():
     dep1 = mpl._all_deprecated
     dep2 = mpl._deprecated_set
     deprecated = list(dep1.union(dep2))
-    #print(deprecated)
-    path_to_rc = mpl.matplotlib_fname()
+    path_to_rc = os.path.join(mpl.get_data_path(), 'matplotlibrc')
     with open(path_to_rc, "r") as f:
         rclines = f.readlines()
     missing = {}
-    for k,v in mpl.defaultParams.items():
+    for k, v in mpl.defaultParams.items():
         if k[0] == "_":
             continue
         if k in deprecated:
@@ -447,7 +446,7 @@ def test_if_rctemplate_is_up_to_date():
             if k in line:
                 found = True
         if not found:
-            missing.update({k:v})
+            missing.update({k: v})
     if missing:
         raise ValueError("The following params are missing " +
                          "in the matplotlibrc.template file: {}"
@@ -457,7 +456,7 @@ def test_if_rctemplate_is_up_to_date():
 def test_if_rctemplate_would_be_valid(tmpdir):
     # This tests if the matplotlibrc.template file would result in a valid
     # rc file if all lines are uncommented.
-    path_to_rc = mpl.matplotlib_fname()
+    path_to_rc = os.path.join(mpl.get_data_path(), 'matplotlibrc')
     with open(path_to_rc, "r") as f:
         rclines = f.readlines()
     newlines = []
@@ -476,10 +475,7 @@ def test_if_rctemplate_would_be_valid(tmpdir):
     with open(fname, "w") as f:
         f.writelines(newlines)
     with pytest.warns(None) as record:
-        dic = mpl.rc_params_from_file(fname,
-                                      fail_on_error=True,
-                                      use_default_template=False)
+        mpl.rc_params_from_file(fname,
+                                fail_on_error=True,
+                                use_default_template=False)
         assert len(record) == 0
-    #d1 = set(dic.keys())
-    #d2 = set(matplotlib.defaultParams.keys())
-    #print(d2-d1)

--- a/pytest.ini
+++ b/pytest.ini
@@ -56,7 +56,6 @@ pep8ignore =
     matplotlib/tests/test_image.py E225 E231 E251 E302 E303 E501
     matplotlib/tests/test_lines.py E231 E261
     matplotlib/tests/test_mathtext.py E261 E302 E501
-    matplotlib/tests/test_rcparams.py E231
     matplotlib/tri/triinterpolate.py E201 E221
     matplotlib/_cm.py E101 E202 E203 W191
     matplotlib/_mathtext_data.py E203 E231 E261


### PR DESCRIPTION
## PR Summary
`matplotlib_fname` returns the first of user config, environment variable-specified config, or default system config. If the user has a matplotlibrc, then this test checks that instead of the system one.

Aiming for 2.2.3 because the test does not pass otherwise.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way