### PR TITLE
Add facecolors kwarg to mplot3d/plot_trisurf

### DIFF
--- a/examples/mplot3d/trisurf3d.py
+++ b/examples/mplot3d/trisurf3d.py
@@ -29,9 +29,12 @@ y = np.append(0, (radii*np.sin(angles)).flatten())
 # Compute z to make the pringle surface.
 z = np.sin(-x*y)
 
+# Compute theta for coloring
+theta = np.arctan2(x,y)
+
 fig = plt.figure()
 ax = fig.gca(projection='3d')
 
-ax.plot_trisurf(x, y, z, linewidth=0.2, antialiased=True)
+ax.plot_trisurf(x, y, z, facecolors=theta, cmap='hsv', linewidth=0.2, antialiased=True)
 
 plt.show()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -375,7 +375,7 @@ class Axes3D(Axes):
         .. versionadded :: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
-        if m < 0 or m > 1 :
+        if m < 0 or m > 1:
             raise ValueError("margin must be in range 0 to 1")
         self._zmargin = m
         self.stale = True
@@ -1340,7 +1340,7 @@ class Axes3D(Axes):
                     self.xaxis.major.formatter.set_scientific(sb)
                 if axis in ['both', 'y']:
                     self.yaxis.major.formatter.set_scientific(sb)
-                if axis in ['both', 'z'] :
+                if axis in ['both', 'z']:
                     self.zaxis.major.formatter.set_scientific(sb)
             if scilimits is not None:
                 if axis in ['both', 'x']:
@@ -1413,7 +1413,7 @@ class Axes3D(Axes):
             This function was added, but not tested. Please report any bugs.
         """
         super().tick_params(axis, **kwargs)
-        if axis in ['z', 'both'] :
+        if axis in ['z', 'both']:
             zkw = dict(kwargs)
             zkw.pop('top', None)
             zkw.pop('bottom', None)
@@ -2049,7 +2049,7 @@ class Axes3D(Axes):
     def add_contourf_set(self, cset, zdir='z', offset=None):
         zdir = '-' + zdir
         for z, linec in zip(cset.levels, cset.collections):
-            if offset is not None :
+            if offset is not None:
                 z = offset
             art3d.poly_collection_2d_to_3d(linec, z, zdir=zdir)
             linec.set_sort_zpos(z)
@@ -2234,9 +2234,9 @@ class Axes3D(Axes):
             - PatchCollection
         '''
         zvals = np.atleast_1d(zs)
-        if len(zvals) > 0 :
+        if len(zvals) > 0:
             zsortval = min(zvals)
-        else :
+        else:
             zsortval = 0   # FIXME: Fairly arbitrary. Is there a better value?
 
         # FIXME: use issubclass() (although, then a 3D collection
@@ -2354,12 +2354,12 @@ class Axes3D(Axes):
             if 'alpha' in kwargs:
                 p.set_alpha(kwargs['alpha'])
 
-        if len(verts) > 0 :
+        if len(verts) > 0:
             # the following has to be skipped if verts is empty
             # NOTE: Bugs could still occur if len(verts) > 0,
             #       but the "2nd dimension" is empty.
             xs, ys = list(zip(*verts))
-        else :
+        else:
             xs, ys = [], []
 
         xs, ys, verts_zs = art3d.juggle_axes(xs, ys, verts_zs, zdir)


### PR DESCRIPTION
## PR Summary

Fixes #9535 by adding handling for the facecolors keyword, both in combination with cmap and without.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there) (N/A)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way (N/A)

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
