### PR TITLE
Define `__repr__`, not `__str__` for transforms.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -34,7 +34,7 @@ class PolarTransform(mtransforms.Transform):
         self._use_rmin = use_rmin
         self._apply_theta_transforms = _apply_theta_transforms
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                 "    use_rmin={},\n"
@@ -100,7 +100,7 @@ class PolarAffine(mtransforms.Affine2DBase):
         self.set_children(scale_transform, limits)
         self._mtx = None
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
@@ -138,7 +138,7 @@ class InvertedPolarTransform(mtransforms.Transform):
         self._use_rmin = use_rmin
         self._apply_theta_transforms = _apply_theta_transforms
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                 "    use_rmin={},\n"
@@ -483,7 +483,7 @@ class _ThetaShift(mtransforms.ScaledTranslation):
         self.mode = mode
         self.pad = pad
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{},\n"
@@ -778,7 +778,7 @@ class _WedgeBbox(mtransforms.Bbox):
         self._originLim = originLim
         self.set_children(viewLim, originLim)
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{},\n"

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -110,7 +110,7 @@ class LogTransformBase(Transform):
                     out[a <= 0] = -1000
         return out
 
-    def __str__(self):
+    def __repr__(self):
         return "{}({!r})".format(
             type(self).__name__, "clip" if self._clip else "mask")
 
@@ -124,7 +124,7 @@ class InvertedLogTransformBase(Transform):
     def transform_non_affine(self, a):
         return ma.power(self.base, a)
 
-    def __str__(self):
+    def __repr__(self):
         return "{}()".format(type(self).__name__)
 
 
@@ -470,7 +470,7 @@ class LogitTransform(Transform):
     def inverted(self):
         return LogisticTransform(self._nonpos)
 
-    def __str__(self):
+    def __repr__(self):
         return "{}({!r})".format(type(self).__name__,
             "clip" if self._clip else "mask")
 
@@ -492,7 +492,7 @@ class LogisticTransform(Transform):
     def inverted(self):
         return LogitTransform(self._nonpos)
 
-    def __str__(self):
+    def __repr__(self):
         return "{}({!r})".format(type(self).__name__, self._nonpos)
 
 

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -83,12 +83,15 @@ def test_logscale_invert_transform():
     assert isinstance(Log10Transform().inverted(), InvertedLog10Transform)
 
 
-def test_logscale_transform_repr():
+@pytest.mark.parametrize('scale', ['log', 'symlog'])
+def test_scale_transform_repr_1(scale):
     # check that repr of log transform succeeds
     fig, ax = plt.subplots()
-    ax.set_yscale('log')
+    ax.set_yscale(scale)
     s = repr(ax.transData)
 
+
+def test_scale_transform_repr_2():
     # check that repr of log transform returns correct string
     s = repr(Log10Transform(nonpos='clip'))
     assert s == "Log10Transform({!r})".format('clip')

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -99,7 +99,7 @@ class TransformNode(object):
         self._shorthand_name = shorthand_name or ''
 
     if DEBUG:
-        def __str__(self):
+        def __repr__(self):
             # either just return the name of this TransformNode, or its repr
             return self._shorthand_name or repr(self)
 
@@ -1045,15 +1045,13 @@ class TransformedBbox(BboxBase):
         self.set_children(bbox, transform)
         self._points = None
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
                 .format(type(self).__name__,
                         _indent_str(self._bbox),
                         _indent_str(self._transform)))
-
-    __repr__ = __str__
 
     def get_points(self):
         if self._invalid:
@@ -1132,15 +1130,13 @@ class LockableBbox(BboxBase):
         mask = [val is None for val in fp]
         self._locked_points = np.ma.array(fp, float, mask=mask).reshape((2, 2))
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
                 .format(type(self).__name__,
                         _indent_str(self._bbox),
                         _indent_str(self._locked_points)))
-
-    __repr__ = __str__
 
     def get_points(self):
         if self._invalid:
@@ -1621,9 +1617,6 @@ class Transform(TransformNode):
         """
         raise NotImplementedError()
 
-    def __repr__(self):
-        return str(self)
-
 
 class TransformWrapper(Transform):
     """
@@ -1662,7 +1655,7 @@ class TransformWrapper(Transform):
     def __eq__(self, other):
         return self._child.__eq__(other)
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{})"
                 .format(type(self).__name__,
@@ -1891,7 +1884,7 @@ class Affine2D(Affine2DBase):
         self._mtx = matrix
         self._invalid = 0
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{})"
                 .format(type(self).__name__,
@@ -2099,7 +2092,7 @@ class IdentityTransform(Affine2DBase):
         return self
     frozen.__doc__ = Affine2DBase.frozen.__doc__
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}()"
                 .format(type(self).__name__))
 
@@ -2200,7 +2193,7 @@ class BlendedGenericTransform(Transform):
         return blended_transform_factory(self._x.frozen(), self._y.frozen())
     frozen.__doc__ = Transform.frozen.__doc__
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
@@ -2309,7 +2302,7 @@ class BlendedAffine2D(Affine2DBase):
         # Note, this is an exact copy of BlendedTransform.contains_branch_seperately
         return self._x.contains_branch(transform), self._y.contains_branch(transform)
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
@@ -2429,7 +2422,7 @@ class CompositeGenericTransform(Transform):
         return self._a.is_separable and self._b.is_separable
     is_separable = property(_get_is_separable)
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
@@ -2521,7 +2514,7 @@ class CompositeAffine2D(Affine2DBase):
         for left, right in self._b._iter_break_from_left_to_right():
             yield self._a + left, right
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
@@ -2589,7 +2582,7 @@ class BboxTransform(Affine2DBase):
         self._mtx = None
         self._inverted = None
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{},\n"
                     "{})"
@@ -2637,7 +2630,7 @@ class BboxTransformTo(Affine2DBase):
         self._mtx = None
         self._inverted = None
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{})"
                 .format(type(self).__name__,
@@ -2696,7 +2689,7 @@ class BboxTransformFrom(Affine2DBase):
         self._mtx = None
         self._inverted = None
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{})"
                 .format(type(self).__name__,
@@ -2732,7 +2725,7 @@ class ScaledTranslation(Affine2DBase):
         self._mtx = None
         self._inverted = None
 
-    def __str__(self):
+    def __repr__(self):
         return ("{}(\n"
                     "{})"
                 .format(type(self).__name__,


### PR DESCRIPTION
str falls back on repr (but not the other way round), so `def
__repr__(self): return str(self)` was causing a recursion error.
Defining `__repr__` directly side-steps the issue.

(https://docs.python.org/3/reference/datamodel.html#object.__str__, e.g.
```
In [1]: class T:
   ...:     def __repr__(self): return "4242"
   ...: 
   ...: 

In [2]: str(T())
Out[2]: '4242'

In [3]: repr(T())
Out[3]: '4242'

In [4]: class T:
   ...:     def __str__(self): return "4242"
   ...: 
   ...: 

In [5]: str(T())
Out[5]: '4242'

In [6]: repr(T())
Out[6]: '<__main__.T object at 0x7fb33f6e88d0>'
```
)

Supersedes #11171; closes #11163.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
