### PR TITLE
mathtext.py style fixes.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -45,7 +45,7 @@ per-file-ignores =
     matplotlib/font_manager.py: E203, E221, E251, E261, E262, E302, E501
     matplotlib/fontconfig_pattern.py: E201, E203, E221, E222, E225, E302
     matplotlib/legend_handler.py: E201, E501
-    matplotlib/mathtext.py: E201, E202, E203, E211, E221, E222, E225, E231, E251, E261, E301, E302, E303, E402, E501
+    matplotlib/mathtext.py: E201, E202, E203, E211, E221, E222, E225, E251, E301, E402
     matplotlib/patheffects.py: E231
     matplotlib/projections/geo.py: E203, E221, E231, E261, E502
     matplotlib/pylab.py: E501

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -40,9 +40,6 @@ from matplotlib._mathtext_data import (latex_to_bakoma, latex_to_standard,
                                        tex2uni, latex_to_cmex,
                                        stix_virtual_fonts)
 
-####################
-
-
 
 ##############################################################################
 # FONTS
@@ -134,6 +131,7 @@ class MathtextBackend(object):
         """
         return LOAD_NO_HINTING
 
+
 class MathtextBackendAgg(MathtextBackend):
     """
     Render glyphs and rectangles to an FTImage buffer, which is later
@@ -208,11 +206,13 @@ class MathtextBackendAgg(MathtextBackend):
         from matplotlib.backends import backend_agg
         return backend_agg.get_hinting_flag()
 
+
 class MathtextBackendBitmap(MathtextBackendAgg):
     def get_results(self, box, used_characters):
         ox, oy, width, height, depth, image, characters = \
             MathtextBackendAgg.get_results(self, box, used_characters)
         return image, depth
+
 
 class MathtextBackendPs(MathtextBackend):
     """
@@ -243,7 +243,8 @@ setfont
         self.pswriter.write(ps)
 
     def render_rect_filled(self, x1, y1, x2, y2):
-        ps = "%f %f %f %f rectfill\n" % (x1, self.height - y2, x2 - x1, y2 - y1)
+        ps = "%f %f %f %f rectfill\n" % (
+            x1, self.height - y2, x2 - x1, y2 - y1)
         self.pswriter.write(ps)
 
     def get_results(self, box, used_characters):
@@ -253,6 +254,7 @@ setfont
                 self.depth,
                 self.pswriter,
                 used_characters)
+
 
 class MathtextBackendPdf(MathtextBackend):
     """
@@ -281,6 +283,7 @@ class MathtextBackendPdf(MathtextBackend):
                 self.glyphs,
                 self.rects,
                 used_characters)
+
 
 class MathtextBackendSvg(MathtextBackend):
     """
@@ -311,6 +314,7 @@ class MathtextBackendSvg(MathtextBackend):
                 svg_elements,
                 used_characters)
 
+
 class MathtextBackendPath(MathtextBackend):
     """
     Store information to write a mathtext rendering to the text path
@@ -328,8 +332,7 @@ class MathtextBackendPath(MathtextBackend):
             (info.font, info.fontsize, thetext, ox, oy))
 
     def render_rect_filled(self, x1, y1, x2, y2):
-        self.rects.append(
-            (x1, self.height-y2 , x2 - x1, y2 - y1))
+        self.rects.append((x1, self.height - y2, x2 - x1, y2 - y1))
 
     def get_results(self, box, used_characters):
         ship(0, 0, box)
@@ -338,6 +341,7 @@ class MathtextBackendPath(MathtextBackend):
                 self.depth,
                 self.glyphs,
                 self.rects)
+
 
 class MathtextBackendCairo(MathtextBackend):
     """
@@ -366,6 +370,7 @@ class MathtextBackendCairo(MathtextBackend):
                 self.depth,
                 self.glyphs,
                 self.rects)
+
 
 class Fonts(object):
     """
@@ -513,7 +518,8 @@ class Fonts(object):
         Get the data needed by the backend to render the math
         expression.  The return value is backend-specific.
         """
-        result = self.mathtext_backend.get_results(box, self.get_used_characters())
+        result = self.mathtext_backend.get_results(
+            box, self.get_used_characters())
         self.destroy()
         return result
 
@@ -525,6 +531,7 @@ class Fonts(object):
         appropriate size for a given situation from this list.
         """
         return [(fontname, sym)]
+
 
 class TruetypeFonts(Fonts):
     """
@@ -610,7 +617,8 @@ class TruetypeFonts(Fonts):
         pclt = font.get_sfnt_table('pclt')
         if pclt is None:
             # Some fonts don't store the xHeight, so we do a poor man's xHeight
-            metrics = self.get_metrics(fontname, rcParams['mathtext.default'], 'x', fontsize, dpi)
+            metrics = self.get_metrics(
+                fontname, rcParams['mathtext.default'], 'x', fontsize, dpi)
             return metrics.iceberg
         xHeight = (pclt['xHeight'] / 64.0) * (fontsize / 12.0) * (dpi / 100.0)
         return xHeight
@@ -627,9 +635,10 @@ class TruetypeFonts(Fonts):
             info1 = self._get_info(font1, fontclass1, sym1, fontsize1, dpi)
             info2 = self._get_info(font2, fontclass2, sym2, fontsize2, dpi)
             font = info1.font
-            return font.get_kerning(info1.num, info2.num, KERNING_DEFAULT) / 64.0
+            return font.get_kerning(info1.num, info2.num, KERNING_DEFAULT) / 64
         return Fonts.get_kern(self, font1, fontclass1, sym1, fontsize1,
                               font2, fontclass2, sym2, fontsize2, dpi)
+
 
 class BakomaFonts(TruetypeFonts):
     """
