### PR TITLE
Doc: Make first line in tables darker & bullets in tables

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -406,7 +406,7 @@ div.seealso {
     color: #3F5E7F;
   }
 
-div.warning {
+div.warning, div.important {
     background-color: #F3E5E5;
     border-color: #CC8E8E;
     color: #7F1919;
@@ -493,6 +493,12 @@ p.topic-title {
 
 .contents > ul > li {
     padding-top: 0.7em;
+}
+
+.contents ul > li::before {
+    content: "\25FE";
+    color: #bbb;
+    padding-right: .3em;
 }
 
 .contents > ul > li > a {
@@ -631,6 +637,10 @@ table.docutils td {
 
 table.docutils tr:last-of-type td {
     border-bottom-color: #888;
+}
+
+table.docutils tr:first-of-type td {
+    border-top-color: #888;
 }
 
 /* Section titles within classes */


### PR DESCRIPTION
## PR Summary

In #11411 @timhoffm made a nice general overhaul of the style sheet for the docs. During that process a little detail got lost. Previously the first and last border line of a table were darker, as to frame the table.  
This PR would restore this behaviour.
Left: Current table look, Right: with this PR

![image](https://user-images.githubusercontent.com/23121882/41322078-58dd647e-6ea7-11e8-9d5f-d36ed3751c2a.png) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![image](https://user-images.githubusercontent.com/23121882/41322261-5641da8c-6ea8-11e8-9d01-55765ee37014.png)

Additionally, I would like to reintroduce the bullets in tables that were removed in that PR

Previously:
![image](https://user-images.githubusercontent.com/23121882/41323572-7ffdfbc4-6eaf-11e8-9b3d-f0847d13a507.png)

With this PR:
![image](https://user-images.githubusercontent.com/23121882/41323547-4825b502-6eaf-11e8-8180-3a6209699a0b.png)

I also gave the "important" admonition the same color as the "warning", instead of it being white

![image](https://user-images.githubusercontent.com/23121882/41325870-de145304-6ebc-11e8-9ae3-29a858c0b5bb.png) &nbsp;&nbsp;&nbsp;&nbsp; ![image](https://user-images.githubusercontent.com/23121882/41325853-c99e54ce-6ebc-11e8-9392-cd6ffd84a1d6.png)





