### PR TITLE
Changes to the pyplot api documentation

### DIFF
--- a/doc/api/colors_api.rst
+++ b/doc/api/colors_api.rst
@@ -2,12 +2,14 @@
 colors
 ******
 
-For a visual representation of the Matplotlib colormaps, see:
+Tutorials and examples about matplotlib colors:
 
+* :doc:`/tutorials/colors/colors` tutorial.
+* :doc:`/tutorials/colors/colormaps` tutorial.
+* All :ref:`tutorials-colors` tutorials.
 * The :ref:`color_examples` examples for examples of controlling color with
   Matplotlib.
-* The :ref:`tutorials-colors` tutorial for an in-depth guide on controlling
-  color.
+
 
 :mod:`matplotlib.colors`
 ========================

--- a/doc/api/pyplot_summary.rst
+++ b/doc/api/pyplot_summary.rst
@@ -1,29 +1,275 @@
-Pyplot function overview
-------------------------
+******
+pyplot
+******
 
-.. currentmodule:: matplotlib
+.. currentmodule:: matplotlib.pyplot
+
+.. automodule:: matplotlib.pyplot
+    :no-members:
+
+Creating figures
+================
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    figure
+    subplots
+
+Global functions
+================
 
 .. autosummary::
-   :toctree: _as_gen
-   :template: autofunctions.rst
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
 
-   pyplot
+    findobj
+    get_plot_commands
+    install_repl_displayhook
+    ioff
+    ion
+    isinteractive
+    pause
+    rc
+    rc_context
+    rcdefaults
+    show
+    switch_backend
+    uninstall_repl_displayhook
+
+Any artist
+==========
+
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    getp
+    setp
+    xkcd
+
+Working with figures
+====================
+
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    clf
+    close
+    connect
+    disconnect
+    draw
+    fignum_exists
+    figure
+    gcf
+    get_current_fig_manager
+    get_figlabels
+    get_fignums
+    ginput
+    savefig
+    waitforbuttonpress
+
+Adding elements to figures
+==========================
+
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    figimage
+    figlegend
+    figtext
+    suptitle
+
+Working with axes
+=================
+
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    axes
+    box
+    cla
+    delaxes
+    gca
+    grid
+    sca
+    subplot
+    subplots
+    subplot2grid
+    subplot_tool
+    subplots_adjust
+    tight_layout
+    twinx
+    twiny
+
+Adding elements to axes
+=======================
+
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    annotate
+    arrow
+    legend
+    table
+    text
+    title
 
 
-.. currentmodule:: matplotlib.pyplot
+Working with axis
+=================
 
-.. autofunction:: plotting
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    autoscale
+    axis
+    locator_params
+    margins
+    minorticks_off
+    minorticks_on
+    rgrids
+    thetagrids
+    tick_params
+    ticklabel_format
+    xlabel
+    ylabel
+    xlim
+    ylim
+    xscale
+    yscale
+    xticks
+    yticks
 
 
-Colors in Matplotlib
---------------------
+Current image
+=============
 
-There are many colormaps you can use to map data onto color values.
-Below we list several ways in which color can be utilized in Matplotlib.
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
 
-For a more in-depth look at colormaps, see the
-:doc:`/tutorials/colors/colormaps` tutorial.
+    clabel
+    clim
+    colorbar
+    colormaps
+    gci
+    sci
+    set_cmap
 
-.. currentmodule:: matplotlib.pyplot
+Working with images
+===================
 
