### PR TITLE
DOC: Adding example references for Images,contours,fields section

### DIFF
--- a/examples/images_contours_and_fields/affine_image.py
+++ b/examples/images_contours_and_fields/affine_image.py
@@ -3,6 +3,13 @@
 Affine transform of an image
 ============================
 
+
+Prepending an affine transformation (:class:`~.transforms.Affine2D`)
+to the :ref:`data transform <data-coords>`
+of an image allows to manipulate the image's shape and orientation.
+This is an example of the concept of
+:ref:`transform chaining <transformation-pipeline>`.
+
 For the backends that support draw_image with optional affine
 transform (e.g., agg, ps backend), the image of the output should
 have its boundary match the dashed yellow rectangle.
@@ -57,3 +64,19 @@ do_plot(ax4, Z, mtransforms.Affine2D().
         rotate_deg(30).skew_deg(30, 15).scale(-1, .5).translate(.5, -1))
 
 plt.show()
+
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.transforms.Affine2D

--- a/examples/images_contours_and_fields/barb_demo.py
+++ b/examples/images_contours_and_fields/barb_demo.py
@@ -51,3 +51,18 @@ fig2, ax2 = plt.subplots()
 ax2.barbs(data['x'], data['y'], masked_u, data['v'], length=8, pivot='middle')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.barbs
+matplotlib.pyplot.barbs
+

--- a/examples/images_contours_and_fields/barcode_demo.py
+++ b/examples/images_contours_and_fields/barcode_demo.py
@@ -3,6 +3,7 @@
 Barcode Demo
 ============
 
+This demo shows how to produce a one-dimensional image, or "bar code".
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -19,7 +20,7 @@ barprops = dict(aspect='auto', cmap=plt.cm.binary, interpolation='nearest')
 
 fig = plt.figure()
 
-# a vertical barcode -- this is broken at present
+# a vertical barcode
 ax1 = fig.add_axes([0.1, 0.3, 0.1, 0.6], **axprops)
 ax1.imshow(x.reshape((-1, 1)), **barprops)
 
@@ -29,3 +30,17 @@ ax2.imshow(x.reshape((1, -1)), **barprops)
 
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow

--- a/examples/images_contours_and_fields/contour_corner_mask.py
+++ b/examples/images_contours_and_fields/contour_corner_mask.py
@@ -3,8 +3,8 @@
 Contour Corner Mask
 ===================
 
-Illustrate the difference between corner_mask=False and corner_mask=True
-for masked contour plots.
+Illustrate the difference between ``corner_mask=False`` and
+``corner_mask=True`` for masked contour plots.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -36,3 +36,19 @@ for ax, corner_mask in zip(axs, corner_masks):
     ax.plot(np.ma.array(x, mask=~mask), y, 'ro')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.contour
+matplotlib.pyplot.contour
+matplotlib.axes.Axes.contourf
+matplotlib.pyplot.contourf

--- a/examples/images_contours_and_fields/contour_demo.py
+++ b/examples/images_contours_and_fields/contour_demo.py
@@ -6,15 +6,15 @@ Contour Demo
 Illustrate simple contour plotting, contours on an image with
 a colorbar for the contours, and labelled contours.
 
-See also contour_image.py.
+See also the
+:ref:`contour image example
+<sphx_glr_gallery_images_contours_and_fields_contour_image.py>`.
 """
 import matplotlib
 import numpy as np
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 
-matplotlib.rcParams['xtick.direction'] = 'out'
-matplotlib.rcParams['ytick.direction'] = 'out'
 
 delta = 0.025
 x = np.arange(-3.0, 3.0, delta)
@@ -116,3 +116,23 @@ ll, bb, ww, hh = CB.ax.get_position().bounds
 CB.ax.set_position([ll, b + 0.1*h, ww, h*0.8])
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.contour
+matplotlib.pyplot.contour
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.axes.Axes.clabel
+matplotlib.pyplot.clabel
+matplotlib.axes.Axes.set_position
+matplotlib.axes.Axes.get_position

--- a/examples/images_contours_and_fields/contour_image.py
+++ b/examples/images_contours_and_fields/contour_image.py
@@ -4,11 +4,15 @@ Contour Image
 =============
 
 Test combinations of contouring, filled contouring, and image plotting.
-For contour labelling, see contour_demo.py.
+For contour labelling, see See also the
+:ref:`contour demo example
+<sphx_glr_gallery_images_contours_and_fields_contour_demo.py>`.
 
 The emphasis in this demo is on showing how to make contours register
 correctly on images, and on how to get both of them oriented as
-desired.  In particular, note the usage of the "origin" and "extent"
+desired.  In particular, note the usage of the 
+:ref:`"origin" and "extent"
+<sphx_glr_tutorials_intermediate_imshow_extent.py>`
 keyword arguments to imshow and contour.
 """
 import matplotlib.pyplot as plt
