### PR TITLE
add __repr__ to GridSpecBase

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -44,6 +44,18 @@ class GridSpecBase(object):
         self.set_height_ratios(height_ratios)
         self.set_width_ratios(width_ratios)
 
+    def __repr__(self):
+        height_arg = (', height_ratios=%r' % self._row_height_ratios
+                      if self._row_height_ratios is not None else '')
+        width_arg = (', width_ratios=%r' % self._col_width_ratios
+                     if self._col_width_ratios is not None else '')
+        return '{clsname}({nrows}, {ncols}{optionals})'.format(
+            clsname=self.__class__.__name__,
+            nrows=self._nrows,
+            ncols=self._ncols,
+            optionals=height_arg + width_arg,
+            )
+
     def get_geometry(self):
         'get the geometry of the grid, e.g., 2,3'
         return self._nrows, self._ncols


### PR DESCRIPTION
## PR Summary

While playing around with gridspecs I found it convenient to have the repr of GridSpec show the number of columns and rows.