### PR TITLE
Replace numeric loc by position string

### DIFF
--- a/doc/users/prev_whats_new/whats_new_2.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_2.1.0.rst
@@ -261,11 +261,11 @@ rectangle for the size bar.
 
     fig, ax = plt.subplots(figsize=(3, 3))
 
-    bar0 = AnchoredSizeBar(ax.transData, 0.3, 'unfilled', loc=3, frameon=False,
-                           size_vertical=0.05, fill_bar=False)
+    bar0 = AnchoredSizeBar(ax.transData, 0.3, 'unfilled', loc='lower left',
+                           frameon=False, size_vertical=0.05, fill_bar=False)
     ax.add_artist(bar0)
-    bar1 = AnchoredSizeBar(ax.transData, 0.3, 'filled', loc=4, frameon=False,
-                           size_vertical=0.05, fill_bar=True)
+    bar1 = AnchoredSizeBar(ax.transData, 0.3, 'filled', loc='lower right',
+                           frameon=False, size_vertical=0.05, fill_bar=True)
     ax.add_artist(bar1)
 
     plt.show()

--- a/examples/api/sankey_basics.py
+++ b/examples/api/sankey_basics.py
@@ -91,7 +91,7 @@ sankey.add(flows=[-0.25, 0.15, 0.1], label='two',
            orientations=[-1, -1, -1], prior=0, connect=(0, 0))
 diagrams = sankey.finish()
 diagrams[-1].patch.set_hatch('/')
-plt.legend(loc='best')
+plt.legend()
 
 ###############################################################################
 # Notice that only one connection is specified, but the systems form a

--- a/examples/axes_grid1/demo_anchored_direction_arrows.py
+++ b/examples/axes_grid1/demo_anchored_direction_arrows.py
@@ -20,7 +20,7 @@ ax.add_artist(simple_arrow)
 high_contrast_part_1 = AnchoredDirectionArrows(
                             ax.transAxes,
                             '111', r'11$\overline{2}$',
-                            loc=1,
+                            loc='upper right',
                             arrow_props={'ec': 'w', 'fc': 'none', 'alpha': 1,
                                          'lw': 2}
                             )
@@ -29,7 +29,7 @@ ax.add_artist(high_contrast_part_1)
 high_contrast_part_2 = AnchoredDirectionArrows(
                             ax.transAxes,
                             '111', r'11$\overline{2}$',
-                            loc=1,
+                            loc='upper right',
                             arrow_props={'ec': 'none', 'fc': 'k'},
                             text_props={'ec': 'w', 'fc': 'k', 'lw': 0.4}
                             )

--- a/examples/axes_grid1/demo_axes_grid2.py
+++ b/examples/axes_grid1/demo_axes_grid2.py
@@ -60,7 +60,7 @@ if 1:
         ax.cax.colorbar(im)
 
     for ax, im_title in zip(grid, ["Image 1", "Image 2", "Image 3"]):
-        t = add_inner_title(ax, im_title, loc=3)
+        t = add_inner_title(ax, im_title, loc='lower left')
         t.patch.set_alpha(0.5)
 
     for ax, z in zip(grid, ZS):
@@ -109,7 +109,7 @@ if 1:
     ax.cax.toggle_label(True)
 
     for ax, im_title in zip(grid2, ["(a)", "(b)", "(c)"]):
-        t = add_inner_title(ax, im_title, loc=2)
+        t = add_inner_title(ax, im_title, loc='upper left')
         t.patch.set_ec("none")
         t.patch.set_alpha(0.5)
 

--- a/examples/axes_grid1/demo_colorbar_of_inset_axes.py
+++ b/examples/axes_grid1/demo_colorbar_of_inset_axes.py
@@ -28,7 +28,7 @@ ax.set(aspect=1,
        ylim=(-20, 5))
 
 
-axins = zoomed_inset_axes(ax, 2, loc=2)  # zoom = 6
+axins = zoomed_inset_axes(ax, zoom=2, loc='upper left')
 im = axins.imshow(Z, extent=extent, interpolation="nearest",
                   origin="lower")
 
