### PR TITLE
Fix embedding_in_tk_canvas example.

### DIFF
--- a/examples/user_interfaces/embedding_in_tk_canvas_sgskip.py
+++ b/examples/user_interfaces/embedding_in_tk_canvas_sgskip.py
@@ -9,9 +9,10 @@ Embedding plots in a Tk Canvas.
 import tkinter
 
 import numpy as np
-import matplotlib as mpl
-import matplotlib.backends.tkagg as tkagg
+# There is no public API for blitting to a tk canvas.
+from matplotlib.backends import _backend_tk
 from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 
 
 def draw_figure(canvas, figure, loc=(0, 0)):
@@ -29,8 +30,9 @@ def draw_figure(canvas, figure, loc=(0, 0)):
     # Position: convert from top-left anchor to center anchor
     canvas.create_image(loc[0] + figure_w/2, loc[1] + figure_h/2, image=photo)
 
-    # Unfortunately, there's no accessor for the pointer to the native renderer
-    tkagg.blit(photo, figure_canvas_agg.get_renderer()._renderer, colormode=2)
+    # There is no public accessor for the pointer to the native renderer.
+    _backend_tk.blit(
+        photo, figure_canvas_agg.get_renderer()._renderer, (0, 1, 2, 3))
 
     # Return a handle which contains a reference to the photo object
     # which must be kept live or else the picture disappears
@@ -48,7 +50,7 @@ X = np.linspace(0, 2 * np.pi, 50)
 Y = np.sin(X)
 
 # Create the figure we desire to add to an existing canvas
-fig = mpl.figure.Figure(figsize=(2, 1))
+fig = Figure(figsize=(2, 1))
 ax = fig.add_axes([0, 0, 1, 1])
 ax.plot(X, Y)
 


### PR DESCRIPTION
1. Import Figure explicitly (otherwise the example fails to run with
   "'matplotlib' has no attribute 'figure'").
2. `mpl.backends.tkagg` is deprecated, replace by
   `mpl.backends._backend_tk`.  The example already relies on a private
   API so introducing another is less an issue -- whether to provide a
   public API to achieve the same would be a separate issue; I don't
   think this is particularly necessary unless someone actually asks for
   it.

(marking as release critical as the example fails to run otherwise)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
