### PR TITLE
More simplifications to FreeType setup on Windows.

### DIFF
--- a/setup_external_compile.py
+++ b/setup_external_compile.py
@@ -19,54 +19,15 @@ For Python 3.3, 3.4:
 - VS 2010, 64 bit -- Windows SDK v7.1
 """
 
-import sys
 import platform
-import os
-import glob
-import shutil
-import zipfile
-import tarfile
 import distutils.msvc9compiler as msvc
 
-def fixproj(project_file, bit_target):
-    """
-    :param bit_target: one of 'Win32' or 'x64'
-    """
-    with open(project_file, 'r') as fd:
-        content = '\n'.join(line.strip() for line in fd if line.strip())
-    content = content.replace('Win32', bit_target).replace('x64', bit_target)
-    with open(project_file, 'w') as fd:
-        fd.write(content)
-
-def tar_extract(tar_file, target):
-    with tarfile.open(tar_file, 'r:gz') as tgz:
-        tgz.extractall(target)
-
-def zip_extract(zip_file, target):
-    with zipfile.ZipFile(zip_file) as zf:
-        zf.extractall(target)
-
 # Configuration selection & declaration:
-DEPSSRC = os.path.join(os.path.dirname(os.path.normpath(__file__)),
-                       'deps_source')
-DEPSBUILD = os.path.join(os.path.dirname(os.path.normpath(__file__)), 'build')
 X64 = platform.architecture()[0] == '64bit'
-PYVER = sys.version_info[:2]
-VS2010 = PYVER >= (3, 3)
 xXX = 'x64' if X64 else 'x86'
-# If not VS2010, then use VS2008
-
-VCVARSALL = None
 
 def prepare_build_cmd(build_cmd, **kwargs):
-    global VCVARSALL
+    VCVARSALL = msvc.find_vcvarsall(10.0)
     if VCVARSALL == None:
-        candidate = msvc.find_vcvarsall(10.0 if VS2010 else 9.0)
-        if candidate == None:
-            raise RuntimeError('Microsoft VS {} required'
-                               .format('2010' if VS2010 else '2008'))
-        else:
-            VCVARSALL = candidate
-
-    return build_cmd.format(
-        vcvarsall=VCVARSALL, xXX=xXX, **kwargs)
+        raise RuntimeError('Microsoft VS 2010 required')
+    return build_cmd.format(vcvarsall=VCVARSALL, xXX=xXX, **kwargs)

--- a/setupext.py
+++ b/setupext.py
@@ -1132,19 +1132,15 @@ set MSBUILD=C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe
 %MSBUILD% "builds\windows\{vc20xx}\freetype.sln" ^
     /t:Clean;Build /p:Configuration="{config}";Platform={WinXX}
 """
-            from setup_external_compile import fixproj, prepare_build_cmd, VS2010, X64, xXX
+            from setup_external_compile import prepare_build_cmd, X64, xXX
             # Note: freetype has no build profile for 2014, so we don't bother...
-            vc = 'vc2010' if VS2010 else 'vc2008'
+            vc = 'vc2010'
             WinXX = 'x64' if X64 else 'Win32'
-            # This is only false for py2.7, even on py3.5...
-            if not VS2010:
-                fixproj(os.path.join(src_path, 'builds', 'windows', vc, 'freetype.sln'), WinXX)
-                fixproj(os.path.join(src_path, 'builds', 'windows', vc, 'freetype.vcproj'), WinXX)
 
             cmdfile = os.path.join("build", "build_freetype.cmd")
             with open(cmdfile, 'w') as cmd:
                 cmd.write(prepare_build_cmd(FREETYPE_BUILD_CMD, vc20xx=vc, WinXX=WinXX,
-                                            config='Release' if VS2010 else 'LIB Release'))
+                                            config='Release'))
 
             shutil.rmtree(str(Path(src_path, "objs")), ignore_errors=True)
             subprocess.check_call([os.path.abspath(cmdfile)],


### PR DESCRIPTION
Another small chunk of #11235.

- VS2010 is now always True -> perform constant folding.
- Remove unused fixproj, tar_extract, zip_extract, DEPSSRC, DEPSBUILD,
  PYVER.
- prepare_build_cmd is only called once so no need to cache VCVARSALL.
- Remove unused imports.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
