### PR TITLE
Use kwonlyargs instead of popping from kwargs

### DIFF
--- a/doc/api/next_api_changes/2018-04-30-ZHD.rst
+++ b/doc/api/next_api_changes/2018-04-30-ZHD.rst
@@ -1,0 +1,13 @@
+Explicit arguments instead of \*args, \*\*kwargs
+------------------------------------------------
+
+:PEP:`3102` describes keyword-only arguments, which allow Matplotlib
+to provide explicit call signatures - where we previously used
+``*args, **kwargs`` and ``kwargs.pop``, we can now expose named
+arguments.  In some places, unknown kwargs were previously ignored but
+now raise ``TypeError`` because ``**kwargs`` has been removed.
+
+- :meth:`matplotlib.axes.Axes.stem` no longer accepts unknown keywords,
+  and raises ``TypeError`` instead of emitting a deprecation.
+- :meth:`mpl_toolkits.axes_grid1.axes_divider.SubPlotDivider` raises
+  ``TypeError`` instead of ``Exception`` when passed unknown kwargs.

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -394,17 +394,16 @@ on, use the key/value keyword args in the function definition rather
 than the ``**kwargs`` idiom.
 
 In some cases, you may want to consume some keys in the local
-function, and let others pass through.  You can ``pop`` the ones to be
-used locally and pass on the rest.  For example, in
+function, and let others pass through.  Instead of poping arguments to
+use off ``**kwargs``, specify them as keyword-only arguments to the local
+function.  This makes it obvious at a glance which arguments will be
+consumed in the function.  For example, in
 :meth:`~matplotlib.axes.Axes.plot`, ``scalex`` and ``scaley`` are
 local arguments and the rest are passed on as
 :meth:`~matplotlib.lines.Line2D` keyword arguments::
 
   # in axes/_axes.py
-  def plot(self, *args, **kwargs):
-      scalex = kwargs.pop('scalex', True)
-      scaley = kwargs.pop('scaley', True)
-      if not self._hold: self.cla()
+  def plot(self, *args, scalex=True, scaley=True, **kwargs):
       lines = []
       for line in self._get_lines(*args, **kwargs):
           self.add_line(line)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2084,7 +2084,8 @@ class FigureCanvasBase(object):
             .format(fmt, ", ".join(sorted(self.get_supported_filetypes()))))
 
     def print_figure(self, filename, dpi=None, facecolor=None, edgecolor=None,
-                     orientation='portrait', format=None, **kwargs):
+                     orientation='portrait', format=None,
+                     *, bbox_inches=None, **kwargs):
         """
         Render the figure to hardcopy. Set the figure patch face and edge
         colors.  This is useful because some of the GUIs have a gray figure
@@ -2165,7 +2166,6 @@ class FigureCanvasBase(object):
             self.figure.set_facecolor(facecolor)
             self.figure.set_edgecolor(edgecolor)
 
-            bbox_inches = kwargs.pop("bbox_inches", None)
             if bbox_inches is None:
                 bbox_inches = rcParams['savefig.bbox']
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -930,8 +930,12 @@ class FigureCanvasPS(FigureCanvasBase):
     def print_eps(self, outfile, *args, **kwargs):
         return self._print_ps(outfile, 'eps', *args, **kwargs)
 
-    def _print_ps(self, outfile, format, *args, **kwargs):
-        papertype = kwargs.pop("papertype", rcParams['ps.papersize'])
+    def _print_ps(self, outfile, format, *args,
+                  papertype=None, dpi=72, facecolor='w', edgecolor='w',
+                  orientation='portrait',
+                  **kwargs):
+        if papertype is None:
+            papertype = rcParams['ps.papersize']
         papertype = papertype.lower()
         if papertype == 'auto':
             pass
@@ -939,22 +943,19 @@ class FigureCanvasPS(FigureCanvasBase):
             raise RuntimeError('%s is not a valid papertype. Use one of %s' %
                                (papertype, ', '.join(papersize)))
 
-        orientation = kwargs.pop("orientation", "portrait").lower()
+        orientation = orientation.lower()
         if orientation == 'landscape': isLandscape = True
         elif orientation == 'portrait': isLandscape = False
         else: raise RuntimeError('Orientation must be "portrait" or "landscape"')
 
         self.figure.set_dpi(72) # Override the dpi kwarg
-        imagedpi = kwargs.pop("dpi", 72)
-        facecolor = kwargs.pop("facecolor", "w")
-        edgecolor = kwargs.pop("edgecolor", "w")
 
         if rcParams['text.usetex']:
-            self._print_figure_tex(outfile, format, imagedpi, facecolor, edgecolor,
+            self._print_figure_tex(outfile, format, dpi, facecolor, edgecolor,
                                    orientation, isLandscape, papertype,
                                    **kwargs)
         else:
-            self._print_figure(outfile, format, imagedpi, facecolor, edgecolor,
+            self._print_figure(outfile, format, dpi, facecolor, edgecolor,
                                orientation, isLandscape, papertype,
                                **kwargs)
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1323,7 +1323,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
 
 
 @docstring.Substitution(make_axes_kw_doc)
-def make_axes_gridspec(parent, **kw):
+def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
     '''
     Resize and reposition a parent axes, and return a child axes
     suitable for a colorbar. This function is similar to
@@ -1359,10 +1359,6 @@ def make_axes_gridspec(parent, **kw):
 
     orientation = kw.setdefault('orientation', 'vertical')
     kw['ticklocation'] = 'auto'
-
-    fraction = kw.pop('fraction', 0.15)
-    shrink = kw.pop('shrink', 1.0)
-    aspect = kw.pop('aspect', 20)
 
     x1 = 1 - fraction
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -791,7 +791,12 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         levels for filled contours.  See :meth:`_process_colors`.
     """
 
