### PR TITLE
Revert explicit linestyle kwarg on step()

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1733,7 +1733,7 @@ class Axes(_AxesBase):
     #### Specialized plotting
 
     @_preprocess_data(replace_names=["x", "y"], label_namer="y")
-    def step(self, x, y, *args, where='pre', linestyle='', **kwargs):
+    def step(self, x, y, *args, where='pre', **kwargs):
         """
         Make a step plot.
 
@@ -1797,7 +1797,7 @@ class Axes(_AxesBase):
         if where not in ('pre', 'post', 'mid'):
             raise ValueError("'where' argument to step must be "
                              "'pre', 'post' or 'mid'")
-        kwargs['linestyle'] = 'steps-' + where + linestyle
+        kwargs['linestyle'] = 'steps-' + where + kwargs.get('linestyle', '')
 
         return self.plot(x, y, *args, **kwargs)
 


### PR DESCRIPTION
## PR Summary

This is a selective revert of #11145 for the kwarg 'linestyle' of `step()`.

The intention of #11145 is making relevant kwargs explicit by removing popping from kwargs.

The case here is different. 'linestyle' belongs to a whole set of style parameters that we do not explicitly state. It's not special from a signature point of view and thus should not be listed explicitly. The popping in the code is done for internal rewriting reasons.