### PR TITLE
Add fig.add_artist method

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -190,6 +190,7 @@ specify a number that is close (i.e. ``ax.title.set_position(0.5, 1.01)``)
 and the title will not be moved via this algorithm.
 
 
+
 New convenience methods for GridSpec
 ------------------------------------
 
@@ -209,6 +210,23 @@ now call `.Figure.add_gridspec` and for the latter `.SubplotSpec.subgridspec`.
     for i in range(3):
         fig.add_subplot(gssub[0, i])
 
+
+Figure has an `~.figure.Figure.add_artist` method
+-------------------------------------------------
+
+A method `~.figure.Figure.add_artist` has been added to the
+:class:`~.figure.Figure` class, which allows artists to be added directly
+to a figure. E.g.
+
+::
+
+    circ = plt.Circle((.7, .5), .05)
+    fig.add_artist(circ)
+
+In case the added artist has no transform set previously, it will be set to
+the figure transform (``fig.transFigure``).
+This new method may be useful for adding artists to figures without axes or to
+easily position static elements in figure coordinates.
 
 
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1048,6 +1048,42 @@ default: 'top'
         key = fixlist(args), fixitems(kwargs.items())
         return key
 
+    def add_artist(self, artist, clip=False):
+        """
+        Add any :class:`~matplotlib.artist.Artist` to the figure.
+
+        Usually artists are added to axes objects using
+        :meth:`matplotlib.axes.Axes.add_artist`, but use this method in the
+        rare cases that adding directly to the figure is necessary.
+
+        Parameters
+        ----------
+        artist : `~matplotlib.artist.Artist`
+            The artist to add to the figure. If the added artist has no
+            transform previously set, its transform will be set to
+            ``figure.transFigure``.
+        clip : bool, optional, default ``False``
+            An optional parameter ``clip`` determines whether the added artist
+            should be clipped by the figure patch. Default is *False*,
+            i.e. no clipping.
+
+        Returns
+        -------
+        artist : The added `~matplotlib.artist.Artist`
+        """
+        artist.set_figure(self)
+        self.artists.append(artist)
+        artist._remove_method = self.artists.remove
+
+        if not artist.is_transform_set():
+            artist.set_transform(self.transFigure)
+
+        if clip:
+            artist.set_clip_path(self.patch)
+
+        self.stale = True
+        return artist
+
     @docstring.dedent_interpd
     def add_axes(self, *args, **kwargs):
         """

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -2,7 +2,7 @@ import sys
 import warnings
 
 from matplotlib import rcParams
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.axes import Axes
 from matplotlib.ticker import AutoMinorLocator, FixedFormatter
 import matplotlib.pyplot as plt
@@ -379,6 +379,32 @@ def test_warn_cl_plus_tl():
         # this should warn,
         fig.subplots_adjust(top=0.8)
     assert not(fig.get_constrained_layout())
+
+
+@check_figures_equal(extensions=["png", "pdf", "svg"])
+def test_add_artist(fig_test, fig_ref):
+    fig_test.set_dpi(100)
+    fig_ref.set_dpi(100)
+
+    ax = fig_test.subplots()
+    l1 = plt.Line2D([.2, .7], [.7, .7])
+    l2 = plt.Line2D([.2, .7], [.8, .8])
+    r1 = plt.Circle((20, 20), 100, transform=None)
+    r2 = plt.Circle((.7, .5), .05)
+    r3 = plt.Circle((4.5, .8), .55, transform=fig_test.dpi_scale_trans,
+                    facecolor='crimson')
+    for a in [l1, l2, r1, r2, r3]:
+        fig_test.add_artist(a)
+    l2.remove()
+
+    ax2 = fig_ref.subplots()
+    l1 = plt.Line2D([.2, .7], [.7, .7], transform=fig_ref.transFigure)
+    r1 = plt.Circle((20, 20), 100, transform=None, clip_on=False, zorder=20)
+    r2 = plt.Circle((.7, .5), .05, transform=fig_ref.transFigure)
+    r3 = plt.Circle((4.5, .8), .55, transform=fig_ref.dpi_scale_trans,
+                    facecolor='crimson', clip_on=False, zorder=20)
+    for a in [l1, r1, r2, r3]:
+        ax2.add_artist(a)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires Python 3.6+")


### PR DESCRIPTION
## PR Summary

As quickly discussed [on gitter](https://gitter.im/matplotlib/matplotlib?at=5af470f5e1cf621dba0ce6c2), an `add_artist()` of `Figure` may be useful in some cases.  
This PR would add such method.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented<strike>, with examples if plot related</strike>
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