-    def __init__(self, ax, *args, **kwargs):
+    def __init__(self, ax, *args,
+                 levels=None, filled=False, linewidths=None, linestyles=None,
+                 alpha=None, origin=None, extent=None,
+                 cmap=None, colors=None, norm=None, vmin=None, vmax=None,
+                 extend='neither', antialiased=None,
+                 **kwargs):
         """
         Draw contour lines or filled regions, depending on
         whether keyword arg *filled* is ``False`` (default) or ``True``.
@@ -837,23 +842,17 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             `~axes.Axes.contour`.
         """
         self.ax = ax
-        self.levels = kwargs.pop('levels', None)
-        self.filled = kwargs.pop('filled', False)
-        self.linewidths = kwargs.pop('linewidths', None)
-        self.linestyles = kwargs.pop('linestyles', None)
-
+        self.levels = levels
+        self.filled = filled
+        self.linewidths = linewidths
+        self.linestyles = linestyles
         self.hatches = kwargs.pop('hatches', [None])
-
-        self.alpha = kwargs.pop('alpha', None)
-        self.origin = kwargs.pop('origin', None)
-        self.extent = kwargs.pop('extent', None)
-        cmap = kwargs.pop('cmap', None)
-        self.colors = kwargs.pop('colors', None)
-        norm = kwargs.pop('norm', None)
-        vmin = kwargs.pop('vmin', None)
-        vmax = kwargs.pop('vmax', None)
-        self.extend = kwargs.pop('extend', 'neither')
-        self.antialiased = kwargs.pop('antialiased', None)
+        self.alpha = alpha
+        self.origin = origin
+        self.extent = extent
+        self.colors = colors
+        self.extend = extend
+        self.antialiased = antialiased
         if self.antialiased is None and self.filled:
             self.antialiased = False  # eliminate artifacts; we are not
                                       # stroking the boundaries.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1758,7 +1758,7 @@ default: 'top'
         """Whenever the axes state change, ``func(self)`` will be called."""
         self._axobservers.append(func)
 
-    def savefig(self, fname, **kwargs):
+    def savefig(self, fname, *, frameon=None, transparent=None, **kwargs):
         """
         Save the current figure.
 
@@ -1842,9 +1842,10 @@ default: 'top'
 
         """
         kwargs.setdefault('dpi', rcParams['savefig.dpi'])
-        frameon = kwargs.pop('frameon', rcParams['savefig.frameon'])
-        transparent = kwargs.pop('transparent',
-                                 rcParams['savefig.transparent'])
+        if frameon is None:
+            frameon = rcParams['savefig.frameon']
+        if transparent is None:
+            transparent = rcParams['savefig.transparent']
 
         if transparent:
             kwargs.setdefault('facecolor', 'none')

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -238,17 +238,20 @@ class QuiverKey(martist.Artist):
     valign = {'N': 'bottom', 'S': 'top', 'E': 'center', 'W': 'center'}
     pivot = {'N': 'middle', 'S': 'middle', 'E': 'tip', 'W': 'tail'}
 
