### PR TITLE
Add private API retrieving the current event loop and backend GUI info.

### DIFF
--- a/doc/api/next_api_changes/2018-06-27-AL.rst
+++ b/doc/api/next_api_changes/2018-06-27-AL.rst
@@ -4,3 +4,10 @@ Changes to backend loading
 Failure to load backend modules (``macosx`` on non-framework builds and
 ``gtk3`` when running headless) now raises `ImportError` (instead of
 `RuntimeError` and `TypeError`, respectively.
+
+Third-party backends that integrate with an interactive framework are now
+encouraged to define the ``required_interactive_framework`` global value to one
+of the following values: "qt5", "qt4", "gtk3", "wx", "tk", or "macosx". This
+information will be used to determine whether it is possible to switch from a
+backend to another (specifically, whether they use the same interactive
+framework).

--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -1,5 +1,7 @@
 import importlib
 import logging
+import os
+import sys
 import traceback
 
 import matplotlib
@@ -12,6 +14,54 @@ _backend_loading_tb = "".join(
     line for line in traceback.format_stack()
     # Filter out line noise from importlib line.
     if not line.startswith('  File "<frozen importlib._bootstrap'))
+
+
+def _get_running_interactive_framework():
+    """
+    Return the interactive framework whose event loop is currently running, if
+    any, or "headless" if no event loop can be started, or None.
+
+    Returns
+    -------
+    Optional[str]
+        One of the following values: "qt5", "qt4", "gtk3", "wx", "tk",
+        "macosx", "headless", ``None``.
+    """
+    QtWidgets = (sys.modules.get("PyQt5.QtWidgets")
+                 or sys.modules.get("PySide2.QtWidgets"))
+    if QtWidgets and QtWidgets.QApplication.instance():
+        return "qt5"
+    QtGui = (sys.modules.get("PyQt4.QtGui")
+             or sys.modules.get("PySide.QtGui"))
+    if QtGui and QtGui.QApplication.instance():
+        return "qt4"
+    Gtk = (sys.modules.get("gi.repository.Gtk")
+           or sys.modules.get("pgi.repository.Gtk"))
+    if Gtk and Gtk.main_level():
+        return "gtk3"
+    wx = sys.modules.get("wx")
+    if wx and wx.GetApp():
+        return "wx"
+    tkinter = sys.modules.get("tkinter")
+    if tkinter:
+        for frame in sys._current_frames().values():
+            while frame:
+                if frame.f_code == tkinter.mainloop.__code__:
+                    return "tk"
+                frame = frame.f_back
+    try:
+        from matplotlib.backends import _macosx
+    except ImportError:
+        pass
+    else:
+        # Note that the NSApp event loop is also running when a non-native
+        # toolkit (e.g. Qt5) is active, but in that case we want to report the
+        # other toolkit; thus, this check comes after the other toolkits.
+        if _macosx.event_loop_is_running():
+            return "macosx"
+    if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
+        return "headless"
+    return None
 
 
 def pylab_setup(name=None):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -994,6 +994,7 @@ Toolbar = ToolbarTk
 
 @_Backend.export
 class _BackendTk(_Backend):
+    required_interactive_framework = "tk"
     FigureManager = FigureManagerTk
 
     @classmethod

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -976,6 +976,7 @@ Toolbar = ToolbarGTK3
 
 @_Backend.export
 class _BackendGTK3(_Backend):
+    required_interactive_framework = "gtk3"
     FigureCanvas = FigureCanvasGTK3
     FigureManager = FigureManagerGTK3
 

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -185,6 +185,7 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
 
 @_Backend.export
 class _BackendMac(_Backend):
+    required_interactive_framework = "macosx"
     FigureCanvas = FigureCanvasMac
     FigureManager = FigureManagerMac
 

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -7,4 +7,4 @@ from .backend_qt5 import FigureCanvasQT as FigureCanvasQT5
 
 @_BackendQT5.export
 class _BackendQT4(_BackendQT5):
-    pass
+    required_interactive_framework = "qt4"

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -1109,6 +1109,7 @@ def exception_handler(type, value, tb):
 
 @_Backend.export
 class _BackendQT5(_Backend):
+    required_interactive_framework = "qt5"
     FigureCanvas = FigureCanvasQT
     FigureManager = FigureManagerQT
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1930,6 +1930,7 @@ class PrintoutWx(wx.Printout):
 
 @_Backend.export
 class _BackendWx(_Backend):
+    required_interactive_framework = "wx"
     FigureCanvas = FigureCanvasWx
     FigureManager = FigureManagerWx
     _frame_class = FigureFrameWx

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2790,6 +2790,16 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
 @end
 
 static PyObject*
+event_loop_is_running(PyObject* self)
+{
+    if ([NSApp isRunning]) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
+}
+
+static PyObject*
 show(PyObject* self)
 {
     [NSApp activateIgnoringOtherApps: YES];
@@ -3038,6 +3048,11 @@ static bool verify_framework(void)
 }
 
 static struct PyMethodDef methods[] = {
+   {"event_loop_is_running",
+    (PyCFunction)event_loop_is_running,
+    METH_NOARGS,
+    "Return whether the NSApp main event loop is currently running."
+   },
    {"show",
     (PyCFunction)show,
     METH_NOARGS,


### PR DESCRIPTION
Work towards implementation of backend switching (#9795).

Note that the API is kept private for now as the lack of extensibility
is a bit unsatisfying; perhaps we'll figure out a better way to do it
if other custom implementers (e.g., code editors?) get interested in
looking into it.

The `required_event_loop` variable could be made private for now, or
not...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
