### PR TITLE
Remove unused code

### DIFF
--- a/examples/lines_bars_and_markers/line_styles_reference.py
+++ b/examples/lines_bars_and_markers/line_styles_reference.py
@@ -6,7 +6,6 @@ Line-style reference
 Reference for line-styles included with Matplotlib.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
 
 

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -49,8 +49,6 @@ import numpy as np
 import logging
 import warnings
 
-from matplotlib.legend import Legend
-import matplotlib.transforms as transforms
 import matplotlib._layoutbox as layoutbox
 
 _log = logging.getLogger(__name__)

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -19,7 +19,6 @@ import itertools
 import kiwisolver as kiwi
 import logging
 import numpy as np
-import warnings
 
 import matplotlib
 

--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -4,7 +4,6 @@ Manage figures for pyplot interface.
 
 import atexit
 import gc
-import sys
 
 
 class Gcf(object):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -33,9 +33,7 @@ import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
-from matplotlib.cbook import (
-    MatplotlibDeprecationWarning, warn_deprecated, STEP_LOOKUP_MAP, iterable,
-    safe_first_element)
+from matplotlib.cbook import iterable
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
 from matplotlib.axes._base import _AxesBase, _process_plot_format
 
@@ -566,9 +564,6 @@ class Axes(_AxesBase):
 
         if inset_ax is not None:
             # want to connect the indicator to the rect....
-
-            pos = inset_ax.get_position()  # this is in fig-fraction.
-            coordsA = 'axes fraction'
             connects = []
             xr = [bounds[0], bounds[0]+bounds[2]]
             yr = [bounds[1], bounds[1]+bounds[3]]
@@ -3185,7 +3180,7 @@ class Axes(_AxesBase):
             # being accepted, when the user meant the 2xN transpose.
             # special case for empty lists
             if len(err) > 1:
-                fe = safe_first_element(err)
+                fe = cbook.safe_first_element(err)
                 if len(err) != len(data) or np.size(fe) > 1:
                     raise ValueError("err must be [ scalar | N, Nx1 "
                                      "or 2xN array-like ]")
@@ -5047,7 +5042,7 @@ class Axes(_AxesBase):
             y1slice = y1[ind0:ind1]
             y2slice = y2[ind0:ind1]
             if step is not None:
-                step_func = STEP_LOOKUP_MAP["steps-" + step]
+                step_func = cbook.STEP_LOOKUP_MAP["steps-" + step]
                 xslice, y1slice, y2slice = step_func(xslice, y1slice, y2slice)
 
             if not len(xslice):
@@ -5230,7 +5225,7 @@ class Axes(_AxesBase):
             x1slice = x1[ind0:ind1]
             x2slice = x2[ind0:ind1]
             if step is not None:
-                step_func = STEP_LOOKUP_MAP["steps-" + step]
+                step_func = cbook.STEP_LOOKUP_MAP["steps-" + step]
                 yslice, x1slice, x2slice = step_func(yslice, x1slice, x2slice)
 
             if not len(yslice):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -27,9 +27,7 @@ import matplotlib.spines as mspines
 import matplotlib.font_manager as font_manager
 import matplotlib.text as mtext
 import matplotlib.image as mimage
-from matplotlib.offsetbox import OffsetBox
 from matplotlib.artist import allow_rasterization
-from matplotlib.legend import Legend
 
 from matplotlib.rcsetup import cycler, validate_axisbelow
 

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -1,5 +1,4 @@
 import functools
-import warnings
 
 from matplotlib import docstring
 import matplotlib.artist as martist

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -47,7 +47,7 @@ from matplotlib import (
     backend_tools as tools, cbook, colors, textpath, tight_bbox, transforms,
     widgets, get_backend, is_interactive, rcParams)
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
+from matplotlib.transforms import Affine2D
 from matplotlib.path import Path
 
 try:

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -8,7 +8,6 @@ This backend depends on cairocffi or pycairo.
 
 import copy
 import gzip
