### PR TITLE
DOC: warn if user is using constrained layout and  use subplots_adjust

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2092,6 +2092,12 @@ default: 'top'
         *None*) and update the subplot locations.
 
         """
+        if self.get_constrained_layout():
+            self.set_constrained_layout(False)
+            warnings.warn("This figure was using constrained_layout==True, "
+                          "but that is incompatible with subplots_adjust and "
+                          "or tight_layout: setting "
+                          "constrained_layout==False. ")
         self.subplotpars.update(left, bottom, right, top, wspace, hspace)
         for ax in self.axes:
             if not isinstance(ax, SubplotBase):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -373,6 +373,14 @@ def test_figure_repr():
     assert repr(fig) == "<Figure size 100x200 with 0 Axes>"
 
 
+def test_warn_cl_plus_tl():
+    fig, ax = plt.subplots(constrained_layout=True)
+    with pytest.warns(UserWarning):
+        # this should warn,
+        fig.subplots_adjust(top=0.8)
+    assert not(fig.get_constrained_layout())
+
+
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires Python 3.6+")
 @pytest.mark.parametrize("fmt", ["png", "pdf", "ps", "eps", "svg"])
 def test_fspath(fmt, tmpdir):


### PR DESCRIPTION
## PR Summary

Mysterious things can happen if constrained_layout=True for a figure and the user then tries to call `subplots_adjust` or `tight_layout`.  This PR emits a warning in that case, and turns constrained_layout off

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots(constrained_layout=True)
fig.subplots_adjust(top=0.8)
ax.set_xlabel('Xlabel')
ax.set_title('Title')
plt.show()
```

```
/Users/jklymak/matplotlib/lib/matplotlib/figure.py:2097: UserWarning: This figure was using constrained_layout==True, but that is incompatible with subplots_adjust and or tight_layout: setting constrained_layout==False.
  warnings.warn("This figure was using constrained_layout==True, "
```

Thanks @afvincent @timhoffm on gitter:  https://gitter.im/matplotlib/matplotlib?at=5b3f0b8881816669a434e201

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->