### PR TITLE
FIX: image respect norm limits w/ None

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -390,12 +390,10 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 # float64's ability to represent changes.  Applying
                 # a norm first would be good, but ruins the interpolation
                 # of over numbers.
-                vmin = self.norm.vmin if self.norm.vmin is not None else a_min
-                vmax = self.norm.vmax if self.norm.vmax is not None else a_max
-
-                dv = (np.float64(vmax) -
-                      np.float64(vmin))
-                vmid = vmin + dv / 2
+                self.norm.autoscale_None(A)
+                dv = (np.float64(self.norm.vmax) -
+                      np.float64(self.norm.vmin))
+                vmid = self.norm.vmin + dv / 2
                 newmin = vmid - dv * 1.e7
                 if newmin < a_min:
                     newmin = None

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -390,22 +390,24 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 # float64's ability to represent changes.  Applying
                 # a norm first would be good, but ruins the interpolation
                 # of over numbers.
-                if self.norm.vmin is not None and self.norm.vmax is not None:
-                    dv = (np.float64(self.norm.vmax) -
-                          np.float64(self.norm.vmin))
-                    vmid = self.norm.vmin + dv / 2
-                    newmin = vmid - dv * 1.e7
-                    if newmin < a_min:
-                        newmin = None
-                    else:
-                        a_min = np.float64(newmin)
-                    newmax = vmid + dv * 1.e7
-                    if newmax > a_max:
-                        newmax = None
-                    else:
-                        a_max = np.float64(newmax)
-                    if newmax is not None or newmin is not None:
-                        A_scaled = np.clip(A_scaled, newmin, newmax)
+                vmin = self.norm.vmin if self.norm.vmin is not None else a_min
+                vmax = self.norm.vmax if self.norm.vmax is not None else a_max
+
+                dv = (np.float64(vmax) -
+                      np.float64(vmin))
+                vmid = vmin + dv / 2
+                newmin = vmid - dv * 1.e7
+                if newmin < a_min:
+                    newmin = None
+                else:
+                    a_min = np.float64(newmin)
+                newmax = vmid + dv * 1.e7
+                if newmax > a_max:
+                    newmax = None
+                else:
+                    a_max = np.float64(newmax)
+                if newmax is not None or newmin is not None:
+                    A_scaled = np.clip(A_scaled, newmin, newmax)
 
                 A_scaled -= a_min
                 # a_min and a_max might be ndarray subclasses so use

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -394,12 +394,13 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 dv = (np.float64(self.norm.vmax) -
                       np.float64(self.norm.vmin))
                 vmid = self.norm.vmin + dv / 2
-                newmin = vmid - dv * 1.e7
+                fact = 1e7 if scaled_dtype == np.float64 else 1e4
+                newmin = vmid - dv * fact
                 if newmin < a_min:
                     newmin = None
                 else:
                     a_min = np.float64(newmin)
-                newmax = vmid + dv * 1.e7
+                newmax = vmid + dv * fact
                 if newmax > a_max:
                     newmax = None
                 else:
@@ -409,7 +410,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
                 A_scaled -= a_min
                 # a_min and a_max might be ndarray subclasses so use
-                # asscalar to ensure they are scalars to avoid errors
+                # asscalar to avoid errors
                 a_min = np.asscalar(a_min.astype(scaled_dtype))
                 a_max = np.asscalar(a_max.astype(scaled_dtype))
 


### PR DESCRIPTION
## PR Summary

Re-closes #10072 

We are slowly suqishing the "big number" bugs in imshow.  

This one was caused by only specifying `vmax` but not `vmin`.  Algorithm is the same as before, but if `vmin` is `None`, then we scale by `a_min`.  

```python
import matplotlib.pyplot as plt
import numpy as np

x=np.random.random([3,3])
x[1,1]=1.e80
plt.imshow(x,vmax=2)

plt.show()
```

#### Before
<img width="528" alt="figure_1" src="https://user-images.githubusercontent.com/1562854/38748075-d11def4c-3f01-11e8-90da-fe99f913ba82.png">


#### After

![figur](https://user-images.githubusercontent.com/1562854/38747511-f1c2a794-3eff-11e8-9235-5a80cee85eed.png)



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->