### PR TITLE
Re-remove six from INSTALL.rst.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -136,16 +136,15 @@ Dependencies
 Matplotlib requires the following dependencies:
 
 * `Python <https://www.python.org/downloads/>`_ (>= 3.5)
+* `FreeType <https://www.freetype.org/>`_ (>= 2.3)
+* `libpng <http://www.libpng.org>`_ (>= 1.2)
 * `NumPy <http://www.numpy.org>`_ (>= |minimum_numpy_version|)
 * `setuptools <https://setuptools.readthedocs.io/en/latest/>`_
-* `dateutil <https://pypi.python.org/pypi/python-dateutil>`_ (>= 2.1)
-* `pyparsing <https://pyparsing.wikispaces.com/>`_
-* `libpng <http://www.libpng.org>`_ (>= 1.2)
-* `pytz <http://pytz.sourceforge.net/>`_
-* `FreeType <https://www.freetype.org/>`_ (>= 2.3)
 * `cycler <http://matplotlib.org/cycler/>`_ (>= 0.10.0)
-* `six <https://pypi.python.org/pypi/six>`_ (>= 1.10)
+* `dateutil <https://pypi.python.org/pypi/python-dateutil>`_ (>= 2.1)
 * `kiwisolver <https://github.com/nucleic/kiwi>`_ (>= 1.0.0)
+* `pyparsing <https://pyparsing.wikispaces.com/>`_
+* `pytz <http://pytz.sourceforge.net/>`_
 
 Optionally, you can also install a number of packages to enable better user
 interface toolkits. See :ref:`what-is-a-backend` for more details on the


### PR DESCRIPTION
The merge of #11254 crossed the removal of six, so re-remove six from INSTALL.rst.

Also group the dependencies in 1) non-pip installable, 2) setup-time
dependencies, 3) run-time dependencies (without actually marking the
groups, that seems a bit overkill).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
