### PR TITLE
[WIP] Add the ability for unit converters to convert back to data with units

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1576,6 +1576,16 @@ class Axis(martist.Artist):
                                          f'units: {x!r}') from e
         return ret
 
+    @property
+    def _can_unconvert_units(self):
+        if self.converter is not None:
+            if hasattr(self.converter, 'un_convert'):
+                return True
+        return False
+
+    def unconvert_units(self, x):
+        return self.converter.un_convert(x, self.units, self)
+
     def set_units(self, u):
         """
         Set the units for axis.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1576,15 +1576,12 @@ class Axis(martist.Artist):
                                          f'units: {x!r}') from e
         return ret
 
-    @property
-    def _can_unconvert_units(self):
-        if self.converter is not None:
-            if hasattr(self.converter, 'un_convert'):
-                return True
-        return False
-
+    # Uncomment this in 3.5 when Converters are enforced to have an
+    # un_convert() method
+    """
     def unconvert_units(self, x):
         return self.converter.un_convert(x, self.units, self)
+    """
 
     def set_units(self, u):
         """

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1929,18 +1929,27 @@ class BaseDateConverter(units.ConversionInterface):
 
 
 class DateConverter(BaseDateConverter):
+    """
+    A converter for `datetime.date` data.
+    """
     @staticmethod
     def un_convert(value, unit, axis):
         return num2date(value)
 
 
 class Datetime64Converter(BaseDateConverter):
+    """
+    A converter for `numpy.datetime64` data.
+    """
     @staticmethod
     def un_convert(value, unit, axis):
         return np.datetime64(num2date(value).replace(tzinfo=None))
 
 
 class DatetimeConverter(BaseDateConverter):
+    """
+    A converter for `datetime.datetime` data.
+    """
     @staticmethod
     def un_convert(value, unit, axis):
         return num2date(value)

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1873,15 +1873,13 @@ def weeks(w):
     return w * DAYS_PER_WEEK
 
 
-class DateConverter(units.ConversionInterface):
+class BaseDateConverter(units.ConversionInterface):
     """
-    Converter for datetime.date and datetime.datetime data,
-    or for date/time data represented as it would be converted
-    by :func:`date2num`.
+    A base converter for datetime.date and datetime.datetime data, or for
+    date/time data represented as it would be converted by :func:`date2num`.
 
     The 'unit' tag for such data is None or a tzinfo instance.
     """
-
     @staticmethod
     def axisinfo(unit, axis):
         """
@@ -1930,6 +1928,24 @@ class DateConverter(units.ConversionInterface):
         return None
 
 
+class DateConverter(BaseDateConverter):
+    @staticmethod
+    def un_convert(value, unit, axis):
+        return num2date(value)
+
+
+class Datetime64Converter(BaseDateConverter):
+    @staticmethod
+    def un_convert(value, unit, axis):
+        return np.datetime64(num2date(value).replace(tzinfo=None))
+
+
+class DatetimeConverter(BaseDateConverter):
+    @staticmethod
+    def un_convert(value, unit, axis):
+        return num2date(value)
+
+
 class ConciseDateConverter(DateConverter):
     """
     Converter for datetime.date and datetime.datetime data,
@@ -1968,6 +1984,6 @@ class ConciseDateConverter(DateConverter):
                               default_limits=(datemin, datemax))
 
 
-units.registry[np.datetime64] = DateConverter()
+units.registry[np.datetime64] = Datetime64Converter()
 units.registry[datetime.date] = DateConverter()
-units.registry[datetime.datetime] = DateConverter()
+units.registry[datetime.datetime] = DatetimeConverter()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -97,7 +97,10 @@ def test_matshow():
                    ])
 def test_formatter_ticker():
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
 
     # This should affect the tick size.  (Tests issue #543)
     matplotlib.rcParams['lines.markeredgewidth'] = 30
@@ -486,7 +489,10 @@ def test_polar_alignment():
 def test_fill_units():
     from datetime import datetime
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
 
     # generate some data
     t = units.Epoch("ET", dt=datetime(2009, 4, 27))
