### PR TITLE
[DO NO MERGE] Remove deprecated OSX checks

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2580,9 +2580,7 @@ static bool verify_framework(void)
     ProcessSerialNumber psn;
     /* These methods are deprecated, but they don't require the app to
        have started  */
-    if (CGMainDisplayID()!=0
-     && GetCurrentProcess(&psn)==noErr
-     && SetFrontProcess(&psn)==noErr) return true;
+    if (CGMainDisplayID()!=0) return true;
     PyErr_SetString(PyExc_ImportError,
         "Python is not installed as a framework. The Mac OS X backend will "
         "not be able to function correctly if Python is not installed as a "


### PR DESCRIPTION
(at least locally) this fixes #12188 . All I have done is get rid of two deprecated functions, `GetCurrentProcess`, and `SetFrontProcess`. This seems to stop the bouncing. I guess that these need to be replaced with their modern alternatives, but I can't work out what they should be...