### PR TITLE
Handle utf-8 output by kpathsea on Windows.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -29,7 +29,7 @@ import textwrap
 
 import numpy as np
 
-from matplotlib import rcParams
+from matplotlib import cbook, rcParams
 
 _log = logging.getLogger(__name__)
 
@@ -990,6 +990,8 @@ def find_tex_file(filename, format=None):
     kpathsea. It is also available as part of MikTeX, a popular
     distribution on Windows.
 
+    *If the file is not found, an empty string is returned*.
+
     Parameters
     ----------
     filename : string or bytestring
@@ -1015,11 +1017,16 @@ def find_tex_file(filename, format=None):
     if format is not None:
         cmd += ['--format=' + format]
     cmd += [filename]
-    _log.debug('find_tex_file(%s): %s', filename, cmd)
-    pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    result = pipe.communicate()[0].rstrip()
-    _log.debug('find_tex_file result: %s', result)
-    return result.decode('ascii')
+    try:  # Below: strip final newline.
+        result = cbook._check_and_log_subprocess(cmd, _log)[:-1]
+    except RuntimeError:
+        return ''
+    if os.name == 'nt':
+        # On Windows only, kpathsea appears to use utf-8 output(?); see
+        # __win32_fputs in the kpathsea sources and mpl issue #11848.
+        return result.decode('utf-8')
+    else:
+        return os.fsdecode(result)
 
 
 @lru_cache()


### PR DESCRIPTION
## PR Summary

cf #11848, especially https://github.com/matplotlib/matplotlib/pull/11848#issuecomment-423954736.  Unfortunately, I haven't been able to find documentation on kpathsea's behavior wrt. encoding, beyond trying to look at the sources.

Thanks to @MortenSHUTE for the original report.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
