### PR TITLE
FIX: make update-from also set the original face/edgecolor

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -168,6 +168,8 @@ class Patch(artist.Artist):
         # getters/setters, so we just copy them directly.
         self._edgecolor = other._edgecolor
         self._facecolor = other._facecolor
+        self._original_edgecolor = other._original_edgecolor
+        self._original_facecolor = other._original_facecolor
         self._fill = other._fill
         self._hatch = other._hatch
         self._hatch_color = other._hatch_color

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -543,3 +543,12 @@ def test_draggable():
     with pytest.warns(MatplotlibDeprecationWarning):
         legend.draggable()
     assert not legend.get_draggable()
+
+
+def test_alpha_handles():
+    x, n, hh = plt.hist([1, 2, 3], alpha=0.25, label='data', color='red')
+    legend = plt.legend()
+    for lh in legend.legendHandles:
+        lh.set_alpha(1.0)
+    assert lh.get_facecolor()[:-1] == hh[1].get_facecolor()[:-1]
+    assert lh.get_edgecolor()[:-1] == hh[1].get_edgecolor()[:-1]


### PR DESCRIPTION
## PR Summary

Closes #11702...

`patches.update_from` wasn't setting `_original_face/edgecolor`



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->