### PR TITLE
ENH: inset_axes anchored-artist API

### DIFF
--- a/examples/subplots_axes_and_figures/zoom_inset_axes.py
+++ b/examples/subplots_axes_and_figures/zoom_inset_axes.py
@@ -16,17 +16,18 @@ def get_demo_image():
     import numpy as np
     f = get_sample_data("axes_grid/bivariate_normal.npy", asfileobj=False)
     z = np.load(f)
+    Z2 = np.zeros([150, 150], dtype="d")
+    ny, nx = z.shape
+    Z2[30:30 + ny, 30:30 + nx] = z
+
     # z is a numpy array of 15x15
-    return z, (-3, 4, -4, 3)
+    extent = (-3, 4, -4, 3)
+    return Z2, extent
 
 fig, ax = plt.subplots(figsize=[5, 4])
 
 # make data
-Z, extent = get_demo_image()
-Z2 = np.zeros([150, 150], dtype="d")
-ny, nx = Z.shape
-Z2[30:30 + ny, 30:30 + nx] = Z
-
+Z2, extent = get_demo_image()
 ax.imshow(Z2, extent=extent, interpolation="nearest",
           origin="lower")
 
@@ -42,7 +43,56 @@ axins.set_xticklabels('')
 axins.set_yticklabels('')
 
 ax.indicate_inset_zoom(axins)
+fig.canvas.draw()
+plt.show()
 
+#############################################################################
+# There is a second interface that closely parallels the interface for
+# `~.axes.legend` whereby we specify a location for the inset axes using
+# a string code.
+
+fig, ax = plt.subplots(figsize=[5, 4])
+
+ax.imshow(Z2, extent=extent, interpolation="nearest",
+          origin="lower")
+
+# inset axes....
+axins = ax.inset_axes('NE', width=0.5, height=0.5)
+
+axins.imshow(Z2, extent=extent, interpolation="nearest",
+          origin="lower")
+# sub region of the original image
+axins.set_xlim(x1, x2)
+axins.set_ylim(y1, y2)
+axins.set_xticklabels('')
+axins.set_yticklabels('')
+
+ax.indicate_inset_zoom(axins)
+fig.canvas.draw()
+plt.show()
+
+#############################################################################
+# Its possible to use either form with a transform in data space instead of
+# in the axes-relative co-ordinates:
+
+fig, ax = plt.subplots(figsize=[5, 4])
+
+ax.imshow(Z2, extent=extent, interpolation="nearest",
+          origin="lower")
+
+# inset axes....
+axins = ax.inset_axes([-2.5, 0, 1.6, 1.6], transform=ax.transData)
+
+axins.imshow(Z2, extent=extent, interpolation="nearest",
+          origin="lower")
+# sub region of the original image
+axins.set_xlim(x1, x2)
+axins.set_ylim(y1, y2)
+axins.set_xticklabels('')
+axins.set_yticklabels('')
+
+ax.indicate_inset_zoom(axins)
+fig.canvas.draw()
 plt.show()
 
 #############################################################################

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5782,3 +5782,51 @@ def test_zoom_inset():
                    [0.8425, 0.907692]])
     np.testing.assert_allclose(axin1.get_position().get_points(),
             xx, rtol=1e-4)
+
+
+def test_inset_codes():
+    """
+    Test that the inset codes put the inset where we want...
+    """
+
+    fig, ax = plt.subplots()
+    poss = [[[0.415625, 0.686111],
+             [0.609375, 0.886111]],
+            [[0.695833, 0.686111],
+             [0.889583, 0.886111]],
+            [[0.695833, 0.4],
+             [0.889583, 0.6]],
+            [[0.695833, 0.113889],
+             [0.889583, 0.313889]],
+            [[0.415625, 0.113889],
+             [0.609375, 0.313889]],
+            [[0.135417, 0.113889],
+             [0.329167, 0.313889]],
+            [[0.135417, 0.4],
+             [0.329167, 0.6]],
+            [[0.135417, 0.686111],
+             [0.329167, 0.886111]],
+            [[0.415625, 0.4],
+             [0.609375, 0.6]]]
+    codes = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW', 'C']
+    for pos, code in zip(poss, codes):
+        axin1 = ax.inset_axes(code)
+        np.testing.assert_allclose(axin1.get_position().get_points(),
+                pos, rtol=1e-4)
+        del axin1
+
+    # test synonyms
+    syns = ['top', 'upper right', 'center right', 'lower right', 'bottom',
+             'lower left', 'center left', 'upper left', 'center']
+    codes = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW', 'C']
+    for syn, code in zip(syns, codes):
+        axin1 = ax.inset_axes(code)
+        axin2 = ax.inset_axes(syn)
+        np.testing.assert_allclose(axin1.get_position().get_points(),
+                axin2.get_position().get_points(), rtol=1e-4)
+
+    # test the borderaxespad
+    axin1 = ax.inset_axes('NE', borderaxespad=20)
+    pos = [[0.671528, 0.653704], [0.865278, 0.853704]]
+    np.testing.assert_allclose(axin1.get_position().get_points(),
+                pos, rtol=1e-4)


### PR DESCRIPTION
## PR Summary

`ax.inset_axes` is now merged for 3.0 (#11026) with a minimal positioning API.  (`ax.inset_axes([l, b, w, h])`), but folks can specify transforms that allow a pad with the edge of the axes.

This PR expands the API to be similar to `ax.legend` and `axes_grid1.inset_axes` and allow a string for the position argument.  So now we can do `ax.inset_axes('NE', width=0.4, height=0.4)`

```python 
import matplotlib.pyplot as plt
import numpy as np


def get_demo_image():
    from matplotlib.cbook import get_sample_data
    import numpy as np
    f = get_sample_data("axes_grid/bivariate_normal.npy", asfileobj=False)
    z = np.load(f)
    Z2 = np.zeros([150, 150], dtype="d")
    ny, nx = z.shape
    Z2[30:30 + ny, 30:30 + nx] = z

    # z is a numpy array of 15x15
    extent = (-3, 4, -4, 3)
    return Z2, extent

fig, ax = plt.subplots(figsize=[5, 4])

# make data
Z2, extent = get_demo_image()
ax.imshow(Z2, extent=extent, interpolation="nearest",
          origin="lower")

# inset axes....
axins = ax.inset_axes('NE', width=0.4, height=0.4)

axins.imshow(Z2, extent=extent, interpolation="nearest",
          origin="lower")
# sub region of the original image
x1, x2, y1, y2 = -1.5, -0.9, -2.5, -1.9
axins.set_xlim(x1, x2)
axins.set_ylim(y1, y2)
axins.set_xticklabels(''); axins.set_yticklabels('')

ax.indicate_inset_zoom(axins)
fig.canvas.draw()
plt.show()
```

![boo](https://user-images.githubusercontent.com/1562854/43040728-161ecaca-8d00-11e8-8654-d4db088fee9a.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->