### PR TITLE
Add link to developer discussions...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,3 +84,5 @@ You've worked out a way to fix it – even better!
 You want to tell us about it – best of all!
 
 Start at the `contributing guide <http://matplotlib.org/devdocs/devel/contributing.html>`_!
+
+Developer notes are now at `_Developer Discussions <https://github.com/orgs/matplotlib/teams/developers/discussions>`_


### PR DESCRIPTION
## PR Summary

Small change to README.rst to link the developer discussions, as discussed during the call (9 Apr 2018)

I didn't find an easy way to find this page, so having a link somewhere prominent will help me at least...



