### PR TITLE
DOC update some examples to use constrained_layout=True

### DIFF
--- a/examples/color/color_cycler.py
+++ b/examples/color/color_cycler.py
@@ -27,7 +27,7 @@ yy = np.transpose([np.sin(x + phi) for phi in offsets])
 plt.rc('lines', linewidth=4)
 plt.rc('axes', prop_cycle=(cycler(color=['r', 'g', 'b', 'y']) +
                            cycler(linestyle=['-', '--', ':', '-.'])))
-fig, (ax0, ax1) = plt.subplots(nrows=2)
+fig, (ax0, ax1) = plt.subplots(nrows=2, constrained_layout=True)
 ax0.plot(yy)
 ax0.set_title('Set default color cycle to rgby')
 
@@ -41,8 +41,6 @@ ax1.set_prop_cycle(color=['c', 'm', 'y', 'k'], lw=[1, 2, 3, 4])
 ax1.plot(yy)
 ax1.set_title('Set axes color cycle to cmyk')
 
-# Tweak spacing between subplots to prevent labels from overlapping
-fig.subplots_adjust(hspace=0.3)
 plt.show()
 
 #############################################################################

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -38,7 +38,7 @@ Z[interior] = np.ma.masked
 # occur on nice boundaries, but we do it here for purposes
 # of illustration.
 
-fig1, ax2 = plt.subplots()
+fig1, ax2 = plt.subplots(constrained_layout=True)
 CS = ax2.contourf(X, Y, Z, 10, cmap=plt.cm.bone, origin=origin)
 
 # Note that in the following, we explicitly pass in a subset of
@@ -58,7 +58,7 @@ cbar.ax.set_ylabel('verbosity coefficient')
 # Add the contour line levels to the colorbar
 cbar.add_lines(CS2)
 
-fig2, ax2 = plt.subplots()
+fig2, ax2 = plt.subplots(constrained_layout=True)
 # Now make a contour plot with the levels specified,
 # and with the colormap generated automatically from a list
 # of colors.
@@ -95,12 +95,11 @@ cmap.set_over("yellow")
 # no effect:
 # cmap.set_bad("red")
 
-fig3, axs = plt.subplots(2, 2)
-fig3.subplots_adjust(hspace=0.3)
+fig, axs = plt.subplots(2, 2, constrained_layout=True)
 
 for ax, extend in zip(axs.ravel(), extends):
     cs = ax.contourf(X, Y, Z, levels, cmap=cmap, extend=extend, origin=origin)
-    fig3.colorbar(cs, ax=ax, shrink=0.9)
+    fig.colorbar(cs, ax=ax, shrink=0.9)
     ax.set_title("extend = %s" % extend)
     ax.locator_params(nbins=4)
 

--- a/examples/images_contours_and_fields/image_nonuniform.py
+++ b/examples/images_contours_and_fields/image_nonuniform.py
@@ -25,8 +25,7 @@ y = np.linspace(-4, 4, 9)
 
 z = np.sqrt(x[np.newaxis, :]**2 + y[:, np.newaxis]**2)
 
