### PR TITLE
FIX: Toolbar disappears in TkAgg if window if resized

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -473,11 +473,11 @@ class FigureManagerTk(FigureManagerBase):
         self.window.withdraw()
         self.set_window_title("Figure %d" % num)
         self.canvas = canvas
+        self.toolbar = self._get_toolbar()
         self.canvas._tkcanvas.pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
         self._num = num
 
         self.toolmanager = self._get_toolmanager()
-        self.toolbar = self._get_toolbar()
         self.statusbar = None
 
         if self.toolmanager:


### PR DESCRIPTION
Should solve #6781
When toolbar is "packed" before canvas, it doesn't disappear when the window is resized.