-    def __init__(self, Q, X, Y, U, label, **kw):
+    def __init__(self, Q, X, Y, U, label,
+                 *, angle=0, coordinates='axes', color=None, labelsep=0.1,
+                 labelpos='N', labelcolor=None, fontproperties=None,
+                 **kw):
         martist.Artist.__init__(self)
         self.Q = Q
         self.X = X
         self.Y = Y
         self.U = U
-        self.angle = kw.pop('angle', 0)
-        self.coord = kw.pop('coordinates', 'axes')
-        self.color = kw.pop('color', None)
+        self.angle = angle
+        self.coord = coordinates
+        self.color = color
         self.label = label
-        self._labelsep_inches = kw.pop('labelsep', 0.1)
+        self._labelsep_inches = labelsep
         self.labelsep = (self._labelsep_inches * Q.ax.figure.dpi)
 
         # try to prevent closure over the real self
@@ -266,9 +269,9 @@ class QuiverKey(martist.Artist):
         self._cid = Q.ax.figure.callbacks.connect('dpi_changed',
                                                   on_dpi_change)
 
-        self.labelpos = kw.pop('labelpos', 'N')
-        self.labelcolor = kw.pop('labelcolor', None)
-        self.fontproperties = kw.pop('fontproperties', dict())
+        self.labelpos = labelpos
+        self.labelcolor = labelcolor
+        self.fontproperties = fontproperties or dict()
         self.kw = kw
         _fp = self.fontproperties
         # boxprops = dict(facecolor='red')
@@ -426,10 +429,13 @@ class Quiver(mcollections.PolyCollection):
     in the draw() method.
     """
 
-    _PIVOT_VALS = ('tail', 'mid', 'middle', 'tip')
+    _PIVOT_VALS = ('tail', 'middle', 'tip')
 
     @docstring.Substitution(_quiver_doc)
-    def __init__(self, ax, *args, **kw):
+    def __init__(self, ax, *args,
+                 scale=None, headwidth=3, headlength=5, headaxislength=4.5,
+                 minshaft=1, minlength=1, units='width', scale_units=None,
+                 angles='uv', width=None, color='k', pivot='tail', **kw):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
@@ -442,28 +448,25 @@ class Quiver(mcollections.PolyCollection):
         self.Y = Y
         self.XY = np.column_stack((X, Y))
         self.N = len(X)
-        self.scale = kw.pop('scale', None)
-        self.headwidth = kw.pop('headwidth', 3)
-        self.headlength = float(kw.pop('headlength', 5))
-        self.headaxislength = kw.pop('headaxislength', 4.5)
-        self.minshaft = kw.pop('minshaft', 1)
-        self.minlength = kw.pop('minlength', 1)
-        self.units = kw.pop('units', 'width')
-        self.scale_units = kw.pop('scale_units', None)
-        self.angles = kw.pop('angles', 'uv')
-        self.width = kw.pop('width', None)
-        self.color = kw.pop('color', 'k')
+        self.scale = scale
+        self.headwidth = headwidth
+        self.headlength = float(headlength)
+        self.headaxislength = headaxislength
+        self.minshaft = minshaft
+        self.minlength = minlength
+        self.units = units
+        self.scale_units = scale_units
+        self.angles = angles
+        self.width = width
+        self.color = color
 
-        pivot = kw.pop('pivot', 'tail').lower()
-        # validate pivot
-        if pivot not in self._PIVOT_VALS:
+        if pivot.lower() == 'mid':
+            pivot = 'middle'
+        self.pivot = pivot.lower()
+        if self.pivot not in self._PIVOT_VALS:
             raise ValueError(
                 'pivot must be one of {keys}, you passed {inp}'.format(
                       keys=self._PIVOT_VALS, inp=pivot))
-        # normalize to 'middle'
-        if pivot == 'mid':
-            pivot = 'middle'
-        self.pivot = pivot
 
         self.transform = kw.pop('transform', ax.transData)
         kw.setdefault('facecolors', self.color)
@@ -902,23 +905,26 @@ class Barbs(mcollections.PolyCollection):
     # 1 triangle and a series of lines.  It works fine as far as I can tell
     # however.
     @docstring.interpd
-    def __init__(self, ax, *args, **kw):
+    def __init__(self, ax, *args,
+                 pivot='tip', length=7, barbcolor=None, flagcolor=None,
+                 sizes=None, fill_empty=False, barb_increments=None,
+                 rounding=True, flip_barb=False, **kw):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
         by the following pylab interface documentation:
         %(barbs_doc)s
         """
