### PR TITLE
FIX: make sure all ticks show up for colorbar minor tick

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -267,7 +267,8 @@ class _ColorbarAutoMinorLocator(ticker.AutoMinorLocator):
         vmin = self._colorbar.norm.vmin
         vmax = self._colorbar.norm.vmax
         ticks = ticker.AutoMinorLocator.__call__(self)
-        return ticks[(ticks >= vmin) & (ticks <= vmax)]
+        rtol = (vmax - vmin) * 1e-10 
+        return ticks[(ticks >= vmin - rtol) & (ticks <= vmax + rtol)]
 
 
 class _ColorbarLogLocator(ticker.LogLocator):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -267,7 +267,7 @@ class _ColorbarAutoMinorLocator(ticker.AutoMinorLocator):
         vmin = self._colorbar.norm.vmin
         vmax = self._colorbar.norm.vmax
         ticks = ticker.AutoMinorLocator.__call__(self)
-        rtol = (vmax - vmin) * 1e-10 
+        rtol = (vmax - vmin) * 1e-10
         return ticks[(ticks >= vmin - rtol) & (ticks <= vmax + rtol)]
 
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -294,6 +294,15 @@ def test_colorbar_minorticks_on_off():
         np.testing.assert_almost_equal(cbar.ax.yaxis.get_minorticklocs(),
                                        np.array([]))
 
+        im.set_clim(vmin=-1.2, vmax=1.2)
+        cbar.minorticks_on()
+        correct_minorticklocs = np.array([-1.2, -1.1, -0.9, -0.8, -0.7, -0.6,
+                                          -0.4, -0.3, -0.2, -0.1,  0.1, 0.2,
+                                           0.3,  0.4,  0.6,  0.7,  0.8,  0.9,
+                                           1.1,  1.2])
+        np.testing.assert_almost_equal(cbar.ax.yaxis.get_minorticklocs(),
+                                       correct_minorticklocs)
+
 
 def test_colorbar_autoticks():
     # Test new autotick modes. Needs to be classic because


### PR DESCRIPTION
## PR Summary

#12095 shows that if you expect a minor colorbar tick right at the end of a colorbar it sometimes doesn't show up due to floating point precision issues.  This fixes that...



## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- n/a New features are documented, with examples if plot related
-  n/a Documentation is sphinx and numpydoc compliant
-  n/a Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
-  n/a Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->