-import sys
 import warnings
 
 import numpy as np

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -1,9 +1,6 @@
-import sys
-
 import numpy as np
 
 from . import backend_agg, backend_cairo, backend_gtk3
-from ._gtk3_compat import gi
 from .backend_cairo import cairo
 from .backend_gtk3 import Gtk, _BackendGTK3
 from matplotlib import transforms

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -1,5 +1,4 @@
 from . import backend_cairo, backend_gtk3
-from ._gtk3_compat import gi
 from .backend_gtk3 import Gtk, _BackendGTK3
 from matplotlib.backend_bases import cursors
 

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -6,7 +6,6 @@
 from base64 import b64encode
 import io
 import json
-import os
 import pathlib
 import uuid
 
@@ -18,7 +17,7 @@ except ImportError:
     # Jupyter/IPython 3.x or earlier
     from IPython.kernel.comm import Comm
 
-from matplotlib import rcParams, is_interactive
+from matplotlib import is_interactive
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, NavigationToolbar2)

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -27,8 +27,7 @@ from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
     RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
-from matplotlib.cbook import (get_realpath_and_stat,
-                              is_writable_file_like, maxdict)
+from matplotlib.cbook import get_realpath_and_stat, maxdict
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, is_opentype_cff_font, get_font
 from matplotlib.afm import AFM
@@ -1999,7 +1998,6 @@ class RendererPdf(RendererBase):
 
         if rcParams['pdf.use14corefonts']:
             font = self._get_font_afm(prop)
-            l, b, w, h = font.get_str_bbox(s)
             fonttype = 1
         else:
             font = self._get_font_ttf(prop)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -12,7 +12,6 @@ import pathlib
 import re
 import shutil
 import subprocess
-import sys
 from tempfile import TemporaryDirectory
 import time
 

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager
 import errno
 from io import BytesIO
 import json
-import os
 from pathlib import Path
 import random
 import sys

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -11,8 +11,6 @@ line segemnts)
 
 import math
 from numbers import Number
-import warnings
-
 import numpy as np
 
 import matplotlib as mpl

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1218,10 +1218,6 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         Determine the contour levels and store in self.levels.
         """
-        if self.filled:
-            fn = 'contourf'
-        else:
-            fn = 'contour'
         self._auto = False
         if self.levels is None:
             if len(args) == 0:

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -29,7 +29,7 @@ import textwrap
 
 import numpy as np
 
-from matplotlib import cbook, rcParams
+from matplotlib import rcParams
 
 _log = logging.getLogger(__name__)
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1927,7 +1927,6 @@ default: 'top'
         restore_to_pylab = state.pop('_restore_to_pylab', False)
 
         if version != _mpl_version:
-            import warnings
             warnings.warn("This figure was saved with matplotlib version %s "
                           "and is unlikely to function correctly." %
                           (version, ))
@@ -2489,7 +2488,6 @@ default: 'top'
             _log.debug(' Working on: %s', ax.get_ylabel())
             ss = ax.get_subplotspec()
             nrows, ncols, row0, row1, col0, col1 = ss.get_rows_columns()
-            same = [ax]
             labpo = ax.yaxis.get_label_position()  # left or right
             # loop through other axes, and search for label positions
             # that are same as this one, and that share the appropriate

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -30,7 +30,6 @@ from matplotlib import rcParams
 from matplotlib import docstring
 from matplotlib.artist import Artist, allow_rasterization
 from matplotlib.cbook import silent_list, is_hashable, warn_deprecated
-import matplotlib.colors as colors
 from matplotlib.font_manager import FontProperties
 from matplotlib.lines import Line2D
 from matplotlib.patches import Patch, Rectangle, Shadow, FancyBboxPatch

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -16,7 +16,7 @@ from .cbook import (
     STEP_LOOKUP_MAP)
 from .markers import MarkerStyle
 from .path import Path
-from .transforms import Bbox, TransformedPath, IdentityTransform
+from .transforms import Bbox, TransformedPath
 
 # Imported here for backward compatibility, even though they don't
 # really belong.

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1718,7 +1718,6 @@ def rk4(derivs, y0, t):
         yout = np.zeros((len(t), Ny), float)
 
     yout[0] = y0
-    i = 0
 
     for i in np.arange(len(t)-1):
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -511,10 +511,6 @@ class Patch(artist.Artist):
         gc.set_url(self._url)
         gc.set_snap(self.get_snap())
 
-        rgbFace = self._facecolor
-        if rgbFace[3] == 0:
-            rgbFace = None  # (some?) renderers expect this as no-fill signal
-
         gc.set_alpha(self._alpha)
 
         if self._hatch:

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -5,8 +5,6 @@ import numpy as np
 
 from matplotlib.axes import Axes
 import matplotlib.axis as maxis
-from matplotlib import cbook
-from matplotlib import docstring
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -18,7 +18,6 @@ from functools import reduce
 import operator
 import os
 import re
-import sys
 
 from matplotlib import cbook
 from matplotlib.cbook import ls_mapper

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -151,8 +151,6 @@ import warnings
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.images import Image
 align = Image.align
-import sphinx
-
 import jinja2  # Sphinx dependency.
 
 import matplotlib

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -642,7 +642,6 @@ def _gen_starting_points(shape):
     xlast = nx - 1
     ylast = ny - 1
     x, y = 0, 0
-    i = 0
     direction = 'right'
     for i in range(nx * ny):
 

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -42,7 +42,6 @@ from numpy.linalg import inv
 
 from matplotlib._path import (
     affine_transform, count_bboxes_overlapping_bbox, update_path_extents)
-from . import cbook
 from .path import Path
 
 DEBUG = False
@@ -2354,8 +2353,6 @@ class CompositeGenericTransform(Transform):
         self._a = a
         self._b = b
         self.set_children(a, b)
-
-    is_affine = property(lambda self: self._a.is_affine and self._b.is_affine)
 
     def frozen(self):
         self._invalid = 0

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -10,8 +10,6 @@ multiple axes at drawing time.
     object that can be used to set the axes_locator of the axes.
 """
 
