### PR TITLE
Add missing `.` to rcParam

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -700,7 +700,7 @@ default: 'top'
             The font size of the text. See `.Text.set_size` for possible
             values.
 
-        fontweight, weight : default: :rc:`figuretitleweight`
+        fontweight, weight : default: :rc:`figure.titleweight`
             The font weight of the text. See `.Text.set_weight` for possible
             values.
 


### PR DESCRIPTION
## PR Summary
Just noticed a missing `.` when reading the figure docstring.

## PR Checklist

- ~~Has Pytest style unit tests~~
- [x] Code is PEP 8 compliant
- ~~New features are documented, with examples if plot related~~
- [x] Documentation is sphinx and numpydoc compliant
- ~~Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- ~~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~