### PR TITLE
Switch grid documentation to numpydoc style

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2681,30 +2681,35 @@ class _AxesBase(martist.Artist):
     @docstring.dedent_interpd
     def grid(self, b=None, which='major', axis='both', **kwargs):
         """
-        Turn the axes grids on or off.
+        Configure the grid lines.
 
-        Set the axes grids on or off; *b* is a boolean.
+        Parameters
+        ----------
+        b : bool or None
+            Whether to show the grid lines. If any *kwargs* are supplied,
+            it is assumed you want the grid on and *b* will be set to True.
 
-        If *b* is *None* and ``len(kwargs)==0``, toggle the grid state.  If
-        *kwargs* are supplied, it is assumed that you want a grid and *b*
-        is thus set to *True*.
+            If *b* is *None* and there are no *kwargs*, this toggles the
+            visibility of the lines.
 
-        *which* can be 'major' (default), 'minor', or 'both' to control
-        whether major tick grids, minor tick grids, or both are affected.
+        which : {'major', 'minor', 'both'}
+            The grid lines to apply the changes on.
 
-        *axis* can be 'both' (default), 'x', or 'y' to control which
-        set of gridlines are drawn.
+        axis : {'both', 'x', 'y'}
+            The axis to apply the changes on.
 
-        *kwargs* are used to set the grid line properties, e.g.,::
+        **kwargs : `.Line2D` properties
+            Define the line properties of the grid, e.g.::
 
-           ax.grid(color='r', linestyle='-', linewidth=2)
+                grid(color='r', linestyle='-', linewidth=2)
 
-        Valid :class:`~matplotlib.lines.Line2D` kwargs are
+            Valid *kwargs* are
 
-        %(Line2D)s
+            %(Line2D)s
 
-        Note that the grid will be drawn according to the axes' zorder and not
-        its own.
+        Notes
+        -----
+        The grid will be drawn according to the axes' zorder and not its own.
         """
         if len(kwargs):
             b = True

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1417,16 +1417,25 @@ class Axis(artist.Artist):
 
     def grid(self, b=None, which='major', **kwargs):
         """
-        Set the axis grid on or off; b is a boolean. Use *which* =
-        'major' | 'minor' | 'both' to set the grid for major or minor ticks.
+        Configure the grid lines.
 
-        If *b* is *None* and len(kwargs)==0, toggle the grid state.  If
-        *kwargs* are supplied, it is assumed you want the grid on and *b*
-        will be set to True.
+        Parameters
+        ----------
+        b : bool or None
+            Whether to show the grid lines. If any *kwargs* are supplied,
+            it is assumed you want the grid on and *b* will be set to True.
 
-        *kwargs* are used to set the line properties of the grids, e.g.,
+            If *b* is *None* and there are no *kwargs*, this toggles the
+            visibility of the lines.
 
-          xax.grid(color='r', linestyle='-', linewidth=2)
+        which : {'major', 'minor', 'both'}
+            The grid lines to apply the changes on.
+
+        **kwargs : `.Line2D` properties
+            Define the line properties of the grid, e.g.::
+
+                grid(color='r', linestyle='-', linewidth=2)
+
         """
         if len(kwargs):
             b = True


### PR DESCRIPTION
## PR Summary

IMHO the docstring is good now.

The underlying code still has some issues:

- The `axis` argument is not checked for sanity. Arbitrary values are taken, in which case the function silently does nothing. This should complain.
- The `which` argument is not checked for sanity. Arbitrary values are taken, in which case the function silently does nothing, except for marking the axis as stale. This should complain.
- The supported `which` values can have arbitrary capitalization. This is not documented. May be ok (I don't want to advertise this feature. On the other hand, it's probably not that important that we would want to break user code by removing that function?)
- While `Axes.grid` supports "textual" bools such as "on", `Axis.grid` does not. This an unexpected mismatch in API functionality. It should be either both or none of them. Do we have a policy for that?
- `grid(False, color='r')` is the same as `grid(True, color='r')` or `grid(color='r')`. While the behavior is correctly documented, `grid(False, color='r')` should at least issue a warning if not an error. It simply does not make sense and likely means that the user is not aware of what he's actually doing.

These can be addressed in a separte PR. I would like to keep this PR docstring-only.