### PR TITLE
FIX: be forgiving about the event for enterEvent not having a pos

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -291,7 +291,11 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         return int(w / self._dpi_ratio), int(h / self._dpi_ratio)
 
     def enterEvent(self, event):
-        x, y = self.mouseEventCoords(event.pos())
+        try:
+            x, y = self.mouseEventCoords(event.pos())
+        except AttributeError:
+            # the event from PyQt4 does not include the position
+            x = y = None
         FigureCanvasBase.enter_notify_event(self, guiEvent=event, xy=(x, y))
 
     def leaveEvent(self, event):


### PR DESCRIPTION
closes #11607

The event object passed in from PyQt4 does not have a `pos` attribute.
Be forgiving of this and fallback to None.  This matches the fallback
behavior in backend_bases if xy is not passed to `enter_notify_event`.

attn @lkjell