### PR TITLE
DOC: Fixup to AnchoredArtist examples in the gallery

### DIFF
--- a/examples/axes_grid1/simple_anchored_artists.py
+++ b/examples/axes_grid1/simple_anchored_artists.py
@@ -3,18 +3,29 @@
 Simple Anchored Artists
 =======================
 
+This example illustrates the use of the anchored helper classes found in
+:py:mod:`~matplotlib.offsetbox` and in the :ref:`toolkit_axesgrid1-index`.
+An implementation of a similar figure, but without use of the toolkit,
+can be found in :ref:`sphx_glr_gallery_misc_anchored_artists.py`.
 """
+
 import matplotlib.pyplot as plt
 
 
 def draw_text(ax):
+    """
+    Draw two text-boxes, anchored by different corners to the upper-left
+    corner of the figure.
+    """
     from matplotlib.offsetbox import AnchoredText
+    # loc=2 is equivalent to loc='upper left'
     at = AnchoredText("Figure 1a",
                       loc=2, prop=dict(size=8), frameon=True,
                       )
     at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
     ax.add_artist(at)
 
+    # loc=3 is eqivalent to loc='lower left'
     at2 = AnchoredText("Figure 1(b)",
                        loc=3, prop=dict(size=8), frameon=True,
                        bbox_to_anchor=(0., 1.),
@@ -24,7 +35,10 @@ def draw_text(ax):
     ax.add_artist(at2)
 
 
-def draw_circle(ax):  # circle in the canvas coordinate
+def draw_circle(ax):
+    """
+    Draw a circle in axis coordinates
+    """
     from mpl_toolkits.axes_grid1.anchored_artists import AnchoredDrawingArea
     from matplotlib.patches import Circle
     ada = AnchoredDrawingArea(20, 20, 0, 0,
@@ -35,8 +49,10 @@ def draw_circle(ax):  # circle in the canvas coordinate
 
 
 def draw_ellipse(ax):
+    """
+    Draw an ellipse of width=0.1, height=0.15 in data coordinates
+    """
     from mpl_toolkits.axes_grid1.anchored_artists import AnchoredEllipse
-    # draw an ellipse of width=0.1, height=0.15 in the data coordinate
     ae = AnchoredEllipse(ax.transData, width=0.1, height=0.15, angle=0.,
                          loc=3, pad=0.5, borderpad=0.4, frameon=True)
 
@@ -44,9 +60,11 @@ def draw_ellipse(ax):
 
 
 def draw_sizebar(ax):
+    """
+    Draw a horizontal bar with length of 0.1 in data coordinates,
+    with a fixed label underneath.
+    """
     from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
-    # draw a horizontal bar with length of 0.1 in Data coordinate
-    # (ax.transData) with a label underneath.
     asb = AnchoredSizeBar(ax.transData,
                           0.1,
                           r"1$^{\prime}$",
@@ -56,13 +74,12 @@ def draw_sizebar(ax):
     ax.add_artist(asb)
 
 
-if 1:
-    ax = plt.gca()
-    ax.set_aspect(1.)
+ax = plt.gca()
+ax.set_aspect(1.)
 
-    draw_text(ax)
-    draw_circle(ax)
-    draw_ellipse(ax)
-    draw_sizebar(ax)
+draw_text(ax)
+draw_circle(ax)
+draw_ellipse(ax)
+draw_sizebar(ax)
 
-    plt.show()
+plt.show()

--- a/examples/misc/anchored_artists.py
+++ b/examples/misc/anchored_artists.py
@@ -3,8 +3,15 @@
 Anchored Artists
 ================
 
+This example illustrates the use of the anchored objects without the
+helper classes found in the :ref:`toolkit_axesgrid1-index`. This version
+of the figure is similar to the one found in
+:ref:`sphx_glr_gallery_axes_grid1_simple_anchored_artists.py`, but it is
+implemented using only the matplotlib namespace, without the help
+of additional toolkits.
 """
 
+from matplotlib import pyplot as plt
 from matplotlib.patches import Rectangle, Ellipse
 from matplotlib.offsetbox import (
     AnchoredOffsetbox, AuxTransformBox, DrawingArea, TextArea, VPacker)
@@ -16,6 +23,61 @@ class AnchoredText(AnchoredOffsetbox):
         self.txt = TextArea(s, minimumdescent=False)
         super().__init__(loc, pad=pad, borderpad=borderpad,
                          child=self.txt, prop=prop, frameon=frameon)
