### PR TITLE
FIX: make unused spines invisible

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4172,7 +4172,18 @@ class _AxesBase(martist.Artist):
         Artists are excluded either by not being visible or
         ``artist.set_in_layout(False)``.
         """
-        return [artist for artist in self.get_children()
+
+        artists = self.get_children()
+        if not (self.axison and self._frameon):
+            # don't do bbox on spines if frame not on.
+            for spine in self.spines.values():
+                artists.remove(spine)
+
+        if not self.axison:
+            for _axis in self._get_axis_list():
+                artists.remove(_axis)
+
+        return [artist for artist in artists
                 if (artist.get_visible() and artist.get_in_layout())]
 
     def get_tightbbox(self, renderer, call_axes_locator=True,

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -126,6 +126,11 @@ class Axes3D(Axes):
 
         self.figure.add_axes(self)
 
+        # mplot3d currently manages its own spines and needs these turned off
+        # for bounding box calculations
+        for k in self.spines.keys():
+            self.spines[k].set_visible(False)
+
     def set_axis_off(self):
         self._axis3don = False
         self.stale = True


### PR DESCRIPTION
## PR Summary

Closes #12239 

mplot3d turned axis off but for whatever reason the spines were still created, and were marked as visible, so get_tightbbox included their nonsense extents in its calculations.  This change just makes the spines not be visible.  


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->