### PR TITLE
Avoid some uses of np.isscalar.

### DIFF
--- a/examples/lines_bars_and_markers/filled_step.py
+++ b/examples/lines_bars_and_markers/filled_step.py
@@ -61,9 +61,8 @@ def filled_hist(ax, edges, values, bottoms=None, orientation='v',
                              lb=len(edges), lv=len(values)))
 
     if bottoms is None:
-        bottoms = np.zeros_like(values)
-    if np.isscalar(bottoms):
-        bottoms = np.ones_like(values) * bottoms
+        bottoms = 0
+    bottoms = np.broadcast_to(bottoms, values.shape)
 
     values = np.r_[values, values[-1]]
     bottoms = np.r_[bottoms, bottoms[-1]]

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -356,15 +356,12 @@ class StreamMask(object):
     """
 
     def __init__(self, density):
-        if np.isscalar(density):
-            if density <= 0:
-                raise ValueError("If a scalar, 'density' must be positive")
-            self.nx = self.ny = int(30 * density)
-        else:
-            if len(density) != 2:
-                raise ValueError("'density' can have at maximum 2 dimensions")
-            self.nx = int(30 * density[0])
-            self.ny = int(30 * density[1])
+        try:
+            self.nx, self.ny = (30 * np.broadcast_to(density, 2)).astype(int)
+        except ValueError:
+            raise ValueError("'density' must be a scalar or be of length 2")
+        if self.nx < 0 or self.ny < 0:
+            raise ValueError("'density' must be positive")
         self._mask = np.zeros((self.ny, self.nx))
         self.shape = self._mask.shape
 


### PR DESCRIPTION
The numpy docs suggest that checking ndim > 0 is usually better.  In the
cases here, though, we can just broadcast directly.

(https://www.numpy.org/devdocs/reference/generated/numpy.isscalar.html)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
