### PR TITLE
text.usetex ticklabel alignment problem solution

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1649,6 +1649,8 @@ class Axis(artist.Artist):
             for t in get_labels:
                 # replace latex "-" sign with latex.amsmath "-" sign
                 ticklabels.append(t.replace('-','\\text{-}'))
+        else:
+            ticklabels = get_labels
 
         if minor:
             self.set_minor_formatter(mticker.FixedFormatter(ticklabels))

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1641,16 +1641,17 @@ class Axis(artist.Artist):
             except AttributeError:
                 get_labels.append(t)
         # replace the ticklabels list with the processed one
-        ticklabels = []
+        ticklabels = get_labels
+        
+        get_labels = []
         if(rcParams['text.usetex'] and
             r'\usepackage{amsmath}' in rcParams['text.latex.preamble']):
             # check text.usetex and amsmath package in text.latex.preamble
             # if True use amsmath package for the negative sign
-            for t in get_labels:
+            for t in ticklabels:
                 # replace latex "-" sign with latex.amsmath "-" sign
-                ticklabels.append(t.replace('-','\\text{-}'))
-        else:
-            ticklabels = get_labels
+                get_labels.append(t.replace('-','\\text{-}'))
+        ticklabels = get_labels
 
         if minor:
             self.set_minor_formatter(mticker.FixedFormatter(ticklabels))

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1641,17 +1641,20 @@ class Axis(artist.Artist):
             except AttributeError:
                 get_labels.append(t)
         # replace the ticklabels list with the processed one
-        
-        ticklabels = []
+        ticklabels = get_labels
+
+        get_labels = []
         if(rcParams['text.usetex'] and
-            'amsmath' in rcParams['text.latex.preamble'][0]):
-            # check text.usetex and amsmath package in text.latex.preamble
-            # if True use amsmath package for the negative sign
-            for t in get_labels:
-                # replace latex "-" sign with latex.amsmath "-" sign
-                ticklabels.append(t.replace('-','\\text{-}'))
-        else:
-            ticklabels = get_labels
+            len(rcParams['text.latex.preamble']) != 0):
+            for presemble in rcParams['text.latex.preamble']:
+                if('usepackage{'  in presemble and 'amsmath' in presemble):
+                    # check text.usetex and amsmath package 
+                    # if True use amsmath package for the negative sign
+                    for t in ticklabels:
+                        # replace latex "-" sign with latex.amsmath "-" sign
+                        get_labels.append(t.replace('-','\\text{-}'))
+                    ticklabels = get_labels
+                    break
 
         if minor:
             self.set_minor_formatter(mticker.FixedFormatter(ticklabels))

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1641,8 +1641,6 @@ class Axis(artist.Artist):
             except AttributeError:
                 get_labels.append(t)
         # replace the ticklabels list with the processed one
-        ticklabels = get_labels
-        
         get_labels = []
         if(rcParams['text.usetex'] and
             r'\usepackage{amsmath}' in rcParams['text.latex.preamble']):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1180,10 +1180,10 @@ class Axis(artist.Artist):
 
         for tick in ticks_to_draw:
             if tick.label1On and tick.label1.get_usetex():
-                lb = tick.label1._text.replace('-', '\\operatorname{-}')
+                lb = tick.label1._text.replace('-', '\operatorname{-}')
                 tick.label1._text = lb
             if tick.label2On and tick.label2.get_usetex():
-                lb = tick.label2._text.replace('-', '\\operatorname{-}')
+                lb = tick.label2._text.replace('-', '\operatorname{-}')
                 tick.label2._text = lb
             tick.draw(renderer)
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1644,7 +1644,7 @@ class Axis(artist.Artist):
         
         ticklabels = []
         if(rcParams['text.usetex'] and
-            r'\usepackage{amsmath}' in rcParams['text.latex.preamble']):
+            'amsmath' in rcParams['text.latex.preamble'][0]):
             # check text.usetex and amsmath package in text.latex.preamble
             # if True use amsmath package for the negative sign
             for t in get_labels:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1179,6 +1179,12 @@ class Axis(artist.Artist):
                                                                 renderer)
 
         for tick in ticks_to_draw:
+            if tick.label1On and tick.label1.get_usetex():
+                lb = tick.label1._text.replace('-', '\\operatorname{-}')
+                tick.label1._text = lb
+            if tick.label2On and tick.label2.get_usetex():
+                lb = tick.label2._text.replace('-', '\\operatorname{-}')
+                tick.label2._text = lb
             tick.draw(renderer)
 
         # scale up the axis label box to also find the neighbors, not
@@ -1642,19 +1648,6 @@ class Axis(artist.Artist):
                 get_labels.append(t)
         # replace the ticklabels list with the processed one
         ticklabels = get_labels
-
-        get_labels = []
-        if(rcParams['text.usetex'] and
-            len(rcParams['text.latex.preamble']) != 0):
-            for presemble in rcParams['text.latex.preamble']:
-                if('usepackage{'  in presemble and 'amsmath' in presemble):
-                    # check text.usetex and amsmath package 
-                    # if True use amsmath package for the negative sign
-                    for t in ticklabels:
-                        # replace latex "-" sign with latex.amsmath "-" sign
-                        get_labels.append(t.replace('-','\\text{-}'))
-                    ticklabels = get_labels
-                    break
 
         if minor:
             self.set_minor_formatter(mticker.FixedFormatter(ticklabels))

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1178,11 +1178,17 @@ class Axis(artist.Artist):
         ticklabelBoxes, ticklabelBoxes2 = self._get_tick_bboxes(ticks_to_draw,
                                                                 renderer)
 
+        presemble_check = False
+        if len(rcParams['text.latex.preamble']) != 0:
+            for presemble in rcParams['text.latex.preamble']:
+                if('usepackage{' in presemble and 'amsmath' in presemble):
+                    presemble_check = True
+
         for tick in ticks_to_draw:
-            if tick.label1On and tick.label1.get_usetex():
+            if tick.label1On and tick.label1.get_usetex() and presemble_check:
                 lb = tick.label1._text.replace('-', '\operatorname{-}')
                 tick.label1._text = lb
-            if tick.label2On and tick.label2.get_usetex():
+            if tick.label2On and tick.label2.get_usetex() and presemble_check:
                 lb = tick.label2._text.replace('-', '\operatorname{-}')
                 tick.label2._text = lb
             tick.draw(renderer)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1641,7 +1641,14 @@ class Axis(artist.Artist):
             except AttributeError:
                 get_labels.append(t)
         # replace the ticklabels list with the processed one
-        ticklabels = get_labels
+        ticklabels = []
+        if(rcParams['text.usetex'] and
+            r'\usepackage{amsmath}' in rcParams['text.latex.preamble']):
+            # check text.usetex and amsmath package in text.latex.preamble
+            # if True use amsmath package for the negative sign
+            for t in get_labels:
+                # replace latex "-" sign with latex.amsmath "-" sign
+                ticklabels.append(t.replace('-','\\text{-}'))
 
         if minor:
             self.set_minor_formatter(mticker.FixedFormatter(ticklabels))

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1641,15 +1641,17 @@ class Axis(artist.Artist):
             except AttributeError:
                 get_labels.append(t)
         # replace the ticklabels list with the processed one
-        get_labels = []
+        
+        ticklabels = []
         if(rcParams['text.usetex'] and
             r'\usepackage{amsmath}' in rcParams['text.latex.preamble']):
             # check text.usetex and amsmath package in text.latex.preamble
             # if True use amsmath package for the negative sign
-            for t in ticklabels:
+            for t in get_labels:
                 # replace latex "-" sign with latex.amsmath "-" sign
-                get_labels.append(t.replace('-','\\text{-}'))
-        ticklabels = get_labels
+                ticklabels.append(t.replace('-','\\text{-}'))
+        else:
+            ticklabels = get_labels
 
         if minor:
             self.set_minor_formatter(mticker.FixedFormatter(ticklabels))


### PR DESCRIPTION
## PR Summary
This text.usetex ticklabel alignment problem mentioned in #11243 . The code uses amsmath negative sign when` 'text.latex.preamble' : [r'\usepackage{amsmath}'] `is updated in `rcParams`. 
`


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