@@ -40,7 +40,7 @@ plt.yticks(visible=False)
 cax = inset_axes(axins,
                  width="5%",  # width = 10% of parent_bbox width
                  height="100%",  # height : 50%
-                 loc=3,
+                 loc='lower left',
                  bbox_to_anchor=(1.05, 0., 1, 1),
                  bbox_transform=axins.transAxes,
                  borderpad=0,

--- a/examples/axes_grid1/demo_colorbar_with_inset_locator.py
+++ b/examples/axes_grid1/demo_colorbar_with_inset_locator.py
@@ -13,7 +13,7 @@ fig, (ax1, ax2) = plt.subplots(1, 2, figsize=[6, 3])
 axins1 = inset_axes(ax1,
                     width="50%",  # width = 10% of parent_bbox width
                     height="5%",  # height : 50%
-                    loc=1)
+                    loc='upper right')
 
 im1 = ax1.imshow([[1, 2], [2, 3]])
 plt.colorbar(im1, cax=axins1, orientation="horizontal", ticks=[1, 2, 3])
@@ -22,7 +22,7 @@ axins1.xaxis.set_ticks_position("bottom")
 axins = inset_axes(ax2,
                    width="5%",  # width = 10% of parent_bbox width
                    height="50%",  # height : 50%
-                   loc=3,
+                   loc='lower left',
                    bbox_to_anchor=(1.05, 0., 1, 1),
                    bbox_transform=ax2.transAxes,
                    borderpad=0,

--- a/examples/axes_grid1/inset_locator_demo.py
+++ b/examples/axes_grid1/inset_locator_demo.py
@@ -14,7 +14,7 @@ def add_sizebar(ax, size):
     asb = AnchoredSizeBar(ax.transData,
                           size,
                           str(size),
-                          loc=8,
+                          loc='lower center',
                           pad=0.1, borderpad=0.5, sep=5,
                           frameon=False)
     ax.add_artist(asb)
@@ -28,7 +28,7 @@ ax.set_aspect(1)
 axins = inset_axes(ax,
                    width="30%",  # width = 30% of parent_bbox
                    height=1.,  # height : 1 inch
-                   loc=3)
+                   loc='lower left')
 
 plt.xticks(visible=False)
 plt.yticks(visible=False)

--- a/examples/axes_grid1/inset_locator_demo2.py
+++ b/examples/axes_grid1/inset_locator_demo2.py
@@ -32,7 +32,7 @@ Z2[30:30 + ny, 30:30 + nx] = Z
 ax.imshow(Z2, extent=extent, interpolation="nearest",
           origin="lower")
 
-axins = zoomed_inset_axes(ax, 6, loc=1)  # zoom = 6
+axins = zoomed_inset_axes(ax, zoom=6, loc='upper right')
 axins.imshow(Z2, extent=extent, interpolation="nearest",
              origin="lower")
 

--- a/examples/axes_grid1/simple_anchored_artists.py
+++ b/examples/axes_grid1/simple_anchored_artists.py
@@ -18,16 +18,14 @@ def draw_text(ax):
     corner of the figure.
     """
     from matplotlib.offsetbox import AnchoredText
-    # loc=2 is equivalent to loc='upper left'
     at = AnchoredText("Figure 1a",
-                      loc=2, prop=dict(size=8), frameon=True,
+                      loc='upper left', prop=dict(size=8), frameon=True,
                       )
     at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
     ax.add_artist(at)
 
-    # loc=3 is eqivalent to loc='lower left'
     at2 = AnchoredText("Figure 1(b)",
-                       loc=3, prop=dict(size=8), frameon=True,
+                       loc='lower left', prop=dict(size=8), frameon=True,
                        bbox_to_anchor=(0., 1.),
                        bbox_transform=ax.transAxes
                        )
@@ -42,7 +40,7 @@ def draw_circle(ax):
     from mpl_toolkits.axes_grid1.anchored_artists import AnchoredDrawingArea
     from matplotlib.patches import Circle
     ada = AnchoredDrawingArea(20, 20, 0, 0,
-                              loc=1, pad=0., frameon=False)
+                              loc='upper right', pad=0., frameon=False)
     p = Circle((10, 10), 10)
     ada.da.add_artist(p)
     ax.add_artist(ada)
@@ -54,7 +52,8 @@ def draw_ellipse(ax):
     """
     from mpl_toolkits.axes_grid1.anchored_artists import AnchoredEllipse
     ae = AnchoredEllipse(ax.transData, width=0.1, height=0.15, angle=0.,
-                         loc=3, pad=0.5, borderpad=0.4, frameon=True)
+                         loc='lower left', pad=0.5, borderpad=0.4,
+                         frameon=True)
 
     ax.add_artist(ae)
 
