### PR TITLE
FIX: clean up unit conversion unpacking of data, particularly for dates and pandas series

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3901,10 +3901,10 @@ class Axes(_AxesBase):
         N = len(bxpstats)
         datashape_message = ("List of boxplot statistics and `{0}` "
                              "values must have same the length")
-        # check position
         if positions is None:
             positions = list(range(1, N + 1))
-        elif len(positions) != N:
+        positions = self.convert_xunits(positions)
+        if len(positions) != N:
             raise ValueError(datashape_message.format("positions"))
 
         # width
@@ -6048,7 +6048,7 @@ class Axes(_AxesBase):
 
         # convert to one dimensional arrays
         C = C.ravel()
-        coords = np.column_stack((X, Y)).astype(float, copy=False)
+        coords = np.column_stack((X, Y)).astype(float)
         collection = mcoll.QuadMesh(Nx - 1, Ny - 1, coords,
                                     antialiased=antialiased, shading=shading,
                                     **kwargs)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -4,6 +4,8 @@ Classes for the ticks and x and y axis
 
 import datetime
 import logging
+import numbers
+import warnings
 
 import numpy as np
 
@@ -1477,9 +1479,14 @@ class Axis(martist.Artist):
         return self.converter is not None or self.units is not None
 
     def convert_units(self, x):
-        # If x is already a number, doesn't need converting
+        # If x is already a number, doesn't need converting, but
+        # some iterables need to be massaged a bit...
         if munits.ConversionInterface.is_numlike(x):
-            return x
+            if isinstance(x, list) or isinstance(x, numbers.Number):
+                return x
+            if issubclass(type(x), np.ma.MaskedArray):
+                return np.ma.asarray(x)
+            return np.asarray(x)
 
         if self.converter is None:
             self.converter = munits.registry.get_converter(x)

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -419,6 +419,11 @@ def date2num(d):
             return _dt64_to_ordinalf(d)
         if not d.size:
             return d
+        if hasattr(d, 'dtype'):
+            if ((isinstance(d, np.ndarray) and
+                    np.issubdtype(d.dtype, np.datetime64)) or
+                    isinstance(d, np.datetime64)):
+                return _dt64_to_ordinalf(d)
         return _to_ordinalf_np_vectorized(d)
 
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -91,17 +91,8 @@ def pd():
     pd = pytest.importorskip('pandas')
     try:
         from pandas.plotting import (
-            register_matplotlib_converters as register)
+            deregister_matplotlib_converters as deregister)
+        deregister()
     except ImportError:
-        from pandas.tseries.converter import register
-    register()
-    try:
-        yield pd
-    finally:
-        try:
-            from pandas.plotting import (
-                deregister_matplotlib_converters as deregister)
-        except ImportError:
-            pass
-        else:
-            deregister()
+        pass
+    return pd

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5422,6 +5422,18 @@ def test_pandas_bar_align_center(pd):
     fig.canvas.draw()
 
 
+def test_pandas_data_unpack(pd):
+    # smoke test for all these different calling methods.
+    dates = [datetime.datetime(2018, 7, i) for i in range(1, 5)]
+    values = np.cumsum(np.random.rand(len(dates)))
+    df = pd.DataFrame({"dates": dates, "values": values})
+    plt.plot(df["dates"].values,  df["values"])
+    plt.scatter(df["dates"],  df["values"])
+    plt.plot("dates", "values", data=df)
+    plt.scatter(x="dates", y="values", data=df)
+    plt.draw()
+
+
 def test_axis_set_tick_params_labelsize_labelcolor():
     # Tests fix for issue 4346
     axis_1 = plt.subplot()

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -616,6 +616,16 @@ def test_date2num_dst_pandas(pd):
     _test_date2num_dst(pd.date_range, tz_convert)
 
 
+def test_dateboxplot_pandas(pd):
+    # smoke test that this doesn't fail.
+    data = np.random.rand(5,2)
+    years = pd.date_range('1/1/2000',
+                          periods=2, freq=pd.DateOffset(years=1)).year
+    # Does not work
+    plt.figure()
+    plt.boxplot(data, positions=years)
+
+
 def _test_rrulewrapper(attach_tz, get_tz):
     SYD = get_tz('Australia/Sydney')
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -618,7 +618,7 @@ def test_date2num_dst_pandas(pd):
 
 def test_dateboxplot_pandas(pd):
     # smoke test that this doesn't fail.
-    data = np.random.rand(5,2)
+    data = np.random.rand(5, 2)
     years = pd.date_range('1/1/2000',
                           periods=2, freq=pd.DateOffset(years=1)).year
     # Does not work


### PR DESCRIPTION
## PR Summary

Closes #10022 and #11391

This does one small thing (run units conversion on the position argument of `bxp/boxplot`) and two big things:

1. At unit conversion, run `np.asarray` on incoming objects to unpack numpy arrays from them.  *Previously* in order to get native pandas support we were unpacking the `values` field, but running 
`np.asarray` does the same thing and allows the packed values to not necessarily be stored in `values`.  i.e. 


```python
dates = np.arange('2005-02', '2005-05', dtype='datetime64[M]')
values = np.sin(np.array(range(len(dates))))
df = pd.DataFrame({'dates': dates, 'z': values})
print(df['dates'])
print(np.asarray(df['dates']))
print(df['dates'].values)
```

returns:

```
0   2005-02-01
1   2005-03-01
2   2005-04-01
Name: dates, dtype: datetime64[ns]
['2005-02-01T00:00:00.000000000' '2005-03-01T00:00:00.000000000'
 '2005-04-01T00:00:00.000000000']
['2005-02-01T00:00:00.000000000' '2005-03-01T00:00:00.000000000'
 '2005-04-01T00:00:00.000000000']
```

This re-does #10638, which unpacked pandas py checking for and using `values`.  

2. For the pandas tests, this deregisters the pandas converters, because its not clear we should be testing those.  With the above, our native `date` handling should be able to strip pandas series of their date information and convert. This passes all the pandas tests, but I admit this may be a controversial step.  

### Immediate fix code:

```python

import numpy as np
import pandas as pd
import matplotlib.pyplot as plt

pd.plotting.deregister_matplotlib_converters()

data = np.random.rand(5,2)
years = pd.date_range('1/1/2000',
                      periods=2, freq=pd.DateOffset(years=1)).year
# Does not work
plt.figure()
plt.boxplot(data, positions=years)
plt.show()

```

failed on master.  This fixes...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->