### PR TITLE
Document change of label visibility on shared axes 

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -407,6 +407,16 @@ Both bindings are disabled if only a subset of the grid lines (in either
 direction) is visible, to avoid making irreversible changes to the figure.
 
 
+Ticklabels are turned off instead of being invisible
+----------------------------------------------------
+
+Internally, :func:`~matplotlib.axis.Axis.set_tick_params` is now used to
+hide tick labels instead of setting the visibility on the tick label objects.
+This improves overall performance and fixes some issues.
+As a consequence, in case those labels ought to be shown, `set_tick_params`
+needs to be used, e.g. `ax.xaxis.set_tick_params(labelbottom=True)`.
+
+
 Removal of warning on empty legends
 -----------------------------------
 

--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -410,11 +410,17 @@ direction) is visible, to avoid making irreversible changes to the figure.
 Ticklabels are turned off instead of being invisible
 ----------------------------------------------------
 
-Internally, :func:`~matplotlib.axis.Axis.set_tick_params` is now used to
-hide tick labels instead of setting the visibility on the tick label objects.
+Internally, the `Tick`'s :func:`~matplotlib.axis.Tick.label1On` attribute
+is now used to hide tick labels instead of setting the visibility on the tick
+label objects.
 This improves overall performance and fixes some issues.
-As a consequence, in case those labels ought to be shown, `set_tick_params`
-needs to be used, e.g. `ax.xaxis.set_tick_params(labelbottom=True)`.
+As a consequence, in case those labels ought to be shown,
+:func:`~matplotlib.axes.Axes.tick_params`
+needs to be used, e.g.
+
+::
+
+    ax.tick_params(labelbottom=True)
 
 
 Removal of warning on empty legends

--- a/doc/users/prev_whats_new/whats_new_2.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_2.1.0.rst
@@ -403,6 +403,16 @@ keyword.
     ax.xaxis.set_tick_params(which='both', rotation=90)
 
 
+Ticklabels are turned off instead of being invisible
+----------------------------------------------------
+
+Internally, :func:`~matplotlib.axis.Axis.set_tick_params` is now used to
+hide tick labels instead of setting the visibility on the tick label objects.
+This improves overall performance and fixes some issues.
+As a consequence, in case those labels ought to be shown, `set_tick_params`
+needs to be used, e.g. `ax.xaxis.set_tick_params(labelbottom=True)`.
+
+
 Shading in 3D bar plots
 -----------------------
 

--- a/doc/users/prev_whats_new/whats_new_2.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_2.1.0.rst
@@ -395,22 +395,28 @@ cases.
 ---------------------------------------------------
 
 Bulk setting of tick label rotation is now possible via
-:func:`~matplotlib.axis.Axis.set_tick_params` using the ``rotation``
+:func:`~matplotlib.axes.Axes.tick_params` using the ``rotation``
 keyword.
 
 ::
 
-    ax.xaxis.set_tick_params(which='both', rotation=90)
+    ax.tick_params(which='both', rotation=90)
 
 
 Ticklabels are turned off instead of being invisible
 ----------------------------------------------------
 
-Internally, :func:`~matplotlib.axis.Axis.set_tick_params` is now used to
-hide tick labels instead of setting the visibility on the tick label objects.
+Internally, the `Tick`'s :func:`~matplotlib.axis.Tick.label1On` attribute
+is now used to hide tick labels instead of setting the visibility on the tick
+label objects.
 This improves overall performance and fixes some issues.
-As a consequence, in case those labels ought to be shown, `set_tick_params`
-needs to be used, e.g. `ax.xaxis.set_tick_params(labelbottom=True)`.
+As a consequence, in case those labels ought to be shown,
+:func:`~matplotlib.axes.Axes.tick_params`
+needs to be used, e.g.
+
+::
+
+    ax.tick_params(labelbottom=True)
 
 
 Shading in 3D bar plots

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1268,11 +1268,11 @@ default: 'top'
             labels of the bottom subplot are created. Similarly, when subplots
             have a shared y-axis along a row, only the y tick labels of the
             first column subplot are created. To later turn other subplots'
-            ticklabels on, use :meth:`~matplotlib.axis.Axis.set_tick_params`.
+            ticklabels on, use :meth:`~matplotlib.axes.Axes.tick_params`.
 
         squeeze : bool, optional, default: True
