### PR TITLE
Fix NumPy FutureWarning for non-tuple indexing.

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -382,17 +382,7 @@ def detrend_mean(x, axis=None):
     if axis is not None and axis+1 > x.ndim:
         raise ValueError('axis(=%s) out of bounds' % axis)
 
-    # short-circuit 0-D array.
-    if not x.ndim:
-        return np.array(0., dtype=x.dtype)
-
-    # short-circuit simple operations
-    if axis == 0 or axis is None or x.ndim <= 1:
-        return x - x.mean(axis)
-
-    ind = [slice(None)] * x.ndim
-    ind[axis] = np.newaxis
-    return x - x.mean(axis)[ind]
+    return x - x.mean(axis, keepdims=True)
 
 
 def detrend_none(x, axis=None):


### PR DESCRIPTION
## PR Summary

This fixes the warning:
```
.../matplotlib/mlab.py:395: FutureWarning: Using a non-tuple sequence
for multidimensional indexing is deprecated; use `arr[tuple(seq)]`
instead of `arr[seq]`. In the future this will be interpreted as an
array index, `arr[np.array(seq)]`, which will result either in an error
or a different result.
```
## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way