### PR TITLE
FIX: improve Text repr to not error if non-float x and y.

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -496,3 +496,10 @@ def test_text_as_text_opacity():
     plt.text(0.25, 0.5, '50% using `alpha`', alpha=0.5)
     plt.text(0.25, 0.75, '50% using `alpha` and 100% `color`', alpha=0.5,
              color=(0, 0, 0, 1))
+
+
+def test_text_repr():
+    # smoketest to make sure text repr doesn't error for category
+    plt.plot(['A', 'B'], [1, 2])
+    txt = plt.text(['A'], 0.5, 'Boo')
+    print(txt)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -132,7 +132,7 @@ class Text(Artist):
     _cached = cbook.maxdict(50)
 
     def __repr__(self):
-        return "Text(%g,%g,%s)" % (self._x, self._y, repr(self._text))
+        return "Text(%s, %s, %s)" % (self._x, self._y, repr(self._text))
 
     def __init__(self,
                  x=0, y=0, text='',


### PR DESCRIPTION
## PR Summary
closes #10996

The `__repr__` of `Text` assumed that `txt._x` and `txt_y` are floats, but they are unitized data, and hence not necessarily floats.

```python

import matplotlib.pyplot as plt
from datetime import datetime

plt.plot([datetime(year=2016,month=4,day=1),datetime(year=2016,month=8,day=1)],[0,4])
tx=plt.text(datetime(year=2016,month=6,day=1), 1, "1", color="black", fontsize=12)
print(tx)
plt.show()
```

### Before:

```
Traceback (most recent call last):
  File "testTextRep.py", line 8, in <module>
    print(tx)
  File "/Users/jklymak/matplotlib/lib/matplotlib/text.py", line 135, in __repr__
    return "Text(%g,%g,%s)" % (self._x, self._y, repr(self._text))
TypeError: must be real number, not datetime.datetime
```

### Now:

```
Text(2016-06-01 00:00:00, 1, '1')
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->