### PR TITLE
fix pkg-config handling to make cross-compiling work

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -221,7 +221,7 @@ def make_extension(name, files, *args, **kwargs):
     """
     Make a new extension.  Automatically sets include_dirs and
     library_dirs to the base directories appropriate for this
-    platform.
+    platform when pkg-config is not available.
 
     `name` is the name of the extension.
 
@@ -231,14 +231,15 @@ def make_extension(name, files, *args, **kwargs):
     `distutils.core.Extension` constructor.
     """
     ext = DelayedExtension(name, files, *args, **kwargs)
-    for dir in get_base_dirs():
-        include_dir = os.path.join(dir, 'include')
-        if os.path.exists(include_dir):
-            ext.include_dirs.append(include_dir)
-        for lib in ('lib', 'lib64'):
-            lib_dir = os.path.join(dir, lib)
-            if os.path.exists(lib_dir):
-                ext.library_dirs.append(lib_dir)
+    if not pkg_config.has_pkgconfig:
+        for dir in get_base_dirs():
+            include_dir = os.path.join(dir, 'include')
+            if os.path.exists(include_dir):
+                ext.include_dirs.append(include_dir)
+            for lib in ('lib', 'lib64'):
+                lib_dir = os.path.join(dir, lib)
+                if os.path.exists(lib_dir):
+                    ext.library_dirs.append(lib_dir)
     ext.include_dirs.append('.')
 
     return ext

--- a/setupext.py
+++ b/setupext.py
@@ -270,26 +270,11 @@ class PkgConfig(object):
             self.has_pkgconfig = False
         else:
             self.pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
-            self.set_pkgconfig_path()
             self.has_pkgconfig = shutil.which(self.pkg_config) is not None
             if not self.has_pkgconfig:
                 print("IMPORTANT WARNING:\n"
                       "    pkg-config is not installed.\n"
                       "    matplotlib may not be able to find some of its dependencies")
-
-    def set_pkgconfig_path(self):
-        pkgconfig_path = sysconfig.get_config_var('LIBDIR')
-        if pkgconfig_path is None:
-            return
-
-        pkgconfig_path = os.path.join(pkgconfig_path, 'pkgconfig')
-        if not os.path.isdir(pkgconfig_path):
-            return
-
-        try:
-            os.environ['PKG_CONFIG_PATH'] += ':' + pkgconfig_path
-        except KeyError:
-            os.environ['PKG_CONFIG_PATH'] = pkgconfig_path
 
     def setup_extension(self, ext, package, default_include_dirs=[],
                         default_library_dirs=[], default_libraries=[],


### PR DESCRIPTION
This series cleans up the pkg-config logic so that cross-compile works properly. There's still some weirdness with the use of freetype-config/libpng-config, but I've ignored that as it only impacts the display and not the actual config/code generation.