### PR TITLE
Make code match comment in sankey.

### DIFF
--- a/doc/api/next_api_changes/2018-08-29-AL-sankey.rst
+++ b/doc/api/next_api_changes/2018-08-29-AL-sankey.rst
@@ -1,0 +1,9 @@
+Passing a single string as *labels* to `Sankey.add`
+```````````````````````````````````````````````````
+
+Previously, `Sankey.add` would only accept a single string as the *labels*
+argument if its length is equal to the number of flows, in which case it would
+use one character of the string for each flow.
+
+The behavior has been changed to match the documented one: when a single string
+is passed, it is used to label all the flows.

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -10,7 +10,7 @@ import numpy as np
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 from matplotlib.transforms import Affine2D
-from matplotlib import docstring
+from matplotlib import cbook, docstring
 from matplotlib import rcParams
 
 _log = logging.getLogger(__name__)
@@ -449,11 +449,8 @@ class Sankey(object):
             "orientations and flows must have the same length.\n"
             "orientations has length %d, but flows has length %d."
             % (len(orientations), n))
-        if labels != '' and getattr(labels, '__iter__', False):
-            # np.iterable() isn't used because it would give True if labels is
-            # a string
-            if len(labels) != n:
-                raise ValueError(
+        if not cbook.is_scalar_or_string(labels) and len(labels) != n:
+            raise ValueError(
                 "If labels is a list, then labels and flows must have the "
                 "same length.\nlabels has length %d, but flows has length %d."
                 % (len(labels), n))


### PR DESCRIPTION
This makes Sankey.add no longer reject a labels that's a *single*
string, consistently with what the docstring states and what the comment
just after implies.

Previously, it would only accept a single string if its length is equal
to the number of flows, in which case it would use one character
of the string for each flow.

Alternatively, we could also change the docstring and delete the comment,
but I think this behavior is more intuitive?  (Not that I ever use
Sankey, though it looks neat...)

Noted in #11959, dates all the way back since this class was added.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
