### PR TITLE
test doc rendering

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -13,3 +13,4 @@ ipywidgets
 numpydoc>=0.4
 pillow
 sphinx-gallery>=0.1.13
+sphinx-automodapi

--- a/doc/_templates/autoclass.rst
+++ b/doc/_templates/autoclass.rst
@@ -1,0 +1,27 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :no-members:
+    :show-inheritance:
+
+    {% if '__init__' in methods %}
+    {% set caught_result = methods.remove('__init__') %}
+    {% endif %}
+
+    {% block methods %}
+    {% if methods %}
+
+    .. rubric:: Methods
+
+    .. autosummary::
+       :template: autosummary.rst
+       :toctree:
+       :nosignatures:
+    {% for item in methods %}
+       ~{{ name }}.{{ item }}
+    {% endfor %}
+
+    {% endif %}
+    {% endblock %}

--- a/doc/_templates/autoclass_onefile.rst
+++ b/doc/_templates/autoclass_onefile.rst
@@ -1,0 +1,57 @@
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+   :class: multicol-toc
+
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :no-members:
+    :show-inheritance:
+
+    {% if '__init__' in methods %}
+    {% set caught_result = methods.remove('__init__') %}
+    {% endif %}
+
+    {% block methods %}
+    {% if methods %}
+
+Methods
+^^^^^^^
+
+    .. autosummary::
+       :nosignatures:
+    {% for item in methods %}
+       ~{{ name }}.{{ item }}
+    {% endfor %}
+
+    {% endif %}
+    {% endblock %}
+
+Documentation
+=============
+
+.. autoclass:: {{ objname }}
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+Examples
+========
+
+.. include:: {{module}}.{{name}}.examples
+{% block examples %}
+{% if methods %}
+{% for item in methods %}
+.. include:: {{module}}.{{name}}.{{item}}.examples
+.. raw:: html
+
+    <div class="clearer"></div>
+{% endfor %}
+{% endif %}
+{% endblock %}
+

--- a/doc/api/collections_api.rst
+++ b/doc/api/collections_api.rst
@@ -9,8 +9,23 @@ collections
 :mod:`matplotlib.collections`
 =============================
 
+.. currentmodule:: matplotlib.collections
+
 .. automodule:: matplotlib.collections
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :inherited-members:
+   :no-members:
+
+
+Classes
+-------
+
+.. automodsumm:: matplotlib.transforms
+    :classes-only:
+    :toctree: _as_gen/
+    :template: autoclass_onefile.rst
+    :nosignatures:
+
+
+
+
+
+

--- a/doc/api/colors_api.rst
+++ b/doc/api/colors_api.rst
@@ -23,7 +23,7 @@ Classes
 
 .. autosummary::
    :toctree: _as_gen/
-   :template: autosummary.rst
+   :template: autoclass_onefile.rst
 
    BoundaryNorm
    Colormap

--- a/doc/api/figure_api.rst
+++ b/doc/api/figure_api.rst
@@ -17,7 +17,7 @@ Classes
 
 .. autosummary::
    :toctree: _as_gen/
-   :template: autosummary.rst
+   :template: autoclass.rst
    :nosignatures:
 
    AxesStack

--- a/doc/api/transformations.rst
+++ b/doc/api/transformations.rst
@@ -2,19 +2,17 @@
 transformations
 ***************
 
-.. inheritance-diagram:: matplotlib.transforms matplotlib.path
-   :parts: 1
-
 :mod:`matplotlib.transforms`
-=============================
+============================
 
 .. automodule:: matplotlib.transforms
-   :members: TransformNode, BboxBase, Bbox, TransformedBbox, Transform,
-       TransformWrapper, AffineBase, Affine2DBase, Affine2D, IdentityTransform,
-       BlendedGenericTransform, BlendedAffine2D, blended_transform_factory,
-       CompositeGenericTransform, CompositeAffine2D,
-       composite_transform_factory, BboxTransform, BboxTransformTo,
-       BboxTransformFrom, ScaledTranslation, TransformedPath, nonsingular,
-       interval_contains, interval_contains_open
-   :show-inheritance:
+   :no-members:
+   :no-undoc-members:
 
+.. automodapi:: matplotlib.transforms
+    :no-main-docstr:
+    :skip: affine_transform
+    :skip: inv
+    :skip: Path
+    :skip: count_bboxes_overlapping_bbox
+    :skip: update_path_extents

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,6 +29,7 @@ sys.path.append(os.path.abspath('.'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx_automodapi.automodapi',
     'sphinx.ext.doctest',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
@@ -48,6 +49,8 @@ extensions = [
 
 exclude_patterns = ['api/api_changes/*', 'users/whats_new/*']
 
+automodapi_toctreedirnm = 'api/_as_gen'
+automodsumm_inherited_members = True
 
 def _check_deps():
     names = {"colorspacious": 'colorspacious',

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1815,7 +1815,9 @@ class Affine2DBase(AffineBase):
     def matrix_from_values(a, b, c, d, e, f):
         """
         (staticmethod) Create a new transformation matrix as a 3x3
-        numpy array of the form::
+        numpy array of the form:
+
+        ::
 
           a c e
           b d f
@@ -1869,7 +1871,9 @@ class Affine2D(Affine2DBase):
 
     def __init__(self, matrix=None, **kwargs):
         """
-        Initialize an Affine transform from a 3x3 numpy float array::
+        Initialize an Affine transform from a 3x3 numpy float array:
+
+        ::
 
           a c e
           b d f
@@ -1894,7 +1898,9 @@ class Affine2D(Affine2DBase):
     def from_values(a, b, c, d, e, f):
         """
         (staticmethod) Create a new Affine2D instance from the given
-        values::
+        values:
+
+        ::
 
           a c e
           b d f
@@ -1907,7 +1913,9 @@ class Affine2D(Affine2DBase):
 
     def get_matrix(self):
         """
-        Get the underlying transformation matrix as a 3x3 numpy array::
+        Get the underlying transformation matrix as a 3x3 numpy array:
+
+        ::
 
           a c e
           b d f
@@ -1920,7 +1928,9 @@ class Affine2D(Affine2DBase):
 
     def set_matrix(self, mtx):
         """
-        Set the underlying transformation matrix from a 3x3 numpy array::
+        Set the underlying transformation matrix from a 3x3 numpy array:
+
+        ::
 
           a c e
           b d f


### PR DESCRIPTION
Work in progress. I am testing a couple of ways to render the documentation. Issue for discussion appear soon.

Test to see if automodapi are installed on CircleCi and to show the results if it is.
 
I am testing the `transforms` module. The result looks ok on my computer.

edit: The same problems with the docstrings with `::` in the first line again. I fix it tomorrow.

~~Ok, automodapi was not installed. I guess that could be fixed by someone. The extension is definitely useful but probable not the best option for all modules.~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
