### PR TITLE
FIX: macosx framework check

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2566,6 +2566,8 @@ static PyTypeObject TimerType = {
 static bool verify_framework(void)
 {
     ProcessSerialNumber psn;
+    /* These methods are deprecated, but they don't require the app to
+       have started  */
     if (CGMainDisplayID()!=0
      && GetCurrentProcess(&psn)==noErr
      && SetFrontProcess(&psn)==noErr) return true;

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2565,24 +2565,10 @@ static PyTypeObject TimerType = {
 
 static bool verify_framework(void)
 {
-#ifdef COMPILING_FOR_10_6
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-    NSRunningApplication* app = [NSRunningApplication currentApplication];
-    NSApplicationActivationPolicy activationPolicy = [app activationPolicy];
-    [pool release];
-    switch (activationPolicy) {
-        case NSApplicationActivationPolicyRegular:
-        case NSApplicationActivationPolicyAccessory:
-            return true;
-        case NSApplicationActivationPolicyProhibited:
-            break;
-    }
-#else
     ProcessSerialNumber psn;
     if (CGMainDisplayID()!=0
      && GetCurrentProcess(&psn)==noErr
      && SetFrontProcess(&psn)==noErr) return true;
-#endif
     PyErr_SetString(PyExc_ImportError,
         "Python is not installed as a framework. The Mac OS X backend will "
         "not be able to function correctly if Python is not installed as a "


### PR DESCRIPTION
## PR Summary

Closes #11846

In the macosx backend, `verify_framework` now (post #11600) gets called before the app gets started, so the checks for the framework always fail.  This PR, ~at the suggestion of @anntzer simply uses the old pre 10.6 checks.  Not sure this is the correct solution versus moving `verify_framework` to a point after the app has started, but it does work on my machine (10.13.6); using framework python (`pythonw`) works, using non-framework python (`python`) gives the appropriate error.~

This PR moves the `verify_framework` check into `lazy_init`, where the app is started, and passes success or failure up a level.  



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->