### PR TITLE
 Fix 999.9... edge case in ticker.EngFormatter for negative numbers 

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -655,6 +655,7 @@ class TestEngFormatter(object):
         (1.23456789, ('1.23457', '1', '1.23')),
         (999.9, ('999.9', '1 k', '999.90')),  # places=0: corner-case rounding
         (999.9999, ('1 k', '1 k', '1.00 k')),  # corner-case roudning for all
+        (-999.9999, ('-1 k', '-1 k', '-1.00 k')),  # negative corner-case
         (1000, ('1 k', '1 k', '1.00 k')),
         (1001, ('1.001 k', '1 k', '1.00 k')),
         (100001, ('100.001 k', '100 k', '100.00 k')),

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1268,7 +1268,8 @@ class EngFormatter(Formatter):
         # Taking care of the cases like 999.9..., which may be rounded to 1000
         # instead of 1 k.  Beware of the corner case of values that are beyond
         # the range of SI prefixes (i.e. > 'Y').
-        if float(format(mant, fmt)) >= 1000 and pow10 < max(self.ENG_PREFIXES):
+        _fmant = float(format(mant, fmt))
+        if (_fmant >= 1000 or _fmant <= -1000) and pow10 < max(self.ENG_PREFIXES):
             mant /= 1000
             pow10 += 3
 


### PR DESCRIPTION
## PR Summary
When using ticker.EngFormatter, a -999.999 value will be displayed as -1000 instead of -1k. The edge case detection for the positive numbers is now extended to the negative numbers.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
