### PR TITLE
Small cleanups.

### DIFF
--- a/doc/api/next_api_changes/2018-02-26-AL-removals.rst
+++ b/doc/api/next_api_changes/2018-02-26-AL-removals.rst
@@ -36,3 +36,7 @@ The following deprecated API elements have been removed:
 - passing non-numbers to ``EngFormatter.format_eng``,
 - passing ``frac`` to ``PolarAxes.set_theta_grids``,
 - any mention of idle events,
+
+The following API elements have been removed:
+
+- ``matplotlib.sphinxext.sphinx_version``,

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -153,12 +153,6 @@ from docutils.parsers.rst.directives.images import Image
 align = Image.align
 import sphinx
 
-sphinx_version = sphinx.__version__.split(".")
-# The split is necessary for sphinx beta versions where the string is
-# '6b1'
-sphinx_version = tuple([int(re.split('[^0-9]', x)[0])
-                        for x in sphinx_version[:2]])
-
 import jinja2  # Sphinx dependency.
 
 import matplotlib

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -1,4 +1,5 @@
 import functools
+import locale
 import warnings
 
 import matplotlib as mpl
@@ -24,8 +25,6 @@ def set_reproducibility_for_testing():
 def setup():
     # The baseline images are created in this locale, so we should use
     # it during all of the tests.
-    import locale
-    from matplotlib.backends import backend_agg, backend_pdf, backend_svg
 
     try:
         locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
@@ -35,15 +34,15 @@ def setup():
         except locale.Error:
             warnings.warn(
                 "Could not set locale to English/United States. "
-                "Some date-related tests may fail")
+                "Some date-related tests may fail.")
 
     mpl.use('Agg', warn=False)  # use Agg backend for these tests
 
-    # These settings *must* be hardcoded for running the comparison tests and
-    # are not necessarily the default values as specified in rcsetup.py
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
         mpl.rcdefaults()  # Start with all defaults
 
+    # These settings *must* be hardcoded for running the comparison tests and
+    # are not necessarily the default values as specified in rcsetup.py.
     set_font_settings_for_testing()
     set_reproducibility_for_testing()

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -1,4 +1,7 @@
 from collections import OrderedDict
+import copy
+from itertools import chain
+import locale
 import os
 from unittest import mock
 import warnings
@@ -9,7 +12,6 @@ import pytest
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
-from itertools import chain
 import numpy as np
 from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 validate_stringlist,
@@ -25,15 +27,13 @@ from matplotlib.rcsetup import (validate_bool_maybe_none,
                                 _validate_linestyle)
 
 
-mpl.rc('text', usetex=False)
-mpl.rc('lines', linewidth=22)
-
-fname = os.path.join(os.path.dirname(__file__), 'test_rcparams.rc')
-
-
 def test_rcparams():
+    mpl.rc('text', usetex=False)
+    mpl.rc('lines', linewidth=22)
+
     usetex = mpl.rcParams['text.usetex']
     linewidth = mpl.rcParams['lines.linewidth']
+    fname = os.path.join(os.path.dirname(__file__), 'test_rcparams.rc')
 
     # test context given dictionary
     with mpl.rc_context(rc={'text.usetex': not usetex}):
@@ -51,11 +51,8 @@ def test_rcparams():
     assert mpl.rcParams['lines.linewidth'] == linewidth
 
     # test rc_file
-    try:
-        mpl.rc_file(fname)
-        assert mpl.rcParams['lines.linewidth'] == 33
-    finally:
-        mpl.rcParams['lines.linewidth'] = linewidth
+    mpl.rc_file(fname)
+    assert mpl.rcParams['lines.linewidth'] == 33
 
 
 def test_RcParams_class():
@@ -131,8 +128,7 @@ def test_Bug_2543():
                 mpl.rcParams[key] = _copy[key]
             mpl.rcParams['text.dvipnghack'] = None
         with mpl.rc_context():
-            from copy import deepcopy
-            _deep_copy = deepcopy(mpl.rcParams)
+            _deep_copy = copy.deepcopy(mpl.rcParams)
         # real test is that this does not raise
         assert validate_bool_maybe_none(None) is None
         assert validate_bool_maybe_none("none") is None
@@ -194,7 +190,6 @@ def test_mec_rcparams():
 def test_Issue_1713():
     utf32_be = os.path.join(os.path.dirname(__file__),
                            'test_utf32_be_rcparams.rc')
-    import locale
     with mock.patch('locale.getpreferredencoding', return_value='UTF-32-BE'):
         rc = mpl.rc_params_from_file(utf32_be, True, False)
     assert rc.get('timezone') == 'UTC'

--- a/setup.py
+++ b/setup.py
@@ -241,10 +241,8 @@ if __name__ == '__main__':
         for mod in ext_modules:
             mod.finalize()
 
-    extra_args = {}
-
     # Finally, pass this all along to distutils to do the heavy lifting.
-    distrib = setup(
+    setup(
         name="matplotlib",
         version=__version__,
         description="Python plotting package",
@@ -278,5 +276,4 @@ if __name__ == '__main__':
         # check for zip safety.
         zip_safe=False,
         cmdclass=cmdclass,
-        **extra_args
     )


### PR DESCRIPTION
Splitting them out of the backend switching PR.

- Removed `matplotlib.sphinxext.plot_directive.sphinx_version` --
  it's unused, and less accurate than `sphinx.version_info` (it's
  limited to major.minor).
- Small reorderings in `testing/__init__.py` -- in particular, one
  comment was misplaced.
- In `test_rcparams.py`, move the global setting of `text.usetex` and
  `lines.linewidth` to the sole test that actually works with them.
  Note that changes to rcParams are cleared at the end of every test
  function by an autouse fixture.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
