### PR TITLE
Fix barplot color if none and alpha is set

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1999,14 +1999,14 @@ class Axes(_AxesBase):
         linewidth = itertools.cycle(np.atleast_1d(linewidth))
         color = itertools.chain(itertools.cycle(mcolors.to_rgba_array(color)),
                                 # Fallback if color == "none".
-                                itertools.repeat([0, 0, 0, 0]))
+                                itertools.repeat('none'))
         if edgecolor is None:
             edgecolor = itertools.repeat(None)
         else:
             edgecolor = itertools.chain(
                 itertools.cycle(mcolors.to_rgba_array(edgecolor)),
                 # Fallback if edgecolor == "none".
-                itertools.repeat([0, 0, 0, 0]))
+                itertools.repeat('none'))
 
         # We will now resolve the alignment and really have
         # left, bottom, width, height vectors

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1456,6 +1456,22 @@ def test_bar_tick_label_multiple_old_alignment():
            align='center')
 
 
+def test_bar_color_none_alpha():
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='none', edgecolor='r')
+    for rect in rects:
+        assert rect.get_facecolor() == (0, 0, 0, 0)
+        assert rect.get_edgecolor() == (1, 0, 0, 0.3)
+
+
+def test_bar_edgecolor_none_alpha():
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='r', edgecolor='none')
+    for rect in rects:
+        assert rect.get_facecolor() == (1, 0, 0, 0.3)
+        assert rect.get_edgecolor() == (0, 0, 0, 0)
+
+
 @image_comparison(baseline_images=['barh_tick_label'],
                   extensions=['png'])
 def test_barh_tick_label():


### PR DESCRIPTION
## PR Summary

Fixes #11628.

The actual fix is a bit hacky. It relies on the fact that in `Rectangle(edgecolor='none', alpha=0.3)` alpha is applied before the color is resolved to [0,0,0,0]. The reverse order would overwrite the alpha of the edgecolor. Maybe the whole color resolution has to be thought through at some point.

Anyway the fix works and has a test. So, it will blow up if the color resolution in Rectangle would be changed. This is good enough for now.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
