### PR TITLE
Add a get_zaxis method for 3d axes.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -197,18 +197,23 @@ class Axes3D(Axes):
 
     def _init_axis(self):
         '''Init 3D axes; overrides creation of regular X/Y axes'''
-        self.w_xaxis = axis3d.XAxis('x', self.xy_viewLim.intervalx,
-                                    self.xy_dataLim.intervalx, self)
-        self.xaxis = self.w_xaxis
-        self.w_yaxis = axis3d.YAxis('y', self.xy_viewLim.intervaly,
-                                    self.xy_dataLim.intervaly, self)
-        self.yaxis = self.w_yaxis
-        self.w_zaxis = axis3d.ZAxis('z', self.zz_viewLim.intervalx,
-                                    self.zz_dataLim.intervalx, self)
-        self.zaxis = self.w_zaxis
+        self.xaxis = axis3d.XAxis('x', self.xy_viewLim.intervalx,
+                                  self.xy_dataLim.intervalx, self)
+        self.yaxis = axis3d.YAxis('y', self.xy_viewLim.intervaly,
+                                  self.xy_dataLim.intervaly, self)
+        self.zaxis = axis3d.ZAxis('z', self.zz_viewLim.intervalx,
+                                  self.zz_dataLim.intervalx, self)
+        # Provide old aliases
+        self.w_xaxis = self.xaxis
+        self.w_yaxis = self.yaxis
+        self.w_zaxis = self.zaxis
 
         for ax in self.xaxis, self.yaxis, self.zaxis:
             ax.init3d()
+
+    def get_zaxis(self):
+        '''Return the ``ZAxis`` (`~.axis3d.Axis`) instance.'''
+        return self.zaxis
 
     def _get_axis_list(self):
         return super()._get_axis_list() + (self.zaxis, )
@@ -2446,8 +2451,7 @@ class Axes3D(Axes):
               6. +X
 
         zsort : str, optional
-            The z-axis sorting scheme passed onto
-            :func:`~mpl_toolkits.mplot3d.art3d.Poly3DCollection`
+            The z-axis sorting scheme passed onto `~.art3d.Poly3DCollection`
 
         shade : bool, optional (default = True)
             When true, this shades the dark sides of the bars (relative
@@ -2455,11 +2459,11 @@ class Axes3D(Axes):
 
         **kwargs
             Any additional keyword arguments are passed onto
-            :class:`~mpl_toolkits.mplot3d.art3d.Poly3DCollection`
+            `~.art3d.Poly3DCollection`.
 
         Returns
         -------
-        collection : Poly3DCollection
+        collection : `~.art3d.Poly3DCollection`
             A collection of three dimensional polygons representing
             the bars.
         """

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -45,7 +45,7 @@ def tick_update_position(tick, tickxs, tickys, labelpos):
 
 
 class Axis(maxis.XAxis):
-
+    """An Axis class for the 3D plots. """
     # These points from the unit cube make up the x, y and z-planes
     _PLANES = (
         (0, 3, 7, 4), (1, 2, 6, 5),     # yz planes


### PR DESCRIPTION
## PR Summary

Because the normal axes.Axes have a `.get_xaxis` and `.get_yaxis` method, which are exposed by the `Axes3D`,  there should be a `get_zaxis` method as well.

This adds a `get_zaxis` method to the `Axes3D`. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
