### PR TITLE
Changed tight_layout doc strings

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2066,20 +2066,18 @@ default: 'top'
     def tight_layout(self, renderer=None, pad=1.08, h_pad=None, w_pad=None,
                      rect=None):
         """
-        Adjust subplot parameters to give specified padding.
+        Automatically adjust subplot parameters to give specified padding.
 
         Parameters
         ----------
         pad : float
-            padding between the figure edge and the edges of subplots,
-            as a fraction of the font-size.
-
+            Padding between the figure edge and the edges of subplots,
+            as a fraction of the font size.
         h_pad, w_pad : float, optional
-            padding (height/width) between edges of adjacent subplots.
-            Defaults to `pad_inches`.
-
+            Padding (height/width) between edges of adjacent subplots,
+            as a fraction of the font size.  Defaults to *pad*.
         rect : tuple (left, bottom, right, top), optional
-            a rectangle (left, bottom, right, top) in the normalized
+            A rectangle (left, bottom, right, top) in the normalized
             figure coordinate that the whole subplots area (including
             labels) will fit into. Default is (0, 0, 1, 1).
         """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1256,15 +1256,15 @@ def tight_layout(pad=1.08, h_pad=None, w_pad=None, rect=None):
     Parameters
     ----------
     pad : float
-        padding between the figure edge and the edges of subplots, as a fraction of the font-size.
-    h_pad, w_pad : float
-        padding (height/width) between edges of adjacent subplots.
-        Defaults to `pad_inches`.
-    rect : if rect is given, it is interpreted as a rectangle
-        (left, bottom, right, top) in the normalized figure
-        coordinate that the whole subplots area (including
+        Padding between the figure edge and the edges of subplots,
+        as a fraction of the font size.
+    h_pad, w_pad : float, optional
+        Padding (height/width) between edges of adjacent subplots,
+        as a fraction of the font size.  Defaults to *pad*.
+    rect : tuple (left, bottom, right, top), optional
+        A rectangle (left, bottom, right, top) in the normalized
+        figure coordinate that the whole subplots area (including
         labels) will fit into. Default is (0, 0, 1, 1).
-
     """
     fig = gcf()
     fig.tight_layout(pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)


### PR DESCRIPTION
I didn't understand what *pad_inches* in the `h_pad`, `w_pad` default was so I copied part of the doc string from  `auto_adjust_subplotpars` in `tight_layout` where the default was correctly explained.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
