### PR TITLE
Remove the unused 'verbose' option from setupext.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -231,11 +231,6 @@ if __name__ == '__main__':
             fd.write(
                 template.safe_substitute(TEMPLATE_BACKEND=default_backend))
 
-        # Build in verbose mode if requested
-        if setupext.options['verbose']:
-            for mod in ext_modules:
-                mod.extra_compile_args.append('-DVERBOSE')
-
         # Finalize the extension modules so they can get the Numpy include
         # dirs
         for mod in ext_modules:

--- a/setupext.py
+++ b/setupext.py
@@ -60,7 +60,6 @@ LOCAL_FREETYPE_HASH = _freetype_hashes.get(LOCAL_FREETYPE_VERSION, 'unknown')
 # matplotlib build options, which can be altered using setup.cfg
 options = {
     'display_status': True,
-    'verbose': False,
     'backend': None,
     'basedirlist': None
     }


### PR DESCRIPTION
It only sets a compilation symbol which has become unused since the
removal of PyCXX (ba40160).

... Not to be confused with the 'display_status'/'status.suppress'
option, which is still used.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
