### PR TITLE
Fix test_large_subscript_title()

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -517,12 +517,12 @@ def test_annotation_update():
 def test_large_subscript_title():
     fig, axs = plt.subplots(1, 2, figsize=(9, 2.5), constrained_layout=True)
     ax = axs[0]
-    ax.set_title('$\sum_{i} x_i$')
+    ax.set_title(r'$\sum_{i} x_i$')
     ax.set_title('New way', loc='left')
     ax.set_xticklabels('')
 
     ax = axs[1]
-    tt = ax.set_title('$\sum_{i} x_i$')
+    tt = ax.set_title(r'$\sum_{i} x_i$')
     x, y = tt.get_position()
     tt.set_position((x, 1.01))
     ax.set_title('Old Way', loc='left')


### PR DESCRIPTION
## PR Summary

When running the test suite locally, pytest failed in `test_large_subscript_title()` because it contains two strings with unescaped backslashes.

This PR fixes the issue by turning them into raw strings (as is already the case for other strings in that test module).

Not sure, why CI did not stumble over the issue.