### PR TITLE
Deprecate the examples.directory rcParam.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -42,6 +42,7 @@ The following classes, methods, functions, and attributes are deprecated:
 - ``text.Annotation.arrow``,
 
 The following rcParams are deprecated:
+- ``examples.directory`` (use ``datapath`` instead),
 - ``pgf.debug`` (the pgf backend relies on logging),
 
 The following keyword arguments are deprecated:

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -894,6 +894,10 @@ class RcParams(MutableMapping, dict):
                 cbook.warn_deprecated(
                     version, key, obj_type="rcparam", alternative=alt_key)
                 return
+            elif key == 'examples.directory':
+                cbook.warn_deprecated(
+                    "3.0", "{} is deprecated; in the future, examples will be "
+                    "found relative to the 'datapath' directory.".format(key))
             try:
                 cval = self.validate[key](val)
             except ValueError as ve:
@@ -916,6 +920,11 @@ class RcParams(MutableMapping, dict):
             cbook.warn_deprecated(
                 version, key, obj_type, alternative=alt_key)
             return dict.__getitem__(self, alt_key) if alt_key else None
+
+        elif key == 'examples.directory':
+            cbook.warn_deprecated(
+                "3.0", "{} is deprecated; in the future, examples will be "
+                "found relative to the 'datapath' directory.".format(key))
 
         return dict.__getitem__(self, key)
 
@@ -1116,7 +1125,8 @@ Please do not ask for support with these customizations active.
 # this is the instance used by the matplotlib classes
 rcParams = rc_params()
 
-if rcParams['examples.directory']:
+# Don't trigger deprecation warning when just fetching.
+if dict.__getitem__(rcParams, 'examples.directory'):
     # paths that are intended to be relative to matplotlib_fname()
     # are allowed for the examples.directory parameter.
     # However, we will need to fully qualify the path because

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -522,7 +522,8 @@ def get_sample_data(fname, asfileobj=True):
 
     If the filename ends in .gz, the file is implicitly ungzipped.
     """
-    if matplotlib.rcParams['examples.directory']:
+    # Don't trigger deprecation warning when just fetching.
+    if dict.__getitem__(matplotlib.rcParams, 'examples.directory'):
         root = matplotlib.rcParams['examples.directory']
     else:
         root = os.path.join(matplotlib._get_data_path(), 'sample_data')

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -463,7 +463,7 @@ def test_if_rctemplate_is_up_to_date():
             continue
         if k in deprecated:
             continue
-        if "verbose" in k:
+        if k.startswith(("verbose.", "examples.directory")):
             continue
         found = False
         for line in rclines:

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -594,9 +594,6 @@ backend      : $TEMPLATE_BACKEND
 #keymap.all_axes : a                 ## enable all axes
 #keymap.copy : ctrl+c, cmd+c         ## Copy figure to clipboard
 
-## Control location of examples data files
-#examples.directory :              ## directory to look in for custom installation
-
 ###ANIMATION settings
 #animation.html :  none            ## How to display the animation as HTML in
                                    ## the IPython notebook. 'html5' uses


### PR DESCRIPTION
It is always found in the sample_data subdirectory relative to what the
``datapath`` rcParam indicates now.  The latter should already provide
enough flexibility for downstream packagers that want to tear the
package apart...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
