### PR TITLE
Simplify/fix some manual manipulation of len(args).

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -410,26 +410,6 @@ local arguments and the rest are passed on as
           self.add_line(line)
           lines.append(line)
 
-Note: there is a use case when ``kwargs`` are meant to be used locally
-in the function (not passed on), but you still need the ``**kwargs``
-idiom.  That is when you want to use ``*args`` to allow variable
-numbers of non-keyword args.  In this case, python will not allow you
-to use named keyword args after the ``*args`` usage, so you will be
-forced to use ``**kwargs``.  An example is
-:meth:`matplotlib.contour.ContourLabeler.clabel`::
-
-  # in contour.py
-  def clabel(self, *args, **kwargs):
-      fontsize = kwargs.get('fontsize', None)
-      inline = kwargs.get('inline', 1)
-      self.fmt = kwargs.get('fmt', '%1.3f')
-      colors = kwargs.get('colors', None)
-      if len(args) == 0:
-          levels = self.levels
-          indices = range(len(self.levels))
-      elif len(args) == 1:
-         ...etc...
-
 .. _using_logging:
 
 Using logging for debug messages

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -156,6 +156,7 @@ class _process_plot_var_args(object):
         self.set_prop_cycle()
 
     def set_prop_cycle(self, *args, **kwargs):
+        # Can't do `args == (None,)` as that crashes cycler.
         if not (args or kwargs) or (len(args) == 1 and args[0] is None):
             prop_cycler = rcParams['axes.prop_cycle']
         else:
@@ -1206,6 +1207,7 @@ class _AxesBase(martist.Artist):
         if args and kwargs:
             raise TypeError("Cannot supply both positional and keyword "
                             "arguments to this method.")
+        # Can't do `args == (None,)` as that crashes cycler.
         if len(args) == 1 and args[0] is None:
             prop_cycle = None
         else:

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -775,7 +775,7 @@ class Rectangle(Patch):
 
         ACCEPTS: (left, bottom, width, height)
         """
-        if len(args) == 0:
+        if len(args) == 1:
             l, b, w, h = args[0]
         else:
             l, b, w, h = args
@@ -2628,7 +2628,7 @@ class FancyBboxPatch(Patch):
 
         ACCEPTS: (left, bottom, width, height)
         """
-        if len(args) == 0:
+        if len(args) == 1:
             l, b, w, h = args[0]
         else:
             l, b, w, h = args

--- a/lib/matplotlib/tri/triplot.py
+++ b/lib/matplotlib/tri/triplot.py
@@ -41,9 +41,7 @@ def triplot(ax, *args, **kwargs):
     x, y, edges = (tri.x, tri.y, tri.edges)
 
     # Decode plot format string, e.g., 'ro-'
-    fmt = ""
-    if len(args) > 0:
-        fmt = args[0]
+    fmt = args[0] if args else ""
     linestyle, marker, color = matplotlib.axes._base._process_plot_format(fmt)
 
     # Insert plot format string into a copy of kwargs (kwargs values prevail).


### PR DESCRIPTION
The note removed in contributing.rst is simply not true anymore in Py3.

The changes in patches.py fix what appears to have been a bug (well, I'd
rather we decide once and for all whether we want to accept `(x, y)` or
`((x, y))` but until then we may as well make sure both work -- end of
rant).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
