### PR TITLE
Fail gracefully if can't decode font names

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -30,7 +30,7 @@ from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.cbook import (get_realpath_and_stat,
                               is_writable_file_like, maxdict)
 from matplotlib.figure import Figure
-from matplotlib.font_manager import findfont, is_opentype_cff_font, get_font
+from matplotlib.font_manager import findfont, is_opentype_cff_font, get_font, get_sfnt_name
 from matplotlib.afm import AFM
 import matplotlib.type1font as type1font
 import matplotlib.dviread as dviread
@@ -1130,13 +1130,7 @@ end"""
         # Beginning of main embedTTF function...
 
         # You are lost in a maze of TrueType tables, all different...
-        sfnt = font.get_sfnt()
-        try:
-            ps_name = sfnt[1, 0, 0, 6].decode('mac_roman')  # Macintosh scheme
-        except KeyError:
-            # Microsoft scheme:
-            ps_name = sfnt[3, 1, 0x0409, 6].decode('utf-16be')
-            # (see freetype/ttnameid.h)
+        ps_name = font_manager.get_sfnt_name(font, 6)
         ps_name = ps_name.encode('ascii', 'replace')
         ps_name = Name(ps_name)
         pclt = font.get_sfnt_table('pclt') or {'capHeight': 0, 'xHeight': 0}

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -19,7 +19,7 @@ from matplotlib.backend_bases import (
 from matplotlib.cbook import (get_realpath_and_stat, is_writable_file_like,
                               maxdict, file_requires_unicode)
 
-from matplotlib.font_manager import findfont, is_opentype_cff_font, get_font
+from matplotlib.font_manager import findfont, is_opentype_cff_font, get_font, get_sfnt_name
 from matplotlib.ft2font import KERNING_DEFAULT, LOAD_NO_HINTING
 from matplotlib.ttconv import convert_ttf_to_ps
 from matplotlib.mathtext import MathTextParser
@@ -714,11 +714,7 @@ grestore
             self.track_characters(font, s)
 
             self.set_color(*gc.get_rgb())
-            sfnt = font.get_sfnt()
-            try:
-                ps_name = sfnt[1, 0, 0, 6].decode('mac_roman')
-            except KeyError:
-                ps_name = sfnt[3, 1, 0x0409, 6].decode('utf-16be')
+            ps_name = get_sfnt_name(font, 6)
             ps_name = ps_name.encode('ascii', 'replace').decode('ascii')
             self.set_font(ps_name, prop.get_size_in_points())
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -19,7 +19,7 @@ from matplotlib.backend_bases import (
      _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.colors import rgb2hex
-from matplotlib.font_manager import findfont, get_font
+from matplotlib.font_manager import findfont, get_font, get_sfnt_name
 from matplotlib.ft2font import LOAD_NO_HINTING
 from matplotlib.mathtext import MathTextParser
 from matplotlib.path import Path
@@ -492,8 +492,8 @@ class RendererSVG(RendererBase):
         for font_fname, chars in six.iteritems(self._fonts):
             font = get_font(font_fname)
             font.set_size(72, 72)
-            sfnt = font.get_sfnt()
-            writer.start('font', id=sfnt[1, 0, 0, 4].decode("mac_roman"))
+            name = get_sfnt_name(font, 4)
+            writer.start('font', id=name)
             writer.element(
                 'font-face',
                 attrib={

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -134,6 +134,32 @@ if not USE_FONTCONFIG and sys.platform != 'win32':
     X11FontDirectories.append(str(Path.home() / ".fonts"))
 
 
+def get_sfnt_name(font, sfnt_id):
+    """
+    Get a sfnt string entry by from the font, given by sfnt_id.
+
+    The possibly IDs are documented `here
+    <https://www.freetype.org/freetype2/docs/reference/ft2-truetype_tables.html#TT_NAME_ID_XXX>`__.
+
+    This will first attempt to find a Unicode name in the file, and if one
+    doesn't exist, will use a MacRoman-encoded entry. If the MacRoman encoding
+    isn't available in your Python, a ValueError exception is raised.
+    """
+    sfnt = font.get_sfnt()
+    # 0x0409 == TT_MS_LANGID_ENGLISH_UNITED_STATES
+    unicode_id = (3, 1, 0x0409, sfnt_id)
+    if unicode_id in sfnt:
+        return sfnt[unicode_id].decode('utf-16be')
+    else:
+        mac_roman_id = (1, 0, 0, sfnt_id)
+        if mac_roman_id in sfnt:
+            try:
+                return sfnt[mac_roman_id].decode('mac_roman')
+            except LookupError:
+                pass
+    raise ValueError('Can not decode sfnt_id {}'.format(sfnt_id))
+
+
 def get_fontext_synonyms(fontext):
     """
     Return a list of file extensions extensions that are synonyms for
