### PR TITLE
Lim parameter naming

### DIFF
--- a/examples/scales/log_demo.py
+++ b/examples/scales/log_demo.py
@@ -40,7 +40,7 @@ ax4.set_yscale("log", nonposy='clip')
 ax4.set(title='Errorbars go negative')
 ax4.errorbar(x, y, xerr=0.1 * x, yerr=5.0 + 0.75 * y)
 # ylim must be set after errorbar to allow errorbar to autoscale limits
-ax4.set_ylim(ymin=0.1)
+ax4.set_ylim(bottom=0.1)
 
 fig.tight_layout()
 plt.show()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7307,8 +7307,8 @@ class Axes(_AxesBase):
                          marker=marker, markersize=markersize, **kwargs)
             self.add_line(marks)
             nr, nc = Z.shape
-            self.set_xlim(xmin=-0.5, xmax=nc - 0.5)
-            self.set_ylim(ymin=nr - 0.5, ymax=-0.5)
+            self.set_xlim(-0.5, nc - 0.5)
+            self.set_ylim(nr - 0.5, -0.5)
             self.set_aspect(aspect)
             ret = marks
         self.title.set_y(1.05)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1297,20 +1297,21 @@ def xlim(*args, **kwargs):
 
     Call signatures::
 
-        xmin, xmax = xlim()  # return the current xlim
-        xlim((xmin, xmax))   # set the xlim to xmin, xmax
-        xlim(xmin, xmax)     # set the xlim to xmin, xmax
+        left, right = xlim()  # return the current xlim
+        xlim((left, right))   # set the xlim to left, right
+        xlim(left, right)     # set the xlim to left, right
 
-    If you do not specify args, you can pass *xmin* or *xmax* as kwargs, i.e.::
+    If you do not specify args, you can pass *left* or *right* as kwargs,
+    i.e.::
 
-        xlim(xmax=3)  # adjust the max leaving min unchanged
-        xlim(xmin=1)  # adjust the min leaving max unchanged
+        xlim(right=3)  # adjust the right leaving left unchanged
+        xlim(left=1)  # adjust the left leaving right unchanged
 
     Setting limits turns autoscaling off for the x-axis.
 
     Returns
     -------
-    xmin, xmax
+    left, right
         A tuple of the new x-axis limits.
 
     Notes
@@ -1333,21 +1334,21 @@ def ylim(*args, **kwargs):
 
     Call signatures::
 
-        ymin, ymax = ylim()  # return the current ylim
-        ylim((ymin, ymax))   # set the ylim to ymin, ymax
-        ylim(ymin, ymax)     # set the ylim to ymin, ymax
+        bottom, top = ylim()  # return the current ylim
+        ylim((bottom, top))   # set the ylim to bottom, top
+        ylim(bottom, top)     # set the ylim to bottom, top
 
-    If you do not specify args, you can alternatively pass *ymin* or *ymax* as
-    kwargs, i.e.::
+    If you do not specify args, you can alternatively pass *bottom* or
+    *top* as kwargs, i.e.::
 
-        ylim(ymax=3)  # adjust the max leaving min unchanged
-        ylim(ymin=1)  # adjust the min leaving max unchanged
+        ylim(top=3)  # adjust the top leaving bottom unchanged
+        ylim(bottom=1)  # adjust the top leaving bottom unchanged
 
     Setting limits turns autoscaling off for the y-axis.
 
     Returns
     -------
-    ymin, ymax
+    bottom, top
         A tuple of the new y-axis limits.
 
     Notes

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1577,7 +1577,7 @@ def test_hist_step_filled():
     for kg, _type, ax in zip(kwargs, types, axes):
         ax.hist(x, n_bins, histtype=_type, stacked=True, **kg)
         ax.set_title('%s/%s' % (kg, _type))
-        ax.set_ylim(ymin=-50)
+        ax.set_ylim(bottom=-50)
 
     patches = axes[0].patches
     assert all(p.get_facecolor() == p.get_edgecolor() for p in patches)

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -33,7 +33,7 @@ def test_overflow():
 
     fig, ax = plt.subplots()
     ax.plot(x, y)
-    ax.set_xlim(xmin=2, xmax=6)
+    ax.set_xlim(2, 6)
 
 
 @image_comparison(baseline_images=['clipping_diamond'], remove_text=True)
@@ -43,8 +43,8 @@ def test_diamond():
 
     fig, ax = plt.subplots()
     ax.plot(x, y)
-    ax.set_xlim(xmin=-0.6, xmax=0.6)
-    ax.set_ylim(ymin=-0.6, ymax=0.6)
+    ax.set_xlim(-0.6, 0.6)
+    ax.set_ylim(-0.6, 0.6)
 
 
 def test_noise():


### PR DESCRIPTION
## PR Summary

In #11137 the kwargs `*xlim` of `set_*lim` were deprecated. This PR removes their occurrences from the code base and examples.

I'm not quite happy with the deprecation, because `xmin, xmax, ymin, ymax` feel more straight forward and are easier to remember  than `left, right, bottom, top`. Anyhow, if we want to go that way, the code itself should be consistent.