### PR TITLE
Correct errors in documentation

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -61,7 +61,7 @@ rasterized figure) and then 'blit' one more artist on top.  Thus, by
 managing a saved 'clean' bitmap, we can only re-draw the few artists
 that are changing at each frame and possibly save significant amounts of
 time.  When using blitting (by passing ``blit=True``), the core loop of
-`FuncAnimation` gets a bit more complicated. ::
+`FuncAnimation` gets a bit more complicated::
 
    ax = fig.gca()
 

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -61,7 +61,7 @@ rasterized figure) and then 'blit' one more artist on top.  Thus, by
 managing a saved 'clean' bitmap, we can only re-draw the few artists
 that are changing at each frame and possibly save significant amounts of
 time.  When using blitting (by passing ``blit=True``) the core loop of
-`FuncAnimation` gets a bit more complicated ::
+`FuncAnimation` gets a bit more complicated. ::
 
    ax = fig.gca()
 

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -60,7 +60,7 @@ general gist is to take an existing bit map (in our case a mostly
 rasterized figure) and then 'blit' one more artist on top.  Thus, by
 managing a saved 'clean' bitmap, we can only re-draw the few artists
 that are changing at each frame and possibly save significant amounts of
-time.  When using blitting (by passing ``blit=True``) the core loop of
+time.  When using blitting (by passing ``blit=True``), the core loop of
 `FuncAnimation` gets a bit more complicated. ::
 
    ax = fig.gca()

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -60,7 +60,7 @@ general gist is to take an existing bit map (in our case a mostly
 rasterized figure) and then 'blit' one more artist on top.  Thus, by
 managing a saved 'clean' bitmap, we can only re-draw the few artists
 that are changing at each frame and possibly save significant amounts of
-time.  When using blitting (by passing ``blit=True``), the core loop of
+time.  When we use blitting (by passing ``blit=True``), the core loop of
 `FuncAnimation` gets a bit more complicated::
 
    ax = fig.gca()

--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -3,7 +3,7 @@
  API Changes
 =============
 
-A log of changes to the most recent version Matplotlib that affect the
+A log of changes to the most recent version of Matplotlib that affect the
 outward-facing API. If updating Matplotlib breaks your scripts, this list may
 help you figure out what caused the breakage and how to fix it by updating
 your code. For API changes in older versions see :doc:`api_changes_old`.

--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -4,7 +4,7 @@
 =============
 
 A log of changes to the most recent version Matplotlib that affect the
-utward-facing API. If updating Matplotlib breaks your scripts, this list may
+outward-facing API. If updating Matplotlib breaks your scripts, this list may
 help you figure out what caused the breakage and how to fix it by updating
 your code. For API changes in older versions see :doc:`api_changes_old`.
 
@@ -39,7 +39,7 @@ API Changes for 3.0.0
 Drop support for python 2
 -------------------------
 
-Matplotlib 3 only supports python 3.5 and higher
+Matplotlib 3 only supports python 3.5 and higher.
 
 
 Hold machinery removed


### PR DESCRIPTION
## PR Summary
I corrected three errors in documentation: two missing periods, and one misspelled word.