### PR TITLE
Update legend loc default value in docstring

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -111,7 +111,7 @@ class DraggableLegend(DraggableOffsetBox):
 
 
 _legend_kw_doc = '''
-loc : int or string or pair of floats, default: 'upper right'
+loc : int or string or pair of floats, default: :rc:`legend.loc`
     The location of the legend. Possible codes are:
 
         ===============   =============


### PR DESCRIPTION
## PR Summary

The default value for legends' `loc` parameter is stated to be `upper right` in the docstring, but it is actually [read from the rcParam `legend.loc`](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/legend.py#L483-L484). Only when the parent of the legend is a figure and the default rcParam is `'best'`, this is overwritten with `'upper right'` since automated legend positioning is not implemented for figures. This can be confusing, as indicated by the [two last comments here](https://github.com/matplotlib/matplotlib/issues/8366#issuecomment-289290918).

Ideally, I would like to add to this PR and make the difference between legends of figures and axes objects explicit, e.g. ```default: :rc:`legend.loc` ('best' for axes, 'upper right' for figures)```, but I noticed elsewhere in the documentation that the default parameter values are not explicitly stated, so I didn't want suggest an inconsistent change here. 

An alternative would be to [not silently change the default value for figures](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/legend.py#L485-L486), but instead raise [the same warning as when `loc='best'` is specified manually](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/legend.py#L502-L506), also when the rcParam is set to `'best'` (so just remove lines 485-486).

## PR Checklist

- ~~Has Pytest style unit tests~~
- [x] Code is PEP 8 compliant
- ~~New features are documented, with examples if plot related~~
- [x] Documentation is sphinx and numpydoc compliant
- ~~Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- ~~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~