### PR TITLE
FIX: don't include text at -inf in bbox

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1145,8 +1145,10 @@ class Axis(artist.Artist):
         bb = []
 
         for a in [self.label, self.offsetText]:
-            if a.get_visible():
-                bb.append(a.get_window_extent(renderer))
+            bbox = a.get_window_extent(renderer)
+            if (np.isfinite(bbox.width) and np.isfinite(bbox.height) and
+                    a.get_visible()):
+                bb.append(bbox)
 
         bb.extend(ticklabelBoxes)
         bb.extend(ticklabelBoxes2)


### PR DESCRIPTION
## PR Summary

Adresses #11386, #5456.  See also #11417 that properly fixes the logit issues...

Code like below caused anything that required the `tightbbox` of the axes to fail for`logit` axes:

This PR does *not* fix logit axes, but instead ignores non-finite values of the text positions when calculating the bbox, since those are assumed to be invalid.  I suppose someone could also figure out how to fix logit, but I'm not too interested in digging into it.

```python
import matplotlib.pyplot as plt
import numpy as np
fig, ax = plt.subplots()

np.random.seed(1)
y = np.random.normal(loc=0.5, scale=0.4, size=1000)
y = y[(y > 0) & (y < 1)]
y.sort()
x = np.arange(len(y))
ax.plot(x, y)
ax.set_yscale('logit')
print(ax.get_tightbbox(fig.canvas.get_renderer()))
```
### Before
```
/Users/jklymak/matplotlib/lib/matplotlib/transforms.py:402: RuntimeWarning: invalid value encountered in double_scalars
  return points[1, 0] - points[0, 0]
Bbox(x0=-inf, y0=nan, x1=1155.5, y1=nan)
```

### After

```
Bbox(x0=-21.6925048828125, y0=58.15555555555555, x1=1155.5, y1=848.3)
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->