### PR TITLE
Doc: Fix Patheditor example

### DIFF
--- a/examples/event_handling/path_editor.py
+++ b/examples/event_handling/path_editor.py
@@ -74,7 +74,7 @@ class PathInteractor(object):
         self.background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self.pathpatch)
         self.ax.draw_artist(self.line)
-        self.canvas.blit(self.ax.bbox)
+        # Do not blit here, because this happens before the screen update 
 
     def pathpatch_changed(self, pathpatch):
         'this method is called whenever the pathpatchgon object is called'


### PR DESCRIPTION
## PR Summary

The [path editor example](https://matplotlib.org/gallery/event_handling/path_editor.html) errors when being run with an interactive backend, due to a recursion in drawing the elements. 

This PR fixes this issue by not blitting inside the draw_event (because that happens before the screen update anyways).

