### PR TITLE
Clarify array shape vs image size in imshow() docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5027,7 +5027,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        X : array_like, shape (n, m) or (n, m, 3) or (n, m, 4)
+        X : array_like, shape (M, N) or (M, N, 3) or (M, N, 4)
             Display the image in `X` to current axes.  `X` may be an
             array or a PIL image. If `X` is an array, it
             can have the following shapes and types:
@@ -5040,10 +5040,10 @@ class Axes(_AxesBase):
             scalar to scalar) and the `cmap` (mapping the normed scalar to
             a color).
 
-            Elements of RGB and RGBA arrays represent pixels of an MxN image.
-            All values should be in the range [0 .. 1] for floats or
-            [0 .. 255] for integers.  Out-of-range values will be clipped to
-            these bounds.
+            Elements of RGB and RGBA arrays represent pixels of an NxM
+            (width x height) image.  All values should be in the range
+            [0 .. 1] for floats or [0 .. 255] for integers.  Out-of-range
+            values will be clipped to these bounds.
 
         cmap : `~matplotlib.colors.Colormap`, optional, default: None
             If None, default to rc `image.cmap` value. `cmap` is ignored


### PR DESCRIPTION
## PR Summary
The shape of a 2D array is `(nrows, ncols)`, but images are normally described by width x height `(ncols, nrows)`. The docstring for `imshow()` had these a bit mixed up in my opinion. This clarifies it.

I'm not sure if the default is to use `(m, n)` or `(n, m)` to represent the shape of a 2D array. Grepping through the project reveals roughly equal use of both. I've left it as `(m, n)` in this PR, but maybe we should do another PR to make the notation consistent throughout the project.
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
