### PR TITLE
FIX: use cached renderer on Legend.get_window_extent

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -976,9 +976,11 @@ class Legend(Artist):
         'Return the `.Text` instance for the legend title.'
         return self._legend_title_box._text
 
-    def get_window_extent(self, *args, **kwargs):
+    def get_window_extent(self, renderer=None):
         'Return extent of the legend.'
-        return self._legend_box.get_window_extent(*args, **kwargs)
+        if renderer is None:
+            renderer = self.figure._cachedRenderer
+        return self._legend_box.get_window_extent(renderer=renderer)
 
     def get_tightbbox(self, renderer):
         """

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -510,6 +510,17 @@ def test_legend_proper_window_extent():
     assert pytest.approx(x01*2, 0.1) == x02
 
 
+def test_window_extent_cached_renderer():
+    fig, ax = plt.subplots(dpi=100)
+    ax.plot(range(10), label='Aardvark')
+    leg = ax.legend()
+    leg2 = fig.legend()
+    fig.canvas.draw()
+    # check that get_window_extent will use the cached renderer
+    leg.get_window_extent()
+    leg2.get_window_extent()
+
+
 def test_legend_title_fontsize():
     # test the title_fontsize kwarg
     fig, ax = plt.subplots()


### PR DESCRIPTION
Closes #11970

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
