### PR TITLE
Give Carreau the ability to mention the backport bot.

### DIFF
--- a/.meeseeksdev.yml
+++ b/.meeseeksdev.yml
@@ -1,0 +1,4 @@
+users:
+  Carreau:
+    can:
+      - backport


### PR DESCRIPTION
Mostly because when the backport bot crashes and pull-requests don't get
backported Carreau needs to fix the bot and then annoys the core dev to re-mention
the bot.

Give Carreau only the ability to mention the bot for backport (no other commands). That avoids having him to push a temporary patch on the
bot itself.

-- 

cc @tacaswell and @QuLogic sorry for bothering you when I'm fixing bugs, I hope that this will make your life a tiny bit easier.

Note that you can also use this config file if you want to give a subset of users the ability to tag, untag, close, re-open... etc. without giving full commit rights.

I'm happy if you don't want to do that. Just a suggestion.