@@ -323,27 +349,11 @@ def ttfFontProperty(font):
     """
     name = font.family_name
 
-    def decode_name(name):
-        try:
-            name = name.decode('mac_roman')
-        except LookupError:
-            name = name.decode('ascii', errors='replace')
-        return name
-
     #  Styles are: italic, oblique, and normal (default)
 
     sfnt = font.get_sfnt()
-    sfnt2 = sfnt.get((1,0,0,2))
-    sfnt4 = sfnt.get((1,0,0,4))
-    if sfnt2:
-        sfnt2 = decode_name(sfnt2).lower()
-    else:
-        sfnt2 = ''
-    sfnt2 = sfnt2.lower()
-    if sfnt4:
-        sfnt4 = decode_name(sfnt4).lower()
-    else:
-        sfnt4 = ''
+    sfnt2 = get_sfnt_name(font, 2)
+    sfnt4 = get_sfnt_name(font, 4)
     if sfnt4.find('oblique') >= 0:
         style = 'oblique'
     elif sfnt4.find('italic') >= 0:

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -323,17 +323,25 @@ def ttfFontProperty(font):
     """
     name = font.family_name
 
+    def decode_name(name):
+        try:
+            name = name.decode('mac_roman')
+        except LookupError:
+            name = name.decode('ascii', errors='replace')
+        return name
+
     #  Styles are: italic, oblique, and normal (default)
 
     sfnt = font.get_sfnt()
     sfnt2 = sfnt.get((1,0,0,2))
     sfnt4 = sfnt.get((1,0,0,4))
     if sfnt2:
-        sfnt2 = sfnt2.decode('mac_roman').lower()
+        sfnt2 = decode_name(sfnt2).lower()
     else:
         sfnt2 = ''
+    sfnt2 = sfnt2.lower()
     if sfnt4:
-        sfnt4 = sfnt4.decode('mac_roman').lower()
+        sfnt4 = decode_name(sfnt4).lower()
     else:
         sfnt4 = ''
     if sfnt4.find('oblique') >= 0:

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -11,7 +11,7 @@ from matplotlib.ft2font import KERNING_DEFAULT, LOAD_NO_HINTING
 from matplotlib.ft2font import LOAD_TARGET_LIGHT
 from matplotlib.mathtext import MathTextParser
 import matplotlib.dviread as dviread
-from matplotlib.font_manager import FontProperties, get_font
+from matplotlib.font_manager import FontProperties, get_font, get_sfnt_name
 from matplotlib.transforms import Affine2D
 
 
@@ -56,11 +56,7 @@ class TextToPath(object):
         """
         Return a unique id for the given font and character-code set.
         """
-        sfnt = font.get_sfnt()
-        try:
-            ps_name = sfnt[1, 0, 0, 6].decode('mac_roman')
-        except KeyError:
-            ps_name = sfnt[3, 1, 0x0409, 6].decode('utf-16be')
+        sfnt = font_manager.get_sfnt_name(font, 6)
         char_id = urllib.parse.quote('%s-%x' % (ps_name, ccode))
         return char_id
 


### PR DESCRIPTION
## PR Summary

Not all Pythons ship with legacy encodings.  A couple of fields in TTF files are encoded in the obsolete encoding "MacRoman", and reading these currently fails on those platforms.  This falls back to decoding as ascii, replacing special characters with `?` if MacRoman isn't available.  This should be ok to do in the vast majority of cases: this will only be different if a font happens to have a diacritical character in the latin alphabet (which none of the fonts that matplotlib ships do).

A more forward-looking patch (but perhaps riskier from a lack-of-testing perspective) would be to look for a unicode name first, and failing that, fall back to this.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
