### PR TITLE
Speed up canvas redraw for GTK3Agg backend.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -74,7 +74,7 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         if self.get_visible() and self.get_mapped():
             allocation = self.get_allocation()
             self._render_figure(allocation.width, allocation.height)
-        super(FigureCanvasGTK3Agg).draw()
+        super().draw()
 
     def print_png(self, filename, *args, **kwargs):
         # Do this so we can save the resolution of figure in the PNG file

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -26,7 +26,6 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         w, h = allocation.width, allocation.height
 
         if not len(self._bbox_queue):
-            self._render_figure(w, h)
             Gtk.render_background(
                 self.get_style_context(), ctx,
                 allocation.x, allocation.y,
@@ -70,6 +69,12 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
 
         self._bbox_queue.append(bbox)
         self.queue_draw_area(x, y, width, height)
+
+    def draw(self):
+        if self.get_visible() and self.get_mapped():
+            allocation = self.get_allocation()
+            self._render_figure(allocation.width, allocation.height)
+        super(FigureCanvasGTK3Agg).draw()
 
     def print_png(self, filename, *args, **kwargs):
         # Do this so we can save the resolution of figure in the PNG file


### PR DESCRIPTION
## PR Summary
Move `_render_figure()` call out of `on_draw_event` handler
in `FigureCanvasGTK3Agg` class and call it from overloaded
`draw()` method.
Fixes #12010

Gtk triggers `draw` event not only when actual plot redraw
required but also when any another widget drawn over canvas.
This makes application with embided plot unresponsive in cases
when popover or popup menu are drawn over plot.
You may try example provided in #12010.

Moving actual plot redraw out of `on_draw_event()` makes GUI
much more responsive.

This changes tested with:
* animation from examples/ directory
* interacive pan and zoom
* cursor widget with bliting
* calling draw_idle() to update interactive chart


## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
