### PR TITLE
Do not use an explicit figum in plt.figure(1, ...) in simple cases

### DIFF
--- a/examples/axes_grid1/demo_axes_divider.py
+++ b/examples/axes_grid1/demo_axes_divider.py
@@ -26,18 +26,18 @@ def demo_simple_image(ax):
     plt.setp(cb.ax.get_yticklabels(), visible=False)
 
 
-def demo_locatable_axes_hard(fig1):
+def demo_locatable_axes_hard(fig):
 
     from mpl_toolkits.axes_grid1 import SubplotDivider, Size
     from mpl_toolkits.axes_grid1.mpl_axes import Axes
 
-    divider = SubplotDivider(fig1, 2, 2, 2, aspect=True)
+    divider = SubplotDivider(fig, 2, 2, 2, aspect=True)
 
     # axes for image
-    ax = Axes(fig1, divider.get_position())
+    ax = Axes(fig, divider.get_position())
 
     # axes for colorbar
-    ax_cb = Axes(fig1, divider.get_position())
+    ax_cb = Axes(fig, divider.get_position())
 
     h = [Size.AxesX(ax),  # main axes
          Size.Fixed(0.05),  # padding, 0.1 inch
@@ -52,8 +52,8 @@ def demo_locatable_axes_hard(fig1):
     ax.set_axes_locator(divider.new_locator(nx=0, ny=0))
     ax_cb.set_axes_locator(divider.new_locator(nx=2, ny=0))
 
-    fig1.add_axes(ax)
-    fig1.add_axes(ax_cb)
+    fig.add_axes(ax)
+    fig.add_axes(ax_cb)
 
     ax_cb.axis["left"].toggle(all=False)
     ax_cb.axis["right"].toggle(ticks=True)
@@ -71,8 +71,8 @@ def demo_locatable_axes_easy(ax):
     divider = make_axes_locatable(ax)
 
     ax_cb = divider.new_horizontal(size="5%", pad=0.05)
-    fig1 = ax.get_figure()
-    fig1.add_axes(ax_cb)
+    fig = ax.get_figure()
+    fig.add_axes(ax_cb)
 
     Z, extent = get_demo_image()
     im = ax.imshow(Z, extent=extent, interpolation="nearest")
@@ -99,31 +99,30 @@ def demo_images_side_by_side(ax):
 
 def demo():
 
-    fig1 = plt.figure(1, (6, 6))
-    fig1.clf()
+    fig = plt.figure(figsize=(6, 6))
 
     # PLOT 1
     # simple image & colorbar
-    ax = fig1.add_subplot(2, 2, 1)
+    ax = fig.add_subplot(2, 2, 1)
     demo_simple_image(ax)
 
     # PLOT 2
     # image and colorbar whose location is adjusted in the drawing time.
     # a hard way
 
-    demo_locatable_axes_hard(fig1)
+    demo_locatable_axes_hard(fig)
 
     # PLOT 3
     # image and colorbar whose location is adjusted in the drawing time.
     # a easy way
 
-    ax = fig1.add_subplot(2, 2, 3)
+    ax = fig.add_subplot(2, 2, 3)
     demo_locatable_axes_easy(ax)
 
     # PLOT 4
     # two images side by side with fixed padding.
 
-    ax = fig1.add_subplot(2, 2, 4)
+    ax = fig.add_subplot(2, 2, 4)
     demo_images_side_by_side(ax)
 
     plt.show()

--- a/examples/axes_grid1/demo_fixed_size_axes.py
+++ b/examples/axes_grid1/demo_fixed_size_axes.py
@@ -11,26 +11,26 @@ from mpl_toolkits.axes_grid1.mpl_axes import Axes
 
 
 def demo_fixed_size_axes():
-    fig1 = plt.figure(1, (6, 6))
+    fig = plt.figure(figsize=(6, 6))
 
     # The first items are for padding and the second items are for the axes.
     # sizes are in inch.
     h = [Size.Fixed(1.0), Size.Fixed(4.5)]
     v = [Size.Fixed(0.7), Size.Fixed(5.)]
 
-    divider = Divider(fig1, (0.0, 0.0, 1., 1.), h, v, aspect=False)
+    divider = Divider(fig, (0.0, 0.0, 1., 1.), h, v, aspect=False)
     # the width and height of the rectangle is ignored.
 
-    ax = Axes(fig1, divider.get_position())
+    ax = Axes(fig, divider.get_position())
     ax.set_axes_locator(divider.new_locator(nx=1, ny=1))
 
-    fig1.add_axes(ax)
+    fig.add_axes(ax)
 
     ax.plot([1, 2, 3])
 
 
 def demo_fixed_pad_axes():
-    fig = plt.figure(2, (6, 6))
+    fig = plt.figure(figsize=(6, 6))
 
     # The first & third items are for padding and the second items are for the
     # axes. Sizes are in inches.

--- a/examples/axes_grid1/simple_axes_divider2.py
+++ b/examples/axes_grid1/simple_axes_divider2.py
@@ -8,11 +8,11 @@ import mpl_toolkits.axes_grid1.axes_size as Size
 from mpl_toolkits.axes_grid1 import Divider
 import matplotlib.pyplot as plt
 
-fig1 = plt.figure(1, (5.5, 4.))
+fig = plt.figure(figsize=(5.5, 4.))
 
 # the rect parameter will be ignore as we will set axes_locator
 rect = (0.1, 0.1, 0.8, 0.8)
-ax = [fig1.add_axes(rect, label="%d" % i) for i in range(4)]
+ax = [fig.add_axes(rect, label="%d" % i) for i in range(4)]
 
 horiz = [Size.Scaled(1.5), Size.Fixed(.5), Size.Scaled(1.),
          Size.Scaled(.5)]
@@ -20,7 +20,7 @@ horiz = [Size.Scaled(1.5), Size.Fixed(.5), Size.Scaled(1.),
 vert = [Size.Scaled(1.), Size.Fixed(.5), Size.Scaled(1.5)]
 
 # divide the axes rectangle into grid whose size is specified by horiz * vert
-divider = Divider(fig1, rect, horiz, vert, aspect=False)
+divider = Divider(fig, rect, horiz, vert, aspect=False)
 
 ax[0].set_axes_locator(divider.new_locator(nx=0, ny=0))
 ax[1].set_axes_locator(divider.new_locator(nx=0, ny=2))

--- a/examples/axes_grid1/simple_axes_divider3.py
+++ b/examples/axes_grid1/simple_axes_divider3.py
@@ -9,18 +9,18 @@ from mpl_toolkits.axes_grid1 import Divider
 import matplotlib.pyplot as plt
 
 
-fig1 = plt.figure(1, (5.5, 4))
+fig = plt.figure(figsize=(5.5, 4))
 
 # the rect parameter will be ignore as we will set axes_locator
 rect = (0.1, 0.1, 0.8, 0.8)
-ax = [fig1.add_axes(rect, label="%d" % i) for i in range(4)]
+ax = [fig.add_axes(rect, label="%d" % i) for i in range(4)]
 
 
 horiz = [Size.AxesX(ax[0]), Size.Fixed(.5), Size.AxesX(ax[1])]
 vert = [Size.AxesY(ax[0]), Size.Fixed(.5), Size.AxesY(ax[2])]
 
 # divide the axes rectangle into grid whose size is specified by horiz * vert
-divider = Divider(fig1, rect, horiz, vert, aspect=False)
+divider = Divider(fig, rect, horiz, vert, aspect=False)
 
 
 ax[0].set_axes_locator(divider.new_locator(nx=0, ny=0))

--- a/examples/axisartist/demo_axis_direction.py
+++ b/examples/axisartist/demo_axis_direction.py
@@ -73,7 +73,7 @@ def add_floating_axis2(ax1):
     return axis
 
 
-fig = plt.figure(1, figsize=(8, 4))
+fig = plt.figure(figsize=(8, 4))
 fig.clf()
 fig.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.99,
                     wspace=0.01, hspace=0.01)

--- a/examples/axisartist/demo_curvelinear_grid.py
+++ b/examples/axisartist/demo_curvelinear_grid.py
@@ -131,7 +131,7 @@ def curvelinear_test2(fig):
     ax1.grid(True, zorder=0)
 
 if 1:
-    fig = plt.figure(1, figsize=(7, 4))
+    fig = plt.figure(figsize=(7, 4))
     fig.clf()
 
     curvelinear_test1(fig)

--- a/examples/axisartist/demo_curvelinear_grid2.py
+++ b/examples/axisartist/demo_curvelinear_grid2.py
@@ -65,7 +65,7 @@ def curvelinear_test1(fig):
 
 
 if 1:
-    fig = plt.figure(1, figsize=(7, 4))
+    fig = plt.figure(figsize=(7, 4))
     fig.clf()
 
     curvelinear_test1(fig)

--- a/examples/axisartist/demo_floating_axes.py
+++ b/examples/axisartist/demo_floating_axes.py
@@ -143,7 +143,7 @@ def setup_axes3(fig, rect):
 
 
 ##########################################################
-fig = plt.figure(1, figsize=(8, 4))
+fig = plt.figure(figsize=(8, 4))
 fig.subplots_adjust(wspace=0.3, left=0.05, right=0.95)
 
 ax1, aux_ax1 = setup_axes1(fig, 131)

--- a/examples/axisartist/demo_floating_axis.py
+++ b/examples/axisartist/demo_floating_axis.py
@@ -64,7 +64,7 @@ def curvelinear_test2(fig):
 
     ax1.grid(True)
 
-fig = plt.figure(1, figsize=(5, 5))
+fig = plt.figure(figsize=(5, 5))
 fig.clf()
 
 curvelinear_test2(fig)

--- a/examples/axisartist/demo_ticklabel_alignment.py
+++ b/examples/axisartist/demo_ticklabel_alignment.py
@@ -22,7 +22,7 @@ def setup_axes(fig, rect):
     return ax
 
 
-fig = plt.figure(1, figsize=(3, 5))
+fig = plt.figure(figsize=(3, 5))
 fig.subplots_adjust(left=0.5, hspace=0.7)
 
 ax = setup_axes(fig, 311)

--- a/examples/axisartist/demo_ticklabel_direction.py
+++ b/examples/axisartist/demo_ticklabel_direction.py
@@ -19,7 +19,7 @@ def setup_axes(fig, rect):
     return ax
 
 
-fig = plt.figure(1, figsize=(6, 3))
+fig = plt.figure(figsize=(6, 3))
 fig.subplots_adjust(bottom=0.2)
 
 ax = setup_axes(fig, 131)

--- a/examples/axisartist/simple_axis_direction03.py
+++ b/examples/axisartist/simple_axis_direction03.py
@@ -19,7 +19,7 @@ def setup_axes(fig, rect):
     return ax
 
 
-fig = plt.figure(1, figsize=(5, 2))
+fig = plt.figure(figsize=(5, 2))
 fig.subplots_adjust(wspace=0.4, bottom=0.3)
 
 ax1 = setup_axes(fig, "121")

--- a/examples/axisartist/simple_axis_pad.py
+++ b/examples/axisartist/simple_axis_pad.py
@@ -73,7 +73,7 @@ def add_floating_axis2(ax1):
     return axis
 
 
-fig = plt.figure(1, figsize=(9, 3.))
+fig = plt.figure(figsize=(9, 3.))
 fig.clf()
 fig.subplots_adjust(left=0.01, right=0.99, bottom=0.01, top=0.99,
                     wspace=0.01, hspace=0.01)

--- a/examples/axisartist/simple_axisline2.py
+++ b/examples/axisartist/simple_axisline2.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axisartist.axislines import SubplotZero
 import numpy as np
 
-fig = plt.figure(1, (4, 3))
+fig = plt.figure(figsize=(4, 3))
 
 # a subplot with two additional axis, "xzero" and "yzero". "xzero" is
 # y=0 line, and "yzero" is x=0 line.

--- a/examples/axisartist/simple_axisline3.py
+++ b/examples/axisartist/simple_axisline3.py
@@ -7,7 +7,7 @@ Simple Axisline3
 import matplotlib.pyplot as plt
 from mpl_toolkits.axisartist.axislines import Subplot
 
-fig = plt.figure(1, (3, 3))
+fig = plt.figure(figsize=(3, 3))
 
 ax = Subplot(fig, 111)
 fig.add_subplot(ax)

--- a/examples/lines_bars_and_markers/scatter_hist.py
+++ b/examples/lines_bars_and_markers/scatter_hist.py
@@ -31,7 +31,7 @@ rect_histx = [left, bottom_h, width, 0.2]
 rect_histy = [left_h, bottom, 0.2, height]
 
 # start with a rectangular Figure
-plt.figure(1, figsize=(8, 8))
+plt.figure(figsize=(8, 8))
 
 axScatter = plt.axes(rect_scatter)
 axHistx = plt.axes(rect_histx)

--- a/examples/misc/demo_agg_filter.py
+++ b/examples/misc/demo_agg_filter.py
@@ -309,7 +309,7 @@ def light_filter_pie(ax):
 
 if 1:
 
-    plt.figure(1, figsize=(6, 6))
+    plt.figure(figsize=(6, 6))
     plt.subplots_adjust(left=0.05, right=0.95)
 
     ax = plt.subplot(221)

--- a/examples/misc/patheffect_demo.py
+++ b/examples/misc/patheffect_demo.py
@@ -9,7 +9,7 @@ import matplotlib.patheffects as PathEffects
 import numpy as np
 
 if 1:
-    plt.figure(1, figsize=(8, 3))
+    plt.figure(figsize=(8, 3))
     ax1 = plt.subplot(131)
     ax1.imshow([[1, 2], [2, 3]])
     txt = ax1.annotate("test", (1., 1.), (0., 0),

--- a/examples/misc/svg_filter_pie.py
+++ b/examples/misc/svg_filter_pie.py
@@ -14,8 +14,8 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Shadow
 
 # make a square figure and axes
-fig1 = plt.figure(1, figsize=(6, 6))
-ax = fig1.add_axes([0.1, 0.1, 0.8, 0.8])
+fig = plt.figure(figsize=(6, 6))
+ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])
 
 labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
 fracs = [15, 30, 45, 10]

