### PR TITLE
Make flake8 exceptions explicit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -92,7 +92,29 @@ per-file-ignores =
     doc/sphinxext/math_symbol_table.py: E302, E501
     doc/sphinxext/skip_deprecated.py: E302
     doc/users/generate_credits.py: E302, E501
-    tutorials/**: E402, E501
+    tutorials/advanced/path_tutorial.py: E402, E501
+    tutorials/advanced/patheffects_guide.py: E402, E501
+    tutorials/advanced/transforms_tutorial.py: E402, E501
+    tutorials/colors/colormaps.py: E501
+    tutorials/colors/colors.py: E402
+    tutorials/intermediate/artists.py: E402, E501
+    tutorials/intermediate/constrainedlayout_guide.py: E402, E501
+    tutorials/intermediate/gridspec.py: E402, E501
+    tutorials/intermediate/legend_guide.py: E402, E501
+    tutorials/intermediate/tight_layout_guide.py: E402, E501
+    tutorials/introductory/customizing.py: E501
+    tutorials/introductory/images.py: E402, E501
+    tutorials/introductory/pyplot.py: E402, E501
+    tutorials/introductory/sample_plots.py: E501
+    tutorials/introductory/usage.py: E402, E501
+    tutorials/text/annotations.py: E501
+    tutorials/text/mathtext.py: E501
+    tutorials/text/pgf.py: E501
+    tutorials/text/text_intro.py: E402
+    tutorials/text/text_props.py: E501
+    tutorials/text/usetex.py: E501
+    tutorials/toolkits/axes_grid.py: E501
+    tutorials/toolkits/axisartist.py: E501
 
     examples/**: E501, E402
     examples/images_contours_and_fields/tricontour_demo.py: E201

--- a/.flake8
+++ b/.flake8
@@ -81,7 +81,7 @@ per-file-ignores =
     mpl_toolkits/axisartist/grid_finder.py: E231, E261, E302, E303, E402
     mpl_toolkits/axisartist/grid_helper_curvelinear.py: E225, E231, E261, E262, E271, E302, E303, E501
     mpl_toolkits/mplot3d/art3d.py: E203, E222, E225, E231
-    mpl_toolkits/mplot3d/axes3d.py: E203, E231, E303, E402, E501, E701
+    mpl_toolkits/mplot3d/axes3d.py: E203, E231, E402, E501, E701
     mpl_toolkits/mplot3d/axis3d.py: E231, E302
     mpl_toolkits/mplot3d/proj3d.py: E231, E302, E303
     mpl_toolkits/tests/test_axes_grid1.py: E201, E202

--- a/.flake8
+++ b/.flake8
@@ -116,24 +116,168 @@ per-file-ignores =
     tutorials/toolkits/axes_grid.py: E501
     tutorials/toolkits/axisartist.py: E501
 
-    examples/**: E501, E402
-    examples/images_contours_and_fields/tricontour_demo.py: E201
-    examples/images_contours_and_fields/tripcolor_demo.py: E201
-    examples/images_contours_and_fields/triplot_demo.py: E201
+    examples/animation/frame_grabbing_sgskip.py: E402
+    examples/axes_grid1/inset_locator_demo.py: E402
+    examples/axisartist/demo_curvelinear_grid.py: E402
+    examples/color/color_by_yvalue.py: E402
+    examples/color/color_cycle_default.py: E402
+    examples/color/color_cycler.py: E402
+    examples/color/color_demo.py: E402
+    examples/color/colorbar_basics.py: E402
+    examples/color/colormap_reference.py: E402
+    examples/color/named_colors.py: E402
+    examples/event_handling/data_browser.py: E501
+    examples/event_handling/path_editor.py: E501
+    examples/event_handling/pick_event_demo.py: E501
+    examples/event_handling/poly_editor.py: E501
+    examples/event_handling/viewlims.py: E501
+    examples/images_contours_and_fields/affine_image.py: E402
+    examples/images_contours_and_fields/barb_demo.py: E402, E501
+    examples/images_contours_and_fields/barcode_demo.py: E402
+    examples/images_contours_and_fields/contour_corner_mask.py: E402
+    examples/images_contours_and_fields/contour_demo.py: E402, E501
+    examples/images_contours_and_fields/contour_image.py: E402
+    examples/images_contours_and_fields/contourf_demo.py: E402, E501
+    examples/images_contours_and_fields/contourf_hatching.py: E402
+    examples/images_contours_and_fields/contourf_log.py: E402
+    examples/images_contours_and_fields/custom_cmap.py: E402
+    examples/images_contours_and_fields/demo_bboximage.py: E402
+    examples/images_contours_and_fields/image_clip_path.py: E402
+    examples/images_contours_and_fields/image_demo.py: E402
+    examples/images_contours_and_fields/image_masked.py: E402
+    examples/images_contours_and_fields/image_transparency_blend.py: E402
+    examples/images_contours_and_fields/image_zcoord.py: E402
+    examples/images_contours_and_fields/interpolation_methods.py: E402
+    examples/images_contours_and_fields/irregulardatagrid.py: E402
+    examples/images_contours_and_fields/layer_images.py: E402
+    examples/images_contours_and_fields/matshow.py: E402
+    examples/images_contours_and_fields/multi_image.py: E402
+    examples/images_contours_and_fields/pcolor_demo.py: E402
+    examples/images_contours_and_fields/plot_streamplot.py: E402
+    examples/images_contours_and_fields/quadmesh_demo.py: E402
+    examples/images_contours_and_fields/quiver_demo.py: E402
+    examples/images_contours_and_fields/quiver_simple_demo.py: E402
+    examples/images_contours_and_fields/shading_example.py: E402, E501
+    examples/images_contours_and_fields/specgram_demo.py: E402, E501
+    examples/images_contours_and_fields/spy_demos.py: E402
+    examples/images_contours_and_fields/tricontour_demo.py: E201, E402
+    examples/images_contours_and_fields/tricontour_smooth_delaunay.py: E402
+    examples/images_contours_and_fields/tricontour_smooth_user.py: E402
+    examples/images_contours_and_fields/trigradient_demo.py: E402
+    examples/images_contours_and_fields/triinterp_demo.py: E402
+    examples/images_contours_and_fields/tripcolor_demo.py: E201, E402
+    examples/images_contours_and_fields/triplot_demo.py: E201, E402
+    examples/images_contours_and_fields/watermark_image.py: E402
+    examples/lines_bars_and_markers/fill_between_demo.py: E402
+    examples/lines_bars_and_markers/filled_step.py: E402
+    examples/lines_bars_and_markers/joinstyle.py: E402
+    examples/lines_bars_and_markers/scatter_piecharts.py: E402
+    examples/lines_bars_and_markers/span_regions.py: E402
+    examples/misc/agg_oo_sgskip.py: E402
+    examples/misc/anchored_artists.py: E501
+    examples/misc/contour_manual.py: E501
+    examples/misc/font_indexing.py: E501
+    examples/misc/ftface_props.py: E501
+    examples/misc/histogram_path.py: E402
+    examples/misc/print_stdout_sgskip.py: E402
+    examples/misc/svg_filter_line.py: E402, E501
+    examples/misc/svg_filter_pie.py: E402, E501
     examples/misc/table_demo.py: E201
-    examples/pyplots/annotate_transform.py: E228, E251
-    examples/pyplots/annotation_polar.py: E231
-    examples/pyplots/auto_subplots_adjust.py: E231, E261, E302
-    examples/pyplots/boxplot_demo_pyplot.py: E231
+    examples/mplot3d/voxels.py: E501
+    examples/mplot3d/wire3d_zero_stride.py: E501
+    examples/pie_and_polar_charts/nested_pie.py: E402
+    examples/pie_and_polar_charts/pie_and_donut_labels.py: E402
+    examples/pie_and_polar_charts/pie_demo2.py: E402
+    examples/pie_and_polar_charts/pie_features.py: E402
+    examples/pie_and_polar_charts/polar_bar.py: E402
+    examples/pie_and_polar_charts/polar_demo.py: E402
+    examples/pie_and_polar_charts/polar_legend.py: E402
+    examples/pie_and_polar_charts/polar_scatter.py: E402
+    examples/pyplots/align_ylabels.py: E402
+    examples/pyplots/annotate_transform.py: E228, E251, E402, E501
+    examples/pyplots/annotation_basic.py: E402
+    examples/pyplots/annotation_polar.py: E231, E402
+    examples/pyplots/auto_subplots_adjust.py: E231, E261, E302, E402
+    examples/pyplots/boxplot_demo_pyplot.py: E231, E402
     examples/pyplots/compound_path_demo.py: E231
-    examples/pyplots/fig_axes_customize_simple.py: E261
-    examples/pyplots/pyplot_formatstr.py: E231
-    examples/pyplots/pyplot_mathtext.py: E231
+    examples/pyplots/dollar_ticks.py: E402
+    examples/pyplots/fig_axes_customize_simple.py: E261, E402
+    examples/pyplots/fig_axes_labels_simple.py: E402
+    examples/pyplots/fig_x.py: E402
+    examples/pyplots/pyplot_formatstr.py: E231, E402
+    examples/pyplots/pyplot_mathtext.py: E231, E402
+    examples/pyplots/pyplot_scales.py: E402
     examples/pyplots/pyplot_simple.py: E231
-    examples/pyplots/pyplot_two_subplots.py: E302
-    examples/pyplots/text_commands.py: E231
-    examples/pyplots/text_layout.py: E231
-    examples/pyplots/whats_new_98_4_fancy.py: E225, E261, E302
-    examples/pyplots/whats_new_98_4_fill_between.py: E225
-    examples/pyplots/whats_new_98_4_legend.py: E228
-    examples/pyplots/whats_new_99_spines.py: E231, E261
+    examples/pyplots/pyplot_simple.py: E402
+    examples/pyplots/pyplot_text.py: E402
+    examples/pyplots/pyplot_three.py: E402
+    examples/pyplots/pyplot_two_subplots.py: E302, E402
+    examples/pyplots/text_commands.py: E231, E402
+    examples/pyplots/text_layout.py: E231, E402
+    examples/pyplots/whats_new_1_subplot3d.py: E402
+    examples/pyplots/whats_new_98_4_fancy.py: E225, E261, E302, E402
+    examples/pyplots/whats_new_98_4_fill_between.py: E225, E402
+    examples/pyplots/whats_new_98_4_legend.py: E228, E402
+    examples/pyplots/whats_new_99_axes_grid.py: E402
+    examples/pyplots/whats_new_99_mplot3d.py: E402
+    examples/pyplots/whats_new_99_spines.py: E231, E261, E402
+    examples/recipes/placing_text_boxes.py: E501
+    examples/scales/power_norm.py: E402
+    examples/shapes_and_collections/artist_reference.py: E402
+    examples/shapes_and_collections/collections.py: E402
+    examples/shapes_and_collections/compound_path.py: E402
+    examples/shapes_and_collections/dolphin.py: E402, E501
+    examples/shapes_and_collections/donut.py: E402
+    examples/shapes_and_collections/ellipse_collection.py: E402
+    examples/shapes_and_collections/ellipse_demo.py: E402
+    examples/shapes_and_collections/fancybox_demo.py: E402
+    examples/shapes_and_collections/hatch_demo.py: E402
+    examples/shapes_and_collections/line_collection.py: E402
+    examples/shapes_and_collections/marker_path.py: E402
+    examples/shapes_and_collections/patch_collection.py: E402
+    examples/shapes_and_collections/path_patch.py: E402, E501
+    examples/shapes_and_collections/quad_bezier.py: E402
+    examples/shapes_and_collections/scatter.py: E402
+    examples/showcase/firefox.py: E501
+    examples/specialty_plots/anscombe.py: E402, E501
+    examples/specialty_plots/radar_chart.py: E402
+    examples/specialty_plots/sankey_basics.py: E402, E501
+    examples/specialty_plots/sankey_links.py: E402
+    examples/specialty_plots/sankey_rankine.py: E402
+    examples/specialty_plots/skewt.py: E402
+    examples/statistics/boxplot_demo.py: E501
+    examples/style_sheets/bmh.py: E501
+    examples/style_sheets/ggplot.py: E501
+    examples/style_sheets/plot_solarizedlight2.py: E501
+    examples/subplots_axes_and_figures/axes_margins.py: E402
+    examples/subplots_axes_and_figures/axes_zoom_effect.py: E402
+    examples/subplots_axes_and_figures/demo_tight_layout.py: E402
+    examples/subplots_axes_and_figures/two_scales.py: E402
+    examples/tests/backend_driver_sgskip.py: E402, E501
+    examples/text_labels_and_annotations/annotation_demo.py: E501
+    examples/text_labels_and_annotations/custom_legends.py: E402
+    examples/text_labels_and_annotations/font_family_rc_sgskip.py: E402
+    examples/text_labels_and_annotations/font_file.py: E402
+    examples/text_labels_and_annotations/legend.py: E402
+    examples/text_labels_and_annotations/line_with_text.py: E402
+    examples/text_labels_and_annotations/mathtext_asarray.py: E402
+    examples/text_labels_and_annotations/tex_demo.py: E402
+    examples/text_labels_and_annotations/watermark_text.py: E402
+    examples/ticks_and_spines/auto_ticks.py: E501
+    examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py: E402
+    examples/user_interfaces/embedding_in_gtk3_sgskip.py: E402
+    examples/user_interfaces/embedding_in_qt_sgskip.py: E402
+    examples/user_interfaces/embedding_in_wx2_sgskip.py: E501
+    examples/user_interfaces/embedding_in_wx3_sgskip.py: E501
+    examples/user_interfaces/embedding_in_wx4_sgskip.py: E501
+    examples/user_interfaces/embedding_in_wx5_sgskip.py: E501
+    examples/user_interfaces/embedding_webagg_sgskip.py: E501
+    examples/user_interfaces/gtk_spreadsheet_sgskip.py: E402
+    examples/user_interfaces/mathtext_wx_sgskip.py: E402, E501
+    examples/user_interfaces/mpl_with_glade3_sgskip.py: E402
+    examples/user_interfaces/pylab_with_gtk_sgskip.py: E402, E501
+    examples/user_interfaces/toolmanager_sgskip.py: E402
+    examples/userdemo/custom_boxstyle01.py: E402
+    examples/userdemo/pgf_preamble_sgskip.py: E402
+    examples/userdemo/simple_annotate01.py: E501
+    examples/widgets/rectangle_selector.py: E501

--- a/.flake8
+++ b/.flake8
@@ -87,8 +87,11 @@ per-file-ignores =
     mpl_toolkits/tests/test_axes_grid1.py: E201, E202
     mpl_toolkits/tests/test_mplot3d.py: E231, E302
 
-    doc/**: E302, E501
-    doc/conf.py: E402
+    doc/conf.py: E402, E501
+    doc/sphinxext/github.py: E302, E501
+    doc/sphinxext/math_symbol_table.py: E302, E501
+    doc/sphinxext/skip_deprecated.py: E302
+    doc/users/generate_credits.py: E302, E501
     tutorials/**: E402, E501
 
     examples/**: E501, E402


### PR DESCRIPTION
## PR Summary

We have some globs being used to define exceptions over a great many files. This instead makes them explicit. There are three reasons: 1) when running `flake8` on a single file, it won't trigger the superfluous warning if the globs are not applicable; 2) it will be easier to remove these exceptions piecemeal as things are fixed, and 3) new files can't accidentally add to the exceptions.

Also, fix the spurious exception issue in `master`.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way