### PR TITLE
Use (float, float) as parameter type for 2D positions in docstrings

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1848,7 +1848,7 @@ class FigureCanvasBase(object):
         ----------
         guiEvent
             the native UI event that generated the mpl event
-        xy : tuple of 2 scalars
+        xy : (float, float)
             the coordinate location of the pointer when the canvas is
             entered
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -179,9 +179,16 @@ class OffsetBox(martist.Artist):
 
     def set_offset(self, xy):
         """
-        Set the offset
+        Set the offset.
 
-        accepts x, y, tuple, or a callable object.
+        Parameters
+        ----------
+        xy : (float, float) or callable
+            The (x,y) coordinates of the offset in display units.
+            A callable must have the signature::
+
+                def offset(width, height, xdescent, ydescent, renderer) \
+-> (float, float)
         """
         self._offset = xy
         self.stale = True
@@ -602,9 +609,12 @@ class DrawingArea(OffsetBox):
 
     def set_offset(self, xy):
         """
-        set offset of the container.
+        Set the offset of the container.
 
-        Accept : tuple of x,y coordinate in display units.
+        Parameters
+        ----------
+        xy : (float, float)
+            The (x,y) coordinates of the offset in display units.
         """
         self._offset = xy
 
@@ -773,9 +783,12 @@ class TextArea(OffsetBox):
 
     def set_offset(self, xy):
         """
-        set offset of the container.
+        Set the offset of the container.
 
-        Accept : tuple of x,y coordinates in display units.
+        Parameters
+        ----------
+        xy : (float, float)
+            The (x,y) coordinates of the offset in display units.
         """
         self._offset = xy
 
@@ -891,9 +904,12 @@ class AuxTransformBox(OffsetBox):
 
     def set_offset(self, xy):
         """
-        set offset of the container.
+        Set the offset of the container.
 
-        Accept : tuple of x,y coordinate in display units.
+        Parameters
+        ----------
+        xy : (float, float)
+            The (x,y) coordinates of the offset in display units.
         """
         self._offset = xy
 
@@ -1294,9 +1310,12 @@ class OffsetImage(OffsetBox):
 
 #     def set_offset(self, xy):
 #         """
-#         set offset of the container.
-
-#         Accept : tuple of x,y coordinate in display units.
+#         Set the offset of the container.
+#
+#         Parameters
+#         ----------
+#         xy : (float, float)
+#             The (x,y) coordinates of the offset in display units.
 #         """
 #         self._offset = xy
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -660,15 +660,15 @@ class Rectangle(Patch):
         """
         Parameters
         ----------
-        xy: length-2 tuple
+        xy : (float, float)
             The bottom and left rectangle coordinates
-        width:
+        width : float
             Rectangle width
-        height:
+        height : float
             Rectangle height
-        angle: float, optional
+        angle : float, optional
           rotation in degrees anti-clockwise about *xy* (default is 0.0)
-        fill: bool, optional
+        fill : bool, optional
             Whether to fill the rectangle (default is ``True``)
 
         Notes
@@ -769,7 +769,7 @@ class Rectangle(Patch):
 
         Parameters
         ----------
-        xy : 2-item sequence
+        xy : (float, float)
         """
         self._x0, self._y0 = xy
         self._update_x1()
@@ -1444,11 +1444,11 @@ class Ellipse(Patch):
         """
         Parameters
         ----------
-        xy : tuple of (scalar, scalar)
+        xy : (float, float)
             xy coordinates of ellipse centre.
-        width : scalar
+        width : float
             Total length (diameter) of horizontal axis.
-        height : scalar
+        height : float
             Total length (diameter) of vertical axis.
         angle : scalar, optional
             Rotation in degrees anti-clockwise.

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -760,7 +760,7 @@ class _WedgeBbox(mtransforms.Bbox):
 
     Parameters
     ----------
-    center : tuple of float
+    center : (float, float)
         Center of the wedge
     viewLim : `~matplotlib.transforms.Bbox`
         Bbox determining the boundaries of the wedge

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2762,7 +2762,7 @@ class Lasso(AxesWidget):
     ----------
     ax : `~matplotlib.axes.Axes`
         The parent axes for the widget.
-    xy : array
+    xy : (float, float)
         Coordinates of the start of the lasso.
     callback : callable
         Whenever the lasso is released, the `callback` function is called and


### PR DESCRIPTION
## PR Summary

Application of #12227 to the docstrings.

## PR Checklist

- [x] Documentation is sphinx and numpydoc compliant
