### PR TITLE
FIX: Postscript allow empty markers

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -525,11 +525,12 @@ grestore
 
         if rgbFace:
             if len(rgbFace) == 4 and rgbFace[3] == 0:
-                return
-            if rgbFace[0] == rgbFace[1] == rgbFace[2]:
-                ps_color = '%1.3f setgray' % rgbFace[0]
+                ps_color = None
             else:
-                ps_color = '%1.3f %1.3f %1.3f setrgbcolor' % rgbFace[:3]
+                if rgbFace[0] == rgbFace[1] == rgbFace[2]:
+                    ps_color = '%1.3f setgray' % rgbFace[0]
+                else:
+                    ps_color = '%1.3f %1.3f %1.3f setrgbcolor' % rgbFace[:3]
 
         # construct the generic marker command:
         ps_cmd = ['/o {', 'gsave', 'newpath', 'translate'] # don't want the translate to be global
@@ -549,7 +550,8 @@ grestore
         if rgbFace:
             if stroke:
                 ps_cmd.append('gsave')
-            ps_cmd.extend([ps_color, 'fill'])
+            if ps_color:
+                ps_cmd.extend([ps_color, 'fill'])
             if stroke:
                 ps_cmd.append('grestore')
 


### PR DESCRIPTION
## PR Summary

If you set a marker to have `markerfacecolor='none'` with the eps backend, no marker is drawn, even if the edgecolor is non-zero.  Thats silly.  This checks and if none, just doesn't issue the fill command instead of returning before anything is drawn...

I couldn't figure out how to make a postscript test.  The saved image is in pdf, but the test spits out an eps, so...

Closes #10921

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->