### PR TITLE
Backport #10971 onto v2.2.2-doc.

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -132,6 +132,8 @@ if sys.version_info >= (3, 6):
 # matplotlib.testing.image_comparison
 @pytest.mark.parametrize('writer, output', WRITER_OUTPUT)
 def test_save_animation_smoketest(tmpdir, writer, output):
+    if writer == 'pillow':
+        pytest.importorskip("PIL")
     try:
         # for ImageMagick the rcparams must be patched to account for
         # 'convert' being a built in MS tool, not the imagemagick


### PR DESCRIPTION
Skip pillow animation test if pillow not importable

IIRC, this fixes the macOS builds.