### PR TITLE
Resolve backend in rcParams.__getitem__("backend").

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1097,10 +1097,10 @@ if dict.__getitem__(rcParams, 'examples.directory'):
         _fullpath = os.path.join(_basedir, rcParams['examples.directory'])
         rcParams['examples.directory'] = _fullpath
 
-rcParamsOrig = rcParams.copy()
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+    rcParamsOrig = RcParams(rcParams.copy())
     rcParamsDefault = RcParams([(key, default) for key, (default, converter) in
                                 defaultParams.items()
                                 if key not in _all_deprecated])

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1292,16 +1292,23 @@ class rc_context:
             if rc:
                 rcParams.update(rc)
         except Exception:
-            # If anything goes wrong, revert to the original rcs.
-            dict.update(rcParams, self._orig)
+            self.__fallback()
             raise
+
+    def __fallback(self):
+        # If anything goes wrong, revert to the original rcs.
+        updated_backend = self._orig['backend']
+        dict.update(rcParams, self._orig)
+        # except for the backend.  If the context block triggered resloving
+        # the auto backend resolution keep that value around
+        if self._orig['backend'] is rcsetup._auto_backend_sentinel:
+            rcParams['backend'] = updated_backend
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        # No need to revalidate the original values.
-        dict.update(rcParams, self._orig)
+        self.__fallback()
 
 
 def use(arg, warn=True, force=False):

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1224,8 +1224,9 @@ def rc_file_defaults():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", mplDeprecation)
         from .style.core import STYLE_BLACKLIST
-        rcParams.update({k: v for k, v in rcParamsOrig.items()
-                         if k not in STYLE_BLACKLIST})
+        rcParams.update({k: rcParamsOrig[k] for k in rcParamsOrig
+                         if k not in STYLE_BLACKLIST and k != 'backend'})
+        rcParams['backend'] = dict.__getitem__(rcParamsOrig, 'backend')
 
 
 def rc_file(fname):

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1345,7 +1345,7 @@ def use(arg, warn=True, force=False):
     name = validate_backend(arg)
 
     # if setting back to the same thing, do nothing
-    if (rcParams['backend'] == name):
+    if (dict.__getitem__(rcParams, 'backend') == name):
         pass
 
     # Check if we have already imported pyplot and triggered

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1245,8 +1245,13 @@ def rc_file(fname):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", mplDeprecation)
         from .style.core import STYLE_BLACKLIST
-        rcParams.update({k: v for k, v in rc_params_from_file(fname).items()
-                         if k not in STYLE_BLACKLIST})
+        rc_from_file = rc_params_from_file(fname)
+        rcParams.update({k: rc_from_file[k] for k in rc_from_file
+                         if k not in STYLE_BLACKLIST and k != 'backend'})
+
+    proposed_backend = dict.__getitem__(rc_from_file, 'backend')
+    if (proposed_backend is not rcsetup._auto_backend_sentinel):
+        rcParams['backend'] = proposed_backend
 
 
 class rc_context:

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -137,7 +137,7 @@ import warnings
 
 # cbook must import matplotlib only within function
 # definitions, so it is safe to import from it here.
-from . import cbook
+from . import cbook, rcsetup
 from matplotlib.cbook import (
     MatplotlibDeprecationWarning, dedent, get_label, sanitize_sequence)
 from matplotlib.cbook import mplDeprecation  # deprecated
@@ -877,6 +877,12 @@ class RcParams(MutableMapping, dict):
                 "3.0", "{} is deprecated; in the future, examples will be "
                 "found relative to the 'datapath' directory.".format(key))
 
+        elif key == "backend":
+            val = dict.__getitem__(self, key)
+            if val is rcsetup._auto_backend_sentinel:
+                from matplotlib import pyplot as plt
+                plt.switch_backend(rcsetup._auto_backend_sentinel)
+
         return dict.__getitem__(self, key)
 
     def __repr__(self):