-import functools
-
 import matplotlib.transforms as mtransforms
 from matplotlib import cbook
 from matplotlib.axes import SubplotBase

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -1,8 +1,6 @@
 import functools
 
-from matplotlib import (
-    artist as martist, collections as mcoll, transforms as mtransforms,
-    rcParams)
+from matplotlib import artist as martist, transforms as mtransforms
 from matplotlib.axes import subplot_class_factory
 from matplotlib.transforms import Bbox
 from .mpl_axes import Axes

--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -11,9 +11,7 @@ import numpy as np
 
 from matplotlib.transforms import Affine2D, IdentityTransform
 from . import grid_helper_curvelinear
-from .axislines import AxisArtistHelper, GridHelperBase
 from .axis_artist import AxisArtist
-from .grid_finder import GridFinder
 
 
 class FloatingAxisArtistHelper(grid_helper_curvelinear.FloatingAxisArtistHelper):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ setup.cfg.template for more information.
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
-from string import Template
 import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand

--- a/setupext.py
+++ b/setupext.py
@@ -10,7 +10,6 @@ import multiprocessing
 import os
 import pathlib
 import platform
-import re
 import shutil
 import subprocess
 import sys

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -14,7 +14,7 @@ this file.
 # analysis tools to parse.
 
 import inspect
-from inspect import Signature, Parameter
+from inspect import Parameter
 from pathlib import Path
 import textwrap
 

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -9,7 +9,6 @@ To generate a report for IPython 2.0, run:
 # Imports
 #-----------------------------------------------------------------------------
 
-import codecs
 import sys
 
 from argparse import ArgumentParser

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -52,8 +52,6 @@ clipped.
 #import matplotlib
 #matplotlib.use('Qt5Agg')
 
-import warnings
-
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib.colors as mcolors


### PR DESCRIPTION
## PR Summary

This fixes a number of lgtm alerts on useless code:
https://lgtm.com/projects/g/matplotlib/matplotlib/alerts/?mode=list&tag=useless-code

All changes are one of:
- unused imports
- unused variables
- duplicate definitions