### PR TITLE
ENH: fix colorbar bad minor ticks

### DIFF
--- a/doc/users/next_whats_new/colorbar_minor_ticks.rst
+++ b/doc/users/next_whats_new/colorbar_minor_ticks.rst
@@ -1,0 +1,10 @@
+Add ``minorticks_on()/off()`` methods for colorbar
+--------------------------------------------------
+
+A new method :meth:`.Colobar.minorticks_on` is
+introduced to correctly display minor ticks on the colorbar. This method
+doesn't allow the minor ticks to extend into the regions beyond vmin and vmax
+when the extend `kwarg` (used while creating the colorbar) is set to 'both',
+'max' or 'min'.
+A complementary method :meth:`.Colobar.minorticks_off`
+is introduced to remove the minor ticks on the colorbar.

--- a/examples/color/colorbar_basics.py
+++ b/examples/color/colorbar_basics.py
@@ -20,7 +20,7 @@ Z = (np.cos(x*0.2) + np.sin(y*0.3))
 Zpos = np.ma.masked_less(Z, 0)
 Zneg = np.ma.masked_greater(Z, 0)
 
-fig, (ax1, ax2) = plt.subplots(figsize=(8, 3), ncols=2)
+fig, (ax1, ax2, ax3) = plt.subplots(figsize=(13, 3), ncols=3)
 
 # plot just the positive data and save the
 # color "mappable" object returned by ax1.imshow
@@ -35,6 +35,13 @@ fig.colorbar(pos, ax=ax1)
 neg = ax2.imshow(Zneg, cmap='Reds_r', interpolation='none')
 fig.colorbar(neg, ax=ax2)
 
+# Plot both positive and negative values betwen +/- 1.2
+pos_neg_clipped = ax3.imshow(Z, cmap='RdBu', vmin=-1.2, vmax=1.2,
+                             interpolation='none')
+# Add minorticks on the colorbar to make it easy to read the
+# values off the colorbar.
+cbar = fig.colorbar(pos_neg_clipped, ax=ax3, extend='both')
+cbar.minorticks_on()
 plt.show()
 
 #############################################################################

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -244,6 +244,32 @@ class _ColorbarAutoLocator(ticker.MaxNLocator):
         return ticks[(ticks >= vmin) & (ticks <= vmax)]
 
 
