### PR TITLE
FIX: subplots don't mutate kwargs passed by user.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1471,6 +1471,9 @@ default: 'top'
             subplot_kw = {}
         if gridspec_kw is None:
             gridspec_kw = {}
+        # don't mutate kwargs passed by user...
+        subplot_kw = subplot_kw.copy()
+        gridspec_kw = gridspec_kw.copy()
 
         if self.get_constrained_layout():
             gs = GridSpec(nrows, ncols, figure=self, **gridspec_kw)

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -149,3 +149,12 @@ def test_get_gridspec():
     # ahem, pretty trivial, but...
     fig, ax = plt.subplots()
     assert ax.get_subplotspec().get_gridspec() == ax.get_gridspec()
+
+
+def test_dont_mutate_kwargs():
+    subplot_kw = {'sharex': 'all'}
+    gridspec_kw = {'width_ratios': [1, 2]}
+    fig, ax = plt.subplots(1, 2, subplot_kw=subplot_kw,
+                           gridspec_kw=gridspec_kw)
+    assert subplot_kw == {'sharex': 'all'}
+    assert gridspec_kw == {'width_ratios': [1, 2]}


### PR DESCRIPTION
## PR Summary

Closes #11515

Don't mess with the user-supplied dictionaries in `subplots`...

Dunno if this really merits a test..

```python
import numpy as np
import matplotlib.pyplot as plt


subplot_kw = {'sharex': 'all'}
print(subplot_kw)
fig, ax = plt.subplots(2, 1, subplot_kw=subplot_kw)
print(subplot_kw)
```

### New:

```
{'sharex': 'all'}
{'sharex': 'all'}
```

### Old:

```
{'sharex': 'all'}
{'sharex': None, 'sharey': None}
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->