### PR TITLE
Remove mplDeprecation

### DIFF
--- a/doc/api/next_api_changes/2018-05-16-TH.rst
+++ b/doc/api/next_api_changes/2018-05-16-TH.rst
@@ -1,0 +1,7 @@
+``matplotlib.cbook.deprecation.mplDeprecation`` is deprecated
+-------------------------------------------------------------
+
+:class:`matplotlib.cbook.deprecation.mplDeprecation` will be removed in
+future versions. It is just an alias for
+:class:`matplotlib.cbook.deprecation.MatplotlibDeprecationWarning`.
+Please use the :class:`~.MatplotlibDeprecationWarning` directly if neccessary.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -140,7 +140,8 @@ import warnings
 # definitions, so it is safe to import from it here.
 from . import cbook
 from matplotlib.cbook import (
-    mplDeprecation, dedent, get_label, sanitize_sequence)
+    MatplotlibDeprecationWarning, dedent, get_label, sanitize_sequence)
+from matplotlib.cbook import mplDeprecation  # deprecated
 from matplotlib.rcsetup import defaultParams, validate_backend, cycler
 
 import numpy
@@ -1092,7 +1093,7 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
 
     iter_params = defaultParams.items()
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", mplDeprecation)
+        warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
         config = RcParams([(key, default) for key, (default, _) in iter_params
                            if key not in _all_deprecated])
     config.update(config_from_file)
@@ -1133,7 +1134,7 @@ if rcParams['examples.directory']:
 rcParamsOrig = rcParams.copy()
 
 with warnings.catch_warnings():
-    warnings.simplefilter("ignore", mplDeprecation)
+    warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
     rcParamsDefault = RcParams([(key, default) for key, (default, converter) in
                                 defaultParams.items()
                                 if key not in _all_deprecated])

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -34,7 +34,7 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
 from matplotlib.cbook import (
-    mplDeprecation, warn_deprecated, STEP_LOOKUP_MAP, iterable,
+    MatplotlibDeprecationWarning, warn_deprecated, STEP_LOOKUP_MAP, iterable,
     safe_first_element)
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
 from matplotlib.axes._base import _AxesBase, _process_plot_format

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -31,8 +31,8 @@ from weakref import ref, WeakKeyDictionary
 import numpy as np
 
 import matplotlib
-from .deprecation import deprecated, warn_deprecated
-from .deprecation import mplDeprecation, MatplotlibDeprecationWarning
+from .deprecation import (
+    mplDeprecation, deprecated, warn_deprecated, MatplotlibDeprecationWarning)
 
 
 @deprecated("3.0")

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -17,6 +17,7 @@ class MatplotlibDeprecationWarning(UserWarning):
 
 
 mplDeprecation = MatplotlibDeprecationWarning
+"""mplDeprecation is deprecated. Use MatplotlibDeprecationWarning instead."""
 
 
 def _generate_deprecation_message(

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _pylab_helpers, tight_layout, rcParams
+from matplotlib import _pylab_helpers, cbook, tight_layout, rcParams
 from matplotlib.transforms import Bbox
 import matplotlib._layoutbox as layoutbox
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2276,9 +2276,9 @@ def plotfile(fname, cols=(0,), plotfuncs=None,
 
     if plotfuncs is None:
         plotfuncs = dict()
-    from matplotlib.cbook import mplDeprecation
+    from matplotlib.cbook import MatplotlibDeprecationWarning
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore', mplDeprecation)
+        warnings.simplefilter('ignore', MatplotlibDeprecationWarning)
         r = mlab.csv2rec(fname, comments=comments, skiprows=skiprows,
                          checkrows=checkrows, delimiter=delimiter, names=names)
 

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -1,7 +1,6 @@
 import warnings
 
 from matplotlib.testing.decorators import image_comparison
-from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest


### PR DESCRIPTION
This is just an alias to `MatplotlibDeprecationWarning`. Explicitly using the latter is preferred.

Is cbook considered public API? If so, we have do add a deprecation cycle for `mplDeprecation`.

## PR Checklist

- [x] Code is PEP 8 compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

