### PR TITLE
PGF: Get unitless positions from Text elements (fix #11116)

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -725,7 +725,8 @@ class RendererPgf(RendererBase):
                 mtext.get_va() != "center_baseline"):
             # if text anchoring can be supported, get the original coordinates
             # and add alignment information
-            x, y = mtext.get_transform().transform_point(mtext.get_position())
+            pos = mtext.get_unitless_position()
+            x, y = mtext.get_transform().transform_point(pos)
             text_args.append("x=%fin" % (x * f))
             text_args.append("y=%fin" % (y * f))
 


### PR DESCRIPTION
Fix issue #11116 in PGF backend.
In some cases the coordinates returned by `Text.get_position()` are not suited for `get_transform()` transformations. Use `Text.get_unitless_position()` instead.