### PR TITLE
Minor fixes to docs and gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,13 +67,13 @@ doc/tutorials
 doc/modules
 doc/pyplots/tex_demo.png
 lib/dateutil
+examples/*/*.eps
 examples/*/*.pdf
 examples/*/*.png
 examples/*/*.svg
-examples/*/*.eps
 examples/*/*.svgz
 examples/tests/*
-!examples/tests/backend_driver.py
+!examples/tests/backend_driver_sgskip.py
 result_images
 
 # Nose/Pytest generated files #

--- a/doc/_templates/autosummary.rst
+++ b/doc/_templates/autosummary.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ fullname | escape | underline }}
 
 
 .. currentmodule:: {{ module }}

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -400,8 +400,8 @@ def inset_axes(parent_axes, width, height, loc='upper right',
     creates in inset axes in the lower left corner of *parent_axes* which spans
     over 30%% in height and 40%% in width of the *parent_axes*. Since the usage
     of `.inset_axes` may become slightly tricky when exceeding such standard
-    cases, it is recommended to read
-    :ref:`the examples <sphx_glr_gallery_axes_grid1_inset_locator_demo.py>`.
+    cases, it is recommended to read :doc:`the examples
+    </gallery/axes_grid1/inset_locator_demo>`.
 
     Notes
     -----
@@ -540,7 +540,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
                       borderpad=0.5):
     """
     Create an anchored inset axes by scaling a parent axes. For usage, also see
-    :ref:`the examples <sphx_glr_gallery_axes_grid1_inset_locator_demo2.py>`.
+    :doc:`the examples </gallery/axes_grid1/inset_locator_demo2>`.
 
     Parameters
     ----------


### PR DESCRIPTION
- Replace sphx_glr_ ref by :doc: (see #11312).
- Fix name of backend_driver_sgskip in gitignore (the file was not
  ignored anyways because git kept track of the rename to _sgskip, but
  it's a bit confusing to exclude a non-existing file from the
  gitignore...)

Factored out as the noncontroversial (hopefully) parts of #11936.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
