### PR TITLE
Fix documentation for xerr and yerr arguments in _axes.py

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1873,7 +1873,7 @@ class Axes(_AxesBase):
 
             - scalar: symmetric +/- values for all bars
             - shape(N,): symmetric +/- values for each bar
-            - shape(2,N): separate + and - values for each bar
+            - shape(2,N): First row lower errors, second row upper errors.
 
             Default: None
 
@@ -2148,7 +2148,7 @@ class Axes(_AxesBase):
 
             - scalar: symmetric +/- values for all bars
             - shape(N,): symmetric +/- values for each bar
-            - shape(2,N): separate + and - values for each bar
+            - shape(2,N): First row lower errors, second row upper errors.
 
             Default: None
 
@@ -2671,7 +2671,7 @@ class Axes(_AxesBase):
 
             - scalar: Symmetric +/- values for all data points.
             - shape(N,): Symmetric +/-values for each data point.
-            - shape(2,N): Separate + and - values for each data point.
+            - shape(2,N): First row lower errors, second row upper errors.
             - *None*: No errorbar.
 
         fmt : plot format string, optional, default: ''

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1873,7 +1873,7 @@ class Axes(_AxesBase):
 
             - scalar: symmetric +/- values for all bars
             - shape(N,): symmetric +/- values for each bar
-            - shape(2,N): Separate +/- values for each bar,
+            - shape(2,N): separate +/- values for each bar,
                 the first row contains the - value, 
                 the second row contains the + value.
 
@@ -2150,7 +2150,7 @@ class Axes(_AxesBase):
 
             - scalar: symmetric +/- values for all bars
             - shape(N,): symmetric +/- values for each bar
-            - shape(2,N): Separate +/- values for each bar,
+            - shape(2,N): separate +/- values for each bar,
                 the first row contains the - value, 
                 the second row contains the + value.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1873,7 +1873,9 @@ class Axes(_AxesBase):
 
             - scalar: symmetric +/- values for all bars
             - shape(N,): symmetric +/- values for each bar
-            - shape(2,N): First row lower errors, second row upper errors.
+            - shape(2,N): Separate +/- values for each bar,
+                the first row contains the - value, 
+                the second row contains the + value.
 
             Default: None
 
@@ -2148,7 +2150,9 @@ class Axes(_AxesBase):
 
             - scalar: symmetric +/- values for all bars
             - shape(N,): symmetric +/- values for each bar
-            - shape(2,N): First row lower errors, second row upper errors.
+            - shape(2,N): Separate +/- values for each bar,
+                the first row contains the - value, 
+                the second row contains the + value.
 
             Default: None
 
@@ -2671,7 +2675,9 @@ class Axes(_AxesBase):
 
             - scalar: Symmetric +/- values for all data points.
             - shape(N,): Symmetric +/-values for each data point.
-            - shape(2,N): First row lower errors, second row upper errors.
+            - shape(2,N): Separate +/- values for each bar, 
+                the first row contains the - value, 
+                the second row contains the + value.
             - *None*: No errorbar.
 
         fmt : plot format string, optional, default: ''


### PR DESCRIPTION
## PR Summary
From issue #11156, documentation for xerr and yerr arguments when they are of shape(2,N) in the bar, barh, and errorbar methods suggests that '+' values are first row while '-' values are second row. The opposite is actually true -- documentation has been changed to more explicitly convey use of xerr and yerr.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ X] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
