### PR TITLE
Sorting drawn artists by their zorder when blitting using FuncAnimation

### DIFF
--- a/doc/api/next_api_changes/2018-06-03-JD-funcani-zorder.rst
+++ b/doc/api/next_api_changes/2018-06-03-JD-funcani-zorder.rst
@@ -1,0 +1,9 @@
+`.FuncAnimation` now draws artists according to their zorder when blitting
+--------------------------------------------------------------------------
+
+`.FuncAnimation` now draws artists returned by the user-
+function according to their zorder when using blitting,
+instead of using the order in which they are being passed.
+However, note that only zorder of passed artists will be
+respected, as they are drawn on top of any existing artists
+(see `#11369 <https://github.com/matplotlib/matplotlib/issues/11369>`_).

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1723,7 +1723,7 @@ class FuncAnimation(TimedAnimation):
 
         # Call the func with framedata and args. If blitting is desired,
         # func needs to return a sequence of any artists that were modified.
-        self._drawn_artists = self._func(framedata, *self._args)
+        self._drawn_artists = sorted(self._func(framedata, *self._args), key=lambda x: x.get_zorder())
         if self._blit:
             if self._drawn_artists is None:
                 raise RuntimeError('The animation function must return a '

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1723,7 +1723,8 @@ class FuncAnimation(TimedAnimation):
 
         # Call the func with framedata and args. If blitting is desired,
         # func needs to return a sequence of any artists that were modified.
-        self._drawn_artists = sorted(self._func(framedata, *self._args), key=lambda x: x.get_zorder())
+        self._drawn_artists = sorted(self._func(framedata, *self._args),
+                                     key=lambda x: x.get_zorder())
         if self._blit:
             if self._drawn_artists is None:
                 raise RuntimeError('The animation function must return a '

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1607,8 +1607,10 @@ class FuncAnimation(TimedAnimation):
        of frames is completed.  Defaults to ``True``.
 
     blit : bool, optional
-       Controls whether blitting is used to optimize drawing.  Defaults
-       to ``False``.
+       Controls whether blitting is used to optimize drawing. Note: when using
+       blitting any animated artists will be drawn according to their zorder.
+       However, they will be drawn on top of any previous artists, regardless
+       of their zorder.  Defaults to ``False``.
 
     '''
     def __init__(self, fig, func, frames=None, init_func=None, fargs=None,


### PR DESCRIPTION
## PR Summary
As pointed out in [issue #11369](https://github.com/matplotlib/matplotlib/issues/11369) using blitting with FuncAnimation can lead to unexpected bevahior with overlapping artists. Essentially their zorder is not being respected, as instead the order in which they are provided by the user-function defines the order in which they are drawn. Sorting artists by their zorder when reciveing them fixes this issue.

## PR Checklist

- [ ] (not applicable) Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] (not applicable) New features are documented, with examples if plot related
- [x]  Documentation is sphinx and numpydoc compliant
- [ ] (not applicable) Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
