### PR TITLE
API changes: use the heading format defined in README.txt

### DIFF
--- a/doc/api/api_changes/2017-12-20-TH.rst
+++ b/doc/api/api_changes/2017-12-20-TH.rst
@@ -1,5 +1,5 @@
 Deprecations
-````````````
+------------
 
 `.Legend.draggable()` is drepecated in favor of `.Legend.set_draggable()`.
 ``Legend.draggable`` may be reintroduced as a property in future releases.

--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -1,5 +1,5 @@
 Deprecations
-````````````
+------------
 The following modules are deprecated:
 
 - :mod:`matplotlib.compat.subprocess`. This was a python 2 workaround, but all

--- a/doc/api/next_api_changes/2018-02-15-ES.rst
+++ b/doc/api/next_api_changes/2018-02-15-ES.rst
@@ -1,5 +1,6 @@
 matplotlib.cbook.Bunch deprecated
-`````````````````````````````````
+---------------------------------
+
 The ``matplotlib.cbook.Bunch`` class has been deprecated. Instead, use
 `types.SimpleNamespace` from the standard library which provides the same
 functionality.

--- a/doc/api/next_api_changes/2018-02-21-AL.rst
+++ b/doc/api/next_api_changes/2018-02-21-AL.rst
@@ -1,5 +1,5 @@
 ``Axes3D.get_xlim``, ``get_ylim`` and ``get_zlim`` now return a tuple
-`````````````````````````````````````````````````````````````````````
+---------------------------------------------------------------------
 
 They previously returned an array.  Returning a tuple is consistent with the
 behavior for 2D axes.

--- a/doc/api/next_api_changes/2018-02-26-AL-removals.rst
+++ b/doc/api/next_api_changes/2018-02-26-AL-removals.rst
@@ -1,5 +1,6 @@
 Removal of deprecated APIs
-``````````````````````````
+--------------------------
+
 The following deprecated API elements have been removed:
 
 - ``matplotlib.checkdep_tex``, ``matplotlib.checkdep_xmllint``,

--- a/doc/api/next_api_changes/2018-03-23-AL.rst
+++ b/doc/api/next_api_changes/2018-03-23-AL.rst
@@ -1,4 +1,4 @@
 ``font_manager.list_fonts`` now follows the platform's casefolding semantics
-````````````````````````````````````````````````````````````````````````````
+----------------------------------------------------------------------------
 
 i.e., it behaves case-insensitively on Windows only.

--- a/doc/api/next_api_changes/2018-04-20-AL.rst
+++ b/doc/api/next_api_changes/2018-04-20-AL.rst
@@ -1,5 +1,5 @@
 ``bar``/``barh`` no longer accepts ``left``/``bottom`` as first named argument
-``````````````````````````````````````````````````````````````````````````````
+------------------------------------------------------------------------------
 
 These arguments were renamed in 2.0 to ``x``/``y`` following the change of the
 default alignment from ``edge`` to ``center``.

--- a/doc/api/next_api_changes/2018-04-22-AL.rst
+++ b/doc/api/next_api_changes/2018-04-22-AL.rst
@@ -1,5 +1,5 @@
 Deprecation of certain marker styles
-````````````````````````````````````
+------------------------------------
 
 Using ``(n, 3)`` as marker style to specify a circle marker is deprecated.  Use
 ``"o"`` instead.

--- a/doc/api/next_api_changes/2018-04-30-AL.rst
+++ b/doc/api/next_api_changes/2018-04-30-AL.rst
@@ -1,5 +1,5 @@
 Remove lib/mpl_examples
-```````````````````````
+-----------------------
 
 The symlink from lib/mpl_examples to ../examples has been removed.
 This is not installed as an importable package and should not affect


### PR DESCRIPTION
## PR Summary

Some entires used `` `````` ``, some used `------`. Switched all to the later as recommended in `docs/README.txt`.

Note to @anntzer: You seem to be prone of using the other format. :smile: Is there a reason?

