### PR TITLE
minor doc update on axes_grid1's inset_axes

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -403,6 +403,25 @@ def inset_axes(parent_axes, width, height, loc='upper right',
     cases, it is recommended to read
     :ref:`the examples <sphx_glr_gallery_axes_grid1_inset_locator_demo.py>`.
 
+    Notes
+    -----
+    The meaning of *bbox_to_anchor* and *bbox_to_transform* is interpreted
+    differently from that of legend. The value of bbox_to_anchor
+    (or the return value of its get_points method; the default is
+    *parent_axes.bbox*) is transformed by the bbox_transform (the default
+    is Identity transform) and then interpreted as points in the pixel
+    coordinate (which is dpi dependent).
+
+    Thus, following three calls are identical and creates an inset axes
+    with respect to the *parent_axes*::
+
+       axins = inset_axes(parent_axes, "30%%", "40%%")
+       axins = inset_axes(parent_axes, "30%%", "40%%",
+                          bbox_to_anchor=parent_axes.bbox)
+       axins = inset_axes(parent_axes, "30%%", "40%%",
+                          bbox_to_anchor=(0, 0, 1, 1),
+                          bbox_transform=parent_axes.transAxes)
+
     Parameters
     ----------
     parent_axes : `matplotlib.axes.Axes`
@@ -432,25 +451,26 @@ def inset_axes(parent_axes, width, height, loc='upper right',
 
     bbox_to_anchor : tuple or `matplotlib.transforms.BboxBase`, optional
         Bbox that the inset axes will be anchored to. If None,
-        *parent_axes.bbox* is used. If a tuple, can be either
+        a tuple of (0, 0, 1, 1) is used if *bbox_transform* is set
+        to *parent_axes.transAxes* or *parent_axes.figure.transFigure*.
+        Otherwise, *parent_axes.bbox* is used. If a tuple, can be either
         [left, bottom, width, height], or [left, bottom].
         If the kwargs *width* and/or *height* are specified in relative units,
-        the 2-tuple [left, bottom] cannot be used. Note that
-        the units of the bounding box are determined through the transform
-        in use. When using *bbox_to_anchor* it almost always makes sense to
-        also specify a *bbox_transform*. This might often be the axes transform
+        the 2-tuple [left, bottom] cannot be used. Note that,
+        unless *bbox_transform* is set, the units of the bounding box
+        are interpreted in the pixel coordinate. When using *bbox_to_anchor*
+        with tuple, it almost always makes sense to also specify
+        a *bbox_transform*. This might often be the axes transform
         *parent_axes.transAxes*.
 
     bbox_transform : `matplotlib.transforms.Transform`, optional
         Transformation for the bbox that contains the inset axes.
-        If None, a `.transforms.IdentityTransform` is used (i.e. pixel
-        coordinates). This is useful when not providing any argument to
-        *bbox_to_anchor*. When using *bbox_to_anchor* it almost always makes
-        sense to also specify a *bbox_transform*. This might often be the
-        axes transform *parent_axes.transAxes*. Inversely, when specifying
-        the axes- or figure-transform here, be aware that not specifying
-        *bbox_to_anchor* will use *parent_axes.bbox*, the units of which are
-        in display (pixel) coordinates.
+        If None, a `.transforms.IdentityTransform` is used. The value
+        of *bbox_to_anchor* (or the return value of its get_points method)
+        is transformed by the *bbox_transform* and then interpreted
+        as points in the pixel coordinate (which is dpi dependent).
+        You may provide *bbox_to_anchor* in some normalized coordinate,
+        and give an appropriate transform (e.g., *parent_axes.transAxes*).
 
     axes_class : `matplotlib.axes.Axes` type, optional
         If specified, the inset axes created will be created with this class's


### PR DESCRIPTION
## PR Summary
Following #11060, this PR try to improve the documentation of the axes_grid1's inset_axes.

Note that the api of inset_axes is more-or-less inclined to use with the *TransformedBbox* instance (e.g. ax.bbox, fig.bbox). And a note is added to make this point.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
