### PR TITLE
DOC: update "What's new" with reference to cividis paper

### DIFF
--- a/doc/users/whats_new.rst
+++ b/doc/users/whats_new.rst
@@ -141,10 +141,10 @@ A new dark blue/yellow colormap named 'cividis' was added. Like
 viridis, cividis is perceptually uniform and colorblind
 friendly. However, cividis also goes a step further: not only is it
 usable by colorblind users, it should actually look effectively
-identical to colorblind and non-colorblind users. For more details,
-see Nunez J, Anderton C, and Renslow R. (submitted). Optimizing
-colormaps with consideration for color vision deficiency to enable
-accurate interpretation of scientific data."
+identical to colorblind and non-colorblind users. For more details
+see `Nuñez J, Anderton C, and Renslow R: "Optimizing colormaps with consideration
+for color vision deficiency to enable accurate interpretation of scientific data"
+<https://doi.org/10.1371/journal.pone.0199239>`_.
 
 .. plot::
 


### PR DESCRIPTION
Update the "What's new" for 2.2.3 with a reference to the [now-published paper discussing cividis](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0199239). I kept most of the original text (but added an accent to the name of the first author) and turned it into one long inline link pointing to the DOI of the paper published in PLoS ONE. The patched version compiles with sphinx.