### PR TITLE
DOC: Sort gallery subsections by filename

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -12,4 +12,4 @@ ipython
 ipywidgets
 numpydoc>=0.4
 pillow
-sphinx-gallery>=0.1.12
+sphinx-gallery>=0.1.13

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,9 +72,10 @@ def _check_deps():
 _check_deps()
 
 # Import only after checking for dependencies.
-from sphinx_gallery.sorting import ExplicitOrder
+from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
 # This is only necessary to monkey patch the signature later on.
 from sphinx_gallery import gen_rst
+
 
 if shutil.which('dot') is None:
     raise OSError(
@@ -129,6 +130,7 @@ sphinx_gallery_conf = {
     },
     'backreferences_dir': 'api/_as_gen',
     'subsection_order': ExplicitOrder(explicit_order_folders),
+    'within_subsection_order': FileNameSortKey,
     'min_reported_time': 1,
 }
 

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -42,12 +42,12 @@ using the Sphinx_ documentation generation tool. There are several extra
 requirements that are needed to build the documentation. They are listed in
 :file:`doc-requirements.txt` and listed below:
 
-* Sphinx>=1.3, !=1.5.0, !=1.6.4
+* Sphinx>=1.3, !=1.5.0, !=1.6.4, !=1.7.3
 * colorspacious
 * IPython
 * numpydoc>=0.4
 * Pillow
-* sphinx-gallery>=0.1.12
+* sphinx-gallery>=0.1.13
 * graphviz
 
 .. note::


### PR DESCRIPTION
## PR Summary

Up to now the subsections of the gallery were sorted by the length of the code section(s) in the respective example. This let the gallery look a bit chaotic.  
Instead it might be useful to **sort the examples within each subsection by the filename of the example**. This would still not give perfect thematic ordering, but since in many cases the filenames start with the name of the function they focus on, some kind of basic ordering would be achieved.

Note that an alternative would be to order by example headline/title. This seems not too useful because we can have the examples named like "A bar plot...", "Bar plot...", "Demo for Bar..", "Subplots with bars" etc.

This PR would introduce ordering by filename, since it seems to be the best one can achieve automatically and without renaming half of the examples. 

## PR Checklist

- [x] Code is PEP 8 compliant
- [x] Documentation is sphinx and numpydoc compliant
