### PR TITLE
Fix Python 3 note

### DIFF
--- a/doc/_templates/sidebar_announcement.html
+++ b/doc/_templates/sidebar_announcement.html
@@ -1,5 +1,5 @@
 <div class="sidebar-announcement">
-  <p>Matplotlib 3.0 Python 3 only.</p>
+  <p>Matplotlib 3.0 is Python 3 only.</p>
   <p>For Python 2 support, Matplotlib 2.2.x will be continued as a LTS release
       and updated with bugfixes until January 1, 2020.</p>
 </div>


### PR DESCRIPTION
## PR Summary

Fixes a typo.

This typo is only present in the v3.0.0-doc branch, because the changes were not applied to master. Not sure what the policy here is, but I would have expected to see the same in master and backport to v3.0.0-doc.