### PR TITLE
Changes to figure.clf() and suplot_adjust

### DIFF
--- a/doc/users/next_whats_new/subplots_adjust_keyword.rst
+++ b/doc/users/next_whats_new/subplots_adjust_keyword.rst
@@ -1,0 +1,13 @@
+subplots_adjust has a new ``kwarg``: ``rc_default``
+---------------------------------------------------
+ 
+`.Figure.subplots_adjust` and `.pyplot.subplots_adjust` have a new ``kwarg``: 
+``rc_default`` that determines the default values for the subplot parameters.
+
+The `.figure.SubplotParams` object has a new get method 
+:meth:`~.SubplotParams.get_subplot_params`
+
+
+
+
+

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1204,25 +1204,49 @@ def twiny(ax=None):
 
 
 def subplots_adjust(left=None, bottom=None, right=None, top=None,
-                    wspace=None, hspace=None):
+                    wspace=None, hspace=None, rc_default=False):
     """
-    Tune the subplot layout.
+    Tune the subplots layout by updating the subplots parameters and
+    the subplot locations.
 
-    The parameter meanings (and suggested defaults) are::
+    All dimensions are fractions of the figure width or height.
 
-      left  = 0.125  # the left side of the subplots of the figure
-      right = 0.9    # the right side of the subplots of the figure
-      bottom = 0.1   # the bottom of the subplots of the figure
-      top = 0.9      # the top of the subplots of the figure
-      wspace = 0.2   # the amount of width reserved for space between subplots,
-                     # expressed as a fraction of the average axis width
-      hspace = 0.2   # the amount of height reserved for space between subplots,
-                     # expressed as a fraction of the average axis height
+    Parameters
+    ----------
+    left : float, optional
+        The left side of the subplots of the figure.
 
-    The actual defaults are controlled by the rc file
+    right : float, optional
+        The right side of the subplots of the figure.
+
+    bottom : float, optional
+        The bottom of the subplots of the figure.
+
+    top : float, optional
+        The top of the subplots of the figure.
+
+    wspace : float, optional
+        The amount of width reserved for space between subplots,
+        expressed as a fraction of the average axis width.
+
+    hspace : float, optional
+        The amount of height reserved for space between subplots,
+        expressed as a fraction of the average axis height.
+
+    rc_default : bool, optional
+        Determine the defaults. *False*, the default, and the values
+        are unchanged. *True* and the values are taken from
+        :rc:`figure.subplot.*`
+
+
+    Notes
+    -----
+    The subplots parameters are stored in the `~.Figure` attribute
+    ``subplotpars`` as a `~.SubplotParams` object.
     """
+
     fig = gcf()
-    fig.subplots_adjust(left, bottom, right, top, wspace, hspace)
+    fig.subplots_adjust(left, bottom, right, top, wspace, hspace, rc_default)
 
 
 def subplot_tool(targetfig=None):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -383,3 +383,45 @@ def test_fspath(fmt, tmpdir):
         # All the supported formats include the format name (case-insensitive)
         # in the first 100 bytes.
         assert fmt.encode("ascii") in file.read(100).lower()
+
+
+def test_clf_subplotpars():
+    keys = ('left', 'right', 'bottom', 'top', 'wspace', 'hspace')
+    rc_params = {key: plt.rcParams['figure.subplot.'+key] for key in keys}
+
+    fig = plt.figure(1)
+    fig.subplots_adjust(left=0.1)
+    fig.clf()
+    assert fig.subplotpars.get_subplot_params() == rc_params
+
+
+def test_suplots_adjust_1():
+    fig = plt.figure(1)
+    wspace = 0
+    fig.subplots_adjust(wspace=wspace)
+    inDict = dict(left=0.1, right=0.7, bottom=0, top=0.9, hspace=0.05)
+    fig.subplots_adjust(**inDict)
+    inDict['wspace'] = wspace
+    assert fig.subplotpars.get_subplot_params() == inDict
+
+
+def test_suplots_adjust_2():
+    fig = plt.figure(1)
+    fig.subplots_adjust(wspace=0)
+    inDict = dict(left=0.1, right=0.7, bottom=0, top=0.9, hspace=0.05,
+                  rc_default=True)
+    fig.subplots_adjust(**inDict)
+    inDict['wspace'] = plt.rcParams['figure.subplot.wspace']
+    del inDict['rc_default']
+    assert fig.subplotpars.get_subplot_params() == inDict
+
+
+def test_suplots_adjust_plt():
+    plt.figure(1)
+    plt.subplots_adjust(wspace=0)
+    inDict = dict(left=0.1, right=0.7, bottom=0, top=0.9, hspace=0.05,
+                  rc_default=True)
+    plt.subplots_adjust(**inDict)
+    inDict['wspace'] = plt.rcParams['figure.subplot.wspace']
+    del inDict['rc_default']
+    assert plt.gcf().subplotpars.get_subplot_params() == inDict


### PR DESCRIPTION
I wrote some code to solve #11059
- `figure.clf()` now sets the subplots parameters to their default values. This is a behavior that I have missed before and I think that it is the correct thing to do.
- A new keyword `rc_default` is added to subplots_adjust to make it simpler to get back to default values when tuning the subplot parameters
- The `SubplotParams` object has got a `__repr__`  function with the important attributes such that it is easier to see and print what the subplot parameters are
- The `SubplotParams` object has got a get function to make it easier to get its parameters
- The code in `SubplotParams.update` has been written more compact
- A few tests have been written to test the old and new behavior
- The docstrings has been changed such that they are more complete and (mostly at least) follows the new docstring directive 

I think that these changes make it easier to work with and understand the subplot parameters without changing the interface to much. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] Documentation is sphinx and numpydoc compliant
 

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
