### PR TITLE
Make HTMLWriter constructor a bit more strict.

### DIFF
--- a/doc/api/next_api_changes/2018-09-06-AL-HTMLWriter.rst
+++ b/doc/api/next_api_changes/2018-09-06-AL-HTMLWriter.rst
@@ -1,0 +1,4 @@
+The HTMLWriter constructor is more strict
+`````````````````````````````````````````
+It no longer normalizes unknown values of *default_mode* to 'loop', but errors
+out instead.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -846,8 +846,8 @@ class HTMLWriter(FileMovieWriter):
         self._bytes_limit *= 1024 * 1024
 
         if self.default_mode not in ['loop', 'once', 'reflect']:
-            self.default_mode = 'loop'
-            _log.warning("unrecognized default_mode: using 'loop'")
+            raise ValueError(
+                "unrecognized default_mode {!r}".format(self.default_mode))
 
         super().__init__(fps, codec, bitrate, extra_args, metadata)
 


### PR DESCRIPTION
There isn't really a reason to be lenient regarding invalid values for
the default_mode arg.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