@@ -1357,7 +1363,7 @@ def use(arg, warn=True, force=False):
 
 
 if os.environ.get('MPLBACKEND'):
-    use(os.environ['MPLBACKEND'])
+    rcParams['backend'] = os.environ.get('MPLBACKEND')
 
 
 def get_backend():

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1229,8 +1229,7 @@ def rc_file_defaults():
         warnings.simplefilter("ignore", mplDeprecation)
         from .style.core import STYLE_BLACKLIST
         rcParams.update({k: rcParamsOrig[k] for k in rcParamsOrig
-                         if k not in STYLE_BLACKLIST and k != 'backend'})
-        rcParams['backend'] = dict.__getitem__(rcParamsOrig, 'backend')
+                         if k not in STYLE_BLACKLIST})
 
 
 def rc_file(fname):
@@ -1247,11 +1246,7 @@ def rc_file(fname):
         from .style.core import STYLE_BLACKLIST
         rc_from_file = rc_params_from_file(fname)
         rcParams.update({k: rc_from_file[k] for k in rc_from_file
-                         if k not in STYLE_BLACKLIST and k != 'backend'})
-
-    proposed_backend = dict.__getitem__(rc_from_file, 'backend')
-    if (proposed_backend is not rcsetup._auto_backend_sentinel):
-        rcParams['backend'] = proposed_backend
+                         if k not in STYLE_BLACKLIST})
 
 
 class rc_context:

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -849,6 +849,10 @@ class RcParams(MutableMapping, dict):
                 cbook.warn_deprecated(
                     "3.0", "{} is deprecated; in the future, examples will be "
                     "found relative to the 'datapath' directory.".format(key))
+            elif key == 'backend':
+                if val is rcsetup._auto_backend_sentinel:
+                    if 'backend' in self:
+                        return
             try:
                 cval = self.validate[key](val)
             except ValueError as ve:

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1343,7 +1343,7 @@ def use(arg, warn=True, force=False):
 
     force : bool, optional
         If True, attempt to switch the backend.  This defaults to
-        false and using `.pyplot.switch_backend` is preferred.
+        False.
 
 
     """

--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -10,12 +10,9 @@ from matplotlib.backend_bases import _Backend
 
 _log = logging.getLogger(__name__)
 
-backend = matplotlib.get_backend()
-# FIXME: Remove.
-_backend_loading_tb = "".join(
-    line for line in traceback.format_stack()
-    # Filter out line noise from importlib line.
-    if not line.startswith('  File "<frozen importlib._bootstrap'))
+
+# NOTE: plt.switch_backend() (called at import time) will add a "backend"
+# attribute here for backcompat.
 
 
 def _get_running_interactive_framework():

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -67,7 +67,7 @@ from .ticker import TickHelper, Formatter, FixedFormatter, NullFormatter,\
            Locator, IndexLocator, FixedLocator, NullLocator,\
            LinearLocator, LogLocator, AutoLocator, MultipleLocator,\
            MaxNLocator
-from matplotlib.backends import pylab_setup
+from matplotlib.backends import pylab_setup, _get_running_interactive_framework
 
 _log = logging.getLogger(__name__)
 
@@ -78,35 +78,15 @@ _log = logging.getLogger(__name__)
 # FIXME: Deprecate.
 def _backend_selection():
     """
