### PR TITLE
Group some print()s in backend_ps.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1082,10 +1082,12 @@ class FigureCanvasPS(FigureCanvasBase):
             if isEPSF:
                 print("%!PS-Adobe-3.0 EPSF-3.0", file=fh)
             else:
-                print("%!PS-Adobe-3.0", file=fh)
+                print("%!PS-Adobe-3.0\n"
+                      "%%DocumentPaperSizes: {papertype}\n"
+                      "%%Pages: 1\n".format(papertype=papertype),
+                      end="", file=fh)
             if title:
                 print("%%Title: " + title, file=fh)
-            print("%%Creator: " + creator_str, file=fh)
             # get source date from SOURCE_DATE_EPOCH, if set
             # See https://reproducible-builds.org/specs/source-date-epoch/
             source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
@@ -1094,14 +1096,14 @@ class FigureCanvasPS(FigureCanvasBase):
                     int(source_date_epoch)).strftime("%a %b %d %H:%M:%S %Y")
             else:
                 source_date = time.ctime()
-            print("%%CreationDate: " + source_date, file=fh)
-            print("%%Orientation: " + orientation, file=fh)
-            if not isEPSF:
-                print("%%DocumentPaperSizes: "+papertype, file=fh)
-            print("%%%%BoundingBox: %d %d %d %d" % bbox, file=fh)
-            if not isEPSF:
-                print("%%Pages: 1", file=fh)
-            print("%%EndComments", file=fh)
+            print("%%Creator: {creator_str}\n"
+                  "%%CreationDate: {source_date}\n"
+                  "%%Orientation: {orientation}\n"
+                  "%%BoundingBox: {bbox[0]} {bbox[1]} {bbox[2]} {bbox[3]}\n"
+                  "%%EndComments\n"
+                  .format(creator_str=creator_str, source_date=source_date,
+                          orientation=orientation, bbox=bbox),
+                  end="", file=fh)
 
             Ndict = len(psDefs)
             print("%%BeginProlog", file=fh)
@@ -1278,7 +1280,6 @@ class FigureCanvasPS(FigureCanvasBase):
                 print("%!PS-Adobe-3.0 EPSF-3.0", file=fh)
                 if title:
                     print("%%Title: "+title, file=fh)
-                print("%%Creator: " + creator_str, file=fh)
                 # get source date from SOURCE_DATE_EPOCH, if set
                 # See https://reproducible-builds.org/specs/source-date-epoch/
                 source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
@@ -1288,20 +1289,24 @@ class FigureCanvasPS(FigureCanvasBase):
                             "%a %b %d %H:%M:%S %Y")
                 else:
                     source_date = time.ctime()
-                print("%%CreationDate: "+source_date, file=fh)
-                print("%%%%BoundingBox: %d %d %d %d" % bbox, file=fh)
-                print("%%EndComments", file=fh)
+                print(
+                    "%%Creator: {creator_str}\n"
+                    "%%CreationDate: {source_date}\n"
+                    "%%BoundingBox: {bbox[0]} {bbox[1]} {bbox[2]} {bbox[3]}\n"
+                    "%%EndComments\n"
+                    .format(creator_str=creator_str, source_date=source_date,
+                            bbox=bbox),
+                    end="", file=fh)
 
-                Ndict = len(psDefs)
-                print("%%BeginProlog", file=fh)
-                print("/mpldict %d dict def" % Ndict, file=fh)
-                print("mpldict begin", file=fh)
-                for d in psDefs:
-                    d = d.strip()
-                    for l in d.split('\n'):
-                        print(l.strip(), file=fh)
-                print("end", file=fh)
-                print("%%EndProlog", file=fh)
+                print("%%BeginProlog\n"
+                      "/mpldict {len_psDefs} dict def\n"
+                      "mpldict begin\n"
+                      "{psDefs}\n"
+                      "end\n"
+                      "%%EndProlog\n"
+                      .format(len_psDefs=len(psDefs),
+                              psDefs="\n".join(psDefs)),
+                      end="", file=fh)
 
                 print("mpldict begin", file=fh)
                 print("%s translate" % _nums_to_str(xo, yo), file=fh)


### PR DESCRIPTION
This results in some comments being reordered, but that's fine per
"PostScript Language Document Structuring Conventions Specification" v3
section 4.4,

    The order of some comments in the document is significant, but in a
    section of the document they may appear in any order. For example, in the
    header section, %%DocumentResources:, %%Title:, and %%Creator: may
    appear in any order.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
