### PR TITLE
Allow creating empty closed paths

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -137,7 +137,7 @@ class Path(object):
             if len(codes) and codes[0] != self.MOVETO:
                 raise ValueError("The first element of 'code' must be equal "
                                  "to 'MOVETO' ({})".format(self.MOVETO))
-        elif closed:
+        elif closed and len(vertices):
             codes = np.empty(len(vertices), dtype=self.code_type)
             codes[0] = self.MOVETO
             codes[1:-1] = self.LINETO

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -12,6 +12,12 @@ import matplotlib.pyplot as plt
 from matplotlib import transforms
 
 
+def test_empty_closed_path():
+    path = Path(np.zeros((0, 2)), closed=True)
+    assert path.vertices.shape == (0, 2)
+    assert path.codes is None
+
+
 def test_readonly_path():
     path = Path.unit_circle()
 


### PR DESCRIPTION
## PR Summary

Fixes #11101.

It has always been possible to create empty paths (`Path(np.zeros((0,2)))`). This PR also allows creating closed empty paths `Path(np.zeros((0,2)), closed=True)`.

Note that the closed-ness is only stored in the vertices not in the object itself. As a consequnce, an empty path and a closed empty path are identical. Mathematically, that makes sense. The only time when that difference could be relvant, would be if one added points later. However that doesn't seem to be supported by any public API. So, I think it's fine as is.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant