### PR TITLE
DOC: update "Previous Whats New" for 2.2 with reference to cividis paper

### DIFF
--- a/doc/users/prev_whats_new/whats_new_2.2.rst
+++ b/doc/users/prev_whats_new/whats_new_2.2.rst
@@ -119,10 +119,10 @@ A new dark blue/yellow colormap named 'cividis' was added. Like
 viridis, cividis is perceptually uniform and colorblind
 friendly. However, cividis also goes a step further: not only is it
 usable by colorblind users, it should actually look effectively
-identical to colorblind and non-colorblind users. For more details,
-see Nunez J, Anderton C, and Renslow R. (submitted). Optimizing
-colormaps with consideration for color vision deficiency to enable
-accurate interpretation of scientific data."
+identical to colorblind and non-colorblind users. For more details
+see `Nuñez J, Anderton C, and Renslow R: "Optimizing colormaps with consideration
+for color vision deficiency to enable accurate interpretation of scientific data"
+<https://doi.org/10.1371/journal.pone.0199239>`_.
 
 .. plot::
 


### PR DESCRIPTION
Update the ["Previously Whats New" for 2.2](https://matplotlib.org/users/prev_whats_new/whats_new_2.2.html#cividis-colormap) with a reference to the now-published paper discussing cividis. I kept most of the original text (but added an accent to the name of the first author) and turned it into one long inline link pointing to the DOI of the paper published in PLoS ONE.

Same change as https://github.com/matplotlib/matplotlib/pull/12179 (that one for 2.2.3 backport, this one for master).