### PR TITLE
 Add deprecation messages for unused kwargs in FancyArrowPatch 

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -100,6 +100,7 @@ def warn_deprecated(
     """
     message = _generate_deprecation_message(
         since, message, name, alternative, pending, obj_type, removal=removal)
+    message = '\n' + message
     warnings.warn(message, mplDeprecation, stacklevel=2)
 
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4060,6 +4060,20 @@ class FancyArrowPatch(Patch):
         Valid kwargs are:
         %(Patch)s
         """
+        if arrow_transmuter is not None:
+            cbook.warn_deprecated(
+                3.0,
+                message=('The "arrow_transmuter" keyword argument is not used,'
+                         ' and will be removed in Matplotlib 3.1'),
+                name='arrow_transmuter',
+                obj_type='keyword argument')
+        if connector is not None:
+            cbook.warn_deprecated(
+                3.0,
+                message=('The "connector" keyword argument is not used,'
+                         ' and will be removed in Matplotlib 3.1'),
+                name='connector',
+                obj_type='keyword argument')
         Patch.__init__(self, **kwargs)
 
         if posA is not None and posB is not None and path is None:


### PR DESCRIPTION
I've gone with removal in `3.1`, but I'm not sure if that's too soon or not? I've also added a newline before deprecation messages, as it makes them more readable, changing them from:
```
/Users/dstansby/github/matplotlib/lib/matplotlib/patches.py:4069: MatplotlibDeprecationWarning: The "arrow_transmuter" keyword argument is not used, and will be removed in Matplotlib 3.1
```
to
```
/Users/dstansby/github/matplotlib/lib/matplotlib/patches.py:4069: MatplotlibDeprecationWarning: 
The "arrow_transmuter" keyword argument is not used, and will be removed in Matplotlib 3.1
```