### PR TITLE
Move TOC back to top in axes documentation

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -4,20 +4,24 @@ axes
 
 .. currentmodule:: matplotlib.axes
 
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+   :class: multicol-toc
+
 .. automodule:: matplotlib.axes
    :no-members:
    :no-undoc-members:
+
+The Axes class
+==============
 
 .. autoclass:: Axes
    :no-members:
    :no-undoc-members:
    :show-inheritance:
 
-.. contents:: Table of Contents
-   :depth: 2
-   :local:
-   :backlinks: entry
-   :class: multicol-toc
 
 Subplots
 ========


### PR DESCRIPTION
## PR Summary

The TOC in https://matplotlib.org/devdocs/api/axes_api.html is burried somewhere below the class doumentation.

This PR brings the TOC back to top and thus increases its usability.

As a remark: Since #11454 the scope of this page has changed from the Axes class to the Axes module. IMO the class docstring should be moved to a sub-page as well. It's the only content part of the page whereas everything else is just a collection of links. But that's something for another PR.