### PR TITLE
Do not use aliases of properties in internal code

### DIFF
--- a/examples/axes_grid1/demo_axes_rgb.py
+++ b/examples/axes_grid1/demo_axes_rgb.py
@@ -79,8 +79,8 @@ def demo_rgb2():
         for sp1 in ax1.spines.values():
             sp1.set_color("w")
         for tick in ax1.xaxis.get_major_ticks() + ax1.yaxis.get_major_ticks():
-            tick.tick1line.set_mec("w")
-            tick.tick2line.set_mec("w")
+            tick.tick1line.set_markeredgecolor("w")
+            tick.tick2line.set_markeredgecolor("w")
 
     return ax
 

--- a/examples/misc/svg_filter_pie.py
+++ b/examples/misc/svg_filter_pie.py
@@ -31,7 +31,7 @@ for w in pies[0]:
     w.set_gid(w.get_label())
 
     # we don't want to draw the edge of the pie
-    w.set_ec("none")
+    w.set_edgecolor("none")
 
 for w in pies[0]:
     # create shadow patch

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -683,7 +683,7 @@ class RendererPgf(RendererBase):
         if mtext and (
                 (angle == 0 or
                  mtext.get_rotation_mode() == "anchor") and
-                mtext.get_va() != "center_baseline"):
+                mtext.get_verticalalignment() != "center_baseline"):
             # if text anchoring can be supported, get the original coordinates
             # and add alignment information
             pos = mtext.get_unitless_position()
@@ -694,8 +694,8 @@ class RendererPgf(RendererBase):
             halign = {"left": "left", "right": "right", "center": ""}
             valign = {"top": "top", "bottom": "bottom",
                       "baseline": "base", "center": ""}
-            text_args.append(halign[mtext.get_ha()])
-            text_args.append(valign[mtext.get_va()])
+            text_args.append(halign[mtext.get_horizontalalignment()])
+            text_args.append(valign[mtext.get_verticalalignment()])
         else:
             # if not, use the text layout provided by matplotlib
             text_args.append("x=%fin" % (x * f))

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -691,7 +691,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
     def get_edgecolor(self):
         if cbook._str_equal(self._edgecolors, 'face'):
-            return self.get_facecolors()
+            return self.get_facecolor()
         else:
             return self._edgecolors
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -368,7 +368,7 @@ class Figure(Artist):
             xy=(0, 0), width=1, height=1,
             facecolor=facecolor, edgecolor=edgecolor, linewidth=linewidth)
         self._set_artist_props(self.patch)
-        self.patch.set_aa(False)
+        self.patch.set_antialiased(False)
 
         self.canvas = None
         self._suptitle = None

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -631,8 +631,8 @@ class RadialTick(maxis.YTick):
             text_angle = user_angle
         if self.label1On:
             if full:
-                ha = self.label1.get_ha()
-                va = self.label1.get_va()
+                ha = self.label1.get_horizontalalignment()
+                va = self.label1.get_verticalalignment()
             else:
                 ha, va = self._determine_anchor(mode, angle, direction > 0)
             self.label1.set_ha(ha)

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -463,8 +463,8 @@ def test_shadow(fig_test, fig_ref):
     rect = mpatches.Rectangle(xy=xy, width=.5, height=.5)
     shadow = mpatches.Rectangle(
         xy=xy + fig_ref.dpi / 72 * dxy, width=.5, height=.5,
-        fc=np.asarray(mcolors.to_rgb(rect.get_fc())) * .3,
-        ec=np.asarray(mcolors.to_rgb(rect.get_fc())) * .3,
+        fc=np.asarray(mcolors.to_rgb(rect.get_facecolor())) * .3,
+        ec=np.asarray(mcolors.to_rgb(rect.get_facecolor())) * .3,
         alpha=.5)
     a2.add_patch(shadow)
     a2.add_patch(rect)

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -536,12 +536,12 @@ class ColorbarBase(cm.ScalarMappable):
 
         if self.extend in ["min", "both"]:
             cc = self.to_rgba([C[0][0]])
-            self.extension_patch1.set_fc(cc[0])
+            self.extension_patch1.set_facecolor(cc[0])
             X, Y, C = X[1:], Y[1:], C[1:]
 
         if self.extend in ["max", "both"]:
             cc = self.to_rgba([C[-1][0]])
-            self.extension_patch2.set_fc(cc[0])
+            self.extension_patch2.set_facecolor(cc[0])
             X, Y, C = X[:-1], Y[:-1], C[:-1]
 
         if self.orientation == 'vertical':


### PR DESCRIPTION
## PR Summary

This PR replaces most uses of property alias getters and setters in the matplotlib codebase.

Aliased property getters and setters are slightly slower and less readable than the original names. We shouldn't use them neither in the library code nor in the examples.

Basically, the use of aliases is only reasonable for property keyword arguments to keep the function call shorter and in interactive use to reduce the amount of typing.
