### PR TITLE
Deprecate smart_bounds handling in Axis and Spine

### DIFF
--- a/doc/api/next_api_changes/2019-07-16-EF.rst
+++ b/doc/api/next_api_changes/2019-07-16-EF.rst
@@ -1,0 +1,6 @@
+Deprecations
+````````````
+
+The "smart_bounds" functionality is deprecated.  This includes
+``Axis.set_smart_bounds()``, ``Axis.get_smart_bounds()``,
+``Spine.set_smart_bounds()``, and ``Spine.get_smart_bounds()``.

--- a/examples/ticks_and_spines/spine_placement_demo.py
+++ b/examples/ticks_and_spines/spine_placement_demo.py
@@ -22,8 +22,6 @@ ax.spines['left'].set_position('center')
 ax.spines['right'].set_color('none')
 ax.spines['bottom'].set_position('center')
 ax.spines['top'].set_color('none')
-ax.spines['left'].set_smart_bounds(True)
-ax.spines['bottom'].set_smart_bounds(True)
 ax.xaxis.set_ticks_position('bottom')
 ax.yaxis.set_ticks_position('left')
 
@@ -34,8 +32,6 @@ ax.spines['left'].set_position('zero')
 ax.spines['right'].set_color('none')
 ax.spines['bottom'].set_position('zero')
 ax.spines['top'].set_color('none')
-ax.spines['left'].set_smart_bounds(True)
-ax.spines['bottom'].set_smart_bounds(True)
 ax.xaxis.set_ticks_position('bottom')
 ax.yaxis.set_ticks_position('left')
 
@@ -46,8 +42,6 @@ ax.spines['left'].set_position(('axes', 0.6))
 ax.spines['right'].set_color('none')
 ax.spines['bottom'].set_position(('axes', 0.1))
 ax.spines['top'].set_color('none')
-ax.spines['left'].set_smart_bounds(True)
-ax.spines['bottom'].set_smart_bounds(True)
 ax.xaxis.set_ticks_position('bottom')
 ax.yaxis.set_ticks_position('left')
 
@@ -58,8 +52,6 @@ ax.spines['left'].set_position(('data', 1))
 ax.spines['right'].set_color('none')
 ax.spines['bottom'].set_position(('data', 2))
 ax.spines['top'].set_color('none')
-ax.spines['left'].set_smart_bounds(True)
-ax.spines['bottom'].set_smart_bounds(True)
 ax.xaxis.set_ticks_position('bottom')
 ax.yaxis.set_ticks_position('left')
 
@@ -71,7 +63,6 @@ def adjust_spines(ax, spines):
     for loc, spine in ax.spines.items():
         if loc in spines:
             spine.set_position(('outward', 10))  # outward by 10 points
-            spine.set_smart_bounds(True)
         else:
             spine.set_color('none')  # don't draw spine
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -763,7 +763,7 @@ class Axis(martist.Artist):
         self.callbacks = cbook.CallbackRegistry()
 
         self._autolabelpos = True
-        self._smart_bounds = False
+        self._smart_bounds = False  # Deprecated in 3.2
 
         self.label = self._get_label()
         self.labelpad = rcParams['axes.labelpad']
@@ -1085,11 +1085,13 @@ class Axis(martist.Artist):
             bbox2 = mtransforms.Bbox.from_extents(0, 0, 0, 0)
         return bbox, bbox2
 
+    @cbook.deprecated("3.2")
     def set_smart_bounds(self, value):
         """Set the axis to have smart bounds."""
         self._smart_bounds = value
         self.stale = True
 
+    @cbook.deprecated("3.2")
     def get_smart_bounds(self):
         """Return whether the axis has smart bounds."""
         return self._smart_bounds
@@ -1121,7 +1123,7 @@ class Axis(martist.Artist):
         if view_low > view_high:
             view_low, view_high = view_high, view_low
 
-        if self._smart_bounds and ticks:
+        if self._smart_bounds and ticks:  # _smart_bounds is deprecated in 3.2
             # handle inverted limits
             data_low, data_high = sorted(self.get_data_interval())
             locs = np.sort([tick.get_loc() for tick in ticks])

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -3,6 +3,7 @@ import numpy as np
 import matplotlib
 from matplotlib import cbook, docstring, rcParams
 from matplotlib.artist import allow_rasterization
+import matplotlib.cbook as cbook
 import matplotlib.transforms as mtransforms
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath
@@ -56,7 +57,7 @@ class Spine(mpatches.Patch):
         self.set_transform(self.axes.transData)  # default transform
 
         self._bounds = None  # default bounds
-        self._smart_bounds = False
+        self._smart_bounds = False  # deprecated in 3.2
 
         # Defer initial position determination. (Not much support for
         # non-rectangular axes is currently implemented, and this lets
@@ -77,6 +78,7 @@ class Spine(mpatches.Patch):
         # Note: This cannot be calculated until this is added to an Axes
         self._patch_transform = mtransforms.IdentityTransform()
 
+    @cbook.deprecated("3.2")
     def set_smart_bounds(self, value):
         """Set the spine and associated axis to have smart bounds."""
         self._smart_bounds = value
@@ -88,6 +90,7 @@ class Spine(mpatches.Patch):
             self.axes.xaxis.set_smart_bounds(value)
         self.stale = True
 
+    @cbook.deprecated("3.2")
     def get_smart_bounds(self):
         """Return whether the spine has smart bounds."""
         return self._smart_bounds
@@ -268,7 +271,7 @@ class Spine(mpatches.Patch):
                 raise ValueError('unknown spine spine_type: %s' %
                                  self.spine_type)
 
-            if self._smart_bounds:
+            if self._smart_bounds:  # deprecated in 3.2
                 # attempt to set bounds in sophisticated way
 
                 # handle inverted limits


### PR DESCRIPTION
## PR Summary
Code related to spines, ticks, and autoscaling needs some simple cleanups, which might be followed by some deeper changes.  To begin:
- Tighten the tolerance for floating point error in deciding which ticks to keep.  Prior to this PR it was supposed to be 0.5 pixel, but I don't think this makes sense; it makes the selection backend-dependent, and it is vastly larger than it needs to be to compensate for floating point error.
- Stop calling `Axis._update_ticks` with a 'renderer' argument; it doesn't use it.
- **Deprecate all "smart_bounds" handling in Axis and Spine.**  It modifies the spine behavior by making the spines extend only to the data limits. 

Edited, 2019-07-16: Everything but the last item has been superceded by other PRs, and therefore has been stripped out of this one.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
