### PR TITLE
Sort named colors example vertically for easier comparison of similar colors

### DIFF
--- a/examples/color/named_colors.py
+++ b/examples/color/named_colors.py
@@ -27,7 +27,7 @@ n = len(sorted_names)
 ncols = 4
 nrows = n // ncols
 
-fig, ax = plt.subplots(figsize=(12, 10))
+fig, ax = plt.subplots(figsize=(9, 7.5))
 
 # Get height and width
 X, Y = fig.get_dpi() * fig.get_size_inches()

--- a/examples/color/named_colors.py
+++ b/examples/color/named_colors.py
@@ -27,7 +27,7 @@ n = len(sorted_names)
 ncols = 4
 nrows = n // ncols
 
-fig, ax = plt.subplots(figsize=(9, 7.5))
+fig, ax = plt.subplots(figsize=(9, 8))
 
 # Get height and width
 X, Y = fig.get_dpi() * fig.get_size_inches()
@@ -43,12 +43,12 @@ for i, name in enumerate(sorted_names):
     xf_line = w * (col + 0.25)
     xi_text = w * (col + 0.3)
 
-    ax.text(xi_text, y, name, fontsize=(h * 0.8),
+    ax.text(xi_text, y, name, fontsize=(h * 0.5),
             horizontalalignment='left',
             verticalalignment='center')
 
     ax.hlines(y + h * 0.1, xi_line, xf_line,
-              color=colors[name], linewidth=(h * 0.8))
+              color=colors[name], linewidth=(h * 0.6))
 
 ax.set_xlim(0, X)
 ax.set_ylim(0, Y)

--- a/examples/color/named_colors.py
+++ b/examples/color/named_colors.py
@@ -25,9 +25,9 @@ sorted_names = [name for hsv, name in by_hsv]
 
 n = len(sorted_names)
 ncols = 4
-nrows = n // ncols + 1
+nrows = n // ncols
 
-fig, ax = plt.subplots(figsize=(8, 5))
+fig, ax = plt.subplots(figsize=(12, 10))
 
 # Get height and width
 X, Y = fig.get_dpi() * fig.get_size_inches()
@@ -35,8 +35,8 @@ h = Y / (nrows + 1)
 w = X / ncols
 
 for i, name in enumerate(sorted_names):
-    col = i % ncols
-    row = i // ncols
+    row = i % nrows
+    col = i // nrows
     y = Y - (row * h) - h
 
     xi_line = w * (col + 0.05)
@@ -48,7 +48,7 @@ for i, name in enumerate(sorted_names):
             verticalalignment='center')
 
     ax.hlines(y + h * 0.1, xi_line, xf_line,
-              color=colors[name], linewidth=(h * 0.6))
+              color=colors[name], linewidth=(h * 0.8))
 
 ax.set_xlim(0, X)
 ax.set_ylim(0, Y)


### PR DESCRIPTION
## PR Summary
Just a suggestion to sort [the named colors example](https://matplotlib.org/examples/color/named_colors.html) vertically in order to place similar colors closer together which can facilitate comparisons. Also changed spacing and the size of the color lines relative the text.

### Old appearance
 ![image](https://user-images.githubusercontent.com/4560057/42728957-5dc5742e-8796-11e8-95da-640cfce5d8d6.png)

### New appearance
![image](https://user-images.githubusercontent.com/4560057/42728961-6de142ca-8796-11e8-996b-d80ba6cf5ea4.png)



## PR Checklist

- ~~Has Pytest style unit tests~~
- [x] Code is PEP 8 compliant
- ~~New features are documented, with examples if plot related~~
- ~~Documentation is sphinx and numpydoc compliant~~
- ~~Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- ~~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~