### PR TITLE
Added inverted/reverse logarithmic axis

### DIFF
--- a/doc/users/next_whats_new/invlog_axis.rst
+++ b/doc/users/next_whats_new/invlog_axis.rst
@@ -1,0 +1,8 @@
+Inverted/reverse logarithmic axis
+---------------------------------
+When plotting a quantity on a logarithmic scale for which the reciprocal value
+`1/x` is the actual quantity of interest, it makes more sense to reverse the
+minor ticks on the logarithmic axis. One area where this is of immediate use is
+when doing Fourier analysis if one is interested in (time/length-)scales
+instead of frequencies. This is shown in the new `inv_log_demo.py` example in
+the gallery.

--- a/examples/scales/invlog_fft_demo.py
+++ b/examples/scales/invlog_fft_demo.py
@@ -43,9 +43,11 @@ ax2.spines['right'].set_visible(True)
 
 ax2.set_xscale('log')
 ax2.xaxis.set_major_locator(ticker.InvLogLocator(inv_factor=2*np.pi))
-ax2.xaxis.set_minor_locator(ticker.InvLogLocator(inv_factor=2*np.pi, subs='auto'))
+ax2.xaxis.set_minor_locator(ticker.InvLogLocator(inv_factor=2*np.pi,
+                                                 subs='auto'))
 ax2.xaxis.set_major_formatter(ticker.InvLogFormatter(inv_factor=2*np.pi))
-ax2.xaxis.set_minor_formatter(ticker.InvLogFormatter(inv_factor=2*np.pi, labelOnlyBase=False))
+ax2.xaxis.set_minor_formatter(ticker.InvLogFormatter(inv_factor=2*np.pi,
+                                                     labelOnlyBase=False))
 
 ax2.set_xlim(xlim)
 ax2.set_xlabel(r'scale')

--- a/examples/scales/invlog_fft_demo.py
+++ b/examples/scales/invlog_fft_demo.py
@@ -1,0 +1,55 @@
+"""
+================
+Inverse Log Axis
+================
+
+This is an example of assigning an inverse log-scale for the x-axis using
+`InvLogLocator` and `InvLogFormatter`. This can be useful when doing Fourier
+analysis, especially when scales of Fourier modes are of interest.
+"""
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import numpy as np
+
+fig, (axsin, axfft) = plt.subplots(2, 1)
+
+# sampling interval
+dx = 0.01
+
+# We measure the height of a sinus-shaped curve along 10 units of x-axis.
+# The sinus period is 2 units of x-axis.
+period = 2
+x = np.arange(0, 10, dx)
+height = np.sin(2 * np.pi * x / period)
+
+axsin.plot(x, height)
+axsin.set_xlabel(r'distance')
+
+height_fourier = np.fft.rfft(height)
+fourier_amplitude = np.abs(height_fourier)
+spatial_frequencies = 2 * np.pi * np.fft.rfftfreq(len(height), d=dx)
+
+axfft.set_xscale('log')
+axfft.plot(spatial_frequencies, fourier_amplitude)
+axfft.set_xlabel(r'spatial frequency')
+
+# add scale axis
+xlim = axfft.get_xlim()
+
+ax2 = axfft.twiny()
+ax2.spines['top'].set_visible(True)
+ax2.spines['right'].set_visible(True)
+
+ax2.set_xscale('log')
+ax2.xaxis.set_major_locator(ticker.InvLogLocator(inv_factor=2*np.pi))
+ax2.xaxis.set_minor_locator(ticker.InvLogLocator(inv_factor=2*np.pi, subs='auto'))
+ax2.xaxis.set_major_formatter(ticker.InvLogFormatter(inv_factor=2*np.pi))
+ax2.xaxis.set_minor_formatter(ticker.InvLogFormatter(inv_factor=2*np.pi, labelOnlyBase=False))
+
+ax2.set_xlim(xlim)
+ax2.set_xlabel(r'scale')
+
+plt.tight_layout()
+
+plt.show()

