### PR TITLE
Minor cleanups.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -12,6 +12,7 @@ The following classes, methods, functions, and attributes are deprecated:
 
 - ``afm.parse_afm``,
 - ``backend_pgf.get_texcommand``,
+- ``backend_ps.get_bbox``,
 - ``backend_qt5.error_msg_qt``, ``backend_qt5.exception_handler``,
 - ``backend_wx.FigureCanvasWx.macros``,
 - ``cbook.GetRealpathAndStat``, ``cbook.Locked``,

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1593,6 +1593,7 @@ def get_bbox_header(lbrt, rotated=False):
 
 # get_bbox is deprecated. I don't see any reason to use ghostscript to
 # find the bounding box, as the required bounding box is alread known.
+@cbook.deprecated("3.0")
 def get_bbox(tmpfile, bbox):
     """
     Use ghostscript's bbox device to find the center of the bounding box.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1124,7 +1124,7 @@ class Legend(Artist):
         Parameters
         ----------
         state : bool
-            ``True`` / ``False`` enables / disables mouse dragging.
+            Whether mouse dragging is enabled.
         use_blit : bool, optional
             Use blitting for faster image composition. For details see
             :ref:`func-animation`.

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -457,11 +457,8 @@ def test_rcparams_reset_after_fail():
 
 
 def test_if_rctemplate_is_up_to_date():
-    # This tests if the matplotlibrc.template file
-    # contains all valid rcParams.
-    dep1 = mpl._all_deprecated
-    dep2 = mpl._deprecated_set
-    deprecated = list(dep1.union(dep2))
+    # This tests if the matplotlibrc.template file contains all valid rcParams.
+    deprecated = {*mpl._all_deprecated, *mpl._deprecated_set}
     path_to_rc = os.path.join(mpl.get_data_path(), 'matplotlibrc')
     with open(path_to_rc, "r") as f:
         rclines = f.readlines()


### PR DESCRIPTION
- backend_ps.get_bbox has been marked as deprecated in comment since
  2010; deprecate it for real.
- Reword the docstring for Legend.set_draggable (https://github.com/matplotlib/matplotlib/pull/10050/files#r189086578).
- Use star-unpacking instead of set.union.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
