### PR TITLE
Fix typos

### DIFF
--- a/examples/shapes_and_collections/arrow_guide.py
+++ b/examples/shapes_and_collections/arrow_guide.py
@@ -14,7 +14,7 @@ stays static when data limits are altered - an example would be a figure title
 or the axis labels.
 
 Arrows consist of a head (and possibly a tail) and a stem drawn between a
-start point and and end point, called 'anchor points' from now on.
+start point and end point, called 'anchor points' from now on.
 Here we show three use cases for plotting arrows, depending on whether the
 head or anchor points need to be fixed in data or display space:
 

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -122,7 +122,7 @@ class LayoutBox(object):
 
         Margin minimums are set to make room for axes decorations.  However,
         the margins can be larger if we are mathicng the position size to
-        otehr axes.
+        other axes.
         """
         sol = self.solver
 

--- a/tutorials/colors/colormap-manipulation.py
+++ b/tutorials/colors/colormap-manipulation.py
@@ -40,7 +40,7 @@ print(viridis(0.56))
 ##############################################################################
 # The list of colors that comprise the colormap can be directly accessed using
 # the ``colors`` property,
-# or it can be acccessed indirectly by calling  ``viridis`` with an array
+# or it can be accessed indirectly by calling  ``viridis`` with an array
 # of values matching the length of the colormap.  Note that the returned list
 # is in the form of an RGBA Nx4 array, where N is the length of the colormap.
 


### PR DESCRIPTION
This PR fixes some typos: `and and`, `otehr`, and `acccessed`.