### PR TITLE
Simpler check for whether a Framework Python build is being used.

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -1,4 +1,17 @@
 import os
+import sysconfig
+
+# PYTHONFRAMEWORK defined in CPython's configure.ac.
+if not sysconfig.get_config_var("PYTHONFRAMEWORK"):
+    raise ImportError(
+        "Python is not installed as a framework. The MacOSX backend will not "
+        "be able to function correctly if Python is not installed as a "
+        "framework. See the Python documentation for more information on "
+        "installing Python as a framework on MacOSX. Please either reinstall "
+        "Python as a framework, or try one of the other backends. If you are "
+        "using (Ana)Conda please install python.app and replace the use of "
+        "'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the "
+        "Matplotlib FAQ for more information.")
 
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2563,38 +2563,6 @@ static PyTypeObject TimerType = {
     Timer_new,                 /* tp_new */
 };
 
-static bool verify_framework(void)
-{
-#ifdef COMPILING_FOR_10_6
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-    NSRunningApplication* app = [NSRunningApplication currentApplication];
-    NSApplicationActivationPolicy activationPolicy = [app activationPolicy];
-    [pool release];
-    switch (activationPolicy) {
-        case NSApplicationActivationPolicyRegular:
-        case NSApplicationActivationPolicyAccessory:
-            return true;
-        case NSApplicationActivationPolicyProhibited:
-            break;
-    }
-#else
-    ProcessSerialNumber psn;
-    if (CGMainDisplayID()!=0
-     && GetCurrentProcess(&psn)==noErr
-     && SetFrontProcess(&psn)==noErr) return true;
-#endif
-    PyErr_SetString(PyExc_ImportError,
-        "Python is not installed as a framework. The Mac OS X backend will "
-        "not be able to function correctly if Python is not installed as a "
-        "framework. See the Python documentation for more information on "
-        "installing Python as a framework on Mac OS X. Please either reinstall "
-        "Python as a framework, or try one of the other backends. If you are "
-        "using (Ana)Conda please install python.app and replace the use of "
-        "'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the "
-        "Matplotlib FAQ for more information.");
-    return false;
-}
-
 static struct PyMethodDef methods[] = {
    {"event_loop_is_running",
     (PyCFunction)event_loop_is_running,
@@ -2642,9 +2610,6 @@ PyObject* PyInit__macosx(void)
      || PyType_Ready(&FigureManagerType) < 0
      || PyType_Ready(&NavigationToolbar2Type) < 0
      || PyType_Ready(&TimerType) < 0)
-        return NULL;
-
-    if (!verify_framework())
         return NULL;
 
     module = PyModule_Create(&moduledef);


### PR DESCRIPTION
This check works even before an NSApp is started.

Simpler alternative to #11850.  Basically the first stackoverflow answer for the question (https://stackoverflow.com/questions/15752390/how-to-tell-if-python-instance-was-compiled-as-framework), from a CPython core dev.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