--- a/examples/scales/invlog_fft_demo.py
+++ b/examples/scales/invlog_fft_demo.py
@@ -8,9 +8,9 @@ This is an example of assigning an inverse log-scale for the x-axis using
 analysis, especially when scales of Fourier modes are of interest.
 """
 
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
 import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
 
 fig, (axsin, axfft) = plt.subplots(2, 1)
 
@@ -42,12 +42,12 @@ ax2.spines['top'].set_visible(True)
 ax2.spines['right'].set_visible(True)
 
 ax2.set_xscale('log')
-ax2.xaxis.set_major_locator(ticker.InvLogLocator(inv_factor=2*np.pi))
-ax2.xaxis.set_minor_locator(ticker.InvLogLocator(inv_factor=2*np.pi,
-                                                 subs='auto'))
-ax2.xaxis.set_major_formatter(ticker.InvLogFormatter(inv_factor=2*np.pi))
-ax2.xaxis.set_minor_formatter(ticker.InvLogFormatter(inv_factor=2*np.pi,
-                                                     labelOnlyBase=False))
+ax2.xaxis.set_major_locator(mticker.InvLogLocator(inv_factor=2*np.pi))
+ax2.xaxis.set_minor_locator(mticker.InvLogLocator(inv_factor=2*np.pi,
+                                                  subs='auto'))
+ax2.xaxis.set_major_formatter(mticker.InvLogFormatter(inv_factor=2*np.pi))
+ax2.xaxis.set_minor_formatter(mticker.InvLogFormatter(inv_factor=2*np.pi,
+                                                      labelOnlyBase=False))
 
 ax2.set_xlim(xlim)
 ax2.set_xlabel(r'scale')

--- a/examples/ticks_and_spines/tick-locators.py
+++ b/examples/ticks_and_spines/tick-locators.py
@@ -27,8 +27,8 @@ def setup(ax):
     ax.patch.set_alpha(0.0)
 
 
-plt.figure(figsize=(8, 6))
-n = 8
+plt.figure(figsize=(9, 6))
+n = 9
 
 # Null Locator
 ax = plt.subplot(n, 1, 1)
@@ -92,6 +92,15 @@ ax.set_xlim(10**3, 10**10)
 ax.set_xscale('log')
 ax.xaxis.set_major_locator(ticker.LogLocator(base=10.0, numticks=15))
 ax.text(0.0, 0.1, "LogLocator(base=10, numticks=15)",
+        fontsize=15, transform=ax.transAxes)
+
+# InvLog Locator
+ax = plt.subplot(n, 1, 9)
+setup(ax)
+ax.set_xlim(10**3, 10**10)
+ax.set_xscale('log')
+ax.xaxis.set_major_locator(ticker.InvLogLocator(inv_base=10.0, numticks=15))
+ax.text(0.0, 0.1, "InvLogLocator(inv_base=10, numticks=15)",
         fontsize=15, transform=ax.transAxes)
 
 # Push the top of the top axes outside the figure because we only show the

--- a/examples/ticks_and_spines/tick-locators.py
+++ b/examples/ticks_and_spines/tick-locators.py
@@ -99,8 +99,11 @@ ax = plt.subplot(n, 1, 9)
 setup(ax)
 ax.set_xlim(10**3, 10**10)
 ax.set_xscale('log')
-ax.xaxis.set_major_locator(ticker.InvLogLocator(inv_base=10.0, numticks=15))
-ax.text(0.0, 0.1, "InvLogLocator(inv_base=10, numticks=15)",
+ax.xaxis.set_major_locator(ticker.InvLogLocator())
+ax.xaxis.set_minor_locator(ticker.InvLogLocator(subs='auto'))
+ax.xaxis.set_major_formatter(ticker.InvLogFormatter())
+ax.xaxis.set_minor_formatter(ticker.InvLogFormatter(labelOnlyBase=False))
+ax.text(0.0, 0.1, "InvLogLocator()",
         fontsize=15, transform=ax.transAxes)
 
 # Push the top of the top axes outside the figure because we only show the

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -434,9 +434,11 @@ class TestInvLogFormatter(object):
         (2 * np.pi, 10, 500000, '1e-05'),
     ]
 
-    @pytest.mark.parametrize('inv_factor, inv_base, value, expected', test_data)
+    @pytest.mark.parametrize('inv_factor, inv_base, value, expected',
+                             test_data)
     def test_basic(self, inv_factor, inv_base, value, expected):
-        formatter = mticker.InvLogFormatter(inv_base=inv_base, inv_factor=inv_factor)
+        formatter = mticker.InvLogFormatter(inv_base=inv_base,
+                                            inv_factor=inv_factor)
         formatter.axis = FakeAxis()
         assert formatter(value) == expected
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -386,6 +386,49 @@ class TestLogFormatterSciNotation(object):
             assert formatter(value) == expected
 
 
+class TestInvLogFormatter(object):
+    test_data = [
+        (1, 2, 0.03125, '32'),
+        (1, 2, 1, '1'),
+        (1, 2, 32, '3e-02'),
+        (1, 2, 0.0375, '26.667'),
+        (1, 2, 1.2, '8e-01'),
+        (1, 2, 38.4, '3e-02'),
+        (1, 10, -1, '1'),
+        (1, 10, 1e-05, '1e+05'),
+        (1, 10, 1, '1'),
+        (1, 10, 100000, '1e-05'),
+        (1, 10, 2e-05, '5e+04'),
+        (1, 10, 2, '5e-01'),
+        (1, 10, 200000, '5e-06'),
+        (1, 10, 5e-05, '2e+04'),
+        (1, 10, 5, '2e-01'),
+        (1, 10, 500000, '2e-06'),
+        (2 * np.pi, 2, 0.03125, '201.06'),
+        (2 * np.pi, 2, 1, '6.28'),
+        (2 * np.pi, 2, 32, '2e-01'),
+        (2 * np.pi, 2, 0.0375, '167.55'),
+        (2 * np.pi, 2, 1.2, '5.24'),
+        (2 * np.pi, 2, 38.4, '2e-01'),
+        (2 * np.pi, 10, -1, '6.28'),
+        (2 * np.pi, 10, 1e-05, '6e+05'),
+        (2 * np.pi, 10, 1, '6.28'),
+        (2 * np.pi, 10, 100000, '6e-05'),
+        (2 * np.pi, 10, 2e-05, '3e+05'),
+        (2 * np.pi, 10, 2, '3.14'),
+        (2 * np.pi, 10, 200000, '3e-05'),
+        (2 * np.pi, 10, 5e-05, '1e+05'),
+        (2 * np.pi, 10, 5, '1.26'),
+        (2 * np.pi, 10, 500000, '1e-05'),
+    ]
+
+    @pytest.mark.parametrize('inv_factor, inv_base, value, expected', test_data)
+    def test_basic(self, inv_factor, inv_base, value, expected):
+        formatter = mticker.InvLogFormatter(inv_base=inv_base, inv_factor=inv_factor)
+        formatter.axis = FakeAxis()
+        assert formatter(value) == expected
+
+
 class TestLogFormatter(object):
     pprint_data = [
         (3.141592654e-05, 0.001, '3.142e-5'),

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -127,6 +127,44 @@ class TestLogLocator(object):
         assert list(loc._subs) == [2.0]
 
 
+class TestInvLogLocator(object):
+    def test_basic(self):
+        loc = mticker.InvLogLocator(numticks=5)
+        with pytest.raises(ZeroDivisionError):
+            loc.tick_values(0, 1000)
+        with pytest.raises(ZeroDivisionError):
+            loc.tick_values(-1000, 0)
+        with pytest.raises(ValueError):
+            loc.tick_values(-2, -1)
+
+        test_value = 1/np.array([1.00000000e-08, 1.00000000e-06,
+                                 1.00000000e-04, 1.00000000e-02,
+                                 1.00000000e+00, 1.00000000e+02,
+                                 1.00000000e+04, 1.00000000e+06])
+        assert_almost_equal(loc.tick_values(0.001, 1.1e5), test_value)
+
+        loc = mticker.InvLogLocator(inv_base=2)
+        test_value = np.array([256., 128., 64., 32., 16., 8., 4., 2., 1., 0.5])
+        assert_almost_equal(loc.tick_values(1, 100), test_value)
+
+    def test_set_params(self):
+        """
+        Create invlog locator with default value, base=10.0, subs=[1.0],
+        numdecs=4, numticks=15, inv_base=10, inv_factor=1 and change it to
+        something else. See if change was successful. Should not raise
+        exception.
+        """
+        loc = mticker.InvLogLocator()
+        loc.set_params(numticks=7, numdecs=8, subs=[2.0], base=4, inv_base=3,
+                       inv_factor=102)
+        assert loc.numticks == 7
+        assert loc.numdecs == 8
+        assert loc._base == 4
+        assert list(loc._subs) == [2.0]
+        assert loc._inv_base == 3
+        assert loc._inv_factor == 102
+
+
 class TestNullLocator(object):
     def test_set_params(self):
         """

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -147,6 +147,18 @@ class TestInvLogLocator(object):
         test_value = np.array([256., 128., 64., 32., 16., 8., 4., 2., 1., 0.5])
         assert_almost_equal(loc.tick_values(1, 100), test_value)
 
