### PR TITLE
animation api documentation changes

### DIFF
--- a/doc/_templates/autosummary_inher.rst
+++ b/doc/_templates/autosummary_inher.rst
@@ -1,0 +1,24 @@
+{{ fullname | escape | underline}}
+
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}
+    :inherited-members:
+    :show-inheritance:
+
+{% if objtype in ['class', 'method', 'function'] %}
+{% if objname in ['AxesGrid', 'Scalable', 'HostAxes', 'FloatingAxes',
+                      'ParasiteAxesAuxTrans', 'ParasiteAxes'] %}
+.. Filter out the above aliases to other classes, as sphinx gallery
+   creates no example file for those (sphinx-gallery/sphinx-gallery#365)
+
+{% else %}
+.. include:: {{module}}.{{objname}}.examples
+
+.. raw:: html
+
+    <div class="clearer"></div>
+
+{% endif %}
+{% endif %}

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -19,6 +19,7 @@ The easiest way to make a live animation in matplotlib is to use one of the
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    FuncAnimation
@@ -163,6 +164,7 @@ all data in memory.
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    PillowWriter
@@ -173,10 +175,11 @@ on all systems.
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    FFMpegWriter
-   ImageMagickFileWriter
+   ImageMagickWriter
    AVConvWriter
 
 The file-based writers save temporary files for each frame which are stitched
@@ -185,10 +188,11 @@ debug.
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    FFMpegFileWriter
-   ImageMagickWriter
+   ImageMagickFileWriter
    AVConvFileWriter
 
 Fundamentally, a `MovieWriter` provides a way to grab sequential frames
@@ -237,6 +241,7 @@ Animation Base Classes
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    Animation
@@ -251,6 +256,7 @@ writer and the class to allow a string to be passed to
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    MovieWriterRegistry
@@ -262,6 +268,7 @@ To reduce code duplication base classes
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    AbstractMovieWriter
@@ -272,6 +279,7 @@ and mixins
 
 .. autosummary::
    :toctree: _as_gen
+   :template: autosummary_inher.rst
    :nosignatures:
 
    AVConvBase
@@ -287,6 +295,8 @@ Inheritance Diagrams
 
 .. inheritance-diagram:: matplotlib.animation.FuncAnimation matplotlib.animation.ArtistAnimation
    :private-bases:
+   :parts: 1
 
 .. inheritance-diagram:: matplotlib.animation.AVConvFileWriter matplotlib.animation.AVConvWriter matplotlib.animation.FFMpegFileWriter matplotlib.animation.FFMpegWriter matplotlib.animation.ImageMagickFileWriter matplotlib.animation.ImageMagickWriter
    :private-bases:
+   :parts: 1


### PR DESCRIPTION
Some changes to the `animation_api.rst` file.

1. the imagemagic file and pip writers where interchanged in the summaries.

2. added a new autosummary_inher.rst templates to the autosummaries. There where a lot of missing links in the old rendered pages and the standard autosummary.rst didn't include any inherited members that made it difficult to understand the functionality on the classes.  

3. made the inheritance diagram readable. 

[FuncAnimation with this pr](https://12353-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/_as_gen/matplotlib.animation.FuncAnimation.html#matplotlib.animation.FuncAnimation)
[FuncAnimation in master](https://matplotlib.org/devdocs/api/_as_gen/matplotlib.animation.FuncAnimation.html#matplotlib.animation.FuncAnimation)