### PR TITLE
Deprecate Axes3D.w_{x,y,z}axis in favor of .{x,y,z}axis.

### DIFF
--- a/doc/api/next_api_changes/2018-10-04-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-10-04-AL-deprecations.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``axes3d.Axes3D.w_xaxis``, ``.w_yaxis``, and ``.w_zaxis`` are deprecated (use
+``.xaxis``, ``.yaxis``, and ``.zaxis`` instead).

--- a/examples/mplot3d/surface3d_3.py
+++ b/examples/mplot3d/surface3d_3.py
@@ -36,6 +36,6 @@ surf = ax.plot_surface(X, Y, Z, facecolors=colors, linewidth=0)
 
 # Customize the z axis.
 ax.set_zlim(-1, 1)
-ax.w_zaxis.set_major_locator(LinearLocator(6))
+ax.zaxis.set_major_locator(LinearLocator(6))
 
 plt.show()

--- a/examples/pyplots/whats_new_1_subplot3d.py
+++ b/examples/pyplots/whats_new_1_subplot3d.py
@@ -23,8 +23,8 @@ surf = ax.plot_surface(X, Y, Z, rstride=1, cstride=1, cmap=cm.viridis,
                        linewidth=0, antialiased=False)
 ax.set_zlim3d(-1.01, 1.01)
 
-#ax.w_zaxis.set_major_locator(LinearLocator(10))
-#ax.w_zaxis.set_major_formatter(FormatStrFormatter('%.03f'))
+#ax.zaxis.set_major_locator(LinearLocator(10))
+#ax.zaxis.set_major_formatter(FormatStrFormatter('%.03f'))
 
 fig.colorbar(surf, shrink=0.5, aspect=5)
 

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -24,16 +24,16 @@ mplDeprecation = MatplotlibDeprecationWarning
 def _generate_deprecation_warning(
         since, message='', name='', alternative='', pending=False,
         obj_type='attribute', addendum='', *, removal=''):
-
-    if removal == "":
-        removal = {"2.2": "in 3.1", "3.0": "in 3.2", "3.1": "in 3.3"}.get(
-            since, "two minor releases later")
-    elif removal:
-        if pending:
+    if pending:
+        if removal:
             raise ValueError(
                 "A pending deprecation cannot have a scheduled removal")
-        removal = "in {}".format(removal)
-
+    else:
+        if removal:
+            removal = "in {}".format(removal)
+        else:
+            removal = {"2.2": "in 3.1", "3.0": "in 3.2", "3.1": "in 3.3"}.get(
+                since, "two minor releases later")
     if not message:
         message = (
             "\nThe %(name)s %(obj_type)s"
@@ -46,10 +46,8 @@ def _generate_deprecation_warning(
             + "."
             + (" Use %(alternative)s instead." if alternative else "")
             + (" %(addendum)s" if addendum else ""))
-
     warning_cls = (PendingDeprecationWarning if pending
                    else MatplotlibDeprecationWarning)
-
     return warning_cls(message % dict(
         func=name, name=name, obj_type=obj_type, since=since, removal=removal,
         alternative=alternative, addendum=addendum))

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -205,16 +205,26 @@ class Axes3D(Axes):
                                   self.xy_dataLim.intervaly, self)
         self.zaxis = axis3d.ZAxis('z', self.zz_viewLim.intervalx,
                                   self.zz_dataLim.intervalx, self)
-        # Provide old aliases
-        self.w_xaxis = self.xaxis
-        self.w_yaxis = self.yaxis
-        self.w_zaxis = self.zaxis
-
         for ax in self.xaxis, self.yaxis, self.zaxis:
             ax.init3d()
 
     def get_zaxis(self):
         '''Return the ``ZAxis`` (`~.axis3d.Axis`) instance.'''
+        return self.zaxis
+
+    @cbook.deprecated("3.1", alternative="xaxis", pending=True)
+    @property
+    def w_xaxis(self):
+        return self.xaxis
+
+    @cbook.deprecated("3.1", alternative="yaxis", pending=True)
+    @property
+    def w_yaxis(self):
+        return self.yaxis
+
+    @cbook.deprecated("3.1", alternative="zaxis", pending=True)
+    @property
+    def w_zaxis(self):
         return self.zaxis
 
     def _get_axis_list(self):


### PR DESCRIPTION
## PR Summary

See discussion at https://github.com/matplotlib/matplotlib/pull/11385#discussion_r193397411 for rationale.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
