### PR TITLE
endless looping GIFs with PillowWriter

### DIFF
--- a/doc/users/next_whats_new/endless_gif.rst
+++ b/doc/users/next_whats_new/endless_gif.rst
@@ -3,5 +3,5 @@
 Endless Looping GIFs with PillowWriter
 --------------------------------------
 
-We acknowledge that most people want to watch a gif more than once.  Saving an animatation
+We acknowledge that most people want to watch a gif more than once.  Saving an animation
 as a gif with PillowWriter now produces an endless looping gif.

--- a/doc/users/next_whats_new/endless_gif.rst
+++ b/doc/users/next_whats_new/endless_gif.rst
@@ -1,7 +1,7 @@
-Looping GIFs with PillowWriter
-------------------------------
+:orphan:
+
+Endless Looping GIFs with PillowWriter
+--------------------------------------
 
 We acknowledge that most people want to watch a gif more than once.  Saving an animatation
-as a gif with PillowWriter now defaults to producing an endless looping gif. Gifs can be set
-to loop a finite number of times by passing the ``loop`` keyword argument to PillowWriter. 
-To restore the old behaviour of not looping use ``PillowWriter(loop=1)``
+as a gif with PillowWriter now produces an endless looping gif.

--- a/doc/users/next_whats_new/endless_gif.rst
+++ b/doc/users/next_whats_new/endless_gif.rst
@@ -1,0 +1,7 @@
+Looping GIFs with PillowWriter
+------------------------------
+
+We acknowledge that most people want to watch a gif more than once.  Saving an animatation
+as a gif with PillowWriter now defaults to producing an endless looping gif. Gifs can be set
+to loop a finite number of times by passing the ``loop`` keyword argument to PillowWriter. 
+To restore the old behaviour of not looping use ``PillowWriter(loop=1)``

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -550,38 +550,14 @@ class PillowWriter(MovieWriter):
             return False
         return True
 
-    def __init__(self, *args, loop=0, **kwargs):
+    def __init__(self, *args, **kwargs):
         '''PillowWriter
 
         Parameters
         ----------
         fps: int
             Framerate for the gif.
-        loop: int
-            The number of times that the gif will loop.
-            A value of 0 is endless.
-        codec: string or None, optional
-            The codec to use. If ``None`` (the default) the ``animation.codec``
-            rcParam is used.
-        bitrate: int or None, optional
-            The bitrate for the saved movie file, which is one way to control
-            the output file size and quality. The default value is ``None``,
-            which uses the ``animation.bitrate`` rcParam.  A value of -1
-            implies that the bitrate should be determined automatically by the
-            underlying utility.
-        extra_args: list of strings or None, optional
-            A list of extra string arguments to be passed to the underlying
-            movie utility. The default is ``None``, which passes the additional
-            arguments in the ``animation.extra_args`` rcParam.
-        metadata: Dict[str, str] or None
-            A dictionary of keys and values for metadata to include in the
-            output file. Some keys that may be of use include:
-            title, artist, genre, subject, copyright, srcform, comment.
         '''
-        if type(loop) == int:
-            self.loop = loop
-        else:
-            raise ValueError("loop must be an int")
         if kwargs.get("extra_args") is None:
             kwargs["extra_args"] = ()
         super().__init__(*args, **kwargs)
@@ -607,7 +583,7 @@ class PillowWriter(MovieWriter):
     def finish(self):
         self._frames[0].save(
             self._outfile, save_all=True, append_images=self._frames[1:],
-            duration=int(1000 / self.fps), loop=self.loop)
+            duration=int(1000 / self.fps), loop=0)
 
 
 # Base class of ffmpeg information. Has the config keys and the common set

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -550,10 +550,10 @@ class PillowWriter(MovieWriter):
             return False
         return True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, loop=0, **kwargs):
+        self.loop = loop
         if kwargs.get("extra_args") is None:
             kwargs["extra_args"] = ()
-        self.loop = kwargs.pop("loop", 0)
         super().__init__(*args, **kwargs)
 
     def setup(self, fig, outfile, dpi=None):

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -551,6 +551,33 @@ class PillowWriter(MovieWriter):
         return True
 
     def __init__(self, *args, loop=0, **kwargs):
+        '''PillowWriter
+
+        Parameters
+        ----------
+        fps: int
+            Framerate for the gif.
+        loop: int
+            The number of times that the gif will loop.
+            A value of 0 is endless.
+        codec: string or None, optional
+            The codec to use. If ``None`` (the default) the ``animation.codec``
+            rcParam is used.
+        bitrate: int or None, optional
+            The bitrate for the saved movie file, which is one way to control
+            the output file size and quality. The default value is ``None``,
+            which uses the ``animation.bitrate`` rcParam.  A value of -1
+            implies that the bitrate should be determined automatically by the
+            underlying utility.
+        extra_args: list of strings or None, optional
+            A list of extra string arguments to be passed to the underlying
+            movie utility. The default is ``None``, which passes the additional
+            arguments in the ``animation.extra_args`` rcParam.
+        metadata: Dict[str, str] or None
+            A dictionary of keys and values for metadata to include in the
+            output file. Some keys that may be of use include:
+            title, artist, genre, subject, copyright, srcform, comment.
+        '''
         self.loop = loop
         if kwargs.get("extra_args") is None:
             kwargs["extra_args"] = ()

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -553,6 +553,7 @@ class PillowWriter(MovieWriter):
     def __init__(self, *args, **kwargs):
         if kwargs.get("extra_args") is None:
             kwargs["extra_args"] = ()
+        self.loop = kwargs.pop("loop", 0)
         super().__init__(*args, **kwargs)
 
     def setup(self, fig, outfile, dpi=None):
@@ -576,7 +577,7 @@ class PillowWriter(MovieWriter):
     def finish(self):
         self._frames[0].save(
             self._outfile, save_all=True, append_images=self._frames[1:],
-            duration=int(1000 / self.fps))
+            duration=int(1000 / self.fps), loop=self.loop)
 
 
 # Base class of ffmpeg information. Has the config keys and the common set

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -551,13 +551,6 @@ class PillowWriter(MovieWriter):
         return True
 
     def __init__(self, *args, **kwargs):
-        '''PillowWriter
-
-        Parameters
-        ----------
-        fps: int
-            Framerate for the gif.
-        '''
         if kwargs.get("extra_args") is None:
             kwargs["extra_args"] = ()
         super().__init__(*args, **kwargs)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -578,7 +578,10 @@ class PillowWriter(MovieWriter):
             output file. Some keys that may be of use include:
             title, artist, genre, subject, copyright, srcform, comment.
         '''
-        self.loop = loop
+        if type(loop) == int:
+            self.loop = loop
+        else:
+            raise ValueError("loop must be an int")
         if kwargs.get("extra_args") is None:
             kwargs["extra_args"] = ()
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## PR Summary

Closes #11787 . ~~Adds an optional parameter to PillowWriter that will set the number of times that a GIF will loop for. Defaults to 0 meaning endless looping. Previously defaulted to 1 (never looping) without a way to change it.~~ API change removed.

Makes PillowWriter produce endless looping gifs like ImageMagickWriter and ImageMagickFileWriter.

## PR Checklist

- ~~[ ] Has Pytest style unit tests~~
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- ~~[ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~
- [x] API consistency 

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
