### PR TITLE
Reuse the noninteractivity warning from Figure.show in _Backend.show.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -185,14 +185,8 @@ class _Backend(object):
         if not managers:
             return
         for manager in managers:
-            try:
-                manager.show()
-            except NonGuiException:
-                warnings.warn(
-                    ('matplotlib is currently using %s, which is a ' +
-                     'non-GUI backend, so cannot show the figure.')
-                    % get_backend())
-                return
+            # Emits a warning if the backend is non-interactive.
+            manager.canvas.figure.show()
         if cls.mainloop is None:
             return
         if block is None:

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -439,10 +439,9 @@ class Figure(Artist):
             except NonGuiException:
                 pass
         if warn:
-            warnings.warn(
-                ('matplotlib is currently using %s, which is a ' +
-                 'non-GUI backend, so cannot show the figure.')
-                % get_backend())
+            warnings.warn('Matplotlib is currently using %s, which is a '
+                          'non-GUI backend, so cannot show the figure.'
+                          % get_backend())
 
     def _get_axes(self):
         return self._axstack.as_list()

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -69,13 +69,11 @@ def test_non_gui_warning():
     with pytest.warns(UserWarning) as rec:
         plt.show()
         assert len(rec) == 1
-        assert 'matplotlib is currently using pdf, ' \
-               'which is a non-GUI backend' \
-               in str(rec[0].message)
+        assert ('Matplotlib is currently using pdf, which is a non-GUI backend'
+                in str(rec[0].message))
 
     with pytest.warns(UserWarning) as rec:
         plt.gcf().show()
         assert len(rec) == 1
-        assert 'matplotlib is currently using pdf, ' \
-               'which is a non-GUI backend' \
-               in str(rec[0].message)
+        assert ('Matplotlib is currently using pdf, which is a non-GUI backend'
+                in str(rec[0].message))


### PR DESCRIPTION
Currently, the warning message "Matplotlib is currently using ..., which
is a non-GUI backend, so cannot show the figure" and the (minor)
associated logic (of catching NonGuiException) is duplicated between
Figure.show and _Backend.show.  Make the latter use the former, to
deduplicate it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
