### PR TITLE
Update doc/conf.py to avoid warnings with (future) sphinx 1.8.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,7 +37,6 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'numpydoc',  # Needs to be loaded *after* autodoc.
     'sphinx_gallery.gen_gallery',
-    'matplotlib.sphinxext.mathmpl',
     'matplotlib.sphinxext.plot_directive',
     'sphinxext.custom_roles',
     'sphinxext.github',
@@ -45,6 +44,8 @@ extensions = [
     'sphinxext.mock_gui_toolkits',
     'sphinxext.skip_deprecated',
 ]
+if sphinx.version_info < (1, 8):
+    extensions.append('matplotlib.sphinxext.mathmpl')
 
 exclude_patterns = ['api/api_changes/*', 'users/whats_new/*']
 
@@ -84,7 +85,10 @@ if shutil.which('dot') is None:
 autosummary_generate = True
 
 autodoc_docstring_signature = True
-autodoc_default_flags = ['members', 'undoc-members']
+if sphinx.version_info < (1, 8):
+    autodoc_default_flags = ['members', 'undoc-members']
+else:
+    autodoc_default_options = {'members': None, 'undoc-members': None}
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),

--- a/doc/sphinxext/github.py
+++ b/doc/sphinxext/github.py
@@ -75,7 +75,6 @@ def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]
     app = inliner.document.settings.env.app
-    #app.info('issue %r' % text)
     if 'pull' in name.lower():
         category = 'pull'
     elif 'issue' in name.lower():
@@ -105,7 +104,6 @@ def ghuser_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param content: The directive content for customization.
     """
     app = inliner.document.settings.env.app
-    #app.info('user link %r' % text)
     ref = 'https://www.github.com/' + text
     node = nodes.reference(rawtext, text, refuri=ref, **options)
     return [node], []
@@ -126,7 +124,6 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param content: The directive content for customization.
     """
     app = inliner.document.settings.env.app
-    #app.info('user link %r' % text)
     try:
         base = app.config.github_project_url
         if not base:
@@ -146,7 +143,6 @@ def setup(app):
 
     :param app: Sphinx application context.
     """
-    app.info('Initializing GitHub plugin')
     app.add_role('ghissue', ghissue_role)
     app.add_role('ghpull', ghissue_role)
     app.add_role('ghuser', ghuser_role)


### PR DESCRIPTION
- sphinx 1.8 activates math by default; don't use mathmpl in that case
  (to avoid a duplicate-role warning) (mathmpl may be later deprecated
  once we depend on sphinx 1.8 for the doc build)
  https://github.com/sphinx-doc/sphinx/pull/4975
- sphinx 1.8 introduced autodoc_default_options to replace
  autodoc_default_flags
  https://github.com/sphinx-doc/sphinx/pull/5315
- sphinx 1.6 deprecated app.info in favor of a logging API, but we don't
  really need either anyways
  http://www.sphinx-doc.org/en/master/changes.html#id52

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
