### PR TITLE
Use GLib.MainLoop() instead of deprecated GObject.MainLoop()

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -96,8 +96,8 @@ def _backend_selection():
             # The mainloop is running.
             rcParams['backend'] = 'qt5Agg'
     elif 'gtk' in sys.modules and 'gi' in sys.modules:
-        from gi.repository import GObject
-        if GObject.MainLoop().is_running():
+        from gi.repository import GLib
+        if GLib.MainLoop().is_running():
             rcParams['backend'] = 'GTK3Agg'
     elif 'Tkinter' in sys.modules and not backend == 'TkAgg':
         # import Tkinter


### PR DESCRIPTION
## PR Summary

Using GObject.MainLoop emits this warning:
```
[omitted]/lib/python3.6/site-packages/matplotlib/pyplot.py:101: PyGIDeprecationWarning: GObject.MainLoop is deprecated; use GLib.MainLoop instead
  ml = GObject.MainLoop
```

My PR follows the suggestion of the warning, and changes GObject.MainLoop for GLib.MainLoop.