### PR TITLE
MNT: remove distutils.sysconfig import from toplevel module

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -121,7 +121,6 @@ import atexit
 from collections import MutableMapping
 import contextlib
 import distutils.version
-import distutils.sysconfig
 import functools
 import io
 import importlib


### PR DESCRIPTION
This makes packaging on debian easier as it is now an explicit
dependency and we do not actually use it.

closes #11021

Looks like this line dates to 2004 (e34a333d00814124d3e19d462b9d78ac35e7a49a) and looks like it was last actually used in 2005 (2acdd1813c35c68e9352190346ea845d2154fc61).

backporting this to the 2.2.x branch an a courtesy to @sandrotosi