### PR TITLE
changed warning in animation

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1124,7 +1124,8 @@ class Animation(object):
                                          extra_args=extra_args,
                                          metadata=metadata)
             else:
-                _log.warning("MovieWriter %s unavailable.", writer)
+                _log.warning("MovieWriter {} unavailable. Trying to use {} "
+                             "instead.".format(writer, writers.list()[0]))
 
                 try:
                     writer = writers[writers.list()[0]](fps, codec, bitrate,


### PR DESCRIPTION
 From #11792. 

The warning message when the writer chosen is not available didn't say that another writer is used instead. That can be confusing and it is changed in this pr.