-        self._pivot = kw.pop('pivot', 'tip')
-        self._length = kw.pop('length', 7)
-        barbcolor = kw.pop('barbcolor', None)
-        flagcolor = kw.pop('flagcolor', None)
-        self.sizes = kw.pop('sizes', dict())
-        self.fill_empty = kw.pop('fill_empty', False)
-        self.barb_increments = kw.pop('barb_increments', dict())
-        self.rounding = kw.pop('rounding', True)
-        self.flip = kw.pop('flip_barb', False)
+        self.sizes = sizes or dict()
+        self.fill_empty = fill_empty
+        self.barb_increments = barb_increments or dict()
+        self.rounding = rounding
+        self.flip = flip_barb
         transform = kw.pop('transform', ax.transData)
+        self._pivot = pivot
+        self._length = length
+        barbcolor = barbcolor
+        flagcolor = flagcolor
 
         # Flagcolor and barbcolor provide convenience parameters for
         # setting the facecolor and edgecolor, respectively, of the barb

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -11,7 +11,9 @@ import numpy as np
 __all__ = ['stackplot']
 
 
-def stackplot(axes, x, *args, **kwargs):
+def stackplot(axes, x, *args,
+              labels=(), colors=None, baseline='zero',
+              **kwargs):
     """
     Draws a stacked area plot.
 
@@ -58,13 +60,10 @@ def stackplot(axes, x, *args, **kwargs):
 
     y = np.row_stack(args)
 
-    labels = iter(kwargs.pop('labels', []))
-
-    colors = kwargs.pop('colors', None)
+    labels = iter(labels)
     if colors is not None:
         axes.set_prop_cycle(color=colors)
 
-    baseline = kwargs.pop('baseline', 'zero')
     # Assume data passed has not been 'stacked', so stack it here.
     # We'll need a float buffer for the upcoming calculations.
     stack = np.cumsum(y, axis=0, dtype=np.promote_types(y.dtype, np.float32))

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -5,7 +5,8 @@ from matplotlib.colors import Normalize
 from matplotlib.tri.triangulation import Triangulation
 
 
-def tripcolor(ax, *args, **kwargs):
+def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
+              vmax=None, shading='flat', facecolors=None, **kwargs):
     """
     Create a pseudocolor plot of an unstructured triangular grid.
 
@@ -45,14 +46,6 @@ def tripcolor(ax, *args, **kwargs):
     The remaining kwargs are the same as for
     :meth:`~matplotlib.axes.Axes.pcolor`.
     """
-    alpha = kwargs.pop('alpha', 1.0)
-    norm = kwargs.pop('norm', None)
-    cmap = kwargs.pop('cmap', None)
-    vmin = kwargs.pop('vmin', None)
-    vmax = kwargs.pop('vmax', None)
-    shading = kwargs.pop('shading', 'flat')
-    facecolors = kwargs.pop('facecolors', None)
-
     if shading not in ['flat', 'gouraud']:
         raise ValueError("shading must be one of ['flat', 'gouraud'] "
                          "not {0}".format(shading))

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -359,7 +359,8 @@ class SubplotDivider(Divider):
     The Divider class whose rectangle area is specified as a subplot geometry.
     """
 
-    def __init__(self, fig, *args, **kwargs):
+    def __init__(self, fig, *args, horizontal=None, vertical=None,
+                 aspect=None, anchor='C'):
         """
         Parameters
         ----------
@@ -417,15 +418,7 @@ class SubplotDivider(Divider):
 
         pos = self.figbox.bounds
 
-        horizontal = kwargs.pop("horizontal", [])
-        vertical = kwargs.pop("vertical", [])
-        aspect = kwargs.pop("aspect", None)
-        anchor = kwargs.pop("anchor", "C")
-
-        if kwargs:
-            raise Exception("")
-
-        Divider.__init__(self, fig, pos, horizontal, vertical,
+        Divider.__init__(self, fig, pos, horizontal or [], vertical or [],
                          aspect=aspect, anchor=anchor)
 
     def get_position(self):

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -753,7 +753,7 @@ class Colorbar(ColorbarBase):
                 self.add_lines(mappable)
 
 @docstring.Substitution(make_axes_kw_doc)
-def make_axes(parent, **kw):
+def make_axes(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
     '''
     Resize and reposition a parent axes, and return a child
     axes suitable for a colorbar
@@ -774,9 +774,6 @@ def make_axes(parent, **kw):
     Returns (cax, kw), the child axes and the reduced kw dictionary.
     '''
     orientation = kw.setdefault('orientation', 'vertical')
-    fraction = kw.pop('fraction', 0.15)
-    shrink = kw.pop('shrink', 1.0)
-    aspect = kw.pop('aspect', 20)
     #pb = transforms.PBox(parent.get_position())
     pb = parent.get_position(original=True).frozen()
     if orientation == 'vertical':

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -267,9 +267,7 @@ class Patch3D(Patch):
     3D patch object.
     """
 
