### PR TITLE
Doc: fix x(filled) marker image

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -28,7 +28,7 @@ marker                         symbol description
 ``"H"``                        |m16|  hexagon2
 ``"+"``                        |m17|  plus
 ``"x"``                        |m18|  x
-``"X"``                        |m21|  x (filled)
+``"X"``                        |m24|  x (filled)
 ``"D"``                        |m19|  diamond
 ``"d"``                        |m20|  thin_diamond
 ``"|"``                        |m21|  vline


### PR DESCRIPTION
## PR Summary

A small mistake that got into showing all markers in the docs (#11437) is that the `x (filled)` marker image shows the wrong image.  
This was pointed out by @afvincent in  https://github.com/matplotlib/matplotlib/pull/11437#discussion_r199023796

Previously:

![image](https://user-images.githubusercontent.com/23121882/42134738-cc7ed144-7d41-11e8-986a-8109bc5ddd84.png)


With this PR:

![image](https://user-images.githubusercontent.com/23121882/42134732-b82ecd52-7d41-11e8-8173-49ca47738fe4.png)
