### PR TITLE
Slightly clarify some invalid shape exceptions for image data.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -338,7 +338,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
         if not unsampled:
             if A.ndim not in (2, 3):
-                raise ValueError("Invalid dimensions, got {}".format(A.shape))
+                raise ValueError("Invalid shape {} for image data"
+                                 .format(A.shape))
 
             if A.ndim == 2:
                 # if we are a 2D array, then we are running through the
@@ -482,7 +483,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 if A.shape[2] == 3:
                     A = _rgb_to_rgba(A)
                 elif A.shape[2] != 4:
-                    raise ValueError("Invalid dimensions, got %s" % (A.shape,))
+                    raise ValueError("Invalid shape {} for image data"
+                                     .format(A.shape))
 
                 output = np.zeros((out_height, out_width, 4), dtype=A.dtype)
 
@@ -638,11 +640,13 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
         if (self._A.dtype != np.uint8 and
                 not np.can_cast(self._A.dtype, float, "same_kind")):
-            raise TypeError("Image data cannot be converted to float")
+            raise TypeError("Image data of dtype {} cannot be converted to "
+                            "float".format(self._A.dtype))
 
         if not (self._A.ndim == 2
                 or self._A.ndim == 3 and self._A.shape[-1] in [3, 4]):
-            raise TypeError("Invalid dimensions for image data")
+            raise TypeError("Invalid shape {} for image data"
+                            .format(self._A.shape))
 
         if self._A.ndim == 3:
             # If the input data has values outside the valid range (after


### PR DESCRIPTION
## PR Summary

Just ran into a case where clarifying the invalid shapes a bit would have helped with the debugging :)
Also make the error messages consistent among themselves.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