-    def __init__(self, *args, **kwargs):
-        zs = kwargs.pop('zs', [])
-        zdir = kwargs.pop('zdir', 'z')
+    def __init__(self, *args, zs=(), zdir='z', **kwargs):
         Patch.__init__(self, *args, **kwargs)
         self.set_3d_properties(zs, zdir)
 
@@ -300,9 +298,7 @@ class PathPatch3D(Patch3D):
     3D PathPatch object.
     """
 
-    def __init__(self, path, **kwargs):
-        zs = kwargs.pop('zs', [])
-        zdir = kwargs.pop('zdir', 'z')
+    def __init__(self, path, *, zs=(), zdir='z', **kwargs):
         Patch.__init__(self, **kwargs)
         self.set_3d_properties(path, zs, zdir)
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1528,7 +1528,7 @@ class Axes3D(Axes):
     text3D = text
     text2D = Axes.text
 
-    def plot(self, xs, ys, *args, **kwargs):
+    def plot(self, xs, ys, *args, zdir='z', **kwargs):
         '''
         Plot 2D or 3D data.
 
@@ -1558,7 +1558,6 @@ class Axes3D(Axes):
                 raise TypeError("plot() for multiple values for argument 'z'")
         else:
             zs = kwargs.pop('zs', 0)
-        zdir = kwargs.pop('zdir', 'z')
 
         # Match length
         zs = np.broadcast_to(zs, len(xs))
@@ -1573,7 +1572,8 @@ class Axes3D(Axes):
 
     plot3D = plot
 
-    def plot_surface(self, X, Y, Z, *args, **kwargs):
+    def plot_surface(self, X, Y, Z, *args, norm=None, vmin=None,
+                     vmax=None, lightsource=None, **kwargs):
         """
         Create a surface plot.
 
@@ -1672,12 +1672,7 @@ class Axes3D(Axes):
             fcolors = None
 
         cmap = kwargs.get('cmap', None)
-        norm = kwargs.pop('norm', None)
-        vmin = kwargs.pop('vmin', None)
-        vmax = kwargs.pop('vmax', None)
-        linewidth = kwargs.get('linewidth', None)
         shade = kwargs.pop('shade', cmap is None)
-        lightsource = kwargs.pop('lightsource', None)
 
         # Shade the data
         if shade and cmap is not None and fcolors is not None:
@@ -1923,7 +1918,8 @@ class Axes3D(Axes):
 
         return linec
 
-    def plot_trisurf(self, *args, **kwargs):
+    def plot_trisurf(self, *args, color=None, norm=None, vmin=None, vmax=None,
+                     lightsource=None, **kwargs):
         """
         ============= ================================================
         Argument      Description
@@ -1975,18 +1971,12 @@ class Axes3D(Axes):
         had_data = self.has_data()
 
         # TODO: Support custom face colours
-        color = kwargs.pop('color', None)
         if color is None:
             color = self._get_lines.get_next_color()
         color = np.array(mcolors.to_rgba(color))
 
         cmap = kwargs.get('cmap', None)
-        norm = kwargs.pop('norm', None)
-        vmin = kwargs.pop('vmin', None)
-        vmax = kwargs.pop('vmax', None)
-        linewidth = kwargs.get('linewidth', None)
         shade = kwargs.pop('shade', cmap is None)
-        lightsource = kwargs.pop('lightsource', None)
 
         tri, args, kwargs = Triangulation.get_from_args_and_kwargs(*args, **kwargs)
         if 'Z' in kwargs:


### PR DESCRIPTION
This pull contains part of my follow-up to #11137, likewise addressing #9912.

For this one, I've only included the cases where a straight translation from kwargs.pop to keyword-only arguments gives exactly the same behaviour (modulo two cases where unknown kwargs now raise TypeError!).  There are many more that require some additional refactoring, but in the hope of a quick review cycle I'm leaving them all for later.

- [x] Code is PEP 8 compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way