### PR TITLE
Drop alpha channel when saving comparison failure diff image.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -422,8 +422,9 @@ def compare_images(expected, actual, tol, in_decorator=False):
 
 
 def save_diff_image(expected, actual, output):
-    expectedImage = _png.read_png(expected)
-    actualImage = _png.read_png(actual)
+    # Drop alpha channels, similarly to compare_images.
+    expectedImage = _png.read_png(expected)[..., :3]
+    actualImage = _png.read_png(actual)[..., :3]
     actualImage, expectedImage = crop_to_same(
         actual, actualImage, expected, expectedImage)
     expectedImage = np.array(expectedImage).astype(float)


### PR DESCRIPTION
We drop (for the better or the worse) the alpha channel when *comparing*
the images (in `compare_images`), but not when saving; thus, a
comparison failure where additionally the reference has no alpha but
the generated image has an alpha channel would so far raise a spurious
"image sizes do not match" when trying to save the diff image, rather
than actually saving the diff image as expected.

Noted while running the Matplotlib test suite with mplcairo.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