+    def test_minor_ticks(self):
+        loc = mticker.InvLogLocator(inv_factor=2*np.pi, subs='auto')
+        test_value = np.array([31.41592654, 20.94395102, 15.70796327,
+                               12.56637061, 10.47197551, 8.97597901,
+                               7.85398163, 6.98131701, 3.14159265,
+                               2.0943951, 1.57079633, 1.25663706,
+                               1.04719755, 0.8975979, 0.78539816,
+                               0.6981317, 0.31415927, 0.20943951,
+                               0.15707963, 0.12566371, 0.10471976,
+                               0.08975979, 0.07853982, 0.06981317])
+        assert_almost_equal(loc.tick_values(2*np.pi, 2*np.pi), test_value)
+
     def test_set_params(self):
         """
         Create invlog locator with default value, base=10.0, subs=[1.0],

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2493,9 +2493,9 @@ class InvLogLocator(LogLocator):
         """Set parameters within this locator."""
         super(InvLogLocator, self).set_params(**kwargs)
         if inv_base is not None:
-            self.inv_base = inv_base
+            self.inv_base(inv_base)
         if inv_factor is not None:
-            self.inv_factor = inv_factor
+            self.inv_factor(inv_factor)
 
     def inv_base(self, inv_base):
         """
@@ -2527,9 +2527,24 @@ class InvLogLocator(LogLocator):
             numticks = self.numticks
 
         ib = self._inv_base
