### PR TITLE
updates error message to run pytest instead of tests.py standalone

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -106,7 +106,7 @@ test_script:
   - python -c "import matplotlib as m; m.use('tkagg'); import matplotlib.pyplot as plt; print(plt.get_backend())"
   # tests
   - echo The following args are passed to pytest %PYTEST_ARGS%
-  - python tests.py %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
 
 after_test:
   # After the tests were a success, build wheels with the static libs

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -265,7 +265,7 @@ tools:
 * Code with a good unittest coverage (at least 70%, better 100%), check with::
 
    python -mpip install coverage
-   python tests.py --with-coverage
+   pytest --cov=matplotlib --showlocals -v
 
 * No pyflakes warnings, check with::
 

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -20,7 +20,8 @@ We use `travis-ci <https://travis-ci.org/matplotlib/matplotlib>`__ for
 continuous integration.  When preparing for a release, the final
 tagged commit should be tested locally before it is uploaded::
 
-   python tests.py --processes=8 --process-timeout=300
+   pytest -n 8 .
+
 
 In addition the following two tests should be run and manually inspected::
 

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -46,7 +46,8 @@ Running the tests is simple. Make sure you have pytest installed and run::
 
 or::
 
-   python tests.py
+   pytest .
+
 
 in the root directory of the distribution. The script takes a set of
 commands, such as:

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ classifiers = [
 class NoopTestCommand(TestCommand):
     def __init__(self, dist):
         print("Matplotlib does not support running tests with "
-              "'python setup.py test'. Please run 'python tests.py'.")
+              "'python setup.py test'. Please run 'pytest'.")
 
 
 class BuildExtraLibraries(BuildExtCommand):

--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -376,7 +376,7 @@ if __name__ == '__main__':
 Triage image comparison test failures.
 
 If no arguments are provided, it assumes you ran the tests at the
-top-level of a source checkout as `python tests.py`.
+top-level of a source checkout as `pytest .`.
 
 Keys:
     left/right: Move between test, expected and diff images


### PR DESCRIPTION
## PR Summary
updates the error message in `NoopTestCommand` to recommend using pytest instead of tests.py

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
