### PR TITLE
Simplify cleanup decorator implementation.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -25,7 +25,8 @@ The following classes, methods, functions, and attributes are deprecated:
 - ``mathtext.unichr_safe`` (use ``chr`` instead),
 - ``table.Table.get_child_artists`` (use ``get_children`` instead),
 - ``testing.compare.ImageComparisonTest``, ``testing.compare.compare_float``,
-- ``testing.decorators.skip_if_command_unavailable``.
+- ``testing.decorators.CleanupTest``,
+  ``testing.decorators.skip_if_command_unavailable``,
 - ``FigureCanvasQT.keyAutoRepeat`` (directly check
   ``event.guiEvent.isAutoRepeat()`` in the event handler to decide whether to
   handle autorepeated key presses).

--- a/doc/api/next_api_changes/2018-05-22-AL.rst
+++ b/doc/api/next_api_changes/2018-05-22-AL.rst
@@ -1,0 +1,4 @@
+The cleanup decorators and test classes in matplotlib.testing.decorators no longer destroy the warnings filter on exit
+``````````````````````````````````````````````````````````````````````````````````````````````````````````````````````
+Instead, they restore the warnings filter that existed before the test started
+using ``warnings.catch_warnings``.

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -3,6 +3,7 @@ import warnings
 
 import matplotlib as mpl
 from matplotlib import cbook
+from matplotlib.cbook import MatplotlibDeprecationWarning
 
 
 def is_called_from_pytest():
@@ -38,10 +39,11 @@ def setup():
 
     mpl.use('Agg', warn=False)  # use Agg backend for these tests
 
-    # These settings *must* be hardcoded for running the comparison
-    # tests and are not necessarily the default values as specified in
-    # rcsetup.py
-    mpl.rcdefaults()  # Start with all defaults
+    # These settings *must* be hardcoded for running the comparison tests and
+    # are not necessarily the default values as specified in rcsetup.py
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+        mpl.rcdefaults()  # Start with all defaults
 
     set_font_settings_for_testing()
     set_reproducibility_for_testing()

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -16,39 +16,37 @@ def pytest_unconfigure(config):
 
 @pytest.fixture(autouse=True)
 def mpl_test_settings(request):
-    from matplotlib.testing.decorators import _do_cleanup
+    from matplotlib.testing.decorators import _cleanup_cm
 
-    original_units_registry = matplotlib.units.registry.copy()
-    original_settings = matplotlib.rcParams.copy()
+    with _cleanup_cm():
 
-    backend = None
-    backend_marker = request.keywords.get('backend')
-    if backend_marker is not None:
-        assert len(backend_marker.args) == 1, \
-            "Marker 'backend' must specify 1 backend."
-        backend = backend_marker.args[0]
-        prev_backend = matplotlib.get_backend()
+        backend = None
+        backend_marker = request.keywords.get('backend')
+        if backend_marker is not None:
+            assert len(backend_marker.args) == 1, \
+                "Marker 'backend' must specify 1 backend."
+            backend = backend_marker.args[0]
+            prev_backend = matplotlib.get_backend()
 
-    style = '_classic_test'  # Default of cleanup and image_comparison too.
-    style_marker = request.keywords.get('style')
-    if style_marker is not None:
-        assert len(style_marker.args) == 1, \
-            "Marker 'style' must specify 1 style."
-        style = style_marker.args[0]
+        style = '_classic_test'  # Default of cleanup and image_comparison too.
+        style_marker = request.keywords.get('style')
+        if style_marker is not None:
+            assert len(style_marker.args) == 1, \
+                "Marker 'style' must specify 1 style."
+            style = style_marker.args[0]
 
-    matplotlib.testing.setup()
-    if backend is not None:
-        # This import must come after setup() so it doesn't load the default
-        # backend prematurely.
-        import matplotlib.pyplot as plt
-        plt.switch_backend(backend)
-    matplotlib.style.use(style)
-    try:
-        yield
-    finally:
+        matplotlib.testing.setup()
         if backend is not None:
-            plt.switch_backend(prev_backend)
-        _do_cleanup(original_units_registry, original_settings)
+            # This import must come after setup() so it doesn't load the
+            # default backend prematurely.
+            import matplotlib.pyplot as plt
+            plt.switch_backend(backend)
+        matplotlib.style.use(style)
+        try:
+            yield
+        finally:
+            if backend is not None:
+                plt.switch_backend(prev_backend)
 
 
 @pytest.fixture

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -1,7 +1,10 @@
+import warnings
+
 import pytest
 
 import matplotlib
 from matplotlib import cbook
+from matplotlib.cbook import MatplotlibDeprecationWarning
 
 
 def pytest_configure(config):
@@ -41,7 +44,9 @@ def mpl_test_settings(request):
             # default backend prematurely.
             import matplotlib.pyplot as plt
             plt.switch_backend(backend)
-        matplotlib.style.use(style)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+            matplotlib.style.use(style)
         try:
             yield
         finally:

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -1,3 +1,4 @@
+import contextlib
 from distutils.version import StrictVersion
 import functools
 import inspect
@@ -8,63 +9,49 @@ import sys
 import unittest
 import warnings
 
