### PR TITLE
changed paths in kwdocs

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1035,7 +1035,7 @@ class Artist(object):
 
 class ArtistInspector(object):
     """
-    A helper class to inspect an :class:`~matplotlib.artist.Artist` and return
+    A helper class to inspect an `~matplotlib.artist.Artist` and return
     information about its settable properties and their current values.
     """
 
@@ -1146,8 +1146,22 @@ class ArtistInspector(object):
                 if name in cls.__dict__:
                     source_class = cls.__module__ + "." + cls.__name__
                     break
+            source_class = self._replace_path(source_class)
             setters.append((name[4:], source_class + "." + name))
         return setters
+
+    def _replace_path(self, source_class):
+        """
+        Changes the full path to the public API path that is used
+        in sphinx. This is needed for links to work.
+        """
+
+        replace_dict = {'_base._AxesBase': 'Axes',
+                      '_axes.Axes': 'Axes'}
+
+        for key, value in replace_dict.items():
+            source_class = source_class.replace(key, value)
+        return source_class
 
     def get_setters(self):
         """
@@ -1443,12 +1457,32 @@ def setp(obj, *args, **kwargs):
     return list(cbook.flatten(ret))
 
 
-def kwdoc(a):
+def kwdoc(artist):
+    """
+    Inspect an `~matplotlib.artist.Artist` class and return
+    information about its settable properties and their current values.
+
+    It use the class `.ArtistInspector`.
+
+    Parameters
+    ----------
+    artist : `~matplotlib.artist.Artist` or an iterable of `Artist`\s
+
+    Returns
+    -------
+    string
+        Returns a string with a list or rst table with the settable properties
+        of the *artist*. The formating depends on the value of
+        :rc:`docstring.hardcopy`. False result in a list that is intended for
+        easy reading as a docstring and True result in a rst table intended
+        for rendering the documentation with sphinx.
+    """
     hardcopy = matplotlib.rcParams['docstring.hardcopy']
     if hardcopy:
-        return '\n'.join(ArtistInspector(a).pprint_setters_rest(
+        return '\n'.join(ArtistInspector(artist).pprint_setters_rest(
                          leadingspace=4))
     else:
-        return '\n'.join(ArtistInspector(a).pprint_setters(leadingspace=2))
+        return '\n'.join(ArtistInspector(artist).pprint_setters(
+                         leadingspace=2))
 
 docstring.interpd.update(Artist=kwdoc(Artist))


### PR DESCRIPTION
 The links to the axes properties where not rendered correctly in the kwdoc table because `axes._base` and `axes._axes` are not included in the documentation. This is a simple solution that change the paths.

edit: So the changes is in the rendered docstrings when `docstring.dedent_interpd` is used with `%(Axes)s`  (and maybe in some other docstrings)

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
