### PR TITLE
fix tight_layout bug #11737

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1621,7 +1621,6 @@ default: 'top'
         Render the figure using :class:`matplotlib.backend_bases.RendererBase`
         instance *renderer*.
         """
-
         # draw the figure bounding box, perhaps none for white figure
         if not self.get_visible():
             return
@@ -1635,6 +1634,12 @@ default: 'top'
 
         try:
             renderer.open_group('figure')
+            if self.frameon:
+                self.patch.draw(renderer)
+
+            mimage._draw_list_compositing_images(
+                renderer, self, artists, self.suppressComposite)
+
             if self.get_constrained_layout() and self.axes:
                 self.execute_constrained_layout(renderer)
             if self.get_tight_layout() and self.axes:
@@ -1644,12 +1649,6 @@ default: 'top'
                 except ValueError:
                     pass
                     # ValueError can occur when resizing a window.
-
-            if self.frameon:
-                self.patch.draw(renderer)
-
-            mimage._draw_list_compositing_images(
-                renderer, self, artists, self.suppressComposite)
 
             renderer.close_group('figure')
         finally:


### PR DESCRIPTION
 I believe that the issue in #11737 where some Spines that had a bounding box outside of the figure. This pr seems to solve the bug I found but I don't know enough about the details about the code to know if it is a good solution or any real solution at all.

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
