### PR TITLE
Use (float, float) as paramter type for 2D positions

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -426,6 +426,8 @@ rules expand on them where the numpydoc conventions are not specific.
 
 Use ``float`` for a type that can be any number.
 
+Use ``(float, float)`` to describe a 2D position.
+
 Use ``array-like`` for homogeneous numeric sequences, which could
 typically be a numpy.array. Dimensionality may be specified using ``2D``,
 ``3D``, ``n-dimensional``. If you need to have variables denoting the


### PR DESCRIPTION
## PR Summary

As noted in #12214, we currently do not have a consistent way of defining the parameter type of 2D positions. Used formats include

- `tuple`
- `iterable`
- `tuple of 2 floats`
- `(float, float)`
- `tuple of (float, float)`

While all are sort of correct, I think it's important to define the length and the element type.

A fully precise definition is `iterable of float of length 2` or `length-2 iterable of float`, which is IMO is not quite readable and scary to less experienced programmers.

Therefore, I propose to use `(float, float)`, e.g.

~~~
        xy : (float, float)
            The point *(x,y)* to annotate.
~~~

This seems simple and clear enough. It concisely defines contained type and size, and does not put emphasis on tuple, which is technically too restrictive as other iterables work as well.