### PR TITLE
Suppress/fix some test warnings.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1112,7 +1112,8 @@ class SymLogNorm(Normalize):
         """
         Inplace transformation.
         """
-        masked = np.abs(a) > self.linthresh
+        with np.errstate(invalid="ignore"):
+            masked = np.abs(a) > self.linthresh
         sign = np.sign(a[masked])
         log = (self._linscale_adj + np.log(np.abs(a[masked]) / self.linthresh))
         log *= sign * self.linthresh

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1714,7 +1714,7 @@ class TestScatter(object):
                     c=[(1, 0, 0), 'y', 'b', 'lime'],
                     s=[60, 50, 40, 30],
                     edgecolors=['k', 'r', 'g', 'b'],
-                    verts=verts)
+                    marker=verts)
 
     @image_comparison(baseline_images=['scatter_2D'], remove_text=True,
                       extensions=['png'])

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -67,11 +67,11 @@ def test_otf():
     if os.path.exists(fname):
         assert is_opentype_cff_font(fname)
 
-    otf_files = [f for f in fontManager.ttffiles if 'otf' in f]
-    for f in otf_files:
-        with open(f, 'rb') as fd:
-            res = fd.read(4) == b'OTTO'
-        assert res == is_opentype_cff_font(f)
+    for f in fontManager.ttflist:
+        if 'otf' in f.fname:
+            with open(f.fname, 'rb') as fd:
+                res = fd.read(4) == b'OTTO'
+            assert res == is_opentype_cff_font(f.fname)
 
 
 @pytest.mark.skipif(not has_fclist, reason='no fontconfig installed')

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1,3 +1,4 @@
+from contextlib import ExitStack
 from copy import copy
 import io
 import os
@@ -875,8 +876,10 @@ def test_empty_imshow(make_norm):
 def test_imshow_float128():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((3, 3), dtype=np.longdouble))
-    # Ensure that drawing doesn't cause crash
-    fig.canvas.draw()
+    with (ExitStack() if np.can_cast(np.longdouble, np.float64, "equiv")
+          else pytest.warns(UserWarning)):
+        # Ensure that drawing doesn't cause crash.
+        fig.canvas.draw()
 
 
 def test_imshow_bool():

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
+from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib.patches import Polygon, Rectangle
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 import matplotlib.pyplot as plt
@@ -344,8 +345,9 @@ def test_patch_str():
     s = mpatches.Shadow(p, 1, 1)
     assert str(s) == "Shadow(ConnectionPatch((1, 2), (3, 4)))"
 
-    p = mpatches.YAArrow(plt.gcf(), (1, 0), (2, 1), width=0.1)
-    assert str(p) == "YAArrow()"
+    with pytest.warns(MatplotlibDeprecationWarning):
+        p = mpatches.YAArrow(plt.gcf(), (1, 0), (2, 1), width=0.1)
+        assert str(p) == "YAArrow()"
 
     # Not testing Arrow, FancyArrow here
     # because they seem to exist only for historical reasons.

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -10,6 +10,7 @@ from cycler import cycler, Cycler
 import pytest
 
 import matplotlib as mpl
+from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 import numpy as np
@@ -120,8 +121,7 @@ def test_Bug_2543():
     # printed in the test suite.
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore',
-                                message='.*(deprecated|obsolete)',
-                                category=UserWarning)
+                                category=MatplotlibDeprecationWarning)
         with mpl.rc_context():
             _copy = mpl.rcParams.copy()
             for key in _copy:


### PR DESCRIPTION
The only remaining test that throws a warning is
test_image.py::test_full_invalid ("converting a masked element to nan"),
which I didn't suppress in the test because I think that should indeed
not throw (we don't throw warnings when passing partially-nan data
either).

(I think ultimately we should make CI fail in the presence of warnings;
looks like this can be done by adding the suitable warnings filter to
pytest.ini https://docs.pytest.org/en/latest/warnings.html.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
