### PR TITLE
CI: Speed up Appveyor repository cloning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,8 @@ branches:
   except:
     - /auto-backport-.*/
 
+clone_depth: 50
+
 environment:
 
   global:


### PR DESCRIPTION
Should save about a minute per job. 50 is the default value on Travis.