### PR TITLE
FIX: remove recursive call to str in transform repr

### DIFF
--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -89,9 +89,8 @@ def test_logscale_transform_repr():
     ax.set_yscale('log')
     s = repr(ax.transData)
 
-    # check that repr of log transform returns correct string
+    # check that repr of log transform succeeds
     s = repr(Log10Transform(nonpos='clip'))
-    assert s == "Log10Transform({!r})".format('clip')
 
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1053,8 +1053,6 @@ class TransformedBbox(BboxBase):
                         _indent_str(self._bbox),
                         _indent_str(self._transform)))
 
-    __repr__ = __str__
-
     def get_points(self):
         if self._invalid:
             p = self._bbox.get_points()
@@ -1139,8 +1137,6 @@ class LockableBbox(BboxBase):
                 .format(type(self).__name__,
                         _indent_str(self._bbox),
                         _indent_str(self._locked_points)))
-
-    __repr__ = __str__
 
     def get_points(self):
         if self._invalid:
@@ -1620,9 +1616,6 @@ class Transform(TransformNode):
         ``x === self.inverted().transform(self.transform(x))``
         """
         raise NotImplementedError()
-
-    def __repr__(self):
-        return str(self)
 
 
 class TransformWrapper(Transform):


### PR DESCRIPTION
## PR Summary

This makes `__repr__` for transform objects just a one-line object repr.  

It retains the pretty-print for `print`.

It fixes the recursion in #11163

Supercedes #11173, if we think that `__repr__` should return something short....  If we think `__repr__` should be more verbose, this is the wrong solution, and #11173 is correct.

Closes #11163.

```
In [1]: from matplotlib import pyplot as plt
   ...: import numpy as np
   ...:
   ...: f, ax = plt.subplots()
   ...: ax.plot(np.arange(100))
   ...: ax.set_yscale('symlog')
   ...: ax.get_yaxis_transform()
   ...:
Out[1]: <matplotlib.transforms.BlendedGenericTransform at 0x10fcff908>

In [2]: print(ax.get_yaxis_transform())
BlendedGenericTransform(
    BboxTransformTo(
        TransformedBbox(
            Bbox(x0=0.125, y0=0.10999999999999999, x1=0.9, y1=0.88),
            BboxTransformTo(
                TransformedBbox(
                    Bbox(x0=0.0, y0=0.0, x1=6.4, y1=4.8),
                    Affine2D(
                        [[ 200.    0.    0.]
                         [   0.  200.    0.]
                         [   0.    0.    1.]]))))),
    CompositeGenericTransform(
        TransformWrapper(
            BlendedGenericTransform(
                IdentityTransform(),
                <matplotlib.scale.SymmetricalLogTransform object at 0x1179b4f28>)),
        CompositeGenericTransform(
            BboxTransformFrom(
                TransformedBbox(
                    Bbox(x0=-4.95, y0=-0.2525144679040212, x1=103.95, y1=136.74800843761523),
                    TransformWrapper(
                        BlendedGenericTransform(
                            IdentityTransform(),
                            <matplotlib.scale.SymmetricalLogTransform object at 0x1179b4f28>)))),
            BboxTransformTo(
                TransformedBbox(
                    Bbox(x0=0.125, y0=0.10999999999999999, x1=0.9, y1=0.88),
                    BboxTransformTo(
                        TransformedBbox(
                            Bbox(x0=0.0, y0=0.0, x1=6.4, y1=4.8),
                            Affine2D(
                                [[ 200.    0.    0.]
                                 [   0.  200.    0.]
                                 [   0.    0.    1.]]))))))))
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->