### PR TITLE
Update venv docs.

### DIFF
--- a/doc/faq/virtualenv_faq.rst
+++ b/doc/faq/virtualenv_faq.rst
@@ -25,14 +25,12 @@ Otherwise, the situation (at the time of writing) is as follows:
 framework bindings  pip-installable? conda or conda-forge-installable?
 ========= ========= ================ =================================
 Qt5       PyQt5     yes              yes
-Qt5       PySide2   yes [#]_         yes
+Qt5       PySide2   yes              yes
 Qt4       PyQt4     no               yes
 Qt4       PySide    OSX and Windows  yes
 GTK3      PyGObject yes [#]_         Linux and OSX
 wxWidgets wxPython  yes [#]_         yes
 ========= ========= ================ =================================
-
-.. [#] See http://lists.qt-project.org/pipermail/pyside/2018-March/002537.html.
 
 .. [#] No wheels available, see
        https://pygobject.readthedocs.io/en/latest/devguide/dev_environ.html
@@ -48,20 +46,19 @@ all cases, the system-wide Python and the venv Python must be of the same
 version):
 
 - `vext <https://pypi.python.org/pypi/vext>`_ allows controlled access
-  from within the virtualenv to specific system-wide packages without the
-  overall shadowing issue.  A specific package needs to be installed for each
-  framework, e.g. `vext.pyqt5 <https://pypi.python.org/pypi/vext.pyqt5>`_, etc.
-  It is recommended to use ``vext>=0.7.0`` as earlier versions misconfigure the
-  logging system.
+  from within the venv to specific system-wide packages.  A specific
+  package needs to be installed for each framework, e.g. `vext.pyqt5
+  <https://pypi.python.org/pypi/vext.pyqt5>`_, etc.  It is recommended to use
+  ``vext>=0.7.0`` as earlier versions misconfigure the logging system.
 
-- When using `virtualenv <https://virtualenv.pypa.io/>` (rather than the
-  stdlib's ``venv``), using the ``--system-site-packages`` option when creating
-  an environment adds all system-wide packages to the virtual environment.
-  However, this breaks the isolation between the virtual environment and the
-  system install.  Among other issues it results in hard to debug problems
-  with system packages shadowing the environment packages.  If you use
-  `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/>`_, this can be
-  toggled with the ``toggleglobalsitepackages`` command.
+- Using the ``--system-site-packages`` option when creating an environment
+  adds all system-wide packages to the virtual environment.  However, this
+  breaks the isolation between the virtual environment and the system
+  install.  Among other issues it results in hard to debug problems with
+  system packages shadowing the environment packages.  If you use `virtualenv
+  <https://virtualenv.pypa.io/>` (rather than the stdlib's ``venv``) together
+  with `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/>`_, this
+  can be toggled with the ``toggleglobalsitepackages`` command.
 
 If you are using Matplotlib on OSX, you may also want to consider the
 :ref:`OSX framework FAQ <osxframework-faq>`.


### PR DESCRIPTION
- PySide2 is now available on PyPI (http://blog.qt.io/blog/2018/07/17/qt-python-available-pypi/).
- --system-site-packages has always worked with stdlib's venv as well.
- uniformize usage of "venv" instead of "virtualenv" as a name.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