+class _ColorbarAutoMinorLocator(ticker.AutoMinorLocator):
+    """
+    AutoMinorLocator for Colorbar
+
+    This locator is just a `.AutoMinorLocator` except the min and max are
+    clipped by the norm's min and max (i.e. vmin/vmax from the
+    image/pcolor/contour object).  This is necessary so that the minorticks
+    don't extrude into the "extend regions".
+    """
+
+    def __init__(self, colorbar, n=None):
+        """
+        This ticker needs to know the *colorbar* so that it can access
+        its *vmin* and *vmax*.
+        """
+        self._colorbar = colorbar
+        self.ndivs = n
+        ticker.AutoMinorLocator.__init__(self, n=None)
+
+    def __call__(self):
+        vmin = self._colorbar.norm.vmin
+        vmax = self._colorbar.norm.vmax
+        ticks = ticker.AutoMinorLocator.__call__(self)
+        return ticks[(ticks >= vmin) & (ticks <= vmax)]
+
+
 class _ColorbarLogLocator(ticker.LogLocator):
     """
     LogLocator for Colorbarbar
@@ -1163,6 +1189,33 @@ class Colorbar(ColorbarBase):
         else:
             # use_gridspec was True
             ax.set_subplotspec(subplotspec)
+
+    def minorticks_on(self):
+        """
+        Turns on the minor ticks on the colorbar without extruding
+        into the "extend regions".
+        """
+        ax = self.ax
+        long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
+
+        if long_axis.get_scale() == 'log':
+            warnings.warn('minorticks_on() has no effect on a '
+                          'logarithmic colorbar axis')
+        else:
+            long_axis.set_minor_locator(_ColorbarAutoMinorLocator(self))
+
+    def minorticks_off(self):
+        """
+        Turns off the minor ticks on the colorbar.
+        """
+        ax = self.ax
+        long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
+
+        if long_axis.get_scale() == 'log':
+            warnings.warn('minorticks_off() has no effect on a '
+                          'logarithmic colorbar axis')
+        else:
+            long_axis.set_minor_locator(ticker.NullLocator())
 
 
 @docstring.Substitution(make_axes_kw_doc)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -270,6 +270,31 @@ def test_colorbar_ticks():
     assert len(cbar.ax.xaxis.get_ticklocs()) == len(clevs)
 
 
+def test_colorbar_minorticks_on_off():
+    # test for github issue #11510 and PR #11584
+    np.random.seed(seed=12345)
+    data = np.random.randn(20, 20)
+    with rc_context({'_internal.classic_mode': False}):
+        fig, ax = plt.subplots()
+        # purposefully setting vmin and vmax to odd fractions
+        # so as to check for the correct locations of the minor ticks
+        im = ax.pcolormesh(data, vmin=-2.3, vmax=3.3)
+
+        cbar = fig.colorbar(im, extend='both')
+        cbar.minorticks_on()
+        correct_minorticklocs = np.array([-2.2, -1.8, -1.6, -1.4, -1.2, -0.8,
+                                          -0.6, -0.4, -0.2, 0.2, 0.4, 0.6,
+                                           0.8, 1.2, 1.4, 1.6, 1.8, 2.2, 2.4,
+                                           2.6, 2.8, 3.2])
+        # testing after minorticks_on()
+        np.testing.assert_almost_equal(cbar.ax.yaxis.get_minorticklocs(),
+                                       correct_minorticklocs)
+        cbar.minorticks_off()
+        # testing after minorticks_off()
+        np.testing.assert_almost_equal(cbar.ax.yaxis.get_minorticklocs(),
+                                       np.array([]))
+
+
 def test_colorbar_autoticks():
     # Test new autotick modes. Needs to be classic because
     # non-classic doesn't go this route.


### PR DESCRIPTION
## PR Summary
This follows the suggestion given in #11556 and builds a method for colorbar to correctly display minor ticks (without extending into the region beyond vmin, vmax when the extend option is used).

Earlier, the only way to display the minor ticks was to use ax.minorticks_on/off methods
(which didn't respect vmin, vmax values).

With this PR, the colorbar gets its own minorticks_on/off methods.

Fixes #11510 and is a follow up to #11556 .

@jklymak Could you please review this?
This builds on top of your suggestions in the discussion here #11556, #11510.

***This is my first (relatively significant) contribution to matplotlib (apart from a minor documentation entry) so I would appreciate any help in how to properly document API change (or if I am missing anything else). ~~I am marking this as WIP since I am not sure how to add tests and other entries from  the PR checklist (I will try to understand the requirements for each item in the list and will work on those soon)~~.*** 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
~~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
**Correct behavior (after the PR)** 
```python
import matplotlib.pyplot as plt
import numpy as np

# Making yticks longer in length to highlight the issue
plt.rcParams['ytick.major.size'] = 10
plt.rcParams['ytick.minor.size'] = 4


np.random.seed(seed=12345)
x = np.random.randn(20, 20)
fig, ax = plt.subplots()
im = ax.pcolormesh(x)

cbar = fig.colorbar(im, extend='both')
###  Colorbar gets its own minorticks_on() method
cbar.minorticks_on()
plt.show()
```
![figure_1](https://user-images.githubusercontent.com/15175620/42357436-e26ab146-80a5-11e8-9a2d-d87395ea3592.png)

**Incorrect behavior**
```python
import matplotlib.pyplot as plt
import numpy as np

# Making yticks longer in length to highlight the issue
plt.rcParams['ytick.major.size'] = 10
plt.rcParams['ytick.minor.size'] = 4


np.random.seed(seed=12345)
x = np.random.randn(20, 20)
fig, ax = plt.subplots()
im = ax.pcolormesh(x)

cbar = fig.colorbar(im, extend='both')

###  older way of adding minorticks (which had incorrect behavior)
cbar.ax.minorticks_on()
plt.show()
```
![figure_1](https://user-images.githubusercontent.com/15175620/41886796-edacdc8c-78cb-11e8-8b53-759fe7a634dd.png)