### PR TITLE
Backport: resolve conflict to get this into v2.2.3

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -272,7 +272,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
                 # This routine makes all the subplot spec containers
                 # have the correct arrangement.  It just stacks the
                 # subplot layoutboxes in the correct order...
-                arange_subplotspecs(child, hspace=hspace, wspace=wspace)
+                _arange_subplotspecs(child, hspace=hspace, wspace=wspace)
 
         # - Align right/left and bottom/top spines of appropriate subplots.
         # - Compare size of subplotspec including height and width ratios
@@ -443,7 +443,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
             ax._set_position(newpos, which='original')
 
 
-def arange_subplotspecs(gs, hspace=0, wspace=0):
+def _arange_subplotspecs(gs, hspace=0, wspace=0):
     """
     arange the subplotspec children of this gridspec, and then recursively
     do the same of any gridspec children of those gridspecs...
@@ -453,9 +453,8 @@ def arange_subplotspecs(gs, hspace=0, wspace=0):
         if child._is_subplotspec_layoutbox():
             for child2 in child.children:
                 # check for gridspec children...
-                name = (child2.name).split('.')[-1][:-3]
-                if name == 'gridspec':
-                    arange_subplotspecs(child2, hspace=hspace, wspace=wspace)
+                if child2._is_gridspec_layoutbox():
+                    _arange_subplotspecs(child2, hspace=hspace, wspace=wspace)
             sschildren += [child]
     # now arrange the subplots...
     for child0 in sschildren:

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -358,20 +358,16 @@ class LayoutBox(object):
         Helper to check if this layoutbox is the layoutbox of a
         subplotspec
         '''
-        name = (self.name).split('.')[-1][:-3]
-        if name == 'ss':
-            return True
-        return False
+        name = (self.name).split('.')[-1]
+        return name[:2] == 'ss'
 
     def _is_gridspec_layoutbox(self):
         '''
         Helper to check if this layoutbox is the layoutbox of a
         gridspec
         '''
-        name = (self.name).split('.')[-1][:-3]
-        if name == 'gridspec':
-            return True
-        return False
+        name = (self.name).split('.')[-1]
+        return name[:8] == 'gridspec'
 
     def find_child_subplots(self):
         '''
@@ -650,7 +646,7 @@ def seq_id():
 
     global _layoutboxobjnum
 
-    return ('%03d' % (next(_layoutboxobjnum)))
+    return ('%06d' % (next(_layoutboxobjnum)))
 
 
 def print_children(lb):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3996,7 +3996,7 @@ def test_psd_noise():
 
 
 @image_comparison(baseline_images=['csd_freqs'], remove_text=True,
-                  extensions=['png'])
+                  extensions=['png'], tol=0.002)
 def test_csd_freqs():
     '''test axes.csd with sinusoidal stimuli'''
     n = 10000


### PR DESCRIPTION
## PR Summary

Backport of #11330; conflict was minor....

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
