### PR TITLE
Update documentation CSS

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -395,100 +395,114 @@ div.sphinxsidebar ul.toc ul li {
     padding: 0;
 }
 
-div.admonition, div.warning {
-    font-size: 0.9em;
-}
-
-div.warning {
-    color: #b94a48;
-    background-color: #F3E5E5;
-    border: 1px solid #eed3d7;
-}
-
-div.deprecated {
-    color: #606060;
-    background-color: #f0f0f0;
-    border: 1px solid #404040;
-}
-
-div.deprecated span.versionmodified {
-    color: #606060;
-    font-weight: bold;
-}
-
-div.green, div.hint {
-    color: #468847;
-    background-color: #dff0d8;
-    border: 1px solid #d6e9c6;
-}
-
-div.admonition p, div.warning p, div.deprecated p {
-    margin: 0.5em 1em 0.5em 1em;
-    padding: 0;
-}
-
-div.admonition pre, div.warning pre {
-    margin: 0.4em 1em 0.4em 1em;
-}
-
-div.admonition p.admonition-title + p {
-    display: inline;
-}
-
-
-div.admonition p.admonition-title,
-div.warning p.admonition-title {
-    margin: 0;
-    font-weight: bold;
-    font-size: 14px;
-}
+/* admonitions */
 
 div.admonition, div.deprecated {
-    margin-bottom: 10px;
-    margin-top: 10px;
-    padding: 7px;
-    border-radius: 4px;
-    -moz-border-radius: 4px;
+    margin: 10px 0px;
+    padding: 0.7em 1.4em;
+    border-left: 5px solid;
   }
 
 div.note {
     background-color: #eee;
-    border: 1px solid #ccc;
-}
-
-div.topic {
-    background-color: #eee;
-    border: 1px solid #CCC;
-    margin: 10px 0px;
-    padding: 7px 7px 0px;
-    border-radius: 4px;
-    -moz-border-radius: 4px;
-}
-
-p.topic-title {
-    font-size: 1.1em;
-    font-weight: bold;
+    border-color: #ccc;
 }
 
 div.seealso {
-    background-color: #FFFBE8;
-    border: 1px solid #fbeed5;
-    color: #AF8A4B;
+    background-color: #EAF1F7;
+    border-color: #8EADCC;
+    color: #3F5E7F;
   }
 
 div.warning {
-    border: 1px solid #940000;
+    background-color: #F3E5E5;
+    border-color: #CC8E8E;
+    color: #7F1919;
 }
 