@@ -68,7 +67,7 @@ def draw_sizebar(ax):
     asb = AnchoredSizeBar(ax.transData,
                           0.1,
                           r"1$^{\prime}$",
-                          loc=8,
+                          loc='lower center',
                           pad=0.1, borderpad=0.5, sep=5,
                           frameon=False)
     ax.add_artist(asb)

--- a/examples/lines_bars_and_markers/markevery_prop_cycle.py
+++ b/examples/lines_bars_and_markers/markevery_prop_cycle.py
@@ -55,7 +55,7 @@ ax = fig.add_axes([0.1, 0.1, 0.6, 0.75])
 
 for i in range(len(cases)):
     ax.plot(yy[:, i], marker='o', label=str(cases[i]))
-    ax.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
+    ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left', borderaxespad=0.)
 
 plt.title('Support for axes.prop_cycle cycler with markevery')
 

--- a/examples/lines_bars_and_markers/scatter_symbol.py
+++ b/examples/lines_bars_and_markers/scatter_symbol.py
@@ -22,5 +22,5 @@ plt.scatter(x, y, s, c="g", alpha=0.5, marker=r'$\clubsuit$',
             label="Luck")
 plt.xlabel("Leprechauns")
 plt.ylabel("Gold")
-plt.legend(loc=2)
+plt.legend(loc='upper left')
 plt.show()

--- a/examples/lines_bars_and_markers/stackplot_demo.py
+++ b/examples/lines_bars_and_markers/stackplot_demo.py
@@ -23,7 +23,7 @@ labels = ["Fibonacci ", "Evens", "Odds"]
 
 fig, ax = plt.subplots()
 ax.stackplot(x, y1, y2, y3, labels=labels)
-ax.legend(loc=2)
+ax.legend(loc='upper left')
 plt.show()
 
 fig, ax = plt.subplots()

--- a/examples/misc/anchored_artists.py
+++ b/examples/misc/anchored_artists.py
@@ -29,8 +29,7 @@ def draw_text(ax):
     """
     Draw a text-box anchored to the upper-left corner of the figure.
     """
-    # loc=2 is equivalent to loc='upper left'
-    at = AnchoredText("Figure 1a", loc=2, frameon=True)
+    at = AnchoredText("Figure 1a", loc='upper left', frameon=True)
     at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
     ax.add_artist(at)
 
@@ -49,7 +48,7 @@ def draw_circle(ax):
     """
     from matplotlib.patches import Circle
     ada = AnchoredDrawingArea(20, 20, 0, 0,
-                              loc=1, pad=0., frameon=False)
+                              loc='upper right', pad=0., frameon=False)
     p = Circle((10, 10), 10)
     ada.da.add_artist(p)
     ax.add_artist(ada)
@@ -75,7 +74,8 @@ def draw_ellipse(ax):
     Draw an ellipse of width=0.1, height=0.15 in data coordinates
     """
     ae = AnchoredEllipse(ax.transData, width=0.1, height=0.15, angle=0.,
-                         loc=3, pad=0.5, borderpad=0.4, frameon=True)
+                         loc='lower left', pad=0.5, borderpad=0.4,
+                         frameon=True)
 
     ax.add_artist(ae)
 
@@ -111,7 +111,7 @@ def draw_sizebar(ax):
     asb = AnchoredSizeBar(ax.transData,
                           0.1,
                           r"1$^{\prime}$",
-                          loc=8,
+                          loc='lower center',
                           pad=0.1, borderpad=0.5, sep=5,
                           frameon=False)
     ax.add_artist(asb)

--- a/examples/misc/patheffect_demo.py
+++ b/examples/misc/patheffect_demo.py
@@ -41,7 +41,7 @@ if 1:
     # shadow as a path effect
     ax3 = plt.subplot(133)
     p1, = ax3.plot([0, 1], [0, 1])
-    leg = ax3.legend([p1], ["Line 1"], fancybox=True, loc=2)
+    leg = ax3.legend([p1], ["Line 1"], fancybox=True, loc='upper left')
     leg.legendPatch.set_path_effects([PathEffects.withSimplePatchShadow()])
 
     plt.show()

