### PR TITLE
Skip pillow animation test if pillow not importable

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -136,6 +136,8 @@ if sys.version_info >= (3, 6):
 # matplotlib.testing.image_comparison
 @pytest.mark.parametrize('writer, output', WRITER_OUTPUT)
 def test_save_animation_smoketest(tmpdir, writer, output):
+    if writer == 'pillow':
+        pytest.importorskip("PIL")
     try:
         # for ImageMagick the rcparams must be patched to account for
         # 'convert' being a built in MS tool, not the imagemagick


### PR DESCRIPTION
xref #10966 - this will skip the pillow test if `PIL` isn't importable. I've milestoned this to v2.2-doc, as that's where the builds seem to be failing.