### PR TITLE
Axes.tick_params() argument checking

### DIFF
--- a/doc/api/next_api_changes/2018-09-22-TH.rst
+++ b/doc/api/next_api_changes/2018-09-22-TH.rst
@@ -1,0 +1,5 @@
+Axes.tick_params argument checking
+``````````````````````````````````
+
+`Axes.tick_params` silently did nothing when an invalid *axis* parameter was
+supplied. This behavior is changed to raise a ValueError instead.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2949,6 +2949,8 @@ class _AxesBase(martist.Artist):
         also be red.  Gridlines will be red and translucent.
 
         """
+        if axis not in ['x', 'y', 'both']:
+            raise ValueError("axis must be one of 'x', 'y' or 'both'")
         if axis in ['x', 'both']:
             xkw = dict(kwargs)
             xkw.pop('left', None)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1412,7 +1412,10 @@ class Axes3D(Axes):
         .. versionadded :: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
-        super().tick_params(axis, **kwargs)
+        if axis not in ['x', 'y', 'z', 'both']:
+            raise ValueError("axis must be one of 'x', 'y', 'z' or 'both'")
+        if axis in ['x', 'y', 'both']:
+            super().tick_params(axis, **kwargs)
         if axis in ['z', 'both']:
             zkw = dict(kwargs)
             zkw.pop('top', None)


### PR DESCRIPTION
## PR Summary

`Axes.tick_params` silently did nothing when an invalid *axis* parameter was
supplied. This behavior is changed to raise a ValueError instead.

## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

