### PR TITLE
FIX: Don't let constrained_layout counter overflow

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -455,8 +455,7 @@ def _arrange_subplotspecs(gs, hspace=0, wspace=0):
         if child._is_subplotspec_layoutbox():
             for child2 in child.children:
                 # check for gridspec children...
-                name = (child2.name).split('.')[-1][:-3]
-                if name == 'gridspec':
+                if child2._is_gridspec_layoutbox():
                     _arrange_subplotspecs(child2, hspace=hspace, wspace=wspace)
             sschildren += [child]
     # now arrange the subplots...

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -354,20 +354,16 @@ class LayoutBox(object):
         Helper to check if this layoutbox is the layoutbox of a
         subplotspec
         '''
-        name = (self.name).split('.')[-1][:-3]
-        if name == 'ss':
-            return True
-        return False
+        name = (self.name).split('.')[-1]
+        return name[:2] == 'ss'
 
     def _is_gridspec_layoutbox(self):
         '''
         Helper to check if this layoutbox is the layoutbox of a
         gridspec
         '''
-        name = (self.name).split('.')[-1][:-3]
-        if name == 'gridspec':
-            return True
-        return False
+        name = (self.name).split('.')[-1]
+        return name[:8] == 'gridspec'
 
     def find_child_subplots(self):
         '''
@@ -646,7 +642,7 @@ def seq_id():
 
     global _layoutboxobjnum
 
-    return ('%03d' % (next(_layoutboxobjnum)))
+    return ('%06d' % (next(_layoutboxobjnum)))
 
 
 def print_children(lb):


### PR DESCRIPTION
## PR Summary

constrained_layout adds a unique number to each layout element.  However, if many figures are open
this number was overflowing 1000.  For some reason kiwisolver doesn't like the longer integers in the variable names (which is a bit of a mystery in itself, but kind of moot - if someone had 1000 elements in their constrained_layout I think they'd be pretty sad about how long it took to render).  

This simply resets the iterator every time a new figure is made....

No test, as it requires making > 1000 elements, and it'd take quite a while (~60 s or so on my machine, though I'm doing a write as well).  Also not sure how to check that the last CL is correct.

Test code:

```python

import numpy as np
import matplotlib.pyplot as plt

plt.ioff()
fig = None
for a in range(40):
    fig, ax = plt.subplots(4, 4, constrained_layout=True)
    ax = ax.flatten()
    ax[0].plot(range(10))
    ax[1].plot(range(20))
    fig.savefig('booos/boo%03d.png'%a)
```

## PR Checklist

- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->