### PR TITLE
Avoid triggering deprecation warnings with pytest 3.8.

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -109,7 +109,7 @@ value.
 Installing Matplotlib in developer mode
 ---------------------------------------
 
-To install Matplotlib (and compile the c-extensions) run the following
+To install Matplotlib (and compile the C-extensions) run the following
 command from the top-level directory ::
 
    python -mpip install -ve .
@@ -147,11 +147,11 @@ environment is set up properly::
 .. _pytest: http://doc.pytest.org/en/latest/
 .. _pep8: https://pep8.readthedocs.io/en/latest/
 .. _Ghostscript: https://www.ghostscript.com/
-.. _Inkscape: https://inkscape.org>
+.. _Inkscape: https://inkscape.org/
 
 .. note::
 
-  **Additional dependencies for testing**: pytest_ (version 3.4 or later),
+  **Additional dependencies for testing**: pytest_ (version 3.6 or later),
   Ghostscript_, Inkscape_
 
 .. seealso::

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -21,11 +21,11 @@ Requirements
 
 Install the latest version of Matplotlib as documented in
 :ref:`installing_for_devs` In particular, follow the instructions to use a
-local FreeType build
+local FreeType build.
 
 The following software is required to run the tests:
 
-- pytest_ (>=3.4)
+- pytest_ (>=3.6)
 - Ghostscript_ (to render PDF files)
 - Inkscape_ (to render SVG files)
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -24,19 +24,19 @@ def mpl_test_settings(request):
     with _cleanup_cm():
 
         backend = None
-        backend_marker = request.keywords.get('backend')
+        backend_marker = request.node.get_closest_marker('backend')
         if backend_marker is not None:
             assert len(backend_marker.args) == 1, \
                 "Marker 'backend' must specify 1 backend."
-            backend = backend_marker.args[0]
+            backend, = backend_marker.args
             prev_backend = matplotlib.get_backend()
 
         style = '_classic_test'  # Default of cleanup and image_comparison too.
-        style_marker = request.keywords.get('style')
+        style_marker = request.node.get_closest_marker('style')
         if style_marker is not None:
             assert len(style_marker.args) == 1, \
                 "Marker 'style' must specify 1 style."
-            style = style_marker.args[0]
+            style, = style_marker.args
 
         matplotlib.testing.setup()
         if backend is not None:
@@ -64,7 +64,7 @@ def mpl_image_comparison_parameters(request, extension):
     # pytest won't get confused.
     # We annotate the decorated function with any parameters captured by this
     # fixture so that they can be used by the wrapper in image_comparison.
-    baseline_images = request.keywords['baseline_images'].args[0]
+    baseline_images, = request.node.get_closest_marker('baseline_images').args
     if baseline_images is None:
         # Allow baseline image list to be produced on the fly based on current
         # parametrization.

--- a/requirements/testing/travis35.txt
+++ b/requirements/testing/travis35.txt
@@ -5,7 +5,7 @@ python-dateutil==2.1
 numpy==1.10.0
 pandas<0.21.0
 pyparsing==2.0.1
-pytest==3.4
+pytest==3.6
 pytest-cov==2.3.1
 pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest 3.4.
 sphinx==1.3

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -6,9 +6,7 @@ cycler
 numpy
 pillow
 pyparsing
-# pytest-timeout master depends on pytest>=3.6. Testing with pytest 3.4 is
-# still supported; this is tested by the first travis python 3.5 build
-pytest>=3.6
+pytest
 pytest-cov
 pytest-faulthandler
 pytest-rerunfailures

--- a/setupext.py
+++ b/setupext.py
@@ -681,7 +681,7 @@ class Toolkits(OptionalPackage):
 
 class Tests(OptionalPackage):
     name = "tests"
-    pytest_min_version = '3.4'
+    pytest_min_version = '3.6'
     default_config = False
 
     def check(self):


### PR DESCRIPTION
The new API was introduced in pytest3.6 so bump the test dependency
accordingly.

xref https://docs.pytest.org/en/latest/changelog.html#pytest-3-6-0-2018-05-23
closes #12107.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
