### PR TITLE
ENH: make subplot reuse gridspecs if they fit

### DIFF
--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -45,7 +45,7 @@ class SubplotBase(object):
                 except ValueError:
                     raise ValueError('Single argument to subplot must be '
                         'a 3-digit integer')
-                num = [num, num]
+                num = [int(num), int(num)]
             elif len(args) == 3:
                 rows, cols, num = args
                 rows = int(rows)
@@ -57,7 +57,7 @@ class SubplotBase(object):
                         raise ValueError(
                             ("num must be 1 <= num <= {maxn}, not {num}"
                             ).format(maxn=rows*cols, num=num))
-                    num = [num, num]
+                    num = [int(num), int(num)]
             else:
                 raise ValueError('Illegal argument(s) to subplot: %s' %
                         (args,))
@@ -65,7 +65,6 @@ class SubplotBase(object):
                     figure=self.figure)
             self._subplotspec = gs[(num[0] - 1):num[1]]
                 # num - 1 for converting from MATLAB to python indexing
-
 
         self.update_params()
 
@@ -98,6 +97,14 @@ class SubplotBase(object):
         for ax in axs:
             if hasattr(ax, 'get_subplotspec'):
                 gs = ax.get_subplotspec().get_gridspec()
+                if hasattr(gs, 'get_topmost_subplotspec'):
+                    # This is needed for colorbar gridspec layouts.
+                    # This is probably OK becase this whole logic tree
+                    # is for when the user is doing simple things with the
+                    # add_subplot command.  Complicated stuff, the proper
+                    # gridspec is passed in...
+                    gs = gs.get_topmost_subplotspec().get_gridspec()
+
                 (nrow, ncol) = gs.get_geometry()
                 if (not (nrow % rows) and not (ncol % cols)):
                     # this gridspec "fits"...

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1197,6 +1197,8 @@ default: 'top'
             fig.add_subplot(111, projection='polar')
 
             # add Subplot instance sub
+            gs = gridspec.GridSpec(2, 3)
+            sub = gs[1, 1]
             fig.add_subplot(sub)
 
         See Also

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -394,7 +394,7 @@ class SubplotSpec(object):
         self._gridspec = gridspec
         self.num1 = num1
         self.num2 = num2
-        if gridspec._layoutbox is not None:
+        if hasattr(gridspec, '_layoutbox') and gridspec._layoutbox is not None:
             glb = gridspec._layoutbox
             # So note that here we don't assign any layout yet,
             # just make the layoutbox that will conatin all items

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -151,14 +151,17 @@ def test_gca():
     assert fig.gca() is ax3
 
     # the final request for a polar axes will end up creating one
-    # with a spec of 111.
+    # with a spec of 121.  The 2 stays in there, because we reuse the
+    # grid spec of the 12x calls...
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         # Changing the projection will throw a warning
         assert fig.gca(polar=True) is not ax3
         assert len(w) == 1
+    assert fig.gca(polar=True) is not ax1
     assert fig.gca(polar=True) is not ax2
-    assert fig.gca().get_geometry() == (1, 1, 1)
+    assert fig.gca(polar=True) is not ax3
+    # assert fig.gca().get_geometry() == (1, 1, 1)
 
     fig.sca(ax1)
     assert fig.gca(projection='rectilinear') is ax1


### PR DESCRIPTION
## PR Summary

Right now, if we call

```python
import matplotlib.pyplot as plt
fig = plt.figure()

ax = fig.add_subplot(3, 4, 1)
ax2 = fig.add_subplot(3, 2, (3, 5))
print(ax.get_subplotspec().get_gridspec())
print(ax2.get_subplotspec().get_gridspec())

plt.show()
```

The gridspecs will be different.    Thats unfortunate, because there is no reason for these two subplots to not share the same gridspec, and if they do, then constrained_layout will work with them.  Note this change will mean that many calls to `pyplot.subplot` and `pyplot.subplot2grid` will now work with `constrained_layout=True` as well.  

This PR changes that so they two subplots use the same gridspec.  

**Note** The more fine-grained subplot call must come first, or the grid specs will not "fit", so this is pretty simple minded.  However, the PR doesn't make things worse, it just makes two gridspecs like it did before.  i.e. if we switch the order of the calls we get two gridspecs:

```python
import matplotlib.pyplot as plt
fig = plt.figure()

ax2 = fig.add_subplot(3, 2, (3, 5))
ax = fig.add_subplot(3, 4, 1)
print(ax.get_subplotspec().get_gridspec())
print(ax2.get_subplotspec().get_gridspec())

plt.show()
```


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->