### PR TITLE
Fix Annotation.contains.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -895,25 +895,26 @@ class Text(Artist):
         return self._verticalalignment
 
     def get_window_extent(self, renderer=None, dpi=None):
-        '''
-        Return a `~matplotlib.transforms.Bbox` object bounding
-        the text, in display units.
+        """
+        Return the `Bbox` bounding the text, in display units.
 
-        In addition to being used internally, this is useful for
-        specifying clickable regions in a png file on a web page.
+        In addition to being used internally, this is useful for specifying
+        clickable regions in a png file on a web page.
 
-        *renderer* defaults to the _renderer attribute of the text
-        object.  This is not assigned until the first execution of
-        :meth:`draw`, so you must use this kwarg if you want
-        to call `.get_window_extent` prior to the first `draw`.  For
-        getting web page regions, it is simpler to call the method after
-        saving the figure.
+        Parameters
+        ----------
+        renderer : Renderer, optional
+            A renderer is needed to compute the bounding box.  If the artist
+            has already been drawn, the renderer is cached; thus, it is only
+            necessary to pass this argument when calling `get_window_extent`
+            before the first `draw`.  In practice, it is usually easier to
+            trigger a draw first (e.g. by saving the figure).
 
-        *dpi* defaults to self.figure.dpi; the renderer dpi is
-        irrelevant.  For the web application, if figure.dpi is not
-        the value used when saving the figure, then the value that
-        was used must be specified as the *dpi* argument.
-        '''
+        dpi : float, optional
+            The dpi value for computing the bbox, defaults to
+            ``self.figure.dpi`` (*not* the renderer dpi); should be set e.g. if
+            to match regions with a figure saved with a custom dpi value.
+        """
         #return _unit_box
         if not self.get_visible():
             return Bbox.unit()
@@ -2351,29 +2352,36 @@ class Annotation(Text, _AnnotationBase):
         Text.draw(self, renderer)
 
     def get_window_extent(self, renderer=None):
-        '''
-        Return a :class:`~matplotlib.transforms.Bbox` object bounding
-        the text and arrow annotation, in display units.
+        """
+        Return the `Bbox` bounding the text and arrow, in display units.
 
-        *renderer* defaults to the _renderer attribute of the text
-        object.  This is not assigned until the first execution of
-        :meth:`draw`, so you must use this kwarg if you want
-        to call :meth:`get_window_extent` prior to the first
-        :meth:`draw`.  For getting web page regions, it is
-        simpler to call the method after saving the figure. The
-        *dpi* used defaults to self.figure.dpi; the renderer dpi is
-        irrelevant.
-        '''
-        self.update_positions(renderer)
+        Parameters
+        ----------
+        renderer : Renderer, optional
+            A renderer is needed to compute the bounding box.  If the artist
+            has already been drawn, the renderer is cached; thus, it is only
+            necessary to pass this argument when calling `get_window_extent`
+            before the first `draw`.  In practice, it is usually easier to
+            trigger a draw first (e.g. by saving the figure).
+        """
+        # This block is the same as in Text.get_window_extent, but we need to
+        # set the renderer before calling update_positions().
         if not self.get_visible():
             return Bbox.unit()
+        if renderer is not None:
+            self._renderer = renderer
+        if self._renderer is None:
+            self._renderer = self.figure._cachedRenderer
+        if self._renderer is None:
+            raise RuntimeError('Cannot get window extent w/o renderer')
 
-        text_bbox = Text.get_window_extent(self, renderer=renderer)
+        self.update_positions(self._renderer)
+
+        text_bbox = Text.get_window_extent(self)
         bboxes = [text_bbox]
 
         if self.arrow_patch is not None:
-            bboxes.append(
-                self.arrow_patch.get_window_extent(renderer=renderer))
+            bboxes.append(self.arrow_patch.get_window_extent())
 
         return Bbox.union(bboxes)
 


### PR DESCRIPTION
Annotation.contains always calls get_window_extents() without setting
the renderer arg, which is thus None (and this is implicitly allowed by
the signature of get_window_extents), but get_window_extents calls
update_positions which *requires* a non-None renderer (it ultimately
calls renderer.points_to_pixels).

Instead, reuse the code from Text.get_window_extents() which defaults to
the artist-or-figure renderer if the arg is None.

Example breaking code:

    from matplotlib import pyplot as plt
    ann = plt.annotate(
        "foo", (.5, .5), arrowprops={"arrowstyle": "->"},
        textcoords="offset points", xytext=(10, 10))
    plt.gcf().canvas.mpl_connect(
        "button_press_event", lambda event: print(ann.contains(event)))
    plt.show()

and click anywhere to trigger an AttributeError.

Regression due to #11801.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
