### PR TITLE
Remove internal warning due to zsort deprecation

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -583,7 +583,7 @@ class Poly3DCollection(PolyCollection):
         # just in case it is a scalarmappable with a colormap.
         self.update_scalarmappable()
         self._sort_zpos = None
-        self.set_zsort(True)
+        self.set_zsort('average')
         self._facecolors3d = PolyCollection.get_facecolor(self)
         self._edgecolors3d = PolyCollection.get_edgecolor(self)
         self._alpha3d = PolyCollection.get_alpha(self)


### PR DESCRIPTION
Passing `True` to `set_zsort` is deprecated; removes a bunch of test warnings that look like:

```
lib/mpl_toolkits/tests/test_mplot3d.py::test_contourf3d[svg]
  /home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/_pytest/python.py:152: MatplotlibDeprecationWarning:
  Passing True to mean 'average' for set_zsort is deprecated and support will be removed in Matplotlib 3.3; pass 'average' instead.
    testfunction(**testargs)
```