### PR TITLE
Skip pillow 5.1.0 on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ env:
     - NOSE=
     - NUMPY=numpy
     - PANDAS=
+    - PILLOW=pillow
     - PYPARSING=pyparsing
     - PYTEST='pytest!=3.3.0,>=3.2.0'
     - PYTEST_COV=pytest-cov
@@ -87,7 +88,9 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: MOCK=mock
+      env:
+        - MOCK=mock
+        - PILLOW='pillow!=5.1.0'
       only: master
       cache:
         # As for now travis caches only "$HOME/.cache/pip"
@@ -139,7 +142,7 @@ install:
         $PANDAS \
         codecov \
         coverage \
-        pillow \
+        $PILLOW \
         $PYPARSING \
         $DATEUTIL \
         $SPHINX


### PR DESCRIPTION
This version is broken, cf. python-pillow/Pillow#3068.

We only really care about `v2.2.x`, but might as well fix the doc build too.