### PR TITLE
func animation warning changes

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1725,11 +1725,13 @@ class FuncAnimation(TimedAnimation):
 
         # Call the func with framedata and args. If blitting is desired,
         # func needs to return a sequence of any artists that were modified.
-        self._drawn_artists = sorted(self._func(framedata, *self._args),
-                                     key=lambda x: x.get_zorder())
+        self._drawn_artists = self._func(framedata, *self._args)
         if self._blit:
             if self._drawn_artists is None:
                 raise RuntimeError('The animation function must return a '
                                    'sequence of Artist objects.')
+            self._drawn_artists = sorted(self._drawn_artists,
+                                         key=lambda x: x.get_zorder())
+
             for a in self._drawn_artists:
                 a.set_animated(self._blit)


### PR DESCRIPTION
 Another pr from #11792 

The example code on that issue raised on error on master but not on v2.2.2. The reason where that the animation function returned None. 

This pr change the order of some of the code to avoid the error and just test for the return value when it is needed when `blit` is True.

I am not sure if this is necessary or if the test is in the right place but the behavior is better now than before. 

The animation function should return an iterative according to the documentation but I think that it is unnecessary to test for it and raise on error or warning when it is not necessary for the code to work.
