### PR TITLE
gridspec tutorial edits

### DIFF
--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -9,7 +9,7 @@ How to create grid-shaped combinations of axes.
         Perhaps the primary function used to create figures and axes.
         It's also similar to :func:`.matplotlib.pyplot.subplot`,
         but creates and places all axes on the figure at once.  See also
-        `.matplotlib.Figure.subplots`.
+        `matplotlib.Figure.subplots`.
 
     :class:`~matplotlib.gridspec.GridSpec`
         Specifies the geometry of the grid that a subplot will be
@@ -56,7 +56,7 @@ fig1, f1_axes = plt.subplots(ncols=2, nrows=2, constrained_layout=True)
 # numpy arrays.
 
 fig2 = plt.figure(constrained_layout=True)
-spec2 = gridspec.GridSpec(ncols=2, nrows=2)
+spec2 = gridspec.GridSpec(ncols=2, nrows=2, figure=fig2)
 f2_ax1 = fig2.add_subplot(spec2[0, 0])
 f2_ax2 = fig2.add_subplot(spec2[0, 1])
 f2_ax3 = fig2.add_subplot(spec2[1, 0])
@@ -68,22 +68,22 @@ f2_ax4 = fig2.add_subplot(spec2[1, 1])
 # `Numpy slice <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_
 # syntax for selecing the part of the gridspec each subplot will occupy.
 #
-# Note that we have also used the convenience method `.Figure.add_grisdpec`
+# Note that we have also used the convenience method `.Figure.add_gridspec`
 # instead of `.gridspec.GridSpec`, potentially saving the user an import,
 # and keeping the namespace cleaner.
 
-fig = plt.figure(constrained_layout=True)
-gs = fig.add_gridspec(3, 3)
-ax1 = fig.add_subplot(gs[0, :])
-ax1.set_title('gs[0, :]')
-ax2 = fig.add_subplot(gs[1, :-1])
-ax2.set_title('gs[1, :-1]')
-ax3 = fig.add_subplot(gs[1:, -1])
-ax3.set_title('gs[1:, -1]')
-ax4 = fig.add_subplot(gs[-1, 0])
-ax4.set_title('gs[-1, 0]')
-ax5 = fig.add_subplot(gs[-1, -2])
-ax5.set_title('gs[-1, -2]')
+fig3 = plt.figure(constrained_layout=True)
+gs = fig3.add_gridspec(3, 3)
+f3_ax1 = fig3.add_subplot(gs[0, :])
+f3_ax1.set_title('gs[0, :]')
+f3_ax2 = fig3.add_subplot(gs[1, :-1])
+f3_ax2.set_title('gs[1, :-1]')
+f3_ax3 = fig3.add_subplot(gs[1:, -1])
+f3_ax3.set_title('gs[1:, -1]')
+f3_ax4 = fig3.add_subplot(gs[-1, 0])
+f3_ax4.set_title('gs[-1, 0]')
+f3_ax5 = fig3.add_subplot(gs[-1, -2])
+f3_ax5.set_title('gs[-1, -2]')
 
 #############################################################################
 # :mod:`~matplotlib.gridspec` is also indispensable for creating subplots
@@ -94,16 +94,16 @@ ax5.set_title('gs[-1, -2]')
 # and then uses numpy indexing and slices to allocate multiple
 # "cells" for a given subplot.
 
-fig3 = plt.figure(constrained_layout=True)
-spec3 = fig3.add_gridspec(ncols=3, nrows=3)
+fig4 = plt.figure(constrained_layout=True)
+spec4 = fig4.add_gridspec(ncols=2, nrows=2)
 anno_opts = dict(xy=(0.5, 0.5), xycoords='axes fraction',
                  va='center', ha='center')
 
-ax1 = fig3.add_subplot(spec3[0, 0])
-ax1.annotate('GridSpec[0, 0]', **anno_opts)
-fig3.add_subplot(spec3[0, 1:]).annotate('GridSpec[0, 1:]', **anno_opts)
-fig3.add_subplot(spec3[1:, 0]).annotate('GridSpec[1:, 0]', **anno_opts)
-fig3.add_subplot(spec3[1:, 1:]).annotate('GridSpec[1:, 1:]', **anno_opts)
+f4_ax1 = fig4.add_subplot(spec4[0, 0])
+f4_ax1.annotate('GridSpec[0, 0]', **anno_opts)
+fig4.add_subplot(spec4[0, 1]).annotate('GridSpec[0, 1:]', **anno_opts)
+fig4.add_subplot(spec4[1, 0]).annotate('GridSpec[1:, 0]', **anno_opts)
+fig4.add_subplot(spec4[1, 1]).annotate('GridSpec[1:, 1:]', **anno_opts)
 
 ############################################################################
 # Another option is to use the ``width_ratios`` and ``height_ratios``
