### PR TITLE
Fix tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,11 @@ envlist = py35, py36
 changedir = /tmp
 setenv =
     MPLCONFIGDIR={envtmpdir}/.matplotlib
+    PIP_USER = 0
+    PIP_ISOLATED = 1
+    MPLLOCALFREETYPE = 1
+usedevelop = True
 commands =
-    {envpython} {toxinidir}/tests.py --processes=-1 --process-timeout=300
+    pytest --pyargs matplotlib
 deps =
-    numpy
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,9 @@ envlist = py35, py36
 
 [testenv]
 changedir = /tmp
+setenv =
+    MPLCONFIGDIR={envtmpdir}/.matplotlib
 commands =
-    sh -c 'rm -f $HOME/.matplotlib/fontList*'
     {envpython} {toxinidir}/tests.py --processes=-1 --process-timeout=300
 deps =
     numpy


### PR DESCRIPTION
## PR Summary
Currently `tox` will delete the font cache in `~/.matplotlib` if invoked. Likely the tests should not be relying on or using *anything* from `~/.matplotlib`, much less modifying the user's environment. This PR sets `MPLCONFIGDIR` to a temporary directory created by `tox` that is cleared on every invocation.

I was unable to test it because of #11361, and because `tox` is not invoked anywhere as part of the CI as far as I can tell.

**Update**
Closes #11361. With help from @anntzer, these changes now also fix the problem with running `tox`.