### PR TITLE
update annotations

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -499,3 +499,15 @@ def test_text_repr():
     plt.plot(['A', 'B'], [1, 2])
     txt = plt.text(['A'], 0.5, 'Boo')
     print(txt)
+
+
+def test_annotation_update():
+    fig, ax = plt.subplots(1, 1)
+    an = ax.annotate('annotation', xy=(0.5, 0.5))
+    extent1 = an.get_window_extent(fig.canvas.get_renderer())
+    fig.tight_layout()
+    extent2 = an.get_window_extent(fig.canvas.get_renderer())
+
+    np.testing.assert_raises(AssertionError, np.testing.assert_allclose,
+                             extent1.get_points(), extent2.get_points(),
+                             rtol=1e-6)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -2354,6 +2354,7 @@ class Annotation(Text, _AnnotationBase):
         *dpi* used defaults to self.figure.dpi; the renderer dpi is
         irrelevant.
         '''
+        self.update_positions(renderer)
         if not self.get_visible():
             return Bbox.unit()
 


### PR DESCRIPTION
 I believe that it was the same problems with annotations as it was with spine. They are not updated before `get_windows_extent` where called and this make `tight_layout` and `constrained_layout` fail.

I hope this fix at least some of the issues in #11800.

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
