### PR TITLE
DOC: fixed typos

### DIFF
--- a/doc/devel/gitwash/set_up_fork.rst
+++ b/doc/devel/gitwash/set_up_fork.rst
@@ -56,7 +56,7 @@ Linking your repository to the upstream repo
 main `Matplotlib`_ repository at `Matplotlib github`_.
 
 Note that we've used ``git://`` for the URL rather than ``https://`` or ``git@``.  The
-``git://`` URL is read only.  This means we that we can't accidentally
+``git://`` URL is read only.  This means that we can't accidentally
 (or deliberately) write to the upstream repo, and we are only going to
 use it to merge into our own code.
 

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -125,7 +125,7 @@ these up; there is no need to do anything further.
 Random data in tests
 --------------------
 
-Random data can is a very convenient way to generate data for examples,
+Random data is a very convenient way to generate data for examples,
 however the randomness is problematic for testing (as the tests
 must be deterministic!).  To work around this set the seed in each test.
 For numpy use::


### PR DESCRIPTION
## PR Summary

2 typos fixes in documentation.

While reading the contribution documentation, I found 2 typos. 
I thought fixing them is a good opportunity to practice the contribution process.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

