### PR TITLE
Avoid recursion for subclasses of str that are also "PathLike" in to_filehandle()

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -452,9 +452,7 @@ def to_filehandle(fname, flag='rU', return_opened=False, encoding=None):
     read/write flag for :func:`file`
     """
     if isinstance(fname, getattr(os, "PathLike", ())):
-        return to_filehandle(
-            os.fspath(fname),
-            flag=flag, return_opened=return_opened, encoding=encoding)
+        fname = os.fspath(fname)
     if isinstance(fname, str):
         if fname.endswith('.gz'):
             # get rid of 'U' in flag for gzipped files.


### PR DESCRIPTION
This is the case for path.py for example.

Fixes gh-11306

## PR Summary

If the path to `savefig` is both a subclass of `str` and a `PathLike` object, `to_filehandle()` creates an infinite recursion.
The PR simplifies the code while avoiding this corner case.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
