### PR TITLE
Deprecate Artist.aname and Axes.aname

### DIFF
--- a/doc/api/next_api_changes/2018-07-22-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-07-22-AL-deprecations.rst
@@ -5,3 +5,6 @@ Support for custom backends that do not provide a ``set_hatch_color`` method is
 deprecated.  We suggest that custom backends let their ``GraphicsContext``
 class inherit from `GraphicsContextBase`, to at least provide stubs for all
 required methods.
+
+The fields ``Artist.aname`` and ``Axes.aname`` are deprecated. Please use
+``isinstance()`` or ``__class__.__name__`` checks instead.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -71,8 +71,11 @@ class Artist(object):
     Abstract base class for someone who renders into a
     :class:`FigureCanvas`.
     """
+    @property
+    @cbook.deprecated("3.1")
+    def aname(self):
+        return 'Artist'
 
-    aname = 'Artist'
     zorder = 0
     # order of precedence when bulk setting/updating properties
     # via update.  The keys should be property names and the values

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -131,7 +131,10 @@ class Axes(_AxesBase):
     """
     ### Labelling, legend and texts
 
-    aname = 'Axes'
+    @property
+    @cbook.deprecated("3.1")
+    def aname(self):
+        return 'Axes'
 
     def get_title(self, loc="center"):
         """


### PR DESCRIPTION
## PR Summary

The field `aname` seems completely unused. It's information can also determined from the class via `isinstance()` checks or `__class__.__name__`.

The field should finally be removed. This PR deprecates the field, just in case any user is relying on it.

The field is turned into a property so that a deprecation warning is issued on access. I've refrained from creating a property setter, because I cannot imagine any real-world usecase that would want to set this to another value.