### PR TITLE
Various cleanups.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2262,14 +2262,13 @@ class _AxesBase(martist.Artist):
             arguments, but can be used individually to alter on e.g.,
             only the y-axis.
 
-        tight : bool, default is True
+        tight : bool or None, default is True
             The *tight* parameter is passed to :meth:`autoscale_view`,
             which is executed after a margin is changed; the default
             here is *True*, on the assumption that when margins are
             specified, no additional padding to match tick marks is
             usually desired.  Set *tight* to *None* will preserve
             the previous setting.
-
 
         Returns
         -------
@@ -2282,7 +2281,6 @@ class _AxesBase(martist.Artist):
         the "sticky artists" will be modified. To force all of the
         margins to be set, set :attr:`use_sticky_edges` to `False`
         before calling :meth:`margins`.
-
         """
 
         if margins and x is not None and y is not None:

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -190,7 +190,6 @@ class ToolToggleBase(ToolBase):
 
         `trigger` calls this method when `toggled` is False
         """
-
         pass
 
     def disable(self, event=None):
@@ -206,7 +205,6 @@ class ToolToggleBase(ToolBase):
         * Another `ToolToggleBase` derived tool is triggered
           (from the same `ToolManager`)
         """
-
         pass
 
     @property

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -279,7 +279,7 @@ def split_path_inout(path, inside, tolerence=0.01, reorder_inout=False):
         path_out = Path(concat([verts_right, path.vertices[i:]]),
                         concat([codes_right, path.codes[i:]]))
 
-    if reorder_inout and begin_inside is False:
+    if reorder_inout and not begin_inside:
         path_in, path_out = path_out, path_in
 
     return path_in, path_out

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -683,7 +683,7 @@ class Line2D(Artist):
                 self.axes.name == 'rectilinear' and
                 self.axes.get_xscale() == 'linear' and
                 self._markevery is None and
-                self.get_clip_on() is True):
+                self.get_clip_on()):
             self._subslice = True
             nanmask = np.isnan(x)
             if nanmask.any():

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -45,13 +45,17 @@ from matplotlib._mathtext_data import (latex_to_bakoma, latex_to_standard,
 # FONTS
 
 def get_unicode_index(symbol, math=True):
-    """get_unicode_index(symbol, [bool]) -> integer
+    r"""
+    Return the integer index (from the Unicode table) of *symbol*.
 
-Return the integer index (from the Unicode table) of symbol.  *symbol*
-can be a single unicode character, a TeX command (i.e. r'\\pi'), or a
-Type1 symbol name (i.e. 'phi').
-If math is False, the current symbol should be treated as a non-math symbol.
-"""
+    Parameters
+    ----------
+    symbol : str
+        A single unicode character, a TeX command (e.g. r'\pi') or a Type1
+        symbol name (e.g. 'phi').
+    math : bool, default is True
+        If False, always treat as a single unicode character.
+    """
     # for a non-math symbol, simply return its unicode index
     if not math:
         return ord(symbol)


### PR DESCRIPTION
- Document that in `margins()`, `tight` can be None, which is different
  from False (it keeps the previous setting).
- Conversely, in two places, don't check for 'is True / is False', but
  just for normal truthiness.  In particular, for the check on
  `get_clip_on()`, this is consistent with the check in
  `Artist.get_tightbbox()`.  (Note that there are plently of other `is
  True` / `is False` checks in the codebase but they arise because the
  variable can also take some other values, e.g. a string or None.)
- Fix a docstring.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