@@ -656,7 +665,6 @@ class BakomaFonts(TruetypeFonts):
             fullpath = findfont(val)
             self.fontmap[key] = fullpath
             self.fontmap[val] = fullpath
-
 
     _slanted_symbols = set(r"\int \oint".split())
 
@@ -743,6 +751,7 @@ class BakomaFonts(TruetypeFonts):
     def get_sized_alternatives_for_symbol(self, fontname, sym):
         return self._size_alternatives.get(sym, [(fontname, sym)])
 
+
 class UnicodeFonts(TruetypeFonts):
     """
     An abstract base class for handling Unicode fonts.
@@ -804,12 +813,11 @@ class UnicodeFonts(TruetypeFonts):
         # Only characters in the "Letter" class should be italicized in 'it'
         # mode.  Greek capital letters should be Roman.
         if found_symbol:
-            if fontname == 'it':
-                if uniindex < 0x10000:
-                    unistring = chr(uniindex)
-                    if (not unicodedata.category(unistring)[0] == "L"
-                        or unicodedata.name(unistring).startswith("GREEK CAPITAL")):
-                        new_fontname = 'rm'
+            if fontname == 'it' and uniindex < 0x10000:
+                char = chr(uniindex)
+                if (not unicodedata.category(char)[0] == "L"
+                        or unicodedata.name(char).startswith("GREEK CAPITAL")):
+                    new_fontname = 'rm'
 
             slanted = (new_fontname == 'it') or sym in self._slanted_symbols
             found_symbol = False
@@ -844,7 +852,7 @@ class UnicodeFonts(TruetypeFonts):
                 fontname = 'rm'
                 new_fontname = fontname
                 font = self._get_font(fontname)
-                uniindex = 0xA4 # currency character, for lack of anything better
+                uniindex = 0xA4  # currency char, for lack of anything better
                 glyphindex = font.get_char_index(uniindex)
                 slanted = False
 
@@ -916,6 +924,7 @@ class DejaVuSerifFonts(DejaVuFonts):
                  0     : 'DejaVu Serif',
                  }
 
+
 class DejaVuSansFonts(DejaVuFonts):
     """
     A font handling class for the DejaVu Sans fonts
@@ -930,6 +939,7 @@ class DejaVuSansFonts(DejaVuFonts):
                  'ex'  : 'DejaVu Sans Display',
                  0     : 'DejaVu Sans',
                  }
+
 
 class StixFonts(UnicodeFonts):
     """
@@ -973,8 +983,8 @@ class StixFonts(UnicodeFonts):
         # Handle these "fonts" that are actually embedded in
         # other fonts.
         mapping = stix_virtual_fonts.get(fontname)
-        if (self._sans and mapping is None and
-            fontname not in ('regular', 'default')):
+        if (self._sans and mapping is None
+                and fontname not in ('regular', 'default')):
             mapping = stix_virtual_fonts['sf']
             doing_sans_conversion = True
         else:
@@ -1009,8 +1019,7 @@ class StixFonts(UnicodeFonts):
                 fontname = rcParams['mathtext.default']
 
         # Handle private use area glyphs
-        if (fontname in ('it', 'rm', 'bf') and
-            uniindex >= 0xe000 and uniindex <= 0xf8ff):
+        if fontname in ('it', 'rm', 'bf') and 0xe000 <= uniindex <= 0xf8ff:
             fontname = 'nonuni' + fontname
 
         return fontname, uniindex
@@ -1050,12 +1059,14 @@ class StixFonts(UnicodeFonts):
         self._size_alternatives[sym] = alternatives
         return alternatives
 
+
 class StixSansFonts(StixFonts):
     """
     A font handling class for the STIX fonts (that uses sans-serif
     characters by default).
     """
     _sans = True
+
 
 class StandardPsFonts(Fonts):
     """
@@ -1064,7 +1075,7 @@ class StandardPsFonts(Fonts):
     Unlike the other font classes, BakomaFont and UnicodeFont, this
     one requires the Ps backend.
     """
-    basepath = os.path.join( get_data_path(), 'fonts', 'afm' )
+    basepath = os.path.join(get_data_path(), 'fonts', 'afm')
 
     fontmap = { 'cal' : 'pzcmi8a',  # Zapf Chancery
                 'rm'  : 'pncr8a',   # New Century Schoolbook
@@ -1120,7 +1131,8 @@ class StandardPsFonts(Fonts):
         # Only characters in the "Letter" class should really be italicized.
         # This class includes greek letters, so we're ok
         if (fontname == 'it' and
-            (len(sym) > 1 or not unicodedata.category(sym).startswith("L"))):
+                (len(sym) > 1
+                 or not unicodedata.category(sym).startswith("L"))):
             fontname = 'rm'
 
         found_symbol = False
@@ -1352,6 +1364,7 @@ def _get_font_constant_set(state):
 class MathTextWarning(Warning):
     pass
 
+
 class Node(object):
     """
     A node in the TeX box model
@@ -1382,6 +1395,7 @@ class Node(object):
     def render(self, x, y):
         pass
 
