### PR TITLE
[wip] Add machinery to generate test-only wheels.

### DIFF
--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -188,6 +188,10 @@ Once you have collected all of the wheels, generate the tarball ::
   git checkout v2.0.0
   git clean -xfd
   python setup.py sdist
+  # Generate test-only wheels.
+  for dir in sub-wheels/*; do
+    (cd "$dir" && python setup.py bdist_wheel)
+  done
 
 and copy all of the wheels into :file:`dist` directory.  You should use
 ``twine`` to upload all of the files to pypi ::

--- a/sub-wheels/matplotlib.tests/README.rst
+++ b/sub-wheels/matplotlib.tests/README.rst
@@ -1,0 +1,12 @@
+Running ``python setup.py bdist_wheel`` (*not* ``pip wheel .``) generates a
+wheel for a ``matplotlib.tests`` distribution (in the distutils sense, i.e.
+a PyPI package) that can be installed alongside a main, test-less Matplotlib
+distribution.
+
+Note that
+
+- ``pip wheel`` doesn't work as that starts by copying the *current* directory
+  to a temporary one (for isolation purposes), before we get to ``chdir`` back
+  to the root directory.
+- ``python setup.py sdist`` doesn't work as that would pick up the
+  ``MANIFEST.in`` file in the root directory.

--- a/sub-wheels/matplotlib.tests/setup.py
+++ b/sub-wheels/matplotlib.tests/setup.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+import sys
+
+
+rootdir = str(Path(__file__).resolve().parents[2])
+sys.path.insert(0, rootdir)
+os.chdir(rootdir)
+
+
+from setuptools import setup, find_packages
+import versioneer
+
+
+__version__ = versioneer.get_version()
+
+
+if "sdist" in sys.argv:
+    sys.exit("Only wheels can be generated.")
+setup(
+    name="matplotlib.tests",
+    version=__version__,
+    package_dir={"": "lib"},
+    packages=find_packages("lib", include=["*.tests"]),
+    include_package_data=True,
+    install_requires=["matplotlib=={}".format(__version__)]
+)


### PR DESCRIPTION
Generate a matplotlib.tests wheel that can be uploaded to PyPI as a
separate PyPI package ("distribution", in distutils parlance), to make
it possible to install tests and test data from PyPI.

This is useful e.g. for mplcairo, whose test suite relies on
matplotlib's one.

attn @tacaswell (I think I remember there were also some discussions re: installing test data or not for conda packages.)
Basically undoing #11055, but in a way that now works...

Would be nice to have for 3.0, but heh :)

As a side point, note that the 2.2.2 manylinux wheel currently on PyPI contains baseline images for mpl_toolkits, but not for matplotlib itself...

-----

Edit: Looks like there can be funny issues if matplotlib is editably installed as this PR causes matplotlib.tests.egg-info to end up in lib, next to matplotlib.egg-info...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
