### PR TITLE
Use skipif instead of xfail when test dependencies are missing.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -14,7 +14,7 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 
 
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not checkdep_usetex(True),
     reason="This test needs a TeX installation")
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -15,12 +15,10 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 
 
-needs_ghostscript = pytest.mark.xfail(
+needs_ghostscript = pytest.mark.skipif(
     matplotlib.checkdep_ghostscript()[0] is None,
     reason="This test needs a ghostscript installation")
-
-
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not matplotlib.checkdep_usetex(True),
     reason="This test needs a TeX installation")
 

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -24,7 +24,7 @@ except AttributeError:
     py_qt_ver = QtCore.__version_info__[0]
 
 if py_qt_ver != 4:
-    pytestmark = pytest.mark.xfail(reason='Qt4 is not available')
+    pytestmark = pytest.mark.skipif(reason='Qt4 is not available')
 
 
 @pytest.mark.backend('Qt4Agg')

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -12,7 +12,7 @@ import matplotlib
 from matplotlib import dviread
 
 
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not matplotlib.checkdep_usetex(True),
     reason="This test needs a TeX installation")
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -21,14 +21,6 @@ from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
 import pytest
 
 
-try:
-    from PIL import Image
-    HAS_PIL = True
-except ImportError:
-    HAS_PIL = False
-needs_pillow = pytest.mark.xfail(not HAS_PIL, reason='Test requires Pillow')
-
-
 @image_comparison(baseline_images=['image_interps'], style='mpl20')
 def test_image_interps():
     'make the basic nearest, bilinear and bicubic interps'
@@ -111,8 +103,8 @@ def test_image_python_io():
     plt.imread(buffer)
 
 
-@needs_pillow
 def test_imread_pil_uint16():
+    pytest.importorskip("PIL")
     img = plt.imread(os.path.join(os.path.dirname(__file__),
                      'baseline_images', 'test_image', 'uint16.tif'))
     assert img.dtype == np.uint16
@@ -120,8 +112,8 @@ def test_imread_pil_uint16():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires Python 3.6+")
-@needs_pillow
 def test_imread_fspath():
+    pytest.importorskip("PIL")
     from pathlib import Path
     img = plt.imread(
         Path(__file__).parent / 'baseline_images/test_image/uint16.tif')
@@ -498,8 +490,8 @@ def test_nonuniformimage_setnorm():
     im.set_norm(plt.Normalize())
 
 
-@needs_pillow
 def test_jpeg_2d():
+    Image = pytest.importorskip('PIL.Image')
     # smoke test that mode-L pillow images work.
     imd = np.ones((10, 10), dtype='uint8')
     for i in range(10):
@@ -510,8 +502,9 @@ def test_jpeg_2d():
     ax.imshow(im)
 
 
-@needs_pillow
 def test_jpeg_alpha():
+    Image = pytest.importorskip('PIL.Image')
+
     plt.figure(figsize=(1, 1), dpi=300)
     # Create an image that is all black, with a gradient from 0-1 in
     # the alpha channel from left to right.

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not matplotlib.checkdep_usetex(True),
     reason="This test needs a TeX installation")
 


### PR DESCRIPTION
In such cases, there's no need to even try running the test and get an
exception out of it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
