### PR TITLE
Add stacklevel=2 to some more warnings.warn() calls

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1335,7 +1335,7 @@ class _AxesBase(martist.Artist):
         """
         if adjustable == 'box-forced':
             warnings.warn("The 'box-forced' keyword argument is deprecated"
-                          " since 2.2.", cbook.mplDeprecation)
+                          " since 2.2.", cbook.mplDeprecation, stacklevel=2)
         if adjustable not in ('box', 'datalim', 'box-forced'):
             raise ValueError("argument must be 'box', or 'datalim'")
         if share:
@@ -1486,7 +1486,7 @@ class _AxesBase(martist.Artist):
                 if aspect != "auto":
                     warnings.warn(
                         'aspect is not supported for Axes with xscale=%s, '
-                        'yscale=%s' % (xscale, yscale))
+                        'yscale=%s' % (xscale, yscale), stacklevel=2)
                     aspect = "auto"
             else:  # some custom projections have their own scales.
                 pass
@@ -2287,7 +2287,8 @@ class _AxesBase(martist.Artist):
 
         if x is None and y is None:
             if tight is not True:
-                warnings.warn('ignoring tight=%r in get mode' % (tight,))
+                warnings.warn('ignoring tight=%r in get mode' % (tight,),
+                              stacklevel=2)
             return self._xmargin, self._ymargin
 
         if x is not None:
@@ -3117,7 +3118,7 @@ class _AxesBase(martist.Artist):
             warnings.warn(
                 ('Attempting to set identical left==right results\n'
                  'in singular transformations; automatically expanding.\n'
-                 'left=%s, right=%s') % (left, right))
+                 'left=%s, right=%s') % (left, right), stacklevel=2)
         left, right = mtransforms.nonsingular(left, right, increasing=False)
 
         if self.get_xscale() == 'log':
@@ -3125,13 +3126,13 @@ class _AxesBase(martist.Artist):
                 warnings.warn(
                     'Attempted to set non-positive left xlim on a '
                     'log-scaled axis.\n'
-                    'Invalid limit will be ignored.')
+                    'Invalid limit will be ignored.', stacklevel=2)
                 left = old_left
             if right <= 0:
                 warnings.warn(
                     'Attempted to set non-positive right xlim on a '
                     'log-scaled axis.\n'
-                    'Invalid limit will be ignored.')
+                    'Invalid limit will be ignored.', stacklevel=2)
                 right = old_right
 
         left, right = self.xaxis.limit_range_for_scale(left, right)
@@ -3456,7 +3457,7 @@ class _AxesBase(martist.Artist):
             warnings.warn(
                 ('Attempting to set identical bottom==top results\n'
                  'in singular transformations; automatically expanding.\n'
-                 'bottom=%s, top=%s') % (bottom, top))
+                 'bottom=%s, top=%s') % (bottom, top), stacklevel=2)
 
         bottom, top = mtransforms.nonsingular(bottom, top, increasing=False)
 
@@ -3465,13 +3466,13 @@ class _AxesBase(martist.Artist):
                 warnings.warn(
                     'Attempted to set non-positive bottom ylim on a '
                     'log-scaled axis.\n'
-                    'Invalid limit will be ignored.')
+                    'Invalid limit will be ignored.', stacklevel=2)
                 bottom = old_bottom
             if top <= 0:
                 warnings.warn(
                     'Attempted to set non-positive top ylim on a '
                     'log-scaled axis.\n'
-                    'Invalid limit will be ignored.')
+                    'Invalid limit will be ignored.', stacklevel=2)
                 top = old_top
         bottom, top = self.yaxis.limit_range_for_scale(bottom, top)
 
@@ -3879,7 +3880,7 @@ class _AxesBase(martist.Artist):
             # should be len 3 or 4 but nothing else
             warnings.warn(
                 "Warning in _set_view_from_bbox: bounding box is not a tuple "
-                "of length 3 or 4. Ignoring the view change.")
+                "of length 3 or 4. Ignoring the view change.", stacklevel=2)
             return
 
         # Just grab bounding box
@@ -4066,7 +4067,7 @@ class _AxesBase(martist.Artist):
                 result = (mtransforms.Bbox(newpoints)
                           .transformed(p.trans_inverse))
             except OverflowError:
-                warnings.warn('Overflow while panning')
+                warnings.warn('Overflow while panning', stacklevel=2)
                 return
         else:
             return

--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -71,7 +71,7 @@ def pylab_setup(name=None):
 Your currently selected backend, '%s' does not support show().
 Please select a GUI backend in your matplotlibrc file ('%s')
 or with matplotlib.use()""" %
