### PR TITLE
Simplify linestyle and fillstyle reference docs.

### DIFF
--- a/examples/lines_bars_and_markers/line_styles_reference.py
+++ b/examples/lines_bars_and_markers/line_styles_reference.py
@@ -5,19 +5,9 @@ Line-style reference
 
 Reference for line-styles included with Matplotlib.
 """
+
 import numpy as np
 import matplotlib.pyplot as plt
-
-
-color = 'cornflowerblue'
-points = np.ones(5)  # Draw 5 points for each line
-text_style = dict(horizontalalignment='right', verticalalignment='center',
-                  fontsize=12, fontdict={'family': 'monospace'})
-
-
-def format_axes(ax):
-    ax.margins(0.2)
-    ax.set_axis_off()
 
 
 # Plot all line styles.
@@ -25,9 +15,11 @@ fig, ax = plt.subplots()
 
 linestyles = ['-', '--', '-.', ':']
 for y, linestyle in enumerate(linestyles):
-    ax.text(-0.1, y, repr(linestyle), **text_style)
-    ax.plot(y * points, linestyle=linestyle, color=color, linewidth=3)
-    format_axes(ax)
-    ax.set_title('line styles')
+    ax.text(-0.1, y, repr(linestyle),
+            horizontalalignment='center', verticalalignment='center')
+    ax.plot([y, y], linestyle=linestyle, linewidth=3, color='tab:blue')
+
+ax.set_axis_off()
+ax.set_title('line styles')
 
 plt.show()

--- a/examples/lines_bars_and_markers/marker_fillstyle_reference.py
+++ b/examples/lines_bars_and_markers/marker_fillstyle_reference.py
@@ -9,30 +9,25 @@ Also refer to the
 :doc:`/gallery/lines_bars_and_markers/marker_fillstyle_reference`
 and :doc:`/gallery/shapes_and_collections/marker_path` examples.
 """
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
 
-points = np.ones(5)  # Draw 3 points for each line
-text_style = dict(horizontalalignment='right', verticalalignment='center',
-                  fontsize=12, fontdict={'family': 'monospace'})
-marker_style = dict(color='cornflowerblue', linestyle=':', marker='o',
-                    markersize=15, markerfacecoloralt='gray')
-
-
-def format_axes(ax):
-    ax.margins(0.2)
-    ax.set_axis_off()
-
+points = np.ones(5)  # Draw 5 points for each line
+marker_style = dict(color='tab:blue', linestyle=':', marker='o',
+                    markersize=15, markerfacecoloralt='tab:red')
 
 fig, ax = plt.subplots()
 
 # Plot all fill styles.
 for y, fill_style in enumerate(Line2D.fillStyles):
-    ax.text(-0.5, y, repr(fill_style), **text_style)
+    ax.text(-0.5, y, repr(fill_style),
+            horizontalalignment='center', verticalalignment='center')
     ax.plot(y * points, fillstyle=fill_style, **marker_style)
-    format_axes(ax)
-    ax.set_title('fill style')
+
+ax.set_axis_off()
+ax.set_title('fill style')
 
 plt.show()


### PR DESCRIPTION
I don't know what's up with "cornflowerblue" but "tab:blue" is just as
good :)

xref #11908

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
