### PR TITLE
Use GtkShortcutsWindow for Help tool.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -847,13 +847,80 @@ class ConfigureSubplotsGTK3(backend_tools.ConfigureSubplotsBase, Gtk.Window):
 
 
 class HelpGTK3(backend_tools.ToolHelpBase):
-    def trigger(self, *args):
+    def _normalize_shortcut(self, key):
+        """
+        Convert Matplotlib key presses to GTK+ accelerator identifiers.
+
+        Related to `FigureCanvasGTK3._get_key`.
+        """
+        special = {
+            'backspace': 'BackSpace',
+            'pagedown': 'Page_Down',
+            'pageup': 'Page_Up',
+            'scroll_lock': 'Scroll_Lock',
+        }
+
+        parts = key.split('+')
+        mods = ['<' + mod + '>' for mod in parts[:-1]]
+        key = parts[-1]
+
+        if key in special:
+            key = special[key]
+        elif len(key) > 1:
+            key = key.capitalize()
+        elif key.isupper():
+            mods += ['<shift>']
+
+        return ''.join(mods) + key
+
+    def _show_shortcuts_window(self):
+        section = Gtk.ShortcutsSection()
+
+        for name, tool in sorted(self.toolmanager.tools.items()):
+            if not tool.description:
+                continue
+
+            # Putting everything in a separate group allows GTK to
+            # automatically split them into separate columns/pages, which is
+            # useful because we have lots of shortcuts, some with many keys
+            # that are very wide.
+            group = Gtk.ShortcutsGroup()
+            section.add(group)
+            # A hack to remove the title since we have no group naming.
+            group.forall(lambda widget, data: widget.set_visible(False), None)
+
+            shortcut = Gtk.ShortcutsShortcut(
+                accelerator=' '.join(
+                    self._normalize_shortcut(key)
+                    for key in self.toolmanager.get_tool_keymap(name)
+                    # Will never be sent:
+                    if 'cmd+' not in key),
+                title=tool.name,
+                subtitle=tool.description)
+            group.add(shortcut)
+
+        window = Gtk.ShortcutsWindow(
+            title='Help',
+            modal=True,
+            transient_for=self._figure.canvas.get_toplevel())
+        section.show()  # Must be done explicitly before add!
+        window.add(section)
+
+        window.show_all()
+
+    def _show_shortcuts_dialog(self):
         dialog = Gtk.MessageDialog(
             self._figure.canvas.get_toplevel(),
             0, Gtk.MessageType.INFO, Gtk.ButtonsType.OK, self._get_help_text(),
             title="Help")
         dialog.run()
         dialog.destroy()
+
+    def trigger(self, *args):
+        if Gtk.check_version(3, 20, 0) is None:
+            self._show_shortcuts_window()
+        else:
+            self._show_shortcuts_dialog()
 
 
 # Define the file to use as the GTk icon


### PR DESCRIPTION
## PR Summary

A followup to #11045, using GTK's builtin widgets for shortcuts, when they are available. I also applied a small hack of putting every shortcut in its own group, because then GTK automatically splits columns and pages.
![screenshot from 2018-04-18 22-32-15](https://user-images.githubusercontent.com/302469/38968209-6c1a617e-4358-11e8-9447-ebff130bd5d9.png)

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way