+
 class Box(Node):
     """
     Represents any node with a physical location.
@@ -1408,6 +1422,7 @@ class Box(Node):
     def render(self, x1, y1, x2, y2):
         pass
 
+
 class Vbox(Box):
     """
     A box with only height (zero width).
@@ -1415,12 +1430,14 @@ class Vbox(Box):
     def __init__(self, height, depth):
         Box.__init__(self, 0., height, depth)
 
+
 class Hbox(Box):
     """
     A box with only width (zero height and depth).
     """
     def __init__(self, width):
         Box.__init__(self, width, 0., 0.)
+
 
 class Char(Node):
     """
@@ -1451,7 +1468,8 @@ class Char(Node):
 
     def _update_metrics(self):
         metrics = self._metrics = self.font_output.get_metrics(
-            self.font, self.font_class, self.c, self.fontsize, self.dpi, self.math)
+            self.font, self.font_class, self.c, self.fontsize, self.dpi,
+            self.math)
         if self.c == ' ':
             self.width = metrics.advance
         else:
@@ -1500,6 +1518,7 @@ class Char(Node):
         self.height   *= GROW_FACTOR
         self.depth    *= GROW_FACTOR
 
+
 class Accent(Char):
     """
     The font metrics need to be dealt with differently for accents,
@@ -1529,6 +1548,7 @@ class Accent(Char):
             x - self._metrics.xmin, y + self._metrics.ymin,
             self.font, self.font_class, self.c, self.fontsize, self.dpi)
 
+
 class List(Box):
     """
     A list of nodes (either horizontal or vertical).
@@ -1536,7 +1556,7 @@ class List(Box):
     def __init__(self, elements):
         Box.__init__(self, 0., 0., 0.)
         self.shift_amount = 0.   # An arbitrary offset
-        self.children     = elements # The child nodes of this list
+        self.children     = elements  # The child nodes of this list
         # The following parameters are set in the vpack and hpack functions
         self.glue_set     = 0.   # The glue setting of this list
         self.glue_sign    = 0    # 0: normal, -1: shrinking, 1: stretching
@@ -1591,6 +1611,7 @@ class List(Box):
         self.shift_amount *= GROW_FACTOR
         self.glue_set     *= GROW_FACTOR
 
+
 class Hlist(List):
     """
     A horizontal list of boxes.
@@ -1632,7 +1653,8 @@ class Hlist(List):
 #             if isinstance(next, Char):
 #                 print "CASE A"
 #                 return self.children[-2].get_kerning(next)
-#             elif isinstance(next, Hlist) and len(next.children) and isinstance(next.children[0], Char):
+#             elif (isinstance(next, Hlist) and len(next.children)
+#                   and isinstance(next.children[0], Char)):
 #                 print "CASE B"
 #                 result = self.children[-2].get_kerning(next.children[0])
 #                 print result
@@ -1660,7 +1682,7 @@ class Hlist(List):
         """
         # I don't know why these get reset in TeX.  Shift_amount is pretty
         # much useless if we do.
-        #self.shift_amount = 0.
+        # self.shift_amount = 0.
         h = 0.
         d = 0.
         x = 0.
@@ -1701,6 +1723,7 @@ class Hlist(List):
             self._set_glue(x, 1, total_stretch, "Overfull")
         else:
             self._set_glue(x, -1, total_shrink, "Underfull")
+
 
 class Vlist(List):
     """
@@ -1751,7 +1774,8 @@ class Vlist(List):
                 x += d + p.width
                 d = 0.
             elif isinstance(p, Char):
-                raise RuntimeError("Internal mathtext error: Char node found in Vlist.")
+                raise RuntimeError(
+                    "Internal mathtext error: Char node found in Vlist")
 
         self.width = w
         if d > l:
@@ -1776,6 +1800,7 @@ class Vlist(List):
         else:
             self._set_glue(x, -1, total_shrink, "Underfull")
 
+
 class Rule(Box):
     """
     A :class:`Rule` node stands for a solid black rectangle; it has
@@ -1793,6 +1818,7 @@ class Rule(Box):
     def render(self, x, y, w, h):
         self.font_output.render_rect_filled(x, y, x + w, y + h)
 
+
 class Hrule(Rule):
     """
     Convenience class to create a horizontal rule.
@@ -1804,6 +1830,7 @@ class Hrule(Rule):
         height = depth = thickness * 0.5
         Rule.__init__(self, np.inf, height, depth, state)
 
+
 class Vrule(Rule):
     """
     Convenience class to create a vertical rule.
@@ -1812,6 +1839,7 @@ class Vrule(Rule):
         thickness = state.font_output.get_underline_thickness(
             state.font, state.fontsize, state.dpi)
         Rule.__init__(self, thickness, np.inf, np.inf, state)
+
 
 class Glue(Node):
     """
@@ -1846,11 +1874,13 @@ class Glue(Node):
             self.glue_spec = self.glue_spec.copy()
             self.glue_spec.width *= GROW_FACTOR
 
+
 class GlueSpec(object):
     """
     See :class:`Glue`.
     """
-    def __init__(self, width=0., stretch=0., stretch_order=0, shrink=0., shrink_order=0):
+    def __init__(self, width=0., stretch=0., stretch_order=0,
+                 shrink=0., shrink_order=0):
         self.width         = width
         self.stretch       = stretch
         self.stretch_order = stretch_order
