### PR TITLE
facecolor stale missing

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1121,6 +1121,7 @@ class _AxesBase(martist.Artist):
         color : color
         """
         self._facecolor = color
+        self.stale = True
         return self.patch.set_facecolor(color)
     set_fc = set_facecolor
 


### PR DESCRIPTION
 `axes.facecolor` doesn't update the figure in interactive mode. 

I added the line
`self.stale = True`
that fix that.