### PR TITLE
remove use of subprocess compatibility shim

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -145,7 +145,7 @@ source_encoding = "utf-8"
 master_doc = 'contents'
 
 # General substitutions.
-from matplotlib.compat.subprocess import check_output
+from subprocess import check_output
 SHA = check_output(['git', 'describe', '--dirty']).decode('utf-8').strip()
 
 html_context = {'sha': SHA}


### PR DESCRIPTION
## PR Summary

With p3k, we don't need our subprocess shims anymore. This should be the last of them.

(cc @ImportanceOfBeingErnest)