### PR TITLE
Remove unnecessary shebang.

### DIFF
--- a/lib/matplotlib/backends/wx_compat.py
+++ b/lib/matplotlib/backends/wx_compat.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 A wx API adapter to hide differences between wxPython classic and phoenix.
 


### PR DESCRIPTION
This file does not include any code to be run standalone, nor is it marked executable. This causes a warning when packaging on Fedora.