### PR TITLE
Reuse axes_grid1's AxisDict in axisartist, instead of duplicating it.

### DIFF
--- a/doc/api/next_api_changes/2018-07-17-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-07-17-AL-deprecations.rst
@@ -1,0 +1,7 @@
+API deprecations
+````````````````
+
+The following API elements are deprecated:
+
+- ``mpl_toolkits.axisartist.axislines.SimpleChainedObjects``,
+  ``mpl_toolkits.Axes.AxisDict``,

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -38,15 +38,15 @@ those of Axes.xaxis unless explicitly specified.
 In addition to AxisArtist, the Axes will have *gridlines* attribute,
 which obviously draws grid lines. The gridlines needs to be separated
 from the axis as some gridlines can never pass any axis.
-
 """
+
 import numpy as np
 
-from matplotlib import cbook
-from matplotlib import rcParams
+from matplotlib import cbook, rcParams
 import matplotlib.artist as martist
 import matplotlib.axes as maxes
 from matplotlib.path import Path
+from mpl_toolkits.axes_grid1 import mpl_axes
 from .axisline_style import AxislineStyle
 from .axis_artist import AxisArtist, GridlinesCollection
 
@@ -487,6 +487,7 @@ class GridHelperRectlinear(GridHelperBase):
         return gridlines
 
 
+@cbook.deprecated("3.1")
 class SimpleChainedObjects(object):
     def __init__(self, objects):
         self._objects = objects
@@ -502,6 +503,7 @@ class SimpleChainedObjects(object):
 
 class Axes(maxes.Axes):
 
+    @cbook.deprecated("3.1")
     class AxisDict(dict):
         def __init__(self, axes):
             self.axes = axes
@@ -549,7 +551,7 @@ class Axes(maxes.Axes):
         if axes is None:
             axes = self
 
-        self._axislines = self.AxisDict(self)
+        self._axislines = mpl_axes.Axes.AxisDict(self)
         new_fixed_axis = self.get_grid_helper().new_fixed_axis
         for loc in ["bottom", "top", "left", "right"]:
             self._axislines[loc] = new_fixed_axis(loc=loc, axes=axes,


### PR DESCRIPTION
Also deprecate axisartist's SimpleChainedObjects, which is only used to
implement AxisDict (again, axes_grid1 is sufficient).

(see the duplication between https://github.com/matplotlib/matplotlib/blob/master/lib/mpl_toolkits/axes_grid1/mpl_axes.py#L6 and https://github.com/matplotlib/matplotlib/blob/master/lib/mpl_toolkits/axisartist/axislines.py#L497)

Do the reuse in this direction as axisartist already imports axes_grid1
for other purposes.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
