### PR TITLE
Add feature to fallback to stix font in mathtext

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -758,7 +758,9 @@ class UnicodeFonts(TruetypeFonts):
 
     def __init__(self, *args, **kwargs):
         # This must come first so the backend's owner is set correctly
-        if rcParams['mathtext.fallback_to_cm']:
+        if rcParams['mathtext.fallback'] == 'stix':
+            self.cm_fallback = StixFonts(*args, **kwargs)
+        elif rcParams['mathtext.fallback'] == 'cm' or rcParams['mathtext.fallback_to_cm']:
             self.cm_fallback = BakomaFonts(*args, **kwargs)
         else:
             self.cm_fallback = None
@@ -825,13 +827,21 @@ class UnicodeFonts(TruetypeFonts):
                     warnings.warn(
                         "Substituting with a symbol from Computer Modern.",
                         MathTextWarning)
-                if (fontname in ('it', 'regular') and
-                        isinstance(self.cm_fallback, StixFonts)):
-                    return self.cm_fallback._get_glyph(
-                            'rm', font_class, sym, fontsize)
-                else:
-                    return self.cm_fallback._get_glyph(
-                        fontname, font_class, sym, fontsize)
+                elif isinstance(self.cm_fallback, StixFonts):
+                    warnings.warn(
+                        "Substituting with a symbol from STIX.",
+                        MathTextWarning)
+                # note sure whether this is still required...
+                # if (fontname in ('it', 'regular') and
+                        # isinstance(self.cm_fallback, StixFonts)):
+                    # return self.cm_fallback._get_glyph(
+                            # 'rm', font_class, sym, fontsize)
+                # else:
+                    # return self.cm_fallback._get_glyph(
+                        # fontname, font_class, sym, fontsize)
+
+                return self.cm_fallback._get_glyph(
+                    fontname, font_class, sym, fontsize)
             else:
                 if (fontname in ('it', 'regular')
                         and isinstance(self, StixFonts)):

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -760,7 +760,8 @@ class UnicodeFonts(TruetypeFonts):
         # This must come first so the backend's owner is set correctly
         if rcParams['mathtext.fallback'] == 'stix':
             self.cm_fallback = StixFonts(*args, **kwargs)
-        elif rcParams['mathtext.fallback'] == 'cm' or rcParams['mathtext.fallback_to_cm']:
+        elif (rcParams['mathtext.fallback'] == 'cm' or
+              rcParams['mathtext.fallback_to_cm']):
             self.cm_fallback = BakomaFonts(*args, **kwargs)
         else:
             self.cm_fallback = None
@@ -835,19 +836,16 @@ class UnicodeFonts(TruetypeFonts):
                         "Substituting with a symbol from Computer Modern.",
                         MathTextWarning)
                 elif isinstance(self.cm_fallback, StixFonts):
-                    warnings.warn(
-                        "Substituting with a symbol from STIX.",
-                        MathTextWarning)
+                    warnings.warn("Substituting with a symbol from STIX.",
+                                  MathTextWarning)
+
                 if (fontname in ('it', 'regular') and
                         isinstance(self.cm_fallback, StixFonts)):
-                    return self.cm_fallback._get_glyph(
-                            'rm', font_class, sym, fontsize)
-                else:
-                    return self.cm_fallback._get_glyph(
-                        fontname, font_class, sym, fontsize)
+                    fontname = 'rm'
 
                 return self.cm_fallback._get_glyph(
                     fontname, font_class, sym, fontsize)
+
             else:
                 if (fontname in ('it', 'regular')
                         and isinstance(self, StixFonts)):

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -774,13 +774,21 @@ class UnicodeFonts(TruetypeFonts):
         prop = FontProperties('cmex10')
         font = findfont(prop)
         self.fontmap['ex'] = font
-        # include stix sized alternatives for glyphs if fallback is stix
+
+        # include STIZ sized alternatives for glyphs if fallback is STIX
         if isinstance(self.cm_fallback, StixFonts):
-            stixsizedaltfonts = "STIXGeneral STIXSizeOneSym STIXSizeTwoSym "\
-                "STIXSizeThreeSym STIXSizeFourSym STIXSizeFiveSym".split()
-            for i, stixfont in enumerate(stixsizedaltfonts):
-                font = findfont(stixfont)
-                self.fontmap[i] = font
+            stixsizedaltfonts = {
+                 0: 'STIXGeneral',
+                 1: 'STIXSizeOneSym',
+                 2: 'STIXSizeTwoSym',
+                 3: 'STIXSizeThreeSym',
+                 4: 'STIXSizeFourSym',
+                 5: 'STIXSizeFiveSym'}
+
+            for size, name in stixsizedaltfonts.items():
+                fullpath = findfont(name)
+                self.fontmap[size] = fullpath
+                self.fontmap[name] = fullpath
 
     _slanted_symbols = set(r"\int \oint".split())
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -773,6 +773,13 @@ class UnicodeFonts(TruetypeFonts):
         prop = FontProperties('cmex10')
         font = findfont(prop)
         self.fontmap['ex'] = font
