### PR TITLE
Fix up some OSX backend issues

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2422,6 +2422,7 @@ Timer__timer_start(Timer* self, PyObject* args)
     CFRunLoopTimerRef timer;
     CFRunLoopTimerContext context;
     double milliseconds;
+    CFAbsoluteTime firstFire;
     CFTimeInterval interval;
     PyObject* attribute;
     PyObject* failure;
@@ -2446,12 +2447,15 @@ Timer__timer_start(Timer* self, PyObject* args)
         PyErr_SetString(PyExc_AttributeError, "Timer has no attribute '_single'");
         return NULL;
     }
+    // Need to tell when to first fire this timer, so get the current time
+    // and add an interval.
+    interval = milliseconds / 1000.0;
+    firstFire = CFAbsoluteTimeGetCurrent() + interval;
     switch (PyObject_IsTrue(attribute)) {
         case 1:
             interval = 0;
             break;
-        case 0:
-            interval = milliseconds / 1000.0;
+        case 0: // Set by default above
             break;
         case -1:
         default:
@@ -2475,7 +2479,7 @@ Timer__timer_start(Timer* self, PyObject* args)
     context.copyDescription = NULL;
     context.info = attribute;
     timer = CFRunLoopTimerCreate(kCFAllocatorDefault,
-                                 0,
+                                 firstFire,
                                  interval,
                                  0,
                                  0,

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1804,8 +1804,16 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     NSWindow* window = [self window];
     if ([window isKeyWindow]==false) return;
 
+    int x, y;
+    NSPoint location = [event locationInWindow];
+    location = [self convertPoint: location fromView: nil];
+    x = location.x * device_scale;
+    y = location.y * device_scale;
+
     gstate = PyGILState_Ensure();
-    result = PyObject_CallMethod(canvas, "enter_notify_event", "");
+    result = PyObject_CallMethod(canvas, "enter_notify_event", "O(ii)",
+            Py_None, x, y);
+
     if(result)
         Py_DECREF(result);
     else


### PR DESCRIPTION
This fixes up a few issues in the OSX backend:
- Deprecation warning due to lack of position information in `enter_notify_event`. Added position information (this would have been much easier if this event wasn't the **only** one that takes position as a tuple). Liberally borrowed code used in other event handlers in OSX backend. Fixes #10948.
- Incorrect behavior of OSX timer. It turns out by passing a 0 for an API call, we were essentially telling OSX to fire the timer as soon as possible. Fixed to pass proper time for initial firing of timer. Fixes #11985.