-div.warning p.admonition-title {
-    border-bottom-color: #940000;
+div.deprecated {
+    background-color: #f0f0f0;
+    border-color: #404040;
+    color: #606060;
 }
 
-div.admonition ul, div.admonition ol,
-div.warning ul, div.warning ol {
-    margin: 0.1em 0.5em 0.5em 3em;
+div.deprecated span.versionmodified {
+    font-weight: bold;
+}
+
+div.green, div.hint {
+    background-color: #E1F2DA;
+    border-color: #A1CC8E;
+    color: #3F7F3F;
+}
+
+div.admonition p.admonition-title {
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+div.admonition p, div.deprecated p {
+    margin: 0.6em 0;
     padding: 0;
 }
+
+div.admonition pre {
+    margin: 0.6em 0;
+}
+
+div.admonition ul, div.admonition ol {
+    margin: 0.1em 0.5em 0.5em 2em;
+    padding: 0;
+}
+
+div.topic {
+    background-color: #f4f4f4;
+    border: 2px solid #ccc;
+    border-left: 0px;
+    border-right: 0px;
+    margin: 10px 0px;
+    padding: 1em 1.4em;
+}
+
+p.topic-title {
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+.contents ul {
+    list-style-type: none;
+    padding-left: 2em;
+}
+
+/* first level */
+.contents > ul {
+    padding-left: 0;
+}
+
+.multicol-toc > ul {
+    column-width: 250px;
+    column-gap: 60px;
+    -webkit-column-width: 250px;
+    -moz-column-width: 250px;
+    column-rule: 1px solid #ccc;
+}
+
+.multicol-toc > li {
+       /* break inside is not yet broadly supported, but we just try */
+    break-inside: avoid-column;
+    -moz-break-inside: avoid-column;
+    -webkit-break-inside: avoid-column;
+}
+
+.contents > ul > li {
+    padding-top: 0.7em;
+}
+
+.contents > ul > li > a {
+    font-size: 1.0em;
+}
+
+
 
 div.versioninfo {
     margin: 1em 0 0 0;
@@ -498,7 +512,6 @@ div.versioninfo {
     line-height: 1.3em;
     font-size: 0.9em;
 }
-
 
 a.headerlink {
     color: #c60f0f!important;
@@ -721,11 +734,6 @@ p.rubric {
     font-size: 19px;
     margin: 15px 0 10px 0;
 }
-p.admonition-title {
-    font-weight: bold;
-    text-decoration: underline;
-}
-
 
 #matplotlib-examples ul li{
   font-size: large;

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -142,10 +142,6 @@ dt:target,
     background-color: #ffffee;
 }
 
-dl.method, dl.attribute {
-    border-top: 1px solid #aaa;
-}
-
 dl.glossary dt {
     font-weight: bold;
     font-size: 1.1em;
@@ -677,7 +673,34 @@ table.docutils td {
 }
 
 
-dl.class em, dl.function em, dl.class big, dl.function big {
+/*** function and class description ***/
+/* top-level definitions */
+dl.class, dl.function {
+    border-top: 1px solid #888;
+    padding-top: 6px;
+    margin-top: 20px;
+}
+
+dl.method, dl.classmethod, dl.staticmethod, dl.attribute {
+    border-top: 1px solid #ccc;
+    padding-top: 6px;
+}
+
+em.property {
+    margin-right: 4px;
+}
+
+.sig-paren {
+    font-size: 14px;
+}
+
+.sig-paren ~ em {
+    font-weight: normal;
+    font-family: monospace;
+    font-size: 14px;
+}
+
+dl.class big, dl.function big {
     font-weight: normal;
     font-family: monospace;
 }
@@ -686,29 +709,23 @@ dl.class dd, dl.function dd {
     padding: 10px;
 }
 
-/* function and class description */
-dl.function, dl.method, dl.attribute {
-    border-top: 1px solid #ccc;
-    padding-top: 6px;
-}
-
-dl.function {
-    border-top: 1px solid #888;
-    margin-top: 15px;
-}
-
-dl.class {
-    padding-top: 6px;
-    margin-top: 15px;
+dl.class > dd {
+    padding: 10px;
+    padding-left: 35px;
+    margin-left: 0px;
+    border-left: 5px solid #f8f8f8;
 }
 
 .descclassname {
     color: #aaa;
     font-weight: normal;
     font-family: monospace;
+    font-size: 14px;
 }
+
 .descname {
     font-family: monospace;
+    font-size: 14px;
 }
 
 table.docutils.field-list {

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -426,8 +426,13 @@ div.deprecated {
     color: #606060;
 }
 
+span.versionmodified {
+    font-style: italic;
+}
+
 div.deprecated span.versionmodified {
     font-weight: bold;
+    font-style: normal;
 }
 
 div.green, div.hint {

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -290,10 +290,6 @@ p {
     margin: 0.8em 0 0.8em 0;
 }
 
-p.rubric {
-    font-weight: bold;
-}
-
 h1 {
     margin: 0.5em 0em;
     padding-top: 0.5em;
@@ -618,11 +614,50 @@ ul.keywordmatches li.goodmatch a {
 table.docutils {
     border-spacing: 2px;
     border-collapse: collapse;
-    border-top-width: 1px;
-    border-right-width: 0px;
-    border-bottom-width: 1px;
-    border-left-width: 0px;
+    border: 0px;
 }
+
+table.docutils th {
+    border-width: 1px 0px;
+    border-color: #888;
+    background-color: #f0f0f0;
+    width: 100px;
+}
+
+table.docutils td {
+    border-width: 1px 0px;
+    border-color: #ccc;
+}
+
+table.docutils tr:last-of-type td {
+    border-bottom-color: #888;
+}
+
+/* Section titles within classes */
+dl.class p.rubric {
+    font-size: 16px;
+}
+
+/* Attribute tables */
+dl.class p.rubric + table.docutils {
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-bottom: 1.5em;
+    border-top: 1px solid #888;
+    border-bottom: 1px solid #888;
+}
+
+dl.class p.rubric + table.docutils td {
+    padding-left: 0px;
+    border-color: #ccc;
+}
+
+dl.class p.rubric + table.docutils td:first-of-type > strong {
+    font-family: monospace;
+    font-size: 14px;
+    font-weight: normal;
+}
+
 
 /* module summary table */
 .longtable.docutils {
@@ -640,16 +675,28 @@ table.docutils {
 /* tables inside parameter descriptions */
 td.field-body table.property-table {
     width: 100%;
+    border-spacing: 2px;
+    border-collapse: collapse;
+    border: 0px;
 }
 
 td.field-body table.property-table th {
     padding: 2px 10px;
-    border: 0;
+    border-width: 1px 0px;
+    border-color: #888;
+    background-color: #f0f0f0;
 }
 
 td.field-body table.property-table td {
     padding: 2px 10px;
+    border-width: 1px 0px;
+    border-color: #ccc;
 }
+
+td.field-body table.property-table tr:last-of-type td {
+    border-bottom-color: #888;
+}
+
 
 /* function and class description */
 .descclassname {
@@ -660,18 +707,6 @@ td.field-body table.property-table td {
 .descname {
     font-family: monospace;
 }
-
-
-table.docutils th {
-    padding: 1px 8px 1px 5px;
-    background-color: #eee;
-    width: 100px;
-}
-
-table.docutils td {
-    border-width: 1px 0 1px 0;
-}
-
 
 /*** function and class description ***/
 /* top-level definitions */
@@ -728,29 +763,30 @@ dl.class > dd {
     font-size: 14px;
 }
 
+/* parameter section table */
 table.docutils.field-list {
     width: 100%;
 }
-
-.docutils.field-list th {
+.docutils.field-list th.field-name {
     background-color: #eee;
     padding: 10px;
     text-align: left;
     vertical-align: top;
     width: 125px;
 }
-.docutils.field-list td {
+.docutils.field-list td.field-body {
     padding: 10px 10px 10px 20px;
     text-align: left;
     vertical-align: top;
 }
-.docutils.field-list td blockquote p {
+.docutils.field-list td.field-body blockquote p {
     font-size: 13px;
     line-height: 18px;
 }
-.docutils.field-list td blockquote p ul li{
+.docutils.field-list td.field-body blockquote p ul li{
     font-size: 13px;
 }
+
 p.rubric {
     font-weight: bold;
     font-size: 19px;

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -810,7 +810,7 @@ figcaption {
   font-weight: bold;
   left: 0;
   min-height: 3em;
-  padding: 0.5em;
+  padding: 0.7em;
   top: 0;
   width: 100%;
   z-index: 10000;
@@ -829,7 +829,7 @@ figcaption {
   font-weight: bold;
   left: 0;
   min-height: 3em;
-  padding: 0.5em;
+  padding: 0.7em;
   position: fixed;
   top: 0;
   width: 100%;

--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -11,6 +11,7 @@
    :depth: 2
    :local:
    :backlinks: entry
+   :class: multicol-toc
 
 
 Plotting


### PR DESCRIPTION
## PR Summary

This updates the CSS of the documentation. In particular this

- Slightly increases the font size of signatures so that the stand out a bit from the following text.
- Changes style and color of admonitions and deprecated info. Text-related have now non-rounded edges and a bar on the left. The old style of boxes with rounded edges is now reserved to code and call signatures. This should make it easier to distinguish the two categories. See e.g. the hint example below.
- Changed the "See Also" color from yellow to blue. The original yellow color was hard to read and reminded more of a warning.
- Restyled the table of contents (optionally use multiple columns)
- Some fixes of CSS inconsistencies and duplicate definitions.

Following are some examples:


## Signature font size

### before:
![grafik](https://user-images.githubusercontent.com/2836374/41204977-35bda48e-6cec-11e8-81a5-72878bb8d2f1.png)

### after:
![grafik](https://user-images.githubusercontent.com/2836374/41204971-198bcd9a-6cec-11e8-9cb5-0d05a529015b.png)

## Deprecation

### before:
![grafik](https://user-images.githubusercontent.com/2836374/41205018-b7ac5cba-6cec-11e8-9c69-68fa3b3ea10b.png)

### after:
![grafik](https://user-images.githubusercontent.com/2836374/41205011-aa55503a-6cec-11e8-98b5-4a6cce0bf5bc.png)

## See Also

### before:
![grafik](https://user-images.githubusercontent.com/2836374/41205043-03c7597e-6ced-11e8-8213-c61a92f45258.png)

### after:
![grafik](https://user-images.githubusercontent.com/2836374/41205034-f52b334a-6cec-11e8-9ff0-40e0bd83cb46.png)  

## Warning

### before:
![grafik](https://user-images.githubusercontent.com/2836374/41205132-db1ecfec-6ced-11e8-8120-d0d2068247ab.png)

### after:
![grafik](https://user-images.githubusercontent.com/2836374/41205070-35ba5f58-6ced-11e8-8b34-51e16704c28a.png)



## Note

### before:
![grafik](https://user-images.githubusercontent.com/2836374/41205092-83f43edc-6ced-11e8-9122-cfb33fcf660e.png)

### after:
![grafik](https://user-images.githubusercontent.com/2836374/41205088-6bc891e6-6ced-11e8-94e1-9383fa99b285.png)

## Hint

### before
![grafik](https://user-images.githubusercontent.com/2836374/41205109-ab72d248-6ced-11e8-919d-429230ad6ff9.png)

### after:
![grafik](https://user-images.githubusercontent.com/2836374/41205097-94bf3cda-6ced-11e8-8725-00027ee45b0a.png)

## Table of contents

### before:
![grafik](https://user-images.githubusercontent.com/2836374/41206912-66a5ebe0-6d0c-11e8-818f-6d406218f555.png)

### after:
![grafik](https://user-images.githubusercontent.com/2836374/41206920-73250efa-6d0c-11e8-9c45-12be68659983.png)


