### PR TITLE
Allow equal aspect box on shared axes

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1496,8 +1496,9 @@ class _AxesBase(martist.Artist):
         fig_aspect = figH / figW
         if self._adjustable in ['box', 'box-forced']:
             if self in self._twinned_axes:
-                raise RuntimeError("Adjustable 'box' is not allowed in a"
-                                   " twinned Axes.  Use 'datalim' instead.")
+                warnings.warn("Using adjustable 'box'  on a twin Axes "
+                              "can lead to an overcontrained system. "
+                              "Consider using 'datalim' instead.")
             if aspect_scale_mode == "log":
                 box_aspect = A * self.get_data_ratio_log()
             else:


### PR DESCRIPTION
## PR Summary

This would allow to set an equal aspect box on a shared axes. 

Until now the following code 

```
from matplotlib import pyplot as plt

fig, ax1 = plt.subplots()
ax2 = plt.twiny() 

ax1.imshow([[0,1],[1,0]], extent=(0,5,10,20))

ax2.set_aspect("equal", adjustable="box", share=True)
ax2.axis([36,41,10,20])  

plt.show()
```

would produce an error. Turning the error into a warning lets this code produce the desired output

![image](https://user-images.githubusercontent.com/23121882/38365869-38b57082-38de-11e8-8155-a2a1a3007503.png)


## PR Checklist

- [ ] Has Pytest style unit tests (would it need one?)
- [x] Code is PEP 8 compliant



<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
