### PR TITLE
ENH: add get_gridspec convenience method to subplots

### DIFF
--- a/doc/users/next_whats_new/subplot_get_gridspec.rst
+++ b/doc/users/next_whats_new/subplot_get_gridspec.rst
@@ -1,0 +1,20 @@
+Add ``ax.get_gridspec`` to `.SubplotBase`
+-----------------------------------------
+
+New method `.SubplotBase.get_gridspec` is added so that users can
+easily get the gridspec that went into making as axes:
+
+  .. code::
+
+    import matplotlib.pyplot as plt
+
+    fig, axs = plt.subplots(3, 2)
+    gs = axs[0, -1].get_gridspec()
+
+    # remove the last column
+    for ax in axs[:,-1].flatten():
+      ax.remove()
+
+    # make a subplot in last column that spans rows.
+    ax = fig.add_subplot(gs[:, -1])
+    plt.show()

--- a/doc/users/next_whats_new/subplot_get_gridspec.rst
+++ b/doc/users/next_whats_new/subplot_get_gridspec.rst
@@ -2,7 +2,7 @@ Add ``ax.get_gridspec`` to `.SubplotBase`
 -----------------------------------------
 
 New method `.SubplotBase.get_gridspec` is added so that users can
-easily get the gridspec that went into making as axes:
+easily get the gridspec that went into making an axes:
 
   .. code::
 

--- a/examples/subplots_axes_and_figures/gridspec_and_subplots.py
+++ b/examples/subplots_axes_and_figures/gridspec_and_subplots.py
@@ -1,0 +1,24 @@
+"""
+==================================================
+Combining two subplots using subplots and GridSpec
+==================================================
+
+Sometimes we want to combine two subplots in an axes layout created with
+`~.Figure.subplots`.  We can get the `~.gridspec.GridSpec` from the axes
+and then remove the covered axes and fill the gap with a new bigger axes.
+Here we create a layout with the bottom two axes in the last column combined.
+
+See: :doc:`/tutorials/intermediate/gridspec`
+"""
+import matplotlib.pyplot as plt
+
+fig, axs = plt.subplots(ncols=3, nrows=3)
+gs = axs[1, 2].get_gridspec()
+# remove the underlying axes
+for ax in axs[1:, -1]:
+    ax.remove()
+axbig = fig.add_subplot(gs[1:, -1])
+axbig.annotate('Big Axes \nGridSpec[1:, -1]', (0.1, 0.5),
+               xycoords='axes fraction', va='center')
+
+fig.tight_layout()

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -117,6 +117,10 @@ class SubplotBase(object):
         """set the SubplotSpec instance associated with the subplot"""
         self._subplotspec = subplotspec
 
+    def get_gridspec(self):
+        """get the GridSpec instance associated with the subplot"""
+        return self._subplotspec.get_gridspec()
+
     def update_params(self):
         """update the subplot position from fig.subplotpars"""
 

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -143,3 +143,9 @@ def test_subplots_offsettext():
     axes[1, 0].plot(x, x)
     axes[0, 1].plot(y, x)
     axes[1, 1].plot(y, x)
+
+
+def test_get_gridspec():
+    # ahem, pretty trivial, but...
+    fig, ax = plt.subplots()
+    assert ax.get_subplotspec().get_gridspec() == ax.get_gridspec()

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -122,6 +122,22 @@ for r, row in enumerate(f5_axes):
 
 fig5.tight_layout()
 
+############################################################################
+# The ``subplots`` and ``gridspec`` methods can be combined since it is
+# sometimes more convenient to make most of the subplots using ``subplots``
+# and then remove some and combine them.  Here we create a layout with
+# the bottom two axes in the last column combined.
+
+fig, axs = plt.subplots(ncols=3, nrows=3)
+gs = axs[1, 2].get_gridspec()
+# remove the underlying axes
+for ax in axs[1:, -1]:
+    ax.remove()
+axbig = fig.add_subplot(gs[1:, -1])
+axbig.annotate('Big Axes \nGridSpec[1:, -1]', (0.1, 0.5),
+               xycoords='axes fraction', va='center')
+
+fig.tight_layout()
 
 ###############################################################################
 # Fine Adjustments to a Gridspec Layout


### PR DESCRIPTION
## PR Summary

As per #11434 its a bit of a pain to get the gridspec after calling `plt.subplots()`.  This change lets you do the following, where the only really change is that we don't have to do the more cumbersome `gs = ax.get_suplotspec().get_gridspec()`.  Much more discoverable.

~To do:  Add to gridspec tutorial which I'll d if this is in general OK.  I don't see the harm in adding this.~

```python
    import matplotlib.pyplot as plt

    fig, axs = plt.subplots(3, 2)
    gs = axs[0, -1].get_gridspec()

    # remove the last column
    for ax in axs[:,-1].flatten():
      ax.remove()

    # make a subplot in last column that spans rows.
    ax = fig.add_subplot(gs[:, -1])
    plt.show()
```



## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->