### PR TITLE
Fix invalid value warning when autoscaling with no data limits

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2429,7 +2429,13 @@ class _AxesBase(martist.Artist):
             do_upper_margin = not np.any(np.isclose(x1, stickies))
             x0, x1 = axis._scale.limit_range_for_scale(x0, x1, minpos)
             x0t, x1t = transform.transform([x0, x1])
-            delta = (x1t - x0t) * margin
+
+            if (np.isfinite(x1t) and np.isfinite(x0t)):
+                delta = (x1t - x0t) * margin
+            else:
+                # If at least one bound isn't finite, set margin to zero
+                delta = 0
+
             if do_lower_margin:
                 x0t -= delta
             if do_upper_margin:


### PR DESCRIPTION
Currently quite a few tests with valid code raise the following warning:

```python
  /Users/dstansby/github/matplotlib/lib/matplotlib/axes/_base.py:2434: RuntimeWarning: invalid value encountered in double_scalars
    delta = (x1t - x0t) * margin
```

The problem is setting the units on an axis includes a call to autoscale the axis, which usually happens before any data has been added to the axes. This fix stops the warning from coming up by manually setting the autoscale margin to 0 if one of the data limits isn't finite.