### PR TITLE
Improve alias signatures

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1915,6 +1915,7 @@ def _define_aliases(alias_d, cls=None):
         return functools.partial(_define_aliases, alias_d)
 
     def make_alias(name):  # Enforce a closure over *name*.
+        @functools.wraps(getattr(cls, name))
         def method(self, *args, **kwargs):
             return getattr(self, name)(*args, **kwargs)
         return method


### PR DESCRIPTION
## PR Summary

Until now, all alias methods had the signature `*args, **kwargs`. This is not very helpful as it's unclear which arguments are expected (well, usually none for getters and one for setters, but the alias method does not tell).

This PR uses inspect to copy the signatures of the original functions to the alias.

### Example setter
before:
![grafik](https://user-images.githubusercontent.com/2836374/44627292-aca54400-a92b-11e8-9319-d29b973512d5.png)

now:
![grafik](https://user-images.githubusercontent.com/2836374/44627288-8b445800-a92b-11e8-99a7-5148378674f2.png)

### Example getter
before:
![grafik](https://user-images.githubusercontent.com/2836374/44627307-d2324d80-a92b-11e8-9022-cf164a36d5b4.png)

now:
![grafik](https://user-images.githubusercontent.com/2836374/44627312-e24a2d00-a92b-11e8-8f2f-4e530c44856b.png)

