### PR TITLE
Remove and old keyword documentation.

### DIFF
--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -200,7 +200,6 @@ plt.show()
 # label                   any string
 # linestyle or ls         [ ``'-'`` | ``'--'`` | ``'-.'`` | ``':'`` | ``'steps'`` | ...]
 # linewidth or lw         float value in points
-# lod                     [True | False]
 # marker                  [ ``'+'`` | ``','`` | ``'.'`` | ``'1'`` | ``'2'`` | ``'3'`` | ``'4'`` ]
 # markeredgecolor or mec  any matplotlib color
 # markeredgewidth or mew  float value in points


### PR DESCRIPTION
Well this does not seem to be used anywhere, or at least nowhere that I
can find. From digging into history `lod` was short for `Level Of
Details` when artists were able to inspect the resolution of things that
were going to be rendered... for whatever reasons.

Note, even if this appear to just be a comment in source code this ends
up being exported in the docs, for example here:

https://matplotlib.org/users/pyplot_tutorial.html
