### PR TITLE
Deprecate frameon kwarg and rcParam to savefig.

### DIFF
--- a/doc/api/next_api_changes/2018-09-25-AL.rst
+++ b/doc/api/next_api_changes/2018-09-25-AL.rst
@@ -1,0 +1,6 @@
+Deprecations
+````````````
+
+The ``frameon`` kwarg to ``savefig`` and the ``savefig.frameon`` rcParam
+are deprecated.  To emulate ``frameon = False``, set ``facecolor`` to fully
+transparent (``"none"``, or ``(0, 0, 0, 0)``).

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -704,6 +704,7 @@ _deprecated_ignore_map = {
 # Values are tuples of (version,)
 _deprecated_remain_as_none = {
     'text.latex.unicode': ('3.0',),
+    'savefig.frameon': ('3.1',),
 }
 
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2020,7 +2020,7 @@ default: 'top'
         """Whenever the axes state change, ``func(self)`` will be called."""
         self._axobservers.append(func)
 
-    def savefig(self, fname, *, frameon=None, transparent=None, **kwargs):
+    def savefig(self, fname, *, transparent=None, **kwargs):
         """
         Save the current figure.
 
@@ -2102,11 +2102,6 @@ default: 'top'
             transparency of these patches will be restored to their
             original values upon exit of this function.
 
-        frameon : bool
-            If *True*, the figure patch will be colored, if *False*, the
-            figure background will be transparent.  If not provided, the
-            rcParam 'savefig.frameon' will be used.
-
         bbox_inches : str or `~matplotlib.transforms.Bbox`, optional
             Bbox in inches. Only the given portion of the figure is
             saved. If 'tight', try to figure out the tight bbox of
@@ -2138,8 +2133,14 @@ default: 'top'
         """
 
         kwargs.setdefault('dpi', rcParams['savefig.dpi'])
-        if frameon is None:
-            frameon = rcParams['savefig.frameon']
+        if "frameon" in kwargs:
+            cbook.warn_deprecated("3.1", name="frameon", obj_type="kwarg",
+                                  alternative="facecolor")
+            frameon = kwargs.pop("frameon")
+            if frameon is None:
+                frameon = dict.__getitem__(rcParams, 'savefig.frameon')
+        else:
+            frameon = False  # Won't pass "if frameon:" below.
         if transparent is None:
             transparent = rcParams['savefig.transparent']
 

--- a/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
@@ -418,7 +418,6 @@ savefig.pad_inches  : 0.1      # Padding to be used when bbox is set to 'tight'
 savefig.jpeg_quality: 95       # when a jpeg is saved, the default quality parameter.
 savefig.transparent : False    # setting that controls whether figures are saved with a
                                # transparent background by default
-savefig.frameon : True
 savefig.orientation : portrait
 
 # ps backend params

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -422,7 +422,6 @@ savefig.pad_inches  : 0.1      # Padding to be used when bbox is set to 'tight'
 savefig.jpeg_quality: 95       # when a jpeg is saved, the default quality parameter.
 savefig.transparent : False    # setting that controls whether figures are saved with a
                                # transparent background by default
-savefig.frameon : True
 savefig.orientation : portrait
 
 # ps backend params

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -540,7 +540,6 @@
                                 ## leave empty to always use current working directory
 #savefig.transparent : False    ## setting that controls whether figures are saved with a
                                 ## transparent background by default
-#savefig.frameon : True			## enable frame of figure when saving
 #savefig.orientation : portrait	## Orientation of saved figure
 
 ### tk backend params


### PR DESCRIPTION
``frameon = False`` has *never* worked since its introduction in 2013 (#1875)
due to the buggy implementation that only took it into account if True:

    if frameon:
        original_frameon = self.get_frameon()
        self.set_frameon(frameon)

(despite the doc stating otherwise).  One can also set the facecolor
kwarg or savefig.facecolor rcParam to fully transparent for the same
effect.

(See also #10023.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
