### PR TITLE
Cleanup Matplotlib API docs

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -40,7 +40,7 @@ endif %}>
         <li><a href="{{ pathto('index') }}">home</a>|&nbsp;</li>
         <li><a href="{{ pathto('gallery/index') }}">examples</a>|&nbsp;</li>
         <li><a href="{{ pathto('tutorials/index') }}">tutorials</a>|&nbsp;</li>
-        <li><a href="{{ pathto('api/pyplot_summary') }}">pyplot</a>|&nbsp;</li>
+        <li><a href="{{ pathto('api/api_overview') }}">API</a>|&nbsp;</li>
         <li><a href="{{ pathto('contents') }}">docs</a> &raquo;</li>
 
         {%- for parent in parents %}

--- a/doc/api/api_overview.rst
+++ b/doc/api/api_overview.rst
@@ -1,0 +1,55 @@
+API Overview
+============
+
+Below we describe several common approaches to plotting with Matplotlib.
+
+.. contents::
+
+The pyplot API
+--------------
+
+`matplotlib.pyplot` is a collection of command style functions that make
+Matplotlib work like MATLAB. Each pyplot function makes some change to a
+figure: e.g., creates a figure, creates a plotting area in a figure, plots
+some lines in a plotting area, decorates the plot with labels, etc.
+
+`.pyplot` is mainly intended for interactive plots and simple cases of
+programmatic plot generation.
+
+Further reading:
+
+- The `matplotlib.pyplot` function reference
+- :doc:`/tutorials/introductory/pyplot`
+- :ref:`Pyplot examples <pyplots_examples>`
+
+The object-oriented API
+-----------------------
+
+At its core, Matbplotlib is object-oriented. We recommend directly working
+with the objects, if you need more control and customization of your plots.
+
+In many cases you will create a `.Figure` and one or more
+`~matplotlib.axes.Axes` using `.pyplot.subplots` and from then on only work
+on these objects. However, it's also possible to create `.Figure`\ s
+explicitly (e.g. when including them in GUI applications).
+
+Further reading:
+
+- `matplotlib.axes.Axes` and `matplotlib.figure.Figure` for an overview of
+  plotting functions.
+- Most of the :ref:`examples <examples-index>` use the object-oriented approach
+  (except for the pyplot section).
+
+
+The pylab API (disapproved)
+---------------------------
+
+.. warning::
+   Since heavily importing into the global namespace may result in unexpected
+   behavior, the use of pylab is strongly discouraged. Use `matplotlib.pyplot`
+   instead.
+
+`matplotlib.pylab` is a module that includes `matplotlib.pyplot`, `numpy`
+and some additional functions within a single namespace. It's original puropse
+was to mimic a MATLAB-like way of working by importing all functions into the
+global namespace. This is considered bad style nowadays.

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -4,17 +4,20 @@
   The Matplotlib API
 ####################
 
-.. only:: html
+.. toctree::
+   :maxdepth: 1
 
-   :Release: |version|
-   :Date: |today|
+   api_overview.rst
+   api_changes.rst
+
+Modules
+=======
 
 .. toctree::
    :maxdepth: 1
 
-   pyplot_summary.rst
-   api_changes.rst
    matplotlib_configuration_api.rst
+   pyplot_summary.rst
    afm_api.rst
    animation_api.rst
    artist_api.rst
@@ -60,22 +63,13 @@
    units_api.rst
    widgets_api.rst
 
-.. currentmodule:: matplotlib
-
-.. autosummary::
-   :toctree: _as_gen
-   :template: autofunctions.rst
-
-   pyplot
-
-
 Toolkits
---------
+========
 
 .. toctree::
    :maxdepth: 1
 
-   
+   toolkits/index.rst
    toolkits/mplot3d.rst
    toolkits/axes_grid1.rst
    toolkits/axisartist.rst

