### PR TITLE
FIX: don't pad axes for ticks if they aren't visible or axis off

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -583,8 +583,12 @@ class _AxesBase(martist.Artist):
         *kwargs* are empty
         """
         bbox = self.bbox
-        x_pad = self.xaxis.get_tick_padding()
-        y_pad = self.yaxis.get_tick_padding()
+        x_pad = 0
+        if self.axison and self.xaxis.get_visible():
+            x_pad = self.xaxis.get_tick_padding()
+        y_pad = 0
+        if self.axison and self.yaxis.get_visible():
+            y_pad = self.yaxis.get_tick_padding()
         return mtransforms.Bbox([[bbox.x0 - x_pad, bbox.y0 - y_pad],
                                  [bbox.x1 + x_pad, bbox.y1 + y_pad]])
 
@@ -4145,7 +4149,6 @@ class _AxesBase(martist.Artist):
             bb.append(bb_xaxis)
 
         self._update_title_position(renderer)
-
         bb.append(self.get_window_extent(renderer))
 
         if self.title.get_visible():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5714,3 +5714,15 @@ def test_markerfacecolor_none_alpha():
     fig2.savefig(buf2)
 
     assert buf1.getvalue() == buf2.getvalue()
+
+
+def test_tick_padding_tightbbox():
+    "Test that tick padding gets turned off if axis is off"
+    plt.rcParams["xtick.direction"] = "out"
+    plt.rcParams["ytick.direction"] = "out"
+    fig, ax = plt.subplots()
+    bb = ax.get_window_extent(fig.canvas.get_renderer())
+    ax.axis('off')
+    bb2 = ax.get_window_extent(fig.canvas.get_renderer())
+    assert bb.x0 < bb2.x0
+    assert bb.y0 < bb2.y0


### PR DESCRIPTION
## PR Summary

Since 1.5.3 (two years ago) we added: 
https://github.com/matplotlib/matplotlib/blob/1652ed1850b879a5fb0aa14bfa05a59ab3826a4a/lib/matplotlib/axes/_base.py#L580-L589

First, this seems like a funny place to put the padding for ticks - I'd have expected it to be in the axis bbox, not the axes bbox.  But presumably someone wanted to know the extent of the axes and its ticks w/o knowing the rest of the decorators?  The original issues that spurred #5683 seemed to be tight_layout not respecting outward ticks.  IMHO this "fix" was wrong and the axis bboxes should include the ticks not the `axes`,  *But* `xaxis.get_tightbbox` does *not* include the ticks even though it controls everything about the ticks.

Second, `ax.set_axis_off` sets a`ax.axison=False`, but it doesn't change the *visibility* of the axis, which is still True.    I haven't fixed this, but it seems strange to have two flags that control the visibility of an axis. 

Anyways, this is an easy fix given how things are now to make the tightbbox actually behave like there are no ticks present.

Closes: #11203

- Probably needs a good test....
- Milestoning 3.0 as this regression is very old.

```python
import numpy as np
from matplotlib import pyplot as plt

# axis ticks removed
fig, ax = plt.subplots(figsize=(1,1))
ax.matshow(np.ones((10,10)), cmap=plt.cm.Blues_r, aspect='auto')
ax.set_xticklabels([])
ax.set_yticklabels([])
ax.axis('off')
fig.tight_layout()
fig.savefig('test_noticks.png', dpi=300, bbox_inches='tight', pad_inches=0, facecolor='red')
```

### before

![test_noticks](https://user-images.githubusercontent.com/1562854/39828385-98875e34-536f-11e8-9c5b-30b85b02927a.png)

### after

![test_noticks](https://user-images.githubusercontent.com/1562854/39828401-ad4a4110-536f-11e8-912c-1b332f06d16e.png)


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->