### PR TITLE
Simplify normalization of multiple images

### DIFF
--- a/doc/api/next_api_changes/2018-07-09-TH.rst
+++ b/doc/api/next_api_changes/2018-07-09-TH.rst
@@ -1,0 +1,7 @@
+Added data argument to `.Normalize`
+-----------------------------------
+
+`.Normalize` got a data keyword argument to easy generation of normalized
+plots. `Normalize(data=d)` is equivalent to
+`Normalize(vmin=np.min(d), vmax=np.max(d))`. For an example see
+:doc:`examples/images_contours_and_fields/multi_image.py`.

--- a/examples/images_contours_and_fields/multi_image.py
+++ b/examples/images_contours_and_fields/multi_image.py
@@ -1,44 +1,93 @@
 """
-===========
-Multi Image
-===========
+==================================
+Multiple images sharing a colorbar
+==================================
 
-Make a set of images with a single colormap, norm, and colorbar.
+A colorbar is always connected to a single image (more precisely, to a single
+`.ScalarMappable`). If we want to use multiple images with a single colorbar,
+we have to create a colorbar for one of the images and make sure that the
+other images use the same color mapping, i.e. the same Colormap and the same
+`.Normalize` instance.
+
 """
-
 from matplotlib import colors
 import matplotlib.pyplot as plt
 import numpy as np
 
 np.random.seed(19680801)
-Nr = 3
-Nc = 2
-cmap = "cool"
+nrows = 3
+ncols = 2
+cmap = "plasma"
 
-fig, axs = plt.subplots(Nr, Nc)
-fig.suptitle('Multiple images')
+data = [((1 + i) / 10) * np.random.rand(11, 21) * 1e-6
+        for i in range(nrows * ncols)]
+
+#############################################################################
+#
+# All data available beforehand
+# -----------------------------
+#
+# In the most simple case, we have all the image data sets available, e.g.
+# in a list, before we start to plot. In this case, we create a common
+# `.Normalize` instance scaling to the global min and max by passing all data
+# to the *data* argument of Normalize. We then use this and a common colormap
+# when creating the images.
+
+fig, axs = plt.subplots(nrows, ncols, sharex=True, sharey=True)
+fig.suptitle('Multiple images sharing a colorbar')
+
+norm = colors.Normalize(data=data)
+images = [ax.imshow(data, cmap=cmap, norm=norm)
+          for data, ax in zip(data, axs.flat)]
+fig.colorbar(images[0], ax=axs, orientation='horizontal', fraction=.06)
+plt.show()
+
+#############################################################################
+#
+# Not all data available beforehand
+# ---------------------------------
+#
+# Things get a bit more complicated, if we don't have all the data beforehand,
+# e.g. when we generate or load the data just before each plot command. In
+# this case, the common norm has to be created and set afterwards. We can use
+# a small helper function for that.
+
+
+def normalize_images(images):
+    """Normalize the given images to their global min and max."""
+    vmin = min(image.get_array().min() for image in images)
+    vmax = max(image.get_array().max() for image in images)
+    norm = colors.Normalize(vmin=vmin, vmax=vmax)
+    for im in images:
+        im.set_norm(norm)
+
+
+fig, axs = plt.subplots(nrows, ncols, sharex=True, sharey=True)
+fig.suptitle('Multiple images sharing a colorbar')
 
 images = []
-for i in range(Nr):
-    for j in range(Nc):
+for i in range(nrows):
+    for j in range(ncols):
         # Generate data with a range that varies from one plot to the next.
-        data = ((1 + i + j) / 10) * np.random.rand(10, 20) * 1e-6
+        data = ((1 + i + j) / 10) * np.random.rand(11, 21) * 1e-6
         images.append(axs[i, j].imshow(data, cmap=cmap))
