### PR TITLE
DOC: better tight_layout error handling

### DIFF
--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -305,3 +305,14 @@ def test_big_decorators_vertical():
     with warnings.catch_warnings(record=True) as w:
         fig.tight_layout()
         assert len(w) == 1
+
+
+def test_badsubplotgrid():
+    # test that we get warning for mismatched subplot grids rather
+    # than an error
+    ax1 = plt.subplot2grid((4, 5), (0, 0))
+    # this is the bad entry:
+    ax5 = plt.subplot2grid((5, 5), (0, 3), colspan=3, rowspan=5)
+    with warnings.catch_warnings(record=True) as w:
+        plt.tight_layout()
+        assert len(w) == 1

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -326,8 +326,16 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
         rows, cols, num1, num2 = subplotspec.get_geometry()
         div_row, mod_row = divmod(max_nrows, rows)
         div_col, mod_col = divmod(max_ncols, cols)
-        if (mod_row != 0) or (mod_col != 0):
-            raise RuntimeError("")
+        if mod_row != 0:
+            warnings.warn('tight_layout not applied: '
+                          'number of rows in subplot specifications must'
+                          'be multiples of one another.')
+            return {}
+        if mod_col != 0:
+            warnings.warn('tight_layout not applied: '
+                          'number of columns in subplot specifications must'
+                          'be multiples of one another.')
+            return {}
 
         rowNum1, colNum1 = divmod(num1, cols)
         if num2 is None:


### PR DESCRIPTION
## PR Summary

Closes #11625

A malformed subplot grid leads to a Runtime Error, which is a bit over the top.  This PR changes to a warning and just doesn't apply `tight_layout`.

```
/Users/jklymak/matplotlib/lib/matplotlib/tight_layout.py:330: UserWarning: Incompatible rows or columns in tight_layout; tight_layout not applied.
  warnings.warn('Incompatible rows or columns in tight_layout; '
```

```python
import numpy as np
import matplotlib.pyplot as plt

plt.figure()

ax1 = plt.subplot2grid((4, 5), (0, 0))
ax2 = plt.subplot2grid((4, 5), (0, 1))
ax3 = plt.subplot2grid((4, 5), (0, 2))
ax4 = plt.subplot2grid((4, 5), (1, 0),colspan=3,rowspan=5)
# this is the bad entry:
ax5 = plt.subplot2grid((5, 5), (0, 3),colspan=3,rowspan=5)

plt.tight_layout()
plt.show()
```


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->