### PR TITLE
MAINT: use collections.abc for 3.7

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1639,7 +1639,8 @@ def pts_to_midstep(x, *args):
         The x location of the steps. May be empty.
 
     y1, ..., yp : array
-        y arrays to be turned into steps; all must be the same length as ``x``.
+        y arrays to be turned into steps; all must be the same length as
+        ``x``.
 
     Returns
     -------
@@ -1715,7 +1716,8 @@ def safe_first_element(obj):
 
 def sanitize_sequence(data):
     """Converts dictview object to list"""
-    return list(data) if isinstance(data, collections.abc.MappingView) else data
+    return (list(data) if isinstance(data, collections.abc.MappingView)
+            else data)
 
 
 def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1697,7 +1697,7 @@ def index_of(y):
 
 
 def safe_first_element(obj):
-    if isinstance(obj, collections.Iterator):
+    if isinstance(obj, collections.abc.Iterator):
         # needed to accept `array.flat` as input.
         # np.flatiter reports as an instance of collections.Iterator
         # but can still be indexed via [].
@@ -1714,7 +1714,7 @@ def safe_first_element(obj):
 
 def sanitize_sequence(data):
     """Converts dictview object to list"""
-    return list(data) if isinstance(data, collections.MappingView) else data
+    return list(data) if isinstance(data, collections.abc.MappingView) else data
 
 
 def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
@@ -2088,9 +2088,9 @@ def _warn_external(message, category=None):
     warnings.warn(message, category, stacklevel)
 
 
-class _OrderedSet(collections.MutableSet):
+class _OrderedSet(collections.abc.MutableSet):
     def __init__(self):
-        self._od = collections.OrderedDict()
+        self._od = collections.abc.OrderedDict()
 
     def __contains__(self, key):
         return key in self._od

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -7,6 +7,7 @@ it imports matplotlib only at runtime.
 """
 
 import collections
+import collections.abc
 import contextlib
 import datetime
 import errno
@@ -2090,7 +2091,7 @@ def _warn_external(message, category=None):
 
 class _OrderedSet(collections.abc.MutableSet):
     def __init__(self):
-        self._od = collections.abc.OrderedDict()
+        self._od = collections.OrderedDict()
 
     def __contains__(self, key):
         return key in self._od


### PR DESCRIPTION
scipy is [getting](https://ci.appveyor.com/project/scipy/scipy/build/1.0.3368/job/5u2vi3yhdlglux4b#L8040) some issues when trying to test on Python 3.7 because of a DeprecationWarning:

```DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working```

This PR just changes a few instances of `collections.X` into `collections.abc.X`.


```
_____________________ TestDendrogram.test_dendrogram_plot _____________________
[gw1] win32 -- Python 3.7.0 C:\Python37-x64\python.exe
self = <scipy.cluster.tests.test_hierarchy.TestDendrogram object at 0x0000005E63E60160>
    @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
    def test_dendrogram_plot(self):
        for orientation in ['top', 'bottom', 'left', 'right']:
>           self.check_dendrogram_plot(orientation)
orientation = 'top'
self       = <scipy.cluster.tests.test_hierarchy.TestDendrogram object at 0x0000005E63E60160>
C:\Python37-x64\lib\site-packages\scipy\cluster\tests\test_hierarchy.py:822: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\Python37-x64\lib\site-packages\scipy\cluster\tests\test_hierarchy.py:842: in check_dendrogram_plot
    ax = fig.add_subplot(221)
C:\Python37-x64\lib\site-packages\matplotlib\figure.py:1239: in add_subplot
    a = subplot_class_factory(projection_class)(self, *args, **kwargs)
C:\Python37-x64\lib\site-packages\matplotlib\axes\_subplots.py:77: in __init__
    self._axes_class.__init__(self, fig, self.figbox, **kwargs)
C:\Python37-x64\lib\site-packages\matplotlib\axes\_base.py:523: in __init__
    self.cla()
C:\Python37-x64\lib\site-packages\matplotlib\axes\_base.py:1032: in cla
    self.set_xlim(0, 1)
C:\Python37-x64\lib\site-packages\matplotlib\axes\_base.py:3110: in set_xlim
    self._process_unit_info(xdata=(left, right))
C:\Python37-x64\lib\site-packages\matplotlib\axes\_base.py:2139: in _process_unit_info
    self.xaxis.update_units(xdata)
C:\Python37-x64\lib\site-packages\matplotlib\axis.py:1463: in update_units
    converter = munits.registry.get_converter(data)
C:\Python37-x64\lib\site-packages\matplotlib\units.py:188: in get_converter
    thisx = safe_first_element(x)
C:\Python37-x64\lib\site-packages\matplotlib\cbook\__init__.py:2347: in safe_first_element
    if isinstance(obj, collections.Iterator):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
name = 'Iterator'
    def __getattr__(name):
        # For backwards compatibility, continue to make the collections ABCs
        # through Python 3.6 available through the collections module.
        # Note, no new collections ABCs were added in Python 3.7
        if name in _collections_abc.__all__:
            obj = getattr(_collections_abc, name)
            import warnings
            warnings.warn("Using or importing the ABCs from 'collections' instead "
                          "of from 'collections.abc' is deprecated, "
                          "and in 3.8 it will stop working",
>                         DeprecationWarning, stacklevel=2)
E           DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
name       = 'Iterator'
obj        = <class 'collections.abc.Iterator'>
warnings   = <module 'warnings' from 'C:\\Python37-x64\\lib\\warnings.py'>
C:\Python37-x64\lib\collections\__init__.py:52: DeprecationWarning
```