### PR TITLE
FIX: let colorbar extends work for PowerNorm

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -79,7 +79,7 @@ per-file-ignores =
     mpl_toolkits/axisartist/grid_finder.py: E231, E261, E302, E303, E402
     mpl_toolkits/axisartist/grid_helper_curvelinear.py: E225, E231, E261, E262, E271, E302, E303, E501
     mpl_toolkits/mplot3d/art3d.py: E203, E222, E225, E231
-    mpl_toolkits/mplot3d/axes3d.py: E203, E231, E303, E402, E501, E701
+    mpl_toolkits/mplot3d/axes3d.py: E203, E231, E402, E501, E701
     mpl_toolkits/mplot3d/axis3d.py: E231, E302
     mpl_toolkits/mplot3d/proj3d.py: E231, E302, E303
     mpl_toolkits/tests/test_axes_grid1.py: E201, E202

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -828,8 +828,9 @@ class ColorbarBase(cm.ScalarMappable):
 
             b = self.norm.inverse(self._uniform_y(self.cmap.N + 1))
 
-            if isinstance(self.norm, colors.LogNorm):
-                # If using a lognorm, ensure extensions don't go negative
+            if isinstance(self.norm, (colors.PowerNorm, colors.LogNorm)):
+                # If using a lognorm or powernorm, ensure extensions don't
+                # go negative
                 if self._extend_lower():
                     b[0] = 0.9 * b[0]
                 if self._extend_upper():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -4,7 +4,7 @@ import pytest
 from matplotlib import rc_context
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
-from matplotlib.colors import BoundaryNorm, LogNorm
+from matplotlib.colors import BoundaryNorm, LogNorm, PowerNorm
 from matplotlib.cm import get_cmap
 from matplotlib.colorbar import ColorbarBase
 
@@ -368,6 +368,14 @@ def test_colorbar_lognorm_extension():
     # Test that colorbar with lognorm is extended correctly
     f, ax = plt.subplots()
     cb = ColorbarBase(ax, norm=LogNorm(vmin=0.1, vmax=1000.0),
+                      orientation='vertical', extend='both')
+    assert cb._values[0] >= 0.0
+
+
+def test_colorbar_powernorm_extension():
+    # Test that colorbar with powernorm is extended correctly
+    f, ax = plt.subplots()
+    cb = ColorbarBase(ax, norm=PowerNorm(gamma=0.5, vmin=0.0, vmax=1.0),
                       orientation='vertical', extend='both')
     assert cb._values[0] >= 0.0
 


### PR DESCRIPTION
## PR Summary

Closes #11486

`PowerNorm` needed similar special casing to `LogNorm` for `extend='min'` for colorbar...

```python

import numpy as np

import matplotlib
import matplotlib.pyplot as plt
import matplotlib.colors as colors

fig, ax = plt.subplots(2, 1)

test_data1 = np.zeros((100,100), ) # data at the bottom bound of the range
disp_obj1 = ax[0].imshow (test_data1, norm=colors.PowerNorm(gamma=0.5, vmin=0.0, vmax=1.0,),)
# ************ to reproduce the bug, use the line with 'both' or 'min' extends *************
#fig.colorbar(disp_obj1, ax=ax[0], )
fig.colorbar(disp_obj1, ax=ax[0], extend='max')
#fig.colorbar(disp_obj1, ax=ax[0], extend='min')
#fig.colorbar(disp_obj1, ax=ax[0], extend='both')

test_data2 = np.ones((100,100), ) * 0.25 # all positive data that's inside the range
disp_obj2 = ax[1].imshow (test_data2, norm=colors.PowerNorm(gamma=0.5, vmin=0.0, vmax=1.0,),)
# ************ to reproduce the bug, use the line with 'both' or 'min' extends *************
#fig.colorbar(disp_obj2, ax=ax[1], )
#fig.colorbar(disp_obj2, ax=ax[1], extend='max')
fig.colorbar(disp_obj2, ax=ax[1], extend='min')
#fig.colorbar(disp_obj2, ax=ax[1], extend='both')

plt.show()

```

### Before:

```

/Users/jklymak/matplotlib/lib/matplotlib/colors.py:1201: RuntimeWarning: invalid value encountered in power
  np.power(resdat, gamma, resdat)
/Users/jklymak/matplotlib/lib/matplotlib/colorbar.py:999: RuntimeWarning: invalid value encountered in true_divide
  z = np.take(y, i0) + (xn - np.take(b, i0)) * dy / db
```

![figure_1](https://user-images.githubusercontent.com/1562854/42464719-c509cc7a-835e-11e8-9f06-4b6b970bd6bb.png)


### After:

![figure_1](https://user-images.githubusercontent.com/1562854/42464689-b24dec06-835e-11e8-8b96-241f76f065b6.png)


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->