+        # include stix sized alternatives for glyphs if fallback is stix
+        if isinstance(self.cm_fallback, StixFonts):
+            stixsizedaltfonts = "STIXGeneral STIXSizeOneSym STIXSizeTwoSym "\
+                "STIXSizeThreeSym STIXSizeFourSym STIXSizeFiveSym".split()
+            for i, stixfont in enumerate(stixsizedaltfonts):
+                font = findfont(stixfont)
+                self.fontmap[i] = font
 
     _slanted_symbols = set(r"\int \oint".split())
 
@@ -831,14 +838,13 @@ class UnicodeFonts(TruetypeFonts):
                     warnings.warn(
                         "Substituting with a symbol from STIX.",
                         MathTextWarning)
-                # note sure whether this is still required...
-                # if (fontname in ('it', 'regular') and
-                        # isinstance(self.cm_fallback, StixFonts)):
-                    # return self.cm_fallback._get_glyph(
-                            # 'rm', font_class, sym, fontsize)
-                # else:
-                    # return self.cm_fallback._get_glyph(
-                        # fontname, font_class, sym, fontsize)
+                if (fontname in ('it', 'regular') and
+                        isinstance(self.cm_fallback, StixFonts)):
+                    return self.cm_fallback._get_glyph(
+                            'rm', font_class, sym, fontsize)
+                else:
+                    return self.cm_fallback._get_glyph(
+                        fontname, font_class, sym, fontsize)
 
                 return self.cm_fallback._get_glyph(
                     fontname, font_class, sym, fontsize)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -448,13 +448,10 @@ def validate_font_properties(s):
 
 def validate_mathtext_fallback(s):
     fallback_fonts = ['cm', 'stix']
-    if s is None:
-        return s
+    if s is None or s == 'None':
+        return None
 
-    if isinstance(s, str):
-        s = s.lower()
-
-    if s in fallback_fonts:
+    if s.lower() in fallback_fonts:
         return s
 
     raise ValueError("%s is not a valid fallback font name. Valid fallback "

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -446,6 +446,20 @@ def validate_font_properties(s):
     return s
 
 
+def validate_mathtext_fallback(s):
+    fallback_fonts = ['cm', 'stix']
+    if s is None:
+        return s
+
+    if isinstance(s, str):
+        s = s.lower()
+
+    if s in fallback_fonts:
+        return s
+
+    raise ValueError("%s is not a valid fallback font name. Valid fallback "
+                     "font names are %s." % (s, ", ".join(fallback_fonts)))
+
 validate_fontset = ValidateInStrings(
     'fontset',
     ['dejavusans', 'dejavuserif', 'cm', 'stix', 'stixsans', 'custom'])
@@ -1117,6 +1131,7 @@ defaultParams = {
     'mathtext.fontset':        ['dejavusans', validate_fontset],
     'mathtext.default':        ['it', validate_mathtext_default],
     'mathtext.fallback_to_cm': [True, validate_bool],
+    'mathtext.fallback':       [None, validate_mathtext_fallback],
 
     'image.aspect':        ['equal', validate_aspect],  # equal, auto, a number
     'image.interpolation': ['nearest', validate_string],
@@ -1368,7 +1383,7 @@ defaultParams = {
     # ignore any color-setting commands from the frontend
     'pdf.inheritcolor': [False, validate_bool],
     # use only the 14 PDF core fonts embedded in every PDF viewing application
-    'pdf.use14corefonts': [False, validate_bool],
+     'pdf.use14corefonts': [False, validate_bool],
     'pdf.fonttype':     [3, validate_fonttype],  # 3 (Type3) or 42 (Truetype)
 
     'pgf.debug':     [False, validate_bool],  # output debug information

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1383,7 +1383,7 @@ defaultParams = {
     # ignore any color-setting commands from the frontend
     'pdf.inheritcolor': [False, validate_bool],
     # use only the 14 PDF core fonts embedded in every PDF viewing application
-     'pdf.use14corefonts': [False, validate_bool],
+    'pdf.use14corefonts': [False, validate_bool],
     'pdf.fonttype':     [3, validate_fonttype],  # 3 (Type3) or 42 (Truetype)
 
     'pgf.debug':     [False, validate_bool],  # output debug information

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -451,6 +451,9 @@ def validate_mathtext_fallback(s):
     if s is None or s == 'None':
         return None
 
+    if not isinstance(s, str):
+        raise ValueError("Must be a string or None.")
+
     if s.lower() in fallback_fonts:
         return s
 


### PR DESCRIPTION
## PR Summary

When using a custom font for math (`mathtext.fontset : custom`), the only fallback for undefined symbols/characters is *Computer Modern* at the moment. See also https://github.com/matplotlib/matplotlib/issues/8619.

The pull request contains a new rcParam `mathtext.fallback` which can be `stix`, `cm` or None.

```
mathtext.fallback: stix
```

Support for the original rcParam `mathtext.fallback_to_cm` is still available. The feature seems to work as the plots shows.

<img src="https://user-images.githubusercontent.com/1986144/42625924-4da38cb2-85c9-11e8-8b6a-c79f2f86de20.png" alt="stix" width="200" /> <img src="https://user-images.githubusercontent.com/1986144/42626544-e5e61a0c-85ca-11e8-8a94-e38f6f16f369.png" alt="cm" width="200" />


(Example plot with *STIX* (left) respectively *CM* (right) as mathtext fallback and *Helvetica Neue* as custom mathtext font)

**If this pull request has any chance of getting merged, I'm happy to clean up the code, add documentation, and testing.**

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way