### PR TITLE
FIX: Stop tight layout collapsing under zoom

### DIFF
--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -176,11 +176,13 @@ def auto_adjust_subplotpars(
         margin_right = 0.4999
         warnings.warn('The left and right margins cannot be made large '
                       'enough to accommodate all axes decorations. ')
+        return None
     if margin_bottom + margin_top >= 1:
         margin_bottom = 0.4999
         margin_top = 0.4999
         warnings.warn('The bottom and top margins cannot be made large '
                       'enough to accommodate all axes decorations. ')
+        return None
 
     kwargs = dict(left=margin_left,
                   right=1 - margin_right,
@@ -302,7 +304,10 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
     for ax, subplotspec in zip(axes_list, subplotspec_list):
         if subplotspec is None:
             continue
-
+        # spines have a problem under zoom; CL ignores zoom events.  TL
+        # ignores spines...
+        for spine in ['left', 'right', 'bottom', 'top']:
+            ax.spines[spine].set_in_layout(False)
         subplots = subplot_dict.setdefault(subplotspec, [])
 
         if not subplots:
@@ -354,6 +359,8 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
                                      subplot_list=subplot_list,
                                      ax_bbox_list=ax_bbox_list,
                                      pad=pad, h_pad=h_pad, w_pad=w_pad)
+    if kwargs is None:
+        return None
 
     if rect is not None:
         # if rect is given, the whole subplots area (including
@@ -384,5 +391,7 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
                                          ax_bbox_list=ax_bbox_list,
                                          pad=pad, h_pad=h_pad, w_pad=w_pad,
                                          rect=(left, bottom, right, top))
+        if kwargs is None:
+            return None
 
     return kwargs


### PR DESCRIPTION
## PR Summary

Fixes #11737, and supersedes #11739 

We are now consulting all axes children when doing `get_tightbbox` (my fault: #10682), including spines.  There is some sort of problem  with spines not having there transform set before draw when zoom is being used, and this leads to impossible bbox calculations.  (See #11627).

This PR adopts the same soln as #11627 and disables `tight_layout` while zoom and pan are active.  This will keep the axes the same size during interactive use, which to my mind is preferable to having the axes change size all the time.  However, others may disagree w that. 

This PR also has failing `tight_layouts` just refuse to update the axes positions, whereas before they drew a collapsed axes.  Again, in my opinion, drawing something reasonable is better than drawing something that is broken.  

```python 
import numpy as np
import matplotlib.pyplot as plt

fig, ax=plt.subplots()
fig.set_tight_layout(True)
plt.show()
```

And use the GUI to zoom.  Before this PR, the axes collapsed.  Now the axes doesn't change at all because zoom is active.  

Note it might be nice to consider when "Zoom" is turned off to trigger a draw, then CL and TL can be made to work.

Of course the original problem is that the transform of the spines is not being set early enough.  Not really sure what the soln to that is.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->