### PR TITLE
Don't try to autoscale if no data present to autoscale to

### DIFF
--- a/doc/api/next_api_changes/2018-09-25-DS-autoscale.rst
+++ b/doc/api/next_api_changes/2018-09-25-DS-autoscale.rst
@@ -1,0 +1,5 @@
+Autoscaling when no data present
+--------------------------------
+
+`.Axes.autoscale_view` now does not attempt to autoscale an axis if there is no
+data with finite coordinates present to use to determine the autoscaling.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2372,8 +2372,9 @@ class _AxesBase(martist.Artist):
         """
         Autoscale the view limits using the data limits.
 
-        You can selectively autoscale only a single axis, e.g., the xaxis by
-        setting *scaley* to *False*.  The autoscaling preserves any
+        If no data with finite coordinates is present, limits are left
+        unchanged. You can selectively autoscale only a single axis, e.g.,
+        the xaxis by setting *scaley* to *False*. The autoscaling preserves any
         axis direction reversal that has already been done.
 
         If *tight* is *False*, the axis major locator will be used
@@ -2426,6 +2427,9 @@ class _AxesBase(martist.Artist):
                 dl = finite_dl
                 dl.extend(x_finite)
                 dl.extend(y_finite)
+            else:
+                # If no finite data to autoscale using, don't do anything
+                return
 
             bb = mtransforms.BboxBase.union(dl)
             x0, x1 = getattr(bb, interval)


### PR DESCRIPTION
If there's no data (with finite coordinates) present, then it doesn't seem sensible to me to try and autoscale an axis. This should be a (probably minor performance boost), because autoscale seems to be called quite a few times on before anything is plotted.