### PR TITLE
don't share axes if share_all is False

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -554,8 +554,8 @@ class ImageGrid(Grid):
                     sharex = None
                     sharey = None
             else:
-                sharex = self._column_refax[col]
-                sharey = self._row_refax[row]
+                sharex = None
+                sharey = None
 
             ax = axes_class(fig, rect, sharex=sharex, sharey=sharey,
                             **axes_class_args)


### PR DESCRIPTION
Bugfix

## PR Summary
If `share_all` is False, we should not share any axes. As it is written, in a 2x2 grid, it will share the row axis on the second cell, the column axis on the third, and both axes by the fourth. It looks like this code was copied from `class Grid`; however, that class has `share_x` and `share_y` options (along with `share_all`):

[axes_grid.py:Grid](https://github.com/matplotlib/matplotlib/blob/f68063ef3ca98410a70f042b1e3c3d45acea927e/lib/mpl_toolkits/axes_grid1/axes_grid.py#L228)

```python
if share_all:
    sharex = self._refax
    sharey = self._refax
else:
    if share_x:
       sharex = self._column_refax[col]
   else:
       sharex = None

    if share_y:
        sharey = self._row_refax[row]
    else:
        sharey = None
```

For some reason, it is the `if share_x:` and `if share_y:` code path that has been copied in ImageGrid.

[axes_grid.py:ImageGrid](https://github.com/matplotlib/matplotlib/blob/f68063ef3ca98410a70f042b1e3c3d45acea927e/lib/mpl_toolkits/axes_grid1/axes_grid.py#L549)
```python
if share_all:
    if self.axes_all:
        sharex = self.axes_all[0]
        sharey = self.axes_all[0]
    else:
        sharex = None
        sharey = None
else:
    sharex = self._column_refax[col]
    sharey = self._row_refax[row]
```

You can see this with a simple test:

```python
import matplotlib.pyplot as plt
from mpl_toolkits.axes_grid1 import ImageGrid
import numpy as np

fig = plt.figure()
a,b,c,d = np.ones((15,15))/1, np.ones((20,20))/2, np.ones((25,25))/3, np.ones((30,30))/4
grid = ImageGrid(fig, '111', nrows_ncols=(2,2), axes_pad=(0.5, 0.), share_all=False, label_mode='all')
for ax, im in zip(grid, [a,b,c,d]):
    ax.imshow(im, clim=[0,1])
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
