### PR TITLE
FIX: remove cwd from mac font path search

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -129,7 +129,6 @@ OSXFontDirectories = [
     "/System/Library/Fonts/",
     # fonts installed via MacPorts
     "/opt/local/share/fonts",
-    "",
 ]
 
 if not USE_FONTCONFIG and sys.platform != 'win32':


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

While including the cwd makes sense at first glance, it does not
because

a) the result is cached so the next time your cwd will be
   different but we will not find those files
b) the time it takes to search all the files is causing problems
c) the other 2 platforms do not do this

The comma was introduced to fix what looked like a bug (implicit
string concatenation instead of adding the empty string to the list)
in #11963.

Original code come in via 479934197664662059ed0b8b2f46c5b10776176e in
2011.

closes #12176