### PR TITLE
multiprocessing.set_start_method() --> mp.set_start_method()

### DIFF
--- a/examples/misc/multiprocess_sgskip.py
+++ b/examples/misc/multiprocess_sgskip.py
@@ -102,5 +102,5 @@ def main():
 
 if __name__ == '__main__':
     if plt.get_backend() == "MacOSX":
-        multiprocessing.set_start_method("forkserver")
+        mp.set_start_method("forkserver")
     main()


### PR DESCRIPTION
line 12 does __import multiprocessing as mp__ so we must align to that name.

flake8 testing of https://github.com/matplotlib/matplotlib on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/misc/multiprocess_sgskip.py:105:9: F821 undefined name 'multiprocessing'
        multiprocessing.set_start_method("forkserver")
        ^
1     F821 undefined name 'multiprocessing'
1
```

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