--- a/examples/recipes/transparent_legends.py
+++ b/examples/recipes/transparent_legends.py
@@ -9,10 +9,10 @@ your data:
 
   ax.legend(loc='upper right')
 
-Other times you don't know where your data is, and loc='best' will try
-and place the legend::
+Other times you don't know where your data is, and the default loc='best'
+will try and place the legend::
 
-  ax.legend(loc='best')
+  ax.legend()
 
 but still, your legend may overlap your data, and in these cases it's
 nice to make the legend frame transparent.
@@ -27,7 +27,7 @@ ax.plot(np.random.randn(300), 'o-', label='normal distribution')
 ax.plot(np.random.rand(300), 's-', label='uniform distribution')
 ax.set_ylim(-3, 3)
 
-ax.legend(loc='best', fancybox=True, framealpha=0.5)
+ax.legend(fancybox=True, framealpha=0.5)
 ax.set_title('fancy, transparent legends')
 
 plt.show()

--- a/examples/text_labels_and_annotations/demo_text_path.py
+++ b/examples/text_labels_and_annotations/demo_text_path.py
@@ -81,7 +81,8 @@ if 1:
     offsetbox.add_artist(p)
 
     # make anchored offset box
-    ao = AnchoredOffsetbox(loc=2, child=offsetbox, frameon=True, borderpad=0.2)
+    ao = AnchoredOffsetbox(loc='upper left', child=offsetbox, frameon=True,
+                           borderpad=0.2)
     ax.add_artist(ao)
 
     # another text

--- a/examples/userdemo/anchored_box01.py
+++ b/examples/userdemo/anchored_box01.py
@@ -11,7 +11,7 @@ from matplotlib.offsetbox import AnchoredText
 fig, ax = plt.subplots(figsize=(3, 3))
 
 at = AnchoredText("Figure 1a",
-                  prop=dict(size=15), frameon=True, loc=2)
+                  prop=dict(size=15), frameon=True, loc='upper left')
 at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
 ax.add_artist(at)
 

--- a/examples/userdemo/anchored_box02.py
+++ b/examples/userdemo/anchored_box02.py
@@ -12,7 +12,7 @@ from mpl_toolkits.axes_grid1.anchored_artists import AnchoredDrawingArea
 fig, ax = plt.subplots(figsize=(3, 3))
 
 ada = AnchoredDrawingArea(40, 20, 0, 0,
-                          loc=1, pad=0., frameon=False)
+                          loc='upper right', pad=0., frameon=False)
 p1 = Circle((10, 10), 10)
 ada.drawing_area.add_artist(p1)
 p2 = Circle((30, 10), 5, fc="r")

--- a/examples/userdemo/anchored_box03.py
+++ b/examples/userdemo/anchored_box03.py
@@ -11,7 +11,7 @@ from mpl_toolkits.axes_grid1.anchored_artists import AnchoredAuxTransformBox
 
 fig, ax = plt.subplots(figsize=(3, 3))
 
-box = AnchoredAuxTransformBox(ax.transData, loc=2)
+box = AnchoredAuxTransformBox(ax.transData, loc='upper left')
 el = Ellipse((0, 0), width=0.1, height=0.4, angle=30)  # in data coordinates!
 box.drawing_area.add_artist(el)
 

--- a/examples/userdemo/anchored_box04.py
+++ b/examples/userdemo/anchored_box04.py
@@ -26,7 +26,7 @@ box = HPacker(children=[box1, box2],
               align="center",
               pad=0, sep=5)
 
