### PR TITLE
FIX: better default spine path (for logit)

### DIFF
--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -481,15 +481,15 @@ class Spine(mpatches.Patch):
         """
         (staticmethod) Returns a linear :class:`Spine`.
         """
-        # all values of 13 get replaced upon call to set_bounds()
+        # all values of 0.999 get replaced upon call to set_bounds()
         if spine_type == 'left':
-            path = mpath.Path([(0.0, 13), (0.0, 13)])
+            path = mpath.Path([(0.0, 0.999), (0.0, 0.999)])
         elif spine_type == 'right':
-            path = mpath.Path([(1.0, 13), (1.0, 13)])
+            path = mpath.Path([(1.0, 0.999), (1.0, 0.999)])
         elif spine_type == 'bottom':
-            path = mpath.Path([(13, 0.0), (13, 0.0)])
+            path = mpath.Path([(0.999, 0.0), (0.999, 0.0)])
         elif spine_type == 'top':
-            path = mpath.Path([(13, 1.0), (13, 1.0)])
+            path = mpath.Path([(0.999, 1.0), (0.999, 1.0)])
         else:
             raise ValueError('unable to make path for spine "%s"' % spine_type)
         result = cls(axes, spine_type, path, **kwargs)

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -17,7 +17,7 @@ def test_log_scales():
 @image_comparison(baseline_images=['logit_scales'], remove_text=True,
                   extensions=['png'])
 def test_logit_scales():
-    ax = plt.figure().add_subplot(111, xscale='logit')
+    fig, ax = plt.subplots()
 
     # Typical extinction curve for logit
     x = np.array([0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5,
@@ -25,7 +25,11 @@ def test_logit_scales():
     y = 1.0 / x
 
     ax.plot(x, y)
+    ax.set_xscale('logit')
     ax.grid(True)
+    bbox = ax.get_tightbbox(fig.canvas.get_renderer())
+    assert np.isfinite(bbox.x0)
+    assert np.isfinite(bbox.y0)
 
 
 def test_log_scatter():


### PR DESCRIPTION
## PR Summary

Closes #11386;  see also #11404 which fixes the errors for tight_layout and constrained_layout.

```python 
import matplotlib.pyplot as plt

fig, ax = plt. subplots()
ax.plot([0.1, 0.2, 0.6, 0.9])
ax.set_yscale('logit')
ax.set_ylabel('Boo')

plt.show()
```

gives a warning, and does not show the ylabel.  Issue is that the yaxis spine path is 
```
Path(array([[  0.,  13.],
       [  0.,  13.]]), None)
```
and `_update_label_position` needs a valid path to get started, whereas the logit scale injects Infs.

This PR changes the default PATH to something that would theoretically fit on the figures (and hence all values are less than 1).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->