### PR TITLE
Update blocking_input.py

### DIFF
--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -135,7 +135,7 @@ class BlockingMouseInput(BlockingInput):
             self.mouse_event_pop(event)
         elif button == self.button_stop:
             self.mouse_event_stop(event)
-        else:
+        elif self.button_add:
             self.mouse_event_add(event)
 
     def key_event(self):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2139,10 +2139,13 @@ default: 'top'
             If True, show a red cross at the location of each click.
         mouse_add : int, one of (1, 2, 3), optional, default: 1 (left click)
             Mouse button used to add points.
+            Use a different button value to disable this mouse action.
         mouse_pop : int, one of (1, 2, 3), optional, default: 3 (right click)
             Mouse button used to remove the most recently added point.
+            Use a different button value to disable this mouse action.
         mouse_stop : int, one of (1, 2, 3), optional, default: 2 (middle click)
             Mouse button used to stop input.
+            Use a different button value to disable this mouse action.
 
         Returns
         -------


### PR DESCRIPTION
ginput doesn´t allow to disable buttons.
With this change you can assign an invalid button to the three mouse buttons and leave the left click empty to zoom or pan.

Only one issue. I´m just starting with python (only worked with matlab and VB, you can tell my proficiency by that alone, so please don´t be too harsh if I made any mistake) and I don´t know if this change in BlockingMouseInput will create a regression issue to any other matplotlib function.

Thanks.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
