### PR TITLE
Automagically set the stacklevel on warnings.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -64,11 +64,11 @@ def _plot_args_replacer(args, data):
         except ValueError:
             pass
         else:
-            warnings.warn(
+            cbook._warn_external(
                 "Second argument {!r} is ambiguous: could be a color spec but "
                 "is in data; using as data.  Either rename the entry in data "
                 "or use three arguments to plot.".format(args[1]),
-                RuntimeWarning, stacklevel=3)
+                RuntimeWarning)
         return ["x", "y"]
     elif len(args) == 3:
         return ["x", "y", "c"]

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -14,7 +14,7 @@ import functools
 import glob
 import gzip
 import io
-from itertools import repeat
+import itertools
 import locale
 import numbers
 import operator
@@ -1254,7 +1254,7 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
 
     ncols = len(X)
     if labels is None:
-        labels = repeat(None)
+        labels = itertools.repeat(None)
     elif len(labels) != ncols:
         raise ValueError("Dimensions of labels and X must be compatible")
 
@@ -2032,3 +2032,21 @@ def _setattr_cm(obj, **kwargs):
                 delattr(obj, attr)
             else:
                 setattr(obj, attr, orig)
+
+
+def _warn_external(message, category=None):
+    """
+    `warnings.warn` wrapper that sets *stacklevel* to "outside Matplotlib".
+
+    The original emitter of the warning can be obtained by patching this
+    function back to `warnings.warn`, i.e. ``cbook._warn_external =
+    warnings.warn`` (or ``functools.partial(warnings.warn, stacklevel=2)``,
+    etc.).
+    """
+    frame = sys._getframe()
+    for stacklevel in itertools.count(1):
+        if not re.match(r"\A(matplotlib|mpl_toolkits)(\Z|\.)",
+                        frame.f_globals["__name__"]):
+            break
+        frame = frame.f_back
+    warnings.warn(message, category, stacklevel)


### PR DESCRIPTION
There are many places in Matplotlib where it is impossible to set a
static stacklevel on warnings that works in all cases, because a same
function may either be called directly or via some wrapper (e.g.
pyplot).

Instead, compute the stacklevel by walking the stack.  Given that
warnings refer to conditions that should, well, be avoided, I believe
we don't need to worry too much about the runtime cost.

As an example, use this mechanism for the "ambiguous second argument to
plot" warning.  Now both
```
plt.gca().plot("x", "y", data={"x": 1, "y": 2})
```
and
```
plt.plot("x", "y", data={"x": 1, "y": 2})
```
emit a warning that refers to the relevant line in the user source,
whereas previously the second snippet would refer to the pyplot wrapper,
which is irrelevant to the user.

Note that this only works from source, not from IPython, as the latter
uses `exec` and AFAICT there is no value of stacklevel that correctly
refers to the string being exec'd.

Of course, the idea would be to ultimately use this throughout the
codebase.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
