### PR TITLE
Simplify version checks for freetype and libpng.

### DIFF
--- a/src/checkdep_freetype2.c
+++ b/src/checkdep_freetype2.c
@@ -1,0 +1,13 @@
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+#define XSTR(x) STR(x)
+#define STR(x) #x
+
+#pragma message("Compiling with FreeType version " \
+  XSTR(FREETYPE_MAJOR) "." XSTR(FREETYPE_MINOR) "." XSTR(FREETYPE_PATCH) ".")
+#if FREETYPE_MAJOR << 16 + FREETYPE_MINOR << 8 + FREETYPE_PATCH < 0x020300
+    #error "FreeType version 2.3 or higher is required." \
+      "Consider setting the MPLLOCALFREETYPE environment variable to 1."
+  #error
+#endif

--- a/src/checkdep_libpng.c
+++ b/src/checkdep_libpng.c
@@ -1,0 +1,5 @@
+#include <png.h>
+#pragma message("Compiling with libpng version " PNG_LIBPNG_VER_STRING ".")
+#if PNG_LIBPNG_VER < 10200
+  #error "libpng version 1.2 or higher is required."
+#endif


### PR DESCRIPTION
Currently, setupext.py replicates a lot of work done by the compiler to
check whether header files are present, and whether freetype and libpng
have sufficiently recent versions.

Instead, we can just add a small stub source file at the top of the
extension sources which just tries to include the header and checks the
version macros.  If the header is not found, compilation will
immediately abort with `foo.h: No such file or directory`; if the
version is too old, we can emit an appropriate error message (`#pragma message`
is supported by all major compilers and allows expanding of
macros in the error message).

Work related to #9737 (the goal being to not list the include paths ourselves).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
