### PR TITLE
FIX: str method for SymmetricalLogTransform

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -327,6 +327,9 @@ class SymmetricalLogTransform(Transform):
         return InvertedSymmetricalLogTransform(self.base, self.linthresh,
                                                self.linscale)
 
+    def __str__(self):
+        return "{}".format(type(self).__name__)
+
 
 class InvertedSymmetricalLogTransform(Transform):
     input_dims = 1
@@ -358,6 +361,9 @@ class InvertedSymmetricalLogTransform(Transform):
     def inverted(self):
         return SymmetricalLogTransform(self.base,
                                        self.linthresh, self.linscale)
+
+    def __str__(self):
+        return "{}".format(type(self).__name__)
 
 
 class SymmetricalLogScale(ScaleBase):


### PR DESCRIPTION
## PR Summary

Fixes recursion error for #11163

```python

from matplotlib import pyplot as plt
import numpy as np

f, ax = plt.subplots()
ax.plot(np.arange(100))
ax.set_yscale('symlog')
print(ax.get_yaxis_transform())

```

I don't think this fix is really the correct fix.  If a Transform doesn't have its str method defined, the default string method should not have a recursion.    But this fixes the error.

Ping @anntzer who did some work on the transform repr recently...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->