### PR TITLE
Fix deprecation messages.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -862,11 +862,11 @@ class RcParams(MutableMapping, dict):
                         "either import that binding first, or set the QT_API "
                         "environment variable.")
                 cbook.warn_deprecated(
-                    "2.2", key, obj_type="rcparam", addendum=addendum)
+                    "2.2", name=key, obj_type="rcparam", addendum=addendum)
             elif key in _deprecated_ignore_map:
                 version, alt_key = _deprecated_ignore_map[key]
                 cbook.warn_deprecated(
-                    version, key, obj_type="rcparam", alternative=alt_key)
+                    version, name=key, obj_type="rcparam", alternative=alt_key)
                 return
             elif key == 'examples.directory':
                 cbook.warn_deprecated(

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -46,10 +46,9 @@ def _generate_deprecation_message(
             + (" Use %(alternative)s instead." if alternative else "")
             + (" %(addendum)s" if addendum else ""))
 
-    return (
-        message % dict(func=name, name=name, obj_type=obj_type, since=since,
-                       removal=removal, alternative=alternative)
-        + addendum)
+    return message % dict(
+        func=name, name=name, obj_type=obj_type, since=since, removal=removal,
+        alternative=alternative, addendum=addendum)
 
 
 def warn_deprecated(


### PR DESCRIPTION
1) in generate_deprecation message, pass `addendum` to the format dict
   (otherwise formatting `%(addendum)s` will throw).
2) in warn_deprecated in the rcParams, `key` is the name of the
   deprecated object, not the whole deprecation message.

release critical per point 1).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
