### PR TITLE
Feature Add: re-factor BBox padding

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2055,7 +2055,10 @@ class FigureCanvasBase(object):
                     if pad is None:
                         pad = rcParams['savefig.pad_inches']
 
-                    bbox_inches = bbox_inches.padded(pad)
+                    if type(pad).__name__ == "tuple":
+                        bbox_inches = bbox_inches.padded_lrtb(pad)
+                    else:
+                        bbox_inches = bbox_inches.padded(pad)
 
                 restore_bbox = tight_bbox.adjust_bbox(self.figure, bbox_inches,
                                                       canvas.fixed_dpi)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -692,7 +692,15 @@ class BboxBase(TransformNode):
         the given value.
         """
         points = self.get_points()
-        return Bbox(points + [[-p, -p], [p, p]])
+        return self.padded_lrtb((p, p, p, p))
+
+    def padded_lrtb(self, lrtb):
+        """
+        Return a new :class:`Bbox` that is padded with specific length
+        on all sides given by lrtb (4-tuple)
+        """
+        points = self.get_points()
+        return Bbox(points + [[-lrtb[0], -lrtb[3]], [lrtb[1], lrtb[2]]])
 
     def translated(self, tx, ty):
         """


### PR DESCRIPTION
Feature Add: In response to Issue #11764, re-factor of how Bbox class assigns padding in order to extend to non-symmetric padding on all sides. If optional argument pad_inches is a 4-tuple, assign in the following orientation in inches (LEFT, RIGHT, TOP, BOTTOM), otherwise if single value P pad with (P, P, P, P).

Test code below:

```python
import numpy as np
import matplotlib.pyplot as plt

# evenly sampled time at 200ms intervals
t = np.arange(0., 5., 0.2)

# red dashes, blue squares and green triangles
plt.plot(t, t, 'r--', t, t**2, 'bs', t, t**3, 'g^')
plt.savefig("test.png", bbox_inches='tight', pad_inches=1)
plt.savefig("test2.png", bbox_inches='tight', pad_inches=(1,2,3,4))
```