--- a/examples/pyplots/whats_new_98_4_fancy.py
+++ b/examples/pyplots/whats_new_98_4_fancy.py
@@ -9,7 +9,7 @@ import matplotlib.patches as mpatch
 import matplotlib.pyplot as plt
 
 figheight = 8
-fig = plt.figure(1, figsize=(9, figheight), dpi=80)
+fig = plt.figure(figsize=(9, figheight), dpi=80)
 fontsize = 0.4 * fig.dpi
 
 def make_boxstyles(ax):

--- a/examples/shapes_and_collections/fancybox_demo.py
+++ b/examples/shapes_and_collections/fancybox_demo.py
@@ -20,14 +20,14 @@ styles = mpatch.BoxStyle.get_styles()
 spacing = 1.2
 
 figheight = (spacing * len(styles) + .5)
-fig1 = plt.figure(1, (4 / 1.5, figheight / 1.5))
+fig = plt.figure(figsize=(4 / 1.5, figheight / 1.5))
 fontsize = 0.3 * 72
 
 for i, stylename in enumerate(sorted(styles)):
-    fig1.text(0.5, (spacing * (len(styles) - i) - 0.5) / figheight, stylename,
+    fig.text(0.5, (spacing * (len(styles) - i) - 0.5) / figheight, stylename,
               ha="center",
               size=fontsize,
-              transform=fig1.transFigure,
+              transform=fig.transFigure,
               bbox=dict(boxstyle=stylename, fc="w", ec="k"))
 
 plt.show()

--- a/examples/subplots_axes_and_figures/axes_zoom_effect.py
+++ b/examples/subplots_axes_and_figures/axes_zoom_effect.py
@@ -106,7 +106,7 @@ def zoom_effect02(ax1, ax2, **kwargs):
 
 import matplotlib.pyplot as plt
 
-plt.figure(1, figsize=(5, 5))
+plt.figure(figsize=(5, 5))
 ax1 = plt.subplot(221)
 ax2 = plt.subplot(212)
 ax2.set_xlim(0, 1)

--- a/examples/text_labels_and_annotations/demo_text_rotation_mode.py
+++ b/examples/text_labels_and_annotations/demo_text_rotation_mode.py
@@ -44,7 +44,7 @@ def test_rotation_mode(fig, mode, subplot_location):
 
 if 1:
     import matplotlib.pyplot as plt
-    fig = plt.figure(1, figsize=(5.5, 4))
+    fig = plt.figure(figsize=(5.5, 4))
     fig.clf()
 
     test_rotation_mode(fig, "default", 121)

--- a/examples/text_labels_and_annotations/fancyarrow_demo.py
+++ b/examples/text_labels_and_annotations/fancyarrow_demo.py
@@ -12,11 +12,11 @@ styles = mpatches.ArrowStyle.get_styles()
 ncol = 2
 nrow = (len(styles) + 1) // ncol
 figheight = (nrow + 0.5)
-fig1 = plt.figure(1, (4 * ncol / 1.5, figheight / 1.5))
+fig = plt.figure(figsize=(4 * ncol / 1.5, figheight / 1.5))
 fontsize = 0.2 * 70
 
 
-ax = fig1.add_axes([0, 0, 1, 1], frameon=False, aspect=1.)
+ax = fig.add_axes([0, 0, 1, 1], frameon=False, aspect=1.)
 
 ax.set_xlim(0, 4 * ncol)
 ax.set_ylim(0, figheight)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1447,7 +1447,7 @@ default: 'top'
             y = np.sin(x**2)
 
             # Create a figure
-            plt.figure(1, clear=True)
+            plt.figure()
 
             # Creates a subplot
             ax = fig.subplots()

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -37,15 +37,15 @@ def test_boxarrow():
     spacing = 1.2
 
     figheight = (n * spacing + .5)
-    fig1 = plt.figure(1, figsize=(4 / 1.5, figheight / 1.5))
+    fig = plt.figure(figsize=(4 / 1.5, figheight / 1.5))
 
     fontsize = 0.3 * 72
 
     for i, stylename in enumerate(sorted(styles)):
-        fig1.text(0.5, ((n - i) * spacing - 0.5)/figheight, stylename,
+        fig.text(0.5, ((n - i) * spacing - 0.5)/figheight, stylename,
                   ha="center",
                   size=fontsize,
-                  transform=fig1.transFigure,
+                  transform=fig.transFigure,
                   bbox=dict(boxstyle=stylename, fc="w", ec="k"))
 
 

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -131,7 +131,7 @@ plt.show()
 names = ['group_a', 'group_b', 'group_c']
 values = [1, 10, 100]
 
-plt.figure(1, figsize=(9, 3))
+plt.figure(figsize=(9, 3))
 
 plt.subplot(131)
 plt.bar(names, values)


### PR DESCRIPTION
## PR Summary

Continuation of #11999 (missed `plt.figure(1, ...)` calls there).

Use `plt.figure(...)` rather than `plt.figure(1, ...)` in simple cases where there is only one figure and the figure number is irrelevant.