### PR TITLE
FIX: make MaxNLocator only follow visible ticks for order of magnitude

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -275,15 +275,17 @@ class TestScalarFormatter(object):
 
     use_offset_data = [True, False]
 
+    #  (sci_type, scilimits, lim, orderOfMag, fewticks)
     scilimits_data = [
-        (False, (0, 0), (10.0, 20.0), 0),
-        (True, (-2, 2), (-10, 20), 0),
-        (True, (-2, 2), (-20, 10), 0),
-        (True, (-2, 2), (-110, 120), 2),
-        (True, (-2, 2), (-120, 110), 2),
-        (True, (-2, 2), (-.001, 0.002), -3),
-        (True, (0, 0), (-1e5, 1e5), 5),
-        (True, (6, 6), (-1e5, 1e5), 6),
+        (False, (0, 0), (10.0, 20.0), 0, False),
+        (True, (-2, 2), (-10, 20), 0, False),
+        (True, (-2, 2), (-20, 10), 0, False),
+        (True, (-2, 2), (-110, 120), 2, False),
+        (True, (-2, 2), (-120, 110), 2, False),
+        (True, (-2, 2), (-.001, 0.002), -3, False),
+        (True, (-7, 7), (0.18e10, 0.83e10), 9, True),
+        (True, (0, 0), (-1e5, 1e5), 5, False),
+        (True, (6, 6), (-1e5, 1e5), 6, False),
     ]
 
     @pytest.mark.parametrize('left, right, offset', offset_data)
@@ -316,14 +318,18 @@ class TestScalarFormatter(object):
             assert use_offset == tmp_form.get_useOffset()
 
     @pytest.mark.parametrize(
-        'sci_type, scilimits, lim, orderOfMag', scilimits_data)
-    def test_scilimits(self, sci_type, scilimits, lim, orderOfMag):
+        'sci_type, scilimits, lim, orderOfMag, fewticks', scilimits_data)
+    def test_scilimits(self, sci_type, scilimits, lim, orderOfMag,
+                       fewticks):
         tmp_form = mticker.ScalarFormatter()
         tmp_form.set_scientific(sci_type)
         tmp_form.set_powerlimits(scilimits)
         fig, ax = plt.subplots()
         ax.yaxis.set_major_formatter(tmp_form)
         ax.set_ylim(*lim)
+        if fewticks:
+            ax.yaxis.set_major_locator(mticker.MaxNLocator(4))
+
         tmp_form.set_locs(ax.yaxis.get_majorticklocs())
         assert orderOfMag == tmp_form.orderOfMagnitude
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -712,7 +712,14 @@ class ScalarFormatter(Formatter):
             # fixed scaling when lower power limit = upper <> 0.
             self.orderOfMagnitude = self._powerlimits[0]
             return
-        locs = np.abs(self.locs)
+        # restrict to visible ticks
+        vmin, vmax = sorted(self.axis.get_view_interval())
+        locs = np.asarray(self.locs)
+        locs = locs[(vmin <= locs) & (locs <= vmax)]
+        locs = np.abs(locs)
+        if not len(locs):
+            self.orderOfMagnitude = 0
+            return
         if self.offset:
             oom = math.floor(math.log10(range))
         else:


### PR DESCRIPTION
## PR Summary

Closes #12072

Order of magnitude for tick formatting in ScalarFormatter was using invisible ticks.  This changes to just use visible.  

Probably obviated by #11004 but won't hurt anything. 



## Before:

![figure_2](https://user-images.githubusercontent.com/1562854/45330522-b9748b00-b51a-11e8-9de2-e2b4dda4ec04.png)

## After

![figure_1](https://user-images.githubusercontent.com/1562854/45330507-a9f54200-b51a-11e8-976b-45fa905b79b3.png)


## Code

```python

import matplotlib.pyplot as plt
import matplotlib.ticker as ticker

sci_nums = [10**9, 8*10**9]
plt.rcParams['ytick.labelsize'] = 13
fig, ax = plt.subplots(1, 2)
ax[0].scatter(range(len(sci_nums)), sci_nums)
ax[1].scatter(range(len(sci_nums)), sci_nums)

ax[1].yaxis.set_major_locator(ticker.MaxNLocator(4))
plt.show()


```



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->