### PR TITLE
Simplify empty-rasterized pdf test.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -234,9 +234,8 @@ def test_failing_latex(tmpdir):
         plt.savefig(path)
 
 
-def test_empty_rasterised():
+def test_empty_rasterized():
     # Check that emtpy figures that are rasterised save to pdf files fine
-    with PdfPages(io.BytesIO()) as pdf:
-        fig, ax = plt.subplots()
-        ax.plot([], [], rasterized=True)
-        fig.savefig(pdf, format="pdf")
+    fig, ax = plt.subplots()
+    ax.plot([], [], rasterized=True)
+    fig.savefig(io.BytesIO(), format="pdf")


### PR DESCRIPTION
The test is about saving empty rasterized artists, not about PdfPages.

This makes the test compatible with mplcairo, which doesn't support
PdfPages.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
