### PR TITLE
fix wx rubberband: correctly ensure x0<=x1

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1639,7 +1639,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
         if y1 < y0:
             y0, y1 = y1, y0
-        if x1 < y0:
+        if x1 < x0:
             x0, x1 = x1, x0
 
         w = x1 - x0
@@ -1771,7 +1771,7 @@ if 'wxMac' not in wx.PlatformInfo:
 
             if y1 < y0:
                 y0, y1 = y1, y0
-            if x1 < y0:
+            if x1 < x0:
                 x0, x1 = x1, x0
 
             w = x1 - x0


### PR DESCRIPTION
## PR Summary
Fix bug in wx rubberband drawing: **y**1 and x0 were compared instead of x1 and x0.
So, when dragging the rubberband from right to left, in many cases the rubberband was not drawn on Windows and Linux.