### PR TITLE
fix sphinx issue in color cycle tutorial

### DIFF
--- a/tutorials/intermediate/color_cycle.py
+++ b/tutorials/intermediate/color_cycle.py
@@ -74,7 +74,7 @@ plt.show()
 # ``.matplotlibrc`` file or a style file (``style.mplstyle``), you can set the
 # ``axes.prop_cycle`` property:
 #
-# ..code-block:: python
+# .. code-block:: python
 #
 #    axes.prop_cycle    : cycler(color='bgrcmyk')
 #


### PR DESCRIPTION
This fixes the styling issue visible here: https://matplotlib.org/tutorials/intermediate/color_cycle.html?highlight=color%20cycle#setting-prop-cycler-in-the-matplotlibrc-file-or-style-files