### PR TITLE
Simplify lookup of animation external commands.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -25,6 +25,7 @@ import logging
 import os
 from pathlib import Path
 import platform
+import shutil
 import subprocess
 import sys
 from tempfile import TemporaryDirectory
@@ -408,27 +409,9 @@ class MovieWriter(AbstractMovieWriter):
     @classmethod
     def isAvailable(cls):
         '''
-        Check to see if a MovieWriter subclass is actually available by
-        running the commandline tool.
+        Check to see if a MovieWriter subclass is actually available.
         '''
-        bin_path = cls.bin_path()
-        if not bin_path:
-            return False
-        try:
-            p = subprocess.Popen(
-                bin_path,
-                shell=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                creationflags=subprocess_creation_flags)
-            return cls._handle_subprocess(p)
-        except OSError:
-            return False
-
-    @classmethod
-    def _handle_subprocess(cls, process):
-        process.communicate()
-        return True
+        return shutil.which(cls.bin_path()) is not None
 
 
 class FileMovieWriter(MovieWriter):
@@ -633,13 +616,14 @@ class FFMpegBase(object):
         return args + ['-y', self.outfile]
 
     @classmethod
-    def _handle_subprocess(cls, process):
-        _, err = process.communicate()
-        # Ubuntu 12.04 ships a broken ffmpeg binary which we shouldn't use
-        # NOTE : when removed, remove the same method in AVConvBase.
-        if 'Libav' in err.decode():
-            return False
-        return True
+    def isAvailable(cls):
+        return (
+            super().isAvailable()
+            # Ubuntu 12.04 ships a broken ffmpeg binary which we shouldn't use.
+            # NOTE: when removed, remove the same method in AVConvBase.
+            and b'LibAv' not in subprocess.run(
+                [cls.bin_path()], creationflags=subprocess_creation_flags,
+                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE).stderr)
 
 
 # Combine FFMpeg options with pipe-based writing
@@ -697,9 +681,7 @@ class AVConvBase(FFMpegBase):
     args_key = 'animation.avconv_args'
 
     # NOTE : should be removed when the same method is removed in FFMpegBase.
-    @classmethod
-    def _handle_subprocess(cls, process):
-        return MovieWriter._handle_subprocess(process)
+    isAvailable = classmethod(MovieWriter.isAvailable.__func__)
 
 
 # Combine AVConv options with pipe-based writing
@@ -771,8 +753,6 @@ class ImageMagickBase(object):
         if bin_path == "convert":
             cls._init_from_registry()
         return super().isAvailable()
-
-ImageMagickBase._init_from_registry()
 
 
 # Note: the base classes need to be in that order to get


### PR DESCRIPTION
... by using shutil.which instead of trying to run the command.

Also, we don't need to explicitly call
ImageMagickBase._init_from_registry because the writers.register
decorator will do that for us (via the call to isAvailable).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
