### PR TITLE
DOC: usetex and maths font

### DIFF
--- a/examples/text_labels_and_annotations/usetex_maths_font.py
+++ b/examples/text_labels_and_annotations/usetex_maths_font.py
@@ -1,0 +1,43 @@
+"""
+============================
+TeX and maths font selection
+============================
+
+Setting the text font in TeX does not (by default) change the maths font.
+It is recommended to use ``text.latex.preamble`` to set the font to ensure
+that both text and maths use the desired font settings.
+"""
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+x = np.linspace(0.0, 1.0, 100)
+y = np.cos(4 * np.pi * x) + 2
+
+with mpl.rc_context(rc={'text.usetex': True,
+                        'font.family': 'sans-serif',
+                        'font.sans-serif': 'DejaVu Sans'}):
+    fig1, ax1 = plt.subplots(figsize=(6, 4), tight_layout=True)
+    ax1.plot(x, y)
+    ax1.set_title(r"Using `font.family', `font.sans-serif' params:"
+                  '\n'+r'$\displaystyle\sum_{n=1}^\infty'
+                  r'\frac{-e^{i\pi}}{2^n}$!'
+                  r'$\leftarrow$ serif font (also in tick labels).',
+                  fontsize=20, color='r')
+    ax1.tick_params(axis='both', labelsize=20)
+    plt.savefig('usetex_maths_DejaVu-Sans.png')
+
+
+with mpl.rc_context(rc={'text.usetex': True,
+                        'text.latex.preamble': r'\usepackage{cmbright}'}):
+
+    fig2, ax2 = plt.subplots(figsize=(6, 4), tight_layout=True)
+    ax2.plot(x, y)
+    ax2.set_title(r'Using \rm{\textbackslash usepackage\{cmbright\}}:'
+                  '\n'+r'$\displaystyle\sum_{n=1}^\infty'
+                  r'\frac{-e^{i\pi}}{2^n}$!'
+                  r'$\leftarrow$ sans-serif font (also in tick labels).',
+                  fontsize=20, color='r')
+    ax2.tick_params(axis='both', labelsize=20)
+    plt.savefig('usetex_maths_cmbright.png')

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -72,6 +72,25 @@ results.
    Therefore, these characters will behave differently depending on
    the rcParam ``text.usetex`` flag.
 
+.. _usetex-mathsfont:
+
+text and maths font selection using tex
+=======================================
+
+Setting the text font in TeX does not (by default) change the maths font.
+It is recommended to use ``text.latex.preamble`` to set the font to ensure
+that both text and maths use the desired font settings when ``text.usetex : True``.
+
+.. figure:: ../../gallery/text_labels_and_annotations/images/usetex_maths_DejaVu-Sans.png
+   :target: ../../gallery/text_labels_and_annotations/usetex_maths_font.html
+   :align: center
+   :scale: 50
+
+.. figure:: ../../gallery/text_labels_and_annotations/images/usetex_maths_cmbright.png
+   :target: ../../gallery/text_labels_and_annotations/usetex_maths_font.html
+   :align: center
+   :scale: 50
+
 .. _usetex-unicode:
 
 usetex with unicode


### PR DESCRIPTION
## PR Summary

Issues #11586, #8436, #6041, #3999.

The current documentation doesn't say that setting  `text.usetex = True` doesn't set the correct maths font (applicable to mathematical symbols and  the numbers in the tick labels).

Based on the answer given here  https://stackoverflow.com/a/16345065  and  here #6041 (by @mdboom) and as suggested by @jklymak in #11586, this is an attempt to fix the documentation at https://matplotlib.org/tutorials/text/usetex.html.

I am not sure about how the sphinx gallery works and where to add the png files.

**usetex_maths_DejaVu-Sans.png**
![usetex_maths_dejavu-sans](https://user-images.githubusercontent.com/15175620/43032078-88abf718-8c7c-11e8-904e-61813b065753.png)

**usetex_maths_cmbright.png**
![usetex_maths_cmbright](https://user-images.githubusercontent.com/15175620/43032080-89f2c25a-8c7c-11e8-8c26-016b1a2ccc32.png)

## PR Checklist

- ~~Has Pytest style unit tests~~
- [x] Code is PEP 8 compliant
- ~~New features are documented, with examples if plot related~~
- [x] Documentation is sphinx and numpydoc compliant
- ~~Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- ~~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~




<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