-fig, axs = plt.subplots(nrows=2, ncols=2)
-fig.subplots_adjust(bottom=0.07, hspace=0.3)
+fig, axs = plt.subplots(nrows=2, ncols=2, constrained_layout=True)
 fig.suptitle('NonUniformImage class', fontsize='large')
 ax = axs[0, 0]
 im = NonUniformImage(ax, interpolation=interp, extent=(-4, 4, -4, 4),

--- a/examples/lines_bars_and_markers/psd_demo.py
+++ b/examples/lines_bars_and_markers/psd_demo.py
@@ -12,10 +12,10 @@ of how this can be accomplished and visualized with Matplotlib.
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib.mlab as mlab
+import matplotlib.gridspec as gridspec
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
-
 
 dt = 0.01
 t = np.arange(0, 10, dt)
@@ -59,14 +59,16 @@ y = 10. * np.sin(2 * np.pi * 4 * t) + 5. * np.sin(2 * np.pi * 4.25 * t)
 y = y + np.random.randn(*t.shape)
 
 # Plot the raw time series
-fig = plt.figure()
-fig.subplots_adjust(hspace=0.45, wspace=0.3)
-ax = fig.add_subplot(2, 1, 1)
+fig = plt.figure(constrained_layout=True)
+gs = gridspec.GridSpec(2, 3, figure=fig)
+ax = fig.add_subplot(gs[0, :])
 ax.plot(t, y)
+ax.set_xlabel('time [s]')
+ax.set_ylabel('signal')
 
 # Plot the PSD with different amounts of zero padding. This uses the entire
 # time series at once
-ax2 = fig.add_subplot(2, 3, 4)
+ax2 = fig.add_subplot(gs[1, 0])
 ax2.psd(y, NFFT=len(t), pad_to=len(t), Fs=fs)
 ax2.psd(y, NFFT=len(t), pad_to=len(t) * 2, Fs=fs)
 ax2.psd(y, NFFT=len(t), pad_to=len(t) * 4, Fs=fs)
@@ -74,7 +76,7 @@ plt.title('zero padding')
 
 # Plot the PSD with different block sizes, Zero pad to the length of the
 # original data sequence.
-ax3 = fig.add_subplot(2, 3, 5, sharex=ax2, sharey=ax2)
+ax3 = fig.add_subplot(gs[1, 1], sharex=ax2, sharey=ax2)
 ax3.psd(y, NFFT=len(t), pad_to=len(t), Fs=fs)
 ax3.psd(y, NFFT=len(t) // 2, pad_to=len(t), Fs=fs)
 ax3.psd(y, NFFT=len(t) // 4, pad_to=len(t), Fs=fs)
@@ -82,7 +84,7 @@ ax3.set_ylabel('')
 plt.title('block size')
 
 # Plot the PSD with different amounts of overlap between blocks
-ax4 = fig.add_subplot(2, 3, 6, sharex=ax2, sharey=ax2)
+ax4 = fig.add_subplot(gs[1, 2], sharex=ax2, sharey=ax2)
 ax4.psd(y, NFFT=len(t) // 2, pad_to=len(t), noverlap=0, Fs=fs)
 ax4.psd(y, NFFT=len(t) // 2, pad_to=len(t),
         noverlap=int(0.05 * len(t) / 2.), Fs=fs)
@@ -106,9 +108,8 @@ f = np.array([150, 140]).reshape(-1, 1)
 xn = (A * np.sin(2 * np.pi * f * t)).sum(axis=0)
 xn += 5 * np.random.randn(*t.shape)
 
-fig, (ax0, ax1) = plt.subplots(ncols=2)
+fig, (ax0, ax1) = plt.subplots(ncols=2, constrained_layout=True)
 
-fig.subplots_adjust(hspace=0.45, wspace=0.3)
 yticks = np.arange(-50, 30, 10)
 yrange = (yticks[0], yticks[-1])
 xticks = np.arange(0, 550, 100)
@@ -147,9 +148,8 @@ A = np.array([2, 8]).reshape(-1, 1)
 f = np.array([150, 140]).reshape(-1, 1)
 xn = (A * np.exp(2j * np.pi * f * t)).sum(axis=0) + 5 * prng.randn(*t.shape)
 
-fig, (ax0, ax1) = plt.subplots(ncols=2)
+fig, (ax0, ax1) = plt.subplots(ncols=2, constrained_layout=True)
 
-fig.subplots_adjust(hspace=0.45, wspace=0.3)
 yticks = np.arange(-50, 30, 10)
 yrange = (yticks[0], yticks[-1])
 xticks = np.arange(-500, 550, 200)

--- a/examples/subplots_axes_and_figures/figure_title.py
+++ b/examples/subplots_axes_and_figures/figure_title.py
@@ -20,19 +20,16 @@ t2 = np.arange(0.0, 5.0, 0.02)
 t3 = np.arange(0.0, 2.0, 0.01)
 
 
-plt.subplot(121)
-plt.plot(t1, f(t1), 'o', t2, f(t2), '-')
-plt.title('subplot 1')
-plt.ylabel('Damped oscillation')
-plt.suptitle('This is a somewhat long figure title', fontsize=16)
+fig, axs = plt.subplots(2, 1, constrained_layout=True)
+axs[0].plot(t1, f(t1), 'o', t2, f(t2), '-')
+axs[0].set_title('subplot 1')
+axs[0].set_xlabel('distance (m)')
+axs[0].set_ylabel('Damped oscillation')
+fig.suptitle('This is a somewhat long figure title', fontsize=16)
 
-
-plt.subplot(122)
-plt.plot(t3, np.cos(2*np.pi*t3), '--')
-plt.xlabel('time (s)')
-plt.title('subplot 2')
-plt.ylabel('Undamped')
-
-plt.subplots_adjust(left=0.2, wspace=0.8, top=0.8)
+axs[1].plot(t3, np.cos(2*np.pi*t3), '--')
+axs[1].set_xlabel('time (s)')
+axs[1].set_title('subplot 2')
+axs[1].set_ylabel('Undamped')
 
 plt.show()

--- a/examples/text_labels_and_annotations/legend_demo.py
+++ b/examples/text_labels_and_annotations/legend_demo.py
@@ -63,7 +63,7 @@ plt.show()
 ###############################################################################
 # Here we attach legends to more complex plots.
 
-fig, axes = plt.subplots(3, 1)
+fig, axes = plt.subplots(3, 1, constrained_layout=True)
 top_ax, middle_ax, bottom_ax = axes
 
 top_ax.bar([0, 1, 2], [0.2, 0.3, 0.1], width=0.4, label="Bar 1",
@@ -81,13 +81,12 @@ middle_ax.legend()
 bottom_ax.stem([0.3, 1.5, 2.7], [1, 3.6, 2.7], label="stem test")
 bottom_ax.legend()
 
-plt.subplots_adjust(hspace=0.7)
 plt.show()
 
 ###############################################################################
 # Now we'll showcase legend entries with more than one legend key.
 
-fig, (ax1, ax2) = plt.subplots(2, 1)
+fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True)
 
 # First plot: two legend keys for a single entry
 p1 = ax1.scatter([1], [5], c='r', marker='s', s=100)
@@ -114,7 +113,6 @@ rpos = ax2.bar(x_left, y_pos, width=0.5, color='k', label='+1')
 l = ax2.legend([(rpos, rneg), (rneg, rpos)], ['pad!=0', 'pad=0'],
                handler_map={(rpos, rneg): HandlerTuple(ndivide=None),
                             (rneg, rpos): HandlerTuple(ndivide=None, pad=0.)})
-
 plt.show()
 
 ###############################################################################
@@ -171,7 +169,6 @@ styles = ['solid', 'dashed', 'dashed', 'dashed', 'solid']
 lines = []
 for i, color, style in zip(range(5), colors, styles):
     ax.plot(x, np.sin(x) - .1 * i, c=color, ls=style)
-
 
 # make proxy artists
 # make list of one line -- doesn't matter what the coordinates are


### PR DESCRIPTION
## PR Summary

There were a number of places where the examples used `subplots_adjust` to make subplots fit on page.  For a smattering of examples (that worked) I changed this to `subplots(2, 2, constrained_layout=True)`.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
