### PR TITLE
FIX: Ensuring both x and y attrs of LocationEvent are int

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1365,8 +1365,8 @@ class LocationEvent(Event):
         *x*, *y* in figure coords, 0,0 = bottom, left
         """
         Event.__init__(self, name, canvas, guiEvent=guiEvent)
-        self.x = x          # x position - pixels from left of canvas
-        self.y = y          # y position - pixels from right of canvas
+        self.x = int(x)          # x position - pixels from left of canvas
+        self.y = int(y)          # y position - pixels from right of canvas
         self.inaxes = None  # the Axes instance if mouse us over axes
         self.xdata = None   # x coord of mouse in data coords
         self.ydata = None   # y coord of mouse in data coords

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1366,9 +1366,9 @@ class LocationEvent(Event):
         """
         Event.__init__(self, name, canvas, guiEvent=guiEvent)
         # x position - pixels from left of canvas
-        self.x = int(x) if x is not None else 0
+        self.x = int(x) if x is not None else x
         # y position - pixels from right of canvas
-        self.y = int(y) if y is not None else 0
+        self.y = int(y) if y is not None else y
         self.inaxes = None  # the Axes instance if mouse us over axes
         self.xdata = None   # x coord of mouse in data coords
         self.ydata = None   # y coord of mouse in data coords

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1342,10 +1342,10 @@ class LocationEvent(Event):
 
     Attributes
     ----------
-    x : scalar
+    x : int
         x position - pixels from left of canvas
 
-    y : scalar
+    y : int
         y position - pixels from bottom of canvas
 
     inaxes : bool
@@ -1365,8 +1365,8 @@ class LocationEvent(Event):
         *x*, *y* in figure coords, 0,0 = bottom, left
         """
         Event.__init__(self, name, canvas, guiEvent=guiEvent)
-        self.x = int(x)          # x position - pixels from left of canvas
-        self.y = int(y)          # y position - pixels from right of canvas
+        self.x = int(x) if x is not None else 0   # x position - pixels from left of canvas
+        self.y = int(y) if y is not None else 0   # y position - pixels from right of canvas
         self.inaxes = None  # the Axes instance if mouse us over axes
         self.xdata = None   # x coord of mouse in data coords
         self.ydata = None   # y coord of mouse in data coords

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1342,10 +1342,10 @@ class LocationEvent(Event):
 
     Attributes
     ----------
-    x : int
+    x : scalar
         x position - pixels from left of canvas
 
-    y : int
+    y : scalar
         y position - pixels from bottom of canvas
 
     inaxes : bool

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1365,8 +1365,10 @@ class LocationEvent(Event):
         *x*, *y* in figure coords, 0,0 = bottom, left
         """
         Event.__init__(self, name, canvas, guiEvent=guiEvent)
-        self.x = int(x) if x is not None else 0   # x position - pixels from left of canvas
-        self.y = int(y) if y is not None else 0   # y position - pixels from right of canvas
+        # x position - pixels from left of canvas
+        self.x = int(x) if x is not None else 0
+        # y position - pixels from right of canvas
+        self.y = int(y) if y is not None else 0
         self.inaxes = None  # the Axes instance if mouse us over axes
         self.xdata = None   # x coord of mouse in data coords
         self.ydata = None   # y coord of mouse in data coords

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -78,14 +78,14 @@ def test_non_gui_warning():
         assert len(rec) == 1
         assert ('Matplotlib is currently using pdf, which is a non-GUI backend'
                 in str(rec[0].message))
-                
-                
+
+
 def test_location_event_position():
     # LocationEvent should cast its x and y arguments
     # to int unless it is None
     fig = plt.figure()
     canvas = FigureCanvasBase(fig)
-    test_positions = [(42, 24), (None, 42), (None, None), 
+    test_positions = [(42, 24), (None, 42), (None, None),
                       (200, 100.01), (205.75, 2.0)]
     for x, y in test_positions:
         event = LocationEvent("test_event", canvas, x, y)
@@ -99,4 +99,3 @@ def test_location_event_position():
         else:
             assert event.y == int(y)
             assert isinstance(event.y, int)
-    

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -1,5 +1,6 @@
 from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.backend_bases import RendererBase
+from matplotlib.backend_bases import LocationEvent
 
 import matplotlib.pyplot as plt
 import matplotlib.transforms as transforms
@@ -77,3 +78,25 @@ def test_non_gui_warning():
         assert len(rec) == 1
         assert ('Matplotlib is currently using pdf, which is a non-GUI backend'
                 in str(rec[0].message))
+                
+                
+def test_location_event_position():
+    # LocationEvent should cast its x and y arguments
+    # to int unless it is None
+    fig = plt.figure()
+    canvas = FigureCanvasBase(fig)
+    test_positions = [(42, 24), (None, 42), (None, None), 
+                      (200, 100.01), (205.75, 2.0)]
+    for x, y in test_positions:
+        event = LocationEvent("test_event", canvas, x, y)
+        if x is None:
+            assert event.x is None
+        else:
+            assert event.x == int(x)
+            assert isinstance(event.x, int)
+        if y is None:
+            assert event.y is None
+        else:
+            assert event.y == int(y)
+            assert isinstance(event.y, int)
+    


### PR DESCRIPTION
## PR Summary

Fixes issue #11496. Both `x` and `y` attributes of `matplotlib.backend_bases.LocationEvent` are casted to `int` in the constructor. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
