### PR TITLE
Fix image size in interpolation example

### DIFF
--- a/examples/images_contours_and_fields/interpolation_methods.py
+++ b/examples/images_contours_and_fields/interpolation_methods.py
@@ -27,7 +27,7 @@ np.random.seed(19680801)
 
 grid = np.random.rand(4, 4)
 
-fig, axs = plt.subplots(nrows=3, ncols=6, figsize=(12, 6),
+fig, axs = plt.subplots(nrows=3, ncols=6, figsize=(9, 4.5),
                         subplot_kw={'xticks': [], 'yticks': []})
 
 fig.subplots_adjust(hspace=0.3, wspace=0.05)
@@ -36,4 +36,5 @@ for ax, interp_method in zip(axs.flat, methods):
     ax.imshow(grid, interpolation=interp_method, cmap='viridis')
     ax.set_title(str(interp_method))
 
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
## PR Summary

Reduce the excessive image size in this example:
https://matplotlib.org/gallery/images_contours_and_fields/interpolation_methods.html?highlight=interpolation