-.. autofunction:: colormaps
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    imread
+    imsave
+
+Plotting functions
+==================
+
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    acorr
+    angle_spectrum
+    axhline
+    axhspan
+    axvline
+    axvspan
+    bar
+    barbs
+    barh
+    boxplot
+    broken_barh
+    cohere
+    contour
+    contourf
+    csd
+    errorbar
+    eventplot
+    fill
+    fill_between
+    fill_betweenx
+    hexbin
+    hist
+    hist2d
+    hlines
+    imshow
+    loglog
+    magnitude_spectrum
+    matshow
+    pcolor
+    pcolormesh
+    phase_spectrum
+    pie
+    plot
+    plot_date
+    plotfile
+    polar
+    psd
+    quiver
+    quiverkey
+    scatter
+    semilogx
+    semilogy
+    specgram
+    spy
+    stackplot
+    stem
+    step
+    streamplot
+    tricontour
+    tricontourf
+    tripcolor
+    triplot
+    violinplot
+    vlines
+    xcorr
+
+Colormaps
+=========
+
+.. autosummary::
+    :toctree: _as_gen
+    :template: autosummary.rst
+    :nosignatures:
+
+    autumn
+    bone
+    cool
+    copper
+    flag
+    gray
+    hot
+    hsv
+    inferno
+    jet
+    magma
+    nipy_spectral
+    pink
+    plasma
+    prism
+    spring
+    summer
+    viridis
+    winter

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -1,8 +1,27 @@
 """
 Builtin colormaps, colormap handling utilities, and the `ScalarMappable` mixin.
 
-See :doc:`/gallery/color/colormap_reference` for a list of builtin colormaps.
-See :doc:`/tutorials/colors/colormaps` for an in-depth discussion of colormaps.
+See :doc:`/gallery/color/colormap_reference` for a list of builtin colormaps
+and :doc:`/tutorials/colors/colormaps` for an in-depth discussion of colormaps.
+
+Attributes
+----------
+cmap_d : dict
+    A dictionary with all registred colormaps.
+
+cmap : for example viridis
+    Every registred colormap is an attribute in the module.
+
+See Also
+--------
+.pyplot.colormaps : Returns a list with the names of all available colormaps.
+.colors.Colormap : The colormap class.
+
+Examples
+--------
+The viridis colormap is returned by::
+
+    matplotlib.cm.viridis
 """
 
 import numpy as np

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1794,242 +1794,46 @@ def get_plot_commands():
 
 def colormaps():
     """
+    Returns a list of available colormaps.
+
     Matplotlib provides a number of colormaps, and others can be added using
-    :func:`~matplotlib.cm.register_cmap`.  This function documents the built-in
-    colormaps, and will also return a list of all registered colormaps if called.
+    `~matplotlib.cm.register_cmap`.  The `matplotlib.cm` module documents the
+    built-in and added colormaps. The `.pyplot.colormaps` function will return
+    a list of all registered colormaps if called.
 
     You can set the colormap for an image, pcolor, scatter, etc,
     using a keyword argument::
 
-      imshow(X, cmap=cm.hot)
+      import matplotlib.pyplot as plt
+      import matplotlib.cm as cm
+      import numpy as np
 
-    or using the :func:`set_cmap` function::
+      X = np.random.randn(10,10)
 
-      imshow(X)
-      pyplot.set_cmap('hot')
-      pyplot.set_cmap('jet')
+      plt.imshow(X, cmap=cm.hot)
 
-    In interactive mode, :func:`set_cmap` will update the colormap post-hoc,
+    , using the `.pyplot.set_cmap` function::
+
+      plt.imshow(X)
+      plt.set_cmap('jet')
+
+    or using the image method `~matplotlib.image.AxesImage.set_cmap`
+    ::
+
+      im = plt.imshow(X)
+      im.set_cmap('viridis')
+
+    In interactive mode, `~.pyplot.set_cmap` will update the colormap post-hoc,
     allowing you to see which one works best for your data.
 
-    All built-in colormaps can be reversed by appending ``_r``: For instance,
-    ``gray_r`` is the reverse of ``gray``.
+    See :doc:`/gallery/color/colormap_reference` for a list of builtin
+    colormaps and :doc:`/tutorials/colors/colormaps` for an in-depth discussion
+    of colormaps.
 
-    There are several common color schemes used in visualization:
-
-    Sequential schemes
-      for unipolar data that progresses from low to high
-    Diverging schemes
-      for bipolar data that emphasizes positive or negative deviations from a
-      central value
-    Cyclic schemes
-      for plotting values that wrap around at the endpoints, such as phase
-      angle, wind direction, or time of day
-    Qualitative schemes
-      for nominal data that has no inherent ordering, where color is used
-      only to distinguish categories
-
-    Matplotlib ships with 4 perceptually uniform color maps which are
-    the recommended color maps for sequential data:
-
-      =========   ===================================================
-      Colormap    Description
-      =========   ===================================================
-      inferno     perceptually uniform shades of black-red-yellow
-      magma       perceptually uniform shades of black-red-white
-      plasma      perceptually uniform shades of blue-red-yellow
-      viridis     perceptually uniform shades of blue-green-yellow
-      =========   ===================================================
-
-    The following colormaps are based on the `ColorBrewer
-    <http://colorbrewer2.org>`_ color specifications and designs developed by
-    Cynthia Brewer:
-
-    ColorBrewer Diverging (luminance is highest at the midpoint, and
-    decreases towards differently-colored endpoints):
-
-      ========  ===================================
-      Colormap  Description
-      ========  ===================================
-      BrBG      brown, white, blue-green
-      PiYG      pink, white, yellow-green
-      PRGn      purple, white, green
-      PuOr      orange, white, purple
-      RdBu      red, white, blue
-      RdGy      red, white, gray
-      RdYlBu    red, yellow, blue
-      RdYlGn    red, yellow, green
-      Spectral  red, orange, yellow, green, blue
-      ========  ===================================
-
-    ColorBrewer Sequential (luminance decreases monotonically):
-
-      ========  ====================================
-      Colormap  Description
-      ========  ====================================
-      Blues     white to dark blue
-      BuGn      white, light blue, dark green
-      BuPu      white, light blue, dark purple
-      GnBu      white, light green, dark blue
-      Greens    white to dark green
-      Greys     white to black (not linear)
-      Oranges   white, orange, dark brown
-      OrRd      white, orange, dark red
-      PuBu      white, light purple, dark blue
-      PuBuGn    white, light purple, dark green
-      PuRd      white, light purple, dark red
-      Purples   white to dark purple
-      RdPu      white, pink, dark purple
-      Reds      white to dark red
-      YlGn      light yellow, dark green
-      YlGnBu    light yellow, light green, dark blue
-      YlOrBr    light yellow, orange, dark brown
-      YlOrRd    light yellow, orange, dark red
-      ========  ====================================
-
-    ColorBrewer Qualitative:
-
-    (For plotting nominal data, :class:`ListedColormap` is used,
-    not :class:`LinearSegmentedColormap`.  Different sets of colors are
-    recommended for different numbers of categories.)
-
-    * Accent
-    * Dark2
-    * Paired
-    * Pastel1
-    * Pastel2
-    * Set1
-    * Set2
-    * Set3
-
-    A set of colormaps derived from those of the same name provided
-    with Matlab are also included:
-
-      =========   =======================================================
-      Colormap    Description
-      =========   =======================================================
-      autumn      sequential linearly-increasing shades of red-orange-yellow
-      bone        sequential increasing black-white color map with
-                  a tinge of blue, to emulate X-ray film
-      cool        linearly-decreasing shades of cyan-magenta
-      copper      sequential increasing shades of black-copper
-      flag        repetitive red-white-blue-black pattern (not cyclic at
-                  endpoints)
-      gray        sequential linearly-increasing black-to-white
-                  grayscale
-      hot         sequential black-red-yellow-white, to emulate blackbody
-                  radiation from an object at increasing temperatures
-      jet         a spectral map with dark endpoints, blue-cyan-yellow-red;
-                  based on a fluid-jet simulation by NCSA [#]_
-      pink        sequential increasing pastel black-pink-white, meant
-                  for sepia tone colorization of photographs
-      prism       repetitive red-yellow-green-blue-purple-...-green pattern
-                  (not cyclic at endpoints)
-      spring      linearly-increasing shades of magenta-yellow
-      summer      sequential linearly-increasing shades of green-yellow
-      winter      linearly-increasing shades of blue-green
-      =========   =======================================================
-
-    A set of palettes from the `Yorick scientific visualisation
-    package <https://dhmunro.github.io/yorick-doc/>`_, an evolution of
-    the GIST package, both by David H. Munro are included:
-
-      ============  =======================================================
-      Colormap      Description
-      ============  =======================================================
-      gist_earth    mapmaker's colors from dark blue deep ocean to green
-                    lowlands to brown highlands to white mountains
-      gist_heat     sequential increasing black-red-orange-white, to emulate
-                    blackbody radiation from an iron bar as it grows hotter
-      gist_ncar     pseudo-spectral black-blue-green-yellow-red-purple-white
-                    colormap from National Center for Atmospheric
-                    Research [#]_
-      gist_rainbow  runs through the colors in spectral order from red to
-                    violet at full saturation (like *hsv* but not cyclic)
-      gist_stern    "Stern special" color table from Interactive Data
-                    Language software
-      ============  =======================================================
-
-    A set of cyclic color maps:
-
-      ================  =========================================================
-      Colormap          Description
-      ================  =========================================================
-      hsv               red-yellow-green-cyan-blue-magenta-red, formed by changing
-                        the hue component in the HSV color space
-      twilight          perceptually uniform shades of white-blue-black-red-white
-      twilight_shifted  perceptually uniform shades of black-blue-white-red-black
-      ================  =========================================================
-
-
-    Other miscellaneous schemes:
-
-      ============= =======================================================
-      Colormap      Description
-      ============= =======================================================
-      afmhot        sequential black-orange-yellow-white blackbody
-                    spectrum, commonly used in atomic force microscopy
-      brg           blue-red-green
-      bwr           diverging blue-white-red
-      coolwarm      diverging blue-gray-red, meant to avoid issues with 3D
-                    shading, color blindness, and ordering of colors [#]_
-      CMRmap        "Default colormaps on color images often reproduce to
-                    confusing grayscale images. The proposed colormap
-                    maintains an aesthetically pleasing color image that
-                    automatically reproduces to a monotonic grayscale with
-                    discrete, quantifiable saturation levels." [#]_
-      cubehelix     Unlike most other color schemes cubehelix was designed
-                    by D.A. Green to be monotonically increasing in terms
-                    of perceived brightness. Also, when printed on a black
-                    and white postscript printer, the scheme results in a
-                    greyscale with monotonically increasing brightness.
-                    This color scheme is named cubehelix because the r,g,b
-                    values produced can be visualised as a squashed helix
-                    around the diagonal in the r,g,b color cube.
-      gnuplot       gnuplot's traditional pm3d scheme
-                    (black-blue-red-yellow)
-      gnuplot2      sequential color printable as gray
-                    (black-blue-violet-yellow-white)
-      ocean         green-blue-white
-      rainbow       spectral purple-blue-green-yellow-orange-red colormap
-                    with diverging luminance
-      seismic       diverging blue-white-red
-      nipy_spectral black-purple-blue-green-yellow-red-white spectrum,
-                    originally from the Neuroimaging in Python project
-      terrain       mapmaker's colors, blue-green-yellow-brown-white,
-                    originally from IGOR Pro
-      ============= =======================================================
-
-    The following colormaps are redundant and may be removed in future
-    versions.  It's recommended to use the names in the descriptions
-    instead, which produce identical output:
-
-      =========  =======================================================
-      Colormap   Description
-      =========  =======================================================
-      gist_gray  identical to *gray*
-      gist_yarg  identical to *gray_r*
-      binary     identical to *gray_r*
-      =========  =======================================================
-
-    .. rubric:: Footnotes
-
-    .. [#] Rainbow colormaps, ``jet`` in particular, are considered a poor
-      choice for scientific visualization by many researchers: `Rainbow Color
-      Map (Still) Considered Harmful
-      <http://ieeexplore.ieee.org/document/4118486/?arnumber=4118486>`_
-
-    .. [#] Resembles "BkBlAqGrYeOrReViWh200" from NCAR Command
-      Language. See `Color Table Gallery
-      <https://www.ncl.ucar.edu/Document/Graphics/color_table_gallery.shtml>`_
-
-    .. [#] See `Diverging Color Maps for Scientific Visualization
-      <http://www.kennethmoreland.com/color-maps/>`_ by Kenneth Moreland.
-
-    .. [#] See `A Color Map for Effective Black-and-White Rendering of
-      Color-Scale Images
-      <https://www.mathworks.com/matlabcentral/fileexchange/2662-cmrmap-m>`_
-      by Carey Rappaport
+    See Also
+    --------
+    matplotlib.cm
+    matplotlib.colors
     """
     return sorted(cm.cmap_d)
 


### PR DESCRIPTION
 I did some formatting to the `pyplot` api page. The sections are mostly taken from the sections in the `pyplot.py` file. 

I took away the colormaps section as it is a function in `pyplot` anyway. 

These changes make it much easier to find out about the pyplot functions.


- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
