### PR TITLE
Deprecate get_py2exe_datafiles.

### DIFF
--- a/doc/api/next_api_changes/2018-08-17-AL-deprecations.rst
+++ b/doc/api/next_api_changes/2018-08-17-AL-deprecations.rst
@@ -3,7 +3,7 @@ API deprecations
 
 The following API elements are deprecated:
 
-- ``tk_window_focus``,
+- ``get_py2exe_datafiles``, ``tk_window_focus``,
 - ``backend_ps.PsBackendHelper``, ``backend_ps.ps_backend_helper``,
 - ``cbook.iterable``,
 - ``mlab.demean``,

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -606,8 +606,8 @@ Write a tutorial on the signal analysis plotting functions like
 :func:`~matplotlib.pyplot.specgram`.  Do you use Matplotlib with
 `django <https://www.djangoproject.com/>`_ or other popular web
 application servers?  Write a FAQ or tutorial and we'll find a place
-for it in the :ref:`users-guide-index`.  Bundle Matplotlib in a
-`py2exe <http://www.py2exe.org/>`_ app?  ... I think you get the idea.
+for it in the :ref:`users-guide-index`.  And so on...  I think you get the
+idea.
 
 Matplotlib is documented using the `sphinx
 <http://www.sphinx-doc.org/index.html>`_ extensions to restructured text

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -682,6 +682,7 @@ def get_data_path():
     return defaultParams['datapath'][0]
 
 
+@cbook.deprecated("3.1")
 def get_py2exe_datafiles():
     data_path = Path(get_data_path())
     d = {}


### PR DESCRIPTION
py2exe never supported even Py3.5 (the oldest python Matplotlib
supports) so I'll just assume it's dead...

Deprecate support for it.

(see https://stackoverflow.com/questions/32963057/is-there-a-py2exe-version-thats-compatible-with-python-3-5, https://sourceforge.net/p/py2exe/svn/765/log/?path=/trunk/py2exe-3 (lack of updates since 2014), and I tried setting it up too :p))

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
