### PR TITLE
Minor formatting update on alias docstrings

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1161,7 +1161,7 @@ class ArtistInspector(object):
         if docstring is None:
             return 'unknown'
 
-        if docstring.startswith('alias for '):
+        if docstring.startswith('Alias for '):
             return None
 
         match = self._get_valid_values_regex.search(docstring)
@@ -1231,7 +1231,7 @@ class ArtistInspector(object):
         ds = o.__doc__
         if ds is None:
             return False
-        return ds.startswith('alias for ')
+        return ds.startswith('Alias for ')
 
     def aliased_name(self, s):
         """

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1927,7 +1927,7 @@ def _define_aliases(alias_d, cls=None):
                 for alias in aliases:
                     method = make_alias(prefix + prop)
                     method.__name__ = prefix + alias
-                    method.__doc__ = "alias for `{}`".format(prefix + prop)
+                    method.__doc__ = "Alias for `{}`.".format(prefix + prop)
                     setattr(cls, prefix + alias, method)
         if not exists:
             raise ValueError(

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1440,7 +1440,7 @@ def longest_contiguous_ones(x):
 
 @cbook.deprecated('2.2')
 def longest_ones(x):
-    '''alias for longest_contiguous_ones'''
+    '''Alias for longest_contiguous_ones.'''
     return longest_contiguous_ones(x)
 
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1253,7 +1253,7 @@ class Text(Artist):
 
     def set_fontname(self, fontname):
         """
-        alias for `.set_family`
+        Alias for `.set_family`.
 
         One-way alias only: the getter differs.
 


### PR DESCRIPTION
## PR Summary

Make alias docstrings conform with the formatting conventions:

- Start with a capital letter.
- Finish with a period.
