### PR TITLE
MAINT Better error message for number of colors versus number of data…

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6538,7 +6538,7 @@ class Axes(_AxesBase):
             color = mcolors.to_rgba_array(color)
             if len(color) != nx:
                 error_message = (
-                    "color kwarg must have one color per data sets. %d data "
+                    "color kwarg must have one color per data set. %d data "
                     "sets and %d colors were provided" % (len(color), nx))
                 raise ValueError(error_message)
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6537,7 +6537,10 @@ class Axes(_AxesBase):
         else:
             color = mcolors.to_rgba_array(color)
             if len(color) != nx:
-                raise ValueError("color kwarg must have one color per dataset")
+                error_message = (
+                    "color kwarg must have one color per data sets. %d data "
+                    "sets and %d colors were provided" % (len(color), nx))
+                raise ValueError(error_message)
 
         # If bins are not specified either explicitly or via range,
         # we need to figure out the range required for all datasets,


### PR DESCRIPTION
Just changing slightly the error message when the number of colors don't match the number of datasets. Sometimes it's down deep after several functions, and it is hard to understand it without providing a bit more context.