### PR TITLE
Use numpydoc-style parameter lists for choices

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -757,7 +757,7 @@ class Axes(_AxesBase):
 
         colors : array_like of colors, optional, default: 'k'
 
-        linestyles : ['solid' | 'dashed' | 'dashdot' | 'dotted'], optional
+        linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
         label : string, optional, default: ''
 
@@ -835,7 +835,7 @@ class Axes(_AxesBase):
 
         colors : array_like of colors, optional, default: 'k'
 
-        linestyles : ['solid' | 'dashed' | 'dashdot' | 'dotted'], optional
+        linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
         label : string, optional, default: ''
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -845,7 +845,7 @@ class _AxesBase(martist.Artist):
         pos : [left, bottom, width, height] or `~matplotlib.transforms.Bbox`
             The new position of the in `.Figure` coordinates.
 
-        which : ['both' | 'active' | 'original'], optional
+        which : {'both', 'active', 'original'}, optional
             Determines which position variables to change.
 
         """
@@ -1210,7 +1210,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        aspect : ['auto' | 'equal'] or num
+        aspect : {'auto', 'equal'} or num
             Possible values:
 
             ========   ================================================
@@ -1223,7 +1223,7 @@ class _AxesBase(martist.Artist):
                        aspect='equal'.
             ========   ================================================
 
-        adjustable : None or ['box' | 'datalim'], optional
+        adjustable : None or {'box', 'datalim'}, optional
             If not ``None``, this defines which parameter will be adjusted to
             meet the required aspect. See `.set_adjustable` for further
             details.
@@ -1284,7 +1284,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        adjustable : ['box' | 'datalim']
+        adjustable : {'box', 'datalim'}
             If 'box', change the physical dimensions of the Axes.
             If 'datalim', change the ``x`` or ``y`` data limits.
 
@@ -2313,7 +2313,7 @@ class _AxesBase(martist.Artist):
             True (default) turns autoscaling on, False turns it off.
             None leaves the autoscaling state unchanged.
 
-        axis : ['both' | 'x' | 'y'], optional
+        axis : {'both', 'x', 'y'}, optional
             which axis to operate on; default is 'both'
 
         tight: bool or None, optional
@@ -2782,7 +2782,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        axis : ['both' | 'x' | 'y'], optional
+        axis : {'both', 'x', 'y'}, optional
             The axis on which to operate.
 
         tight : bool or None, optional

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -557,7 +557,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         Parameters
         ----------
-        cs : ['butt' | 'round' | 'projecting']
+        cs : {'butt', 'round', 'projecting'}
             The capstyle
         """
         if cs in ('butt', 'round', 'projecting'):
@@ -575,7 +575,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         Parameters
         ----------
-        js : ['miter' | 'round' | 'bevel']
+        js : {'miter', 'round', 'bevel'}
             The joinstyle
         """
         if js in ('miter', 'round', 'bevel'):
@@ -1568,28 +1568,32 @@ class EllipseCollection(Collection):
     @docstring.dedent_interpd
     def __init__(self, widths, heights, angles, units='points', **kwargs):
         """
-        *widths*: sequence
-            lengths of first axes (e.g., major axis lengths)
+        Parameters
+        ----------
+        widths : array-like
+            The lengths of the first axes (e.g., major axis lengths).
 
-        *heights*: sequence
-            lengths of second axes
+        heights : array-like
+            The lengths of second axes.
 
-        *angles*: sequence
-            angles of first axes, degrees CCW from the X-axis
+        angles : array-like
+            The angles of the first axes, degrees CCW from the x-axis.
 
-        *units*: ['points' | 'inches' | 'dots' | 'width' | 'height'
-        | 'x' | 'y' | 'xy']
+        units : {'points', 'inches', 'dots', 'width', 'height', 'x', 'y', 'xy'}
 
-            units in which majors and minors are given; 'width' and
+            The units in which majors and minors are given; 'width' and
             'height' refer to the dimensions of the axes, while 'x'
             and 'y' refer to the *offsets* data units. 'xy' differs
             from all others in that the angle as plotted varies with
             the aspect ratio, and equals the specified angle only when
             the aspect ratio is unity.  Hence it behaves the same as
             the :class:`~matplotlib.patches.Ellipse` with
-            axes.transData as its transform.
+            ``axes.transData`` as its transform.
 
-        Additional kwargs inherited from the base :class:`Collection`:
+        Other Parameters
+        ----------------
+        **kwargs
+            Additional kwargs inherited from the base :class:`Collection`.
 
         %(Collection)s
         """

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1126,7 +1126,7 @@ class Legend(Artist):
         use_blit : bool, optional
             Use blitting for faster image composition. For details see
             :ref:`func-animation`.
-        update : ['loc' | 'bbox'], optional
+        update : {'loc', 'bbox'}, optional
             The legend parameter to be changed when dragged:
 
             - 'loc': update the *loc* parameter of the legend

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -234,8 +234,7 @@ class Patch(artist.Artist):
 
     def get_linestyle(self):
         """
-        Return the linestyle.  Will be one of ['solid' | 'dashed' |
-        'dashdot' | 'dotted']
+        Return the linestyle.
         """
         return self._linestyle
 

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -220,7 +220,7 @@ class LogScale(ScaleBase):
         *basex*/*basey*:
            The base of the logarithm
 
-        *nonposx*/*nonposy*: ['mask' | 'clip' ]
+        *nonposx*/*nonposy*: {'mask', 'clip'}
           non-positive values in *x* or *y* can be masked as
           invalid, or clipped to a very small positive number
 
@@ -507,7 +507,7 @@ class LogitScale(ScaleBase):
 
     def __init__(self, axis, nonpos='mask'):
         """
-        *nonpos*: ['mask' | 'clip' ]
+        *nonpos*: {'mask', 'clip'}
           values beyond ]0, 1[ can be masked as invalid, or clipped to a number
           very close to 0 or 1
         """

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -29,7 +29,7 @@ def stackplot(axes, x, *args,
             stackplot(x, y)               # where y is MxN
             stackplot(x, y1, y2, y3, y4)  # where y1, y2, y3, y4, are all 1xNm
 
-    baseline : ['zero' | 'sym' | 'wiggle' | 'weighted_wiggle']
+    baseline : {'zero', 'sym', 'wiggle', 'weighted_wiggle'}
         Method used to calculate the baseline:
 
         - ``'zero'``: Constant zero baseline, i.e. a simple stacked plot.


### PR DESCRIPTION
## PR Summary

Note: Not all of the corrected places are converted to full numpydoc Parameter sections yet. However, it's also easier to do so later, if we have already the possible parameter values formatted correctly.