@@ -91,3 +95,23 @@ fig.colorbar(im, ax=axs[3])
 
 fig.tight_layout()
 plt.show()
+
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.contour
+matplotlib.pyplot.contour
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.colors.Normalize

--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -6,7 +6,8 @@ Contour Label Demo
 Illustrate some of the more advanced things that one can do with
 contour labels.
 
-See also contour_demo.py.
+See also the :ref:`contour demo example
+<sphx_glr_gallery_images_contours_and_fields_contour_demo.py>`.
 """
 
 import matplotlib
@@ -14,9 +15,6 @@ import numpy as np
 import matplotlib.cm as cm
 import matplotlib.ticker as ticker
 import matplotlib.pyplot as plt
-
-matplotlib.rcParams['xtick.direction'] = 'out'
-matplotlib.rcParams['ytick.direction'] = 'out'
 
 ###############################################################################
 # Define our surface
@@ -89,3 +87,20 @@ ax2.clabel(CS2, CS2.levels, fmt=fmt)
 ax2.set_title("$100^Z$")
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+matplotlib.axes.Axes.contour
+matplotlib.pyplot.contour
+matplotlib.axes.Axes.clabel
+matplotlib.pyplot.clabel
+matplotlib.ticker.LogFormatterMathtext
+matplotlib.ticker.TickHelper.create_dummy_axis

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -3,7 +3,7 @@
 Contourf Demo
 =============
 
-How to use the ``contourf`` function to create filled contour plots.
+How to use the :meth:`.axes.Axes.contourf` method to create filled contour plots.
 """
 import numpy as np
 import matplotlib.pyplot as plt
@@ -105,3 +105,27 @@ for ax, extend in zip(axs.ravel(), extends):
     ax.locator_params(nbins=4)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.contour
+matplotlib.pyplot.contour
+matplotlib.axes.Axes.contourf
+matplotlib.pyplot.contourf
+matplotlib.axes.Axes.clabel
+matplotlib.pyplot.clabel
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.colors.Colormap
+matplotlib.colors.Colormap.set_bad
+matplotlib.colors.Colormap.set_under
+matplotlib.colors.Colormap.set_over

