### PR TITLE
Avoid incorrect warning in savefig

### DIFF
--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -18,7 +18,10 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
 
     origBbox = fig.bbox
     origBboxInches = fig.bbox_inches
+    orig_tight_layout = fig.get_tight_layout()
     _boxout = fig.transFigure._boxout
+
+    fig.set_tight_layout(False)
 
     asp_list = []
     locator_list = []
@@ -33,13 +36,13 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
         ax.set_aspect("auto")
 
     def restore_bbox():
-
         for ax, asp, loc in zip(fig.axes, asp_list, locator_list):
             ax.set_aspect(asp)
             ax.set_axes_locator(loc)
 
         fig.bbox = origBbox
         fig.bbox_inches = origBboxInches
+        fig.set_tight_layout(orig_tight_layout)
         fig.transFigure._boxout = _boxout
         fig.transFigure.invalidate()
         fig.patch.set_bounds(0, 0, 1, 1)


### PR DESCRIPTION
 The following code 
```python
    import matplotlib.pyplot as plt
    import matplotlib.transforms as tf
    fig, ax=plt.subplots(1,1, num=1, clear=True)
    fig.set_tight_layout(True)
    fig.savefig('test1.jpg', bbox_inches='tight')
    #or 
    fig.savefig('test2.jpg', bbox_inches=tf.Bbox([[0,0],[3,3]]))
```
Throws the following "incorrect" or at least irrelevant warning to the user:
```
matplotlib\lib\matplotlib\figure.py:2352: UserWarning: This figure includes 
Axes that are not compatible with tight_layout, so results might be incorrect.
  warnings.warn("This figure includes Axes that are not compatible " 
```
The reason is that `tight_bbox.adjust_bbox` sets the `axes_locator` to a function that makes the subplot axes not behave as a subplot axes in the tight layout calculation. The axes is thus ignored in that calculation and the warning appears. I believe that this is the intended behavior, except for the warning.

This pr change the code such that tight_layout is not called after the call to `tight_bbox.adjust_bbox` to avoid the warning. The actual behavior should be the same and it is in my tests. 

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
