### PR TITLE
Revert "Deprecate text.latex.unicode."

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -39,4 +39,3 @@ The following classes, methods, functions, and attributes are deprecated:
 
 The following rcParams are deprecated:
 - ``pgf.debug`` (the pgf backend relies on logging),
-- ``text.latex.unicode``,

--- a/doc/api/next_api_changes/2018-05-15-AL.rst
+++ b/doc/api/next_api_changes/2018-05-15-AL.rst
@@ -1,8 +1,0 @@
-Changes regarding the text.latex.unicode rcParam
-````````````````````````````````````````````````
-
-The rcParam now defaults to True and is deprecated (i.e., in future versions
-of Maplotlib, unicode input will always be supported).
-
-Moreover, the underlying implementation now uses ``\usepackage[utf8]{inputenc}``
-instead of ``\usepackage{ucs}\usepackage[utf8x]{inputenc}``.

--- a/examples/text_labels_and_annotations/tex_demo.py
+++ b/examples/text_labels_and_annotations/tex_demo.py
@@ -17,6 +17,7 @@ Notice how the label for the y axis is provided using unicode!
 import numpy as np
 import matplotlib
 matplotlib.rcParams['text.usetex'] = True
+matplotlib.rcParams['text.latex.unicode'] = True
 import matplotlib.pyplot as plt
 
 

--- a/examples/text_labels_and_annotations/usetex_baseline_test.py
+++ b/examples/text_labels_and_annotations/usetex_baseline_test.py
@@ -11,6 +11,7 @@ import matplotlib.axes as maxes
 
 from matplotlib import rcParams
 rcParams['text.usetex'] = True
+rcParams['text.latex.unicode'] = True
 
 
 class Axes(maxes.Axes):

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -813,8 +813,7 @@ _obsolete_set = {'pgf.debug', 'plugins.directory', 'text.dvipnghack'}
 # do NOT include in _all_deprecated
 _deprecated_set = {'axes.hold',
                    'backend.qt4',
-                   'backend.qt5',
-                   'text.latex.unicode'}
+                   'backend.qt5'}
 
 _all_deprecated = set(itertools.chain(
     _deprecated_ignore_map, _deprecated_map, _obsolete_set))

--- a/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
@@ -109,6 +109,8 @@ text.usetex         : False  # use latex for all text handling. The following fo
                              # If another font is desired which can loaded using the
                              # LaTeX \usepackage command, please inquire at the
                              # matplotlib mailing list
+text.latex.unicode : False # use "ucs" and "inputenc" LaTeX packages for handling
+                           # unicode strings.
 text.latex.preamble :  # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
                            # AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
                            # IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -111,6 +111,8 @@ text.usetex         : False  # use latex for all text handling. The following fo
                              # If another font is desired which can loaded using the
                              # LaTeX \usepackage command, please inquire at the
                              # matplotlib mailing list
+text.latex.unicode : False # use "ucs" and "inputenc" LaTeX packages for handling
+                           # unicode strings.
 text.latex.preamble :  # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
                            # AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
                            # IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1100,7 +1100,7 @@ defaultParams = {
     # text props
     'text.color':          ['black', validate_color],
     'text.usetex':         [False, validate_bool],
-    'text.latex.unicode':  [True, validate_bool],
+    'text.latex.unicode':  [False, validate_bool],
     'text.latex.preamble': [[''], validate_stringlist],
     'text.latex.preview':  [False, validate_bool],
     'text.dvipnghack':     [None, validate_bool_maybe_none],

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -32,11 +32,11 @@ needs_usetex = pytest.mark.xfail(
     needs_ghostscript(
         ('ps', False, {'ps.usedistiller': 'ghostscript'})),
     needs_usetex(needs_ghostscript(
-        ('ps', False, {'text.usetex': True}))),
+        ('ps', False, {'text.latex.unicode': True, 'text.usetex': True}))),
     ('eps', False, {}),
     ('eps', True, {'ps.useafm': True}),
     needs_usetex(needs_ghostscript(
-        ('eps', False, {'text.usetex': True}))),
+        ('eps', False, {'text.latex.unicode': True, 'text.usetex': True}))),
 ], ids=[
     'ps',
     'ps with distiller',

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -468,7 +468,7 @@ def test_if_rctemplate_is_up_to_date():
             continue
         if k in deprecated:
             continue
-        if k.startswith(("text.latex.unicode", "verbose.")):
+        if "verbose" in k:
             continue
         found = False
         for line in rclines:

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -203,7 +203,8 @@ class TexManager(object):
 
         if rcParams['text.latex.unicode']:
             unicode_preamble = r"""
-\usepackage[utf8]{inputenc}"""
+\usepackage{ucs}
+\usepackage[utf8x]{inputenc}"""
         else:
             unicode_preamble = ''
 
@@ -254,7 +255,8 @@ class TexManager(object):
 
         if rcParams['text.latex.unicode']:
             unicode_preamble = r"""
-\usepackage[utf8]{inputenc}"""
+\usepackage{ucs}
+\usepackage[utf8x]{inputenc}"""
         else:
             unicode_preamble = ''
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -225,6 +225,8 @@ backend      : $TEMPLATE_BACKEND
                               ## If another font is desired which can loaded using the
                               ## LaTeX \usepackage command, please inquire at the
                               ## matplotlib mailing list
+#text.latex.unicode : False ## use "ucs" and "inputenc" LaTeX packages for handling
+                            ## unicode strings.
 #text.latex.preamble :      ## IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
                             ## AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
                             ## IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.


### PR DESCRIPTION
Reverts matplotlib/matplotlib#11255

This is causing a lot of spam on CI.  Should be restored along with the internal clean up required.