-        # max and min swapped
+
+        # max and min swapped: vmin determines ivmax and vice versa
         ivmax = self._inv_factor / vmin
         ivmin = self._inv_factor / vmax
+
+        if vmin <= 0.0:
+            if self.axis is not None:
+                ivmax = self._inv_factor / self.axis.get_minpos()
+
+        if vmax <= 0.0:
+            if self.axis is not None:
+                ivmin = self._inv_factor / self.axis.get_maxpos()
+
+            if ivmin <= 0.0 or not np.isfinite(ivmin):
+                raise ValueError(
+                    "Data has no positive values, and therefore can not be "
+                    "log-scaled.")
+    
         # dummy axis has no axes attribute
         if hasattr(self.axis, 'axes') and self.axis.axes.name == 'polar':
             ivmax = math.ceil(math.log(ivmax) / math.log(ib))
@@ -2539,15 +2554,6 @@ class InvLogLocator(LogLocator):
             ticklocs = self._inv_factor / i_ticklocs
 
             return ticklocs
-
-        if ivmax <= 0.0:
-            if self.axis is not None:
-                ivmax = self._inv_factor / self.axis.get_minpos()
-
-            if ivmax <= 0.0 or not np.isfinite(ivmax):
-                raise ValueError(
-                    "Data has no positive values, and therefore can not be "
-                    "log-scaled.")
 
         ivmin = math.log(ivmin) / math.log(ib)
         ivmax = math.log(ivmax) / math.log(ib)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2544,7 +2544,7 @@ class InvLogLocator(LogLocator):
                 raise ValueError(
                     "Data has no positive values, and therefore can not be "
                     "log-scaled.")
-    
+
         # dummy axis has no axes attribute
         if hasattr(self.axis, 'axes') and self.axis.axes.name == 'polar':
             ivmax = math.ceil(math.log(ivmax) / math.log(ib))


### PR DESCRIPTION
## PR Summary

When plotting a quantity on a logarithmic scale for which the reciprocal value `1/x` is the actual quantity of interest, it makes more sense to reverse the minor ticks on the logarithmic axis. One area where this is of immediate use is when doing Fourier analysis if one is interested in (time/length-)scales instead of frequencies. This is shown in the new `invlog_fft_demo.py` example in
the gallery. I personally needed this for my (cosmology) research (plotting power spectra), so I thought let's try to do it right :)

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] ~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->