### PR TITLE
ENH: Don't center the HTML animation rendering (Fixes #11795)

### DIFF
--- a/lib/matplotlib/_animation_data.py
+++ b/lib/matplotlib/_animation_data.py
@@ -148,7 +148,8 @@ css/font-awesome.min.css">
 
 # HTML template for HTMLWriter
 DISPLAY_TEMPLATE = """
-<div class="animation" align="center">
+<div class="animation"
+     style="display:inline-block; margin: 0 auto; text-align: center">
     <img id="_anim_img{id}">
     <br>
     <input id="_anim_slider{id}" type="range" style="width:350px"


### PR DESCRIPTION
Centering the animations makes them align differently than the regular
images in the notebook. Also, align attribute is somewhat deprecated.

This adjusts some of the styling as well so that the controls are
somewhat aligned with themselves.

Closes #11795 .

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way