### PR TITLE
Change {FigureCanvasAgg,RendererAgg}.buffer_rgba to return a memoryview.

### DIFF
--- a/doc/api/next_api_changes/2018-07-22-AL.rst
+++ b/doc/api/next_api_changes/2018-07-22-AL.rst
@@ -1,0 +1,7 @@
+`FigureCanvasAgg.buffer_rgba` and `RendererAgg.buffer_rgba` now return a memoryview
+```````````````````````````````````````````````````````````````````````````````````
+
+The ``buffer_rgba`` method now allows direct access to the renderer's
+underlying buffer (as a ``(m, n, 4)``-shape memoryview) rather than copying the
+data to a new bytestring.  This is consistent with the behavior on Py2, where a
+buffer object was returned.

--- a/examples/misc/agg_buffer_to_array.py
+++ b/examples/misc/agg_buffer_to_array.py
@@ -15,7 +15,7 @@ ax.set_title('a simple figure')
 fig.canvas.draw()
 
 # grab the pixel buffer and dump it into a numpy array
-X = np.array(fig.canvas.renderer._renderer)
+X = np.array(fig.canvas.renderer.buffer_rgba())
 
 # now display the array X as an Axes in a new figure
 fig2 = plt.figure()

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -265,14 +265,14 @@ class RendererAgg(RendererBase):
         """
         return points * self.dpi / 72
 
-    def tostring_rgb(self):
-        return self._renderer.tostring_rgb()
-
-    def tostring_argb(self):
-        return self._renderer.tostring_argb()
-
     def buffer_rgba(self):
         return memoryview(self._renderer)
+
+    def tostring_argb(self):
+        return np.asarray(self._renderer).take([3, 0, 1, 2], axis=2).tobytes()
+
+    def tostring_rgb(self):
+        return np.asarray(self._renderer).take([0, 1, 2], axis=2).tobytes()
 
     def clear(self):
         self._renderer.clear()

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -272,7 +272,7 @@ class RendererAgg(RendererBase):
         return self._renderer.tostring_argb()
 
     def buffer_rgba(self):
-        return self._renderer.buffer_rgba()
+        return memoryview(self._renderer)
 
     def clear(self):
         self._renderer.clear()
@@ -421,7 +421,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         return self.renderer
 
     def tostring_rgb(self):
-        '''Get the image as an RGB byte string.
+        """Get the image as an RGB byte string.
 
         `draw` must be called at least once before this function will work and
         to update the renderer for any subsequent changes to the Figure.
@@ -429,11 +429,11 @@ class FigureCanvasAgg(FigureCanvasBase):
         Returns
         -------
         bytes
-        '''
+        """
         return self.renderer.tostring_rgb()
 
     def tostring_argb(self):
-        '''Get the image as an ARGB byte string
+        """Get the image as an ARGB byte string.
 
         `draw` must be called at least once before this function will work and
         to update the renderer for any subsequent changes to the Figure.
@@ -441,20 +441,19 @@ class FigureCanvasAgg(FigureCanvasBase):
         Returns
         -------
         bytes
-
-        '''
+        """
         return self.renderer.tostring_argb()
 
     def buffer_rgba(self):
-        '''Get the image as an RGBA byte string.
+        """Get the image as a memoryview to the renderer's buffer.
 
         `draw` must be called at least once before this function will work and
         to update the renderer for any subsequent changes to the Figure.
 
         Returns
         -------
-        bytes
-        '''
+        memoryview
+        """
         return self.renderer.buffer_rgba()
 
     def print_raw(self, filename_or_obj, *args, **kwargs):

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -156,29 +156,6 @@ bool RendererAgg::render_clippath(py::PathIterator &clippath,
     return has_clippath;
 }
 
-void RendererAgg::tostring_rgb(uint8_t *buf)
-{
-    // "Return the rendered buffer as an RGB string"
-
-    int row_len = width * 3;
-
-    agg::rendering_buffer renderingBufferTmp;
-    renderingBufferTmp.attach(buf, width, height, row_len);
-
-    agg::color_conv(&renderingBufferTmp, &renderingBuffer, agg::color_conv_rgba32_to_rgb24());
-}
-
-void RendererAgg::tostring_argb(uint8_t *buf)
-{
-    //"Return the rendered buffer as an RGB string";
-
-    int row_len = width * 4;
-
-    agg::rendering_buffer renderingBufferTmp;
-    renderingBufferTmp.attach(buf, width, height, row_len);
-    agg::color_conv(&renderingBufferTmp, &renderingBuffer, agg::color_conv_rgba32_to_argb32());
-}
-
 agg::rect_i RendererAgg::get_content_extents()
 {
     agg::rect_i r(width, height, 0, 0);

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -203,8 +203,6 @@ class RendererAgg
                                 ColorArray &colors,
                                 agg::trans_affine &trans);
 
-    void tostring_rgb(uint8_t *buf);
-    void tostring_argb(uint8_t *buf);
     agg::rect_i get_content_extents();
     void clear();
 

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -525,38 +525,6 @@ PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args, PyObje
     Py_RETURN_NONE;
 }
 
-static PyObject *PyRendererAgg_tostring_rgb(PyRendererAgg *self, PyObject *args, PyObject *kwds)
-{
-    PyObject *buffobj = NULL;
-
-    buffobj = PyBytes_FromStringAndSize(NULL, self->x->get_width() * self->x->get_height() * 3);
-    if (buffobj == NULL) {
-        return NULL;
-    }
-
-    CALL_CPP_CLEANUP("tostring_rgb",
-                     (self->x->tostring_rgb((uint8_t *)PyBytes_AS_STRING(buffobj))),
-                     Py_DECREF(buffobj));
-
-    return buffobj;
-}
-
-static PyObject *PyRendererAgg_tostring_argb(PyRendererAgg *self, PyObject *args, PyObject *kwds)
-{
-    PyObject *buffobj = NULL;
-
-    buffobj = PyBytes_FromStringAndSize(NULL, self->x->get_width() * self->x->get_height() * 4);
-    if (buffobj == NULL) {
-        return NULL;
-    }
-
-    CALL_CPP_CLEANUP("tostring_argb",
-                     (self->x->tostring_argb((uint8_t *)PyBytes_AS_STRING(buffobj))),
-                     Py_DECREF(buffobj));
-
-    return buffobj;
-}
-
 static PyObject *
 PyRendererAgg_get_content_extents(PyRendererAgg *self, PyObject *args, PyObject *kwds)
 {
@@ -664,8 +632,6 @@ static PyTypeObject *PyRendererAgg_init_type(PyObject *m, PyTypeObject *type)
         {"draw_gouraud_triangle", (PyCFunction)PyRendererAgg_draw_gouraud_triangle, METH_VARARGS, NULL},
         {"draw_gouraud_triangles", (PyCFunction)PyRendererAgg_draw_gouraud_triangles, METH_VARARGS, NULL},
 
-        {"tostring_rgb", (PyCFunction)PyRendererAgg_tostring_rgb, METH_NOARGS, NULL},
-        {"tostring_argb", (PyCFunction)PyRendererAgg_tostring_argb, METH_NOARGS, NULL},
         {"get_content_extents", (PyCFunction)PyRendererAgg_get_content_extents, METH_NOARGS, NULL},
         {"buffer_rgba", (PyCFunction)PyRendererAgg_buffer_rgba, METH_NOARGS, NULL},
         {"clear", (PyCFunction)PyRendererAgg_clear, METH_NOARGS, NULL},


### PR DESCRIPTION
The `buffer_rgba` method now allows direct access to the renderer's
underlying buffer (as a `(m, n, 4)`-shape memoryview) rather than
copying the data to a new bytestring.  This is consistent with the
behavior on Py2, where a buffer object was returned.

While this is technically a backwards-incompatible change, memoryviews
are in fact quite compatible with bytes for most uses, and I'd argue
that the bigger compatibility break was the change from no-copy in Py2
to copy in Py3 (after all that's the main point of the method...).

See also discussion in #11726.

---

Added second commit: reimplement tostring_rgba, tostring_rgb using numpy to access the buffer.  Note that this was one of the suggestions of the original removal of PyCXX (https://github.com/matplotlib/matplotlib/pull/3646) :-)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
