### PR TITLE
Don't include the postscript title if it is not latin-1 encodable.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -984,6 +984,7 @@ class FigureCanvasPS(FigureCanvasBase):
         if isinstance(outfile,
                       (six.string_types, getattr(os, "PathLike", ()),)):
             outfile = title = getattr(os, "fspath", lambda obj: obj)(outfile)
+            title = title.encode("latin-1", "replace").decode()
             passed_in_file_object = False
         elif is_writable_file_like(outfile):
             title = None
@@ -1071,7 +1072,7 @@ class FigureCanvasPS(FigureCanvasBase):
             else:
                 print("%!PS-Adobe-3.0", file=fh)
             if title:
-                print("%%Title: "+title, file=fh)
+                print("%%Title: " + title, file=fh)
             print("%%Creator: " + creator_str, file=fh)
             # get source date from SOURCE_DATE_EPOCH, if set
             # See https://reproducible-builds.org/specs/source-date-epoch/
@@ -1081,7 +1082,7 @@ class FigureCanvasPS(FigureCanvasBase):
                     int(source_date_epoch)).strftime("%a %b %d %H:%M:%S %Y")
             else:
                 source_date = time.ctime()
-            print("%%CreationDate: "+source_date, file=fh)
+            print("%%CreationDate: " + source_date, file=fh)
             print("%%Orientation: " + orientation, file=fh)
             if not isEPSF:
                 print("%%DocumentPaperSizes: "+papertype, file=fh)


### PR DESCRIPTION
## PR Summary

Closes #11124.

There does not appear to be a complete Unicode encoding available for postscript, so even if certain non-latin1 characters can be handled (won't be done in this PR, in any case), we'll always need to know what to do in the case we can't encode the title.

The %%Title is optional, as is clear from the `is_writable_file_like(outfile)` clause.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
