### PR TITLE
Let plt.rc = matplotlib.rc, instead of being a trivial wrapper.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -38,10 +38,8 @@ from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.figure import Figure, figaspect
 from matplotlib.gridspec import GridSpec
 from matplotlib import rcParams, rcParamsDefault, get_backend
-from matplotlib import rc_context
 from matplotlib.rcsetup import interactive_bk as _interactive_bk
-from matplotlib.artist import getp, get, Artist
-from matplotlib.artist import setp as _setp
+from matplotlib.artist import Artist
 from matplotlib.axes import Axes, Subplot
 from matplotlib.projections import PolarAxes
 from matplotlib import mlab  # for csv2rec, detrend_none, window_hanning
@@ -250,9 +248,12 @@ def show(*args, **kw):
     return _show(*args, **kw)
 
 
-def isinteractive():
-    """Return the status of interactive mode."""
-    return matplotlib.is_interactive()
+# Note: While one could directly import these (``from matplotlib import ...``),
+# explicitly writing the alias makes it clear to linters that these are
+# intended as part of the API.  Same below.
+isinteractive = matplotlib.is_interactive
+rc = matplotlib.rc
+rc_context = matplotlib.rc_context
 
 
 def ioff():
@@ -293,16 +294,6 @@ def pause(interval):
         time.sleep(interval)
 
 
-@docstring.copy_dedent(matplotlib.rc)
-def rc(group, **kwargs):
-    matplotlib.rc(group, **kwargs)
-
-
-@docstring.copy_dedent(matplotlib.rc_context)
-def rc_context(rc=None, fname=None):
-    return matplotlib.rc_context(rc, fname)
-
-
 @docstring.copy_dedent(matplotlib.rcdefaults)
 def rcdefaults():
     matplotlib.rcdefaults()
@@ -333,10 +324,9 @@ def gci():
 ## Any Artist ##
 
 
-# (getp is simply imported)
-@docstring.copy(_setp)
-def setp(obj, *args, **kwargs):
-    return _setp(obj, *args, **kwargs)
+get = matplotlib.artist.get
+getp = matplotlib.artist.getp
+setp = matplotlib.artist.setp
 
 
 def xkcd(scale=1, length=100, randomness=2):
@@ -1997,14 +1987,8 @@ def set_cmap(cmap):
         im.set_cmap(cmap)
 
 
-@docstring.copy_dedent(matplotlib.image.imread)
-def imread(fname, format=None):
-    return matplotlib.image.imread(fname, format)
-
-
-@docstring.copy_dedent(matplotlib.image.imsave)
-def imsave(fname, arr, **kwargs):
-    return matplotlib.image.imsave(fname, arr, **kwargs)
+imread = matplotlib.image.imread
+imsave = matplotlib.image.imsave
 
 
 def matshow(A, fignum=None, **kw):


### PR DESCRIPTION
We previously had, in pyplot.py

    def rc(...): matplotlib.rc(...)

plus some docstring copying.

Instead, one can just do

    rc = matplotlib.rc

and likewise for a few other functions.

(Doing ``from matplotlib import rc``, which may seem even simpler, would
cause linters to complain about unused names.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
