### PR TITLE
Fix layout of Other Parameters in docs

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -702,7 +702,7 @@ table.docutils.field-list {
     padding: 10px;
     text-align: left;
     vertical-align: top;
-    width: 120px;
+    width: 125px;
 }
 .docutils.field-list td {
     padding: 10px 10px 10px 20px;

--- a/doc/docutils.conf
+++ b/doc/docutils.conf
@@ -1,0 +1,4 @@
+# These entries affect HTML output:
+[html4css1 writer]
+# Required for docutils-update, the website build system:
+field-name-limit: 20


### PR DESCRIPTION
## PR Summary

This fixes #6924.

The cause is within docutils, which have a configuration option 
`html4css1.writer.field-name-limit: 14`. Longer field names such as "Other Parameters" are spread over two columns. An example can be seen in the [numpydoc example](https://numpydoc.readthedocs.io/en/latest/example.html#module-example).

The two-column case does not play nicely with matplotlibs CSS.

This PR changes the docutils settings so that the field-name-limit is larger than "Other Parameters". Consequently, they are rendered like everything else.

Now:
![grafik](https://user-images.githubusercontent.com/2836374/38469842-6ca04d84-3b5b-11e8-9033-bcd2fff29e4c.png)

Before:
![grafik](https://user-images.githubusercontent.com/2836374/38469862-ae1cd70a-3b5b-11e8-8c9b-24169bb031c7.png)


