### PR TITLE
adding show inheritance to autosummary template

### DIFF
--- a/doc/_templates/autosummary.rst
+++ b/doc/_templates/autosummary.rst
@@ -3,14 +3,22 @@
 
 .. currentmodule:: {{ module }}
 
+
+{% if objtype in ['class'] %}
 .. auto{{ objtype }}:: {{ objname }}
+    :show-inheritance:
+
+{% else %}
+.. auto{{ objtype }}:: {{ objname }}
+
+{% endif %}
 
 {% if objtype in ['class', 'method', 'function'] %}
 {% if objname in ['AxesGrid', 'Scalable', 'HostAxes', 'FloatingAxes',
                       'ParasiteAxesAuxTrans', 'ParasiteAxes'] %}
 .. Filter out the above aliases to other classes, as sphinx gallery
    creates no example file for those (sphinx-gallery/sphinx-gallery#365)
-   
+
 {% else %}
 .. include:: {{module}}.{{objname}}.examples
 


### PR DESCRIPTION
 This small edit make the inheritance show up in the docstring for classes when the default template `autosummary.rst` is used.  I think that it should be included.