### PR TITLE
Binder jupytext

### DIFF
--- a/.jupyter/jupyter_notebook_config.py
+++ b/.jupyter/jupyter_notebook_config.py
@@ -1,1 +1,3 @@
 c.NotebookApp.contents_manager_class = 'jupytext.TextFileContentsManager'  # noqa
+c.ContentsManager.preferred_jupytext_formats_read = 'py:sphinx'  # noqa
+c.ContentsManager.sphinx_convert_rst2md = True  # noqa

--- a/.jupyter/jupyter_notebook_config.py
+++ b/.jupyter/jupyter_notebook_config.py
@@ -1,0 +1,1 @@
+c.NotebookApp.contents_manager_class = 'jupytext.TextFileContentsManager'  # noqa

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Travis|_ |AppVeyor|_ |Codecov|_ |LGTM|_ |PyPi|_ |Gitter|_ |NUMFocus|_
+|Travis|_ |AppVeyor|_ |Codecov|_ |LGTM|_ |PyPi|_ |Gitter|_ |NUMFocus|_ |Examples|_ |Tutorials|_
 
 
 .. |Travis| image:: https://travis-ci.org/matplotlib/matplotlib.svg?branch=master
@@ -22,6 +22,11 @@
 .. |NUMFocus| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
 .. _NUMFocus: http://www.numfocus.org
 
+.. |Examples| image:: https://mybinder.org/badge.svg
+.. _Examples: https://mybinder.org/v2/gh/mwouts/matplotlib/master?filepath=examples
+
+.. |Tutorials| image:: https://mybinder.org/badge.svg
+.. _Tutorials: https://mybinder.org/v2/gh/mwouts/matplotlib/master?filepath=tutorials
 
 ##########
 Matplotlib

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@
 .. _NUMFocus: http://www.numfocus.org
 
 .. |Examples| image:: https://mybinder.org/badge.svg
-.. _Examples: https://mybinder.org/v2/gh/mwouts/matplotlib/master?filepath=examples
+.. _Examples: https://mybinder.org/v2/gh/matplotlib/matplotlib/master?filepath=examples
 
 .. |Tutorials| image:: https://mybinder.org/badge.svg
-.. _Tutorials: https://mybinder.org/v2/gh/mwouts/matplotlib/master?filepath=tutorials
+.. _Tutorials: https://mybinder.org/v2/gh/matplotlib/matplotlib/master?filepath=tutorials
 
 ##########
 Matplotlib

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,2 @@
+jupytext >= 0.6.5
+matplotlib

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,2 @@
-jupytext >= 0.6.5
+jupytext >= 0.7.0
 matplotlib


### PR DESCRIPTION
The binder project and Jupytext can turn the matplotlib example library into a collection of interactive notebooks.

Try it now at https://mybinder.org/v2/gh/mwouts/matplotlib/master?filepath=examples

Further work is apparently required on the examples themselves - not all plots are shown correctly in Jupyter (Is that a Jupyter configuration issue? Your probably know better than me).

![image](https://user-images.githubusercontent.com/29915202/45548672-76b9f800-b825-11e8-9643-a9ce49500c7c.png)
