### PR TITLE
Some unrelated cleanups.

### DIFF
--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -1,3 +1,4 @@
+import functools
 import warnings
 
 from matplotlib import docstring
@@ -183,9 +184,8 @@ class SubplotBase(object):
         self._twinned_axes.join(self, ax2)
         return ax2
 
-_subplot_classes = {}
 
-
+@functools.lru_cache(None)
 def subplot_class_factory(axes_class=None):
     # This makes a new class that inherits from SubplotBase and the
     # given axes_class (which is assumed to be a subclass of Axes).
@@ -194,15 +194,10 @@ def subplot_class_factory(axes_class=None):
     # not have to be created for every type of Axes.
     if axes_class is None:
         axes_class = Axes
+    return type("%sSubplot" % axes_class.__name__,
+                (SubplotBase, axes_class),
+                {'_axes_class': axes_class})
 
-    new_class = _subplot_classes.get(axes_class)
-    if new_class is None:
-        new_class = type(str("%sSubplot") % (axes_class.__name__),
-                         (SubplotBase, axes_class),
-                         {'_axes_class': axes_class})
-        _subplot_classes[axes_class] = new_class
-
-    return new_class
 
 # This is provided for backward compatibility
 Subplot = subplot_class_factory()

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1360,9 +1360,6 @@ class Node(object):
         self.size = 0
 
     def __repr__(self):
-        return self.__internal_repr__()
-
-    def __internal_repr__(self):
         return self.__class__.__name__
 
     def get_kerning(self, next):
@@ -1449,7 +1446,7 @@ class Char(Node):
         # pack phase, after we know the real fontsize
         self._update_metrics()
 
-    def __internal_repr__(self):
+    def __repr__(self):
         return '`%s`' % self.c
 
     def _update_metrics(self):
@@ -1547,7 +1544,7 @@ class List(Box):
 
     def __repr__(self):
         return '[%s <%.02f %.02f %.02f %.02f> %s]' % (
-            self.__internal_repr__(),
+            super().__repr__(),
             self.width, self.height,
             self.depth, self.shift_amount,
             ' '.join([repr(x) for x in self.children]))

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -38,9 +38,6 @@ class Patch(artist.Artist):
     # subclass-by-subclass basis.
     _edge_default = False
 