--- a/doc/api/pyplot_summary.rst
+++ b/doc/api/pyplot_summary.rst
@@ -1,33 +1,19 @@
-Below we describe several common approaches to plotting with Matplotlib.
+Pyplot function overview
+------------------------
 
-.. contents::
+.. currentmodule:: matplotlib
 
-The Pyplot API
---------------
+.. autosummary::
+   :toctree: _as_gen
+   :template: autofunctions.rst
 
-The :mod:`matplotlib.pyplot` module contains functions that allow you to generate
-many kinds of plots quickly. For examples that showcase the use
-of the :mod:`matplotlib.pyplot` module, see the
-:doc:`/tutorials/introductory/pyplot`
-or the :ref:`pyplots_examples`. We also recommend that you look into
-the object-oriented approach to plotting, described below.
+   pyplot
+
 
 .. currentmodule:: matplotlib.pyplot
 
 .. autofunction:: plotting
 
-The Object-Oriented API
------------------------
-
-Most of these functions also exist as methods in the
-:class:`matplotlib.axes.Axes` class. You can use them with the
-"Object Oriented" approach to Matplotlib.
-
-While it is easy to quickly generate plots with the
-:mod:`matplotlib.pyplot` module,
-we recommend using the object-oriented approach for more control
-and customization of your plots. See the methods in the
-:meth:`matplotlib.axes.Axes` class for many of the same plotting functions.
 
 Colors in Matplotlib
 --------------------
@@ -37,5 +23,7 @@ Below we list several ways in which color can be utilized in Matplotlib.
 
 For a more in-depth look at colormaps, see the
 :doc:`/tutorials/colors/colormaps` tutorial.
+
+.. currentmodule:: matplotlib.pyplot
 
 .. autofunction:: colormaps

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -16,10 +16,9 @@ Overview
 
    users/index.rst
    faq/index.rst
-   api/toolkits/index.rst
+   api/index.rst
    resources/index.rst
    thirdpartypackages/index.rst
-   api/index.rst
    devel/index.rst
    glossary/index.rst
 

--- a/doc/users/index.rst
+++ b/doc/users/index.rst
@@ -12,11 +12,11 @@ User's Guide
 .. toctree::
     :maxdepth: 2
 
-    history.rst
     installing.rst
     ../tutorials/index.rst
     interactive.rst
     whats_new.rst
+    history.rst
     github_stats.rst
     license.rst
     credits.rst


### PR DESCRIPTION
## PR Summary

This PR cleans up some parts of the Matplotlib API documentation structure. Links in the following refer to the existing documentation. Links to the changes will be added once the documentation is built.

- Order of topics in Users Guide (https://matplotlib.org/contents.html): Moved "History" behind "What's new". This is not one of the most important or looked for topics and should thus be further down the list
- Restructured the [API toc](https://matplotlib.org/api/index.html) into blocks
  - General Information
  - Modules
  - Toolkits
- <s>Renamed [`pyplot_summary.rst`](https://matplotlib.org/api/pyplot_summary.html) to `api_overview.rst` because that's what it actually contains. Additionally rewrote parts of the descriptions to be more to the point.
  *Note:* The "Colors in Matplotlib" section is still in here. It should be moved somewhere else - something like a concepts section (which I don't think exists in that form currently). For now, I'll still leave it here. Can be worked on in a separate PR.</s>
- <s>Switched the link of the top-level `pyplot` menu entry to link to https://matplotlib.org/api/_as_gen/matplotlib.pyplot.html This contains essentially the same information as the former `pyplot_summary.rst`, including the list of functions.
  *Note:* Not sure if it's reasonable to have a pyplot entry in the top level menu, but I'll leave that for now. May be worked on in a separate PR.</s>

Edit:
- Created [`api_overview.rst`](https://10586-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/api_overview.html) and moved the relevant parts of [`pyplot_summary.rst`](https://matplotlib.org/api/pyplot_summary.html) there.
  Replaced the `pyplot` link in the main menu by `API`, linking to the above API overview.




