### PR TITLE
Don't pretend @deprecated applies to classmethods.

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -117,6 +117,11 @@ def deprecated(since, message='', name='', alternative='', pending=False,
     """
     Decorator to mark a function or a class as deprecated.
 
+    When deprecating a classmethod, a staticmethod, or a property, the
+    ``@deprecated`` decorator should go *under* the ``@classmethod``, etc.
+    decorator (i.e., `deprecated` should directly decorate the underlying
+    callable).
+
     Parameters
     ----------
     since : str
@@ -183,8 +188,8 @@ def deprecated(since, message='', name='', alternative='', pending=False,
 
         if isinstance(obj, type):
             obj_type = "class"
-            old_doc = obj.__doc__
             func = obj.__init__
+            old_doc = obj.__doc__
 
             def finalize(wrapper, new_doc):
                 obj.__doc__ = new_doc
@@ -192,22 +197,13 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                 return obj
         else:
             obj_type = "function"
-            if isinstance(obj, classmethod):
-                func = obj.__func__
-                old_doc = func.__doc__
+            func = obj
+            old_doc = func.__doc__
 
-                def finalize(wrapper, new_doc):
-                    wrapper = functools.wraps(func)(wrapper)
-                    wrapper.__doc__ = new_doc
-                    return classmethod(wrapper)
-            else:
-                func = obj
-                old_doc = func.__doc__
-
-                def finalize(wrapper, new_doc):
-                    wrapper = functools.wraps(func)(wrapper)
-                    wrapper.__doc__ = new_doc
-                    return wrapper
+            def finalize(wrapper, new_doc):
+                wrapper = functools.wraps(func)(wrapper)
+                wrapper.__doc__ = new_doc
+                return wrapper
 
         message = _generate_deprecation_message(
             since, message, name, alternative, pending, obj_type, addendum,
@@ -221,9 +217,11 @@ def deprecated(since, message='', name='', alternative='', pending=False,
 
         old_doc = textwrap.dedent(old_doc or '').strip('\n')
         message = message.strip()
-        new_doc = (('\n.. deprecated:: %(since)s'
-                    '\n    %(message)s\n\n' %
-                    {'since': since, 'message': message}) + old_doc)
+        new_doc = ('.. deprecated:: {since}\n'
+                   '   {message}\n'
+                   '\n'
+                   '{old_doc}'
+                   .format(since=since, message=message, old_doc=old_doc))
         if not old_doc:
             # This is to prevent a spurious 'unexected unindent' warning from
             # docutils when the original docstring was blank.

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -1,5 +1,5 @@
 import functools
-import textwrap
+import inspect
 import warnings
 
 
@@ -215,7 +215,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             warnings.warn(message, category, stacklevel=2)
             return func(*args, **kwargs)
 
-        old_doc = textwrap.dedent(old_doc or '').strip('\n')
+        old_doc = inspect.cleandoc(old_doc or '').strip('\n')
         message = message.strip()
         new_doc = ('.. deprecated:: {since}\n'
                    '   {message}\n'


### PR DESCRIPTION
The `@deprecated` decorator has a branch for handling deprecation of
classmethods, but that won't ever work because we start by getting
the `__name__` attribute on the object, which raises an AttributeError
on classmethods.

This could be fixed by fetching `obj.__func__.__name__` instead, but
given that one can as well put the `@deprecated` decorator *under* the
`@classmethod` decorator (so that it sees the underlying function), we
can just remove that non-functioning code.

Also switch some docstring formatting to str.format.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
