### PR TITLE
Some changes in make.bat and the build documentation documentation

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -47,7 +47,7 @@ requirements that are needed to build the documentation. They are listed in
 * IPython
 * numpydoc>=0.4
 * Pillow
-* sphinx-gallery>=0.1.13
+* sphinx-gallery>=0.2.0
 * graphviz
 
 .. note::
@@ -72,13 +72,18 @@ Other useful invocations include
 
 .. code-block:: sh
 
-   # Delete built files.  May help if you get errors about missing paths or
-   # broken links.
+   # Delete built files.  May help if you get errors about 
+   # missing paths or broken links. 
    make clean
 
    # Build pdf docs.
    make latexpdf
 
+Linux, macOS
+~~~~~~~~~~~~
+The documentation is built using the ``Makefile`` file and parameters 
+can be set either in the ``Makefile`` or on the command line.
+ 
 The ``SPHINXOPTS`` variable is set to ``-W`` by default to turn warnings into
 errors.  To unset it, use
 
@@ -88,16 +93,89 @@ errors.  To unset it, use
 
 You can use the ``O`` variable to set additional options:
 
-* ``make O=-j4 html`` runs a parallel build with 4 processes.
-* ``make O=-Dplot_formats=png:100 html`` saves figures in low resolution.
-* ``make O=-Dplot_gallery=0 html`` skips the gallery build.
+.. code-block:: sh
+    
+    #runs a parallel build with 4 processes.
+    make O=-j4 html 
+    
+    #saves figures in low resolution.
+    make O=-Dplot_formats=png:100 html 
+    
+    #builds the gallery without executing the scripts
+    make O=-Dplot_gallery=0 html 
 
-Multiple options can be combined using e.g. ``make O='-j4 -Dplot_gallery=0'
-html``.
+    #Multiple options can be combined using e.g.    
+    make O='-j4 -Dplot_gallery=0' html
+    
+Windows
+~~~~~~~
+   
+The documentation is build using the ``make.bat`` file. The options are set using 
+environment variables and variables can be set either in the 
+``make.bat`` file or set on the command line befor running ``make.bat``.
 
-On Windows, options needs to be set as environment variables, e.g. ``set O=-W
--j4 & make html``.
+Environment variables are set with
 
+.. code-block:: sh
+
+    #in cmd
+    set SPHINXOPTS=-W
+    set O=-Dplot_gallery=0  
+
+    #in powershell
+    Set-Item env:SPHINXOPTS "-W"
+    Set-Item env:O "-Dplot_gallery=0" 
+
+The ``SPHINXOPTS`` variable is set to ``-W`` by default to turn warnings into
+errors.  To unset it, set the ``SPHINXOPTS`` variable to any argument except 
+nothing. A space can used to overide the default.
+
+.. code-block:: sh
+    
+    #in cmd
+    #use the default -W option
+    make html 
+    set SPHINXOPTS=& make html
+    
+    #to not use the default
+    set SPHINXOPTS= & make html
+  
+You can use the ``O`` variable to set additional options, for example (see 
+linux, macOS above for more options) 
+
+.. code-block:: sh
+
+   set O=-j4 -Dplot_gallery=0
+   
+The total command is then run with 
+
+.. code-block:: sh
+
+    #in cmd
+    set O=-Dplot_gallery=0
+    make html
+    
+    #or on one line
+    set O=-Dplot_gallery=0 & make html
+     
+    #in powershell
+    Set-Item env:O "-Dplot_gallery=0"
+    .\make html
+    
+    #or on one line
+    Set-Item env:O "-Dplot_gallery=0"; .\make html
+         
+Both ``SPHINXOPTS`` and ``O`` are unset at the end of the ``make.bat`` file 
+if cmd is used but not if powershell is used. So a variable must be unset 
+manually with 
+
+.. code-block:: sh
+
+    Set-Item evn:O
+    
+in powershell before running ``make.bat`` again if the default behavior is 
+wanted.
+    
 .. _writing-rest-pages:
 
 Writing ReST pages

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -10,9 +10,11 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR=.
 set BUILDDIR=build
 set SPHINXPROJ=matplotlib
-set SPHINXOPTS=-W
-set O=
 
+if "%SPHINXOPTS%" == "" (
+    set SPHINXOPTS=-W
+)
+ 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.
@@ -28,11 +30,16 @@ if errorlevel 9009 (
 
 if "%1" == "" goto help
 
+echo %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 
 :help
+
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 
 :end
+set SPHINXBUILD=
+set O=
+set SPHINXOPTS=
 popd


### PR DESCRIPTION
## PR Summary
I changed the ``make.bat`` file so that it is possible to set command line options and wrote a more detailed instruction on how to build the documentation on windows. 

(I am not really sure if everything works when building on windows though because I get some warnings but it works for my use)
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
