### PR TITLE
Correct the removal of -Wstrict-prototypes from compiler flags.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,15 +107,16 @@ class NoopTestCommand(TestCommand):
 
 
 class BuildExtraLibraries(BuildExtCommand):
-    def run(self):
-        # Remove the -Wstrict-prototypes option, it's not valid for C++.
+    def build_extensions(self):
+        # Remove the -Wstrict-prototypes option, it's not valid for C++.  Fixed
+        # in Py3.7 as bpo-5755.
         try:
             self.compiler.compiler_so.remove('-Wstrict-prototypes')
         except (ValueError, AttributeError):
             pass
         for package in good_packages:
             package.do_custom_build()
-        return BuildExtCommand.run(self)
+        return super().build_extensions()
 
 
 cmdclass = versioneer.get_cmdclass()


### PR DESCRIPTION
Trying to remove the invalid flag in run() was too early (.compiler is
still None at that point so we would just always get a (silenced)
AttributeError -- catching the AttributeError is necessary to make
things work on Windows).  Indeed, the Py3.5 build currently displays a
lot of warnings about -Wstrict-prototypes.  Doing the removal in
build_extensions() instead works.

This went unnoticed because the upstream issue in distutils
(https://bugs.python.org/issue5755) was recently fixed in Py3.6.6 and
3.7.0; but this still affects Py3.5 and Py3.6.{0-5}.

Corrects #11965.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
