### PR TITLE
Slightly improve doc sidebar layout

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -245,7 +245,8 @@ div.sphinxsidebar h3 a {
 
 div.sphinxsidebar ul {
     padding-left: 1.5em;
-    margin-top: 7px;
+    margin-top: 10px;
+    margin-bottom: 10px;
     list-style: none;
     padding: 0;
     line-height: 130%;
@@ -253,7 +254,9 @@ div.sphinxsidebar ul {
 
 div.sphinxsidebar ul ul {
     list-style: square;
-    margin-left: 20px;
+    margin-top: 6px;
+    margin-bottom: 6px;
+    margin-left: 16px;
 }
 
 div.sphinxsidebar #searchbox input {


### PR DESCRIPTION
## PR Summary

- adjusted vertical spacing between elements
- slightly reduced indentation so that longer items will fit a bit better (some items will still always be too long).

old / new

![grafik](https://user-images.githubusercontent.com/2836374/41501963-e8406aee-71ae-11e8-89e1-1bc581edf119.png)  ![grafik](https://user-images.githubusercontent.com/2836374/41501969-fda639b8-71ae-11e8-9207-74dd9cd9e6b4.png)

