### PR TITLE
FIX: pcolor/pcolormesh honour edgecolors kwarg when facecolors is set 'none'

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5789,6 +5789,13 @@ class Axes(_AxesBase):
         corners = (minx, miny), (maxx, maxy)
         self.update_datalim(corners)
         self.autoscale_view()
+        # The following block of code addresses github issue #1302
+        for face_color in ['facecolor', 'facecolors']:
+            try:
+                if kwargs.get(face_color).lower() == 'none':
+                    collection._is_stroked = False
+            except AttributeError:
+                pass
         return collection
 
     @_preprocess_data(label_namer=None)
@@ -6002,6 +6009,13 @@ class Axes(_AxesBase):
         corners = (minx, miny), (maxx, maxy)
         self.update_datalim(corners)
         self.autoscale_view()
+        # The following block of code addresses github issue #1302
+        for face_color in ['facecolor', 'facecolors']:
+            try:
+                if kwargs.get(face_color).lower() == 'none':
+                    collection._is_stroked = False
+            except AttributeError:
+                pass
         return collection
 
     @_preprocess_data(label_namer=None)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -922,3 +922,19 @@ def test_relim():
     ax.relim()
     ax.autoscale()
     assert ax.get_xlim() == ax.get_ylim() == (0, 1)
+
+
+def test_edgefacecolor_pcolor_pcolormesh():
+    # Test that pcolor/pcolormesh honours edgecolors kwarg when facecolors
+    # is set to 'none' (github issue #1302 and fixed by PR #12226).
+    fig, ax = plt.subplots(2)
+    im0 = ax[0].pcolor(np.arange(12).reshape(4, 3),
+                       edgecolors='red', facecolors='none')
+    im1 = ax[1].pcolormesh(np.arange(12).reshape(4, 3),
+                       edgecolors='red', facecolors='none')
+    # triggering draw() to make sure that the edges of the mesh are drawn.
+    fig.canvas.draw()
+    np.testing.assert_equal(im0.get_edgecolors(),
+                            np.array([[1., 0., 0., 1.]]))
+    np.testing.assert_equal(im1.get_edgecolors(),
+                            np.array([[1., 0., 0., 1.]]))


### PR DESCRIPTION
## PR Summary

Closes #1302

This fixes the issue #1302  [edgecolor(s) being ignored by pcolor/pcolormesh when facecolor(s)  is set to 'none'].

From a quick look at the discussion in #1302 and looking at the underlying code, I think this PR should work. ~~**NOTE: I am not entirely familiar with how the Collection object is supposed to behave. If this PR fails the tests then I will close this PR and dig deeper to find the correct approach.**~~ (all the tests passed!).

Example:
```python
import matplotlib.pyplot as plt
import numpy as np

plt.pcolor(np.arange(12).reshape(4, 3), edgecolors='red', facecolors='none')
plt.show()
```

Current outcome:
![test](https://user-images.githubusercontent.com/15175620/45924687-644e5700-bed4-11e8-83b9-749ea3501eaa.png)

Correct outcome (after applying the fix in this PR):
![test1](https://user-images.githubusercontent.com/15175620/45924691-7203dc80-bed4-11e8-98b0-7c326a53b25d.png)

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- ~~[ ] New features are documented, with examples if plot related~~
- [x] Documentation is sphinx and numpydoc compliant
- ~~[ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- ~~[ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
