### PR TITLE
moving toolmanager initialization up before toolbar

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -511,12 +511,13 @@ class FigureManagerTk(FigureManagerBase):
         self.window.withdraw()
         self.set_window_title("Figure %d" % num)
         self.canvas = canvas
+        # If using toolmanager it has to be present when initializing the toolbar
+        self.toolmanager = self._get_toolmanager()
         # packing toolbar first, because if space is getting low, last packed widget is getting shrunk first (-> the canvas)
         self.toolbar = self._get_toolbar()
         self.canvas._tkcanvas.pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
         self._num = num
 
-        self.toolmanager = self._get_toolmanager()
         self.statusbar = None
 
         if self.toolmanager:


### PR DESCRIPTION
## PR Summary
When running the toolmanager example with the tk backend we get the following error
```
09:40 $ python3 examples/user_interfaces/toolmanager_sgskip.py 
Traceback (most recent call last):
  File "examples/user_interfaces/toolmanager_sgskip.py", line 79, in <module>
    fig = plt.figure()
  File "/home/federico.ariza/workspace/matplotlib/lib/matplotlib/pyplot.py", line 521, in figure
    **kwargs)
  File "/home/federico.ariza/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 3214, in new_figure_manager
    return cls.new_figure_manager_given_figure(num, fig)
  File "/home/federico.ariza/workspace/matplotlib/lib/matplotlib/backends/_backend_tk.py", line 1025, in new_figure_manager_given_figure
    manager = cls.FigureManager(canvas, num, window)
  File "/home/federico.ariza/workspace/matplotlib/lib/matplotlib/backends/_backend_tk.py", line 515, in __init__
    self.toolbar = self._get_toolbar()
  File "/home/federico.ariza/workspace/matplotlib/lib/matplotlib/backends/_backend_tk.py", line 535, in _get_toolbar
    toolbar = ToolbarTk(self.toolmanager, self.window)
  File "/home/federico.ariza/workspace/matplotlib/lib/matplotlib/backends/_backend_tk.py", line 816, in __init__
    ToolContainerBase.__init__(self, toolmanager)
  File "/home/federico.ariza/workspace/matplotlib/lib/matplotlib/backend_bases.py", line 3030, in __init__
    self.toolmanager.toolmanager_connect('tool_removed_event',
AttributeError: 'NoneType' object has no attribute 'toolmanager_connect'
```
In PR https://github.com/matplotlib/matplotlib/pull/11559  the tk toolbar initialization was moved up (packaging problem).  
When working with the toolmanager, the toolmanager has to be initialized before the toolbar. 
This fix just moves up the toolmanager initialization

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
