### PR TITLE
Adding the possible to add full command line in animation

### DIFF
--- a/examples/animation/full_command_line_sgskip.py
+++ b/examples/animation/full_command_line_sgskip.py
@@ -1,0 +1,103 @@
+"""
+==================================
+Using the full command line option
+==================================
+
+This example show:
+- how to get a slow animation work in for example the VLC player
+- how to use the full command line option when the default command line is not
+  general enough
+- one way to animate an axes title with `.ArtistAnimation`
+- several ways of saving the animation
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+
+plt.close('animation')
+fig, ax = plt.subplots(num='animation')
+
+# There is a problem with animation of the axis title with artist animation.
+# The problem is because the title is one object in the axes object that just
+# get updated and not changed. This solution use a an ordinary text object with
+# some of the title properties so that it behaves like the axes title.
+transform = ax.title.get_transform()
+title_kwargs = dict(transform=transform, horizontalalignment='center')
+
+def f(x, y, i):
+    return np.sin(x+i*np.pi/15) + np.cos(y+i*np.pi/20)
+
+x = np.linspace(0, 2*np.pi, 120)
+y = np.linspace(0, 2*np.pi, 100).reshape(-1, 1)
+
+ims = []
+for i in range(10):
+    im = ax.imshow(f(x, y, i))
+    number = ax.text(60, 50, str(i), fontsize=50, ha='center',
+                     transform=ax.transData)
+    title = ax.text(0.5, 1, 'Frame number: {}'.format(i), **title_kwargs)
+    ims.append([im, number, title])
+
+anim = animation.ArtistAnimation(fig, ims, interval=2000, repeat_delay=1000)
+
+# The animation can be saved to an animated gif with the ImageMagick or Pillow
+# writers with for example.
+anim.save('anim.gif', writer='imagemagick')
+
+# or to a html file with for example.
+writer_html = animation.HTMLWriter(fps=0.5, embed_frames=True)
+anim.save('anim.html', writer=writer_html)
+
+# It can also be saved to an .mp4 file with the ffmpeg or avconv writers with
+# for example.
+
+writer1 = animation.FFMpegFileWriter(fps=0.5)
+anim.save('anim1.mp4', writer=writer1)
+
+##########################
+# ``anim1.mp4`` might not work well in all movie players though. The proplems is
+# that the frame rate of the movie is 0.5 frames per second and all players cant
+# handle such a low frame rate. This can be solved by having different input
+# and output frame rates. You can read more here_.
+
+# This can be done in matplotlib using the full command line option.
+
+# .. _here: rac.ffmpeg.org/wiki/Slideshow
+
+# See how the command used before looks like.
+command1 = writer1.get_command()
+print(command1)
+# ffmpeg -r 0.5 -i _tmp%07d.png -vframes 11 -vcodec h264 -pix_fmt
+# yuv420p -y anim1.mp4
+#
+# We can change that command line to a formated one to be able to save the
+# movie with an output framerate of 25 fps.
+full_command = ['{path} -framerate {fps} -i _tmp%07d.png  -vf fps=25 -vcodec '
+                'h264 -pix_fmt yuv420p -y {outfile}'][0]
+
+writer2 = animation.FFMpegFileWriter(fps=0.5, extra_args=full_command)
+anim.save('anim2.mp4', writer=writer2)
+
+# Another way to achieve a workable movie is the use the extra_args option
+# in the FFMpegWriter (the same method doesn't work in the FFMpegFileWriter
+# due to the -vframes argument).
+writer3 = animation.FFMpegWriter(fps=0.5, extra_args=['-vf', 'fps=25'])
+anim.save('anim3.mp4', writer=writer3)
+
+plt.show()
+
+##############################
+# References
+# ----------
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.animation.ArtistAnimation
+matplotlib.animation.ArtistAnimation.save
+matplotlib.animation.ImageMagickWriter
+matplotlib.animation.HTMLWriter
+matplotlib.animation.FFMpegFileWriter
+matplotlib.animation.FFMpegFileWriter.get_command


### PR DESCRIPTION
I added the possibility to add a full command line in the animation writers that call an outside executive. 

The reason for this is that that there are a lot of different possibilities to call `ffmpeg` and that the default command line with options is not always general enough. This happened to me when I tried to make slowly updated mp4 animations with ffmpeg. 

So I added the possibility to use a command string like for example:
```
'{path} -framerate {fps} -i _tmp%07d.png  -vf fps=25 -vcodec 'h264 -pix_fmt yuv420p -y {outfile}'
```
A general string where is it possible to use keywords to put in parameters from the code in the command. 

I also added a method `get_command` that returns the command line that have been used with a writer, some tests and an example that show this functionality and how to use some other writers.

I believe that these changes would have made it much easier for me to get working movies when I worked with that. It also makes the writers much more general when you can use any commands to write movies from the pics or streams that the writers create for you.

I added the full command line option to the `extra_args` parameter. 

Docstrings and the example definitively needs some editing but I want to see if things seems to work or if someone has any comments. 
 
- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
