### PR TITLE
Unbreak formlayout for image edits.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/formlayout.py
@@ -243,8 +243,14 @@ class FormWidget(QtWidgets.QWidget):
             elif isinstance(value, str):
                 field = QtWidgets.QLineEdit(value, self)
             elif isinstance(value, (list, tuple)):
+                if isinstance(value, tuple):
+                    value = list(value)
+                # Note: get() below checks the type of value[0] in self.data so
+                # it is essential that value gets modified in-place.
+                # This means that the code is actually broken in the case where
+                # value is a tuple, but fortunately we always pass a list...
+                selindex = value.pop(0)
                 field = QtWidgets.QComboBox(self)
-                selindex, *value = value
                 if isinstance(value[0], (list, tuple)):
                     keys = [key for key, _val in value]
                     value = [val for _key, val in value]


### PR DESCRIPTION
As of master, the qt editor is broken when editing an axes that contains
an image throws an error when clicking OK.  This is because `self.data`
needs to be modified *in-place* in FormWidget.setup, as FormWidget.get
later checks some explicit types in there.

This means, as a side note, that passing a tuple instead of a list to
generate a QComboBox is broken (one can test that by modifying the
example at the bottom of the module -- the results are different
depending on whether 'list2' is a list or a tuple) but that's something
we can deal with some other day...

Partial revert of #11684 (well, I naively assumed that the base code was
correct...).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
