### PR TITLE
CI: don't run tox to test pytz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,6 @@ script:
   - |
     echo "Calling pytest with the following arguments: $PYTEST_ADDOPTS"
     python -mpytest
-  - tox -e pytz
   - |
     if [[ $RUN_FLAKE8 == 1 ]]; then
       flake8 --statistics && echo "Flake8 passed without any issues!"

--- a/requirements/testing/travis36.txt
+++ b/requirements/testing/travis36.txt
@@ -4,3 +4,4 @@ flake8
 flake8-per-file-ignores
 jupyter
 pandas<0.21.0
+pytz


### PR DESCRIPTION
We install pandas on 2 of the entries in the test matrix which in
pytz.  Additionally explicitly install pytz on one of the py3.6 runs.

This is to address the tox run being a bit flaky during pytest collection.

The figure of merit on this PR is that the coverage does not go down at all.