### PR TITLE
Deactivate smartquotes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -223,10 +223,6 @@ html_file_suffix = '.html'
 # using the given strftime format.
 html_last_updated_fmt = '%b %d, %Y'
 
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-#html_use_smartypants = True
-
 # Content template for the index page.
 html_index = 'index.html'
 
@@ -254,6 +250,9 @@ html_use_opensearch = 'False'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Matplotlibdoc'
+
+# Use typographic quote characters.
+smartquotes = False
 
 # Path to favicon
 html_favicon = '_static/favicon.ico'


### PR DESCRIPTION
## PR Summary

[Sphinx smartquotes](http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes) converts simple quotes to typographic codes. Since we mainly use quotes to represent python strings in the docs without additional formatting (` ``'text'`` ` is really too cumbersome and visually distracting in plain docstrings), using straight quotes instead of typographic quotes is the better choice.