### PR TITLE
DOC: add links to examples for a few examples

### DIFF
--- a/examples/images_contours_and_fields/pcolormesh_levels.py
+++ b/examples/images_contours_and_fields/pcolormesh_levels.py
@@ -9,6 +9,7 @@ way to the levels keyword argument to contour/contourf.
 
 """
 
+import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.colors import BoundaryNorm
 from matplotlib.ticker import MaxNLocator
@@ -55,3 +56,16 @@ ax1.set_title('contourf with levels')
 fig.tight_layout()
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+matplotlib.axes.Axes.pcolormesh
+matplotlib.axes.Axes.contourf
+matplotlib.figure.Figure.colorbar

--- a/examples/lines_bars_and_markers/simple_plot.py
+++ b/examples/lines_bars_and_markers/simple_plot.py
@@ -6,6 +6,7 @@ Simple Plot
 Create a simple plot.
 """
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -24,3 +25,17 @@ ax.grid()
 
 fig.savefig("test.png")
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+matplotlib.axes.Axes.plot
+matplotlib.pyplot.plot
+matplotlib.pyplot.subplots
+matplotlib.figure.Figure.savefig

--- a/examples/shapes_and_collections/scatter.py
+++ b/examples/shapes_and_collections/scatter.py
@@ -20,3 +20,16 @@ area = (30 * np.random.rand(N))**2  # 0 to 15 point radii
 
 plt.scatter(x, y, s=area, c=colors, alpha=0.5)
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+import matplotlib
+
+matplotlib.axes.Axes.scatter
+matplotlib.pyplot.scatter

--- a/examples/statistics/histogram_features.py
+++ b/examples/statistics/histogram_features.py
@@ -19,6 +19,7 @@ select these parameters:
 http://docs.astropy.org/en/stable/visualization/histogram.html
 """
 
+import matplotlib
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -47,3 +48,17 @@ ax.set_title(r'Histogram of IQ: $\mu=100$, $\sigma=15$')
 # Tweak spacing to prevent clipping of ylabel
 fig.tight_layout()
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+matplotlib.axes.Axes.hist
+matplotlib.axes.Axes.set_title
+matplotlib.axes.Axes.set_xlabel
+matplotlib.axes.Axes.set_ylabel


### PR DESCRIPTION
## PR Summary

Following the suggestion in #10974 by @ImportanceOfBeingErnest , this PR adds a "References" sections to a few randomly chosen examples.  This should form links in the API docs to the examples.

The only disadvantage to this approach that I can see is that we have to `import matplotlib` for the examples to still work.  

This isn't meant to be comprehensive (at all) but following this approach for future examples and modified examples would greatly increase the cross-referencing between examples and API docs...

The code to include is 

```python
#############################################################################
#
# ------------
#
# References
# """"""""""
#
# The use of the following functions and methods is shown in this example:

import matplotlib 
matplotlib.axes.Axes.hist
matplotlib.axes.Axes.set_title
matplotlib.axes.Axes.set_xlabel
matplotlib.axes.Axes.set_ylabel
```

#### plot

https://8868-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/_as_gen/matplotlib.axes.Axes.plot.html#examples-using-matplotlib-axes-axes-plot

#### pcolormesh:

https://8868-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/_as_gen/matplotlib.axes.Axes.pcolormesh.html#matplotlib.axes.Axes.pcolormesh

#### scatter:

https://8868-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/_as_gen/matplotlib.axes.Axes.scatter.html#matplotlib.axes.Axes.scatter

#### hist

https://8868-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/_as_gen/matplotlib.axes.Axes.hist.html#matplotlib.axes.Axes.hist

