### PR TITLE
Fix CSS for module-level data

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -731,7 +731,7 @@ td.field-body table.property-table tr:last-of-type td {
 
 /*** function and class description ***/
 /* top-level definitions */
-dl.class, dl.function {
+dl.class, dl.function, dl.data {
     border-top: 1px solid #888;
     padding-top: 0px;
     margin-top: 20px;
@@ -744,7 +744,7 @@ dl.method, dl.classmethod, dl.staticmethod, dl.attribute {
 
 
 dl.class > dt, dl.classmethod > dt, dl.method > dt, dl.function > dt,
-dl.attribute > dt, dl.staticmethod > dt {
+dl.attribute > dt, dl.staticmethod > dt, dl.data > dt {
     background-color: #eff3f4;
     padding-left: 6px;
     padding-right: 6px;
@@ -771,7 +771,7 @@ dl.class big, dl.function big {
     font-family: monospace;
 }
 
-dl.class dd, dl.function dd {
+dl.class dd, dl.function dd, dl.data dd {
     padding: 10px;
 }
 


### PR DESCRIPTION
## PR Summary

e.g. `matplotlib.rcParams`.

Before:

![grafik](https://user-images.githubusercontent.com/2836374/45986705-73b4d800-c06d-11e8-9d3a-6975a19d4495.png)

After:

![grafik](https://user-images.githubusercontent.com/2836374/45986735-9d6dff00-c06d-11e8-9800-919deef67a7e.png)


