### PR TITLE
FIX: colorbar re-check norm before draw for autolabels

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -240,7 +240,8 @@ class _ColorbarAutoLocator(ticker.MaxNLocator):
         vmin = max(vmin, self._colorbar.norm.vmin)
         vmax = min(vmax, self._colorbar.norm.vmax)
         ticks = super().tick_values(vmin, vmax)
-        return ticks[(ticks >= vmin) & (ticks <= vmax)]
+        rtol = (vmax - vmin) * 1e-10
+        return ticks[(ticks >= vmin - rtol) & (ticks <= vmax + rtol)]
 
 
 class _ColorbarAutoMinorLocator(ticker.AutoMinorLocator):
@@ -296,7 +297,10 @@ class _ColorbarLogLocator(ticker.LogLocator):
         vmin = self._colorbar.norm.vmin
         vmax = self._colorbar.norm.vmax
         ticks = super().tick_values(vmin, vmax)
-        return ticks[(ticks >= vmin) & (ticks <= vmax)]
+        rtol = (np.log10(vmax) - np.log10(vmin)) * 1e-10
+        ticks = ticks[(np.log10(ticks) >= np.log10(vmin) - rtol) &
+              (np.log10(ticks) <= np.log10(vmax) + rtol)]
+        return ticks
 
 
 class ColorbarBase(cm.ScalarMappable):
@@ -405,7 +409,6 @@ class ColorbarBase(cm.ScalarMappable):
         else:
             self.formatter = format  # Assume it is a Formatter
         # The rest is in a method so we can recalculate when clim changes.
-        self.config_axis()
         self.draw_all()
 
     def _extend_lower(self):
@@ -439,6 +442,7 @@ class ColorbarBase(cm.ScalarMappable):
         # units:
         X, Y = self._mesh()
         C = self._values[:, np.newaxis]
+        self.config_axis()
         self._config_axes(X, Y)
         if self.filled:
             self._add_solids(X, Y, C)
@@ -593,6 +597,7 @@ class ColorbarBase(cm.ScalarMappable):
         ax.set_frame_on(False)
         ax.set_navigate(False)
         xy = self._outline(X, Y)
+        ax.ignore_existing_data_limits = True
         ax.update_datalim(xy)
         ax.set_xlim(*ax.dataLim.intervalx)
         ax.set_ylim(*ax.dataLim.intervaly)
@@ -1150,7 +1155,6 @@ class Colorbar(ColorbarBase):
         self.set_alpha(mappable.get_alpha())
         self.cmap = mappable.cmap
         self.norm = mappable.norm
-        self.config_axis()
         self.draw_all()
         if isinstance(self.mappable, contour.ContourSet):
             CS = self.mappable

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import BoundaryNorm, LogNorm, PowerNorm
 from matplotlib.cm import get_cmap
 from matplotlib.colorbar import ColorbarBase
+from matplotlib.ticker import LogLocator, LogFormatter
 
 
 def _get_cmap_norms():
@@ -411,3 +412,27 @@ def test_colorbar_log_minortick_labels():
                     r'$\mathdefault{4\times10^{4}}$']
         for l, exp in zip(lb, expected):
             assert l.get_text() == exp
+
+
+def test_colorbar_renorm():
+    x, y = np.ogrid[-4:4:31j, -4:4:31j]
+    z = 120000*np.exp(-x**2 - y**2)
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(z)
+    cbar = fig.colorbar(im)
+
+    norm = LogNorm(z.min(), z.max())
+    im.set_norm(norm)
+    cbar.set_norm(norm)
+    cbar.locator = LogLocator()
+    cbar.formatter = LogFormatter()
+    cbar.update_normal(im)
+    assert np.isclose(cbar.vmin, z.min())
+
+    norm = LogNorm(z.min() * 1000, z.max() * 1000)
+    im.set_norm(norm)
+    cbar.set_norm(norm)
+    cbar.update_normal(im)
+    assert np.isclose(cbar.vmin, z.min() * 1000)
+    assert np.isclose(cbar.vmax, z.max() * 1000)


### PR DESCRIPTION
## PR Summary

closes #12155 

If a user changes the norm on a colorbar from a linear to logarithmic, we were not changing the scale of the colorbar axes to a logarithmic scale.  That needs to be done after #9903 because we now use normal locators for colorbar axes.  



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
