### PR TITLE
DOC: reorder examples and fix top level heading

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -9,16 +9,15 @@ from sphinx_gallery.sorting import ExplicitOrder
 # Gallery sections shall be diplayed in the following order.
 # Non-matching sections are appended.
 explicit_order_folders = [
-                          '../examples/api',
-                          '../examples/pyplots',
-                          '../examples/subplots_axes_and_figures',
-                          '../examples/color',
-                          '../examples/statistics',
                           '../examples/lines_bars_and_markers',
                           '../examples/images_contours_and_fields',
-                          '../examples/shapes_and_collections',
-                          '../examples/text_labels_and_annotations',
+                          '../examples/subplots_axes_and_figures',
+                          '../examples/statistics',
                           '../examples/pie_and_polar_charts',
+                          '../examples/text_labels_and_annotations',
+                          '../examples/pyplots',
+                          '../examples/color',
+                          '../examples/shapes_and_collections',
                           '../examples/style_sheets',
                           '../examples/axes_grid1',
                           '../examples/axisartist',

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -2,6 +2,7 @@
 
 .. _gallery:
 
+=======
 Gallery
 =======
 


### PR DESCRIPTION
## PR Summary

This re-roders the examples primarily to not have pyplot at the top, removes `../examples/API` from the list since its gone, and tries to fix the "Gallery" heading to have the correct heading level (higher than all the subsections)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
