### PR TITLE
FIX: correct macro logic in file_compat.h

### DIFF
--- a/src/file_compat.h
+++ b/src/file_compat.h
@@ -48,7 +48,7 @@ extern "C" {
 /*
  * PyFile_* compatibility
  */
-#if defined(PY3K) | defined(PYPY_VERSION)
+#if PY3K | defined(PYPY_VERSION)
 
 /*
  * Get a FILE* handle to the file represented by the Python object


### PR DESCRIPTION
Following up on #11635 / #11636 another bug was found.

PY3K is always defined in mplutils.h so we were always going through
the nominally (py3 + pypy) only code path on all version of python
which exposes an issue with fflush (eventually called by py27
internals) on BSD systems.

attn @QuLogic @mattip 