### PR TITLE
FIX: update spine positions before get extents

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -145,14 +145,6 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
 
     '''
 
-    try:
-        if fig.canvas.toolbar._active in ('PAN', 'ZOOM'):
-            # don't do constrained layout during zoom and pan.
-            return
-    except AttributeError:
-        # not toolbar, or no _active attribute..
-        pass
-
     invTransFig = fig.transFigure.inverted().transform_bbox
 
     # list of unique gridspecs that contain child axes:

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -150,7 +150,7 @@ class Spine(mpatches.Patch):
         # make sure the location is updated so that transforms etc are
         # correct:
         self._adjust_location()
-        return self.get_path().get_extents(self.get_transform())
+        return super().get_window_extent(renderer=renderer)
 
     def get_path(self):
         return self._path

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -146,6 +146,12 @@ class Spine(mpatches.Patch):
         else:
             return super().get_patch_transform()
 
+    def get_window_extent(self, renderer=None):
+        # make sure the location is updated so that transforms etc are
+        # correct:
+        self._adjust_location()
+        return self.get_path().get_extents(self.get_transform())
+
     def get_path(self):
         return self._path
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5782,3 +5782,13 @@ def test_zoom_inset():
                    [0.8425, 0.907692]])
     np.testing.assert_allclose(axin1.get_position().get_points(),
             xx, rtol=1e-4)
+
+
+def test_spines_properbbox_after_zoom():
+    fig, ax = plt.subplots()
+    bb = ax.spines['bottom'].get_window_extent(fig.canvas.get_renderer())
+    # this is what zoom calls:
+    ax._set_view_from_bbox((320, 320, 500, 500), 'in',
+                      None, False, False)
+    bb2 = ax.spines['bottom'].get_window_extent(fig.canvas.get_renderer())
+    np.testing.assert_allclose(bb.get_points(), bb2.get_points(), rtol=1e-6)


### PR DESCRIPTION
## PR Summary

Closes #11737 (supercedes #11739, #11742)  

If you zoomed on an axes, `get_tightbbox` would return a huge bounding box because spine objects didn't have their x/ylims properly set from the axis info yet.  This PR sets those limits when `get_window_extent` is called making the bounding box accurate..

This also rolls back a change in #11627 where constrained_layout was turned off under ZOOM and PAN...

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->