@@ -1869,6 +1899,7 @@ class GlueSpec(object):
         return cls._types[glue_type]
     factory = classmethod(factory)
 
+
 GlueSpec._types = {
     'fil':         GlueSpec(0., 1., 1, 0., 0),
     'fill':        GlueSpec(0., 1., 2, 0., 0),
@@ -1880,35 +1911,44 @@ GlueSpec._types = {
     'ss':          GlueSpec(0., 1., 1, -1., 1)
 }
 
+
 # Some convenient ways to get common kinds of glue
+
 
 class Fil(Glue):
     def __init__(self):
         Glue.__init__(self, 'fil')
 
+
 class Fill(Glue):
     def __init__(self):
         Glue.__init__(self, 'fill')
+
 
 class Filll(Glue):
     def __init__(self):
         Glue.__init__(self, 'filll')
 
+
 class NegFil(Glue):
     def __init__(self):
         Glue.__init__(self, 'neg_fil')
+
 
 class NegFill(Glue):
     def __init__(self):
         Glue.__init__(self, 'neg_fill')
 
+
 class NegFilll(Glue):
     def __init__(self):
         Glue.__init__(self, 'neg_filll')
 
+
 class SsGlue(Glue):
     def __init__(self):
         Glue.__init__(self, 'ss')
+
 
 class HCentered(Hlist):
     """
@@ -1919,6 +1959,7 @@ class HCentered(Hlist):
         Hlist.__init__(self, [SsGlue()] + elements + [SsGlue()],
                        do_kern=False)
 
+
 class VCentered(Hlist):
     """
     A convenience class to create a :class:`Vlist` whose contents are
@@ -1926,6 +1967,7 @@ class VCentered(Hlist):
     """
     def __init__(self, elements):
         Vlist.__init__(self, [SsGlue()] + elements + [SsGlue()])
+
 
 class Kern(Node):
     """
@@ -1956,6 +1998,7 @@ class Kern(Node):
         Node.grow(self)
         self.width *= GROW_FACTOR
 
+
 class SubSuperCluster(Hlist):
     """
     :class:`SubSuperCluster` is a sort of hack to get around that fact
@@ -1969,6 +2012,7 @@ class SubSuperCluster(Hlist):
         self.sub = None
         self.super = None
         Hlist.__init__(self, [])
+
 
 class AutoHeightChar(Hlist):
     """
@@ -2006,6 +2050,7 @@ class AutoHeightChar(Hlist):
 
         Hlist.__init__(self, [char])
         self.shift_amount = shift
+
 
 class AutoWidthChar(Hlist):
     """
@@ -2045,7 +2090,7 @@ class Ship(object):
     state as it processes have become member variables here.
     """
     def __call__(self, ox, oy, box):
-        self.max_push    = 0 # Deepest nesting of push commands so far
+        self.max_push    = 0  # Deepest nesting of push commands so far
         self.cur_s       = 0
         self.cur_v       = 0.
         self.cur_h       = 0.
@@ -2112,14 +2157,14 @@ class Ship(object):
                 # node625
                 glue_spec = p.glue_spec
                 rule_width = glue_spec.width - cur_g
-                if glue_sign != 0: # normal
-                    if glue_sign == 1: # stretching
+                if glue_sign != 0:  # normal
+                    if glue_sign == 1:  # stretching
                         if glue_spec.stretch_order == glue_order:
                             cur_glue += glue_spec.stretch
-                            cur_g = np.round(clamp(float(box.glue_set) * cur_glue))
+                            cur_g = round(clamp(box.glue_set * cur_glue))
                     elif glue_spec.shrink_order == glue_order:
                         cur_glue += glue_spec.shrink
-                        cur_g = np.round(clamp(float(box.glue_set) * cur_glue))
+                        cur_g = round(clamp(box.glue_set * cur_glue))
                 rule_width += cur_g
                 self.cur_h += rule_width
         self.cur_s -= 1
@@ -2168,25 +2213,28 @@ class Ship(object):
             elif isinstance(p, Glue):
                 glue_spec = p.glue_spec
                 rule_height = glue_spec.width - cur_g
-                if glue_sign != 0: # normal
-                    if glue_sign == 1: # stretching
+                if glue_sign != 0:  # normal
+                    if glue_sign == 1:  # stretching
                         if glue_spec.stretch_order == glue_order:
                             cur_glue += glue_spec.stretch
-                            cur_g = np.round(clamp(float(box.glue_set) * cur_glue))
-                    elif glue_spec.shrink_order == glue_order: # shrinking
+                            cur_g = round(clamp(box.glue_set * cur_glue))
+                    elif glue_spec.shrink_order == glue_order:  # shrinking
                         cur_glue += glue_spec.shrink
-                        cur_g = np.round(clamp(float(box.glue_set) * cur_glue))
+                        cur_g = round(clamp(box.glue_set * cur_glue))
                 rule_height += cur_g
                 self.cur_v += rule_height
             elif isinstance(p, Char):
-                raise RuntimeError("Internal mathtext error: Char node found in vlist")
+                raise RuntimeError(
+                    "Internal mathtext error: Char node found in vlist")
         self.cur_s -= 1
 
 
 ship = Ship()
 
+
 ##############################################################################
 # PARSER
+
 
 def Error(msg):
     """
@@ -2198,6 +2246,7 @@ def Error(msg):
     empty = Empty()
     empty.setParseAction(raise_error)
     return empty
+
 
 class Parser(object):
     """
@@ -2229,16 +2278,16 @@ class Parser(object):
 
     _relation_symbols = set('''
       = < > :
-      \\leq            \\geq             \\equiv           \\models
-      \\prec           \\succ            \\sim             \\perp
-      \\preceq         \\succeq          \\simeq           \\mid
-      \\ll             \\gg              \\asymp           \\parallel
-      \\subset         \\supset          \\approx          \\bowtie
-      \\subseteq       \\supseteq        \\cong            \\Join
-      \\sqsubset       \\sqsupset        \\neq             \\smile
-      \\sqsubseteq     \\sqsupseteq      \\doteq           \\frown
-      \\in             \\ni              \\propto          \\vdash
-      \\dashv          \\dots            \\dotplus         \\doteqdot'''.split())
+      \\leq        \\geq        \\equiv   \\models
+      \\prec       \\succ       \\sim     \\perp
+      \\preceq     \\succeq     \\simeq   \\mid
+      \\ll         \\gg         \\asymp   \\parallel
+      \\subset     \\supset     \\approx  \\bowtie
+      \\subseteq   \\supseteq   \\cong    \\Join
+      \\sqsubset   \\sqsupset   \\neq     \\smile
+      \\sqsubseteq \\sqsupseteq \\doteq   \\frown
+      \\in         \\ni         \\propto  \\vdash
+      \\dashv      \\dots       \\dotplus \\doteqdot'''.split())
 
     _arrow_symbols = set('''
       \\leftarrow              \\longleftarrow           \\uparrow
@@ -2263,11 +2312,12 @@ class Parser(object):
        '''.split())
 
     _overunder_functions = set(
-        r"lim liminf limsup sup max min".split())
+        "lim liminf limsup sup max min".split())
 
     _dropsub_symbols = set(r'''\int \oint'''.split())
 
-    _fontnames = set("rm cal it tt sf bf default bb frak circled scr regular".split())
+    _fontnames = set(
+        "rm cal it tt sf bf default bb frak circled scr regular".split())
 
     _function_names = set("""
       arccos csc ker min arcsin deg lg Pr arctan det lim sec arg dim
@@ -2348,58 +2398,78 @@ class Parser(object):
         p.bslash        <<= Literal('\\')
 
         p.space         <<= oneOf(list(self._space_widths))
-        p.customspace   <<= (Suppress(Literal(r'\hspace'))
-                          - ((p.lbrace + p.float_literal + p.rbrace)
-                            | Error(r"Expected \hspace{n}")))
+        p.customspace   <<= (
+            Suppress(Literal(r'\hspace'))
+            - ((p.lbrace + p.float_literal + p.rbrace)
+               | Error(r"Expected \hspace{n}"))
+        )
 
         unicode_range =  "\U00000080-\U0001ffff"
-        p.single_symbol <<= Regex(r"([a-zA-Z0-9 +\-*/<>=:,.;!\?&'@()\[\]|%s])|(\\[%%${}\[\]_|])" %
-                               unicode_range)
+        p.single_symbol <<= Regex(
+            r"([a-zA-Z0-9 +\-*/<>=:,.;!\?&'@()\[\]|%s])|(\\[%%${}\[\]_|])" %
+            unicode_range)
         p.snowflake     <<= Suppress(p.bslash) + oneOf(self._snowflake)
-        p.symbol_name   <<= (Combine(p.bslash + oneOf(list(tex2uni))) +
-                          FollowedBy(Regex("[^A-Za-z]").leaveWhitespace() | StringEnd()))
+        p.symbol_name   <<= (
+            Combine(p.bslash + oneOf(list(tex2uni)))
+            + FollowedBy(Regex("[^A-Za-z]").leaveWhitespace() | StringEnd())
+        )
         p.symbol        <<= (p.single_symbol | p.symbol_name).leaveWhitespace()
 
         p.apostrophe    <<= Regex("'+")
 
-        p.c_over_c      <<= Suppress(p.bslash) + oneOf(list(self._char_over_chars))
+        p.c_over_c      <<= (
+            Suppress(p.bslash)
+            + oneOf(list(self._char_over_chars))
+        )
 
         p.accent        <<= Group(
-                             Suppress(p.bslash)
-                           + oneOf([*self._accent_map, *self._wide_accents])
-                           - p.placeable
-                         )
+            Suppress(p.bslash)
+            + oneOf([*self._accent_map, *self._wide_accents])
+            - p.placeable
+        )
 
-        p.function      <<= Suppress(p.bslash) + oneOf(list(self._function_names))
+        p.function      <<= (
+            Suppress(p.bslash)
+            + oneOf(list(self._function_names))
+        )
 
         p.start_group   <<= Optional(p.latexfont) + p.lbrace
         p.end_group     <<= p.rbrace.copy()
         p.simple_group  <<= Group(p.lbrace + ZeroOrMore(p.token) + p.rbrace)
         p.required_group<<= Group(p.lbrace + OneOrMore(p.token) + p.rbrace)
-        p.group         <<= Group(p.start_group + ZeroOrMore(p.token) + p.end_group)
+        p.group         <<= Group(
+            p.start_group + ZeroOrMore(p.token) + p.end_group
+        )
 
         p.font          <<= Suppress(p.bslash) + oneOf(list(self._fontnames))
-        p.latexfont     <<= Suppress(p.bslash) + oneOf(['math' + x for x in self._fontnames])
+        p.latexfont     <<= (
+            Suppress(p.bslash)
+            + oneOf(['math' + x for x in self._fontnames])
+        )
 
         p.frac          <<= Group(
-                             Suppress(Literal(r"\frac"))
-                           - ((p.required_group + p.required_group) | Error(r"Expected \frac{num}{den}"))
-                         )
+            Suppress(Literal(r"\frac"))
+            - ((p.required_group + p.required_group)
+               | Error(r"Expected \frac{num}{den}"))
+        )
 
         p.dfrac         <<= Group(
-                             Suppress(Literal(r"\dfrac"))
-                           - ((p.required_group + p.required_group) | Error(r"Expected \dfrac{num}{den}"))
-                         )
+            Suppress(Literal(r"\dfrac"))
+            - ((p.required_group + p.required_group)
+               | Error(r"Expected \dfrac{num}{den}"))
+        )
 
         p.stackrel      <<= Group(
-                             Suppress(Literal(r"\stackrel"))
-                           - ((p.required_group + p.required_group) | Error(r"Expected \stackrel{num}{den}"))
-                         )
+            Suppress(Literal(r"\stackrel"))
+            - ((p.required_group + p.required_group)
+               | Error(r"Expected \stackrel{num}{den}"))
+        )
 
         p.binom         <<= Group(
-                             Suppress(Literal(r"\binom"))
-                           - ((p.required_group + p.required_group) | Error(r"Expected \binom{num}{den}"))
-                         )
+            Suppress(Literal(r"\binom"))
+            - ((p.required_group + p.required_group)
+               | Error(r"Expected \binom{num}{den}"))
+        )
 
         p.ambi_delim    <<= oneOf(list(self._ambi_delim))
         p.left_delim    <<= oneOf(list(self._left_delim))
@@ -2407,76 +2477,90 @@ class Parser(object):
         p.right_delim_safe <<= oneOf([*(self._right_delim - {'}'}), r'\}'])
 
         p.genfrac       <<= Group(
-                             Suppress(Literal(r"\genfrac"))
-                           - (((p.lbrace + Optional(p.ambi_delim | p.left_delim, default='') + p.rbrace)
-                           +   (p.lbrace + Optional(p.ambi_delim | p.right_delim_safe, default='') + p.rbrace)
-                           +   (p.lbrace + p.float_literal + p.rbrace)
-                           +   p.simple_group + p.required_group + p.required_group)
-                           | Error(r"Expected \genfrac{ldelim}{rdelim}{rulesize}{style}{num}{den}"))
-                         )
+            Suppress(Literal(r"\genfrac"))
+            - ((  (p.lbrace
+                 + Optional(p.ambi_delim | p.left_delim, default='')
+                 + p.rbrace)
+                + (p.lbrace
+                   + Optional(p.ambi_delim | p.right_delim_safe, default='')
+                   + p.rbrace)
+                + (p.lbrace + p.float_literal + p.rbrace)
+                + p.simple_group + p.required_group + p.required_group)
+               | Error("Expected "
+                       r"\genfrac{ldelim}{rdelim}{rulesize}{style}{num}{den}"))
+        )
 
         p.sqrt          <<= Group(
-                             Suppress(Literal(r"\sqrt"))
-                           - ((Optional(p.lbracket + p.int_literal + p.rbracket, default=None)
-                              + p.required_group)
-                           | Error("Expected \\sqrt{value}"))
-                         )
+            Suppress(Literal(r"\sqrt"))
+            - ((Optional(p.lbracket + p.int_literal + p.rbracket, default=None)
+                + p.required_group)
+               | Error("Expected \\sqrt{value}"))
+        )
 
         p.overline      <<= Group(
-                             Suppress(Literal(r"\overline"))
-                           - (p.required_group | Error("Expected \\overline{value}"))
-                         )
+            Suppress(Literal(r"\overline"))
+            - (p.required_group | Error("Expected \\overline{value}"))
+        )
 
         p.unknown_symbol<<= Combine(p.bslash + Regex("[A-Za-z]*"))
 
         p.operatorname  <<= Group(
-                             Suppress(Literal(r"\operatorname"))
-                           - ((p.lbrace + ZeroOrMore(p.simple | p.unknown_symbol) + p.rbrace)
-                              | Error("Expected \\operatorname{value}"))
-                         )
+            Suppress(Literal(r"\operatorname"))
+            - ((p.lbrace + ZeroOrMore(p.simple | p.unknown_symbol) + p.rbrace)
+               | Error("Expected \\operatorname{value}"))
+        )
 
-        p.placeable     <<= ( p.snowflake # this needs to be before accent so named symbols
-                                          # that are prefixed with an accent name work
-                         | p.accent # Must be before symbol as all accents are symbols
-                         | p.symbol # Must be third to catch all named symbols and single chars not in a group
-                         | p.c_over_c
-                         | p.function
-                         | p.group
-                         | p.frac
-                         | p.dfrac
-                         | p.stackrel
-                         | p.binom
-                         | p.genfrac
-                         | p.sqrt
-                         | p.overline
-                         | p.operatorname
-                         )
+        p.placeable     <<= (
+            p.snowflake  # Must be before accent so named symbols that are
+                         # prefixed with an accent name work
+            | p.accent   # Must be before symbol as all accents are symbols
+            | p.symbol   # Must be third to catch all named symbols and single
+                         # chars not in a group
+            | p.c_over_c
+            | p.function
+            | p.group
+            | p.frac
+            | p.dfrac
+            | p.stackrel
+            | p.binom
+            | p.genfrac
+            | p.sqrt
+            | p.overline
+            | p.operatorname
+        )
 
-        p.simple        <<= ( p.space
-                         | p.customspace
-                         | p.font
-                         | p.subsuper
-                         )
+        p.simple        <<= (
+            p.space
+            | p.customspace
+            | p.font
+            | p.subsuper
+        )
 
         p.subsuperop    <<= oneOf(["_", "^"])
 
         p.subsuper      <<= Group(
-                             (Optional(p.placeable) + OneOrMore(p.subsuperop - p.placeable) + Optional(p.apostrophe))
-                           | (p.placeable + Optional(p.apostrophe))
-                           | p.apostrophe
-                         )
+            (Optional(p.placeable)
+             + OneOrMore(p.subsuperop - p.placeable)
+             + Optional(p.apostrophe))
+            | (p.placeable + Optional(p.apostrophe))
+            | p.apostrophe
+        )
 
-        p.token         <<= ( p.simple
-                         | p.auto_delim
-                         | p.unknown_symbol # Must be last
-                         )
+        p.token         <<= (
+            p.simple
+            | p.auto_delim
+            | p.unknown_symbol  # Must be last
+        )
 
-        p.auto_delim    <<= (Suppress(Literal(r"\left"))
-                          - ((p.left_delim | p.ambi_delim) | Error("Expected a delimiter"))
-                          + Group(ZeroOrMore(p.simple | p.auto_delim))
-                          + Suppress(Literal(r"\right"))
-                          - ((p.right_delim | p.ambi_delim) | Error("Expected a delimiter"))
-                         )
+        p.auto_delim    <<= (
+            Suppress(Literal(r"\left"))
+            - ((p.left_delim | p.ambi_delim)
+               | Error("Expected a delimiter"))
+            + Group(ZeroOrMore(p.simple | p.auto_delim))
+            + Suppress(Literal(r"\right"))
+            - ((p.right_delim | p.ambi_delim)
+               | Error("Expected a delimiter"))
+        )
 
         p.math          <<= OneOrMore(p.token)
 
@@ -2484,7 +2568,9 @@ class Parser(object):
 
         p.non_math      <<= Regex(r"(?:(?:\\[$])|[^$])*").leaveWhitespace()
 
-        p.main          <<= (p.non_math + ZeroOrMore(p.math_string + p.non_math)) + StringEnd()
+        p.main          <<= (
+            p.non_math + ZeroOrMore(p.math_string + p.non_math) + StringEnd()
+        )
 
         # Set actions
         for key, val in vars(p).items():
@@ -2502,7 +2588,8 @@ class Parser(object):
 
         Returns the parse tree of :class:`Node` instances.
         """
-        self._state_stack = [self.State(fonts_object, 'default', 'rm', fontsize, dpi)]
+        self._state_stack = [
+            self.State(fonts_object, 'default', 'rm', fontsize, dpi)]
         self._em_width_cache = {}
         try:
             result = self._expression.parseString(s)
@@ -2596,23 +2683,25 @@ class Parser(object):
         width = self._em_width_cache.get(key)
         if width is None:
             metrics = state.font_output.get_metrics(
-                state.font, rcParams['mathtext.default'], 'm', state.fontsize, state.dpi)
+                state.font, rcParams['mathtext.default'], 'm', state.fontsize,
+                state.dpi)
             width = metrics.advance
             self._em_width_cache[key] = width
         return Kern(width * percentage)
 
-    _space_widths = { r'\,'         : 0.16667,  # 3/18 em = 3 mu
-                      r'\thinspace' : 0.16667,  # 3/18 em = 3 mu
-                      r'\/'         : 0.16667,  # 3/18 em = 3 mu
-                      r'\>'         : 0.22222,  # 4/18 em = 4 mu
-                      r'\:'         : 0.22222,  # 4/18 em = 4 mu
-                      r'\;'         : 0.27778,  # 5/18 em = 5 mu
-                      r'\ '         : 0.33333,  # 6/18 em = 6 mu
-                      r'\enspace'   : 0.5,      # 9/18 em = 9 mu
-                      r'\quad'      : 1,        # 1 em = 18 mu
-                      r'\qquad'     : 2,        # 2 em = 36 mu
-                      r'\!'         : -0.16667, # -3/18 em = -3 mu
+    _space_widths = { r'\,'         : 0.16667,   # 3/18 em = 3 mu
+                      r'\thinspace' : 0.16667,   # 3/18 em = 3 mu
+                      r'\/'         : 0.16667,   # 3/18 em = 3 mu
+                      r'\>'         : 0.22222,   # 4/18 em = 4 mu
+                      r'\:'         : 0.22222,   # 4/18 em = 4 mu
+                      r'\;'         : 0.27778,   # 5/18 em = 5 mu
+                      r'\ '         : 0.33333,   # 6/18 em = 6 mu
+                      r'\enspace'   : 0.5,       # 9/18 em = 9 mu
+                      r'\quad'      : 1,         # 1 em = 18 mu
+                      r'\qquad'     : 2,         # 2 em = 36 mu
+                      r'\!'         : -0.16667,  # -3/18 em = -3 mu
                       }
+
     def space(self, s, loc, toks):
         assert len(toks)==1
         num = self._space_widths[toks[0]]
@@ -2641,7 +2730,7 @@ class Parser(object):
             else:
                 return [Hlist([self._make_space(0.2),
                                char,
-                               self._make_space(0.2)] ,
+                               self._make_space(0.2)],
                                do_kern = True)]
         elif c in self._punctuation_symbols:
 
@@ -2833,8 +2922,8 @@ class Parser(object):
         sub = None
         super = None
 
-        # Pick all of the apostrophes out, including first apostrophes that have
-        # been parsed as characters
+        # Pick all of the apostrophes out, including first apostrophes that
+        # have been parsed as characters
         napostrophes = 0
         new_toks = []
         for tok in toks[0]:
@@ -2851,7 +2940,7 @@ class Parser(object):
             nucleus = Hbox(0.0)
         elif len(toks) == 1:
             if not napostrophes:
-                return toks[0] # .asList()
+                return toks[0]  # .asList()
             else:
                 nucleus = toks[0]
         elif len(toks) in (2, 3):
@@ -2893,7 +2982,8 @@ class Parser(object):
                 super = Hlist([])
             for i in range(napostrophes):
                 super.children.extend(self.symbol(s, loc, ['\\prime']))
-            # kern() and hpack() needed to get the metrics right after extending
+            # kern() and hpack() needed to get the metrics right after
+            # extending
             super.kern()
             super.hpack()
 
@@ -2926,9 +3016,9 @@ class Parser(object):
             result = Hlist([vlist])
             return [result]
 
-        # We remove kerning on the last character for consistency (otherwise it
-        # will compute kerning based on non-shrinked characters and may put them
-        # too close together when superscripted)
+        # We remove kerning on the last character for consistency (otherwise
+        # it will compute kerning based on non-shrinked characters and may put
+        # them too close together when superscripted)
         # We change the width of the last character to match the advance to
         # consider some fonts with weird metrics: e.g. stix's f has a width of
         # 7.75 and a kerning of -4.0 for an advance of 3.72, and we want to put
@@ -2938,7 +3028,7 @@ class Parser(object):
             new_children = nucleus.children
             if len(new_children):
                 # remove last kern
-                if (isinstance(new_children[-1],Kern) and
+                if (isinstance(new_children[-1], Kern) and
                         hasattr(new_children[-2], '_metrics')):
                     new_children = new_children[:-1]
                 last_char = new_children[-1]
@@ -2991,8 +3081,8 @@ class Parser(object):
                 shift_up = constants.sup1 * xHeight
             if sub is None:
                 x.shift_amount = -shift_up
-            else: # Both sub and superscript
-                y = Hlist([Kern(subkern),sub])
+            else:  # Both sub and superscript
+                y = Hlist([Kern(subkern), sub])
                 y.shrink()
                 if self.is_dropsub(last_char):
                     shift_down = lc_baseline + constants.subdrop * xHeight
@@ -3003,9 +3093,10 @@ class Parser(object):
                        ((shift_up - x.depth) - (y.height - shift_down)))
                 if clr > 0.:
                     shift_up += clr
-                x = Vlist([x,
-                           Kern((shift_up - x.depth) - (y.height - shift_down)),
-                           y])
+                x = Vlist([
+                    x,
+                    Kern((shift_up - x.depth) - (y.height - shift_down)),
+                    y])
                 x.shift_amount = shift_down
 
         if not self.is_dropsub(last_char):
@@ -3184,10 +3275,12 @@ class Parser(object):
         parts = []
         # \left. and \right. aren't supposed to produce any symbols
         if front != '.':
-            parts.append(AutoHeightChar(front, height, depth, state, factor=factor))
+            parts.append(
+                AutoHeightChar(front, height, depth, state, factor=factor))
         parts.extend(middle)
         if back != '.':
-            parts.append(AutoHeightChar(back, height, depth, state, factor=factor))
+            parts.append(
+                AutoHeightChar(back, height, depth, state, factor=factor))
         hlist = Hlist(parts)
         return hlist
 
@@ -3196,10 +3289,10 @@ class Parser(object):
 
         return self._auto_sized_delimiter(front, middle.asList(), back)
 
-###
 
 ##############################################################################
 # MAIN
+
 
 class MathTextParser(object):
     _parser = None
@@ -3353,7 +3446,8 @@ class MathTextParser(object):
         Returns the offset of the baseline from the bottom of the
         image in pixels.
         """
-        rgba, depth = self.to_rgba(texstr, color=color, dpi=dpi, fontsize=fontsize)
+        rgba, depth = self.to_rgba(
+            texstr, color=color, dpi=dpi, fontsize=fontsize)
         _png.write_png(rgba, filename)
         return depth
 
@@ -3375,6 +3469,7 @@ class MathTextParser(object):
         prop = FontProperties(size=fontsize)
         ftimage, depth = self.parse(texstr, dpi=dpi, prop=prop)
         return depth
+
 
 def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
     """


### PR DESCRIPTION
The only non-trivial fix is a replacement of np.round to the builtin
round (mostly because it helps squeezing a line withing 79 chars);
np.round was introduced in 95fda79 to get consistent Py2/Py3 behavior
but Py3 matches np.round anyways (Py2's builtin round rounds halfway
away from zero, Py3's builtin round and np.round round to even).
Builtin round is faster than np.round for scalars, too (not that it
really matters).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