-            - If True, extra dimensions are squeezed out from the returned Axes
-              object:
+            - If True, extra dimensions are squeezed out from the returned
+              array of Axes:
 
                 - if only one subplot is constructed (nrows=ncols=1), the
                   resulting single Axes object is returned as a scalar.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1265,21 +1265,21 @@ default: 'top'
                 - 'col': each subplot column will share an x- or y-axis.
 
             When subplots have a shared x-axis along a column, only the x tick
-            labels of the bottom subplot are visible.  Similarly, when
-            subplots have a shared y-axis along a row, only the y tick labels
-            of the first column subplot are visible.
+            labels of the bottom subplot are created. Similarly, when subplots
+            have a shared y-axis along a row, only the y tick labels of the
+            first column subplot are created. To later turn other subplots'
+            ticklabels on, use :meth:`~matplotlib.axis.Axis.set_tick_params`.
 
-        squeeze : bool, default: True
-            - If True, extra dimensions are squeezed out from the returned
-              axis object:
+        squeeze : bool, optional, default: True
+            - If True, extra dimensions are squeezed out from the returned Axes
+              object:
 
                 - if only one subplot is constructed (nrows=ncols=1), the
                   resulting single Axes object is returned as a scalar.
-                - for Nx1 or 1xN subplots, the returned object is a 1D numpy
-                  object array of Axes objects are returned as numpy 1D
-                  arrays.
-                - for NxM, subplots with N>1 and M>1 are returned as a 2D
-                  arrays.
+                - for Nx1 or 1xM subplots, the returned object is a 1D numpy
+                  object array of Axes objects.
+                - for NxM, subplots with N>1 and M>1 are returned
+                  as a 2D array.
 
             - If False, no squeezing at all is done: the returned Axes object
               is always a 2D array containing Axes instances, even if it ends

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1012,9 +1012,10 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
             - 'col': each subplot column will share an x- or y-axis.
 
         When subplots have a shared x-axis along a column, only the x tick
-        labels of the bottom subplot are visible.  Similarly, when subplots
+        labels of the bottom subplot are created. Similarly, when subplots
         have a shared y-axis along a row, only the y tick labels of the first
-        column subplot are visible.
+        column subplot are created. To later turn other subplots' ticklabels
+        on, use :meth:`~matplotlib.axis.Axis.set_tick_params`.
 
     squeeze : bool, optional, default: True
         - If True, extra dimensions are squeezed out from the returned Axes
@@ -1022,9 +1023,9 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
 
             - if only one subplot is constructed (nrows=ncols=1), the
               resulting single Axes object is returned as a scalar.
-            - for Nx1 or 1xN subplots, the returned object is a 1D numpy
-              object array of Axes objects are returned as numpy 1D arrays.
-            - for NxM, subplots with N>1 and M>1 are returned as a 2D arrays.
+            - for Nx1 or 1xM subplots, the returned object is a 1D numpy
+              object array of Axes objects.
+            - for NxM, subplots with N>1 and M>1 are returned as a 2D array.
 
         - If False, no squeezing at all is done: the returned Axes object is
           always a 2D array containing Axes instances, even if it ends up

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1015,11 +1015,11 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         labels of the bottom subplot are created. Similarly, when subplots
         have a shared y-axis along a row, only the y tick labels of the first
         column subplot are created. To later turn other subplots' ticklabels
-        on, use :meth:`~matplotlib.axis.Axis.set_tick_params`.
+        on, use :meth:`~matplotlib.axes.Axes.tick_params`.
 
     squeeze : bool, optional, default: True
-        - If True, extra dimensions are squeezed out from the returned Axes
-          object:
+        - If True, extra dimensions are squeezed out from the returned
+          array of Axes:
 
             - if only one subplot is constructed (nrows=ncols=1), the
               resulting single Axes object is returned as a scalar.


### PR DESCRIPTION
## PR Summary

In #8678 internal use of `Axis.set_tick_params` has been introduced to some methods previously using the ticklabels properties themselves. This change has led to the labels of shared axes not be turned invisible, but instead not being created at all. Previously working ways to turn the labels visible again are therefore failing, see [Get ticklabels back on shared axis #10911](https://github.com/matplotlib/matplotlib/issues/10911). 

This PR partially fixes #10911 in the sense of creating a what's new entry for this change and updating the documentation of `sharex`. 

If possible it should be backported to 2.1.0 where this change was silently introduced.


Note that further actions might be required to fully introduce `set_tick_params` as viable alternative to setting individual artist properties. Those go beyond the scope of this PR and should probably be introduced as new features.

## PR Checklist

- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
