### PR TITLE
Simplfy zorder_demo example for individual order

### DIFF
--- a/examples/misc/zorder_demo.py
+++ b/examples/misc/zorder_demo.py
@@ -56,16 +56,13 @@ plt.tight_layout()
 # A new figure, with individually ordered items
 
 x = np.linspace(0, 2*np.pi, 100)
+plt.rcParams['lines.linewidth'] = 10
 plt.figure()
-plt.plot(x, np.sin(x), linewidth=10, label='zorder=10',
-         zorder=10)  # on top
-plt.plot(x, np.cos(1.3*x), linewidth=10, label='zorder=1',
-         zorder=1)  # bottom
-plt.plot(x, np.sin(2.1*x), linewidth=10, label='zorder=3',
-         zorder=3)
-plt.axhline(0, linewidth=10, label='zorder=2',
-            zorder=2)
+plt.plot(x, np.sin(x), label='zorder=10', zorder=10)  # on top
+plt.plot(x, np.sin(1.1*x), label='zorder=1', zorder=1)  # bottom
+plt.plot(x, np.sin(1.2*x), label='zorder=3',  zorder=3)
+plt.axhline(0, label='zorder=2', color='grey', zorder=2)
 plt.title('Custom order of elements')
-l = plt.legend()
+l = plt.legend(loc='upper right')
 l.set_zorder(20)  # put the legend on top
 plt.show()


### PR DESCRIPTION
## PR Summary

Follow up to #10962.

As discussed there:

The overall layout of the second plot could use some additional improvements:
[appearence in this PR](https://754-74355158-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/misc/zorder_demo.html?highlight=zorder)

- The curves are quite chaotic and distract from the zorder.
- The legend is autoplaced to a position where it does not overlap with the data, so the zorder effect is not visible.
- The `axhline` has the color `C1` (is this  a bug?). Anyway, since it has the same color as the first curve, the zorder is indistinguishable.
- Use `rcParams['lines.linewidth']` to declutter the `plot` args.

I propose this plot:

![grafik](https://user-images.githubusercontent.com/2836374/38380611-80d0c04e-3904-11e8-8746-264e11795c34.png)