### PR TITLE
Document preference order for backend auto selection

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -29,13 +29,15 @@
 
 ##### CONFIGURATION BEGINS HERE
 
-## The default backend; one of GTK3Agg GTK3Cairo MacOSX Qt4Agg Qt5Agg TkAgg
-## WX WXAgg Agg Cairo PS PDF SVG Template.
+## The default backend. If you omit this parameter, the first
+## working backend from the following list is used:
+## MacOSX Qt5Agg Qt4Agg Gtk3Agg GTK3Cairo TkAgg WxAgg Agg Cairo
+##
+## Other choices include: WX PS PDF SVG Template.
+##
 ## You can also deploy your own backend outside of matplotlib by
 ## referring to the module name (which must be in the PYTHONPATH) as
 ## 'module://my_backend'.
-##
-## If you omit this parameter, the backend will be determined by fallback.
 #backend      : Agg
 
 ## Note that this can be overridden by the environment variable


### PR DESCRIPTION
If I understand #11600 correctly, this is the order in which backends are tried. It would be nice to document this, especially for those who need to decide whether to override it.

