### PR TITLE
Deprecate the `verts` kwarg to `scatter`.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -40,3 +40,6 @@ The following classes, methods, functions, and attributes are deprecated:
 
 The following rcParams are deprecated:
 - ``pgf.debug`` (the pgf backend relies on logging),
+
+The following keyword arguments are deprecated:
+- passing ``verts`` to ``scatter`` (use ``marker`` instead),

--- a/examples/lines_bars_and_markers/scatter_custom_symbol.py
+++ b/examples/lines_bars_and_markers/scatter_custom_symbol.py
@@ -19,6 +19,6 @@ x, y, s, c = np.random.rand(4, 30)
 s *= 10**2.
 
 fig, ax = plt.subplots()
-ax.scatter(x, y, s, c, marker=None, verts=verts)
+ax.scatter(x, y, s, c, marker=verts)
 
 plt.show()

--- a/examples/lines_bars_and_markers/scatter_star_poly.py
+++ b/examples/lines_bars_and_markers/scatter_star_poly.py
@@ -26,9 +26,7 @@ plt.scatter(x, y, s=80, c=z, marker=(5, 0))
 
 verts = np.array([[-1, -1], [1, -1], [1, 1], [-1, -1]])
 plt.subplot(323)
-plt.scatter(x, y, s=80, c=z, marker=(verts, 0))
-# equivalent:
-# plt.scatter(x, y, s=80, c=z, marker=None, verts=verts)
+plt.scatter(x, y, s=80, c=z, marker=verts)
 
 plt.subplot(324)
 plt.scatter(x, y, s=80, c=z, marker=(5, 1))

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3818,11 +3818,6 @@ class Axes(_AxesBase):
             is 'face'. You may want to change this as well.
             If *None*, defaults to rcParams ``lines.linewidth``.
 
-        verts : sequence of (x, y), optional
-            If *marker* is *None*, these vertices will be used to construct
-            the marker.  The center of the marker is located at (0, 0) in
-            normalized units.  The overall marker is rescaled by *s*.
-
         edgecolors : color or sequence of color, optional, default: 'face'
             The edge color of the marker. Possible values:
 
@@ -3960,9 +3955,11 @@ class Axes(_AxesBase):
         scales = s   # Renamed for readability below.
 
         # to be API compatible
-        if marker is None and verts is not None:
-            marker = (verts, 0)
-            verts = None
+        if verts is not None:
+            cbook.warn_deprecated("3.0", name="'verts'", obj_type="kwarg",
+                                  alternative="'marker'")
+            if marker is None:
+                marker = verts
 
         # load default marker from rcParams
         if marker is None:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1743,7 +1743,7 @@ def test_scatter_marker():
                 c=[(1, 0, 0), 'y', 'b', 'lime'],
                 s=[60, 50, 40, 30],
                 edgecolors=['k', 'r', 'g', 'b'],
-                verts=verts)
+                marker=verts)
 
 
 @image_comparison(baseline_images=['scatter_2D'], remove_text=True,


### PR DESCRIPTION
The `marker` kwarg is completely compatible and more general.

Also closes #11390.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
