### PR TITLE
Fix CirclePolygon __str__ + adding tests

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -794,7 +794,9 @@ class RegularPolygon(Patch):
     A regular polygon patch.
     """
     def __str__(self):
-        return "Poly%d(%g,%g)" % (self._numVertices, self._xy[0], self._xy[1])
+        s = "RegularPolygon((%g, %g), %d, radius=%g, orientation=%g)"
+        return s % (self._xy[0], self._xy[1], self._numVertices, self._radius,
+                    self._orientation)
 
     @docstring.dedent_interpd
     def __init__(self, xy, numVertices, radius=5, orientation=0,
@@ -880,7 +882,8 @@ class PathPatch(Patch):
     _edge_default = True
 
     def __str__(self):
-        return "Poly((%g, %g) ...)" % tuple(self._path.vertices[0])
+        s = "PathPatch%d((%g, %g) ...)"
+        return s % (len(self._path.vertices), *tuple(self._path.vertices[0]))
 
     @docstring.dedent_interpd
     def __init__(self, path, **kwargs):
@@ -908,7 +911,8 @@ class Polygon(Patch):
     A general polygon patch.
     """
     def __str__(self):
-        return "Poly((%g, %g) ...)" % tuple(self._path.vertices[0])
+        s = "Polygon%d((%g, %g) ...)"
+        return s % (len(self._path.vertices), *tuple(self._path.vertices[0]))
 
     @docstring.dedent_interpd
     def __init__(self, xy, closed=True, **kwargs):
@@ -1381,7 +1385,8 @@ class CirclePolygon(RegularPolygon):
     A polygon-approximation of a circle patch.
     """
     def __str__(self):
-        return "CirclePolygon(%d,%d)" % self.center
+        s = "CirclePolygon((%g, %g), radius=%g, resolution=%d)"
+        return s % (self._xy[0], self._xy[1], self._radius, self._numVertices)
 
     @docstring.dedent_interpd
     def __init__(self, xy, radius=5,
@@ -2451,9 +2456,8 @@ class FancyBboxPatch(Patch):
     _edge_default = True
 
     def __str__(self):
-        return self.__class__.__name__ \
-                           + "(%g,%g;%gx%g)" % (self._x, self._y,
-                                                self._width, self._height)
+        s = self.__class__.__name__ + "((%g, %g), width=%g, height=%g)"
+        return s % (self._x, self._y, self._width, self._height)
 
     @docstring.dedent_interpd
     def __init__(self, xy, width, height,
@@ -3966,7 +3970,7 @@ class FancyArrowPatch(Patch):
         if self._posA_posB is not None:
             (x1, y1), (x2, y2) = self._posA_posB
             return self.__class__.__name__ \
-                + "(%g,%g->%g,%g)" % (x1, y1, x2, y2)
+                + "((%g, %g)->(%g, %g))" % (x1, y1, x2, y2)
         else:
             return self.__class__.__name__ \
                 + "(%s)" % (str(self._path_original),)
@@ -4374,7 +4378,7 @@ class ConnectionPatch(FancyArrowPatch):
     connecting lines between two points (possibly in different axes).
     """
     def __str__(self):
-        return "ConnectionPatch((%g,%g),(%g,%g))" % \
+        return "ConnectionPatch((%g, %g), (%g, %g))" % \
                (self.xy1[0], self.xy1[1], self.xy2[0], self.xy2[1])
 
     @docstring.dedent_interpd

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -318,6 +318,43 @@ def test_patch_str():
     expected = 'Arc(xy=(1, 2), width=3, height=4, angle=5, theta1=6, theta2=7)'
     assert str(p) == expected
 
+    p = mpatches.RegularPolygon((1, 2), 20, radius=5)
+    assert str(p) == "RegularPolygon((1, 2), 20, radius=5, orientation=0)"
+
+    p = mpatches.CirclePolygon(xy=(1, 2), radius=5, resolution=20)
+    assert str(p) == "CirclePolygon((1, 2), radius=5, resolution=20)"
+
+    p = mpatches.FancyBboxPatch((1, 2), width=3, height=4)
+    assert str(p) == "FancyBboxPatch((1, 2), width=3, height=4)"
+
+    # Further nice __str__ which cannot be `eval`uated:
+    path_data = [([1, 2], mpath.Path.MOVETO), ([2, 2], mpath.Path.LINETO),
+                 ([1, 2], mpath.Path.CLOSEPOLY)]
+    p = mpatches.PathPatch(mpath.Path(*zip(*path_data)))
+    assert str(p) == "PathPatch3((1, 2) ...)"
+
+    data = [[1, 2], [2, 2], [1, 2]]
+    p = mpatches.Polygon(data)
+    assert str(p) == "Polygon3((1, 2) ...)"
+
+    p = mpatches.FancyArrowPatch(path=mpath.Path(*zip(*path_data)))
+    assert str(p)[:27] == "FancyArrowPatch(Path(array("
+
+    p = mpatches.FancyArrowPatch((1, 2), (3, 4))
+    assert str(p) == "FancyArrowPatch((1, 2)->(3, 4))"
+
+    p = mpatches.ConnectionPatch((1, 2), (3, 4), 'data')
+    assert str(p) == "ConnectionPatch((1, 2), (3, 4))"
+
+    s = mpatches.Shadow(p, 1, 1)
+    assert str(s) == "Shadow(ConnectionPatch((1, 2), (3, 4)))"
+
+    p = mpatches.YAArrow(plt.gcf(), (1, 0), (2, 1), width=0.1)
+    assert str(p) == "YAArrow()"
+
+    # Not testing Arrow, FancyArrow here
+    # because they seem to exist only for historical reasons.
+
 
 @image_comparison(baseline_images=['multi_color_hatch'],
                   remove_text=True, style='default')


### PR DESCRIPTION
## Bug report

Previously, the following 

```
from matplotlib.patches import CirclePolygon
circle = CirclePolygon((1, 2), radius = 1)
print(circle)
```

would fail with a

```
AttributeError: 'CirclePolygon' object has no attribute 'center'
```

## PR Summary

This PR
* fixes the above error by replacing the `__str__` 
* adds a test for this
* Replaces a couple of other `__str__` representations for `patches` and adds tests for them as well, such that by now all patches are tested, except for `Arrow` and `FancyArrow` because it seems they are not really needed anyways.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
