### PR TITLE
Use pytest.warns instead of home-baked warnings capture.

### DIFF
--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -282,12 +282,12 @@ class TestLegendFunction(object):
         th = np.linspace(0, 2*np.pi, 1024)
         lns, = ax.plot(th, np.sin(th), label='sin', lw=5)
         lnc, = ax.plot(th, np.cos(th), label='cos', lw=5)
-        with mock.patch('warnings.warn') as warn:
+        with pytest.warns(UserWarning) as record:
             ax.legend((lnc, lns), labels=('a', 'b'))
-
-        warn.assert_called_with("You have mixed positional and keyword "
-                                "arguments, some input may be "
-                                "discarded.")
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "You have mixed positional and keyword arguments, some input may "
+            "be discarded.")
 
     def test_parasite(self):
         from mpl_toolkits.axes_grid1 import host_subplot
@@ -356,11 +356,12 @@ class TestLegendFigureFunction(object):
         fig, axs = plt.subplots(1, 2)
         lines = axs[0].plot(range(10))
         lines2 = axs[1].plot(np.arange(10) * 2.)
-        with mock.patch('warnings.warn') as warn:
+        with pytest.warns(UserWarning) as record:
             fig.legend((lines, lines2), labels=('a', 'b'))
-        warn.assert_called_with("You have mixed positional and keyword "
-                                "arguments, some input may be "
-                                "discarded.")
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "You have mixed positional and keyword arguments, some input may "
+            "be discarded.")
 
 
 @image_comparison(baseline_images=['legend_stackplot'], extensions=['png'])


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
