### PR TITLE
FIX: fix figure.set_dpi when pixel ratio not 1

### DIFF
--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -95,7 +95,7 @@ class MixedModeRenderer(object):
         """
 
         # change the dpi of the figure temporarily.
-        self.figure.set_dpi(self.dpi)
+        self.figure.dpi = self.dpi
 
         if self._bbox_inches_restore:  # when tight bbox is used
             r = process_figure_for_rasterizing(self.figure,
@@ -141,7 +141,7 @@ class MixedModeRenderer(object):
             self._rasterizing = False
 
             # restore the figure dpi.
-            self.figure.set_dpi(self._figdpi)
+            self.figure.dpi = self._figdpi
 
         if self._bbox_inches_restore:  # when tight bbox is used
             r = process_figure_for_rasterizing(self.figure,

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2559,7 +2559,7 @@ class FigureCanvasPdf(FigureCanvasBase):
                   dpi=72,  # dpi to use for images
                   bbox_inches_restore=None, metadata=None,
                   **kwargs):
-        self.figure.set_dpi(72)            # there are 72 pdf points to an inch
+        self.figure.dpi = 72            # there are 72 pdf points to an inch
         width, height = self.figure.get_size_inches()
         if isinstance(filename, PdfPages):
             file = filename._file

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -948,7 +948,7 @@ class FigureCanvasPS(FigureCanvasBase):
         elif orientation == 'portrait': isLandscape = False
         else: raise RuntimeError('Orientation must be "portrait" or "landscape"')
 
-        self.figure.set_dpi(72) # Override the dpi kwarg
+        self.figure.dpi = 72 # Override the dpi kwarg
 
         if rcParams['text.usetex']:
             self._print_figure_tex(outfile, format, dpi, facecolor, edgecolor,

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -229,7 +229,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         self.figure = figure
         # We don't want to scale up the figure DPI more than once.
         # Note, we don't handle a signal for changing DPI yet.
-        figure._original_dpi = figure.dpi
         self._update_figure_dpi()
         # In cases with mixed resolution displays, we need to be careful if the
         # dpi_ratio changes - in this case we need to resize the canvas

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1214,7 +1214,7 @@ class FigureCanvasSVG(FigureCanvasBase):
 
     def _print_svg(
             self, filename, fh, *, dpi=72, bbox_inches_restore=None, **kwargs):
-        self.figure.set_dpi(72.0)
+        self.figure.dpi = 72.0
         width, height = self.figure.get_size_inches()
         w, h = width * 72, height * 72
 


### PR DESCRIPTION
## PR Summary

As described in #11227, Qt5Agg interacts in strange ways with `figure.set_dpi` and the use of `figure.savefig(dpi='figure')`.  

This was due to the fact that if you have a Retina/hi-dpi screen, Qt5Agg was calling the private 
`figure._set_dpi(dpi, forward=False)` to a doubled dpi from the one specified by the user and/or the rcParam, and saving the "_original_dpi" (or nominal dpi) on the figure.

Here the suggestion is that the figure should set its own nominal dpi at creation and that `figure.set_dpi` should only change the nominal dpi.  If the dpi had been doubled by a backend, it 
is detected at this point and doubled internally by setting `fig.dpi = nominal * factor`.

Fixes the QT5Agg part of #11227  ping @tacaswell @ImportanceOfBeingErnest 

```python
import matplotlib
matplotlib.use('qt5Agg')
import matplotlib.pyplot as plt

fig, ax = plt.subplots(figsize=(4,4), dpi=40, num='starts40')
fig.set_dpi(100)
fig.savefig('Boo40200.png', dpi=200)

fig, ax = plt.subplots(figsize=(4,4), dpi=100, num='starts100')
fig.savefig('Boo100200.png', dpi=200)
plt.show()
```

### Before

<img width="614" alt="starts100_and_starts40_and_5__python_testdpi_py__python3_6__and_4__ _zsh__tmux_" src="https://user-images.githubusercontent.com/1562854/39937168-becf0502-5503-11e8-8d8d-e9ee68762382.png">

### After

<img width="810" alt="starts100_and_starts40_and_5__python_testdpi_py__python3_6__and_4__ _zsh__tmux_" src="https://user-images.githubusercontent.com/1562854/39937070-75c1987a-5503-11e8-806d-b30c80e42277.png">


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->