### PR TITLE
Deprecate support for 3rd-party backends without set_hatch_color.

### DIFF
--- a/doc/api/next_api_changes/2018-07-22-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-07-22-AL-deprecations.rst
@@ -1,0 +1,7 @@
+Deprecations
+------------
+
+Support for custom backends that do not provide a ``set_hatch_color`` method is
+deprecated.  We suggest that custom backends let their ``GraphicsContext``
+class inherit from `GraphicsContextBase`, to at least provide stubs for all
+required methods.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -271,8 +271,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 gc.set_hatch_color(self._hatch_color)
             except AttributeError:
                 # if we end up with a GC that does not have this method
-                warnings.warn("Your backend does not support setting the "
-                              "hatch color.")
+                cbook.warn_deprecated(
+                    "3.1", "Your backend does not support setting the hatch "
+                    "color; such backends will become unsupported in "
+                    "Matplotlib 3.3.")
 
         if self.get_sketch_params() is not None:
             gc.set_sketch_params(*self.get_sketch_params())

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -515,8 +515,10 @@ class Patch(artist.Artist):
                 gc.set_hatch_color(self._hatch_color)
             except AttributeError:
                 # if we end up with a GC that does not have this method
-                warnings.warn(
-                    "Your backend does not support setting the hatch color.")
+                cbook.warn_deprecated(
+                    "3.1", "Your backend does not support setting the hatch "
+                    "color; such backends will become unsupported in "
+                    "Matplotlib 3.3.")
 
         if self.get_sketch_params() is not None:
             gc.set_sketch_params(*self.get_sketch_params())
@@ -4285,8 +4287,10 @@ class FancyArrowPatch(Patch):
                     gc.set_hatch_color(self._hatch_color)
                 except AttributeError:
                     # if we end up with a GC that does not have this method
-                    warnings.warn("Your backend does not support setting the "
-                                  "hatch color.")
+                    cbook.warn_deprecated(
+                        "3.1", "Your backend does not support setting the "
+                        "hatch color; such backends will become unsupported "
+                        "in Matplotlib 3.3.")
 
         if self.get_sketch_params() is not None:
             gc.set_sketch_params(*self.get_sketch_params())


### PR DESCRIPTION
Inheriting from GraphicsContextBase to get a stub definition of
set_hatch_color (or providing your own stub) is really not that much to
ask, I believe.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