@@ -114,14 +114,14 @@ fig3.add_subplot(spec3[1:, 1:]).annotate('GridSpec[1:, 1:]', **anno_opts)
 # For the sake of demonstration, we'll blindly create the axes within
 # ``for`` loops since we won't need them later.
 
-fig4 = plt.figure(constrained_layout=True)
+fig5 = plt.figure(constrained_layout=True)
 widths = [2, 3, 1.5]
 heights = [1, 3, 2]
-spec4 = fig4.add_gridspec(ncols=3, nrows=3, width_ratios=widths,
+spec5 = fig5.add_gridspec(ncols=3, nrows=3, width_ratios=widths,
                           height_ratios=heights)
 for row in range(3):
     for col in range(3):
-        ax = fig4.add_subplot(spec4[row, col])
+        ax = fig5.add_subplot(spec5[row, col])
         label = 'Width: {}\nHeight: {}'.format(widths[col], heights[row])
         ax.annotate(label, (0.1, 0.5), xycoords='axes fraction', va='center')
 
@@ -136,14 +136,12 @@ for row in range(3):
 # gridspec instance.
 
 gs_kw = dict(width_ratios=widths, height_ratios=heights)
-fig5, f5_axes = plt.subplots(ncols=3, nrows=3, constrained_layout=True,
+fig6, f6_axes = plt.subplots(ncols=3, nrows=3, constrained_layout=True,
         gridspec_kw=gs_kw)
-for r, row in enumerate(f5_axes):
+for r, row in enumerate(f6_axes):
     for c, ax in enumerate(row):
         label = 'Width: {}\nHeight: {}'.format(widths[c], heights[r])
         ax.annotate(label, (0.1, 0.5), xycoords='axes fraction', va='center')
-
-fig5.tight_layout()
 
 ############################################################################
 # The ``subplots`` and ``gridspec`` methods can be combined since it is
@@ -151,16 +149,16 @@ fig5.tight_layout()
 # and then remove some and combine them.  Here we create a layout with
 # the bottom two axes in the last column combined.
 
-fig, axs = plt.subplots(ncols=3, nrows=3)
-gs = axs[1, 2].get_gridspec()
+fig7, f7_axs = plt.subplots(ncols=3, nrows=3)
+gs = f7_axs[1, 2].get_gridspec()
 # remove the underlying axes
-for ax in axs[1:, -1]:
+for ax in f7_axs[1:, -1]:
     ax.remove()
-axbig = fig.add_subplot(gs[1:, -1])
+axbig = fig7.add_subplot(gs[1:, -1])
 axbig.annotate('Big Axes \nGridSpec[1:, -1]', (0.1, 0.5),
                xycoords='axes fraction', va='center')
 
-fig.tight_layout()
+fig7.tight_layout()
 
 ###############################################################################
 # Fine Adjustments to a Gridspec Layout
@@ -172,11 +170,11 @@ fig.tight_layout()
 # `.Figure.tight_layout` which both adjust subplot sizes to fill the
 # figure.
 
-fig6 = plt.figure(constrained_layout=False)
-gs1 = fig6.add_gridspec(nrows=3, ncols=3, left=0.05, right=0.48, wspace=0.05)
-ax1 = fig6.add_subplot(gs1[:-1, :])
-ax2 = fig6.add_subplot(gs1[-1, :-1])
-ax3 = fig6.add_subplot(gs1[-1, -1])
+fig8 = plt.figure(constrained_layout=False)
+gs1 = fig8.add_gridspec(nrows=3, ncols=3, left=0.05, right=0.48, wspace=0.05)
+f8_ax1 = fig8.add_subplot(gs1[:-1, :])
+f8_ax2 = fig8.add_subplot(gs1[-1, :-1])
+f8_ax3 = fig8.add_subplot(gs1[-1, -1])
 
 ###############################################################################
 # This is similar to :func:`~matplotlib.pyplot.subplots_adjust`, but it only
@@ -184,19 +182,18 @@ ax3 = fig6.add_subplot(gs1[-1, -1])
 #
 # For example, compare the left and right sides of this figure:
 
-fig7 = plt.figure(constrained_layout=False)
-gs1 = fig7.add_gridspec(nrows=3, ncols=3, left=0.05, right=0.48,
+fig9 = plt.figure(constrained_layout=False)
+gs1 = fig9.add_gridspec(nrows=3, ncols=3, left=0.05, right=0.48,
                         wspace=0.05)
-ax1 = fig7.add_subplot(gs1[:-1, :])
-ax2 = fig7.add_subplot(gs1[-1, :-1])
-ax3 = fig7.add_subplot(gs1[-1, -1])
+f9_ax1 = fig9.add_subplot(gs1[:-1, :])
+f9_ax2 = fig9.add_subplot(gs1[-1, :-1])
+f9_ax3 = fig9.add_subplot(gs1[-1, -1])
 
-gs2 = fig7.add_gridspec(nrows=3, ncols=3, left=0.55, right=0.98,
+gs2 = fig9.add_gridspec(nrows=3, ncols=3, left=0.55, right=0.98,
                         hspace=0.05)
-ax4 = fig7.add_subplot(gs2[:, :-1])
-ax5 = fig7.add_subplot(gs2[:-1, -1])
-ax6 = fig7.add_subplot(gs2[-1, -1])
-
+f9_ax4 = fig9.add_subplot(gs2[:, :-1])
+f9_ax5 = fig9.add_subplot(gs2[:-1, -1])
+f9_ax6 = fig9.add_subplot(gs2[-1, -1])
 
 ###############################################################################
 # GridSpec using SubplotSpec
@@ -209,16 +206,16 @@ ax6 = fig7.add_subplot(gs2[-1, -1])
 # Note this is also available from the more verbose
 # `.gridspec.GridSpecFromSubplotSpec`.
 
-fig = plt.figure(constrained_layout=True)
-gs0 = fig.add_gridspec(1, 2)
+fig10 = plt.figure(constrained_layout=True)
+gs0 = fig10.add_gridspec(1, 2)
 
 gs00 = gs0[0].subgridspec(2, 3)
 gs01 = gs0[1].subgridspec(3, 2)
 
 for a in range(2):
     for b in range(3):
-        fig.add_subplot(gs00[a, b])
-        fig.add_subplot(gs01[b, a])
+        fig10.add_subplot(gs00[a, b])
+        fig10.add_subplot(gs01[b, a])
 
 ###############################################################################
 # A Complex Nested GridSpec using SubplotSpec
@@ -235,23 +232,23 @@ from itertools import product
 def squiggle_xy(a, b, c, d, i=np.arange(0.0, 2*np.pi, 0.05)):
     return np.sin(i*a)*np.cos(i*b), np.sin(i*c)*np.cos(i*d)
 
-
-fig = plt.figure(figsize=(8, 8), constrained_layout=False)
+10
+fig11 = plt.figure(figsize=(8, 8), constrained_layout=False)
 
 # gridspec inside gridspec
-outer_grid = fig.add_gridspec(4, 4, wspace=0.0, hspace=0.0)
+outer_grid = fig11.add_gridspec(4, 4, wspace=0.0, hspace=0.0)
 
 for i in range(16):
     inner_grid = outer_grid[i].subgridspec(3, 3, wspace=0.0, hspace=0.0)
     a, b = int(i/4)+1, i % 4+1
     for j, (c, d) in enumerate(product(range(1, 4), repeat=2)):
-        ax = plt.Subplot(fig, inner_grid[j])
+        ax = plt.Subplot(fig11, inner_grid[j])
         ax.plot(*squiggle_xy(a, b, c, d))
         ax.set_xticks([])
         ax.set_yticks([])
-        fig.add_subplot(ax)
+        fig11.add_subplot(ax)
 
-all_axes = fig.get_axes()
+all_axes = fig11.get_axes()
 
 # show only the outside spines
 for ax in all_axes:

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -232,7 +232,7 @@ from itertools import product
 def squiggle_xy(a, b, c, d, i=np.arange(0.0, 2*np.pi, 0.05)):
     return np.sin(i*a)*np.cos(i*b), np.sin(i*c)*np.cos(i*d)
 
-10
+
 fig11 = plt.figure(figsize=(8, 8), constrained_layout=False)
 
 # gridspec inside gridspec


### PR DESCRIPTION
Some small edit to the gridspec tutorial.

1. Fixed two links to the documentation (I hope).
2. Added `figure` kwarg to the `gridspec` in figure 2 so that it works with constrained_layout.
3. Deleted `tight_layout ` in figure 6.
4. Added and changed some figure and axes numbers to show the example numbers. This was used in same of the examples before but not in all.

edit: The plot rendering are fixed with #11801
