### PR TITLE
Don't associate Wx timers with the parent frame.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL-deprecations.rst
@@ -48,3 +48,6 @@ The following rcParams are deprecated:
 The following keyword arguments are deprecated:
 - passing ``verts`` to ``Axes.scatter`` (use ``marker`` instead),
 - passing ``obj_type`` to ``cbook.deprecated``,
+
+The following call signatures are deprecated:
+- passing a ``wx.EvtHandler`` as first argument to ``backend_wx.TimerWx``,

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -118,19 +118,15 @@ class TimerWx(TimerBase):
 
     '''
 
-    def __init__(self, parent, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+        if isinstance(args[0], wx.EvtHandler):
+            cbook.warn_deprecated(
+                "3.0", "Passing a wx.EvtHandler as first argument to the "
+                "TimerWx constructor is deprecated since %(version)s.")
+            args = args[1:]
         TimerBase.__init__(self, *args, **kwargs)
-
-        # Create a new timer and connect the timer event to our handler.
-        # For WX, the events have to use a widget for binding.
-        self.parent = parent
-        self._timer = wx.Timer(self.parent, wx.NewId())
-        self.parent.Bind(wx.EVT_TIMER, self._on_timer, self._timer)
-
-     # Unbinding causes Wx to stop for some reason. Disabling for now.
-#    def __del__(self):
-#        TimerBase.__del__(self)
-#        self.parent.Bind(wx.EVT_TIMER, None, self._timer)
+        self._timer = wx.Timer()
+        self._timer.Notify = self._on_timer
 
     def _timer_start(self):
         self._timer.Start(self._interval, self._single)
@@ -143,9 +139,6 @@ class TimerWx(TimerBase):
 
     def _timer_set_single_shot(self):
         self._timer.Start()
-
-    def _on_timer(self, *args):
-        TimerBase._on_timer(self)
 
 
 class RendererWx(RendererBase):
@@ -704,7 +697,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
             will be executed by the timer every *interval*.
 
         """
-        return TimerWx(self, *args, **kwargs)
+        return TimerWx(*args, **kwargs)
 
     def flush_events(self):
         wx.Yield()


### PR DESCRIPTION
This is consistent with the behavior on Qt and GTK, and avoids a
segfault due to lack of disconnection of the timer after the parent
widget is destroyed (otherwise, we'd need to keep track of timers
associated with each widget and tear them down when the widget is
destroyed).

Closes #11582.

Marking as release-critical per "fixes a segfault", though not a regression so not insisting on it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
