### PR TITLE
Deprecate certain marker styles that have simpler synonyms.

### DIFF
--- a/doc/api/next_api_changes/2018-04-22-AL.rst
+++ b/doc/api/next_api_changes/2018-04-22-AL.rst
@@ -1,0 +1,8 @@
+Deprecation of certain marker styles
+````````````````````````````````````
+
+Using ``(n, 3)`` as marker style to specify a circle marker is deprecated.  Use
+``"o"`` instead.
+
+Using ``([(x0, y0), (x1, y1), ...], 0)`` as marker style to specify a custom
+marker path is deprecated.  Use ``[(x0, y0), (x1, y1), ...]`` instead.

--- a/examples/api/scatter_piecharts.py
+++ b/examples/api/scatter_piecharts.py
@@ -38,11 +38,11 @@ xy3 = np.column_stack([x, y])
 s3 = np.abs(xy3).max()
 
 fig, ax = plt.subplots()
-ax.scatter(range(3), range(3), marker=(xy1, 0),
+ax.scatter(range(3), range(3), marker=xy1,
            s=s1 ** 2 * sizes, facecolor='blue')
-ax.scatter(range(3), range(3), marker=(xy2, 0),
+ax.scatter(range(3), range(3), marker=xy2,
            s=s2 ** 2 * sizes, facecolor='green')
-ax.scatter(range(3), range(3), marker=(xy3, 0),
+ax.scatter(range(3), range(3), marker=xy3,
            s=s3 ** 2 * sizes, facecolor='red')
 
 plt.show()

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -68,15 +68,15 @@ path                           a `~matplotlib.path.Path` instance.
                                      an asterisk
                                    3
                                      a circle (`numsides` and `angle` is
-                                     ignored)
+                                     ignored); deprecated.
 
                                `angle`:
                                    the angle of rotation of the symbol
 ============================== ===============================================
 
-For backward compatibility, the form (`verts`, 0) is also accepted,
-but it is equivalent to just `verts` for giving a raw set of vertices
-that define the shape.
+For backward compatibility, the form (`verts`, 0) is also accepted, but it is
+deprecated and equivalent to just `verts` for giving a raw set of vertices that
+define the shape.
 
 `None` is the default which means 'nothing', however this table is
 referred to from other docs for the valid inputs from marker inputs and in
@@ -307,9 +307,17 @@ class MarkerStyle(object):
                 self._filled = False
                 self._joinstyle = 'bevel'
             elif symstyle == 3:
+                cbook.warn_deprecated(
+                    "3.0", "Setting a circle marker using `(..., 3)` is "
+                    "deprecated since Matplotlib 3.0, and support for it will "
+                    "be removed in 3.2.  Directly pass 'o' instead.")
                 self._path = Path.unit_circle()
             self._transform = Affine2D().scale(0.5).rotate_deg(rotation)
         else:
+            cbook.warn_deprecated(
+                "3.0", "Passing vertices as `(verts, 0)` is deprecated since "
+                "Matplotlib 3.0, and support for it will be removed in 3.2.  "
+                "Directly pass `verts` instead.")
             verts = np.asarray(marker[0])
             path = Path(verts)
             self._set_custom_marker(path)


### PR DESCRIPTION
## PR Summary

Using ``(n, 3)`` as marker style to specify a circle marker is deprecated.  Use
``"o"`` instead.
 
Using ``([(x0, y0), (x1, y1), ...], 0)`` as marker style to specify a custom
marker path is deprecated.  Use ``[(x0, y0), (x1, y1), ...]`` instead.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
