### PR TITLE
Update doc on the *progressive* and *optimize* keywords in savefig

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1204,14 +1204,14 @@ class TimerBase(object):
 
     def add_callback(self, func, *args, **kwargs):
         '''
-        Register `func` to be called by timer when the event fires. Any
-        additional arguments provided will be passed to `func`.
+        Register *func* to be called by timer when the event fires. Any
+        additional arguments provided will be passed to *func*.
         '''
         self.callbacks.append((func, args, kwargs))
 
     def remove_callback(self, func, *args, **kwargs):
         '''
-        Remove `func` from list of callbacks. `args` and `kwargs` are optional
+        Remove *func* from list of callbacks. *args* and *kwargs* are optional
         and used to distinguish between copies of the same function registered
         to be called with different arguments.
         '''

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2021,11 +2021,12 @@ default: 'top'
             If *True*, indicates that the JPEG encoder should make an extra
             pass over the image in order to select optimal encoder settings.
             Applicable only if *format* is jpg or jpeg, ignored otherwise.
+            Is *False* by default.
 
         progressive : bool
             If *True*, indicates that this image should be stored as a
             progressive JPEG file. Applicable only if *format* is jpg or
-            jpeg, ignored otherwise.
+            jpeg, ignored otherwise. Is *False* by default.
 
         facecolor : color spec or None, optional
             The facecolor of the figure; if *None*, defaults to

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2018,12 +2018,14 @@ default: 'top'
             JPEG quantization stage.
 
         optimize : bool
-            If *True*, indicates that the encoder should make an extra pass
+            If *True*, indicates that the JPEG encoder should make an extra pass
             over the image in order to select optimal encoder settings.
+            Applicable only if *format* is jpg or jpeg, ignored otherwise.
 
         progressive : bool
             If *True*, indicates that this image should be stored as a
-            progressive JPEG file.
+            progressive JPEG file. Applicable only if *format* is jpg or
+            jpeg, ignored otherwise.
 
         facecolor : color spec or None, optional
             The facecolor of the figure; if *None*, defaults to

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2018,8 +2018,8 @@ default: 'top'
             JPEG quantization stage.
 
         optimize : bool
-            If *True*, indicates that the JPEG encoder should make an extra pass
-            over the image in order to select optimal encoder settings.
+            If *True*, indicates that the JPEG encoder should make an extra
+            pass over the image in order to select optimal encoder settings.
             Applicable only if *format* is jpg or jpeg, ignored otherwise.
 
         progressive : bool

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2017,6 +2017,14 @@ default: 'top'
             Values above 95 should be avoided; 100 completely disables the
             JPEG quantization stage.
 
+        optimize : bool
+            If *True*, indicates that the encoder should make an extra pass
+            over the image in order to select optimal encoder settings.
+
+        progressive : bool
+            If *True*, indicates that this image should be stored as a
+            progressive JPEG file.
+
         facecolor : color spec or None, optional
             The facecolor of the figure; if *None*, defaults to
             :rc:`savefig.facecolor`.


### PR DESCRIPTION
## PR Summary

This PR addresses issue #458. 

The *progressive* and *optimize* keywords are implemented within the Agg backend through the Pillow (PIL) JPEG image writer . FigureCanvasBase registers Agg as the default backend for saving to JPEG if Pillow is installed. If not, there is no JPEG support. I tested these features on matplotlib version 2.0.2 and they seem to work as expected (at least all of them have an impact on the compressed file size).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
