### PR TITLE
Fix non-functional Sphinx link

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -238,7 +238,7 @@ endtrans %}
     {%- endif %}
     {%- if show_sphinx %}
 	{% trans sphinx_version=sphinx_version|e %}Created using
-	<ahref="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
+	<a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
     {%- endif %}
     {%- if sha %}
 	Doc version {{ sha }}.


### PR DESCRIPTION
A space character was missing

GitHub’s syntax highlighting caught this while browsing https://github.com/matplotlib/matplotlib/blob/b3154da1bc688a4dba821547ad4edfcf6d986cd2/doc/_templates/layout.html