### PR TITLE
Deprecate the MATPLOTLIBDATA environment variable.

### DIFF
--- a/doc/api/next_api_changes/2018-08-17-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-08-17-AL-deprecations.rst
@@ -7,3 +7,6 @@ The following API elements are deprecated:
 - ``backend_ps.PsBackendHelper``, ``backend_ps.ps_backend_helper``,
 - ``cbook.iterable``,
 - ``mlab.demean``,
+
+The following environment variables are deprecated:
+- ``MATPLOTLIBDATA``,

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -652,6 +652,8 @@ def _get_data_path():
         if not os.path.isdir(path):
             raise RuntimeError('Path in environment MATPLOTLIBDATA not a '
                                'directory')
+        cbook.warn_deprecated(
+            "3.1", name="MATPLOTLIBDATA", obj_type="environment variable")
         return path
 
     def get_candidate_paths():


### PR DESCRIPTION
The MATPLOTLIBDATA environment variable is only relevant to non-standard
installs (e.g., debian) that move the mpl-data directory to a separate
location (in debian's case, /usr/share/matplotlib/mpl-data); but for
whoever is already patching Matplotlib to achieve this, they may as well
also patch `get_data_path` to always return the new correct path (which
debian already does in their `20_matplotlibrc_path_search_fix.patch`),
reproduced here:

    diff --git a/lib/matplotlib/__init__.py b/lib/matplotlib/__init__.py
    index 9339707..563b0a8 100644
    --- a/lib/matplotlib/__init__.py
    +++ b/lib/matplotlib/__init__.py
    @@ -738,10 +738,12 @@ def _get_data_path():
            return path

        _file = _decode_filesystem_path(__file__)
    -    path = os.sep.join([os.path.dirname(_file), 'mpl-data'])
    +    path = '/usr/share/matplotlib/mpl-data'
        if os.path.isdir(path):
            return path

    +    raise RuntimeError('Could not find the matplotlib data files')
    +
        # setuptools' namespace_packages may highjack this init file
        # so need to try something known to be in matplotlib, not basemap
        import matplotlib.afm
    @@ -836,7 +838,7 @@ def matplotlib_fname():
                yield matplotlibrc
                yield os.path.join(matplotlibrc, 'matplotlibrc')
            yield os.path.join(_get_configdir(), 'matplotlibrc')
    -        yield os.path.join(get_data_path(), 'matplotlibrc')
    +        yield '/etc/matplotlibrc'

        for fname in gen_candidates():
            if os.path.exists(fname):

attn @sandrotosi I guess :)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