+
+
+def draw_text(ax):
+    """
+    Draw a text-box anchored to the upper-left corner of the figure.
+    """
+    # loc=2 is equivalent to loc='upper left'
+    at = AnchoredText("Figure 1a", loc=2, frameon=True)
+    at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
+    ax.add_artist(at)
+
+
+class AnchoredDrawingArea(AnchoredOffsetbox):
+    def __init__(self, width, height, xdescent, ydescent,
+                 loc, pad=0.4, borderpad=0.5, prop=None, frameon=True):
+        self.da = DrawingArea(width, height, xdescent, ydescent)
+        super().__init__(loc, pad=pad, borderpad=borderpad,
+                         child=self.da, prop=None, frameon=frameon)
+
+
+def draw_circle(ax):
+    """
+    Draw a circle in axis coordinates
+    """
+    from matplotlib.patches import Circle
+    ada = AnchoredDrawingArea(20, 20, 0, 0,
+                              loc=1, pad=0., frameon=False)
+    p = Circle((10, 10), 10)
+    ada.da.add_artist(p)
+    ax.add_artist(ada)
+
+
+class AnchoredEllipse(AnchoredOffsetbox):
+    def __init__(self, transform, width, height, angle, loc,
+                 pad=0.1, borderpad=0.1, prop=None, frameon=True):
+        """
+        Draw an ellipse the size in data coordinate of the give axes.
+
+        pad, borderpad in fraction of the legend font size (or prop)
+        """
+        self._box = AuxTransformBox(transform)
+        self.ellipse = Ellipse((0, 0), width, height, angle)
+        self._box.add_artist(self.ellipse)
+        super().__init__(loc, pad=pad, borderpad=borderpad,
+                         child=self._box, prop=prop, frameon=frameon)
+
+
+def draw_ellipse(ax):
+    """
+    Draw an ellipse of width=0.1, height=0.15 in data coordinates
+    """
+    ae = AnchoredEllipse(ax.transData, width=0.1, height=0.15, angle=0.,
+                         loc=3, pad=0.5, borderpad=0.4, frameon=True)
+
+    ax.add_artist(ae)
 
 
 class AnchoredSizeBar(AnchoredOffsetbox):
@@ -41,56 +103,11 @@ class AnchoredSizeBar(AnchoredOffsetbox):
                          child=self._box, prop=prop, frameon=frameon)
 
 
-class AnchoredEllipse(AnchoredOffsetbox):
-    def __init__(self, transform, width, height, angle, loc,
-                 pad=0.1, borderpad=0.1, prop=None, frameon=True):
-        """
-        Draw an ellipse the size in data coordinate of the give axes.
-
-        pad, borderpad in fraction of the legend font size (or prop)
-        """
-        self._box = AuxTransformBox(transform)
-        self.ellipse = Ellipse((0, 0), width, height, angle)
-        self._box.add_artist(self.ellipse)
-        super().__init__(loc, pad=pad, borderpad=borderpad,
-                         child=self._box, prop=prop, frameon=frameon)
-
-
-class AnchoredDrawingArea(AnchoredOffsetbox):
-    def __init__(self, width, height, xdescent, ydescent,
-                 loc, pad=0.4, borderpad=0.5, prop=None, frameon=True):
-        self.da = DrawingArea(width, height, xdescent, ydescent)
-        super().__init__(loc, pad=pad, borderpad=borderpad,
-                         child=self.da, prop=None, frameon=frameon)
-
-
-if __name__ == "__main__":
-
-    import matplotlib.pyplot as plt
-
-    ax = plt.gca()
-    ax.set_aspect(1.)
-
-    at = AnchoredText("Figure 1a",
-                      loc=2, frameon=True)
-    at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
-    ax.add_artist(at)
-
-    from matplotlib.patches import Circle
-    ada = AnchoredDrawingArea(20, 20, 0, 0,
-                              loc=1, pad=0., frameon=False)
-    p = Circle((10, 10), 10)
-    ada.da.add_artist(p)
-    ax.add_artist(ada)
-
-    # draw an ellipse of width=0.1, height=0.15 in the data coordinate
-    ae = AnchoredEllipse(ax.transData, width=0.1, height=0.15, angle=0.,
-                         loc=3, pad=0.5, borderpad=0.4, frameon=True)
-
-    ax.add_artist(ae)
-
-    # draw a horizontal bar with length of 0.1 in Data coordinate
-    # (ax.transData) with a label underneath.
+def draw_sizebar(ax):
+    """
+    Draw a horizontal bar with length of 0.1 in data coordinates,
+    with a fixed label underneath.
+    """
     asb = AnchoredSizeBar(ax.transData,
                           0.1,
                           r"1$^{\prime}$",
@@ -99,5 +116,13 @@ if __name__ == "__main__":
                           frameon=False)
     ax.add_artist(asb)
 
-    plt.draw()
-    plt.show()
+
+ax = plt.gca()
+ax.set_aspect(1.)
+
+draw_text(ax)
+draw_circle(ax)
+draw_ellipse(ax)
+draw_sizebar(ax)
+
+plt.show()

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -340,7 +340,7 @@ available in ``mpl_toolkits.axes_grid1.anchored_artists`` others in
 
     from matplotlib.offsetbox import AnchoredText
     at = AnchoredText("Figure 1a",
-                      prop=dict(size=8), frameon=True,
+                      prop=dict(size=15), frameon=True,
                       loc=2,
                       )
     at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")


### PR DESCRIPTION
Response to issue #11092. Instead of deleting the user gallery example called `anchored_bbox01`, I made it a non-duplicate. It did not make sense to remove it entirely given that there are perfectly reasonable `anchored_bbox` examples up to `04`. I did remove the clearly obsolete `misc/anchored_artists.html` and renamed `axes_grid1/simple_anchored_artists.html` to `axes_grid1/anchored_artists.html`. Hopefully the changes I made to the comments and docstrings in the example came out as an improvement.