### PR TITLE
Don't flush file object opened for reading

### DIFF
--- a/src/file_compat.h
+++ b/src/file_compat.h
@@ -59,12 +59,15 @@ static NPY_INLINE FILE *mpl_PyFile_Dup(PyObject *file, char *mode, mpl_off_t *or
     mpl_off_t pos;
     FILE *handle;
 
-    /* Flush first to ensure things end up in the file in the correct order */
-    ret = PyObject_CallMethod(file, (char *)"flush", (char *)"");
-    if (ret == NULL) {
-        return NULL;
+    if (mode[0] != 'r') {
+        /* Flush first to ensure things end up in the file in the correct order */
+        ret = PyObject_CallMethod(file, (char *)"flush", (char *)"");
+        if (ret == NULL) {
+            return NULL;
+        }
+        Py_DECREF(ret);
     }
-    Py_DECREF(ret);
+
     fd = PyObject_AsFileDescriptor(file);
     if (fd == -1) {
         return NULL;


### PR DESCRIPTION
Don't attempt to flush a file object opened for reading, because on BSD systems, it results in an error return from fflush(), with the end result that "import matplotlib.pyplot" fails with the error message "TypeError: First argument must be a path or file object reading bytes".  

Closes #11635. 
