### PR TITLE
Make AxesImage.contains account for transforms

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -603,11 +603,12 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             xmin, xmax = xmax, xmin
         if ymin > ymax:
             ymin, ymax = ymax, ymin
-
-        if x is not None and y is not None:
-            inside = (xmin <= x <= xmax) and (ymin <= y <= ymax)
-        else:
-            inside = False
+  
+        trans = self.get_transform()
+        bbox = Bbox(np.array([[xmin, ymin], [xmax, ymax]]))
+        transformed_bbox = TransformedBbox(bbox, trans)
+       
+        inside = transformed_bbox.contains(mouseevent.x,mouseevent.y)
 
         return inside, {}
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -597,19 +597,19 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         # collection on nonlinear transformed coordinates.
         # TODO: consider returning image coordinates (shouldn't
         # be too difficult given that the image is rectilinear
-        x, y = mouseevent.xdata, mouseevent.ydata
+        x, y = mouseevent.x, mouseevent.y
         xmin, xmax, ymin, ymax = self.get_extent()
         if xmin > xmax:
             xmin, xmax = xmax, xmin
         if ymin > ymax:
             ymin, ymax = ymax, ymin
-  
+            
         trans = self.get_transform()
         bbox = Bbox(np.array([[xmin, ymin], [xmax, ymax]]))
         transformed_bbox = TransformedBbox(bbox, trans)
-       
-        inside = transformed_bbox.contains(mouseevent.x,mouseevent.y)
-
+        
+        inside = transformed_bbox.contains(x, y)
+        
         return inside, {}
 
     def write_png(self, fname):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -597,19 +597,20 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         # collection on nonlinear transformed coordinates.
         # TODO: consider returning image coordinates (shouldn't
         # be too difficult given that the image is rectilinear
-        x, y = mouseevent.x, mouseevent.y
+        trans = self.get_transform()
+        x, y = trans.inverted().transform((mouseevent.x, mouseevent.y))
+
         xmin, xmax, ymin, ymax = self.get_extent()
         if xmin > xmax:
             xmin, xmax = xmax, xmin
         if ymin > ymax:
             ymin, ymax = ymax, ymin
-            
-        trans = self.get_transform()
-        bbox = Bbox(np.array([[xmin, ymin], [xmax, ymax]]))
-        transformed_bbox = TransformedBbox(bbox, trans)
-        
-        inside = transformed_bbox.contains(x, y)
-        
+
+        if x is not None and y is not None:
+            inside = (xmin <= x <= xmax) and (ymin <= y <= ymax)
+        else:
+            inside = False
+
         return inside, {}
 
     def write_png(self, fname):


### PR DESCRIPTION
Corrects contains() method for AxesImages with transforms applied See. https://github.com/matplotlib/matplotlib/issues/12042

## PR Summary
As described in https://github.com/matplotlib/matplotlib/issues/12042

Proposed change creates a bounding box from the image extents, applies the current transform to the bounding box and then tests whether the mouse event occurred within the transformed bounding box.