-# Note - don't import nose up here - import it only as needed in functions.
-# This allows other functions here to be used by pytest-based testing suites
-# without requiring nose to be installed.
-
-
 import matplotlib as mpl
 import matplotlib.style
 import matplotlib.units
 import matplotlib.testing
 from matplotlib import cbook
-from matplotlib import ticker
-from matplotlib import pyplot as plt
 from matplotlib import ft2font
-from matplotlib.testing.compare import (
-    comparable_formats, compare_images, make_test_filename)
+from matplotlib import pyplot as plt
+from matplotlib import ticker
 from . import is_called_from_pytest
+from .compare import comparable_formats, compare_images, make_test_filename
 from .exceptions import ImageComparisonFailure
 
 
-def _do_cleanup(original_units_registry, original_settings):
-    plt.close('all')
-
-    mpl.rcParams.clear()
-    mpl.rcParams.update(original_settings)
-    matplotlib.units.registry.clear()
-    matplotlib.units.registry.update(original_units_registry)
-    warnings.resetwarnings()  # reset any warning filters set in tests
-
-
-class CleanupTest(object):
-    @classmethod
-    def setup_class(cls):
-        cls.original_units_registry = matplotlib.units.registry.copy()
-        cls.original_settings = mpl.rcParams.copy()
-        matplotlib.testing.setup()
-
-    @classmethod
-    def teardown_class(cls):
-        _do_cleanup(cls.original_units_registry,
-                    cls.original_settings)
-
-    def test(self):
-        self._func()
+@contextlib.contextmanager
+def _cleanup_cm():
+    orig_units_registry = matplotlib.units.registry.copy()
+    try:
+        with warnings.catch_warnings(), matplotlib.rc_context():
+            yield
+    finally:
+        matplotlib.units.registry.clear()
+        matplotlib.units.registry.update(orig_units_registry)
+        plt.close("all")
 
 
 class CleanupTestCase(unittest.TestCase):
-    '''A wrapper for unittest.TestCase that includes cleanup operations'''
+    """A wrapper for unittest.TestCase that includes cleanup operations."""
     @classmethod
     def setUpClass(cls):
-        import matplotlib.units
-        cls.original_units_registry = matplotlib.units.registry.copy()
-        cls.original_settings = mpl.rcParams.copy()
+        cls._cm = _cleanup_cm().__enter__()
 
     @classmethod
     def tearDownClass(cls):
-        _do_cleanup(cls.original_units_registry,
-                    cls.original_settings)
+        cls._cm.__exit__(None, None, None)
+
+
+@cbook.deprecated("3.0")
+class CleanupTest(object):
+    setup_class = classmethod(CleanupTestCase.setUpClass.__func__)
+    teardown_class = classmethod(CleanupTestCase.tearDownClass.__func__)
+
+    def test(self):
+        self._func()
 
 
 def cleanup(style=None):
@@ -78,34 +65,23 @@ def cleanup(style=None):
         The name of the style to apply.
     """
 
-    # If cleanup is used without arguments, `style` will be a
-    # callable, and we pass it directly to the wrapper generator.  If
-    # cleanup if called with an argument, it is a string naming a
-    # style, and the function will be passed as an argument to what we
-    # return.  This is a confusing, but somewhat standard, pattern for
-    # writing a decorator with optional arguments.
+    # If cleanup is used without arguments, `style` will be a callable, and we
+    # pass it directly to the wrapper generator.  If cleanup if called with an
+    # argument, it is a string naming a style, and the function will be passed
+    # as an argument to what we return.  This is a confusing, but somewhat
+    # standard, pattern for writing a decorator with optional arguments.
 
     def make_cleanup(func):
         if inspect.isgeneratorfunction(func):
             @functools.wraps(func)
             def wrapped_callable(*args, **kwargs):
-                original_units_registry = matplotlib.units.registry.copy()
-                original_settings = mpl.rcParams.copy()
-                matplotlib.style.use(style)
-                try:
+                with _cleanup_cm(), matplotlib.style.context(style):
                     yield from func(*args, **kwargs)
-                finally:
-                    _do_cleanup(original_units_registry, original_settings)
         else:
             @functools.wraps(func)
             def wrapped_callable(*args, **kwargs):
-                original_units_registry = matplotlib.units.registry.copy()
-                original_settings = mpl.rcParams.copy()
-                matplotlib.style.use(style)
-                try:
+                with _cleanup_cm(), matplotlib.style.context(style):
                     func(*args, **kwargs)
-                finally:
-                    _do_cleanup(original_units_registry, original_settings)
 
         return wrapped_callable
 


### PR DESCRIPTION
Introduce a single private `_cleanup_cm` contextmanager and use it to
implement `CleanupTestCase` and `@cleanup`.

Use `warnings.catch_warnings` to avoid completely destroying a
preexisting warnings filter, instead just restoring the filter that
existed before the test started.

Use `matplotlib.style.context` to restore the style at exit, as it
relies on rc_context which is ultimately more efficient than
`rcParams.update` as it skips revalidation.

Deprecate CleanupTest (and implement it in terms of CleanupTestCase), as
it is clearly a nose-oriented base class that could have been deprecated
at the same time as ImageComparisonTest.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
