### PR TITLE
Add PEP8-compliant aliases to transAxes, transData, etc.

### DIFF
--- a/doc/users/next_whats_new/pep8-transattrs.rst
+++ b/doc/users/next_whats_new/pep8-transattrs.rst
@@ -1,0 +1,6 @@
+PEP8-compliant ``axes_transform``, etc. aliases to ``transAxes``, etc.
+----------------------------------------------------------------------
+
+The ``Axes.transAxes``, ``transScale``, ``transLimits``, and ``transData``
+attributes can now also be accessed under the names ``axes_transform``,
+``scale_transform``, ``limits_transform``, and ``data_transform``.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -659,6 +659,38 @@ class _AxesBase(martist.Artist):
         self._yaxis_transform = mtransforms.blended_transform_factory(
             self.transAxes, self.transData)
 
+    @property
+    def axes_transform(self):
+        return self.transAxes
+
+    @axes_transform.setter
+    def axes_transform(self, value):
+        self.transAxes = value
+
+    @property
+    def scale_transform(self):
+        return self.transScale
+
+    @scale_transform.setter
+    def scale_transform(self, value):
+        self.transScale = value
+
+    @property
+    def limits_transform(self):
+        return self.transLimits
+
+    @limits_transform.setter
+    def limits_transform(self, value):
+        self.transLimits = value
+
+    @property
+    def data_transform(self):
+        return self.transData
+
+    @data_transform.setter
+    def data_transform(self, value):
+        self.transData = value
+
     def get_xaxis_transform(self, which='grid'):
         """
         Get the transformation used for drawing x-axis labels, ticks


### PR DESCRIPTION
ax.transAxes / transData / etc. are perhaps one of the most user-facing
parts of mpl that are not pep8 compliant.  Provide some PEP8-compliant
aliases for those (like myself) who are excessively (and unduly?)
bothered by that.

Note that (quite unusually for myself :-)) I am **not** proposing to
deprecate the camelCase names.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
