### PR TITLE
TESTS: Increase tolerance for aarch64 tests

### DIFF
--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -1,4 +1,5 @@
 import pytest
+import platform
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.patches as mpatches
@@ -68,6 +69,7 @@ def __prepare_fancyarrow_dpi_cor_test():
 
 @image_comparison(baseline_images=['fancyarrow_dpi_cor_100dpi'],
                   remove_text=True, extensions=['png'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   savefig_kwarg=dict(dpi=100))
 def test_fancyarrow_dpi_cor_100dpi():
     """
@@ -83,6 +85,7 @@ def test_fancyarrow_dpi_cor_100dpi():
 
 @image_comparison(baseline_images=['fancyarrow_dpi_cor_200dpi'],
                   remove_text=True, extensions=['png'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   savefig_kwarg=dict(dpi=200))
 def test_fancyarrow_dpi_cor_200dpi():
     """

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -69,7 +69,7 @@ def __prepare_fancyarrow_dpi_cor_test():
 
 @image_comparison(baseline_images=['fancyarrow_dpi_cor_100dpi'],
                   remove_text=True, extensions=['png'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   savefig_kwarg=dict(dpi=100))
 def test_fancyarrow_dpi_cor_100dpi():
     """
@@ -85,7 +85,7 @@ def test_fancyarrow_dpi_cor_100dpi():
 
 @image_comparison(baseline_images=['fancyarrow_dpi_cor_200dpi'],
                   remove_text=True, extensions=['png'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   savefig_kwarg=dict(dpi=200))
 def test_fancyarrow_dpi_cor_200dpi():
     """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1,6 +1,7 @@
 from itertools import product
 from distutils.version import LooseVersion
 import io
+import platform
 
 import datetime
 
@@ -3349,7 +3350,8 @@ def test_vertex_markers():
 
 
 @image_comparison(baseline_images=['vline_hline_zorder',
-                                   'errorbar_zorder'])
+                                   'errorbar_zorder'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
 def test_eb_line_zorder():
     x = list(range(10))
 
@@ -5120,7 +5122,8 @@ def test_title_location_roundtrip():
 
 
 @image_comparison(baseline_images=["loglog"], remove_text=True,
-                  extensions=['png'])
+                  extensions=['png'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
 def test_loglog():
     fig, ax = plt.subplots()
     x = np.arange(1, 11)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3351,7 +3351,7 @@ def test_vertex_markers():
 
 @image_comparison(baseline_images=['vline_hline_zorder',
                                    'errorbar_zorder'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_eb_line_zorder():
     x = list(range(10))
 
@@ -5123,7 +5123,7 @@ def test_title_location_roundtrip():
 
 @image_comparison(baseline_images=["loglog"], remove_text=True,
                   extensions=['png'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_loglog():
     fig, ax = plt.subplots()
     x = np.arange(1, 11)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -2,6 +2,7 @@
 Tests specific to the collections module.
 """
 import io
+import platform
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -441,6 +442,7 @@ def test_barb_limits():
 
 @image_comparison(baseline_images=['EllipseCollection_test_image'],
                   extensions=['png'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   remove_text=True)
 def test_EllipseCollection():
     # Test basic functionality

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -442,7 +442,7 @@ def test_barb_limits():
 
 @image_comparison(baseline_images=['EllipseCollection_test_image'],
                   extensions=['png'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   remove_text=True)
 def test_EllipseCollection():
     # Test basic functionality

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -10,7 +10,7 @@ from cycler import cycler
 
 
 @image_comparison(baseline_images=['color_cycle_basic'], remove_text=True,
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'])
 def test_colorcycle_basic():
     fig, ax = plt.subplots()
@@ -28,7 +28,7 @@ def test_colorcycle_basic():
 
 
 @image_comparison(baseline_images=['marker_cycle', 'marker_cycle'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   remove_text=True, extensions=['png'])
 def test_marker_cycle():
     fig, ax = plt.subplots()
@@ -62,7 +62,7 @@ def test_marker_cycle():
 
 
 @image_comparison(baseline_images=['lineprop_cycle_basic'], remove_text=True,
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'])
 def test_linestylecycle_basic():
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -1,4 +1,5 @@
 import warnings
+import platform
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
@@ -9,6 +10,7 @@ from cycler import cycler
 
 
 @image_comparison(baseline_images=['color_cycle_basic'], remove_text=True,
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'])
 def test_colorcycle_basic():
     fig, ax = plt.subplots()
@@ -26,6 +28,7 @@ def test_colorcycle_basic():
 
 
 @image_comparison(baseline_images=['marker_cycle', 'marker_cycle'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   remove_text=True, extensions=['png'])
 def test_marker_cycle():
     fig, ax = plt.subplots()
@@ -59,6 +62,7 @@ def test_marker_cycle():
 
 
 @image_comparison(baseline_images=['lineprop_cycle_basic'], remove_text=True,
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'])
 def test_linestylecycle_basic():
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,5 +1,6 @@
 import sys
 import warnings
+import platform
 
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison
@@ -12,7 +13,8 @@ import numpy as np
 import pytest
 
 
-@image_comparison(baseline_images=['figure_align_labels'])
+@image_comparison(baseline_images=['figure_align_labels'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
 def test_align_labels():
     # Check the figure.align_labels() command
     fig = plt.figure(tight_layout=True)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -14,7 +14,7 @@ import pytest
 
 
 @image_comparison(baseline_images=['figure_align_labels'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_align_labels():
     # Check the figure.align_labels() command
     fig = plt.figure(tight_layout=True)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -760,7 +760,7 @@ def test_imshow_endianess():
 
 
 @image_comparison(baseline_images=['imshow_masked_interpolation'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   remove_text=True, style='mpl20')
 def test_imshow_masked_interpolation():
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -2,6 +2,7 @@ from copy import copy
 import io
 import os
 import sys
+import platform
 import urllib.request
 import warnings
 
@@ -759,6 +760,7 @@ def test_imshow_endianess():
 
 
 @image_comparison(baseline_images=['imshow_masked_interpolation'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   remove_text=True, style='mpl20')
 def test_imshow_masked_interpolation():
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -108,7 +108,7 @@ def test_multiple_keys():
 
 
 @image_comparison(baseline_images=['rgba_alpha'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=True)
 def test_alpha_rgba():
     import matplotlib.pyplot as plt
@@ -120,7 +120,7 @@ def test_alpha_rgba():
 
 
 @image_comparison(baseline_images=['rcparam_alpha'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=True)
 def test_alpha_rcparam():
     import matplotlib.pyplot as plt
@@ -149,7 +149,7 @@ def test_fancy():
 
 
 @image_comparison(baseline_images=['framealpha'], remove_text=True,
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_framealpha():
     x = np.linspace(1, 100, 100)
     y = x

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1,5 +1,6 @@
 import collections
 import inspect
+import platform
 from unittest import mock
 
 import numpy as np
@@ -107,6 +108,7 @@ def test_multiple_keys():
 
 
 @image_comparison(baseline_images=['rgba_alpha'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=True)
 def test_alpha_rgba():
     import matplotlib.pyplot as plt
@@ -118,6 +120,7 @@ def test_alpha_rgba():
 
 
 @image_comparison(baseline_images=['rcparam_alpha'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=True)
 def test_alpha_rcparam():
     import matplotlib.pyplot as plt
@@ -145,7 +148,8 @@ def test_fancy():
                ncol=2, shadow=True, title="My legend", numpoints=1)
 
 
-@image_comparison(baseline_images=['framealpha'], remove_text=True)
+@image_comparison(baseline_images=['framealpha'], remove_text=True,
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0))
 def test_framealpha():
     x = np.linspace(1, 100, 100)
     y = x

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -44,7 +44,7 @@ def test_simple():
 
 @image_comparison(baseline_images=['multi_pickle'],
                   extensions=['png'], remove_text=True,
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   style='mpl20')
 def test_complete():
     fig = plt.figure('Figure with a label?', figsize=(10, 6))

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -1,4 +1,5 @@
 import pickle
+import platform
 from io import BytesIO
 
 import numpy as np
@@ -43,6 +44,7 @@ def test_simple():
 
 @image_comparison(baseline_images=['multi_pickle'],
                   extensions=['png'], remove_text=True,
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   style='mpl20')
 def test_complete():
     fig = plt.figure('Figure with a label?', figsize=(10, 6))

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -99,7 +99,7 @@ def test_logscale_transform_repr():
 
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], style='mpl20')
 def test_logscale_nonpos_values():
     np.random.seed(19680801)

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 from matplotlib.scale import Log10Transform, InvertedLog10Transform
 import numpy as np
 import io
+import platform
 import pytest
 
 
@@ -98,6 +99,7 @@ def test_logscale_transform_repr():
 
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], style='mpl20')
 def test_logscale_nonpos_values():
     np.random.seed(19680801)

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -1,4 +1,5 @@
 import sys
+import platform
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
@@ -48,6 +49,7 @@ def test_colormap():
 
 
 @image_comparison(baseline_images=['streamplot_linewidth'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   remove_text=True, style='mpl20')
 def test_linewidth():
     X, Y, U, V = velocity_field()

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -49,7 +49,7 @@ def test_colormap():
 
 
 @image_comparison(baseline_images=['streamplot_linewidth'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   remove_text=True, style='mpl20')
 def test_linewidth():
     X, Y, U, V = velocity_field()

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -41,7 +41,7 @@ class Quantity(object):
 # Tests that the conversion machinery works properly for classes that
 # work as a facade over numpy arrays (like pint)
 @image_comparison(baseline_images=['plot_pint'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=False, style='mpl20')
 def test_numpy_facade():
     # Create an instance of the conversion interface and
@@ -86,7 +86,7 @@ def test_numpy_facade():
 
 # Tests gh-8908
 @image_comparison(baseline_images=['plot_masked_units'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=True, style='mpl20')
 def test_plot_masked_units():
     data = np.linspace(-5, 5)

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -1,4 +1,3 @@
-import datetime
 from unittest.mock import MagicMock
 
 from matplotlib.cbook import iterable
@@ -7,6 +6,7 @@ from matplotlib.testing.decorators import image_comparison
 import matplotlib.units as munits
 import numpy as np
 import datetime
+import platform
 
 
 # Basic class that wraps numpy array and has units
@@ -41,6 +41,7 @@ class Quantity(object):
 # Tests that the conversion machinery works properly for classes that
 # work as a facade over numpy arrays (like pint)
 @image_comparison(baseline_images=['plot_pint'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=False, style='mpl20')
 def test_numpy_facade():
     # Create an instance of the conversion interface and
@@ -85,6 +86,7 @@ def test_numpy_facade():
 
 # Tests gh-8908
 @image_comparison(baseline_images=['plot_masked_units'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'], remove_text=True, style='mpl20')
 def test_plot_masked_units():
     data = np.linspace(-5, 5)

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -21,6 +21,7 @@ from matplotlib.transforms import Bbox, TransformedBbox, \
 from itertools import product
 
 import pytest
+import platform
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -358,6 +359,7 @@ def test_zooming_with_inverted_axes():
 
 
 @image_comparison(baseline_images=['anchored_direction_arrows'],
+                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
                   extensions=['png'])
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -359,7 +359,7 @@ def test_zooming_with_inverted_axes():
 
 
 @image_comparison(baseline_images=['anchored_direction_arrows'],
-                  tol={'aarch64':0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   extensions=['png'])
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -1,4 +1,5 @@
 import numpy as np
+import platform
 
 import matplotlib.pyplot as plt
 from matplotlib.path import Path
@@ -84,7 +85,8 @@ def test_custom_transform():
 
 
 @image_comparison(baseline_images=['polar_box'],
-                  extensions=['png'], style='default', tol=0.03)
+                  tol={'aarch64':0.04}.get(platform.machine(), 0.03),
+                  extensions=['png'], style='default')
 def test_polar_box():
     fig = plt.figure(figsize=(5, 5))
 

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -85,7 +85,7 @@ def test_custom_transform():
 
 
 @image_comparison(baseline_images=['polar_box'],
-                  tol={'aarch64':0.04}.get(platform.machine(), 0.03),
+                  tol={'aarch64': 0.04}.get(platform.machine(), 0.03),
                   extensions=['png'], style='default')
 def test_polar_box():
     fig = plt.figure(figsize=(5, 5))


### PR DESCRIPTION
## PR Summary

Tests had been failing on aarch64 machines due to human-imperceptible differences (antialiasing, perhaps, floating point rounding, perhaps). This PR adds a small pad to tests which failed, only for `platform.machine() == 'aarch64'`.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there) (N/A)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