--- a/examples/images_contours_and_fields/contourf_hatching.py
+++ b/examples/images_contours_and_fields/contourf_hatching.py
@@ -39,3 +39,25 @@ cs = ax2.contourf(x, y, z, n_levels, colors='none',
 artists, labels = cs.legend_elements()
 ax2.legend(artists, labels, handleheight=2)
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.contour
+matplotlib.pyplot.contour
+matplotlib.axes.Axes.contourf
+matplotlib.pyplot.contourf
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.axes.Axes.legend
+matplotlib.pyplot.legend
+matplotlib.contour.ContourSet
+matplotlib.contour.ContourSet.legend_elements

--- a/examples/images_contours_and_fields/contourf_log.py
+++ b/examples/images_contours_and_fields/contourf_log.py
@@ -47,3 +47,22 @@ cs = ax.contourf(X, Y, z, locator=ticker.LogLocator(), cmap=cm.PuBu_r)
 cbar = fig.colorbar(cs)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.contourf
+matplotlib.pyplot.contourf
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.axes.Axes.legend
+matplotlib.pyplot.legend
+matplotlib.ticker.LogLocator

--- a/examples/images_contours_and_fields/custom_cmap.py
+++ b/examples/images_contours_and_fields/custom_cmap.py
@@ -3,9 +3,11 @@
 Creating a colormap from a list of colors
 =========================================
 
-Creating a colormap from a list of colors can be done with the `from_list`
-method of `LinearSegmentedColormap`. You must pass a list of RGB tuples that
-define the mixture of colors from 0 to 1.
+Creating a :ref:`colormap <sphx_glr_tutorials_colors_colormaps.py>`
+from a list of colors can be done with the
+:meth:`~.colors.LinearSegmentedColormap.from_list` method of
+`LinearSegmentedColormap`. You must pass a list of RGB tuples that define the
+mixture of colors from 0 to 1.
 
 
 Creating custom colormaps
@@ -223,3 +225,26 @@ fig.suptitle('Custom Blue-Red colormaps', fontsize=16)
 fig.subplots_adjust(top=0.9)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.colors
+matplotlib.colors.LinearSegmentedColormap
+matplotlib.colors.LinearSegmentedColormap.from_list
+matplotlib.cm
+matplotlib.cm.ScalarMappable.set_cmap
+matplotlib.pyplot.register_cmap
+matplotlib.cm.register_cmap

--- a/examples/images_contours_and_fields/demo_bboximage.py
+++ b/examples/images_contours_and_fields/demo_bboximage.py
@@ -1,65 +1,87 @@
 """
 ==============
-Demo BboxImage
+BboxImage Demo
 ==============
 
+A :class:`~matplotlib.image.BboxImage` can be used to position
+an image according to a bounding box. This demo shows how to
+show an image inside a `text.Text`'s bounding box as well as
+how to manually create a bounding box for the image.
 """
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.image import BboxImage
 from matplotlib.transforms import Bbox, TransformedBbox
 
-if __name__ == "__main__":
 
-    fig, (ax1, ax2) = plt.subplots(ncols=2)
+fig, (ax1, ax2) = plt.subplots(ncols=2)
 
-    txt = ax1.text(0.5, 0.5, "test", size=30, ha="center", color="w")
-    kwargs = dict()
+# ----------------------------
+# Create a BboxImage with Text
+# ----------------------------
+txt = ax1.text(0.5, 0.5, "test", size=30, ha="center", color="w")
+kwargs = dict()
 
-    bbox_image = BboxImage(txt.get_window_extent,
+bbox_image = BboxImage(txt.get_window_extent,
+                       norm=None,
+                       origin=None,
+                       clip_on=False,
+                       **kwargs
+                       )
+a = np.arange(256).reshape(1, 256)/256.
+bbox_image.set_data(a)
+ax1.add_artist(bbox_image)
+
+# ------------------------------------
+# Create a BboxImage for each colormap
+# ------------------------------------
+a = np.linspace(0, 1, 256).reshape(1, -1)
+a = np.vstack((a, a))
+
+# List of all colormaps; skip reversed colormaps.
+maps = sorted(m for m in plt.cm.cmap_d if not m.endswith("_r"))
+
+ncol = 2
+nrow = len(maps)//ncol + 1
+
+xpad_fraction = 0.3
+dx = 1./(ncol + xpad_fraction*(ncol - 1))
+
+ypad_fraction = 0.3
+dy = 1./(nrow + ypad_fraction*(nrow - 1))
+
+for i, m in enumerate(maps):
+    ix, iy = divmod(i, nrow)
+
+    bbox0 = Bbox.from_bounds(ix*dx*(1 + xpad_fraction),
+                             1. - iy*dy*(1 + ypad_fraction) - dy,
+                             dx, dy)
+    bbox = TransformedBbox(bbox0, ax2.transAxes)
+
+    bbox_image = BboxImage(bbox,
+                           cmap=plt.get_cmap(m),
                            norm=None,
                            origin=None,
-                           clip_on=False,
                            **kwargs
                            )
-    a = np.arange(256).reshape(1, 256)/256.
+
     bbox_image.set_data(a)
-    ax1.add_artist(bbox_image)
+    ax2.add_artist(bbox_image)
 
-    a = np.linspace(0, 1, 256).reshape(1, -1)
-    a = np.vstack((a, a))
+plt.show()
 
-    maps = sorted(m for m in plt.cm.cmap_d
-                  if not m.endswith("_r"))  # Skip reversed colormaps.
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
 
-    # fig.subplots_adjust(top=0.99, bottom=0.01, left=0.2, right=0.99)
-
-    ncol = 2
-    nrow = len(maps)//ncol + 1
-
-    xpad_fraction = 0.3
-    dx = 1./(ncol + xpad_fraction*(ncol - 1))
-
-    ypad_fraction = 0.3
-    dy = 1./(nrow + ypad_fraction*(nrow - 1))
-
-    for i, m in enumerate(maps):
-        ix, iy = divmod(i, nrow)
-        # plt.figimage(a, 10, i*10, cmap=plt.get_cmap(m), origin='lower')
-        bbox0 = Bbox.from_bounds(ix*dx*(1 + xpad_fraction),
-                                 1. - iy*dy*(1 + ypad_fraction) - dy,
-                                 dx, dy)
-        bbox = TransformedBbox(bbox0, ax2.transAxes)
-
-        bbox_image = BboxImage(bbox,
-                               cmap=plt.get_cmap(m),
-                               norm=None,
-                               origin=None,
-                               **kwargs
-                               )
-
-        bbox_image.set_data(a)
-        ax2.add_artist(bbox_image)
-
-    plt.draw()
-    plt.show()
+import matplotlib
+matplotlib.image.BboxImage
+matplotlib.transforms.Bbox
+matplotlib.transforms.TransformedBbox
+matplotlib.text.Text

--- a/examples/images_contours_and_fields/figimage_demo.py
+++ b/examples/images_contours_and_fields/figimage_demo.py
@@ -20,3 +20,17 @@ im1 = fig.figimage(Z, xo=50, yo=0, origin='lower')
 im2 = fig.figimage(Z, xo=100, yo=100, alpha=.8, origin='lower')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+matplotlib.figure.Figure
+matplotlib.figure.Figure.figimage
+matplotlib.pyplot.figimage

--- a/examples/images_contours_and_fields/image_clip_path.py
+++ b/examples/images_contours_and_fields/image_clip_path.py
@@ -20,3 +20,18 @@ im.set_clip_path(patch)
 
 ax.axis('off')
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.artist.Artist.set_clip_path

--- a/examples/images_contours_and_fields/image_demo.py
+++ b/examples/images_contours_and_fields/image_demo.py
@@ -6,7 +6,7 @@ Image Demo
 Many ways to plot images in Matplotlib.
 
 The most common way to plot images in Matplotlib is with
-imshow. The following examples demonstrate much of the
+:meth:`~.axes.Axes.imshow`. The following examples demonstrate much of the
 functionality of imshow and the many images you can create.
 
 """
@@ -114,7 +114,8 @@ plt.show()
 # This allows you to plot the full range of your array w/o edge effects,
 # and for example to layer multiple images of different sizes over one
 # another with different interpolation methods - see
-# examples/layer_images.py.  It also implies a performance hit, as this
+# :ref:`sphx_glr_gallery_images_contours_and_fields_layer_images.py`.
+# It also implies a performance hit, as this
 # new temporary, padded array must be created.  Sophisticated
 # interpolation also implies a performance hit, so if you need maximal
 # performance or have very large images, interpolation='nearest' is
@@ -135,7 +136,9 @@ plt.show()
 # You can specify whether images should be plotted with the array origin
 # x[0,0] in the upper left or lower right by using the origin parameter.
 # You can also control the default setting image.origin in your
-# :ref:`matplotlibrc file <customizing-with-matplotlibrc-files>`
+# :ref:`matplotlibrc file <customizing-with-matplotlibrc-files>`. For more on
+# this topic see the :ref:`complete guide on origin and extent
+# <sphx_glr_tutorials_intermediate_imshow_extent.py>`.
 
 x = np.arange(120).reshape((10, 12))
 
@@ -171,3 +174,19 @@ im = ax.imshow(Z, interpolation='bilinear', cmap=cm.gray,
 im.set_clip_path(patch)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.artist.Artist.set_clip_path
+matplotlib.patches.PathPatch

--- a/examples/images_contours_and_fields/image_masked.py
+++ b/examples/images_contours_and_fields/image_masked.py
@@ -73,3 +73,22 @@ cbar.set_label('proportional')
 
 fig.suptitle('imshow, with out-of-range and masked data')
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.colors.BoundaryNorm
+matplotlib.colorbar.ColorbarBase.set_label
+

--- a/examples/images_contours_and_fields/image_transparency_blend.py
+++ b/examples/images_contours_and_fields/image_transparency_blend.py
@@ -124,3 +124,21 @@ plt.show()
 ax.contour(weights[::-1], levels=[-.0001, .0001], colors='k', linestyles='-')
 ax.set_axis_off()
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.axes.Axes.contour
+matplotlib.pyplot.contour
+matplotlib.colors.Normalize
+matplotlib.axes.Axes.set_axis_off

--- a/examples/images_contours_and_fields/interpolation_methods.py
+++ b/examples/images_contours_and_fields/interpolation_methods.py
@@ -3,16 +3,17 @@
 Interpolations for imshow/matshow
 =================================
 
-This example displays the difference between interpolation methods for imshow
-and matshow.
+This example displays the difference between interpolation methods for
+:meth:`~.axes.Axes.imshow` and :meth:`~.axes.Axes.matshow`.
 
-If `interpolation` is None, it defaults to the rc image.interpolation
-parameter. If the interpolation is `none`, then no interpolation is performed
-for the Agg, ps and pdf backends. Other backends will default to 'nearest'.
+If `interpolation` is None, it defaults to the ``image.interpolation``
+:ref:`rc parameter <sphx_glr_tutorials_introductory_customizing.py>`.
+If the interpolation is ``'none'``, then no interpolation is performed
+for the Agg, ps and pdf backends. Other backends will default to ``'nearest'``.
 
-For the Agg, ps and pdf backends, interpolation = 'none' works well when a big
-image is scaled down, while interpolation = 'nearest' works well when a small
-image is scaled up.
+For the Agg, ps and pdf backends, ``interpolation = 'none'`` works well when a
+big image is scaled down, while ``interpolation = 'nearest'`` works well when
+a small image is scaled up.
 """
 
 import matplotlib.pyplot as plt
@@ -27,10 +28,10 @@ np.random.seed(19680801)
 
 grid = np.random.rand(4, 4)
 
-fig, axs = plt.subplots(nrows=3, ncols=6, figsize=(9, 4.5),
+fig, axs = plt.subplots(nrows=3, ncols=6, figsize=(9.3, 6),
                         subplot_kw={'xticks': [], 'yticks': []})
 
-fig.subplots_adjust(hspace=0.3, wspace=0.05)
+fig.subplots_adjust(left=0.03, right=0.97, hspace=0.3, wspace=0.05)
 
 for ax, interp_method in zip(axs.flat, methods):
     ax.imshow(grid, interpolation=interp_method, cmap='viridis')
@@ -38,3 +39,17 @@ for ax, interp_method in zip(axs.flat, methods):
 
 plt.tight_layout()
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow

--- a/examples/images_contours_and_fields/layer_images.py
+++ b/examples/images_contours_and_fields/layer_images.py
@@ -40,3 +40,17 @@ im2 = plt.imshow(Z2, cmap=plt.cm.viridis, alpha=.9, interpolation='bilinear',
                  extent=extent)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow

--- a/examples/images_contours_and_fields/matshow.py
+++ b/examples/images_contours_and_fields/matshow.py
@@ -3,7 +3,7 @@
 Matshow
 =======
 
-Simple matshow() example.
+Simple `~.axes.Axes.matshow` example.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -21,3 +21,17 @@ def samplemat(dims):
 plt.matshow(samplemat((15, 15)))
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.matshow
+matplotlib.pyplot.matshow

--- a/examples/images_contours_and_fields/multi_image.py
+++ b/examples/images_contours_and_fields/multi_image.py
@@ -51,3 +51,24 @@ for im in images:
     im.callbacksSM.connect('changed', update)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.colors.Normalize
+matplotlib.cm.ScalarMappable.set_cmap
+matplotlib.cm.ScalarMappable.set_norm
+matplotlib.cm.ScalarMappable.set_clim
+matplotlib.cbook.CallbackRegistry.connect

--- a/examples/images_contours_and_fields/pcolor_demo.py
+++ b/examples/images_contours_and_fields/pcolor_demo.py
@@ -3,10 +3,10 @@
 Pcolor Demo
 ===========
 
-Generating images with pcolor.
+Generating images with :meth:`~.axes.Axes.pcolor`.
 
 Pcolor allows you to generate 2-D image-style plots. Below we will show how
-to do so in Matplotlib.
+to do so in Matplotlib. 
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,8 +33,9 @@ plt.show()
 # Comparing pcolor with similar functions
 # ---------------------------------------
 #
-# Demonstrates similarities between pcolor, pcolormesh, imshow and pcolorfast
-# for drawing quadrilateral grids.
+# Demonstrates similarities between :meth:`~.axes.Axes.pcolor`,
+# :meth:`~.axes.Axes.pcolormesh`, :meth:`~.axes.Axes.imshow` and
+# :meth:`~.axes.Axes.pcolorfast` for drawing quadrilateral grids.
 
 # make these smaller to increase the resolution
 dx, dy = 0.15, 0.05
@@ -106,3 +107,25 @@ c = ax1.pcolor(X, Y, Z, cmap='PuBu_r')
 fig.colorbar(c, ax=ax1)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.pcolor
+matplotlib.pyplot.pcolor
+matplotlib.axes.Axes.pcolormesh
+matplotlib.pyplot.pcolormesh
+matplotlib.axes.Axes.pcolorfast
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow
+matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.colors.LogNorm

--- a/examples/images_contours_and_fields/pcolormesh_levels.py
+++ b/examples/images_contours_and_fields/pcolormesh_levels.py
@@ -4,7 +4,8 @@ pcolormesh
 ==========
 
 Shows how to combine Normalization and Colormap instances to draw
-"levels" in pcolor, pcolormesh and imshow type plots in a similar
+"levels" in :meth:`~.axes.Axes.pcolor`, :meth:`~.axes.Axes.pcolormesh`
+and :meth:`~.axes.Axes.imshow` type plots in a similar
 way to the levels keyword argument to contour/contourf.
 
 """
@@ -67,5 +68,10 @@ plt.show()
 # The use of the following functions and methods is shown in this example:
 
 matplotlib.axes.Axes.pcolormesh
+matplotlib.pyplot.pcolormesh
 matplotlib.axes.Axes.contourf
+matplotlib.pyplot.contourf
 matplotlib.figure.Figure.colorbar
+matplotlib.pyplot.colorbar
+matplotlib.colors.BoundaryNorm
+matplotlib.ticker.MaxNLocator

--- a/examples/images_contours_and_fields/plot_streamplot.py
+++ b/examples/images_contours_and_fields/plot_streamplot.py
@@ -4,7 +4,7 @@ Streamplot
 ==========
 
 A stream plot, or streamline plot, is used to display 2D vector fields. This
-example shows a few features of the streamplot function:
+example shows a few features of the :meth:`~.axes.Axes.streamplot` function:
 
     * Varying the color along a streamline.
     * Varying the density of streamlines.
@@ -71,3 +71,18 @@ ax4.set_aspect('equal')
 
 plt.tight_layout()
 plt.show()
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+import matplotlib
+matplotlib.axes.Axes.streamplot
+matplotlib.pyplot.streamplot
+matplotlib.gridspec
+matplotlib.gridspec.GridSpec
+

--- a/examples/images_contours_and_fields/quadmesh_demo.py
+++ b/examples/images_contours_and_fields/quadmesh_demo.py
@@ -3,8 +3,8 @@
 QuadMesh Demo
 =============
 
-pcolormesh uses a QuadMesh, a faster generalization of pcolor, but
-with some restrictions.
+`~.axes.Axes.pcolormesh` uses a `~matplotlib.collections.QuadMesh`,
+a faster generalization of `~.axes.Axes.pcolor`, but with some restrictions.
 
 This demo illustrates a bug in quadmesh with masked data.
 """
@@ -30,7 +30,7 @@ fig, axs = plt.subplots(nrows=1, ncols=3)
 axs[0].pcolormesh(Qx, Qz, Z, shading='gouraud')
 axs[0].set_title('Without masked values')
 
-# You can control the color of the masked region.  We copy the default colormap
+# You can control the color of the masked region. We copy the default colormap
 # before modifying it.
 cmap = copy.copy(cm.get_cmap(plt.rcParams['image.cmap']))
 cmap.set_bad('y', 1.0)
@@ -43,3 +43,16 @@ axs[2].set_title('With masked values')
 
 fig.tight_layout()
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+import matplotlib
+matplotlib.axes.Axes.pcolormesh
+matplotlib.pyplot.pcolormesh

--- a/examples/images_contours_and_fields/quiver_demo.py
+++ b/examples/images_contours_and_fields/quiver_demo.py
@@ -3,6 +3,10 @@
 Demonstration of advanced quiver and quiverkey functions
 ========================================================
 
+Demonstrates some more advanced options for `~.axes.Axes.quiver`. 
+For a simple example refer to 
+:ref:`sphx_glr_gallery_images_contours_and_fields_quiver_simple_demo.py`.
+
 Known problem: the plot autoscaling does not take into account
 the arrows, so those on the boundaries are often out of the picture.
 This is *not* an easy problem to solve in a perfectly general way.
@@ -46,3 +50,18 @@ qk = ax3.quiverkey(Q, 0.9, 0.9, 1, r'$1 \frac{m}{s}$', labelpos='E',
 ax3.scatter(X, Y, color='k', s=5)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+import matplotlib
+matplotlib.axes.Axes.quiver
+matplotlib.pyplot.quiver
+matplotlib.axes.Axes.quiverkey
+matplotlib.pyplot.quiverkey

--- a/examples/images_contours_and_fields/quiver_simple_demo.py
+++ b/examples/images_contours_and_fields/quiver_simple_demo.py
@@ -3,7 +3,11 @@
 Quiver Simple Demo
 ==================
 
-A simple example of a quiver plot with a quiverkey.
+A simple example of a `~.axes.Axes.quiver` plot with a
+`~.axes.Axes.quiverkey`.
+
+For more advanced options refer to 
+:ref:`sphx_glr_gallery_images_contours_and_fields_quiver_demo.py`.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -18,3 +22,19 @@ ax.quiverkey(q, X=0.3, Y=1.1, U=10,
              label='Quiver key, length = 10', labelpos='E')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+import matplotlib
+matplotlib.axes.Axes.quiver
+matplotlib.pyplot.quiver
+matplotlib.axes.Axes.quiverkey
+matplotlib.pyplot.quiverkey
+

--- a/examples/images_contours_and_fields/shading_example.py
+++ b/examples/images_contours_and_fields/shading_example.py
@@ -61,3 +61,17 @@ def compare(z, cmap, ve=1):
 
 if __name__ == '__main__':
     main()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown in this example:
+
+import matplotlib
+matplotlib.colors.LightSource
+matplotlib.axes.Axes.imshow
+matplotlib.pyplot.imshow

--- a/examples/images_contours_and_fields/specgram_demo.py
+++ b/examples/images_contours_and_fields/specgram_demo.py
@@ -3,7 +3,8 @@
 Spectrogram Demo
 ================
 
-Demo of a spectrogram plot.
+Demo of a spectrogram plot
+(:meth:`~.axes.Axes.specgram`).
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -36,3 +37,17 @@ Pxx, freqs, bins, im = ax2.specgram(x, NFFT=NFFT, Fs=Fs, noverlap=900)
 # - bins: the centers of the time bins
 # - im: the matplotlib.image.AxesImage instance representing the data in the plot
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.specgram
+matplotlib.pyplot.specgram

--- a/examples/images_contours_and_fields/spy_demos.py
+++ b/examples/images_contours_and_fields/spy_demos.py
@@ -3,7 +3,7 @@
 Spy Demos
 =========
 
-Plot the sparsity pattern of arrays
+Plot the sparsity pattern of arrays.
 """
 
 import matplotlib.pyplot as plt
@@ -26,3 +26,17 @@ ax3.spy(x)
 ax4.spy(x, precision=0.1)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.spy
+matplotlib.pyplot.spy

--- a/examples/images_contours_and_fields/tricontour_demo.py
+++ b/examples/images_contours_and_fields/tricontour_demo.py
@@ -110,3 +110,18 @@ ax2.set_xlabel('Longitude (degrees)')
 ax2.set_ylabel('Latitude (degrees)')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.tricontourf
+matplotlib.pyplot.tricontourf
+matplotlib.tri.Triangulation

--- a/examples/images_contours_and_fields/tricontour_smooth_delaunay.py
+++ b/examples/images_contours_and_fields/tricontour_smooth_delaunay.py
@@ -4,7 +4,7 @@ Tricontour Smooth Delaunay
 ==========================
 
 Demonstrates high-resolution tricontouring of a random set of points ;
-a matplotlib.tri.TriAnalyzer is used to improve the plot quality.
+a `matplotlib.tri.TriAnalyzer` is used to improve the plot quality.
 
 The initial data points and triangular grid for this demo are:
 
@@ -16,12 +16,12 @@ The initial data points and triangular grid for this demo are:
 The proposed generic procedure to obtain a high resolution contouring of such
 a data set is the following:
 
-1. Compute an extended mask with a matplotlib.tri.TriAnalyzer, which will
+1. Compute an extended mask with a `matplotlib.tri.TriAnalyzer`, which will
    exclude badly shaped (flat) triangles from the border of the
    triangulation. Apply the mask to the triangulation (using set_mask).
 2. Refine and interpolate the data using a
-   matplotlib.tri.UniformTriRefiner.
-3. Plot the refined data with tricontour.
+   `matplotlib.tri.UniformTriRefiner`.
+3. Plot the refined data with `~.axes.Axes.tricontour`.
 
 """
 from matplotlib.tri import Triangulation, TriAnalyzer, UniformTriRefiner
@@ -137,3 +137,25 @@ if plot_masked_tri:
     ax.triplot(flat_tri, color='red')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.tricontour
+matplotlib.pyplot.tricontour
+matplotlib.axes.Axes.tricontourf
+matplotlib.pyplot.tricontourf
+matplotlib.axes.Axes.triplot
+matplotlib.pyplot.triplot
+matplotlib.tri
+matplotlib.tri.Triangulation
+matplotlib.tri.TriAnalyzer
+matplotlib.tri.UniformTriRefiner

--- a/examples/images_contours_and_fields/tricontour_smooth_user.py
+++ b/examples/images_contours_and_fields/tricontour_smooth_user.py
@@ -4,7 +4,7 @@ Tricontour Smooth User
 ======================
 
 Demonstrates high-resolution tricontouring on user-defined triangular grids
-with matplotlib.tri.UniformTriRefiner
+with `matplotlib.tri.UniformTriRefiner`.
 """
 import matplotlib.tri as tri
 import matplotlib.pyplot as plt
@@ -76,3 +76,22 @@ ax.tricontour(tri_refi, z_test_refi, levels=levels,
 ax.set_title("High-resolution tricontouring")
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.tricontour
+matplotlib.pyplot.tricontour
+matplotlib.axes.Axes.tricontourf
+matplotlib.pyplot.tricontourf
+matplotlib.tri
+matplotlib.tri.Triangulation
+matplotlib.tri.UniformTriRefiner

--- a/examples/images_contours_and_fields/trigradient_demo.py
+++ b/examples/images_contours_and_fields/trigradient_demo.py
@@ -3,7 +3,8 @@
 Trigradient Demo
 ================
 
-Demonstrates computation of gradient with matplotlib.tri.CubicTriInterpolator.
+Demonstrates computation of gradient with
+`matplotlib.tri.CubicTriInterpolator`.
 """
 from matplotlib.tri import (
     Triangulation, UniformTriRefiner, CubicTriInterpolator)
@@ -85,3 +86,26 @@ ax.quiver(triang.x, triang.y, Ex/E_norm, Ey/E_norm,
 
 ax.set_title('Gradient plot: an electrical dipole')
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.tricontour
+matplotlib.pyplot.tricontour
+matplotlib.axes.Axes.triplot
+matplotlib.pyplot.triplot
+matplotlib.tri
+matplotlib.tri.Triangulation
+matplotlib.tri.CubicTriInterpolator
+matplotlib.tri.CubicTriInterpolator.gradient
+matplotlib.tri.UniformTriRefiner
+matplotlib.axes.Axes.quiver
+matplotlib.pyplot.quiver

--- a/examples/images_contours_and_fields/triinterp_demo.py
+++ b/examples/images_contours_and_fields/triinterp_demo.py
@@ -58,3 +58,27 @@ axs[3].set_title("Cubic interpolation,\nkind='min_E'")
 
 fig.tight_layout()
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.tricontourf
+matplotlib.pyplot.tricontourf
+matplotlib.axes.Axes.triplot
+matplotlib.pyplot.triplot
+matplotlib.axes.Axes.contourf
+matplotlib.pyplot.contourf
+matplotlib.axes.Axes.plot
+matplotlib.pyplot.plot
+matplotlib.tri
+matplotlib.tri.LinearTriInterpolator
+matplotlib.tri.CubicTriInterpolator
+matplotlib.tri.Triangulation

--- a/examples/images_contours_and_fields/tripcolor_demo.py
+++ b/examples/images_contours_and_fields/tripcolor_demo.py
@@ -124,3 +124,19 @@ ax3.set_xlabel('Longitude (degrees)')
 ax3.set_ylabel('Latitude (degrees)')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.tripcolor
+matplotlib.pyplot.tripcolor
+matplotlib.tri
+matplotlib.tri.Triangulation

--- a/examples/images_contours_and_fields/triplot_demo.py
+++ b/examples/images_contours_and_fields/triplot_demo.py
@@ -104,3 +104,19 @@ ax2.set_xlabel('Longitude (degrees)')
 ax2.set_ylabel('Latitude (degrees)')
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.triplot
+matplotlib.pyplot.triplot
+matplotlib.tri
+matplotlib.tri.Triangulation

--- a/tutorials/advanced/transforms_tutorial.py
+++ b/tutorials/advanced/transforms_tutorial.py
@@ -242,7 +242,7 @@ ax.add_patch(circ)
 plt.show()
 
 ###############################################################################
-# .. blended_transformations:
+# .. _blended_transformations:
 #
 # Blended transformations
 # =======================
@@ -303,7 +303,7 @@ plt.show()
 #
 #     trans = ax.get_xaxis_transform()
 #
-# .. offset-transforms-shadow:
+# .. _offset-transforms-shadow:
 #
 # Using offset transforms to create a shadow effect
 # =================================================
@@ -371,7 +371,7 @@ ax.set_title('creating a shadow effect with an offset transform')
 plt.show()
 
 ###############################################################################
-# .. transformation-pipeline:
+# .. _transformation-pipeline:
 #
 # The transformation pipeline
 # ===========================


### PR DESCRIPTION
## PR Summary

This is part of creating backreferences for the examples.
as discussed in #11019 and #10148 and #10974.

This PR concerns the ***Images, Contours, and Fields***  section of the gallery.

## PR Checklist

- [x] Code is PEP 8 compliant
- [x] Documentation is sphinx and numpydoc compliant
