### PR TITLE
Cleanups.

### DIFF
--- a/doc/api/next_api_changes/2018-02-26-AL-removals.rst
+++ b/doc/api/next_api_changes/2018-02-26-AL-removals.rst
@@ -48,4 +48,5 @@ The following deprecated API elements have been removed:
 
 The following API elements have been removed:
 
-- ``matplotlib.sphinxext.sphinx_version``,
+- ``backend_cairo.HAS_CAIRO_CFFI``,
+- ``sphinxext.sphinx_version``,

--- a/doc/sphinxext/mock_gui_toolkits.py
+++ b/doc/sphinxext/mock_gui_toolkits.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 
 class MyCairoCffi(MagicMock):
-    pass
+    __name__ = "cairocffi"
 
 
 class MyPyQt4(MagicMock):

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1417,19 +1417,15 @@ default_test_modules = [
 
 
 def _init_tests():
-    try:
+    # CPython's faulthandler since v3.6 handles exceptions on Windows
+    # https://bugs.python.org/issue23848 but until v3.6.4 it was printing
+    # non-fatal exceptions https://bugs.python.org/issue30557
+    import platform
+    if not (sys.platform == 'win32' and
+            (3, 6) < sys.version_info < (3, 6, 4) and
+            platform.python_implementation() == 'CPython'):
         import faulthandler
-    except ImportError:
-        pass
-    else:
-        # CPython's faulthandler since v3.6 handles exceptions on Windows
-        # https://bugs.python.org/issue23848 but until v3.6.4 it was
-        # printing non-fatal exceptions https://bugs.python.org/issue30557
-        import platform
-        if not (sys.platform == 'win32' and
-                (3, 6) < sys.version_info < (3, 6, 4) and
-                platform.python_implementation() == 'CPython'):
-            faulthandler.enable()
+        faulthandler.enable()
 
     # The version of FreeType to install locally for running the
     # tests.  This must match the value in `setupext.py`

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -54,7 +54,7 @@ try:
     from PIL import Image
     from PIL import PILLOW_VERSION
     from distutils.version import LooseVersion
-    if LooseVersion(PILLOW_VERSION) >= LooseVersion("3.4"):
+    if LooseVersion(PILLOW_VERSION) >= "3.4":
         _has_pil = True
     else:
         _has_pil = False

--- a/lib/matplotlib/backends/_gtk3_compat.py
+++ b/lib/matplotlib/backends/_gtk3_compat.py
@@ -14,7 +14,6 @@ Thus, to force usage of PGI when both bindings are installed, import it first.
 import importlib
 import sys
 
-
 if "gi" in sys.modules:
     import gi
 elif "pgi" in sys.modules:
@@ -28,6 +27,16 @@ else:
         except ImportError:
             raise ImportError("The Gtk3 backend requires PyGObject or pgi")
 
+from .backend_cairo import cairo  # noqa
+# The following combinations are allowed:
+#   gi + pycairo
+#   gi + cairocffi
+#   pgi + cairocffi
+# (pgi doesn't work with pycairo)
+# We always try to import cairocffi first so if a check below fails it means
+# that cairocffi was unavailable to start with.
+if gi.__name__ == "pgi" and cairo.__name__ == "cairo":
+    raise ImportError("pgi and pycairo are not compatible")
 
 gi.require_version("Gtk", "3.0")
 globals().update(

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -24,14 +24,11 @@ except ImportError:
         raise ImportError("cairo backend requires that cairocffi or pycairo "
                           "is installed")
     else:
-        HAS_CAIRO_CFFI = False
         if cairo.version_info < (1, 11, 0):
             # Introduced create_for_data for Py3.
             raise ImportError(
                 "cairo {} is installed; cairo>=1.11.0 is required"
                 .format(cairo.version))
-else:
-    HAS_CAIRO_CFFI = True
 
 backend_version = cairo.version
 
@@ -65,7 +62,7 @@ def _premultiplied_argb32_to_unmultiplied_rgba8888(buf):
     return rgba
 
 
-if HAS_CAIRO_CFFI:
+if cairo.__name__ == "cairocffi":
     # Convert a pycairo context to a cairocffi one.
     def _to_context(ctx):
         if not isinstance(ctx, cairo.Context):
@@ -177,7 +174,8 @@ def _append_paths_fast(ctx, paths, transforms, clip=None):
     cairo.cairo.cairo_append_path(ctx._pointer, ptr)
 
 
-_append_paths = _append_paths_fast if HAS_CAIRO_CFFI else _append_paths_slow
+_append_paths = (_append_paths_fast if cairo.__name__ == "cairocffi"
+                 else _append_paths_slow)
 
 
 def _append_path(ctx, path, transform, clip=None):

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 
 import numpy as np
 
@@ -8,16 +7,6 @@ from ._gtk3_compat import gi
 from .backend_cairo import cairo
 from .backend_gtk3 import Gtk, _BackendGTK3
 from matplotlib import transforms
-
-# The following combinations are allowed:
-#   gi + pycairo
-#   gi + cairocffi
-#   pgi + cairocffi
-# (pgi doesn't work with pycairo)
-# We always try to import cairocffi first so if a check below fails it means
-# that cairocffi was unavailable to start with.
-if gi.__name__ == "pgi" and cairo.__name__ == "cairo":
-    raise ImportError("pgi and pycairo are not compatible")
 
 
 class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -1,19 +1,7 @@
 from . import backend_cairo, backend_gtk3
 from ._gtk3_compat import gi
-from .backend_cairo import cairo
 from .backend_gtk3 import Gtk, _BackendGTK3
 from matplotlib.backend_bases import cursors
-
-
-# The following combinations are allowed:
-#   gi + pycairo
-#   gi + cairocffi
-#   pgi + cairocffi
-# (pgi doesn't work with pycairo)
-# We always try to import cairocffi first so if a check below fails it means
-# that cairocffi was unavailable to start with.
-if gi.__name__ == "pgi" and cairo.__name__ == "cairo":
-    raise ImportError("pgi and pycairo are not compatible")
 
 
 class RendererGTK3Cairo(backend_cairo.RendererCairo):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1331,15 +1331,6 @@ def imread(fname, format=None):
     .. _Pillow documentation: http://pillow.readthedocs.io/en/latest/
     """
 
-    def pilread(fname):
-        """try to load the image with PIL or return None"""
-        try:
-            from PIL import Image
-        except ImportError:
-            return None
-        with Image.open(fname) as image:
-            return pil_to_array(image)
-
     handlers = {'png': _png.read_png, }
     if format is None:
         if isinstance(fname, str):
@@ -1358,13 +1349,15 @@ def imread(fname, format=None):
     else:
         ext = format
 
-    if ext not in handlers:
-        im = pilread(fname)
-        if im is None:
+    if ext not in handlers:  # Try to load the image with PIL.
+        try:
+            from PIL import Image
+        except ImportError:
             raise ValueError('Only know how to handle extensions: %s; '
                              'with Pillow installed matplotlib can handle '
                              'more images' % list(handlers))
-        return im
+        with Image.open(fname) as image:
+            return pil_to_array(image)
 
     handler = handlers[ext]
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -115,7 +115,7 @@ def test_image_python_io():
 def test_imread_pil_uint16():
     img = plt.imread(os.path.join(os.path.dirname(__file__),
                      'baseline_images', 'test_image', 'uint16.tif'))
-    assert (img.dtype == np.uint16)
+    assert img.dtype == np.uint16
     assert np.sum(img) == 134184960
 
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -13,13 +13,6 @@ import matplotlib.cbook as cbook
 from matplotlib.cbook.deprecation import MatplotlibDeprecationWarning
 
 
-try:
-    from mpl_toolkits.natgrid import _natgrid
-    HAS_NATGRID = True
-except ImportError:
-    HAS_NATGRID = False
-
-
 '''
 A lot of mlab.py has been deprecated in Matplotlib 2.2 and is scheduled for
 removal in the future. The tests that use deprecated methods have a block
@@ -2174,8 +2167,9 @@ def test_griddata_linear():
                                   np.ma.getmask(correct_zi_masked))
 
 
-@pytest.mark.xfail(not HAS_NATGRID, reason='natgrid not installed')
 def test_griddata_nn():
+    pytest.importorskip('mpl_toolkits.natgrid')
+
     # z is a linear function of x and y.
     def get_z(x, y):
         return 3.0*x - y


### PR DESCRIPTION
- faulthandler is present in all versions of Python we support; no need
  for `try... except ImportError` anymore.
- LooseVersions can directly be compared to strings (it casts the other
  argument to a LooseVersion).
- Move the gi+cairocffi incompatibility check (duplicated between
  backend_gtk3agg and backend_gtk3cairo) to the common _gtk3_compat.
- Replace HAS_CAIRO_CFFI with checking `cairo.__name__`, which is
  consistent with e.g. the check on `gi.__name__`.
- Inline the (single-used, internal) pilread (I think the new version is
  also more readable as we don't need to handle None as special value).
- Replace HAS_NATGRID by pytest.importorskip.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
