### PR TITLE
FIX: Fix get_facecolors

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1510,7 +1510,7 @@ def setp(obj, *args, **kwargs):
 
 
 def kwdoc(artist):
-    """
+    r"""
     Inspect an `~matplotlib.artist.Artist` class and return
     information about its settable properties and their current values.
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -710,6 +710,9 @@ class Poly3DCollection(PolyCollection):
     def get_edgecolor(self):
         return self._edgecolors2d
 
+    def get_facecolors(self):
+        return self._facecolors
+
 
 def poly_collection_2d_to_3d(col, zs=0, zdir='z'):
     """Convert a PolyCollection to a Poly3DCollection object."""

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -256,7 +256,9 @@ def test_trisurf3d():
 
     fig = plt.figure()
     ax = fig.gca(projection='3d')
-    ax.plot_trisurf(x, y, z, cmap=cm.jet, linewidth=0.2)
+    tri = ax.plot_trisurf(x, y, z, cmap=cm.jet, linewidth=0.2)
+    # smoke test for facecolors
+    tri.get_facecolors()
 
 
 @image_comparison(baseline_images=['trisurf3d_shaded'], remove_text=True,


### PR DESCRIPTION
On `master` the added test throws:
```
lib/mpl_toolkits/tests/test_mplot3d.py:261: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/matplotlib/cbook/__init__.py:1918: in method
    return getattr(self, name)(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <mpl_toolkits.mplot3d.art3d.Poly3DCollection object at 0x7f80a4da6f60>

    def get_facecolor(self):
>       return self._facecolors2d
E       AttributeError: 'Poly3DCollection' object has no attribute '_facecolors2d'
```
Now it passes.

I also added a `r"""` on a docstring in `lib/matplotlib/artist.py` that had a `\s` in it as it was raising a SyntaxError on my system without it.