### PR TITLE
Group figure.subplot.* rc to a single rcParam.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -36,4 +36,7 @@ The following classes, methods, functions, and attributes are deprecated:
 - ``text.Annotation.arrow``,
 
 The following rcParams are deprecated:
+
+- ``figure.subplot.left``, ``figure.subplot.right``, etc (instead, set the
+  single ``figure.subplot`` rcParam to the appropriate dict value).
 - ``pgf.debug`` (the pgf backend relies on logging),

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -906,6 +906,11 @@ class RcParams(MutableMapping, dict):
                           mplDeprecation)
             return None
 
+        elif key.startswith('figure.subplot.'):
+            cbook.warn_deprecated(
+                "3.0",
+                "{} is deprecated; use figure.subplot instead".format(key))
+
         val = dict.__getitem__(self, key)
         if inverse_alt is not None:
             return inverse_alt(val)

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -48,7 +48,7 @@ def _generate_deprecation_message(
 
 def warn_deprecated(
         since, message='', name='', alternative='', pending=False,
-        obj_type='attribute', addendum='', *, removal=''):
+        obj_type='attribute', addendum='', *, removal='', stacklevel=2):
     """
     Used to display deprecation warning in a standard way.
 
@@ -88,6 +88,9 @@ def warn_deprecated(
     addendum : str, optional
         Additional text appended directly to the final message.
 
+    stacklevel : int, optional
+        The stack level used by the `warnings.warn` call.
+
     Examples
     --------
 
@@ -100,7 +103,7 @@ def warn_deprecated(
     """
     message = _generate_deprecation_message(
         since, message, name, alternative, pending, obj_type, removal=removal)
