### PR TITLE
Link rcParams role to docs

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -23,6 +23,10 @@ a {
     text-decoration: none;
 }
 
+a:hover {
+    color: #2491CF;
+}
+
 div.highlight-python a {
     color: #CA7900;
 }
@@ -33,10 +37,6 @@ div.highlight-python a:hover {
 
 strong {
   font-weight: strong;
-}
-
-a:hover {
-    color: #2491CF;
 }
 
 pre {

--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -3,7 +3,14 @@ from docutils import nodes
 
 def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     rendered = nodes.Text('rcParams["{}"]'.format(text))
-    return [nodes.literal(rawtext, rendered)], []
+
+    rel_source = inliner.document.attributes['source'].split('/doc/', 1)[1]
+    levels = rel_source.count('/')
+    refuri = ('../' * levels +
+              'tutorials/introductory/customizing.html#matplotlib-rcparams')
+
+    ref = nodes.reference(rawtext, rendered, refuri=refuri)
+    return [nodes.literal('', '', ref)], []
 
 
 def setup(app):


### PR DESCRIPTION
## PR Summary

Follow up to #10226. This turns the text generated by the `:rc:` role into a link to the rc documentation.

Note: I'm no expert in docutils and it's really difficult to find good documentation. There generation of the `refuri` feels a bit clumsy, because I have to build the final url. Naturally, one would like to have some function `label_to_uri('matplotlib-rcparams')` but I couldn't find something like that. The downside is that we rely on a hard coded file structure, but I can live with that (We're not likely to change that often).