### PR TITLE
Revert "Skip wx interactive tests on OSX."

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -30,8 +30,6 @@ def _get_testable_interactive_backends():
             reason = "No $DISPLAY"
         elif any(importlib.util.find_spec(dep) is None for dep in deps):
             reason = "Missing dependency"
-        elif "wx" in deps and sys.platform == "darwin":
-            reason = "wx backends known not to work on OSX"
         backends.append(pytest.mark.skip(reason=reason)(backend) if reason
                         else backend)
     return backends


### PR DESCRIPTION
Reverts matplotlib/matplotlib#11593

Lets see if wx is fixed!