### PR TITLE
Lazily resolve colors for Patches.

### DIFF
--- a/doc/api/next_api_changes/2018-07-20-AL.rst
+++ b/doc/api/next_api_changes/2018-07-20-AL.rst
@@ -1,0 +1,12 @@
+Lazy color resolution for patches
+`````````````````````````````````
+
+Patches now lazily resolve colors and apply alpha at draw time, similarly
+to Line2Ds.  In particular, this means that they will be affected by later
+modifications to :rc:`patch.facecolor` and :rc:`patch.edgecolor`, and that
+``patch.get_facecolor()`` and ``patch.get_edgecolor()`` no longer necessarily
+return RGBA tuples but rather whatever was passed in with the corresponding
+setters.
+
+:rc:`hatch.color` is still resolved at artist creation time as there is no
+other way to set the hatch color.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1461,16 +1461,16 @@ def test_bar_color_none_alpha():
     ax = plt.gca()
     rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='none', edgecolor='r')
     for rect in rects:
-        assert rect.get_facecolor() == (0, 0, 0, 0)
-        assert rect.get_edgecolor() == (1, 0, 0, 0.3)
+        assert rect._get_drawn_facecolor() == (0, 0, 0, 0)
+        assert rect._get_drawn_edgecolor() == (1, 0, 0, 0.3)
 
 
 def test_bar_edgecolor_none_alpha():
     ax = plt.gca()
     rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='r', edgecolor='none')
     for rect in rects:
-        assert rect.get_facecolor() == (1, 0, 0, 0.3)
-        assert rect.get_edgecolor() == (0, 0, 0, 0)
+        assert rect._get_drawn_facecolor() == (1, 0, 0, 0.3)
+        assert rect._get_drawn_edgecolor() == (0, 0, 0, 0)
 
 
 @image_comparison(baseline_images=['barh_tick_label'],
@@ -5659,7 +5659,8 @@ def test_bar_broadcast_args():
     ax.bar(0, 1, bottom=range(4), width=1, orientation='horizontal')
     # Check that edgecolor gets broadcasted.
     rect1, rect2 = ax.bar([0, 1], [0, 1], edgecolor=(.1, .2, .3, .4))
-    assert rect1.get_edgecolor() == rect2.get_edgecolor() == (.1, .2, .3, .4)
+    assert rect1._get_drawn_edgecolor() == rect2._get_drawn_edgecolor() \
+        == (.1, .2, .3, .4)
 
 
 def test_invalid_axis_limits():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -9,10 +9,11 @@ import pytest
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib as mpl
-import matplotlib.transforms as mtransforms
 import matplotlib.collections as mcollections
-from matplotlib.legend_handler import HandlerTuple
+import matplotlib.colors as mcolors
 import matplotlib.legend as mlegend
+from matplotlib.legend_handler import HandlerTuple
+import matplotlib.transforms as mtransforms
 from matplotlib.cbook.deprecation import MatplotlibDeprecationWarning
 
 
@@ -543,3 +544,14 @@ def test_draggable():
     with pytest.warns(MatplotlibDeprecationWarning):
         legend.draggable()
     assert not legend.get_draggable()
+
+
+def test_alpha_handles():
+    x, n, hh = plt.hist([1, 2, 3], alpha=0.25, label='data', color='red')
+    legend = plt.legend()
+    for lh in legend.legendHandles:
+        lh.set_alpha(1.0)
+    assert mcolors.to_rgb(lh.get_facecolor()) \
+        == mcolors.to_rgb(hh[1].get_facecolor())
+    assert mcolors.to_rgb(lh.get_edgecolor()) \
+        == mcolors.to_rgb(hh[1].get_edgecolor())

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -176,14 +176,6 @@ def test_patch_alpha_override():
     ax.set_ylim([-1, 2])
 
 
-@pytest.mark.style('default')
-def test_patch_color_none():
-    # Make sure the alpha kwarg does not override 'none' facecolor.
-    # Addresses issue #7478.
-    c = plt.Circle((0, 0), 1, facecolor='none', alpha=1)
-    assert c.get_facecolor()[0] == 0
-
-
 @image_comparison(baseline_images=['patch_custom_linestyle'],
                   remove_text=True)
 def test_patch_custom_linestyle():

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -172,7 +172,7 @@ def test_legend_colors(color_type, param_dict, target):
         _, ax = plt.subplots()
         ax.plot(range(3), label='test')
         leg = ax.legend()
-        assert getattr(leg.legendPatch, get_func)() == target
+        assert mcolors.same_color(getattr(leg.legendPatch, get_func)(), target)
 
 
 def test_mfc_rcparams():


### PR DESCRIPTION
See explanation in #11710 (which this closes).

This is consistent with Line2Ds and avoids complications with
_original_{face,edge}color.

test_patch_color_none was removed as it doesn't make much sense anymore
(fixing it would just mean testing that mcolors.to_rgba is working as
expected).

Also closes #11702; includes the test from #11703.

(We may also want to do the same thing with Collections.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
