### PR TITLE
Fix spelling in title

### DIFF
--- a/examples/ticks_and_spines/scalarformatter.py
+++ b/examples/ticks_and_spines/scalarformatter.py
@@ -1,6 +1,6 @@
 """
 =========================================
-Tick formatting using the ScalarFromatter
+Tick formatting using the ScalarFormatter
 =========================================
 
 The example shows use of ScalarFormatter with different settings.


### PR DESCRIPTION
Corrected the spelling of the `ScalarFormatter` module in the [gallery title](https://matplotlib.org/gallery/ticks_and_spines/scalarformatter.html). 