### PR TITLE
Fix typos

### DIFF
--- a/examples/pie_and_polar_charts/pie_and_donut_labels.py
+++ b/examples/pie_and_polar_charts/pie_and_donut_labels.py
@@ -17,7 +17,7 @@ as well as with :meth:`annotations <matplotlib.axes.Axes.annotate>`.
 #
 # We can provide a function to the ``autopct`` argument, which will expand
 # automatic percentage labeling by showing absolute values; we calculate
-# the latter back from realtive data and the known sum of all values.
+# the latter back from relative data and the known sum of all values.
 #
 # We then create the pie and store the returned objects for later.
 # The first returned element of the returned tuple is a list of the wedges.

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -245,7 +245,7 @@ def _make_ghost_gridspec_slots(fig, gs):
 def _make_layout_margins(ax, renderer, h_pad, w_pad):
     """
     For each axes, make a margin between the *pos* layoutbox and the
-    *axes* layoutbox be a minimum size that can accomodate the
+    *axes* layoutbox be a minimum size that can accommodate the
     decorations on the axis.
     """
     fig = ax.figure

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4594,7 +4594,7 @@ class Axes(_AxesBase):
         ----------
         args : sequence of x, y, [color]
             Each polygon is defined by the lists of *x* and *y* positions of
-            its nodes, optionally followed by by a *color* specifier. See
+            its nodes, optionally followed by a *color* specifier. See
             :mod:`matplotlib.colors` for supported color specifiers. The
             standard color cycle is used for polygons without a color
             specifier.
@@ -5279,7 +5279,7 @@ class Axes(_AxesBase):
         .. hint::
 
             ``pcolor()`` can be very slow for large arrays. In most
-            cases you should use the the similar but much faster
+            cases you should use the similar but much faster
             `~.Axes.pcolormesh` instead. See there for a discussion of the
             differences.
 

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -171,8 +171,8 @@ class UnitData(object):
     def update(self, data):
         """Maps new values to integer identifiers.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         data: iterable
               sequence of string values
 

--- a/tutorials/intermediate/imshow_extent.py
+++ b/tutorials/intermediate/imshow_extent.py
@@ -240,7 +240,7 @@ set_extent_None_text(columns['lower'][0])
 # Explicit extent and axes limits
 # -------------------------------
 #
-# If we fix the axes limits by explicity setting `set_xlim` / `set_ylim`, we
+# If we fix the axes limits by explicitly setting `set_xlim` / `set_ylim`, we
 # force a certain size and orientation of the axes.
 # This can decouple the 'left-right' and 'top-bottom' sense of the image from
 # the orientation on the screen.


### PR DESCRIPTION
This PR fixes some typos: `realtive`, `accomodate`, `by by`, `the the`, `Paramters` and `explicity`.