### PR TITLE
Actually ignore invalid log-axis limit setting

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3048,13 +3048,13 @@ class _AxesBase(martist.Artist):
         left, right = mtransforms.nonsingular(left, right, increasing=False)
 
         if self.get_xscale() == 'log':
-            if left <= 0.0:
+            if left <= 0:
                 warnings.warn(
                     'Attempted to set non-positive left xlim on a '
                     'log-scaled axis.\n'
                     'Invalid limit will be ignored.')
                 left = old_left
-            if right <= 0.0:
+            if right <= 0:
                 warnings.warn(
                     'Attempted to set non-positive right xlim on a '
                     'log-scaled axis.\n'
@@ -3378,13 +3378,13 @@ class _AxesBase(martist.Artist):
         bottom, top = mtransforms.nonsingular(bottom, top, increasing=False)
 
         if self.get_yscale() == 'log':
-            if bottom <= 0.0:
+            if bottom <= 0:
                 warnings.warn(
                     'Attempted to set non-positive bottom ylim on a '
                     'log-scaled axis.\n'
                     'Invalid limit will be ignored.')
                 bottom = old_bottom
-            if top <= 0.0:
+            if top <= 0:
                 warnings.warn(
                     'Attempted to set non-positive top ylim on a '
                     'log-scaled axis.\n'

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3047,10 +3047,20 @@ class _AxesBase(martist.Artist):
                  'left=%s, right=%s') % (left, right))
         left, right = mtransforms.nonsingular(left, right, increasing=False)
 
-        if self.get_xscale() == 'log' and (left <= 0.0 or right <= 0.0):
-            warnings.warn(
-                'Attempted to set non-positive xlimits for log-scale axis; '
-                'invalid limits will be ignored.')
+        if self.get_xscale() == 'log':
+            if left <= 0.0:
+                warnings.warn(
+                    'Attempted to set non-positive left xlim on a '
+                    'log-scaled axis.\n'
+                    'Invalid limit will be ignored.')
+                left = old_left
+            if right <= 0.0:
+                warnings.warn(
+                    'Attempted to set non-positive right xlim on a '
+                    'log-scaled axis.\n'
+                    'Invalid limit will be ignored.')
+                right = old_right
+
         left, right = self.xaxis.limit_range_for_scale(left, right)
 
         self.viewLim.intervalx = (left, right)
@@ -3367,10 +3377,19 @@ class _AxesBase(martist.Artist):
 
         bottom, top = mtransforms.nonsingular(bottom, top, increasing=False)
 
-        if self.get_yscale() == 'log' and (bottom <= 0.0 or top <= 0.0):
-            warnings.warn(
-                'Attempted to set non-positive ylimits for log-scale axis; '
-                'invalid limits will be ignored.')
+        if self.get_yscale() == 'log':
+            if bottom <= 0.0:
+                warnings.warn(
+                    'Attempted to set non-positive bottom ylim on a '
+                    'log-scaled axis.\n'
+                    'Invalid limit will be ignored.')
+                bottom = old_bottom
+            if top <= 0.0:
+                warnings.warn(
+                    'Attempted to set non-positive top ylim on a '
+                    'log-scaled axis.\n'
+                    'Invalid limit will be ignored.')
+                top = old_top
         bottom, top = self.yaxis.limit_range_for_scale(bottom, top)
 
         self.viewLim.intervaly = (bottom, top)

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -133,9 +133,15 @@ def test_invalid_log_lims():
     with pytest.warns(UserWarning):
         ax.set_xlim(left=0)
     assert ax.get_xlim() == original_xlim
+    with pytest.warns(UserWarning):
+        ax.set_xlim(right=-1)
+    assert ax.get_xlim() == original_xlim
 
     ax.set_yscale('log')
     original_ylim = ax.get_ylim()
     with pytest.warns(UserWarning):
         ax.set_ylim(bottom=0)
+    assert ax.get_ylim() == original_ylim
+    with pytest.warns(UserWarning):
+        ax.set_ylim(top=-1)
     assert ax.get_ylim() == original_ylim

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -121,3 +121,21 @@ def test_logscale_nonpos_values():
 
     ax4.set_yscale('log')
     ax4.set_xscale('log')
+
+
+def test_invalid_log_lims():
+    # Check that invalid log scale limits are ignored
+    fig, ax = plt.subplots()
+    ax.scatter(range(0, 4), range(0, 4))
+
+    ax.set_xscale('log')
+    original_xlim = ax.get_xlim()
+    with pytest.warns(UserWarning):
+        ax.set_xlim(left=0)
+    assert ax.get_xlim() == original_xlim
+
+    ax.set_yscale('log')
+    original_ylim = ax.get_ylim()
+    with pytest.warns(UserWarning):
+        ax.set_ylim(bottom=0)
+    assert ax.get_ylim() == original_ylim


### PR DESCRIPTION
This PR makes sure the warning does what it says on the tin, which is not taking into account limits which are <= 0 on a log scaled axis.

Fixes #7733.