### PR TITLE
Simplify FreeType Windows build.

### DIFF
--- a/setup_external_compile.py
+++ b/setup_external_compile.py
@@ -53,6 +53,7 @@ DEPSBUILD = os.path.join(os.path.dirname(os.path.normpath(__file__)), 'build')
 X64 = platform.architecture()[0] == '64bit'
 PYVER = sys.version_info[:2]
 VS2010 = PYVER >= (3, 3)
+xXX = 'x64' if X64 else 'x86'
 # If not VS2010, then use VS2008
 
 VCVARSALL = None
@@ -68,4 +69,4 @@ def prepare_build_cmd(build_cmd, **kwargs):
             VCVARSALL = candidate
 
     return build_cmd.format(
-        vcvarsall=VCVARSALL, xXX='x64' if X64 else 'x86', **kwargs)
+        vcvarsall=VCVARSALL, xXX=xXX, **kwargs)

--- a/setupext.py
+++ b/setupext.py
@@ -1122,23 +1122,15 @@ class FreeType(SetupPackage):
             subprocess.check_call(["make"], env=env, cwd=src_path)
         else:
             # compilation on windows
-            FREETYPE_BUILD_CMD = """\
-call "%ProgramFiles%\\Microsoft SDKs\\Windows\\v7.0\\Bin\\SetEnv.Cmd" /Release /{xXX} /xp
+            FREETYPE_BUILD_CMD = r"""
+call "%ProgramFiles%\Microsoft SDKs\Windows\v7.0\Bin\SetEnv.Cmd" ^
+    /Release /{xXX} /xp
 call "{vcvarsall}" {xXX}
-set MSBUILD=C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\MSBuild.exe
-rd /S /Q %FREETYPE%\\objs
-%MSBUILD% %FREETYPE%\\builds\\windows\\{vc20xx}\\freetype.sln /t:Clean;Build /p:Configuration="{config}";Platform={WinXX}
-echo Build completed, moving result"
-:: move to the "normal" path for the unix builds...
-mkdir %FREETYPE%\\objs\\.libs
-:: REMINDER: fix when changing the version
-copy %FREETYPE%\\objs\\{vc20xx}\\{xXX}\\freetype261.lib %FREETYPE%\\objs\\.libs\\libfreetype.lib
-if errorlevel 1 (
-  rem This is a py27 version, which has a different location for the lib file :-/
-  copy %FREETYPE%\\objs\\win32\\{vc20xx}\\freetype261.lib %FREETYPE%\\objs\\.libs\\libfreetype.lib
-)
+set MSBUILD=C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe
+%MSBUILD% "builds\windows\{vc20xx}\freetype.sln" ^
+    /t:Clean;Build /p:Configuration="{config}";Platform={WinXX}
 """
-            from setup_external_compile import fixproj, prepare_build_cmd, VS2010, X64
+            from setup_external_compile import fixproj, prepare_build_cmd, VS2010, X64, xXX
             # Note: freetype has no build profile for 2014, so we don't bother...
             vc = 'vc2010' if VS2010 else 'vc2008'
             WinXX = 'x64' if X64 else 'Win32'
@@ -1147,13 +1139,21 @@ if errorlevel 1 (
                 fixproj(os.path.join(src_path, 'builds', 'windows', vc, 'freetype.sln'), WinXX)
                 fixproj(os.path.join(src_path, 'builds', 'windows', vc, 'freetype.vcproj'), WinXX)
 
-            cmdfile = os.path.join("build", 'build_freetype.cmd')
+            cmdfile = os.path.join("build", "build_freetype.cmd")
             with open(cmdfile, 'w') as cmd:
                 cmd.write(prepare_build_cmd(FREETYPE_BUILD_CMD, vc20xx=vc, WinXX=WinXX,
                                             config='Release' if VS2010 else 'LIB Release'))
 
-            os.environ['FREETYPE'] = src_path
-            subprocess.check_call([cmdfile], shell=True)
+            shutil.rmtree(str(Path(src_path, "objs")), ignore_errors=True)
+            subprocess.check_call([os.path.abspath(cmdfile)],
+                                  shell=True, cwd=src_path)
+            # Move to the corresponding Unix build path.
+            Path(src_path, "objs/.libs").mkdir()
+            # Be robust against change of FreeType version.
+            lib_path, = (Path(src_path, "objs", vc, xXX)
+                         .glob("freetype*.lib"))
+            shutil.copy2(str(lib_path),
+                         str(Path(src_path, "objs/.libs/libfreetype.lib")))
 
 
 class FT2Font(SetupPackage):


### PR DESCRIPTION
attn @timhoffm: breaking #11235 into smaller pieces.

- Make FREETYPE_BUILD_CMD a raw string to avoid doubling all
  backslashes.
- Line-wrap two overly long lines in FREETYPE_BUILD_CMD.
- Move the `rd /S /Q %FREETYPE%\objs` to python (`shutil.rmtree`).
- Move the `copy %FREETYPE\objs\...` to python (`shutil.copy2`).
- Get rid of the Py27 part (`if errorlevel 1 ...`).
- Run the FREETYPE_BUILD_CMD script with `src_path` as cwd, which avoids
  the need to define the %FREETYPE% environment variable.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