-    def __str__(self):
-        return str(self.__class__).split('.')[-1]
-
     def __init__(self,
                  edgecolor=None,
                  facecolor=None,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1779,6 +1779,7 @@ def test_as_mpl_axes_api():
         def _as_mpl_axes(self):
             # implement the matplotlib axes interface
             return PolarAxes, {'theta_offset': self.theta_offset}
+
     prj = Polar()
     prj2 = Polar()
     prj2.theta_offset = np.pi
@@ -1793,7 +1794,7 @@ def test_as_mpl_axes_api():
 
     # testing axes creation with gca
     ax = plt.gca(projection=prj)
-    assert type(ax) == maxes._subplots._subplot_classes[PolarAxes]
+    assert type(ax) == maxes._subplots.subplot_class_factory(PolarAxes)
     ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     # try getting the axes given a different polar projection
@@ -1814,7 +1815,7 @@ def test_as_mpl_axes_api():
 
     # testing axes creation with subplot
     ax = plt.subplot(121, projection=prj)
-    assert type(ax) == maxes._subplots._subplot_classes[PolarAxes]
+    assert type(ax) == maxes._subplots.subplot_class_factory(PolarAxes)
     plt.close()
 
 

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -1,4 +1,4 @@
-import six
+import functools
 
 from matplotlib import (
     artist as martist, collections as mcoll, transforms as mtransforms,
@@ -40,31 +40,20 @@ class ParasiteAxesBase(object):
             self.yaxis.set_zorder(2.5)
 
 
-_parasite_axes_classes = {}
+@functools.lru_cache(None)
 def parasite_axes_class_factory(axes_class=None):
     if axes_class is None:
         axes_class = Axes
 
-    new_class = _parasite_axes_classes.get(axes_class)
-    if new_class is None:
-        def _get_base_axes_attr(self, attrname):
-            return getattr(axes_class, attrname)
+    def _get_base_axes_attr(self, attrname):
+        return getattr(axes_class, attrname)
 
-        new_class = type(str("%sParasite" % (axes_class.__name__)),
-                         (ParasiteAxesBase, axes_class),
-                         {'_get_base_axes_attr': _get_base_axes_attr})
-        _parasite_axes_classes[axes_class] = new_class
+    return type("%sParasite" % axes_class.__name__,
+                (ParasiteAxesBase, axes_class),
+                {'_get_base_axes_attr': _get_base_axes_attr})
 
-    return new_class
 
 ParasiteAxes = parasite_axes_class_factory()
-
-# #class ParasiteAxes(ParasiteAxesBase, Axes):
-
-#     @classmethod
-#     def _get_base_axes_attr(cls, attrname):
-#         return getattr(Axes, attrname)
-
 
 
 class ParasiteAxesAuxTransBase(object):
@@ -189,8 +178,7 @@ class ParasiteAxesAuxTransBase(object):
         #ParasiteAxes.apply_aspect()
 
 
-
-_parasite_axes_auxtrans_classes = {}
+@functools.lru_cache(None)
 def parasite_axes_auxtrans_class_factory(axes_class=None):
     if axes_class is None:
         parasite_axes_class = ParasiteAxes
@@ -198,21 +186,14 @@ def parasite_axes_auxtrans_class_factory(axes_class=None):
         parasite_axes_class = parasite_axes_class_factory(axes_class)
     else:
         parasite_axes_class = axes_class
-
-    new_class = _parasite_axes_auxtrans_classes.get(parasite_axes_class)
-    if new_class is None:
-        new_class = type(str("%sParasiteAuxTrans" % (parasite_axes_class.__name__)),
-                         (ParasiteAxesAuxTransBase, parasite_axes_class),
-                         {'_parasite_axes_class': parasite_axes_class,
-                         'name': 'parasite_axes'})
-        _parasite_axes_auxtrans_classes[parasite_axes_class] = new_class
-
-    return new_class
+    return type("%sParasiteAuxTrans" % parasite_axes_class.__name__,
+                (ParasiteAxesAuxTransBase, parasite_axes_class),
+                {'_parasite_axes_class': parasite_axes_class,
+                 'name': 'parasite_axes'})
 
 
-ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(axes_class=ParasiteAxes)
-
-
+ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(
+    axes_class=ParasiteAxes)
 
 
 def _get_handles(ax):
@@ -391,32 +372,28 @@ class HostAxesBase(object):
         return _bbox
 
 
-_host_axes_classes = {}
+@functools.lru_cache(None)
 def host_axes_class_factory(axes_class=None):
     if axes_class is None:
         axes_class = Axes
 
-    new_class = _host_axes_classes.get(axes_class)
-    if new_class is None:
-        def _get_base_axes(self):
-            return axes_class
+    def _get_base_axes(self):
+        return axes_class
 
-        def _get_base_axes_attr(self, attrname):
-            return getattr(axes_class, attrname)
+    def _get_base_axes_attr(self, attrname):
+        return getattr(axes_class, attrname)
 
-        new_class = type(str("%sHostAxes" % (axes_class.__name__)),
-                         (HostAxesBase, axes_class),
-                         {'_get_base_axes_attr': _get_base_axes_attr,
-                          '_get_base_axes': _get_base_axes})
+    return type("%sHostAxes" % axes_class.__name__,
+                (HostAxesBase, axes_class),
+                {'_get_base_axes_attr': _get_base_axes_attr,
+                 '_get_base_axes': _get_base_axes})
 
-        _host_axes_classes[axes_class] = new_class
-
-    return new_class
 
 def host_subplot_class_factory(axes_class):
     host_axes_class = host_axes_class_factory(axes_class=axes_class)
     subplot_host_class = subplot_class_factory(host_axes_class)
     return subplot_host_class
+
 
 HostAxes = host_axes_class_factory(axes_class=Axes)
 SubplotHost = subplot_class_factory(HostAxes)

--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -1,8 +1,8 @@
 """
 An experimental support for curvilinear grid.
 """
-import six
-from six.moves import zip
+
+import functools
 
 # TODO :
 # see if tick_iterator method can be simplified by reusing the parent method.
@@ -506,19 +506,12 @@ class FloatingAxesBase(object):
         self.set_ylim(ymin-dy, ymax+dy)
 
 
-
-_floatingaxes_classes = {}
-
+@functools.lru_cache(None)
 def floatingaxes_class_factory(axes_class):
+    return type("Floating %s" % axes_class.__name__,
+                (FloatingAxesBase, axes_class),
+                {'_axes_class_floating': axes_class})
 
-    new_class = _floatingaxes_classes.get(axes_class)
-    if new_class is None:
-        new_class = type(str("Floating %s" % (axes_class.__name__)),
-                         (FloatingAxesBase, axes_class),
-                         {'_axes_class_floating': axes_class})
-        _floatingaxes_classes[axes_class] = new_class
-
-    return new_class
 
 from .axislines import Axes
 from mpl_toolkits.axes_grid1.parasite_axes import host_axes_class_factory


### PR DESCRIPTION
1) Simplify a bit the pickling setup for SubplotBase subclasses
   (basically, there was one layer of callable that was unnecessary).
2) Remove some commented out code that doesn't seem to achieve much, and
   has likely been commented out for years now.
3) No need to define `__internal_repr__` in mathtext and have `__repr__`
   call it; directly defining `__repr__` is sufficient.
4) The current definition of `Patch.__str__` has `str(Patch())` return
   `"Patch'>"`, which is clearly worse than even the default repr.  I
   guess the intent was just to return `"Patch"`, but that's not the
   point of this PR; that can go in another PR if desired.
5) Use lru_cache in `*_class_factory` (instead of manual caching).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
