### PR TITLE
Remove support for ghostscript 8.60.

### DIFF
--- a/doc/api/next_api_changes/2018-08-17-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-08-17-AL-deprecations.rst
@@ -4,5 +4,6 @@ API deprecations
 The following API elements are deprecated:
 
 - ``tk_window_focus``,
+- ``backend_ps.PsBackendHelper``, ``backend_ps.ps_backend_helper``,
 - ``cbook.iterable``,
 - ``mlab.demean``,

--- a/doc/api/next_api_changes/2018-08-31-AL-gs.rst
+++ b/doc/api/next_api_changes/2018-08-31-AL-gs.rst
@@ -1,0 +1,5 @@
+Remove support for ghostscript 8.60
+```````````````````````````````````
+
+Support for ghostscript 8.60 (released in 2007) has been removed.  The oldest
+supported version of ghostscript is now 9.0 (released in 2010).

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -175,11 +175,11 @@ def compare_versions(a, b):
     "return True if a is greater than or equal to b"
     if isinstance(a, bytes):
         cbook.warn_deprecated(
-            "3.0", "compare_version arguments should be strs.")
+            "3.0", "compare_versions arguments should be strs.")
         a = a.decode('ascii')
     if isinstance(b, bytes):
         cbook.warn_deprecated(
-            "3.0", "compare_version arguments should be strs.")
+            "3.0", "compare_versions arguments should be strs.")
         b = b.decode('ascii')
     if a:
         a = distutils.version.LooseVersion(a)
@@ -445,8 +445,9 @@ def checkdep_ghostscript():
                 stdout, stderr = s.communicate()
                 if s.returncode == 0:
                     v = stdout[:-1].decode('ascii')
-                    checkdep_ghostscript.executable = gs_exec
-                    checkdep_ghostscript.version = v
+                    if compare_versions(v, '9.0'):
+                        checkdep_ghostscript.executable = gs_exec
+                        checkdep_ghostscript.version = v
             except (IndexError, ValueError, OSError):
                 pass
     return checkdep_ghostscript.executable, checkdep_ghostscript.version
@@ -492,13 +493,12 @@ def checkdep_ps_distiller(s):
         return False
 
     flag = True
-    gs_req = '8.60'
     gs_exec, gs_v = checkdep_ghostscript()
-    if not compare_versions(gs_v, gs_req):
+    if not gs_exec:
         flag = False
-        warnings.warn(('matplotlibrc ps.usedistiller option can not be used '
-                       'unless ghostscript-%s or later is installed on your '
-                       'system') % gs_req)
+        warnings.warn('matplotlibrc ps.usedistiller option can not be used '
+                      'unless ghostscript 9.0 or later is installed on your '
+                      'system')
 
     if s == 'xpdf':
         pdftops_req = '3.0'

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -47,6 +47,7 @@ class PsBackendHelper(object):
         self._cached = {}
 
     @property
+    @cbook.deprecated("3.1")
     def gs_exe(self):
         """
         executable name of ghostscript.
@@ -64,6 +65,7 @@ class PsBackendHelper(object):
         return str(gs_exe)
 
     @property
+    @cbook.deprecated("3.1")
     def gs_version(self):
         """
         version of ghostscript.
@@ -86,6 +88,7 @@ class PsBackendHelper(object):
         return gs_version
 
     @property
+    @cbook.deprecated("3.1")
     def supports_ps2write(self):
         """
         True if the installed ghostscript supports ps2write device.
@@ -1465,15 +1468,10 @@ def gs_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
     psfile = tmpfile + '.ps'
     dpi = rcParams['ps.distiller.res']
 
-    gs_exe = ps_backend_helper.gs_exe
-    if ps_backend_helper.supports_ps2write:  # gs version >= 9
-        device_name = "ps2write"
-    else:
-        device_name = "pswrite"
-
+    gs_exe, gs_version = checkdep_ghostscript()
     cbook._check_and_log_subprocess(
         [gs_exe, "-dBATCH", "-dNOPAUSE", "-r%d" % dpi,
-         "-sDEVICE=%s" % device_name, paper_option,
+         "-sDEVICE=ps2write", paper_option,
          "-sOutputFile=%s" % psfile, tmpfile], _log)
 
     os.remove(tmpfile)
@@ -1484,14 +1482,9 @@ def gs_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
     # the original bbox can be restored during the pstoeps step.
 
     if eps:
-        # For some versions of gs, above steps result in an ps file
-        # where the original bbox is no more correct. Do not adjust
-        # bbox for now.
-        if ps_backend_helper.supports_ps2write:
-            # fo gs version >= 9 w/ ps2write device
-            pstoeps(tmpfile, bbox, rotated=rotated)
-        else:
-            pstoeps(tmpfile)
+        # For some versions of gs, above steps result in an ps file where the
+        # original bbox is no more correct. Do not adjust bbox for now.
+        pstoeps(tmpfile, bbox, rotated=rotated)
 
 
 def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):


### PR DESCRIPTION
Support for ghostscript 8.60 (released in 2007) has been removed.  The
oldest supported version of ghostscript is now 9.0 (released in 2010).

(Allows removing some conditional paths and unifying the version checks
to a single place, as we previously needed to handle gs<9 differently
from gs>=9.)

Extracted from #9639.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
