### PR TITLE
FIX: fix importing backend with non-ascii characters

### DIFF
--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -12,10 +12,11 @@ import logging
 _log = logging.getLogger(__name__)
 
 backend = matplotlib.get_backend()
-_backend_loading_tb = "".join(
+# the `str` calls here are to make non-ascii paths work on python2
+_backend_loading_tb = str("").join(
     line for line in traceback.format_stack()
     # Filter out line noise from importlib line.
-    if not line.startswith('  File "<frozen importlib._bootstrap'))
+    if not line.startswith(str('  File "<frozen importlib._bootstrap')))
 
 
 def pylab_setup(name=None):


### PR DESCRIPTION
The issue is that the lines coming out of `traceback.format_stack()`
are bytes (aka python2 str).  This file uses `unicode_literals` so
the string literals are unicode.  If any of the paths in the stack
have non-ascii we get UnicodeDecode exceptions when trying to convert
the byte strings to unicode with ascii.

The `str` calls will have no effect on python3 and down-cast the
unicode to bytes so the operations will work.

A better fix would be to sort out what encoding the bytes from
`format_stack` are in and convert them to unicode, but this is simpler
and is unlikely to make things worse than they were.

closes #11955

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