-anchored_box = AnchoredOffsetbox(loc=3,
+anchored_box = AnchoredOffsetbox(loc='lower left',
                                  child=box, pad=0.,
                                  frameon=True,
                                  bbox_to_anchor=(0., 1.02),

--- a/examples/userdemo/simple_legend01.py
+++ b/examples/userdemo/simple_legend01.py
@@ -12,13 +12,13 @@ plt.plot([1, 2, 3], label="test1")
 plt.plot([3, 2, 1], label="test2")
 # Place a legend above this subplot, expanding itself to
 # fully use the given bounding box.
-plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3,
+plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
            ncol=2, mode="expand", borderaxespad=0.)
 
 plt.subplot(223)
 plt.plot([1, 2, 3], label="test1")
 plt.plot([3, 2, 1], label="test2")
 # Place a legend to the right of this smaller subplot.
-plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
+plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left', borderaxespad=0.)
 
 plt.show()

--- a/examples/userdemo/simple_legend02.py
+++ b/examples/userdemo/simple_legend02.py
@@ -12,12 +12,12 @@ line1, = ax.plot([1, 2, 3], label="Line 1", linestyle='--')
 line2, = ax.plot([3, 2, 1], label="Line 2", linewidth=4)
 
 # Create a legend for the first line.
-first_legend = ax.legend(handles=[line1], loc=1)
+first_legend = ax.legend(handles=[line1], loc='upper right')
 
 # Add the legend manually to the current Axes.
 ax.add_artist(first_legend)
 
 # Create another legend for the second line.
-ax.legend(handles=[line2], loc=4)
+ax.legend(handles=[line2], loc='lower right')
 
 plt.show()

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2192,7 +2192,7 @@ def plotfile(fname, cols=(0,), plotfuncs=None,
                 ax.set_xlabel('')
 
     if not subplots:
-        ax.legend(ynamelist, loc='best')
+        ax.legend(ynamelist)
 
     if xname=='date':
         fig.autofmt_xdate()

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -43,7 +43,7 @@ def test_bbox_inches_tight():
                   remove_text=False, savefig_kwarg={'bbox_inches': 'tight'})
 def test_bbox_inches_tight_suptile_legend():
     plt.plot(np.arange(10), label='a straight line')
-    plt.legend(bbox_to_anchor=(0.9, 1), loc=2, )
+    plt.legend(bbox_to_anchor=(0.9, 1), loc='upper left')
     plt.title('Axis title')
     plt.suptitle('Figure title')
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -28,7 +28,8 @@ def test_legend_ordereddict():
 
     handles, labels = ax.get_legend_handles_labels()
     legend = collections.OrderedDict(zip(labels, handles))
-    ax.legend(legend.values(), legend.keys(), loc=6, bbox_to_anchor=(1, .5))
+    ax.legend(legend.values(), legend.keys(),
+              loc='center left', bbox_to_anchor=(1, .5))
 
 
 @image_comparison(baseline_images=['legend_auto1'], remove_text=True)
@@ -39,7 +40,7 @@ def test_legend_auto1():
     x = np.arange(100)
     ax.plot(x, 50 - x, 'o', label='y=1')
     ax.plot(x, x - 50, 'o', label='y=-1')
-    ax.legend(loc=0)
+    ax.legend(loc='best')
 
 
 @image_comparison(baseline_images=['legend_auto2'], remove_text=True)
@@ -50,7 +51,7 @@ def test_legend_auto2():
     x = np.arange(100)
     b1 = ax.bar(x, x, align='edge', color='m')
     b2 = ax.bar(x, x[::-1], align='edge', color='g')
-    ax.legend([b1[0], b2[0]], ['up', 'down'], loc=0)
+    ax.legend([b1[0], b2[0]], ['up', 'down'], loc='best')
 
 
 @image_comparison(baseline_images=['legend_auto3'])
@@ -63,7 +64,7 @@ def test_legend_auto3():
     ax.plot(x, y, 'o-', label='line')
     ax.set_xlim(0.0, 1.0)
     ax.set_ylim(0.0, 1.0)
-    ax.legend(loc=0)
+    ax.legend(loc='best')
 
 
 @image_comparison(baseline_images=['legend_various_labels'], remove_text=True)
@@ -74,7 +75,7 @@ def test_various_labels():
     ax.plot(np.arange(4), 'o', label=1)
     ax.plot(np.linspace(4, 4.1), 'o', label='Développés')
     ax.plot(np.arange(4, 1, -1), 'o', label='__nolegend__')
-    ax.legend(numpoints=1, loc=0)
+    ax.legend(numpoints=1, loc='best')
 
 
 @image_comparison(baseline_images=['legend_labels_first'], extensions=['png'],
@@ -86,7 +87,7 @@ def test_labels_first():
     ax.plot(np.arange(10), '-o', label=1)
     ax.plot(np.ones(10)*5, ':x', label="x")
     ax.plot(np.arange(20, 10, -1), 'd', label="diamond")
-    ax.legend(loc=0, markerfirst=False)
+    ax.legend(loc='best', markerfirst=False)
 
 
 @image_comparison(baseline_images=['legend_multiple_keys'], extensions=['png'],
@@ -111,7 +112,7 @@ def test_alpha_rgba():
 
     fig, ax = plt.subplots(1, 1)
     ax.plot(range(10), lw=5)
-    leg = plt.legend(['Longlabel that will go away'], loc=10)
+    leg = plt.legend(['Longlabel that will go away'], loc='center')
     leg.legendPatch.set_facecolor([1, 0, 0, 0.5])
 
 
@@ -123,7 +124,7 @@ def test_alpha_rcparam():
     fig, ax = plt.subplots(1, 1)
     ax.plot(range(10), lw=5)
     with mpl.rc_context(rc={'legend.framealpha': .75}):
-        leg = plt.legend(['Longlabel that will go away'], loc=10)
+        leg = plt.legend(['Longlabel that will go away'], loc='center')
         # this alpha is going to be over-ridden by the rcparam with
         # sets the alpha of the patch to be non-None which causes the alpha
         # value of the face color to be discarded.  This behavior may not be
@@ -177,12 +178,12 @@ def test_legend_expand():
     x = np.arange(100)
     for ax, mode in zip(axes_list, legend_modes):
         ax.plot(x, 50 - x, 'o', label='y=1')
-        l1 = ax.legend(loc=2, mode=mode)
+        l1 = ax.legend(loc='upper left', mode=mode)
         ax.add_artist(l1)
         ax.plot(x, x - 50, 'o', label='y=-1')
-        l2 = ax.legend(loc=5, mode=mode)
+        l2 = ax.legend(loc='right', mode=mode)
         ax.add_artist(l2)
-        ax.legend(loc=3, mode=mode, ncol=2)
+        ax.legend(loc='lower left', mode=mode, ncol=2)
 
 
 @image_comparison(baseline_images=['hatching'], remove_text=True,
@@ -370,7 +371,7 @@ def test_legend_stackplot():
     ax.stackplot(x, y1, y2, y3, labels=['y1', 'y2', 'y3'])
     ax.set_xlim((0, 10))
     ax.set_ylim((0, 70))
-    ax.legend(loc=0)
+    ax.legend(loc='best')
 
 
 def test_cross_figure_patch_legend():

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -27,7 +27,7 @@ def test_offsetbox_clipping():
                          color='black',
                          linewidth=10)
     anchored_box = AnchoredOffsetbox(
-        loc=10,
+        loc='center',
         child=da,
         pad=0.,
         frameon=False,
@@ -61,7 +61,7 @@ def test_offsetbox_clip_children():
                          color='black',
                          linewidth=10)
     anchored_box = AnchoredOffsetbox(
-        loc=10,
+        loc='center',
         child=da,
         pad=0.,
         frameon=False,

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -50,7 +50,7 @@ def test_patheffect3():
                          path_effects.Normal()])
     plt.title(r'testing$^{123}$',
         path_effects=[path_effects.withStroke(linewidth=1, foreground="r")])
-    leg = plt.legend([p1], [r'Line 1$^2$'], fancybox=True, loc=2)
+    leg = plt.legend([p1], [r'Line 1$^2$'], fancybox=True, loc='upper left')
     leg.legendPatch.set_path_effects([path_effects.withSimplePatchShadow()])
 
     text = plt.text(2, 3, 'Drop test', color='white',

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -211,7 +211,7 @@ def add_offsetboxes(ax, size=10, margin=.1, color='black'):
         da.add_artist(background)
 
         anchored_box = AnchoredOffsetbox(
-            loc=10,
+            loc='center',
             child=da,
             pad=0.,
             frameon=False,

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -73,7 +73,8 @@ class AnchoredDrawingArea(AnchoredOffsetbox):
         To display blue and red circles of different sizes in the upper right
         of an axes *ax*:
 
-        >>> ada = AnchoredDrawingArea(20, 20, 0, 0, loc=1, frameon=False)
+        >>> ada = AnchoredDrawingArea(20, 20, 0, 0,
+        ...                           loc='upper right', frameon=False)
         >>> ada.drawing_area.add_artist(Circle((10, 10), 10, fc="b"))
         >>> ada.drawing_area.add_artist(Circle((30, 10), 5, fc="r"))
         >>> ax.add_artist(ada)
@@ -146,7 +147,7 @@ class AnchoredAuxTransformBox(AnchoredOffsetbox):
         To display an ellipse in the upper left, with a width of 0.1 and
         height of 0.4 in data coordinates:
 
-        >>> box = AnchoredAuxTransformBox(ax.transData, loc=2)
+        >>> box = AnchoredAuxTransformBox(ax.transData, loc='upper left')
         >>> el = Ellipse((0,0), width=0.1, height=0.4, angle=30)
         >>> box.drawing_area.add_artist(el)
         >>> ax.add_artist(box)

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -383,7 +383,7 @@ def _add_inset_axes(parent_axes, inset_axes):
 
 
 @docstring.dedent_interpd
-def inset_axes(parent_axes, width, height, loc=1,
+def inset_axes(parent_axes, width, height, loc='upper right',
                bbox_to_anchor=None, bbox_transform=None,
                axes_class=None,
                axes_kwargs=None,
@@ -470,7 +470,7 @@ def inset_axes(parent_axes, width, height, loc=1,
 
 
 @docstring.dedent_interpd
-def zoomed_inset_axes(parent_axes, zoom, loc=1,
+def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
                       bbox_to_anchor=None, bbox_transform=None,
                       axes_class=None,
                       axes_kwargs=None,

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -136,7 +136,7 @@ def test_inset_locator():
     ax.imshow(Z2, extent=extent, interpolation="nearest",
               origin="lower")
 
-    axins = zoomed_inset_axes(ax, 6, loc=1)  # zoom = 6
+    axins = zoomed_inset_axes(ax, zoom=6, loc='upper right')
     axins.imshow(Z2, extent=extent, interpolation="nearest",
                  origin="lower")
     axins.yaxis.get_major_locator().set_params(nbins=7)
@@ -156,7 +156,7 @@ def test_inset_locator():
     asb = AnchoredSizeBar(ax.transData,
                           0.5,
                           '0.5',
-                          loc=8,
+                          loc='lower center',
                           pad=0.1, borderpad=0.5, sep=5,
                           frameon=False)
     ax.add_artist(asb)
@@ -208,7 +208,7 @@ def test_inset_axes():
     asb = AnchoredSizeBar(ax.transData,
                           0.5,
                           '0.5',
-                          loc=8,
+                          loc='lower center',
                           pad=0.1, borderpad=0.5, sep=5,
                           frameon=False)
     ax.add_artist(asb)
@@ -250,7 +250,7 @@ def test_fill_facecolor():
     p.set_clip_on(False)
     ax[0].add_patch(p)
     # set color to marked area
-    axins = zoomed_inset_axes(ax[0], 1, loc=1)
+    axins = zoomed_inset_axes(ax[0], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
     plt.gca().axes.get_xaxis().set_ticks([])
@@ -267,7 +267,7 @@ def test_fill_facecolor():
     p.set_clip_on(False)
     ax[1].add_patch(p)
     # set color to marked area
-    axins = zoomed_inset_axes(ax[1], 1, loc=1)
+    axins = zoomed_inset_axes(ax[1], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
     plt.gca().axes.get_xaxis().set_ticks([])
@@ -284,7 +284,7 @@ def test_fill_facecolor():
     p.set_clip_on(False)
     ax[2].add_patch(p)
     # set color to marked area
-    axins = zoomed_inset_axes(ax[2], 1, loc=1)
+    axins = zoomed_inset_axes(ax[2], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
     plt.gca().axes.get_xaxis().set_ticks([])
@@ -301,7 +301,7 @@ def test_fill_facecolor():
     p.set_clip_on(False)
     ax[3].add_patch(p)
     # marked area won't show green
-    axins = zoomed_inset_axes(ax[3], 1, loc=1)
+    axins = zoomed_inset_axes(ax[3], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
     axins.get_xaxis().set_ticks([])
@@ -316,13 +316,13 @@ def test_zooming_with_inverted_axes():
     fig, ax = plt.subplots()
     ax.plot([1, 2, 3], [1, 2, 3])
     ax.axis([1, 3, 1, 3])
-    inset_ax = zoomed_inset_axes(ax, zoom=2.5, loc=4)
+    inset_ax = zoomed_inset_axes(ax, zoom=2.5, loc='lower right')
     inset_ax.axis([1.1, 1.4, 1.1, 1.4])
 
     fig, ax = plt.subplots()
     ax.plot([1, 2, 3], [1, 2, 3])
     ax.axis([3, 1, 3, 1])
-    inset_ax = zoomed_inset_axes(ax, zoom=2.5, loc=4)
+    inset_ax = zoomed_inset_axes(ax, zoom=2.5, loc='lower right')
     inset_ax.axis([1.4, 1.1, 1.4, 1.1])
 
 

--- a/tutorials/intermediate/legend_guide.py
+++ b/tutorials/intermediate/legend_guide.py
@@ -117,14 +117,14 @@ plt.plot([3, 2, 1], label="test2")
 
 # Place a legend above this subplot, expanding itself to
 # fully use the given bounding box.
-plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3,
+plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
            ncol=2, mode="expand", borderaxespad=0.)
 
 plt.subplot(223)
 plt.plot([1, 2, 3], label="test1")
 plt.plot([3, 2, 1], label="test2")
 # Place a legend to the right of this smaller subplot.
-plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
+plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left', borderaxespad=0.)
 
 plt.show()
 
@@ -144,13 +144,13 @@ line1, = plt.plot([1, 2, 3], label="Line 1", linestyle='--')
 line2, = plt.plot([3, 2, 1], label="Line 2", linewidth=4)
 
 # Create a legend for the first line.
-first_legend = plt.legend(handles=[line1], loc=1)
+first_legend = plt.legend(handles=[line1], loc='upper right')
 
 # Add the legend manually to the current Axes.
 ax = plt.gca().add_artist(first_legend)
 
 # Create another legend for the second line.
-plt.legend(handles=[line2], loc=4)
+plt.legend(handles=[line2], loc='lower right')
 
 plt.show()
 

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -341,7 +341,7 @@ available in ``mpl_toolkits.axes_grid1.anchored_artists`` others in
     from matplotlib.offsetbox import AnchoredText
     at = AnchoredText("Figure 1a",
                       prop=dict(size=15), frameon=True,
-                      loc=2,
+                      loc='upper left',
                       )
     at.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
     ax.add_artist(at)
@@ -370,7 +370,7 @@ area itself. Only the initial size matters. ::
     from mpl_toolkits.axes_grid1.anchored_artists import AnchoredDrawingArea
 
     ada = AnchoredDrawingArea(20, 20, 0, 0,
-                              loc=1, pad=0., frameon=False)
+                              loc='upper right', pad=0., frameon=False)
     p1 = Circle((10, 10), 10)
     ada.drawing_area.add_artist(p1)
     p2 = Circle((30, 10), 5, fc="r")
@@ -396,7 +396,7 @@ determined during the drawing time respecting the specified transform. ::
 
   from mpl_toolkits.axes_grid1.anchored_artists import AnchoredAuxTransformBox
 
-  box = AnchoredAuxTransformBox(ax.transData, loc=2)
+  box = AnchoredAuxTransformBox(ax.transData, loc='upper left')
   el = Ellipse((0,0), width=0.1, height=0.4, angle=30)  # in data coordinates!
   box.drawing_area.add_artist(el)
 

--- a/tutorials/toolkits/axes_grid.py
+++ b/tutorials/toolkits/axes_grid.py
@@ -341,7 +341,7 @@ of the parent axes. For example,::
     inset_axes = inset_axes(parent_axes,
                             width="30%", # width = 30% of parent_bbox
                             height=1., # height : 1 inch
-                            loc=3)
+                            loc='lower left')
 
 creates an inset axes whose width is 30% of the parent axes and whose
 height is fixed at 1 inch.
@@ -352,7 +352,7 @@ some factor. For example, ::
 
     inset_axes = zoomed_inset_axes(ax,
                                    0.5, # zoom = 0.5
-                                   loc=1)
+                                   loc='upper right')
 
 creates an inset axes whose data scale is half of the parent axes.
 Here is complete examples.


### PR DESCRIPTION
## PR Summary

For better readability use `legend(loc='upper right')` instead of `legend(loc=1)`

The numbers will remain valid but won't be used anywhere in the docs and only very rarely in internal code.