### PR TITLE
DOC: make signature background grey

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -712,13 +712,23 @@ td.field-body table.property-table tr:last-of-type td {
 /* top-level definitions */
 dl.class, dl.function {
     border-top: 1px solid #888;
-    padding-top: 6px;
+    padding-top: 0px;
     margin-top: 20px;
 }
 
 dl.method, dl.classmethod, dl.staticmethod, dl.attribute {
     border-top: 1px solid #ccc;
-    padding-top: 6px;
+    padding-top: 0px;
+}
+
+
+dl.class > dt, dl.classmethod > dt, dl.method > dt, dl.function > dt, 
+dl.attribute > dt, dl.staticmethod > dt {
+    background-color: #eff3f4;
+    padding-left: 6px;
+    padding-right: 6px;
+    padding-top: 2px;
+    padding-bottom: 1px;
 }
 
 em.property {


### PR DESCRIPTION
## PR Summary

This is a follow up on #11411 where the signatures in the documentation did get a slightly larger font size. In addition, to give the docs a clearer structure, one could give the background of the signature lines a slight shade of grey. This allows for a better visual separation between several classes and functions.

### Before:

![image](https://user-images.githubusercontent.com/23121882/41286317-46de8dba-6e3f-11e8-8cb2-7eb1679bc873.png)


### After:

![image](https://user-images.githubusercontent.com/23121882/41286391-8fb88572-6e3f-11e8-9687-362d89a3c925.png)


