### PR TITLE
Add note concerning python2 support on doc start page

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -309,11 +309,11 @@ h2 {
     margin: 0.5em 0 0.2em 0;
     padding-top: 0.5em;
     font-size: 1.7em;
-    padding: 0;
 }
 
 h3 {
     margin: 0.2em 0 0.1em 0;
+    padding-top: 0.5em;
     font-size: 1.2em;
 }
 
@@ -846,14 +846,12 @@ figcaption {
 }
 
 #sidebar-donations {
-    margin-top: 28px;
+    margin-top: 40px;
 }
 
 .donate_button {
     background:#11557C;
     font-weight:normal;
-    border:solid 1px #fff;
-    outline: solid 1px #11557C;
     clear: both;
     display: block;
     width:200px;
@@ -864,6 +862,7 @@ figcaption {
     color:#fff;
     text-decoration: none;
     margin: 30px auto 0;
+    border-radius: 6px;
     z-index:1;
     transition: background .25s ease;
 }
@@ -972,3 +971,13 @@ p.sphx-glr-signature a.reference.external {
     font-weight: 400;
 }
 
+.sidebar-announcement {
+    border: 1px solid #11557C;
+    background: #eff9ff;
+    padding: 2px;
+    margin-top: 40px;
+}
+
+.sidebar-announcement p {
+    margin: 0.4em 0.4em 0.6em 0.4em;
+}

--- a/doc/_templates/sidebar_announcement.html
+++ b/doc/_templates/sidebar_announcement.html
@@ -1,0 +1,5 @@
+<div class="sidebar-announcement">
+  <p>The upcoming version Matplotlib 3.0 will be Python 3 only.</p>
+  <p>For Python 2 support, Matplotlib 2.2.x will be continued as a LTS release
+      and updated with bugfixes until January 1, 2020.</p>
+</div>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -233,7 +233,8 @@ html_index = 'index.html'
 
 # Custom sidebar templates, maps page names to templates.
 html_sidebars = {
-    'index': ['searchbox.html', 'donate_sidebar.html'],
+    'index': ['searchbox.html', 'sidebar_announcement.html',
+              'donate_sidebar.html'],
     '**': ['searchbox.html', 'localtoc.html', 'relations.html',
            'pagesource.html']
 }


### PR DESCRIPTION
## PR Summary

As discussed a few days ago on gitter, it's good to publicly announce our policy of migrating to Python 3.

This PR contains some minor CSS cleanups, e.g. the support buttons have rounded corners to set them visually apart from informational elements like titles and the announcement box, which have edge corners.

![grafik](https://user-images.githubusercontent.com/2836374/38642633-e6a32f3a-3dda-11e8-8daf-ac7f2eb2b20c.png)
