### PR TITLE
Country specific characters in Windows user folder name when locating .tfm-file

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1021,7 +1021,7 @@ def find_tex_file(filename, format=None):
     pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     result = pipe.communicate()[0].rstrip()
     _log.debug('find_tex_file result: %s', result)
-    return result.decode('ascii')
+    return result.decode('utf-8')
 
 
 @lru_cache()

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1021,7 +1021,14 @@ def find_tex_file(filename, format=None):
     pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     result = pipe.communicate()[0].rstrip()
     _log.debug('find_tex_file result: %s', result)
-    return result.decode('utf-8')
+    
+    # workaround for when a tex file has a country
+    # specfic character in its path name
+    try:
+        res = result.decode('ascii')
+    except UnicodeDecodeError:
+        res = result.decode('utf-8')
+    return res
 
 
 @lru_cache()

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1021,7 +1021,7 @@ def find_tex_file(filename, format=None):
     pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     result = pipe.communicate()[0].rstrip()
     _log.debug('find_tex_file result: %s', result)
-    
+
     # workaround for when a tex file has a country
     # specfic character in its path name
     try:


### PR DESCRIPTION
Change to utf-8 format, due to return result.decode('ascii') returning an UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 17: ordinal not in range(128), when æ,ø or å appears in the path to the .tfm-file.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
