### PR TITLE
Update Ellipse position with ellipse.center

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1414,7 +1414,7 @@ class Ellipse(Patch):
     A scale-free ellipse.
     """
     def __str__(self):
-        pars = (self.center[0], self.center[1],
+        pars = (self.xy[0], self.xy[1],
                 self.width, self.height, self.angle)
         fmt = "Ellipse(xy=(%s, %s), width=%s, height=%s, angle=%s)"
         return fmt % pars
@@ -1439,7 +1439,7 @@ class Ellipse(Patch):
         """
         Patch.__init__(self, **kwargs)
 
-        self.center = xy
+        self.xy = xy
         self.width, self.height = width, height
         self.angle = angle
         self._path = Path.unit_circle()
@@ -1452,8 +1452,8 @@ class Ellipse(Patch):
                  makes it very important to call the accessor method and
                  not directly access the transformation member variable.
         """
-        center = (self.convert_xunits(self.center[0]),
-                  self.convert_yunits(self.center[1]))
+        center = (self.convert_xunits(self.xy[0]),
+                  self.convert_yunits(self.xy[1]))
         width = self.convert_xunits(self.width)
         height = self.convert_yunits(self.height)
         self._patch_transform = transforms.Affine2D() \
@@ -1470,6 +1470,23 @@ class Ellipse(Patch):
     def get_patch_transform(self):
         self._recompute_transform()
         return self._patch_transform
+
+    def set_center(self, xy):
+        """
+        Set the center of the ellipse
+
+        ACCEPTS: (x, y)
+        """
+        self.xy = xy
+        self.stale = True
+
+    def get_center(self):
+        """
+        Return the center of the ellipse
+        """
+        return self.xy
+
+    center = property(get_center, set_center)
 
 
 class Circle(Ellipse):
@@ -1506,7 +1523,9 @@ class Circle(Ellipse):
         self.stale = True
 
     def get_radius(self):
-        'return the radius of the circle'
+        """
+        Return the radius of the circle
+        """
         return self.width / 2.
 
     radius = property(get_radius, set_radius)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1414,7 +1414,7 @@ class Ellipse(Patch):
     A scale-free ellipse.
     """
     def __str__(self):
-        pars = (self.xy[0], self.xy[1],
+        pars = (self._center[0], self._center[1],
                 self.width, self.height, self.angle)
         fmt = "Ellipse(xy=(%s, %s), width=%s, height=%s, angle=%s)"
         return fmt % pars
@@ -1439,7 +1439,7 @@ class Ellipse(Patch):
         """
         Patch.__init__(self, **kwargs)
 
-        self.xy = xy
+        self._center = xy
         self.width, self.height = width, height
         self.angle = angle
         self._path = Path.unit_circle()
@@ -1452,8 +1452,8 @@ class Ellipse(Patch):
                  makes it very important to call the accessor method and
                  not directly access the transformation member variable.
         """
-        center = (self.convert_xunits(self.xy[0]),
-                  self.convert_yunits(self.xy[1]))
+        center = (self.convert_xunits(self._center[0]),
+                  self.convert_yunits(self._center[1]))
         width = self.convert_xunits(self.width)
         height = self.convert_yunits(self.height)
         self._patch_transform = transforms.Affine2D() \
@@ -1477,14 +1477,14 @@ class Ellipse(Patch):
 
         ACCEPTS: (x, y)
         """
-        self.xy = xy
+        self._center = xy
         self.stale = True
 
     def get_center(self):
         """
         Return the center of the ellipse
         """
-        return self.xy
+        return self._center
 
     center = property(get_center, set_center)
 


### PR DESCRIPTION
## PR Summary
Fixed an issue where Ellipses would not move when `ellipse.center` was set.

Example:
```python
import matplotlib.pyplot as plt
from matplotlib.patches import Ellipse

def onmove(event):
    ellipse.center = event.xdata, event.ydata
    # ellipse.stale = True # (old fix)
    # Ellipse position would not update after plt.draw()
    # Should move with mouse
    plt.draw()

ellipse = Ellipse((1,1), 1, 1)
plt.gca().add_patch(ellipse)
plt.gca().set_aspect('equal')
plt.gcf().canvas.mpl_connect('motion_notify_event', onmove)
plt.xlim(0, 4)
plt.ylim(0, 4)
plt.show()
```
__Old__
![old](https://user-images.githubusercontent.com/17667220/38805483-234c39f8-41b5-11e8-87aa-aaebd09c01eb.png)
__New__
![new](https://user-images.githubusercontent.com/17667220/38805489-289bddbe-41b5-11e8-8fa0-5bb014e59e2f.png)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
