### PR TITLE
Fix collections import warnings for Python 3.7

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -115,7 +115,7 @@ See Matplotlib `INSTALL.rst` file for more information:
 """)
 
 import atexit
-from collections import MutableMapping
+from collections.abc import MutableMapping
 import contextlib
 import distutils.version
 import functools

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -44,7 +44,7 @@ Matplotlib recognizes the following formats to specify a color:
 All string specifications of color, other than "CN", are case-insensitive.
 """
 
-from collections import Sized
+from collections.abc import Sized
 import itertools
 import re
 

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -150,7 +150,7 @@ Examples showing the use of markers:
 .. |m37| image:: /_static/markers/m37.png
 """
 
-from collections import Sized
+from collections.abc import Sized
 from numbers import Number
 
 import numpy as np

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -13,7 +13,7 @@ that actually reflects the values given here. Any additions or deletions to the
 parameter set listed here should also be visited to the
 :file:`matplotlibrc.template` in matplotlib's root source directory.
 """
-from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from functools import reduce
 import operator
 import os


### PR DESCRIPTION
## PR Summary

This is in continuation of #11733.

As @amueller pointed out on gitter, there were still some abstract base classes imported via `collections` instead of `collections.abc`.