### PR TITLE
add subplots to axes documentation

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -1,11 +1,13 @@
-================
- ``Axes`` class
-================
+====
+axes
+====
+
 .. currentmodule:: matplotlib.axes
 
 .. autoclass:: Axes
    :no-members:
    :no-undoc-members:
+   :show-inheritance:
 
 .. contents:: Table of Contents
    :depth: 2
@@ -13,6 +15,16 @@
    :backlinks: entry
    :class: multicol-toc
 
+Subplots
+========
+
+.. autosummary::
+   :toctree: _as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   SubplotBase
+   subplot_class_factory
 
 Plotting
 ========

--- a/doc/api/figure_api.rst
+++ b/doc/api/figure_api.rst
@@ -18,6 +18,7 @@ Classes
 .. autosummary::
    :toctree: _as_gen/
    :template: autosummary.rst
+   :nosignatures:
 
    AxesStack
    Figure
@@ -29,6 +30,6 @@ Functions
 .. autosummary::
    :toctree: _as_gen/
    :template: autosummary.rst
+   :nosignatures:
 
    figaspect
-   

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -187,11 +187,13 @@ class SubplotBase(object):
 
 @functools.lru_cache(None)
 def subplot_class_factory(axes_class=None):
-    # This makes a new class that inherits from SubplotBase and the
-    # given axes_class (which is assumed to be a subclass of Axes).
-    # This is perhaps a little bit roundabout to make a new class on
-    # the fly like this, but it means that a new Subplot class does
-    # not have to be created for every type of Axes.
+    """
+    This makes a new class that inherits from `.SubplotBase` and the
+    given axes_class (which is assumed to be a subclass of `.axes.Axes`).
+    This is perhaps a little bit roundabout to make a new class on
+    the fly like this, but it means that a new Subplot class does
+    not have to be created for every type of Axes.
+    """
     if axes_class is None:
         axes_class = Axes
     return type("%sSubplot" % axes_class.__name__,


### PR DESCRIPTION
Added the ` _subplots` module to the axes documentation. Changed `subplot_class_factory` docstring to a docstring and put `:nosignatures:` in the `figure_api.rst` file because I think it looks nicer.

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
