### PR TITLE
Cleanup stix_fonts_demo example.

### DIFF
--- a/examples/text_labels_and_annotations/stix_fonts_demo.py
+++ b/examples/text_labels_and_annotations/stix_fonts_demo.py
@@ -5,14 +5,10 @@ STIX Fonts Demo
 
 """
 
-import subprocess
-import sys
-import re
-import gc
 import matplotlib.pyplot as plt
 import numpy as np
 
-stests = [
+tests = [
     r'$\mathcircled{123} \mathrm{\mathcircled{123}}'
     r' \mathbf{\mathcircled{123}}$',
     r'$\mathsf{Sans \Omega} \mathrm{\mathsf{Sans \Omega}}'
@@ -25,39 +21,12 @@ stests = [
     r'$\mathfrak{Fraktur} \mathbf{\mathfrak{Fraktur}}$',
     r'$\mathscr{Script}$']
 
-if sys.maxunicode > 0xffff:
-    s = r'Direct Unicode: $\u23ce \mathrm{\ue0f2 \U0001D538}$'
 
+plt.figure(figsize=(8, (len(tests) * 1) + 2))
+plt.plot([0, 0], 'r')
+plt.axis([0, 3, -len(tests), 0])
+plt.yticks(-np.arange(len(tests)))
+for i, s in enumerate(tests):
+    plt.text(0.1, -i, s, fontsize=32)
 
-def doall():
-    tests = stests
-
-    plt.figure(figsize=(8, (len(tests) * 1) + 2))
-    plt.plot([0, 0], 'r')
-    plt.grid(False)
-    plt.axis([0, 3, -len(tests), 0])
-    plt.yticks(np.arange(len(tests)) * -1)
-    for i, s in enumerate(tests):
-        plt.text(0.1, -i, s, fontsize=32)
-
-    plt.savefig('stix_fonts_example')
-    plt.show()
-
-
-if '--latex' in sys.argv:
-    fd = open("stix_fonts_examples.ltx", "w")
-    fd.write("\\documentclass{article}\n")
-    fd.write("\\begin{document}\n")
-    fd.write("\\begin{enumerate}\n")
-
-    for i, s in enumerate(stests):
-        s = re.sub(r"(?<!\\)\$", "$$", s)
-        fd.write("\\item %s\n" % s)
-
-    fd.write("\\end{enumerate}\n")
-    fd.write("\\end{document}\n")
-    fd.close()
-
-    subprocess.call(["pdflatex", "stix_fonts_examples.ltx"])
-else:
-    doall()
+plt.show()


### PR DESCRIPTION
- The `s` variable conditionally defined was never used.
- The `'--latex' in sys.argv` branch (which dates back to the origin of
  the example, a567601), likely never worked (\mathbb requires
  \usepackage{amsfonts}), so just kill it.
- Saving the figure doesn't really help with the example and tends to
  clutter the source tree when running the example, so don't do it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
