### PR TITLE
DOC: Sanitize some internal documentation links

### DIFF
--- a/examples/lines_bars_and_markers/markevery_prop_cycle.py
+++ b/examples/lines_bars_and_markers/markevery_prop_cycle.py
@@ -5,8 +5,9 @@ Implemented support for prop_cycle property markevery in rcParams
 
 This example demonstrates a working solution to issue #8576, providing full
 support of the markevery property for axes.prop_cycle assignments through
-rcParams. Makes use of the same list of markevery cases from
-https://matplotlib.org/examples/pylab_examples/markevery_demo.html
+rcParams. Makes use of the same list of markevery cases from the
+:doc:`markevery demo
+</gallery/lines_bars_and_markers/markevery_demo>`.
 
 Renders a plot with shifted-sine curves along each column with
 a unique markevery value for each sine curve.

--- a/examples/text_labels_and_annotations/annotation_demo.py
+++ b/examples/text_labels_and_annotations/annotation_demo.py
@@ -7,7 +7,7 @@ The following examples show how it is possible to annotate plots in matplotlib.
 This includes highlighting specific points of interest and using various
 visual tools to call attention to this point. For a more complete and in-depth
 description of the annotation and text tools in :mod:`matplotlib`, see the
-`tutorial on annotation <http://matplotlib.org/users/annotations.html>`_.
+:doc:`tutorial on annotation </tutorials/text/annotations>`.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/text_labels_and_annotations/tex_demo.py
+++ b/examples/text_labels_and_annotations/tex_demo.py
@@ -4,9 +4,9 @@ Rendering math equation using TeX
 =================================
 
 You can use TeX to render all of your matplotlib text if the rc
-parameter text.usetex is set.  This works currently on the agg and ps
+parameter ``text.usetex`` is set.  This works currently on the agg and ps
 backends, and requires that you have tex and the other dependencies
-described at http://matplotlib.org/users/usetex.html
+described in the :doc:`/tutorials/text/usetex` tutorial
 properly installed on your system.  The first time you run a script
 you will see a lot of output from tex and associated tools.  The next
 time, the run may be silent, as a lot of the information is cached.

--- a/examples/ticks_and_spines/custom_ticker1.py
+++ b/examples/ticks_and_spines/custom_ticker1.py
@@ -4,13 +4,12 @@ Custom Ticker1
 ==============
 
 The new ticker code was designed to explicitly support user customized
-ticking.  The documentation
-http://matplotlib.org/api/ticker_api.html#module-matplotlib.ticker details this
+ticking. The documentation of :mod:`matplotlib.ticker` details this
 process.  That code defines a lot of preset tickers but was primarily
 designed to be user extensible.
 
 In this example a user defined function is used to format the ticks in
-millions of dollars on the y axis
+millions of dollars on the y axis.
 """
 from matplotlib.ticker import FuncFormatter
 import matplotlib.pyplot as plt

--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -22,8 +22,8 @@ Set the colormap and norm to correspond to the data for which the colorbar
 will be used. Then create the colorbar by calling
 :class:`~matplotlib.colorbar.ColorbarBase` and specify axis, colormap, norm
 and orientation as parameters. Here we create a basic continuous colorbar
-with ticks and labels. More information on the colorbar API can be found
-`here <https://matplotlib.org/api/colorbar_api.html>`_.
+with ticks and labels. For more information see the
+:mod:`~matplotlib.colorbar` API.
 """
 
 import matplotlib.pyplot as plt

--- a/tutorials/colors/colors.py
+++ b/tutorials/colors/colors.py
@@ -38,6 +38,12 @@ means that pixel of the Artist is transparent.
 
 All string specifications of color, other than "CN", are case-insensitive.
 
+For more information on colors in matplotlib see
+
+* the :doc:`/gallery/color/color_demo` example;
+* the `matplotlib.colors` API;
+* the :doc:`/gallery/color/named_colors` example.
+
 "CN" color selection
 --------------------
 

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -8,8 +8,9 @@ Using style sheets
 ------------------
 
 The ``style`` package adds support for easy-to-switch plotting "styles" with
-the same parameters as a matplotlibrc_ file (which is read at startup to
-configure matplotlib).
+the same parameters as a
+:ref:`matplotlib rc <customizing-with-matplotlibrc-files>` file (which is read
+at startup to configure matplotlib).
 
 There are a number of pre-defined styles provided by matplotlib. For
 example, there's a pre-defined style called "ggplot", which emulates the
@@ -183,6 +184,5 @@ plt.plot(data)
 # .. literalinclude:: ../../../matplotlibrc.template
 #
 #
-# .. _matplotlibrc: http://matplotlib.org/users/customizing.html
 # .. _ggplot: http://ggplot2.org/
 # .. _R: https://www.r-project.org/

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -42,8 +42,8 @@ useful for quickly and easily experimenting with various plot
 settings.  The alternative is the object-oriented interface, which is also
 very powerful, and generally more suitable for large application
 development.  If you'd like to learn about the object-oriented
-interface, a great place to start is our `FAQ on usage
-<http://matplotlib.org/faq/usage_faq.html>`_.  For now, let's get on
+interface, a great place to start is our :doc:`Usage guide
+</tutorials/introductory/usage>`.  For now, let's get on
 with the imperative-style approach:
 """
 

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -23,7 +23,7 @@ An introduction to the pyplot interface.
 # the current figure and plotting area, and the plotting
 # functions are directed to the current axes (please note that "axes" here
 # and in most places in the documentation refers to the *axes*
-# `part of a figure <http://matplotlib.org/faq/usage_faq.html#parts-of-a-figure>`__
+# :ref:`part of a figure <figure_parts>`
 # and not the strict mathematical term for more than one axis).
 #
 # .. note::

--- a/tutorials/text/pgf.py
+++ b/tutorials/text/pgf.py
@@ -188,7 +188,7 @@ Troubleshooting
   `tex.stackexchange.com <http://tex.stackexchange.com/questions/7953>`_.
   Another way would be to "rasterize" parts of the graph causing problems
   using either the ``rasterized=True`` keyword, or ``.set_rasterized(True)`` as per
-  `this example <http://matplotlib.org/examples/misc/rasterization_demo.html>`_.
+  :doc:`this example </gallery/misc/rasterization_demo>`.
 
 * If you still need help, please see :ref:`reporting-problems`
 

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -21,11 +21,11 @@ compliant font finding algorithm.
 
 The user has a great deal of control over text properties (font size, font
 weight, text location and color, etc.) with sensible defaults set in
-the `rc file <http://matplotlib.org/users/customizing.html>`.
+the :doc:`rc file </tutorials/introductory/customizing>`.
 And significantly, for those interested in mathematical
 or scientific figures, matplotlib implements a large number of TeX
-math symbols and commands, supporting :ref:`mathematical expressions
-<sphx_glr_tutorials_text_mathtext.py>` anywhere in your figure.
+math symbols and commands, supporting :doc:`mathematical expressions
+</tutorials/text/mathtext>` anywhere in your figure.
 
 
 Basic text commands


### PR DESCRIPTION
## PR Summary

At some places in the documentation, links pointed to the online version of the docs instead of the internal version. E.g. `http://matplotlib.org/whatever` instead of `whatever`. This is undesired because the documentation should be self consistent and not accidentally point to a different version which may be available online. 

This PR fixes those links. (I'm 99% sure, I found them all, but you can't ever be certain ;-))

## PR Checklist

- [x] Code is PEP 8 compliant
- [x] Documentation is sphinx and numpydoc compliant


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
