### PR TITLE
Allow disabling specific mouse actions in blocking_input

### DIFF
--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -135,7 +135,7 @@ class BlockingMouseInput(BlockingInput):
             self.mouse_event_pop(event)
         elif button == self.button_stop:
             self.mouse_event_stop(event)
-        else:
+        elif button == self.button_add:
             self.mouse_event_add(event)
 
     def key_event(self):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2181,11 +2181,20 @@ default: 'top'
         Wait until the user clicks *n* times on the figure, and return the
         coordinates of each click in a list.
 
-        The buttons used for the various actions (adding points, removing
-        points, terminating the inputs) can be overridden via the arguments
-        *mouse_add*, *mouse_pop* and *mouse_stop*, that set the associated
-        mouse button: 1 for left, 2 for middle, 3 for right.  Using a different
-        value (e.g. None) disables the corresponding mouse action.
+        There are three possible interactions:
+
+        - Add a point.
+        - Remove the most recently added point.
+        - Stop the interaction and return the points added so far.
+
+        The actions are assigned to mouse buttons via the arguments
+        *mouse_add*, *mouse_pop* and *mouse_stop*. Mouse buttons are defined
+        by the numbers:
+
+        - 1: left mouse button
+        - 2: middle mouse button
+        - 3: right mouse button
+        - None: no mouse button
 
         Parameters
         ----------
@@ -2197,11 +2206,11 @@ default: 'top'
             will never timeout.
         show_clicks : bool, optional, default: False
             If True, show a red cross at the location of each click.
-        mouse_add : int, one of (1, 2, 3), optional, default: 1 (left click)
+        mouse_add : {1, 2, 3, None}, optional, default: 1 (left click)
             Mouse button used to add points.
-        mouse_pop : int, one of (1, 2, 3), optional, default: 3 (right click)
+        mouse_pop : {1, 2, 3, None}, optional, default: 3 (right click)
             Mouse button used to remove the most recently added point.
-        mouse_stop : int, one of (1, 2, 3), optional, default: 2 (middle click)
+        mouse_stop : {1, 2, 3, None}, optional, default: 2 (middle click)
             Mouse button used to stop input.
 
         Returns

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2182,10 +2182,10 @@ default: 'top'
         coordinates of each click in a list.
 
         The buttons used for the various actions (adding points, removing
-        points, terminating the inputs) can be overridden via the
-        arguments *mouse_add*, *mouse_pop* and *mouse_stop*, that give
-        the associated mouse button: 1 for left, 2 for middle, 3 for
-        right.
+        points, terminating the inputs) can be overridden via the arguments
+        *mouse_add*, *mouse_pop* and *mouse_stop*, that set the associated
+        mouse button: 1 for left, 2 for middle, 3 for right.  Using a different
+        value (e.g. None) disables the corresponding mouse action.
 
         Parameters
         ----------


### PR DESCRIPTION
This is https://github.com/matplotlib/matplotlib/pull/11661 taking into account @timhoffm's comment and fixing the docs.  Thanks to @saksmito for the PR.

ginput doesn´t allow to disable buttons.
With this change you can assign an invalid button to the three mouse buttons and leave the left click empty to zoom or pan.

Updated the documentation associated with ginput, regarding the changes applied to blocking_input to allow for pan and zoom

(PR cleanup by the committer.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
