### PR TITLE
Fixed the source path on windows in rcparam_role

### DIFF
--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -1,10 +1,13 @@
 from docutils import nodes
+from os.path import sep
 
 
 def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     rendered = nodes.Text('rcParams["{}"]'.format(text))
 
-    rel_source = inliner.document.attributes['source'].split('/doc/', 1)[1]
+    source = inliner.document.attributes['source'].replace(sep, '/')
+    rel_source = source.split('/doc/', 1)[1]
+
     levels = rel_source.count('/')
     refuri = ('../' * levels +
               'tutorials/introductory/customizing.html#matplotlib-rcparams')


### PR DESCRIPTION
 `inliner.document.attributes['source']` returns a string with `\\` on windows and this pull request change those to `/`, as the rest of the code expects. 

I used os.path.sep.
~~I don't know if it would be better to use `os.path.sep` instead of `\\` or some other replacement method.~~

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
