### PR TITLE
Fix contour return link

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1679,7 +1679,7 @@ class QuadContourSet(ContourSet):
 
         Returns
         -------
-        :class:`~matplotlib.contour.QuadContourSet`
+        c : `~.contour.QuadContourSet`
 
         Other Parameters
         ----------------


### PR DESCRIPTION
See the Returns section of https://matplotlib.org/devdocs/api/_as_gen/matplotlib.axes.Axes.contour.html?highlight=contour#matplotlib.axes.Axes.contour - the link to the return type is not present. This fixes that.