### PR TITLE
Let digits toggle axes nav only if they correspond to an existing axes.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2411,21 +2411,20 @@ def key_press_handler(event, canvas, toolbar=None):
                 warnings.warn(str(exc))
                 ax.set_xscale('linear')
             ax.figure.canvas.draw_idle()
-
-    elif (event.key.isdigit() and event.key != '0') or event.key in all_keys:
-        # keys in list 'all' enables all axes (default key 'a'),
-        # otherwise if key is a number only enable this particular axes
-        # if it was the axes, where the event was raised
-        if event.key not in all_keys:
-            n = int(event.key) - 1
-        for i, a in enumerate(canvas.figure.get_axes()):
-            # consider axes, in which the event was raised
-            # FIXME: Why only this axes?
+    # enable nagivation for all axes that contain the event (default key 'a')
+    elif event.key in all_keys:
+        for a in canvas.figure.get_axes():
             if (event.x is not None and event.y is not None
-                    and a.in_axes(event)):
-                if event.key in all_keys:
-                    a.set_navigate(True)
-                else:
+                    and a.in_axes(event)):  # FIXME: Why only these?
+                a.set_navigate(True)
+    # enable navigation only for axes with this index (if such an axes exist,
+    # otherwise do nothing)
+    elif event.key.isdigit() and event.key != '0':
+        n = int(event.key) - 1
+        if n < len(canvas.figure.get_axes()):
+            for i, a in enumerate(canvas.figure.get_axes()):
+                if (event.x is not None and event.y is not None
+                        and a.in_axes(event)):  # FIXME: Why only these?
                     a.set_navigate(i == n)
 
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -426,10 +426,11 @@ class ToolEnableNavigation(ToolBase):
             return
 
         n = int(event.key) - 1
-        for i, a in enumerate(self.figure.get_axes()):
-            if (event.x is not None and event.y is not None
-                    and a.in_axes(event)):
-                a.set_navigate(i == n)
+        if n < len(self.figure.get_axes()):
+            for i, a in enumerate(self.figure.get_axes()):
+                if (event.x is not None and event.y is not None
+                        and a.in_axes(event)):
+                    a.set_navigate(i == n)
 
 
 class _ToolGridBase(ToolBase):


### PR DESCRIPTION
Currently, pressing a (1-9) digit key while the cursor is on an axes
will change whether axes, in general, are responsive to "navigation" UI
(pan/zoom/interactive cursor): if the cursor is over axes *m* and digit
*n* is pressed, then axes *m* will become unresponsive to navigation UI
if m!=n, and become responsive again if m==n.

That's likely not the originally desired behavior: in the patch below, I
think the check `a.in_axes(event)` (which has a FIXME comment...) should
be removed...

While this is getting sorted out, in the meantime, this patch changes
the behavior above to *not* disable axes *m* if m!=n and *n* is greater
than the total number of axes (i.e., in a case where *n* does not
correspond to any valid axes).  The use case here is to use "4" and "6"
as navigation keys for an interactive image stack viewer (unfortunately
one can't by default use either left/right or h/l as Matplotlib already
assigns default meanings for these keys).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
