### PR TITLE
Improve layout of Fill Betweenx Demo

### DIFF
--- a/examples/lines_bars_and_markers/fill_betweenx_demo.py
+++ b/examples/lines_bars_and_markers/fill_betweenx_demo.py
@@ -3,7 +3,8 @@
 Fill Betweenx Demo
 ==================
 
-Using ``fill_betweenx`` to color between two horizontal curves.
+Using `~.Axes.fill_betweenx` to color along the horizontal direction between
+two curves.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,35 +14,35 @@ y = np.arange(0.0, 2, 0.01)
 x1 = np.sin(2 * np.pi * y)
 x2 = 1.2 * np.sin(4 * np.pi * y)
 
-fig, [ax1, ax2, ax3] = plt.subplots(3, 1, sharex=True)
+fig, [ax1, ax2, ax3] = plt.subplots(1, 3, sharey=True, figsize=(6, 6))
 
 ax1.fill_betweenx(y, 0, x1)
-ax1.set_ylabel('(x1, 0)')
+ax1.set_title('between (x1, 0)')
 
 ax2.fill_betweenx(y, x1, 1)
-ax2.set_ylabel('(x1, 1)')
+ax2.set_title('between (x1, 1)')
+ax2.set_xlabel('x')
 
 ax3.fill_betweenx(y, x1, x2)
-ax3.set_ylabel('(x1, x2)')
-ax3.set_xlabel('x')
+ax3.set_title('between (x1, x2)')
 
 # now fill between x1 and x2 where a logical condition is met.  Note
 # this is different than calling
 #   fill_between(y[where], x1[where], x2[where])
 # because of edge effects over multiple contiguous regions.
 
-fig, [ax, ax1] = plt.subplots(2, 1, sharex=True)
+fig, [ax, ax1] = plt.subplots(1, 2, sharey=True, figsize=(6, 6))
 ax.plot(x1, y, x2, y, color='black')
 ax.fill_betweenx(y, x1, x2, where=x2 >= x1, facecolor='green')
 ax.fill_betweenx(y, x1, x2, where=x2 <= x1, facecolor='red')
-ax.set_title('fill between where')
+ax.set_title('fill_betweenx where')
 
 # Test support for masked arrays.
 x2 = np.ma.masked_greater(x2, 1.0)
 ax1.plot(x1, y, x2, y, color='black')
 ax1.fill_betweenx(y, x1, x2, where=x2 >= x1, facecolor='green')
 ax1.fill_betweenx(y, x1, x2, where=x2 <= x1, facecolor='red')
-ax1.set_title('Now regions with x2 > 1 are masked')
+ax1.set_title('regions with x2 > 1 are masked')
 
 # This example illustrates a problem; because of the data
 # gridding, there are undesired unfilled triangles at the crossover


### PR DESCRIPTION
## PR Summary

The layout of the [Fill Betweenx Demo](https://matplotlib.org/gallery/lines_bars_and_markers/fill_betweenx_demo.html#sphx-glr-gallery-lines-bars-and-markers-fill-betweenx-demo-py) is a bit cramped.

This PR fixes this by changing from a row layout to a column layout. It includes some minor text cleanup as well.

[New layout](https://13049-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/lines_bars_and_markers/fill_betweenx_demo.html?highlight=fill%20betweenx%20demo)