### PR TITLE
Properly position markers in step plots.

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -739,8 +739,8 @@ class Line2D(Artist):
             subslice = slice(max(i0 - 1, 0), i1 + 1)
             self.ind_offset = subslice.start
             self._transform_path(subslice)
-
-        transf_path = self._get_transformed_path()
+        else:
+            subslice = None
 
         if self.get_path_effects():
             from matplotlib.patheffects import PathEffectRenderer
@@ -748,7 +748,8 @@ class Line2D(Artist):
 
         renderer.open_group('line2d', self.get_gid())
         if self._lineStyles[self._linestyle] != '_draw_nothing':
-            tpath, affine = transf_path.get_transformed_path_and_affine()
+            tpath, affine = (self._get_transformed_path()
+                             .get_transformed_path_and_affine())
             if len(tpath.vertices):
                 gc = renderer.new_gc()
                 self._set_gc_clip(gc)
@@ -796,7 +797,20 @@ class Line2D(Artist):
             gc.set_foreground(ec_rgba, isRGBA=True)
 
             marker = self._marker
-            tpath, affine = transf_path.get_transformed_points_and_affine()
+
+            # Markers *must* be drawn ignoring the drawstyle (but don't pay the
+            # recaching if drawstyle is already "default").
+            if self.get_drawstyle() != "default":
+                with cbook._setattr_cm(
+                        self, _drawstyle="default", _transformed_path=None):
+                    self.recache()
+                    self._transform_path(subslice)
+                    tpath, affine = (self._get_transformed_path()
+                                    .get_transformed_path_and_affine())
+            else:
+                tpath, affine = (self._get_transformed_path()
+                                 .get_transformed_path_and_affine())
+
             if len(tpath.vertices):
                 # subsample the markers if markevery is not None
                 markevery = self.get_markevery()

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -1,6 +1,8 @@
 """
 Tests specific to the lines module.
 """
+
+from io import BytesIO
 import itertools
 import matplotlib.lines as mlines
 import pytest
@@ -195,3 +197,15 @@ def test_nan_is_sorted():
     assert line._is_sorted(np.array([1, 2, 3]))
     assert line._is_sorted(np.array([1, np.nan, 3]))
     assert not line._is_sorted([3, 5] + [np.nan] * 100 + [0, 2])
+
+
+def test_step_markers():
+    fig, ax = plt.subplots()
+    ax.step([0, 1], "-o")
+    buf1 = BytesIO()
+    fig.savefig(buf1)
+    fig, ax = plt.subplots()
+    ax.plot([0, 0, 1], [0, 1, 1], "-o", markevery=[0, 2])
+    buf2 = BytesIO()
+    fig.savefig(buf2)
+    assert buf1.getvalue() == buf2.getvalue()


### PR DESCRIPTION
Closes #11031.

While it may appear costly to recache the path at every draw, this only
occurs when using step plots with markers (a relatively rare case) and
is still better than before the bug was introduced (#6497), when step plots used
to need to be recomputed at every draw, regardless of whether markers
are present.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
