### PR TITLE
fix the filtering of non-integer ticks in maxNlocator with *integer = True*

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1944,6 +1944,7 @@ class MaxNLocator(Locator):
         steps = self._extended_steps
 
         if self._integer:
+            print("self.interger is " + str(self._integer))
             # For steps > 1, keep only integer values.
             igood = (steps >= 1) & (np.abs(steps - np.round(steps)) < 0.001)
             steps = steps[igood]


### PR DESCRIPTION
Reference to issue #12072

## PR Summary

Handling of the *integer* keyword does not seem right

>        *integer*
>          If True, ticks will take only integer values, provided
>          at least `min_n_ticks` integers are found within the
>          view limits.

When *True* it is supposed to provide only integer values for tick label. Here is the outputs printed out at different steps in the code. We first start by the list of possible tick spacing, `self.extended_steps`:

```
self._extended_steps = [ 0.1   0.15  0.2   0.25  0.3   0.4   0.5   0.6   0.8   1.    1.5   2.
  2.5   3.    4.    5.    6.    8.   10.   15.  ]
```
Then we multiply it by `scale`:
```
scale = 1000000000.0
steps = self._extended_steps * scale
steps = [1.0e+08 1.5e+08 2.0e+08 2.5e+08 3.0e+08 4.0e+08 5.0e+08 6.0e+08 8.0e+08 1.0e+09 1.5e+09 2.0e+09 2.5e+09 3.0e+09 4.0e+09 5.0e+09 6.0e+09 8.0e+09
 1.0e+10 1.5e+10]

```
Then comes the two lines of code that are supposed to filter the ticks < 1 and keep only integer ticks. 
```
        if self._integer:
            # For steps > 1, keep only integer values.
            igood = (steps < 1) | (np.abs(steps - np.round(steps)) < 0.001)
            steps = steps[igood]
```
The result of this filtering is:
```
steps = [1.0e+08 1.5e+08 2.0e+08 2.5e+08 3.0e+08 4.0e+08 5.0e+08 6.0e+08 8.0e+08
 1.0e+09 1.5e+09 2.0e+09 2.5e+09 3.0e+09 4.0e+09 5.0e+09 6.0e+09 8.0e+09
 1.0e+10 1.5e+10]
```
This does not seem correct. The following PR suggest changes to the code that produces the following output:
```
self._extended_steps = [ 0.1   0.15  0.2   0.25  0.3   0.4   0.5   0.6   0.8   1.    1.5   2.
  2.5   3.    4.    5.    6.    8.   10.   15.  ]
```
FIRST, filtering of non-integer ticks:
```
steps = [ 1.  2.  3.  4.  5.  6.  8. 10. 15.]

```
THEN, multiplication by `scale`
```
scale = 1000000000.0
steps = self._extended_steps * scale 
steps = [1.0e+09 2.0e+09 3.0e+09 4.0e+09 5.0e+09 6.0e+09 8.0e+09 1.0e+10 1.5e+10]

```


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
