### PR TITLE
Doc: Remove huge note box from examples.

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -1056,6 +1056,10 @@ p.sphx-glr-signature {
    display: none !important;
 }
 
+div.sphx-glr-download-link-note {
+   display: none !important;
+}
+
 .sphx-glr-thumbcontainer a.internal {
     font-weight: 400;
 }


### PR DESCRIPTION
## PR Summary

Sphinx-gallery introduced a Note-Box on top of all examples linking to the bottom of each page from where to download the code. 

![image](https://user-images.githubusercontent.com/23121882/41320052-757ba4c8-6e9e-11e8-8df5-988e938baee4.png)


I find this unnecessary and disturbing. After all, a page should start with its title, not a note. Since there is no way to move that box somewhere else, my proposal is to remove it entirely. 

