### PR TITLE
FIX: constrained_layout and repeated calls to suptitle

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -235,7 +235,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
                 ax._poslayoutbox.constrain_left_margin(0, strength='weak')
 
     # do layout for suptitle.
-    if fig._suptitle is not None:
+    if fig._suptitle is not None and fig._suptitle._layoutbox is not None:
         sup = fig._suptitle
         bbox = invTransFig(sup.get_window_extent(renderer=renderer))
         height = bbox.y1 - bbox.y0

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -344,3 +344,43 @@ def test_constrained_layout20():
     ax = fig.add_axes([0, 0, 1, 1])
     mesh = ax.pcolormesh(gx, gx, img)
     fig.colorbar(mesh)
+
+
+def test_constrained_layout21():
+    '#11035: repeated calls to suptitle should not alter the layout'
+    fig, ax = plt.subplots(constrained_layout=True)
+
+    fig.suptitle("Suptitle0")
+    fig.canvas.draw()
+    extents0 = np.copy(ax.get_position().extents)
+
+    fig.suptitle("Suptitle1")
+    fig.canvas.draw()
+    extents1 = np.copy(ax.get_position().extents)
+
+    np.testing.assert_allclose(extents0, extents1)
+
+
+def test_constrained_layout22():
+    '#11035: suptitle should not be include in CL if manually positioned'
+    fig, ax = plt.subplots(constrained_layout=True)
+
+    fig.canvas.draw()
+    extents0 = np.copy(ax.get_position().extents)
+
+    fig.suptitle("Suptitle", y=0.5)
+    fig.canvas.draw()
+    extents1 = np.copy(ax.get_position().extents)
+
+    np.testing.assert_allclose(extents0, extents1)
+
+
+def test_constrained_layout23():
+    '''
+    Comment in #11035: suptitle used to cause an exception when
+    reusing a figure w/ CL with ``clear=True``.
+    '''
+
+    for i in range(2):
+        fig, ax = plt.subplots(num="123", constrained_layout=True, clear=True)
+        fig.suptitle("Suptitle{}".format(i))


### PR DESCRIPTION
## PR Summary

As pointed out by @afvincent on gitter, repeated calls to `suptitle` using `constrained_layout=True` were making room for each call.  This fixes the logic to only create the layout box if the subtitle is new.  

Note that the change is just indenting a block...


```python

import matplotlib.pyplot as plt

fig, axs = plt.subplots(1, 2, num="issue_suptitle", constrained_layout=True)

for idx in range(10):
    fig.suptitle(f"Suptitle #{idx}")
plt.show()
```

### Before

![issue_suptitle2](https://user-images.githubusercontent.com/1562854/38689719-2cecfa6a-3e31-11e8-9301-8fe9f6520a55.png)


### Now

![issue_suptitle](https://user-images.githubusercontent.com/1562854/38689546-cbe30976-3e30-11e8-8dbc-eb6492f1e8a7.png)


## PR Checklist

- [x] Code is PEP 8 compliant
