### PR TITLE
Reduce the use of C++ exceptions

### DIFF
--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -398,6 +398,15 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         m_strides = strides;
     }
 
+    array_view(PyArrayObject *arr)
+    {
+        m_arr = arr;
+        Py_XINCREF(arr);
+        m_shape = PyArray_DIMS(m_arr);
+        m_strides = PyArray_STRIDES(m_arr);
+        m_data = (char *)PyArray_BYTES(m_arr);
+    }
+
     array_view(npy_intp shape[ND]) : m_arr(NULL), m_shape(NULL), m_strides(NULL), m_data(NULL)
     {
         PyObject *arr = PyArray_SimpleNew(ND, shape, type_num_of<T>::value);
@@ -456,18 +465,18 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
                 m_data = NULL;
                 m_shape = zeros;
                 m_strides = zeros;
-		if (PyArray_NDIM(tmp) == 0 && ND == 0) {
-		    m_arr = tmp;
-		    return 1;
-		}
+                if (PyArray_NDIM(tmp) == 0 && ND == 0) {
+                    m_arr = tmp;
+                    return 1;
+                }
             }
-	    if (PyArray_NDIM(tmp) != ND) {
-		PyErr_Format(PyExc_ValueError,
-			     "Expected %d-dimensional array, got %d",
-			     ND,
-			     PyArray_NDIM(tmp));
-		Py_DECREF(tmp);
-		return 0;
+            if (PyArray_NDIM(tmp) != ND) {
+                PyErr_Format(PyExc_ValueError,
+                             "Expected %d-dimensional array, got %d",
+                             ND,
+                             PyArray_NDIM(tmp));
+                Py_DECREF(tmp);
+                return 0;
             }
 
             /* Copy some of the data to the view object for faster access */


### PR DESCRIPTION
## PR Summary

This is hopefully the last of the pyodide-related patches for a while.

Emscripten has only limited support for C++ exceptions.  The support that is there doesn't seem to work fully correctly over the matplotlib code base, and even if it did work, it has a large performance penalty which will be hard to resolve.  The best available option at the moment is to have C++ exception support turned off, which means a `throw` from C++ aborts the current WebAssembly frame, exiting back to Javascript without a chance for any C++ `catch` blocks to handle the exception.  (This is weaker than an unhandled exception in "native" code which would terminate the application altogether).  In most cases, this behavior is "good enough" when the exceptions are truly "exceptional".  It's not ideal, since there isn't an opportunity to cleanup or provide friendly error messages from C++.

However there is a very small handful of places in matplotlib where exception-handling is used for cases that are the normal course of business, such as dealing with an input differently based on the number of its dimensions.  This grew out of the fact that a constructor can not return an error code, so must raise an exception to indicate a dimension mismatch.  I think it's worth fixing these three places to just use the C-level Numpy API instead of the `numpy_cpp.h` abstraction, even though that's not strictly necessary for most platforms.  There should be performance benefits for everyone, however, since it avoids interpreting the array-like input twice.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