-    If rcParams['backend_fallback'] is true, check to see if the
-    current backend is compatible with the current running event loop,
-    and if not switches to a compatible one.
+    If rcParams['backend_fallback'] is true, we will check (at backend
+    load-time) to see if the current backend is compatible with the current
+    running event loop, and if not switches to a compatible one.
     """
-    backend = rcParams['backend']
-    if not rcParams['backend_fallback'] or backend not in _interactive_bk:
-        return
-    is_agg_backend = rcParams['backend'].endswith('Agg')
-    if 'wx' in sys.modules and backend not in ('WX', 'WXAgg'):
-        import wx
-        if wx.App.IsMainLoopRunning():
-            rcParams['backend'] = 'wx' + 'Agg' * is_agg_backend
-    elif 'PyQt4.QtCore' in sys.modules and not backend == 'Qt4Agg':
-        import PyQt4.QtGui
-        if not PyQt4.QtGui.qApp.startingUp():
-            # The mainloop is running.
-            rcParams['backend'] = 'qt4Agg'
-    elif 'PyQt5.QtCore' in sys.modules and not backend == 'Qt5Agg':
-        import PyQt5.QtWidgets
-        if not PyQt5.QtWidgets.qApp.startingUp():
-            # The mainloop is running.
-            rcParams['backend'] = 'qt5Agg'
-    elif 'gtk' in sys.modules and 'gi' in sys.modules:
-        from gi.repository import GLib
-        if GLib.MainLoop().is_running():
-            rcParams['backend'] = 'GTK3Agg'
-    elif 'Tkinter' in sys.modules and not backend == 'TkAgg':
-        # import Tkinter
-        pass  # what if anything do we need to do for tkinter?
+    if rcParams["backend_fallback"]:
+        if (dict.__getitem__(rcParams, "backend") in _interactive_bk
+                and _get_running_interactive_framework()):
+            dict.__setitem__(
+                rcParams, "backend", rcsetup._auto_backend_sentinel)
 
 
 _backend_selection()

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -39,7 +39,7 @@ from matplotlib import docstring
 from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.figure import Figure, figaspect
 from matplotlib.gridspec import GridSpec
-from matplotlib import rcParams, rcParamsDefault, get_backend
+from matplotlib import rcParams, rcParamsDefault, get_backend, rcParamsOrig
 from matplotlib import rc_context
 from matplotlib.rcsetup import interactive_bk as _interactive_bk
 from matplotlib.artist import getp, get, Artist
@@ -217,6 +217,7 @@ def switch_backend(newbackend):
             except ImportError:
                 continue
             else:
+                rcParamsOrig['backend'] = candidate
                 return
 
     backend_name = (

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -36,7 +36,7 @@ def setup():
                 "Could not set locale to English/United States. "
                 "Some date-related tests may fail.")
 
-    mpl.use('Agg', warn=False)  # use Agg backend for these tests
+    mpl.use('Agg', force=True, warn=False)  # use Agg backend for these tests
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", MatplotlibDeprecationWarning)

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -53,6 +53,8 @@ def mpl_test_settings(request):
             if backend is not None:
                 plt.switch_backend(prev_backend)
 
+    assert matplotlib.get_backend() == 'agg'
+
 
 @pytest.fixture
 def mpl_image_comparison_parameters(request, extension):

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -8,7 +8,7 @@ from matplotlib.cbook import MatplotlibDeprecationWarning
 
 
 def pytest_configure(config):
-    matplotlib.use('agg')
+    matplotlib.use('agg', force=True)
     matplotlib._called_from_pytest = True
     matplotlib._init_tests()
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -139,7 +139,7 @@ def test_determinism(filename, usetex):
                 [sys.executable, '-R', '-c',
                  'import matplotlib; '
                  'matplotlib._called_from_pytest = True; '
-                 'matplotlib.use("svg"); '
+                 'matplotlib.use("svg", force=True); '
                  'from matplotlib.tests.test_backend_svg '
                  'import _test_determinism_save;'
                  '_test_determinism_save(%r, %r)' % (filename, usetex)],


### PR DESCRIPTION
... to avoid leaking the non-string sentinel.

Changes to `backends/__init__` and `_backend_selection()` were necessary
to avoid import-time cycles.

The fallback order in `backend_fallback` slightly changed in that the
FooCairo backends now fallback to WxAgg instead of Wx when a wx event
loop is active, but I wouldn't worry too much about it anyways given
that the Wx backend is deprecated and the correct fallback would be
WxCairo to start with.

attn @tacaswell, xref #11844.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