-    warnings.warn(message, mplDeprecation, stacklevel=2)
+    warnings.warn(message, mplDeprecation, stacklevel=stacklevel)
 
 
 def deprecated(since, message='', name='', alternative='', pending=False,

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -228,20 +228,18 @@ class SubplotParams(object):
             self.hspace = thishspace
 
         if self.validate:
-            if self.left >= self.right:
+            if not self.left < self.right:
                 reset()
-                raise ValueError('left cannot be >= right')
-
-            if self.bottom >= self.top:
+                raise ValueError('One must have right < left')
+            if not self.bottom < self.top:
                 reset()
-                raise ValueError('bottom cannot be >= top')
+                raise ValueError('One must have bottom < top')
 
     def _update_this(self, s, val):
         if val is None:
             val = getattr(self, s, None)
             if val is None:
-                key = 'figure.subplot.' + s
-                val = rcParams[key]
+                val = rcParams['figure.subplot'][s]
 
         setattr(self, s, val)
 
@@ -1406,8 +1404,11 @@ default: 'top'
         """
         Clear the figure.
 
-        Set *keep_observers* to True if, for example,
-        a gui widget is tracking the axes in the figure.
+        Parameters
+        ----------
+        keep_observers : bool, optional
+            Set *keep_observers* to True if, for example,
+            a gui widget is tracking the axes in the figure.
         """
         self.suppressComposite = None
         self.callbacks = cbook.CallbackRegistry()
@@ -1429,6 +1430,7 @@ default: 'top'
         if not keep_observers:
             self._axobservers = []
         self._suptitle = None
+        self.subplotpars.update(**rcParams['figure.subplot'])
         if self.get_constrained_layout():
             layoutbox.nonetree(self._layoutbox)
         self.stale = True

--- a/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
@@ -307,16 +307,8 @@ figure.autolayout : False  # When True, automatically adjust subplot
                            # parameters to make the plot fit the figure
 figure.frameon : True
 
-# The figure subplot parameters.  All dimensions are a fraction of the
-# figure width or height
-figure.subplot.left    : 0.125  # the left side of the subplots of the figure
-figure.subplot.right   : 0.9    # the right side of the subplots of the figure
-figure.subplot.bottom  : 0.1    # the bottom of the subplots of the figure
-figure.subplot.top     : 0.9    # the top of the subplots of the figure
-figure.subplot.wspace  : 0.2    # the amount of width reserved for space between subplots,
-                                # expressed as a fraction of the average axis width
-figure.subplot.hspace  : 0.2    # the amount of height reserved for space between subplots,
-                                # expressed as a fraction of the average axis height
+# The figure subplot parameters (see matplotlib.figure.SubplotParams).
+figure.subplot : {"left": 0.125, "right": 0.9, "bottom": 0.1, "top": 0.9, "wspace": 0.2, "hspace": 0.2}
 
 ### IMAGES
 image.aspect : equal             # equal | auto | a number

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -311,16 +311,8 @@ figure.autolayout : False  # When True, automatically adjust subplot
                            # parameters to make the plot fit the figure
 figure.frameon : True
 
-# The figure subplot parameters.  All dimensions are a fraction of the
-# figure width or height
-figure.subplot.left    : 0.125  # the left side of the subplots of the figure
-figure.subplot.right   : 0.9    # the right side of the subplots of the figure
-figure.subplot.bottom  : 0.1    # the bottom of the subplots of the figure
-figure.subplot.top     : 0.9    # the top of the subplots of the figure
-figure.subplot.wspace  : 0.2    # the amount of width reserved for space between subplots,
-                                # expressed as a fraction of the average axis width
-figure.subplot.hspace  : 0.2    # the amount of height reserved for space between subplots,
-                                # expressed as a fraction of the average axis height
+# The figure subplot parameters (see matplotlib.figure.SubplotParams).
+figure.subplot : {"left": 0.125, "right": 0.9, "bottom": 0.1, "top": 0.9, "wspace": 0.2, "hspace": 0.2}
 
 ### IMAGES
 image.aspect : equal             # equal | auto | a number

--- a/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
@@ -34,7 +34,5 @@ font.size:14.0
 savefig.edgecolor: f0f0f0
 savefig.facecolor: f0f0f0
 
-figure.subplot.left: 0.08
-figure.subplot.right: 0.95
-figure.subplot.bottom: 0.07
+figure.subplot : {"left": 0.08, "right": 0.95, "bottom": 0.07}
 figure.facecolor: f0f0f0

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -31,7 +31,7 @@ def _do_cleanup(original_units_registry, original_settings):
     plt.close('all')
 
     mpl.rcParams.clear()
-    mpl.rcParams.update(original_settings)
+    dict.update(mpl.rcParams, original_settings)
     matplotlib.units.registry.clear()
     matplotlib.units.registry.update(original_units_registry)
     warnings.resetwarnings()  # reset any warning filters set in tests

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -383,3 +383,11 @@ def test_fspath(fmt, tmpdir):
         # All the supported formats include the format name (case-insensitive)
         # in the first 100 bytes.
         assert fmt.encode("ascii") in file.read(100).lower()
+
+
+def test_clf_subplotpars():
+    fig = plt.figure()
+    orig_subplot_vars = vars(fig.subplotpars).copy()
+    fig.subplots_adjust(left=0.1)
+    fig.clf()
+    assert vars(fig.subplotpars) == orig_subplot_vars

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -476,7 +476,7 @@ def test_if_rctemplate_is_up_to_date():
             continue
         if k in deprecated:
             continue
-        if "verbose" in k:
+        if "verbose" in k or "figure.subplot." in k:
             continue
         found = False
         for line in rclines:

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -436,15 +436,8 @@ backend      : $TEMPLATE_BACKEND
 #figure.max_open_warning : 20  ## The maximum number of figures to open through
                                ## the pyplot interface before emitting a warning.
                                ## If less than one this feature is disabled.
-## The figure subplot parameters.  All dimensions are a fraction of the
-#figure.subplot.left    : 0.125  ## the left side of the subplots of the figure
-#figure.subplot.right   : 0.9    ## the right side of the subplots of the figure
-#figure.subplot.bottom  : 0.11   ## the bottom of the subplots of the figure
-#figure.subplot.top     : 0.88   ## the top of the subplots of the figure
-#figure.subplot.wspace  : 0.2    ## the amount of width reserved for space between subplots,
-                                 ## expressed as a fraction of the average axis width
-#figure.subplot.hspace  : 0.2    ## the amount of height reserved for space between subplots,
-                                 ## expressed as a fraction of the average axis height
+## The figure subplot parameters (see matplotlib.figure.SubplotParams).
+#figure.subplot : {"left": 0.125, "right": 0.9, "bottom": 0.1, "top": 0.9, "wspace": 0.2, "hspace": 0.2}
 
 ## Figure layout
 #figure.autolayout : False     ## When True, automatically adjust subplot


### PR DESCRIPTION
The idea is to make it easier to restore a figure's subplotparams to the
rc-provided defaults.  Specifically, this can now be done with

    fig.subplots_adjust(**rcParams["figure.subplot"])

or

    fig.subplots_adjust(**dict(rcParams["figure.subplot"], left=...))

if some values need to be overridden.

Also make Figure.clf() restore the subplotsparams to these rc-provided
defaults (that is the original motivation for the change).

Note that this PR runs into a limitation of the rcParams API: it would
be nicer if the validators took the rcParams as parameters (e.g.
implicitly by being methods of the RcParams class), so that they can
actually depend on another key in the same instance.

Also, the tests now restore original rcParams using `dict.update` to
avoid revalidating them and running into the warnings.
(`rc_context.__exit__` does the same.)

Alternative to #11086.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
