### PR TITLE
Don't assume cwd in test_ipynb.

### DIFF
--- a/lib/matplotlib/tests/test_backend_nbagg.py
+++ b/lib/matplotlib/tests/test_backend_nbagg.py
@@ -1,7 +1,7 @@
-
-import os
+from pathlib import Path
 import subprocess
 import tempfile
+
 import pytest
 
 nbformat = pytest.importorskip('nbformat')
@@ -29,5 +29,6 @@ def _notebook_run(nb_file):
 
 
 def test_ipynb():
-    nb, errors = _notebook_run('lib/matplotlib/tests/test_nbagg_01.ipynb')
+    nb, errors = _notebook_run(
+        str(Path(__file__).parent / 'test_nbagg_01.ipynb'))
     assert errors == []


### PR DESCRIPTION
The Matplotlib test suite can be run from outside of the root git
directory, e.g. with

    pytest --pyargs matplotlib.tests.test_backend_nbagg

(mplcairo explicitly relies on that to reuse the Matplotlib test suite).

To ensure this, find the example notebook relative to the path of the
test module, rather than relative to the current working directory.

(Marking as release critical to avoid causing difficulties to mplcairo's test suite, but I can always xfail that test instead from mplcairo otherwise.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
