### PR TITLE
Don't cache the renderer on the Axes instance.

### DIFF
--- a/examples/event_handling/pong_sgskip.py
+++ b/examples/event_handling/pong_sgskip.py
@@ -36,7 +36,7 @@ def start_anim(event):
     canvas.mpl_disconnect(start_anim.cid)
 
     def local_draw():
-        if animation.ax._cachedRenderer:
+        if animation.ax.get_renderer_cache():
             animation.draw(None)
     start_anim.timer.add_callback(local_draw)
     start_anim.timer.start()

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -486,7 +486,6 @@ class _AxesBase(martist.Artist):
         self.fmt_xdata = None
         self.fmt_ydata = None
 
-        self._cachedRenderer = None
         self.set_navigate(True)
         self.set_navigate_mode(None)
 
@@ -542,7 +541,7 @@ class _AxesBase(martist.Artist):
         # The renderer should be re-created by the figure, and then cached at
         # that point.
         state = super().__getstate__()
-        for key in ['_cachedRenderer', '_layoutbox', '_poslayoutbox']:
+        for key in ['_layoutbox', '_poslayoutbox']:
             state[key] = None
         # Prune the sharing & twinning info to only contain the current group.
         for grouper_name in [
@@ -2510,7 +2509,7 @@ class _AxesBase(martist.Artist):
     def draw(self, renderer=None, inframe=False):
         """Draw everything (plot lines, axes, labels)"""
         if renderer is None:
-            renderer = self._cachedRenderer
+            renderer = self.figure._cachedRenderer
 
         if renderer is None:
             raise RuntimeError('No renderer defined')
@@ -2581,7 +2580,6 @@ class _AxesBase(martist.Artist):
         mimage._draw_list_compositing_images(renderer, self, artists)
 
         renderer.close_group('axes')
-        self._cachedRenderer = renderer
         self.stale = False
 
     def draw_artist(self, a):
@@ -2590,10 +2588,10 @@ class _AxesBase(martist.Artist):
         caches the renderer.  It is used to efficiently update Axes
         data (axis ticks, labels, etc are not updated)
         """
-        if self._cachedRenderer is None:
+        if self.figure._cachedRenderer is None:
             raise AttributeError("draw_artist can only be used after an "
                                  "initial draw which caches the renderer")
-        a.draw(self._cachedRenderer)
+        a.draw(self.figure._cachedRenderer)
 
     def redraw_in_frame(self):
         """
@@ -2601,13 +2599,13 @@ class _AxesBase(martist.Artist):
         caches the renderer.  It is used to efficiently update Axes
         data (axis ticks, labels, etc are not updated)
         """
-        if self._cachedRenderer is None:
+        if self.figure._cachedRenderer is None:
             raise AttributeError("redraw_in_frame can only be used after an "
                                  "initial draw which caches the renderer")
-        self.draw(self._cachedRenderer, inframe=True)
+        self.draw(self.figure._cachedRenderer, inframe=True)
 
     def get_renderer_cache(self):
-        return self._cachedRenderer
+        return self.figure._cachedRenderer
 
     # Axes rectangle characteristics
 


### PR DESCRIPTION
The cache on the figure is sufficient.

Noted in https://github.com/matplotlib/matplotlib/issues/11602#issuecomment-404755705; note that @tacaswell's fix in https://github.com/matplotlib/matplotlib/issues/11602#issuecomment-404755705 is actually the correct fix for #11602; this patch is more just a simplification of the state of the affairs.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
