### PR TITLE
PGF: Replace \pgfimage by \includegraphics to fix \import regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
   apt:
     sources:
       - sourceline: ppa:jonathonf/ffmpeg-3
+      - sourceline: ppa:jonathonf/texlive-2015
     packages:
       - cm-super
       - dvipng

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -690,7 +690,7 @@ class RendererPgf(RendererBase):
         interp = str(transform is None).lower()  # interpolation in PDF reader
         writeln(self.fh,
                 r"\pgftext[left,bottom]"
-                r"{\pgfimage[interpolate=%s,width=%fin,height=%fin]{%s}}" %
+                r"{\includegraphics[interpolate=%s,width=%fin,height=%fin]{%s}}" %
                 (interp, w, h, fname_img))
         writeln(self.fh, r"\end{pgfscope}")
 


### PR DESCRIPTION
The suggested method for importing PGF figures from other directories using the import package does not work anymore. Tex does not find the images referenced by the PGF file. Replacing `\pgfimage` by `\includegraphics` fixes this problem (fixes issue #10963).