### PR TITLE
Respect QT_API even when the backend is not Qt{4,5}{Agg,Cairo}.

### DIFF
--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -24,7 +24,12 @@ QT_API_PYSIDE2 = "PySide2"
 QT_API_PYQTv2 = "PyQt4v2"
 QT_API_PYSIDE = "PySide"
 QT_API_PYQT = "PyQt4"   # Use the old sip v1 API (Py3 defaults to v2).
-QT_API_ENV = os.environ.get('QT_API')
+QT_API_ENV = os.environ.get("QT_API")
+# Mapping of QT_API_ENV to requested binding.  ETS does not support PyQt4v1.
+# (https://github.com/enthought/pyface/blob/master/pyface/qt/__init__.py)
+_ETS = {"pyqt5": QT_API_PYQT5, "pyside2": QT_API_PYSIDE2,
+        "pyqt": QT_API_PYQTv2, "pyside": QT_API_PYSIDE,
+        None: None}
 # First, check if anything is already imported.
 if "PyQt5" in sys.modules:
     QT_API = QT_API_PYQT5
@@ -41,13 +46,13 @@ elif "PySide" in sys.modules:
 # Otherwise, check the QT_API environment variable (from Enthought).  This can
 # only override the binding, not the backend (in other words, we check that the
 # requested backend actually matches).
-elif rcParams["backend"] == "Qt5Agg":
+elif rcParams["backend"] in ["Qt5Agg", "Qt5Cairo"]:
     if QT_API_ENV == "pyqt5":
         dict.__setitem__(rcParams, "backend.qt5", QT_API_PYQT5)
     elif QT_API_ENV == "pyside2":
         dict.__setitem__(rcParams, "backend.qt5", QT_API_PYSIDE2)
     QT_API = dict.__getitem__(rcParams, "backend.qt5")
-elif rcParams["backend"] == "Qt4Agg":
+elif rcParams["backend"] in ["Qt4Agg", "Qt4Cairo"]:
     if QT_API_ENV == "pyqt4":
         dict.__setitem__(rcParams, "backend.qt4", QT_API_PYQTv2)
     elif QT_API_ENV == "pyside":
@@ -56,7 +61,12 @@ elif rcParams["backend"] == "Qt4Agg":
 # A non-Qt backend was selected but we still got there (possible, e.g., when
 # fully manually embedding Matplotlib in a Qt app without using pyplot).
 else:
-    QT_API = None
+    try:
+        QT_API = _ETS[QT_API_ENV]
+    except KeyError:
+        raise RuntimeError(
+            "The environment variable QT_API has the unrecognized value {!r};"
+            "valid values are 'pyqt5', 'pyside2', 'pyqt', and 'pyside'")
 
 
 def _setup_pyqt5():


### PR DESCRIPTION
- When rcParams["backend"] was not QtXAgg, we previously ignored QT_API.
  Don't do so anymore.  (example: mplcairo.qt...)
- Also add the QtCairo backends to the checks.

Note: before https://github.com/matplotlib/matplotlib/pull/9993, we would follow QT_API in the non-qt-backend case *only* if it specified a qt5 binding (PyQt5 or PySide2) -- per the default value of QT_RC_MAJOR_VERSION (so #9993 is a partial regression, also in 2.2.3).

I don't think this is critical to hold up 3.0 (as no one seems to have noticed this in 2.2.3 :)), but should be backported to 2.2.4.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
