### PR TITLE
DOC: make Line2D docstring definition easier to find

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -614,7 +614,7 @@ Then in any function accepting `~.Line2D` pass-through ``kwargs``, e.g.,
       Some stuff omitted
 
       The kwargs are Line2D properties:
-      %(Line2D)s
+      %(_Line2D_docstr)s
 
       kwargs scalex and scaley, if defined, are passed on
       to autoscale_view to determine whether the x and y axes are

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -759,7 +759,7 @@ class Axes(_AxesBase):
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
             with the exception of 'transform':
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         See also
         --------
@@ -829,7 +829,7 @@ class Axes(_AxesBase):
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
             with the exception of 'transform':
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         Examples
         --------
@@ -1498,7 +1498,7 @@ class Axes(_AxesBase):
 
             Here is a list of available `.Line2D` properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         Returns
         -------
@@ -1650,7 +1650,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
 
         See Also
@@ -3015,7 +3015,7 @@ class Axes(_AxesBase):
 
             Valid kwargs for the marker properties are `.Lines2D` properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         Notes
         -----
@@ -6938,7 +6938,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7063,7 +7063,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7161,7 +7161,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7258,7 +7258,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7340,7 +7340,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7419,7 +7419,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         References
         ----------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -759,7 +759,7 @@ class Axes(_AxesBase):
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
             with the exception of 'transform':
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         See also
         --------
@@ -829,7 +829,7 @@ class Axes(_AxesBase):
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
             with the exception of 'transform':
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         Examples
         --------
@@ -1498,7 +1498,7 @@ class Axes(_AxesBase):
 
             Here is a list of available `.Line2D` properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         Returns
         -------
@@ -1650,7 +1650,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
 
         See Also
@@ -3015,7 +3015,7 @@ class Axes(_AxesBase):
 
             Valid kwargs for the marker properties are `.Lines2D` properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         Notes
         -----
@@ -6938,7 +6938,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7063,7 +7063,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7161,7 +7161,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7258,7 +7258,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7340,7 +7340,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         See Also
         --------
@@ -7419,7 +7419,7 @@ class Axes(_AxesBase):
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         References
         ----------
@@ -7681,7 +7681,7 @@ class Axes(_AxesBase):
             For the marker style, you can pass any `.Line2D` property except
             for *linestyle*:
 
-        %(Line2D)s
+        %(_Line2D_docstr)s
         """
         if marker is None and markersize is None and hasattr(Z, 'tocoo'):
             marker = 's'

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2716,7 +2716,7 @@ class _AxesBase(martist.Artist):
 
             Valid *kwargs* are
 
-            %(_Line2D_docstr)s
+        %(_Line2D_docstr)s
 
         Notes
         -----

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2716,7 +2716,7 @@ class _AxesBase(martist.Artist):
 
             Valid *kwargs* are
 
-            %(Line2D)s
+            %(_Line2D_docstr)s
 
         Notes
         -----

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -300,7 +300,7 @@ class Line2D(Artist):
 
         The kwargs are :class:`~matplotlib.lines.Line2D` properties:
 
-        %(Line2D)s
+        %(_Line2D_docstr)s
 
         See :meth:`set_linestyle` for a description of the line styles,
         :meth:`set_marker` for a description of the markers, and
@@ -1531,7 +1531,7 @@ lineMarkers = MarkerStyle.markers
 drawStyles = Line2D.drawStyles
 fillStyles = MarkerStyle.fillstyles
 
-docstring.interpd.update(Line2D=artist.kwdoc(Line2D))
+docstring.interpd.update(_Line2D_docstr=artist.kwdoc(Line2D))
 
 # You can not set the docstring of an instancemethod,
 # but you can on the underlying function.  Go figure.


### PR DESCRIPTION
## PR Summary

As above, I could never find the where the docstring interpolation is defined.  Now maybe my bad for not knowing the convention, but I think this is actually easier to follow.   

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
