### PR TITLE
Changed fill.py example to be less misleading

### DIFF
--- a/examples/lines_bars_and_markers/fill.py
+++ b/examples/lines_bars_and_markers/fill.py
@@ -5,23 +5,21 @@ Fill plot demo
 
 Demo fill plot.
 """
-import numpy as np
-import matplotlib.pyplot as plt
-
-x = np.linspace(0, 1, 500)
-y = np.sin(4 * np.pi * x) * np.exp(-5 * x)
 
 ###############################################################################
 # First, the most basic fill plot a user can make with matplotlib:
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+x = [0, 0, 1, 2, 2]
+y = [0, 1, 2, 1, 0]
 
 fig, ax = plt.subplots()
-
 ax.fill(x, y, zorder=10)
 ax.grid(True, zorder=5)
 
-x = np.linspace(0, 2 * np.pi, 500)
-y1 = np.sin(x)
-y2 = np.sin(3 * x)
+
 
 ###############################################################################
 # Next, a few more optional features:
@@ -30,6 +28,20 @@ y2 = np.sin(3 * x)
 # * Setting the fill color.
 # * Setting the opacity (alpha value).
 
+
+x = np.linspace(0, 1.5 * np.pi, 500)
+y1 = np.sin(x)
+y2 = np.sin(3 * x)
+
 fig, ax = plt.subplots()
+
 ax.fill(x, y1, 'b', x, y2, 'r', alpha=0.3)
+
+# Also outline the region we've filled in
+ax.plot(x, y1, c='b', alpha=0.8)
+ax.plot(x, y2, c='r', alpha=0.8)
+ax.plot([x[0], x[-1]], [y1[0], y1[-1]], c='b', alpha=0.8)
+ax.plot([x[0], x[-1]], [y2[0], y2[-1]], c='r', alpha=0.8)
+
+
 plt.show()

--- a/examples/lines_bars_and_markers/fill.py
+++ b/examples/lines_bars_and_markers/fill.py
@@ -16,11 +16,7 @@ y = [1, 2, 1, 0]
 
 fig, ax = plt.subplots()
 ax.fill(x, y)
-# Outline of the region we've filled in
-ax.plot([x[0], x[1]], [y[0], y[1]], c='k', linewidth=2.0)
-ax.plot([x[1], x[2]], [y[1], y[2]], c='k', linewidth=2.0)
-ax.plot([x[2], x[3]], [y[2], y[3]], c='k', linewidth=2.0)
-ax.plot([x[3], x[0]], [y[3], y[0]], c='k', linewidth=2.0)
+plt.show()
 
 ###############################################################################
 # Next, a few more optional features:

--- a/examples/lines_bars_and_markers/fill.py
+++ b/examples/lines_bars_and_markers/fill.py
@@ -11,15 +11,16 @@ Demo fill plot.
 import numpy as np
 import matplotlib.pyplot as plt
 
-
-x = [0, 0, 1, 2, 2]
-y = [0, 1, 2, 1, 0]
+x = [0, 1, 2, 1]
+y = [1, 2, 1, 0]
 
 fig, ax = plt.subplots()
-ax.fill(x, y, zorder=10)
-ax.grid(True, zorder=5)
-
-
+ax.fill(x, y)
+# Outline of the region we've filled in
+ax.plot([x[0], x[1]], [y[0], y[1]], c='k', linewidth=2.0)
+ax.plot([x[1], x[2]], [y[1], y[2]], c='k', linewidth=2.0)
+ax.plot([x[2], x[3]], [y[2], y[3]], c='k', linewidth=2.0)
+ax.plot([x[3], x[0]], [y[3], y[0]], c='k', linewidth=2.0)
 
 ###############################################################################
 # Next, a few more optional features:
@@ -37,11 +38,10 @@ fig, ax = plt.subplots()
 
 ax.fill(x, y1, 'b', x, y2, 'r', alpha=0.3)
 
-# Also outline the region we've filled in
+# Outline of the region we've filled in
 ax.plot(x, y1, c='b', alpha=0.8)
 ax.plot(x, y2, c='r', alpha=0.8)
 ax.plot([x[0], x[-1]], [y1[0], y1[-1]], c='b', alpha=0.8)
 ax.plot([x[0], x[-1]], [y2[0], y2[-1]], c='r', alpha=0.8)
-
 
 plt.show()


### PR DESCRIPTION
## PR Summary
I've changed /examples/lines_bars_and_markers/fill.py to be less misleading, following issues #5827 and #7956. 

These plots were over-simplified because fill was acting just like fill_between, since the final line of the region to be filled was completely along the x-axis. I've changed the first example to be a simple polygon (as suggested in #5827) and the second to not have the final point at y=0 anymore. I've also outlined the region being filled, to make what's going on more obvious. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
