### PR TITLE
Doc changes to plt.show

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -319,7 +319,10 @@ class _BackendWebAgg(_Backend):
         manager.canvas.draw_idle()
 
     @staticmethod
-    def show():
+    def show(block=True):
+        if not block:
+            block = True
+
         WebAggApplication.initialize()
 
         url = "http://127.0.0.1:{port}{prefix}".format(

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -230,24 +230,54 @@ def switch_backend(newbackend):
     _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
 
 
-def show(*args, **kw):
+def show(block=None):
     """
-    Display a figure.
-    When running in ipython with its pylab mode, display all
-    figures and return to the ipython prompt.
+    Draw and display all figures.
 
-    In non-interactive mode, display all figures and block until
-    the figures have been closed; in interactive mode it has no
-    effect unless figures were created prior to a change from
-    non-interactive to interactive mode (not recommended).  In
-    that case it displays the figures but does not block.
+    Mainly used in non-interactive mode to draw and display
+    the figures. It usually does nothing in interactive mode.
 
-    A single experimental keyword argument, *block*, may be
-    set to True or False to override the blocking behavior
-    described above.
+    Parameters
+    ----------
+
+    block : bool or None
+        True means that the execution is blocked until the figures are closed
+        and False means that the python execution continues after the figures
+        are displayed.
+
+        The default behavior is different in interactive and non-interactive
+        mode and whether or not `%matplotlib`_ is used in IPython. The default
+        is False in interactive mode and True in non-interactive mode except
+        when `%matplotlib`_ has been used in IPython, it is False in that case.
+
+    Notes
+    -----
+    Blocking is necessary when running ``python script.py`` to be able to see
+    the figures before the python session finish but blocking is often not the
+    expected behavior when running Python interactively.
+
+    The difference between non-interactive and interactive mode is that the
+    figures are drawn and updated automatically after each plot command in
+    interactive mode.
+
+    Interactive mode can be set on and off with `.pyplot.ion` and
+    `.pyplot.ioff` in both vanilla Python and IPython and set to on with
+    `%matplotlib`_ in IPython.
+
+    .. _`%matplotlib`:
+        http://ipython.readthedocs.io/en/stable/interactive/plotting.html#id1
+
+    See Also
+    --------
+    .pyplot.ion
+    .pyplot.ioff
+    .pyplot.isinteractive
     """
     global _show
-    return _show(*args, **kw)
+    if block is not None:
+        if type(block) != bool:
+            raise TypeError('"block" should be a bool or None')
+    return _show(block=block)
 
 
 def isinteractive():


### PR DESCRIPTION
Rewrote the `pyplot.show` docstring and made the single kwarg `block` explicit. 

Are the `block` keyword still experimental?

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
