### PR TITLE
No clf() needed after creating a figure

### DIFF
--- a/examples/axisartist/demo_axis_direction.py
+++ b/examples/axisartist/demo_axis_direction.py
@@ -74,7 +74,6 @@ def add_floating_axis2(ax1):
 
 
 fig = plt.figure(figsize=(8, 4))
-fig.clf()
 fig.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.99,
                     wspace=0.01, hspace=0.01)
 

--- a/examples/axisartist/demo_curvelinear_grid.py
+++ b/examples/axisartist/demo_curvelinear_grid.py
@@ -130,9 +130,9 @@ def curvelinear_test2(fig):
 
     ax1.grid(True, zorder=0)
 
+
 if 1:
     fig = plt.figure(figsize=(7, 4))
-    fig.clf()
 
     curvelinear_test1(fig)
     curvelinear_test2(fig)

--- a/examples/axisartist/demo_curvelinear_grid2.py
+++ b/examples/axisartist/demo_curvelinear_grid2.py
@@ -66,7 +66,5 @@ def curvelinear_test1(fig):
 
 if 1:
     fig = plt.figure(figsize=(7, 4))
-    fig.clf()
-
     curvelinear_test1(fig)
     plt.show()

--- a/examples/axisartist/demo_floating_axis.py
+++ b/examples/axisartist/demo_floating_axis.py
@@ -64,9 +64,7 @@ def curvelinear_test2(fig):
 
     ax1.grid(True)
 
+
 fig = plt.figure(figsize=(5, 5))
-fig.clf()
-
 curvelinear_test2(fig)
-
 plt.show()

--- a/examples/axisartist/simple_axis_pad.py
+++ b/examples/axisartist/simple_axis_pad.py
@@ -74,7 +74,6 @@ def add_floating_axis2(ax1):
 
 
 fig = plt.figure(figsize=(9, 3.))
-fig.clf()
 fig.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.99,
                     wspace=0.01, hspace=0.01)
 

--- a/examples/text_labels_and_annotations/demo_text_rotation_mode.py
+++ b/examples/text_labels_and_annotations/demo_text_rotation_mode.py
@@ -45,8 +45,6 @@ def test_rotation_mode(fig, mode, subplot_location):
 if 1:
     import matplotlib.pyplot as plt
     fig = plt.figure(figsize=(5.5, 4))
-    fig.clf()
-
     test_rotation_mode(fig, "default", 121)
     test_rotation_mode(fig, "anchor", 122)
     plt.show()

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1753,7 +1753,6 @@ class DraggableAnnotation(DraggableBase):
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
     fig = plt.figure()
-    fig.clf()
     ax = plt.subplot(121)
 
     #txt = ax.text(0.5, 0.5, "Test", size=30, ha="center", color="w")

--- a/lib/mpl_toolkits/tests/test_axisartist_floating_axes.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_floating_axes.py
@@ -14,8 +14,6 @@ from mpl_toolkits.axisartist import angle_helper
 
 def test_subplot():
     fig = plt.figure(figsize=(5, 5))
-    fig.clf()
-
     ax = Subplot(fig, 111)
     fig.add_subplot(ax)
 
@@ -24,7 +22,6 @@ def test_subplot():
                   extensions=['png'], style='default', tol=0.01)
 def test_curvelinear3():
     fig = plt.figure(figsize=(5, 5))
-    fig.clf()
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
           mprojections.PolarAxes.PolarTransform())
@@ -80,7 +77,6 @@ def test_curvelinear3():
                   extensions=['png'], style='default', tol=0.015)
 def test_curvelinear4():
     fig = plt.figure(figsize=(5, 5))
-    fig.clf()
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
           mprojections.PolarAxes.PolarTransform())


### PR DESCRIPTION
## PR Summary

AFAIK `fig.clf()` does nothing on a freshly created figure. So clearing a freshly created figure is bad style and we shouldn't do it.