### PR TITLE
Use Format_ARGB32_Premultiplied instead of RGBA8888 for Qt backends.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -6,6 +6,7 @@ import ctypes
 
 from matplotlib.transforms import Bbox
 
+from .. import cbook
 from .backend_agg import FigureCanvasAgg
 from .backend_qt5 import (
     QtCore, QtGui, QtWidgets, _BackendQT5, FigureCanvasQT, FigureManagerQT,
@@ -52,9 +53,10 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
             [[left, self.renderer.height - (top + height * self._dpi_ratio)],
              [left + width * self._dpi_ratio, self.renderer.height - top]])
         reg = self.copy_from_bbox(bbox)
-        buf = memoryview(reg)
-        qimage = QtGui.QImage(
-            buf, buf.shape[1], buf.shape[0], QtGui.QImage.Format_RGBA8888)
+        buf = cbook._unmultipled_rgba8888_to_premultiplied_argb32(
+            memoryview(reg))
+        qimage = QtGui.QImage(buf, buf.shape[1], buf.shape[0],
+                              QtGui.QImage.Format_ARGB32_Premultiplied)
         if hasattr(qimage, 'setDevicePixelRatio'):
             # Not available on Qt4 or some older Qt5.
             qimage.setDevicePixelRatio(self._dpi_ratio)


### PR DESCRIPTION
I missed the fact that support for the latter was only added in Qt5.2
and is thus unavailable in Qt4.

Move the supporting helper functions from backend_cairo to cbook.

Fixes part (2) of #11844.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