-        axs[i, j].label_outer()
-
-# Find the min and max of all colors for use in setting the color scale.
-vmin = min(image.get_array().min() for image in images)
-vmax = max(image.get_array().max() for image in images)
-norm = colors.Normalize(vmin=vmin, vmax=vmax)
-for im in images:
-    im.set_norm(norm)
-
-fig.colorbar(images[0], ax=axs, orientation='horizontal', fraction=.1)
+normalize_images(images)
+fig.colorbar(images[0], ax=axs, orientation='horizontal', fraction=.06)
 
 
-# Make images respond to changes in the norm of other images (e.g. via the
-# "edit axis, curves and images parameters" GUI on Qt), but be careful not to
-# recurse infinitely!
+#############################################################################
+#
+# Dynamically adapting to changes of the norm and cmap
+# ----------------------------------------------------
+#
+# If the images norm or cmap can change later on (e.g. via the
+# "edit axis, curves and images parameters" GUI on Qt), one can propagate
+# these changes to all images by connecting to the 'changed' callback.
+#
+# Note: It's important to have the ``if`` statement to check whether there
+# are really changes to apply. Otherwise, you would run into an infinite
+# recursion with all images notifying each other infinitely.
+
 def update(changed_image):
     for im in images:
         if (changed_image.get_cmap() != im.get_cmap()
@@ -50,7 +99,6 @@ def update(changed_image):
 for im in images:
     im.callbacksSM.connect('changed', update)
 
-plt.show()
 
 #############################################################################
 #

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -859,7 +859,7 @@ class Normalize(object):
     the ``[0.0, 1.0]`` interval.
 
     """
-    def __init__(self, vmin=None, vmax=None, clip=False):
+    def __init__(self, vmin=None, vmax=None, clip=False, *, data=None):
         """
         If *vmin* or *vmax* is not given, they are initialized from the
         minimum and maximum value respectively of the first input
@@ -876,10 +876,16 @@ class Normalize(object):
         the over, under, and masked colors in the colormap, so it is
         likely to lead to surprises; therefore the default is
         *clip* = *False*.
+
+        You can pass an array-like object to *data*, e.g. a list of
+        numpy arrays. If *vmin* or *vmax* are *None*, the respective min/max
+        of the array is taken as *vmin* / *vmax*.
         """
         self.vmin = _sanitize_extrema(vmin)
         self.vmax = _sanitize_extrema(vmax)
         self.clip = clip
+        if data is not None:
+            self.autoscale_None(data)
 
     @staticmethod
     def process_value(value):
@@ -1061,8 +1067,8 @@ class SymLogNorm(Normalize):
     *linthresh* allows the user to specify the size of this range
     (-*linthresh*, *linthresh*).
     """
-    def __init__(self,  linthresh, linscale=1.0,
-                 vmin=None, vmax=None, clip=False):
+    def __init__(self, linthresh, linscale=1.0,
+                 vmin=None, vmax=None, clip=False, *, data=None):
         """
         *linthresh*:
         The range within which the plot is linear (to
@@ -1076,11 +1082,15 @@ class SymLogNorm(Normalize):
         default), the space used for the positive and negative
         halves of the linear range will be equal to one decade in
         the logarithmic range. Defaults to 1.
+
+        You can pass an array-like object to *data*, e.g. a list of
+        numpy arrays. If *vmin* or *vmax* are *None*, the respective min/max
+        of the array is taken as *vmin* / *vmax*.
         """
-        Normalize.__init__(self, vmin, vmax, clip)
+        Normalize.__init__(self, vmin, vmax, clip, data=data)
         self.linthresh = float(linthresh)
         self._linscale_adj = (linscale / (1.0 - np.e ** -1))
-        if vmin is not None and vmax is not None:
+        if self.vmin is not None and self.vmax is not None:
             self._transform_vmin_vmax()
 
     def __call__(self, value, clip=None):
@@ -1173,8 +1183,8 @@ class PowerNorm(Normalize):
     Normalize a given value to the ``[0, 1]`` interval with a power-law
     scaling. This will clip any negative data points to 0.
     """
-    def __init__(self, gamma, vmin=None, vmax=None, clip=False):
-        Normalize.__init__(self, vmin, vmax, clip)
+    def __init__(self, gamma, vmin=None, vmax=None, clip=False, *, data=None):
+        Normalize.__init__(self, vmin, vmax, clip, data=data)
         self.gamma = gamma
 
     def __call__(self, value, clip=None):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -212,6 +212,12 @@ def test_Normalize():
     assert 0 < norm(1 + 50 * eps) < 1
 
 
+def test_Normalize_data():
+    vals = np.linspace(-1, 2, 5)
+    norm = mcolors.Normalize(data=vals)
+    assert_array_equal([norm.vmin, norm.vmax], [vals.min(), vals.max()])
+
+
 def test_SymLogNorm():
     """
     Test SymLogNorm behavior


### PR DESCRIPTION
## PR Summary

In response to #11377. This adds two simpler ways for creating a common normalization for images. 

In particular the [linked example](https://matplotlib.org/gallery/images_contours_and_fields/multi_image.html) is quite verbose. That (at least the first) half gets significantly easier with this PR.

### Pre-imshow normalization

if the data are known beforehand, one can create a `Normalize` instance scaled to the global min/max of the data:

~~~
import matplotlib.pyplot as plt
from matplotlib.colors import Normalize

fields = [np.random.randn(10, 10) + 2*i for i in range(3)]

_, axes = plt.subplots(ncols=3)
norm = Normalize(data=fields)                     # New API: create Normalize
for ax, field in zip(axes, fields):
    im = ax.imshow(field, norm=norm, cmap="RdBu_r")    # use Normalize
plt.colorbar(im, ax=axes)
~~~

![grafik](https://user-images.githubusercontent.com/2836374/41001137-61aff5fe-6910-11e8-9340-cc0a6919d61b.png)

### Post-imshow normalization

<s>Alternatively, one can collect the images and create a `Normalize` instance from their values and apply the norm to the images:

~~~
_, axes = plt.subplots(ncols=3)
images = []
for ax, field in zip(axes, fields):
    images.append(ax.imshow(field, cmap="RdBu_r"))
Normalize.apply_autoscale(images)                       # New API
plt.colorbar(im, ax=axes)
~~~
</s> (withdrawn after discussion)

This is a proof of concept. Documentation, tests and examples are not yet complete. Feedback on the general API is much apreciated.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
