### PR TITLE
get_clip_path checks for nan

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -837,7 +837,12 @@ class GraphicsContextBase:
         an affine transform to apply to the path before clipping.
         """
         if self._clippath is not None:
-            return self._clippath.get_transformed_path_and_affine()
+            tpath, tr = self._clippath.get_transformed_path_and_affine()
+            if np.all(np.isfinite(tpath.vertices)):
+                return tpath, tr
+            else:
+                warnings.warn("Ill-defined clip_path detected. Returning None.")
+                return None, None
         return None, None
 
     def get_dashes(self):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -841,7 +841,7 @@ class GraphicsContextBase:
             if np.all(np.isfinite(tpath.vertices)):
                 return tpath, tr
             else:
-                warnings.warn("Ill-defined clip_path detected. Returning None.")
+                _log.warning("Ill-defined clip_path detected. Returning None.")
                 return None, None
         return None, None
 


### PR DESCRIPTION
## PR Summary

Specifying an ill-defined *clip_path* leads to a seg-fault (#4448) with agg backends. Here is an minimal example.

```python
import io
import numpy as np

import matplotlib.figure as mfigure
from matplotlib.projections import PolarAxes
import matplotlib.patches as mpatches
from matplotlib.backends.backend_agg import FigureCanvasAgg

fig = mfigure.Figure()
ax = fig.add_subplot(111)
l1, = ax.plot([-1, 1], [-1, 1])

tr = PolarAxes.PolarTransform()
p = mpatches.Polygon(np.arange(-3, 3).reshape((3, 2)), transform=tr)

l1.set_clip_path(p)

FigureCanvasAgg(fig).print_png(io.BytesIO())

```

The current PR simply fix this by making *GraphicsContextBase.get_clip_path* returns None if it contains values that are not finite.


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
