### PR TITLE
Fix ArtistInspector.get_aliases.

### DIFF
--- a/doc/users/next_whats_new/2018-09-06-AL.rst
+++ b/doc/users/next_whats_new/2018-09-06-AL.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+Return type of ArtistInspector.get_aliases changed
+``````````````````````````````````````````````````
+
+`ArtistInspector.get_aliases` previously returned the set of aliases as
+``{fullname: {alias1: None, alias2: None, ...}}``.  The dict-to-None mapping
+was used to simulate a set in earlier versions of Python.  It has now been
+replaced by a set, i.e. ``{fullname: {alias1, alias2, ...}}``.
+
+This value is also stored in `ArtistInspector.aliasd`, which has likewise
+changed.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1189,15 +1189,14 @@ class ArtistInspector(object):
 
     def get_aliases(self):
         """
-        Get a dict mapping *fullname* -> *alias* for each *alias* in
-        the :class:`~matplotlib.artist.ArtistInspector`.
+        Get a dict mapping property fullnames to sets of aliases for each alias
+        in the :class:`~matplotlib.artist.ArtistInspector`.
 
         e.g., for lines::
 
-          {'markerfacecolor': 'mfc',
-           'linewidth'      : 'lw',
+          {'markerfacecolor': {'mfc'},
+           'linewidth'      : {'lw'},
           }
-
         """
         names = [name for name in dir(self.o)
                  if name.startswith(('set_', 'get_'))
@@ -1207,9 +1206,9 @@ class ArtistInspector(object):
             func = getattr(self.o, name)
             if not self.is_alias(func):
                 continue
-            docstring = func.__doc__
-            fullname = docstring.replace('`', '')[10:]
-            aliases.setdefault(fullname[4:], {})[name[4:]] = None
+            propname = re.search("`({}.*)`".format(name[:4]),  # get_.*/set_.*
+                                 func.__doc__).group(1)
+            aliases.setdefault(propname, set()).add(name[4:])
         return aliases
 
     _get_valid_values_regex = re.compile(

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -30,7 +30,7 @@ GRIDLINE_INTERPOLATION_STEPS = 180
 # allows all Line2D kwargs.
 _line_AI = artist.ArtistInspector(mlines.Line2D)
 _line_param_names = _line_AI.get_setters()
-_line_param_aliases = [list(d.keys())[0] for d in _line_AI.aliasd.values()]
+_line_param_aliases = [list(d)[0] for d in _line_AI.aliasd.values()]
 _gridline_param_names = ['grid_' + name
                          for name in _line_param_names + _line_param_aliases]
 


### PR DESCRIPTION
The docstring parsing in get_aliases was brittle and didn't handle the
final dot that cbook._define_aliases added to the docstring, so as of
master it would return the keys with an additional dot.  Instead, use a
regex which will loudly error out if the format is incorrect.

Also replace {key: None, ...} mapping simulating a set to, well, a set.
(The use of sets instead of lists was added in ed9c2b5 apparently to
handle the case where the same alias is added twice.)

(Yes, the whole alias machinery could now be simplified e.g. by adding
an `is_mpl_alias` attribute on the aliases instead.)

At least the parsing fix should be considered RC as the issue came in in
#9475.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
