### PR TITLE
Manual backport #11035

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -244,7 +244,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
                 ax._poslayoutbox.constrain_left_margin(0, strength='weak')
 
     # do layout for suptitle.
-    if fig._suptitle is not None:
+    if fig._suptitle is not None and fig._suptitle._layoutbox is not None:
         sup = fig._suptitle
         bbox = invTransFig(sup.get_window_extent(renderer=renderer))
         height = bbox.y1 - bbox.y0

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -718,6 +718,8 @@ class Figure(Artist):
 
           fig.suptitle('this is the figure title', fontsize=12)
         """
+        manual_position = ('x' in kwargs or 'y' in kwargs)
+
         x = kwargs.pop('x', 0.5)
         y = kwargs.pop('y', 0.98)
 
@@ -740,19 +742,22 @@ class Figure(Artist):
             sup.remove()
         else:
             self._suptitle = sup
-        if self._layoutbox is not None:
-            # assign a layout box to the suptitle...
-            figlb = self._layoutbox
-            self._suptitle._layoutbox = layoutbox.LayoutBox(
-                                            parent=figlb,
-                                            name=figlb.name+'.suptitle')
-            for child in figlb.children:
-                if not (child == self._suptitle._layoutbox):
-                    w_pad, h_pad, wspace, hspace =  \
-                            self.get_constrained_layout_pads(
-                                    relative=True)
-                    layoutbox.vstack([self._suptitle._layoutbox, child],
-                                     padding=h_pad*2., strength='required')
+            self._suptitle._layoutbox = None
+            if self._layoutbox is not None and not manual_position:
+                w_pad, h_pad, wspace, hspace =  \
+                        self.get_constrained_layout_pads(relative=True)
+                figlb = self._layoutbox
+                self._suptitle._layoutbox = layoutbox.LayoutBox(
+                        parent=figlb, artist=self._suptitle,
+                        name=figlb.name+'.suptitle')
+                # stack the suptitle on top of all the children.
+                # Some day this should be on top of all the children in the
+                # gridspec only.
+                for child in figlb.children:
+                    if child is not self._suptitle._layoutbox:
+                        layoutbox.vstack([self._suptitle._layoutbox,
+                                          child],
+                                         padding=h_pad*2., strength='required')
         self.stale = True
         return self._suptitle
 

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -388,3 +388,43 @@ def test_constrained_layout20():
     ax = fig.add_axes([0, 0, 1, 1])
     mesh = ax.pcolormesh(gx, gx, img)
     fig.colorbar(mesh)
+
+
+def test_constrained_layout21():
+    '#11035: repeated calls to suptitle should not alter the layout'
+    fig, ax = plt.subplots(constrained_layout=True)
+
+    fig.suptitle("Suptitle0")
+    fig.canvas.draw()
+    extents0 = np.copy(ax.get_position().extents)
+
+    fig.suptitle("Suptitle1")
+    fig.canvas.draw()
+    extents1 = np.copy(ax.get_position().extents)
+
+    np.testing.assert_allclose(extents0, extents1)
+
+
+def test_constrained_layout22():
+    '#11035: suptitle should not be include in CL if manually positioned'
+    fig, ax = plt.subplots(constrained_layout=True)
+
+    fig.canvas.draw()
+    extents0 = np.copy(ax.get_position().extents)
+
+    fig.suptitle("Suptitle", y=0.5)
+    fig.canvas.draw()
+    extents1 = np.copy(ax.get_position().extents)
+
+    np.testing.assert_allclose(extents0, extents1)
+
+
+def test_constrained_layout23():
+    '''
+    Comment in #11035: suptitle used to cause an exception when
+    reusing a figure w/ CL with ``clear=True``.
+    '''
+
+    for i in range(2):
+        fig, ax = plt.subplots(num="123", constrained_layout=True, clear=True)
+        fig.suptitle("Suptitle{}".format(i))


### PR DESCRIPTION
## PR Summary

Manual backport #11035 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
