### PR TITLE
fix format of bar_of_pie example

### DIFF
--- a/examples/pie_and_polar_charts/bar_of_pie.py
+++ b/examples/pie_and_polar_charts/bar_of_pie.py
@@ -2,6 +2,7 @@
 ==========
 Bar of pie
 ==========
+
 Make a "bar of pie" chart where the first slice of the pie is
 "exploded" into a bar chart with a further breakdown of said slice's
 characteristics. The example demonstrates using a figure with multiple


### PR DESCRIPTION
## PR Summary

Rergresion from #11865: formatting issue (missing space after heading).

This resulted in an error when trying to build the docs:

~~~
ValueError: Example docstring should have a header for the example title and at least a paragraph explaining what the example is about. Please check the example file:
 bar_of_pie.py
~~~

Not sure why this did not appear during CI.