@@ -654,7 +660,10 @@ def test_polar_wrap(fig_test, fig_ref):
 @check_figures_equal()
 def test_polar_units_1(fig_test, fig_ref):
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
     xs = [30.0, 45.0, 60.0, 90.0]
     ys = [1.0, 2.0, 3.0, 4.0]
 
@@ -669,7 +678,10 @@ def test_polar_units_1(fig_test, fig_ref):
 @check_figures_equal()
 def test_polar_units_2(fig_test, fig_ref):
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
     xs = [30.0, 45.0, 60.0, 90.0]
     xs_deg = [x * units.deg for x in xs]
     ys = [1.0, 2.0, 3.0, 4.0]
@@ -838,7 +850,10 @@ def test_aitoff_proj():
 def test_axvspan_epoch():
     from datetime import datetime
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
 
     # generate some data
     t0 = units.Epoch("ET", dt=datetime(2009, 1, 20))
@@ -854,7 +869,10 @@ def test_axvspan_epoch():
 def test_axhspan_epoch():
     from datetime import datetime
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
 
     # generate some data
     t0 = units.Epoch("ET", dt=datetime(2009, 1, 20))

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -165,7 +165,10 @@ def test_too_many_date_ticks(caplog):
 @image_comparison(['RRuleLocator_bounds.png'])
 def test_RRuleLocator():
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
 
     # This will cause the RRuleLocator to go out of bounds when it tries
     # to add padding to the limits, so we make sure it caps at the correct
@@ -198,7 +201,10 @@ def test_RRuleLocator_dayrange():
 @image_comparison(['DateFormatter_fractionalSeconds.png'])
 def test_DateFormatter():
     import matplotlib.testing.jpl_units as units
-    units.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        units.register()
 
     # Lets make sure that DateFormatter will allow us to have tick marks
     # at intervals of fractional seconds.

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -367,7 +367,10 @@ def test_multi_color_hatch():
 @image_comparison(['units_rectangle.png'])
 def test_units_rectangle():
     import matplotlib.testing.jpl_units as U
-    U.register()
+    # Catch warnings thrown whilst jpl unit converters don't have an
+    # un_convert() method
+    with pytest.warns(Warning, match='does not define an un_convert'):
+        U.register()
 
     p = mpatches.Rectangle((5*U.km, 6*U.km), 1*U.km, 2*U.km)
 

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -58,7 +58,7 @@ def quantity_converter():
             return Quantity(value, axis.get_units()).to(unit).magnitude
 
     def un_convert(value, unit, axis):
-        return Quantitfy(value, unit)
+        return Quantity(value, unit)
 
     def default_units(value, axis):
         if hasattr(value, 'units'):

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -138,6 +138,14 @@ class ConversionInterface:
         return obj
 
     @staticmethod
+    def un_convert(data, unit, axis):
+        """
+        Convert data that has already been converted back to its original
+        value.
+        """
+        return data
+
+    @staticmethod
     def is_numlike(x):
         """
         The Matplotlib datalim, autoscaling, locators etc work with scalars

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -212,7 +212,6 @@ class DecimalConverter(ConversionInterface):
         """
         return Decimal(value)
 
-
     @staticmethod
     def axisinfo(unit, axis):
         # Since Decimal is a kind of Number, don't need specific axisinfo.


### PR DESCRIPTION
Inspired by #7462, and not-so-recent units discussions on the mailing list, I have made a minimal implementation of having an `un_convert` method for `ConversionInterface` classes. The benifit of this is that Matplotlib can re-convert from "axis coordinates" to "data/unit coordinates", and return data with units. This is particularly useful for things like `ginput`.

I will write this up more in the future, but for to keep a paper trail this is a pre-requisite for a `accepts_units` decorator (see https://github.com/matplotlib/matplotlib/pull/10411 for an attempt at this) that would automatically catch issues such as https://github.com/matplotlib/matplotlib/issues/15332 , 