### PR TITLE
plt.box_bug_fix

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1282,19 +1282,24 @@ def tight_layout(pad=1.08, h_pad=None, w_pad=None, rect=None):
 
 def box(on=None):
     """
-    Turn the axes box on or off.
+    Turn the axes box on or off on the current axes.
 
     Parameters
     ----------
     on : bool or None
-        The new axes box state.  If ``None``, toggle the state.
+        The new `~matplotlib.axes.Axes` box state. If ``None``, toggle
+        the state.
+
+    See Also
+    --------
+    :meth:`matplotlib.axes.Axes.set_frame_on`
+    :meth:`matplotlib.axes.Axes.get_frame_on`
     """
     ax = gca()
-    on = _string_to_bool(on)
     if on is None:
         on = not ax.get_frame_on()
+    on = _string_to_bool(on)
     ax.set_frame_on(on)
-
 
 ## Axis ##
 

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -19,3 +19,15 @@ def test_pyplot_up_to_date():
         assert orig_contents == new_contents
     finally:
         Path(plt.__file__).write_text(orig_contents)
+
+
+def test_pyplot_box():
+    fig, ax = plt.subplots()
+    plt.box(False)
+    assert not ax.get_frame_on()
+    plt.box(True)
+    assert ax.get_frame_on()
+    plt.box()
+    assert not ax.get_frame_on()
+    plt.box()
+    assert ax.get_frame_on()


### PR DESCRIPTION
I found a small bug in `plt.box`. The toggling didn't work because `_string_to_bool` changed None to False before the test for None.

edit: I have no idea why `codecov/patch` complain.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
