### PR TITLE
Fix DeprecationWarning on LocatableAxes

### DIFF
--- a/examples/axes_grid1/demo_axes_divider.py
+++ b/examples/axes_grid1/demo_axes_divider.py
@@ -28,16 +28,16 @@ def demo_simple_image(ax):
 
 def demo_locatable_axes_hard(fig1):
 
-    from mpl_toolkits.axes_grid1 \
-        import SubplotDivider, LocatableAxes, Size
+    from mpl_toolkits.axes_grid1 import SubplotDivider, Size
+    from mpl_toolkits.axes_grid1.mpl_axes import Axes
 
     divider = SubplotDivider(fig1, 2, 2, 2, aspect=True)
 
     # axes for image
-    ax = LocatableAxes(fig1, divider.get_position())
+    ax = Axes(fig1, divider.get_position())
 
     # axes for colorbar
-    ax_cb = LocatableAxes(fig1, divider.get_position())
+    ax_cb = Axes(fig1, divider.get_position())
 
     h = [Size.AxesX(ax),  # main axes
          Size.Fixed(0.05),  # padding, 0.1 inch

--- a/examples/axes_grid1/demo_fixed_size_axes.py
+++ b/examples/axes_grid1/demo_fixed_size_axes.py
@@ -6,7 +6,8 @@ Demo Fixed Size Axes
 """
 import matplotlib.pyplot as plt
 
-from mpl_toolkits.axes_grid1 import Divider, LocatableAxes, Size
+from mpl_toolkits.axes_grid1 import Divider, Size
+from mpl_toolkits.axes_grid1.mpl_axes import Axes
 
 
 def demo_fixed_size_axes():
@@ -20,7 +21,7 @@ def demo_fixed_size_axes():
     divider = Divider(fig1, (0.0, 0.0, 1., 1.), h, v, aspect=False)
     # the width and height of the rectangle is ignored.
 
-    ax = LocatableAxes(fig1, divider.get_position())
+    ax = Axes(fig1, divider.get_position())
     ax.set_axes_locator(divider.new_locator(nx=1, ny=1))
 
     fig1.add_axes(ax)
@@ -39,7 +40,7 @@ def demo_fixed_pad_axes():
     divider = Divider(fig, (0.0, 0.0, 1., 1.), h, v, aspect=False)
     # the width and height of the rectangle is ignored.
 
-    ax = LocatableAxes(fig, divider.get_position())
+    ax = Axes(fig, divider.get_position())
     ax.set_axes_locator(divider.new_locator(nx=1, ny=1))
 
     fig.add_axes(ax)


### PR DESCRIPTION
## PR Summary

Fixes the following warning when building the examples.

~~~
MatplotlibDeprecationWarning: The LocatableAxes class was deprecated in Matplotlib 3.0 and will be removed in 3.2. Use mpl_toolkits.axes_grid1.mpl_axes.Axes instead.
~~~
