### PR TITLE
Remove unused imports in examples

### DIFF
--- a/examples/event_handling/ginput_manual_clabel_sgskip.py
+++ b/examples/event_handling/ginput_manual_clabel_sgskip.py
@@ -14,12 +14,9 @@ See also ginput_demo.py
 
 """
 
-
 import time
-import matplotlib
+
 import numpy as np
-import matplotlib.cm as cm
-import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
 
 

--- a/examples/frontpage/3D.py
+++ b/examples/frontpage/3D.py
@@ -6,7 +6,9 @@ Frontpage 3D example
 This example reproduces the frontpage 3D example.
 
 """
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 from matplotlib import cbook
 from matplotlib import cm
 from matplotlib.colors import LightSource

--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -12,7 +12,6 @@ See also the :doc:`contour demo example
 
 import matplotlib
 import numpy as np
-import matplotlib.cm as cm
 import matplotlib.ticker as ticker
 import matplotlib.pyplot as plt
 

--- a/examples/images_contours_and_fields/figimage_demo.py
+++ b/examples/images_contours_and_fields/figimage_demo.py
@@ -8,7 +8,6 @@ This illustrates placing images directly in the figure, with no Axes objects.
 """
 import numpy as np
 import matplotlib
-import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 
 

--- a/examples/images_contours_and_fields/quadmesh_demo.py
+++ b/examples/images_contours_and_fields/quadmesh_demo.py
@@ -11,7 +11,7 @@ This demo illustrates a bug in quadmesh with masked data.
 
 import copy
 
-from matplotlib import cm, colors, pyplot as plt
+from matplotlib import cm, pyplot as plt
 import numpy as np
 
 n = 12

--- a/examples/images_contours_and_fields/quiver_demo.py
+++ b/examples/images_contours_and_fields/quiver_demo.py
@@ -13,7 +13,6 @@ expand the Axes objects.
 """
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import ma
 
 X, Y = np.meshgrid(np.arange(0, 2 * np.pi, .2), np.arange(0, 2 * np.pi, .2))
 U = np.cos(X)

--- a/examples/lines_bars_and_markers/scatter_symbol.py
+++ b/examples/lines_bars_and_markers/scatter_symbol.py
@@ -8,7 +8,6 @@ Scatter plot with clover symbols.
 """
 import matplotlib.pyplot as plt
 import numpy as np
-import matplotlib
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)

--- a/examples/misc/load_converter.py
+++ b/examples/misc/load_converter.py
@@ -7,7 +7,6 @@ Load Converter
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
-import matplotlib.dates as mdates
 from matplotlib.dates import bytespdate2num
 
 datafile = cbook.get_sample_data('msft.csv', asfileobj=False)

--- a/examples/misc/plotfile_demo.py
+++ b/examples/misc/plotfile_demo.py
@@ -6,8 +6,6 @@ Plotfile Demo
 Example use of ``plotfile`` to plot data directly from a file.
 """
 import matplotlib.pyplot as plt
-import numpy as np
-
 import matplotlib.cbook as cbook
 
 fname = cbook.get_sample_data('msft.csv', asfileobj=False)

--- a/examples/misc/transoffset.py
+++ b/examples/misc/transoffset.py
@@ -23,7 +23,6 @@ import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 import numpy as np
 
-from matplotlib.transforms import offset_copy
 
 xs = np.arange(7)
 ys = xs**2

--- a/examples/mplot3d/2dcollections3d.py
+++ b/examples/mplot3d/2dcollections3d.py
@@ -7,7 +7,9 @@ Demonstrates using ax.plot's zdir keyword to plot 2D data on
 selective axes of a 3D plot.
 """
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/examples/mplot3d/3d_bars.py
+++ b/examples/mplot3d/3d_bars.py
@@ -10,7 +10,8 @@ shading.
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 
 # setup the figure and axes

--- a/examples/mplot3d/bars3d.py
+++ b/examples/mplot3d/bars3d.py
@@ -7,7 +7,9 @@ Demonstrates making a 3D plot which has 2D bar graphs projected onto
 planes y=0, y=1, etc.
 """
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/custom_shaded_3d_surface.py
+++ b/examples/mplot3d/custom_shaded_3d_surface.py
@@ -6,7 +6,9 @@ Custom hillshading in a 3D surface plot
 Demonstrates using custom hillshading in a 3D surface plot.
 """
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 from matplotlib import cbook
 from matplotlib import cm
 from matplotlib.colors import LightSource

--- a/examples/mplot3d/hist3d.py
+++ b/examples/mplot3d/hist3d.py
@@ -6,7 +6,9 @@ Create 3D histogram of 2D data
 Demo of a histogram for 2 dimensional data as a bar graph in 3D.
 """
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/lines3d.py
+++ b/examples/mplot3d/lines3d.py
@@ -6,12 +6,14 @@ Parametric Curve
 This example demonstrates plotting a parametric curve in 3D.
 '''
 
-import matplotlib as mpl
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import numpy as np
 import matplotlib.pyplot as plt
 
-mpl.rcParams['legend.fontsize'] = 10
+
+plt.rcParams['legend.fontsize'] = 10
 
 fig = plt.figure()
 ax = fig.gca(projection='3d')

--- a/examples/mplot3d/lorenz_attractor.py
+++ b/examples/mplot3d/lorenz_attractor.py
@@ -15,7 +15,8 @@ Note: Because this is a simple non-linear ODE, it would be more easily
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 
 def lorenz(x, y, z, s=10, r=28, b=2.667):

--- a/examples/mplot3d/mixed_subplots.py
+++ b/examples/mplot3d/mixed_subplots.py
@@ -5,7 +5,9 @@
 
 This example shows a how to plot a 2D and 3D plot on the same figure.
 """
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/offset.py
+++ b/examples/mplot3d/offset.py
@@ -13,7 +13,9 @@ y axis by adding 1e5 to X and Y. Anything less would not
 automatically trigger it.
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/pathpatch3d.py
+++ b/examples/mplot3d/pathpatch3d.py
@@ -9,11 +9,11 @@ Demonstrate using pathpatch_2d_to_3d to 'draw' shapes and text on a 3D plot.
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, PathPatch
-# register Axes3D class with matplotlib by importing Axes3D
-from mpl_toolkits.mplot3d import Axes3D
-import mpl_toolkits.mplot3d.art3d as art3d
 from matplotlib.text import TextPath
 from matplotlib.transforms import Affine2D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+import mpl_toolkits.mplot3d.art3d as art3d
 
 
 def text3d(ax, xyz, s, zdir="z", size=None, angle=0, usetex=False, **kwargs):

--- a/examples/mplot3d/polys3d.py
+++ b/examples/mplot3d/polys3d.py
@@ -8,7 +8,9 @@ graph. In this example polygons are semi-transparent, creating a sort
 of 'jagged stained glass' effect.
 """
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 from matplotlib.collections import PolyCollection
 import matplotlib.pyplot as plt
 from matplotlib import colors as mcolors

--- a/examples/mplot3d/quiver3d.py
+++ b/examples/mplot3d/quiver3d.py
@@ -6,7 +6,9 @@
 Demonstrates plotting directional arrows at points on a 3d meshgrid.
 '''
 
-from mpl_toolkits.mplot3d import axes3d
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/scatter3d.py
+++ b/examples/mplot3d/scatter3d.py
@@ -6,7 +6,9 @@
 Demonstration of a basic scatterplot in 3D.
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/subplot3d.py
+++ b/examples/mplot3d/subplot3d.py
@@ -7,9 +7,12 @@ Demonstrate including 3D plots as subplots.
 '''
 
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d.axes3d import Axes3D, get_test_data
 from matplotlib import cm
 import numpy as np
+
+from mpl_toolkits.mplot3d.axes3d import get_test_data
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 
 # set up a figure twice as wide as it is tall

--- a/examples/mplot3d/surface3d.py
+++ b/examples/mplot3d/surface3d.py
@@ -10,7 +10,9 @@ Also demonstrates using the LinearLocator and custom formatting for the
 z axis tick labels.
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 from matplotlib import cm
 from matplotlib.ticker import LinearLocator, FormatStrFormatter

--- a/examples/mplot3d/surface3d_2.py
+++ b/examples/mplot3d/surface3d_2.py
@@ -6,7 +6,9 @@
 Demonstrates a very basic plot of a 3D surface using a solid color.
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/surface3d_3.py
+++ b/examples/mplot3d/surface3d_3.py
@@ -8,7 +8,6 @@ Demonstrates plotting a 3D surface colored in a checkerboard pattern.
 
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
-from matplotlib import cm
 from matplotlib.ticker import LinearLocator
 import numpy as np
 

--- a/examples/mplot3d/surface3d_3.py
+++ b/examples/mplot3d/surface3d_3.py
@@ -6,7 +6,9 @@
 Demonstrates plotting a 3D surface colored in a checkerboard pattern.
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 from matplotlib.ticker import LinearLocator
 import numpy as np

--- a/examples/mplot3d/surface3d_radial.py
+++ b/examples/mplot3d/surface3d_radial.py
@@ -10,7 +10,9 @@ Also demonstrates writing axis labels with latex math mode.
 Example contributed by Armin Moser.
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/text3d.py
+++ b/examples/mplot3d/text3d.py
@@ -16,7 +16,9 @@ Functionality shown:
 
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 
 

--- a/examples/mplot3d/tricontour3d.py
+++ b/examples/mplot3d/tricontour3d.py
@@ -9,8 +9,10 @@ The data used is the same as in the second plot of trisurf3d_demo2.
 tricontourf3d_demo shows the filled version of this example.
 """
 
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.tri as tri
 import numpy as np
 

--- a/examples/mplot3d/tricontourf3d.py
+++ b/examples/mplot3d/tricontourf3d.py
@@ -9,8 +9,10 @@ The data used is the same as in the second plot of trisurf3d_demo2.
 tricontour3d_demo shows the unfilled version of this example.
 """
 
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.tri as tri
 import numpy as np
 

--- a/examples/mplot3d/trisurf3d.py
+++ b/examples/mplot3d/trisurf3d.py
@@ -6,7 +6,9 @@ Triangular 3D surfaces
 Plot a 3D surface with a triangular mesh.
 '''
 
-from mpl_toolkits.mplot3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/mplot3d/trisurf3d_2.py
+++ b/examples/mplot3d/trisurf3d_2.py
@@ -12,8 +12,10 @@ to plot_trisurf.
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.tri as mtri
+
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 
 fig = plt.figure(figsize=plt.figaspect(0.5))

--- a/examples/mplot3d/voxels.py
+++ b/examples/mplot3d/voxels.py
@@ -8,7 +8,10 @@ Demonstrates plotting 3D volumetric objects with ``ax.voxels``
 
 import matplotlib.pyplot as plt
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
+
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 
 # prepare some coordinates
 x, y, z = np.indices((8, 8, 8))

--- a/examples/mplot3d/voxels_numpy_logo.py
+++ b/examples/mplot3d/voxels_numpy_logo.py
@@ -7,7 +7,9 @@ Demonstrates using ``ax.voxels`` with uneven coordinates
 '''
 import matplotlib.pyplot as plt
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
+
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 
 def explode(data):

--- a/examples/mplot3d/voxels_rgb.py
+++ b/examples/mplot3d/voxels_rgb.py
@@ -8,7 +8,9 @@ Demonstrates using ``ax.voxels`` to visualize parts of a color space
 
 import matplotlib.pyplot as plt
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
+
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 
 def midpoints(x):

--- a/examples/mplot3d/voxels_torus.py
+++ b/examples/mplot3d/voxels_torus.py
@@ -9,7 +9,9 @@ Demonstrates using the ``x, y, z`` arguments of ``ax.voxels``.
 import matplotlib.pyplot as plt
 import matplotlib.colors
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
+
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
 
 def midpoints(x):

--- a/examples/mplot3d/wire3d_animation_sgskip.py
+++ b/examples/mplot3d/wire3d_animation_sgskip.py
@@ -10,7 +10,9 @@ intentionally takes a long time to run)
 """
 
 
-from mpl_toolkits.mplot3d import axes3d
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 import matplotlib.pyplot as plt
 import numpy as np
 import time

--- a/examples/pyplots/fig_axes_customize_simple.py
+++ b/examples/pyplots/fig_axes_customize_simple.py
@@ -5,7 +5,7 @@ Fig Axes Customize Simple
 
 Customize the background, labels and ticks of a simple plot.
 """
-import numpy as np
+
 import matplotlib.pyplot as plt
 
 ###############################################################################

--- a/examples/pyplots/fig_x.py
+++ b/examples/pyplots/fig_x.py
@@ -5,7 +5,6 @@ Fig X
 
 Add lines to a figure (without axes).
 """
-import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.lines as lines
 

--- a/examples/pyplots/whats_new_1_subplot3d.py
+++ b/examples/pyplots/whats_new_1_subplot3d.py
@@ -5,7 +5,9 @@ Whats New 1 Subplot3d
 
 Create two three-dimensional plots in the same figure.
 """
-from mpl_toolkits.mplot3d.axes3d import Axes3D
+# This import registers the 3D projection, but is otherwise unused.
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
+
 from matplotlib import cm
 #from matplotlib.ticker import LinearLocator, FixedLocator, FormatStrFormatter
 import matplotlib.pyplot as plt

--- a/examples/shapes_and_collections/patch_collection.py
+++ b/examples/shapes_and_collections/patch_collection.py
@@ -8,7 +8,6 @@ This example demonstrates how to use
 """
 
 import numpy as np
-import matplotlib
 from matplotlib.patches import Circle, Wedge, Polygon
 from matplotlib.collections import PatchCollection
 import matplotlib.pyplot as plt

--- a/examples/specialty_plots/sankey_basics.py
+++ b/examples/specialty_plots/sankey_basics.py
@@ -5,7 +5,7 @@ The Sankey class
 
 Demonstrate the Sankey class by producing three basic diagrams.
 """
-import numpy as np
+
 import matplotlib.pyplot as plt
 
 from matplotlib.sankey import Sankey

--- a/examples/specialty_plots/sankey_links.py
+++ b/examples/specialty_plots/sankey_links.py
@@ -6,8 +6,6 @@ Long chain of connections using Sankey
 Demonstrate/test the Sankey class by producing a long chain of connections.
 """
 
-from itertools import cycle
-
 import matplotlib.pyplot as plt
 from matplotlib.sankey import Sankey
 

--- a/examples/statistics/violinplot.py
+++ b/examples/statistics/violinplot.py
@@ -16,7 +16,6 @@ For more information on violin plots and KDE, the scikit-learn docs
 have a great section: http://scikit-learn.org/stable/modules/density.html
 """
 
-import random
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/examples/subplots_axes_and_figures/figure_title.py
+++ b/examples/subplots_axes_and_figures/figure_title.py
@@ -5,7 +5,6 @@ Figure Title
 
 Create a figure with separate subplot titles and a centered figure title.
 """
-from matplotlib.font_manager import FontProperties
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/tests/backend_driver_sgskip.py
+++ b/examples/tests/backend_driver_sgskip.py
@@ -357,7 +357,6 @@ def drive(backend, directories, python=['python'], switches=[]):
     # Clear the destination directory for the examples
     path = backend
     if os.path.exists(path):
-        import glob
         for fname in os.listdir(path):
             os.unlink(os.path.join(path, fname))
     else:

--- a/examples/text_labels_and_annotations/date.py
+++ b/examples/text_labels_and_annotations/date.py
@@ -16,7 +16,6 @@ These can convert between `datetime.datetime` objects and
 :class:`numpy.datetime64` objects.
 """
 
-import datetime
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates

--- a/examples/text_labels_and_annotations/fonts_demo_kw.py
+++ b/examples/text_labels_and_annotations/fonts_demo_kw.py
@@ -8,9 +8,7 @@ Set font properties using kwargs.
 See :doc:`fonts_demo` to achieve the same effect using setters.
 """
 
-from matplotlib.font_manager import FontProperties
 import matplotlib.pyplot as plt
-import numpy as np
 
 plt.subplot(111, facecolor='w')
 alignment = {'horizontalalignment': 'center', 'verticalalignment': 'baseline'}

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import subprocess
 import sys
 import re
-import gc
 
 # Selection of features following "Writing mathematical expressions" tutorial
 mathtext_titles = {

--- a/examples/text_labels_and_annotations/text_alignment.py
+++ b/examples/text_labels_and_annotations/text_alignment.py
@@ -9,8 +9,6 @@ layout.
 """
 
 import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
-from matplotlib.patches import Rectangle
 
 # Build a rectangle in axes coords
 left, width = .25, .5

--- a/examples/text_labels_and_annotations/usetex_baseline_test.py
+++ b/examples/text_labels_and_annotations/usetex_baseline_test.py
@@ -5,7 +5,6 @@ Usetex Baseline Test
 
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.axes as maxes
 

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -11,7 +11,6 @@ import numpy as np
 
 import matplotlib.units as units
 import matplotlib.ticker as ticker
-from matplotlib.axes import Axes
 from matplotlib.cbook import iterable
 
 

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -21,11 +21,6 @@ This was derived from embedding_in_wx and dynamic_image_wxagg.
 Thanks to matplotlib and wx teams for creating such great software!
 """
 
-
-import sys
-import time
-import os
-import gc
 import matplotlib
 import matplotlib.cm as cm
 import matplotlib.cbook as cbook

--- a/examples/user_interfaces/mpl_with_glade3_sgskip.py
+++ b/examples/user_interfaces/mpl_with_glade3_sgskip.py
@@ -12,7 +12,6 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 from matplotlib.figure import Figure
-from matplotlib.axes import Subplot
 from matplotlib.backends.backend_gtk3agg import (
     FigureCanvasGTK3Agg as FigureCanvas)
 import numpy as np

--- a/examples/userdemo/connectionstyle_demo.py
+++ b/examples/userdemo/connectionstyle_demo.py
@@ -6,7 +6,6 @@ Connectionstyle Demo
 """
 
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
 
 
 fig, axs = plt.subplots(3, 5, figsize=(8, 4.8))

--- a/examples/widgets/menu.py
+++ b/examples/widgets/menu.py
@@ -5,7 +5,6 @@ Menu
 
 """
 import numpy as np
-import matplotlib
 import matplotlib.colors as colors
 import matplotlib.patches as patches
 import matplotlib.mathtext as mathtext


### PR DESCRIPTION
## PR Summary

Because extra imports make things look less simple, and simple is clearer, I think. Also, annotate the reason for the `Axes3D` import, which is generally non-obvious unless you happen to be looking at the one example with a comment about it.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way