### PR TITLE
Add parameter doc to save_diff_image

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -451,6 +451,16 @@ def compare_images(expected, actual, tol, in_decorator=False):
 
 
 def save_diff_image(expected, actual, output):
+    '''
+    Parameters
+    ----------
+    expected : str
+        File path of expected image.
+    actual : str
+        File path of actual image.
+    output : str
+        File path to save difference image to.
+    '''
     # Drop alpha channels, similarly to compare_images.
     expectedImage = _png.read_png(expected)[..., :3]
     actualImage = _png.read_png(actual)[..., :3]


### PR DESCRIPTION
Might be nice to let `save_diff_image` take `pathlib.Path` objects in future, but for now this makes it clear that only `str` is accepted.