### PR TITLE
HTMLWriter, put initialisation of frames in setup

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -842,15 +842,16 @@ class HTMLWriter(FileMovieWriter):
             self.default_mode = 'loop'
             _log.warning("unrecognized default_mode: using 'loop'")
 
-        self._saved_frames = []
-        self._total_bytes = 0
-        self._hit_limit = False
         super().__init__(fps, codec, bitrate, extra_args, metadata)
 
     def setup(self, fig, outfile, dpi, frame_dir=None):
         root, ext = os.path.splitext(outfile)
         if ext not in ['.html', '.htm']:
             raise ValueError("outfile must be *.htm or *.html")
+
+        self._saved_frames = []
+        self._total_bytes = 0
+        self._hit_limit = False
 
         if not self.embed_frames:
             if frame_dir is None:
@@ -868,7 +869,6 @@ class HTMLWriter(FileMovieWriter):
             # Just stop processing if we hit the limit
             if self._hit_limit:
                 return
-            suffix = '.' + self.frame_format
             f = BytesIO()
             self.fig.savefig(f, format=self.frame_format,
                              dpi=self.dpi, **savefig_kwargs)
@@ -902,11 +902,12 @@ class HTMLWriter(FileMovieWriter):
         if self.embed_frames:
             fill_frames = _embedded_frames(self._saved_frames,
                                            self.frame_format)
+            Nframes = len(self._saved_frames)
         else:
             # temp names is filled by FileMovieWriter
             fill_frames = _included_frames(self._temp_names,
                                            self.frame_format)
-
+            Nframes = len(self._temp_names)
         mode_dict = dict(once_checked='',
                          loop_checked='',
                          reflect_checked='')
@@ -917,7 +918,7 @@ class HTMLWriter(FileMovieWriter):
         with open(self.outfile, 'w') as of:
             of.write(JS_INCLUDE)
             of.write(DISPLAY_TEMPLATE.format(id=uuid.uuid4().hex,
-                                             Nframes=len(self._temp_names),
+                                             Nframes=Nframes,
                                              fill_frames=fill_frames,
                                              interval=interval,
                                              **mode_dict))


### PR DESCRIPTION
Some initiation data in the `HTMLWriter` with `embed_frames=True` is not set to "zero" when the same writer is used another time. So the following code
```
writer=HTMLWriter(fps=1, embed_frames=True)
anim1.save('anim1.html', writer)
anim2.save('anim2.html', writer)
```
would result in an `anim2.html` animation that starts with the `anim1` animation.

This pr move the initiation from `__init__` to `setup` to avoid that problem. 

It also set the correct `Nframes` in the embeded case. This doesn't seems to be necessary but it seems better and clearer when the variable is there. The only thing I think it does is to set 
```
var frames = new Array(Nframes)
```
and `Nframes=0` seems to work . I don't know javascript so I don't know if there are any important difference if the length of the Array is set before it is used or not.

I also deleted a variable that is not used anywhere. 

- [ ] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
