### PR TITLE
Change win32InstalledFonts return value

### DIFF
--- a/doc/api/next_api_changes/2018-09-22-TH-win32InstalledFonts.rst
+++ b/doc/api/next_api_changes/2018-09-22-TH-win32InstalledFonts.rst
@@ -1,0 +1,5 @@
+matplotlib.font_manager.win32InstalledFonts return value
+````````````````````````````````````````````````````````
+
+`matplotlib.font_manager.win32InstalledFonts` returns an empty list instead
+of None if no fonts are found.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -181,7 +181,6 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
     filenames are returned by default, or AFM fonts if *fontext* ==
     'afm'.
     """
-
     import winreg
 
     if directory is None:
@@ -203,10 +202,9 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
                     path = Path(directory, direc).resolve()
                     if path.suffix.lower() in fontext:
                         items.add(str(path))
-                return list(items)
         except (OSError, MemoryError):
             continue
-    return None
+    return list(items)
 
 
 def OSXInstalledFonts(directories=None, fontext='ttf'):


### PR DESCRIPTION
## PR Summary

In the context of #12173 it was noted that `matplotlib.font_manager.win32InstalledFonts()` returned None if no fonts are found. This is inconsistent with the docs which claims that a list of fonts is returned. This PR changes the return value to an empty list, which is a more natural choice and is more convenient than the None value. If the value can be None, we have to explicitly check before doing any list-operations on the return value. An empty list can be handled more gracefully.

Returning an empty list is also the behavior of `OSXInstalledFonts()`.

This is in principle a breaking API change. However, I think it's ok to document it and apply it right away.

Note: this fixes one of the exceptions in #12173:

~~~
  File "C:\Python\Python35\lib\site-packages\matplotlib\font_manager.py", line 264, in findSystemFonts
    fontfiles.update(win32InstalledFonts(fontext=fontext))
TypeError: 'NoneType' object is not iterable
~~~

## PR Checklist

- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way