-                          (name, matplotlib.matplotlib_fname()))
+                          (name, matplotlib.matplotlib_fname()), stacklevel=2)
 
     def do_nothing(*args, **kwargs):
         pass

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -637,7 +637,7 @@ class FigureCanvasCairo(FigureCanvasBase):
                     fo = gzip.GzipFile(None, 'wb', fileobj=fo)
             surface = cairo.SVGSurface(fo, width_in_points, height_in_points)
         else:
-            warnings.warn("unknown format: %s" % fmt)
+            warnings.warn("unknown format: %s" % fmt, stacklevel=2)
             return
 
         # surface.set_dpi() can be used

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1567,10 +1567,11 @@ end"""
                     'Trapped': check_trapped}
         for k in self.infoDict:
             if k not in keywords:
-                warnings.warn('Unknown infodict keyword: %s' % k)
+                warnings.warn('Unknown infodict keyword: %s' % k, stacklevel=2)
             else:
                 if not keywords[k](self.infoDict[k]):
-                    warnings.warn('Bad value for infodict keyword %s' % k)
+                    warnings.warn('Bad value for infodict keyword %s' % k,
+                                  stacklevel=2)
 
         self.infoObject = self.reserveObject('info')
         self.writeObject(self.infoObject, self.infoDict)

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -420,7 +420,7 @@ class RendererPgf(RendererBase):
             if not hasattr(fh, 'name') or not os.path.exists(fh.name):
                 warnings.warn("streamed pgf-code does not support raster "
                               "graphics, consider using the pgf-to-pdf option",
-                              UserWarning)
+                              UserWarning, stacklevel=2)
                 self.__dict__["draw_image"] = lambda *args, **kwargs: None
 
     def draw_markers(self, gc, marker_path, marker_trans, path, trans,

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -241,7 +241,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
 
     def handle_unknown_event(self, event):
         warnings.warn('Unhandled message type {0}. {1}'.format(
-            event['type'], event))
+            event['type'], event), stacklevel=2)
 
     def handle_ack(self, event):
         # Network latency tends to decrease if traffic is flowing

--- a/lib/matplotlib/backends/qt_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/formlayout.py
@@ -92,7 +92,7 @@ def to_qcolor(color):
     try:
         rgba = mcolors.to_rgba(color)
     except ValueError:
-        warnings.warn('Ignoring invalid color %r' % color)
+        warnings.warn('Ignoring invalid color %r' % color, stacklevel=2)
         return qcolor  # return invalid QColor
     qcolor.setRgbF(*rgba)
     return qcolor
@@ -259,7 +259,7 @@ class FormWidget(QtWidgets.QWidget):
                 elif not isinstance(selindex, int):
                     warnings.warn(
                         "index '%s' is invalid (label: %s, value: %s)" %
-                        (selindex, label, value))
+                        (selindex, label, value), stacklevel=2)
                     selindex = 0
                 field.setCurrentIndex(selindex)
             elif isinstance(value, bool):

--- a/lib/matplotlib/sphinxext/mathmpl.py
+++ b/lib/matplotlib/sphinxext/mathmpl.py
@@ -50,7 +50,7 @@ def latex2png(latex, filename, fontset='cm'):
             depth = mathtext_parser.to_png(filename, latex, dpi=100)
         except:
             warnings.warn("Could not render math expression %s" % latex,
-                          Warning)
+                          Warning, stacklevel=2)
             depth = 0
     rcParams['mathtext.fontset'] = orig_fontset
     sys.stdout.write("#")

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -45,7 +45,7 @@ def _remove_blacklisted_style_params(d, warn=True):
             if warn:
                 warnings.warn(
                     "Style includes a parameter, '{0}', that is not related "
-                    "to style.  Ignoring".format(key))
+                    "to style.  Ignoring".format(key), stacklevel=2)
         else:
             o[key] = val
     return o
@@ -184,7 +184,7 @@ def read_style_directory(style_dir):
 
         for w in warns:
             message = 'In %s: %s' % (path, w.message)
-            warnings.warn(message)
+            warnings.warn(message, stacklevel=2)
 
     return styles
 

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -45,7 +45,7 @@ def _remove_blacklisted_style_params(d, warn=True):
             if warn:
                 warnings.warn(
                     "Style includes a parameter, '{0}', that is not related "
-                    "to style.  Ignoring".format(key), stacklevel=2)
+                    "to style.  Ignoring".format(key), stacklevel=3)
         else:
             o[key] = val
     return o


### PR DESCRIPTION
## PR Summary
Have found some more warnings.warn() calls that have not set stacklevels and have set them all to 2. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
