### PR TITLE
io.open and codecs.open are redundant with open on Py3.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -974,7 +974,7 @@ def _open_file_or_url(fname):
         encoding = locale.getpreferredencoding(do_setlocale=False)
         if encoding is None:
             encoding = "utf-8"
-        with io.open(fname, encoding=encoding) as f:
+        with open(fname, encoding=encoding) as f:
             yield f
 
 

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -111,11 +111,8 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
         else:
             output = stream
         super().get_javascript(stream=output)
-        with io.open(os.path.join(
-                os.path.dirname(__file__),
-                "web_backend", 'js',
-                "nbagg_mpl.js"), encoding='utf8') as fd:
-            output.write(fd.read())
+        output.write((Path(__file__).parent / "web_backend/js/nbagg_mpl.js")
+                     .read_text(encoding="utf-8"))
         if stream is None:
             return output.getvalue()
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -834,7 +834,7 @@ class FigureCanvasPgf(FigureCanvasBase):
 
         # figure out where the pgf is to be written to
         if isinstance(fname_or_fh, str):
-            with codecs.open(fname_or_fh, "w", encoding="utf-8") as fh:
+            with open(fname_or_fh, "w", encoding="utf-8") as fh:
                 self._print_pgf_to_fh(fh, *args, **kwargs)
         elif is_writable_file_like(fname_or_fh):
             fh = codecs.getwriter("utf-8")(fname_or_fh)
@@ -868,8 +868,7 @@ class FigureCanvasPgf(FigureCanvasBase):
 \\centering
 \\input{figure.pgf}
 \\end{document}""" % (w, h, latex_preamble, latex_fontspec)
-            with codecs.open(fname_tex, "w", "utf-8") as fh_tex:
-                fh_tex.write(latexcode)
+            pathlib.Path(fname_tex).write_text(latexcode, encoding="utf-8")
 
             texcommand = rcParams["pgf.texsystem"]
             cmdargs = [texcommand, "-interaction=nonstopmode",

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -11,9 +11,10 @@ Displays Agg images in the browser, with interactivity
 #   application, implemented with tornado.
 
 import datetime
-import io
+from io import StringIO
 import json
 import os
+from pathlib import Path
 import warnings
 
 import numpy as np
@@ -448,15 +449,12 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
     @classmethod
     def get_javascript(cls, stream=None):
         if stream is None:
-            output = io.StringIO()
+            output = StringIO()
         else:
             output = stream
 
-        with io.open(os.path.join(
-                os.path.dirname(__file__),
-                "web_backend", "js",
-                "mpl.js"), encoding='utf8') as fd:
-            output.write(fd.read())
+        output.write((Path(__file__).parent / "web_backend/js/mpl.js")
+                     .read_text(encoding="utf-8"))
 
         toolitems = []
         for name, tooltip, image, method in cls.ToolbarCls.toolitems:

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -466,7 +466,7 @@ def to_filehandle(fname, flag='rU', return_opened=False, encoding=None):
             flag = flag.replace('U', '')
             fh = bz2.BZ2File(fname, flag)
         else:
-            fh = io.open(fname, flag, encoding=encoding)
+            fh = open(fname, flag, encoding=encoding)
         opened = True
     elif hasattr(fname, 'seek'):
         fh = fname

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -134,10 +134,17 @@ The plot directive has the following configuration options:
     plot_template
         Provide a customized template for preparing restructured text.
 """
+
+import contextlib
+from io import StringIO
 import itertools
-import sys, os, shutil, io, re, textwrap
+import os
 from os.path import relpath
 from pathlib import Path
+import re
+import shutil
+import sys
+import textwrap
 import traceback
 import warnings
 
@@ -479,21 +486,8 @@ def run_code(code, code_path, ns=None, function_name=None):
         os.chdir(dirname)
         sys.path.insert(0, dirname)
 
