### PR TITLE
Make CI fail if interactive toolkits can't be tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,6 @@ matrix:
     - python: "nightly"
       env: PRE=--pre
     - os: osx
-      python: 3.6
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       only: master
       cache:
@@ -104,7 +103,7 @@ before_install: |
     export PATH=/usr/lib/ccache:$PATH
   else
     ci/silence brew update
-    brew upgrade python
+    brew upgrade python3.6
     brew install ffmpeg imagemagick mplayer ccache
     hash -r
     which python

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,25 +124,16 @@ install:
   - |
     # Install dependencies from PyPI.
     python -mpip install --upgrade $PRE -r requirements/testing/travis_all.txt $EXTRAREQS $PINNEDVERS
-    # GUI toolkits are pip-installable only for some versions of Python so
-    # don't fail if we can't install them.  Make it easier to check whether the
-    # install was successful by trying to import the toolkit (sometimes, the
+    # Check for the successful installation of GUI toolkits (sometimes, the
     # install appears to be successful but shared libraries cannot be loaded at
     # runtime, so an actual import is a better check).
-    python -mpip install cairocffi pgi &&
-      python -c 'import pgi as gi; gi.require_version("Gtk", "3.0"); from pgi.repository import Gtk' &&
-      echo 'pgi is available' ||
-      echo 'pgi is not available'
-    python -mpip install pyqt5 &&
-      python -c 'import PyQt5.QtCore' &&
-      echo 'PyQt5 is available' ||
-      echo 'PyQt5 is not available'
-    python -mpip install -U \
-      -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 \
-      wxPython &&
-      python -c 'import wx' &&
-      echo 'wxPython is available' ||
-      echo 'wxPython is not available'
+    if [[ $TRAVIS_OS_NAME = linux ]]; then
+      # pgi is only installable on Linux.
+      python -mpip install --upgrade $PRE cairocffi pgi
+      python -c 'import pgi as gi; gi.require_version("Gtk", "3.0"); from pgi.repository import Gtk'
+    fi
+    python -c 'import PyQt5.QtCore'
+    python -c 'import wx'
 
   - |
     # Install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ matrix:
     - python: "nightly"
       env: PRE=--pre
     - os: osx
+      python: 3.6
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       only: master
       cache:

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -1,13 +1,22 @@
 # pip requirements for all the travis builds
 
+--find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04
+
 codecov
 coverage
-cycler
-numpy
 pillow
 pyparsing
+
+# GUI toolkits
+
+# pgi is only installable on Linux.
+pyqt5
+# wxpython 4.0.2 and 4.0.3 are broken on OSX.
+wxpython!=4.0.2,!=4.0.3
+
 # pytest-timeout master depends on pytest>=3.6. Testing with pytest 3.4 is
-# still supported; this is tested by the first travis python 3.5 build
+# still supported; this is tested by the first travis python 3.5 build.
+
 pytest>=3.6
 pytest-cov
 pytest-faulthandler


### PR DESCRIPTION
~~PyQt5.11 appears to break the build (I can reproduce the failure
locally).~~

Also make it a failure to fail to install the GUI toolkits for testing,
to avoid missing new failures there.

Also supersedes #11494.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
