### PR TITLE
Fix some lgtm convention alerts

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -33,7 +33,7 @@ per-file-ignores =
     matplotlib/backend_bases.py: E225
     matplotlib/backends/_backend_tk.py: E203, E222, E225, E231, E271, E301, E303, E401, E501, E701
     matplotlib/backends/backend_agg.py: E261, E302, E701
-    matplotlib/backends/backend_cairo.py: E203, E221, E261, E303, E402, E711
+    matplotlib/backends/backend_cairo.py: E203, E221, E261, E303, E402
     matplotlib/backends/backend_gtk3.py: E203, E221, E222, E225, E251, E261, E501
     matplotlib/backends/backend_pgf.py: E303, E731
     matplotlib/backends/qt_editor/formlayout.py: E301, E501
@@ -62,7 +62,7 @@ per-file-ignores =
     mpl_toolkits/axes_grid1/inset_locator.py: E501
     mpl_toolkits/axes_grid1/mpl_axes.py: E501
     mpl_toolkits/axisartist/angle_helper.py: E201, E203, E221, E222, E225, E231, E251, E261, E262, E302, E303, E501
-    mpl_toolkits/axisartist/axis_artist.py: E201, E202, E221, E225, E228, E231, E251, E261, E262, E302, E303, E402, E501, E701, E711
+    mpl_toolkits/axisartist/axis_artist.py: E201, E202, E221, E225, E228, E231, E251, E261, E262, E302, E303, E402, E501, E701
     mpl_toolkits/axisartist/axisline_style.py: E231, E261, E262, E302, E303
     mpl_toolkits/axisartist/axislines.py: E225, E231, E261, E303, E501
     mpl_toolkits/axisartist/clip_path.py: E225, E302, E303, E501

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -506,7 +506,7 @@ class GraphicsContextCairo(GraphicsContextBase):
 
     def set_dashes(self, offset, dashes):
         self._dashes = offset, dashes
-        if dashes == None:
+        if dashes is None:
             self.ctx.set_dash([], 0)  # switch dashes off
         else:
             self.ctx.set_dash(

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -128,8 +128,8 @@ OSXFontDirectories = [
     "/Network/Library/Fonts/",
     "/System/Library/Fonts/",
     # fonts installed via MacPorts
-    "/opt/local/share/fonts"
-    ""
+    "/opt/local/share/fonts",
+    "",
 ]
 
 if not USE_FONTCONFIG and sys.platform != 'win32':

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1089,7 +1089,7 @@ defaultParams = {
     'font.cursive':    [['Apple Chancery', 'Textile', 'Zapf Chancery',
                          'Sand', 'Script MT', 'Felipa', 'cursive'],
                         validate_stringlist],
-    'font.fantasy':    [['Comic Sans MS', 'Chicago', 'Charcoal', 'Impact'
+    'font.fantasy':    [['Comic Sans MS', 'Chicago', 'Charcoal', 'Impact',
                          'Western', 'Humor Sans', 'xkcd', 'fantasy'],
                         validate_stringlist],
     'font.monospace':  [['DejaVu Sans Mono', 'Bitstream Vera Sans Mono',

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -972,7 +972,7 @@ class AxisArtist(martist.Artist):
         available styles as a list of strings.
         """
 
-        if axisline_style==None:
+        if axisline_style is None:
             return AxislineStyle.pprint_styles()
 
         if isinstance(axisline_style, AxislineStyle._Base):

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -144,8 +144,7 @@ class Line3D(lines.Line2D):
         try:
             # If *zs* is a list or array, then this will fail and
             # just proceed to juggle_axes().
-            zs = float(zs)
-            zs = [zs for x in xs]
+            zs = np.full_like(xs, fill_value=float(zs))
         except TypeError:
             pass
         self._verts3d = juggle_axes(xs, ys, zs, zdir)


### PR DESCRIPTION
## PR Summary

- The missing commas are actually bugs.
- `zs = [float(zs)] * len(xs)` is just rewritten to make the intention more clear. Can we make zs a numpy array instead of a list here? If so, that can be further simplified to `np.full_like(xs, fill_value=float(zs))`.