-    # Reset sys.argv
-    old_sys_argv = sys.argv
-    sys.argv = [code_path]
-
-    # Redirect stdout
-    stdout = sys.stdout
-    sys.stdout = io.StringIO()
-
-    # Assign a do-nothing print function to the namespace.  There
-    # doesn't seem to be any other way to provide a way to (not) print
-    # that works correctly across Python 2 and 3.
-    def _dummy_print(*arg, **kwarg):
-        pass
-
-    try:
+    with cbook._setattr_cm(sys, argv=[code_path]), \
+            contextlib.redirect_stdout(StringIO()):
         try:
             code = unescape_doctest(code)
             if ns is None:
@@ -504,7 +498,6 @@ def run_code(code, code_path, ns=None, function_name=None):
                          'from matplotlib import pyplot as plt\n', ns)
                 else:
                     exec(str(setup.config.plot_pre_code), ns)
-            ns['print'] = _dummy_print
             if "__main__" in code:
                 ns['__name__'] = '__main__'
             exec(code, ns)
@@ -512,11 +505,9 @@ def run_code(code, code_path, ns=None, function_name=None):
                 exec(function_name + "()", ns)
         except (Exception, SystemExit) as err:
             raise PlotError(traceback.format_exc())
-    finally:
-        os.chdir(pwd)
-        sys.argv = old_sys_argv
-        sys.path[:] = old_sys_path
-        sys.stdout = stdout
+        finally:
+            os.chdir(pwd)
+            sys.path[:] = old_sys_path
     return ns
 
 
@@ -678,8 +669,7 @@ def run(arguments, content, options, state_machine, state, lineno):
         else:
             function_name = None
 
-        with io.open(source_file_name, 'r', encoding='utf-8') as fd:
-            code = fd.read()
+        code = Path(source_file_name).read_text(encoding='utf-8')
         output_base = os.path.basename(source_file_name)
     else:
         source_file_name = rst_file
@@ -831,12 +821,8 @@ def run(arguments, content, options, state_machine, state, lineno):
                     shutil.copyfile(fn, destimg)
 
     # copy script (if necessary)
-    target_name = os.path.join(dest_dir, output_base + source_ext)
-    with io.open(target_name, 'w', encoding="utf-8") as f:
-        if source_file_name == rst_file:
-            code_escaped = unescape_doctest(code)
-        else:
-            code_escaped = code
-        f.write(code_escaped)
+    Path(dest_dir, output_base + source_ext).write_text(
+        unescape_doctest(code) if source_file_name == rst_file else code,
+        encoding='utf-8')
 
     return errors

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -468,7 +468,6 @@ def run_code(code, code_path, ns=None, function_name=None):
     # it can get at its data files, if any.  Add its path to sys.path
     # so it can import any helper modules sitting beside it.
     pwd = os.getcwd()
-    old_sys_path = sys.path.copy()
     if setup.config.plot_working_directory is not None:
         try:
             os.chdir(setup.config.plot_working_directory)
@@ -480,13 +479,12 @@ def run_code(code, code_path, ns=None, function_name=None):
             raise TypeError(str(err) + '\n`plot_working_directory` option in '
                             'Sphinx configuration file must be a string or '
                             'None')
-        sys.path.insert(0, setup.config.plot_working_directory)
     elif code_path is not None:
         dirname = os.path.abspath(os.path.dirname(code_path))
         os.chdir(dirname)
-        sys.path.insert(0, dirname)
 
-    with cbook._setattr_cm(sys, argv=[code_path]), \
+    with cbook._setattr_cm(
+            sys, argv=[code_path], path=[os.getcwd(), *sys.path]), \
             contextlib.redirect_stdout(StringIO()):
         try:
             code = unescape_doctest(code)
@@ -507,7 +505,6 @@ def run_code(code, code_path, ns=None, function_name=None):
             raise PlotError(traceback.format_exc())
         finally:
             os.chdir(pwd)
-            sys.path[:] = old_sys_path
     return ns
 
 


### PR DESCRIPTION
Also, use contextlib.redirect_stderr/cbook._setattr_cm where
appropriate.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
