### PR TITLE
Fix Agg extent calculations for empty draws

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -232,3 +232,11 @@ def test_failing_latex(tmpdir):
     plt.xlabel("$22_2_2$")
     with pytest.raises(RuntimeError):
         plt.savefig(path)
+
+
+def test_empty_rasterised():
+    # Check that emtpy figures that are rasterised save to pdf files fine
+    with PdfPages(io.BytesIO()) as pdf:
+        fig, ax = plt.subplots()
+        ax.plot([], [], rasterized=True)
+        fig.savefig(pdf, format="pdf")

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -201,10 +201,15 @@ agg::rect_i RendererAgg::get_content_extents()
         }
     }
 
-    r.x1 = std::max(0, r.x1);
-    r.y1 = std::max(0, r.y1);
-    r.x2 = std::min(r.x2 + 1, (int)width);
-    r.y2 = std::min(r.y2 + 1, (int)height);
+    if (r.x1 == width && r.x2 == 0) {
+      // The buffer is completely empty.
+      r.x1 = r.y1 = r.x2 = r.y2 = 0;
+    } else {
+      r.x1 = std::max(0, r.x1);
+      r.y1 = std::max(0, r.y1);
+      r.x2 = std::min(r.x2 + 1, (int)width);
+      r.y2 = std::min(r.y2 + 1, (int)height);
+    }
 
     return r;
 }


### PR DESCRIPTION
Fixes #12003. Putting this on 2.2.4, since it fixes plotting rasterised .pdf files with numpy 1.15.