### PR TITLE
Use _warn_external for deprecations warnings.

### DIFF
--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -1002,7 +1002,7 @@ a cleaner separation between subplots.
        with mpl.rc_context(rc=rcparams):
 
            ax = fig.add_subplot(2, 2, j)
-           ax.hist(np.random.beta(0.5, 0.5, 10000), 25, normed=True)
+           ax.hist(np.random.beta(0.5, 0.5, 10000), 25, density=True)
            ax.set_xlim([0, 1])
            ax.set_title(title)
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1991,7 +1991,8 @@ def _warn_external(message, category=None):
     frame = sys._getframe()
     for stacklevel in itertools.count(1):  # lgtm[py/unused-loop-variable]
         if not re.match(r"\A(matplotlib|mpl_toolkits)(\Z|\.)",
-                        frame.f_globals["__name__"]):
+                        # Work around sphinx-gallery not setting __name__.
+                        frame.f_globals.get("__name__", "")):
             break
         frame = frame.f_back
     warnings.warn(message, category, stacklevel)

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -109,7 +109,8 @@ def warn_deprecated(
         removal=removal)
     category = (PendingDeprecationWarning if pending
                 else MatplotlibDeprecationWarning)
-    warnings.warn(message, category, stacklevel=2)
+    from . import _warn_external
+    _warn_external(message, category)
 
 
 def deprecated(since, message='', name='', alternative='', pending=False,
@@ -216,7 +217,8 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                     else MatplotlibDeprecationWarning)
 
         def wrapper(*args, **kwargs):
-            warnings.warn(message, category, stacklevel=2)
+            from . import _warn_external
+            _warn_external(message, category)
             return func(*args, **kwargs)
 
         old_doc = textwrap.dedent(old_doc or '').strip('\n')


### PR DESCRIPTION
We'll probably switch to _warn_external everywhere at some point, but in
the meantime I think deprecations warnings are ones of those that
benefit the most from warn_external ("oh, that's the place that needs to
be fixed.").

Note the internal import to workaround the circular import loop between
cbook and cbook.deprecation.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
