### PR TITLE
Increase the width of property tables in class docs

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -685,6 +685,14 @@ dl.class p.rubric + table.docutils td:first-of-type > strong {
     background-color: #eff3f4;
 }
 
+/* tables inside class descriptions */
+dl.class table.property-table {
+    width: 85%;
+    border-spacing: 2px;
+    border-collapse: collapse;
+    border: 0px;
+}
+
 /* tables inside parameter descriptions */
 td.field-body table.property-table {
     width: 100%;


### PR DESCRIPTION
## PR Summary

The current property tables in class definitions are quite narrow. This leads to a lot of wrapping:

(before)
![grafik](https://user-images.githubusercontent.com/2836374/44551460-81ea9e00-a727-11e8-95d9-c5ee76ef94fd.png)

This patch increase the table width:

(after):
![grafik](https://user-images.githubusercontent.com/2836374/44551579-ea397f80-a727-11e8-82d0-59267a12f699.png)
