### PR TITLE
Suppress the "non-GUI backend" warning from the .. plot:: directive...

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -156,6 +156,7 @@ import sphinx
 import jinja2  # Sphinx dependency.
 
 import matplotlib
+from matplotlib.backend_bases import FigureManagerBase
 try:
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("error", UserWarning)
@@ -491,9 +492,13 @@ def run_code(code, code_path, ns=None, function_name=None):
                     exec(str(setup.config.plot_pre_code), ns)
             if "__main__" in code:
                 ns['__name__'] = '__main__'
-            exec(code, ns)
-            if function_name is not None:
-                exec(function_name + "()", ns)
+
+            # Patch out non-interactive show() to avoid triggering a warning.
+            with cbook._setattr_cm(FigureManagerBase, show=lambda self: None):
+                exec(code, ns)
+                if function_name is not None:
+                    exec(function_name + "()", ns)
+
         except (Exception, SystemExit) as err:
             raise PlotError(traceback.format_exc())
         finally:

--- a/lib/matplotlib/sphinxext/tests/test_tinypages.py
+++ b/lib/matplotlib/sphinxext/tests/test_tinypages.py
@@ -19,11 +19,13 @@ def test_tinypages(tmpdir):
     # Build the pages with warnings turned into errors
     cmd = [sys.executable, '-msphinx', '-W', '-b', 'html', '-d', doctree_dir,
            pjoin(dirname(__file__), 'tinypages'), html_dir]
-    proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = proc.communicate()
     assert proc.returncode == 0, \
-        "'{} -msphinx' failed with stdout:\n{}\nstderr:\n{}\n".format(
-            sys.executable, out, err)
+        "sphinx build failed with stdout:\n{}\nstderr:\n{}\n".format(out, err)
+    if err:
+        pytest.fail("sphinx build emitted the following warnings:\n{}"
+                    .format(err))
 
     assert isdir(html_dir)
 


### PR DESCRIPTION
... when the example file contains a call to `show()` (the
examples are always run with the agg backend).  To do so, patch
FigureManagerBase.show to be a no-op when running the example.

Also modified a test to check for this behavior.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
