### PR TITLE
DOC: Small tweak to customizing tutorial default style files can be found on github

### DIFF
--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -1,8 +1,8 @@
 """
-Customizing matplotlib
-======================
+Customizing Matplotlib with style sheets and rcParams
+=====================================================
 
-Tips for customizing the properties and default styles of matplotlib.
+Tips for customizing the properties and default styles of Matplotlib.
 
 Using style sheets
 ------------------
@@ -12,7 +12,7 @@ the same parameters as a
 :ref:`matplotlib rc <customizing-with-matplotlibrc-files>` file (which is read
 at startup to configure matplotlib).
 
-There are a number of pre-defined styles provided by matplotlib. For
+There are a number of pre-defined styles `provided by Matplotlib`_. For
 example, there's a pre-defined style called "ggplot", which emulates the
 aesthetics of ggplot_ (a popular plotting package for R_). To use this style,
 just add:
@@ -186,3 +186,4 @@ plt.plot(data)
 #
 # .. _ggplot: http://ggplot2.org/
 # .. _R: https://www.r-project.org/
+# .. _provided by Matplotlib: https://github.com/matplotlib/matplotlib/tree/master/lib/matplotlib/mpl-data/stylelib


### PR DESCRIPTION
## PR Summary

Indicate where on GitHub to find the default style files (probably easier than finding them in the local install for most of us).  Also lengthened the name of the tutorial to "Customizing Matplotlib with style sheets and rcParams" since it wasn't obvious to me that this explained anything about style files.  But maybe too long. .

