### PR TITLE
Allow pie textprops to take alignment and rotation arguments

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2770,10 +2770,10 @@ class Axes(_AxesBase):
                     raise TypeError(
                         'autopct must be callable or a format string')
 
-                t = self.text(xt, yt, s,
-                              horizontalalignment='center',
-                              verticalalignment='center',
-                              **textprops)
+                props = dict(horizontalalignment='center',
+                             verticalalignment='center')
+                props.update(textprops)
+                t = self.text(xt, yt, s, **props)
 
                 autotexts.append(t)
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2749,10 +2749,10 @@ class Axes(_AxesBase):
             if rotatelabels:
                 label_alignment_v = yt > 0 and 'bottom' or 'top'
                 label_rotation = np.rad2deg(thetam) + (0 if xt > 0 else 180)
-            props = dict(horizontalalignment = label_alignment_h,
-                          verticalalignment = label_alignment_v,
-                          rotation = label_rotation,
-                          size = rcParams['xtick.labelsize'])
+            props = dict(horizontalalignment=label_alignment_h,
+                          verticalalignment=label_alignment_v,
+                          rotation=label_rotation,
+                          size=rcParams['xtick.labelsize'])
             props.update(textprops)
 
             t = self.text(xt, yt, label, **props)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2749,13 +2749,13 @@ class Axes(_AxesBase):
             if rotatelabels:
                 label_alignment_v = yt > 0 and 'bottom' or 'top'
                 label_rotation = np.rad2deg(thetam) + (0 if xt > 0 else 180)
+            props = dict(horizontalalignment = label_alignment_h,
+                          verticalalignment = label_alignment_v,
+                          rotation = label_rotation,
+                          size = rcParams['xtick.labelsize'])
+            props.update(textprops)
 
-            t = self.text(xt, yt, label,
-                          size=rcParams['xtick.labelsize'],
-                          horizontalalignment=label_alignment_h,
-                          verticalalignment=label_alignment_v,
-                          rotation=label_rotation,
-                          **textprops)
+            t = self.text(xt, yt, label, **props)
 
             texts.append(t)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4666,6 +4666,28 @@ def test_pie_rotatelabels_true():
     plt.axis('equal')
 
 
+def test_pie_textprops():
+    data = [23,34,45]
+    labels=["Long name 1", "Long name 2", "Long name 3"]
+
+    textprops = dict(horizontalalignment="center",
+                     verticalalignment="top",
+                     rotation=90,
+                     rotation_mode="anchor",
+                     size=12, color="red")
+
+    _, texts, autopct = plt.gca().pie(data, labels=labels, autopct='%.2f',
+                                      textprops=textprops)
+    for labels in [texts,autopct]:
+        for tx in labels:
+            assert tx.get_ha() == textprops["horizontalalignment"]
+            assert tx.get_va() == textprops["verticalalignment"]
+            assert tx.get_rotation() == textprops["rotation"]
+            assert tx.get_rotation_mode() == textprops["rotation_mode"]
+            assert tx.get_size() == textprops["size"]
+            assert tx.get_color() == textprops["color"]
+
+
 @image_comparison(baseline_images=['set_get_ticklabels'], extensions=['png'])
 def test_set_get_ticklabels():
     # test issue 2246

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4667,8 +4667,8 @@ def test_pie_rotatelabels_true():
 
 
 def test_pie_textprops():
-    data = [23,34,45]
-    labels=["Long name 1", "Long name 2", "Long name 3"]
+    data = [23, 34, 45]
+    labels = ["Long name 1", "Long name 2", "Long name 3"]
 
     textprops = dict(horizontalalignment="center",
                      verticalalignment="top",
@@ -4678,7 +4678,7 @@ def test_pie_textprops():
 
     _, texts, autopct = plt.gca().pie(data, labels=labels, autopct='%.2f',
                                       textprops=textprops)
-    for labels in [texts,autopct]:
+    for labels in [texts, autopct]:
         for tx in labels:
             assert tx.get_ha() == textprops["horizontalalignment"]
             assert tx.get_va() == textprops["verticalalignment"]


### PR DESCRIPTION
## PR Summary

Fixes #10941. In that Issue it was proposed to let pie take horizontalalignment as textprop argument.

    ax.pie(..., textprops=dict(horizontalalignment='center'))

This was until now hindered by the horizontal, vertical alignment as well as rotation being passed individually to `Text` when creating the label. 

This PR allows to provide any argument through textprops. More precisely: horizontalalignment, verticalalignment, rotation and size. All others were unproblematic anyways.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
