### PR TITLE
FIX: Don't apply tight_layout if axes collapse

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -38,7 +38,8 @@ API Changes for 3.0.1
 
 `.tight_layout.auto_adjust_subplotpars` can return ``None`` now if the new
 subplotparams will collapse axes to zero width or height.  This prevents
-``tight_layout`` from being executed.  
+``tight_layout`` from being executed.  Similarly
+`.tight_layout.get_tight_layout_figure` will return None.  
 
 API Changes for 3.0.0
 =====================

--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -33,6 +33,13 @@ This pages lists API changes for the most recent version of Matplotlib.
 
    next_api_changes/*
 
+API Changes for 3.0.1
+=====================
+
+`.tight_layout.auto_adjust_subplotpars` can return ``None`` now if the new
+subplotparams will collapse axes to zero width or height.  This prevents
+``tight_layout`` from being executed.  
+
 API Changes for 3.0.0
 =====================
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2390,7 +2390,8 @@ default: 'top'
         kwargs = get_tight_layout_figure(
             self, self.axes, subplotspec_list, renderer,
             pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)
-        self.subplots_adjust(**kwargs)
+        if kwargs:
+            self.subplots_adjust(**kwargs)
 
     def align_xlabels(self, axs=None):
         """

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -341,7 +341,8 @@ class GridSpec(GridSpecBase):
         kwargs = tight_layout.get_tight_layout_figure(
             figure, figure.axes, subplotspec_list, renderer,
             pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)
-        self.update(**kwargs)
+        if kwargs:
+            self.update(**kwargs)
 
 
 class GridSpecFromSubplotSpec(GridSpecBase):

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -316,3 +316,19 @@ def test_badsubplotgrid():
     with warnings.catch_warnings(record=True) as w:
         plt.tight_layout()
         assert len(w) == 1
+
+
+def test_collapsed():
+    # test that if a call to tight_layout will collapes the axes that
+    # it does not get applied:
+    fig, ax = plt.subplots(tight_layout=True)
+    ax.set_xlim([0, 1])
+    ax.set_ylim([0, 1])
+
+    ax.annotate('BIG LONG STRING', xy=(1.25, 2), xytext=(10.5, 1.75),)
+    p1 = ax.get_position()
+    with warnings.catch_warnings(record=True) as w:
+        plt.tight_layout()
+        p2 = ax.get_position()
+        assert p1.width == p2.width
+        assert len(w) == 1

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -38,7 +38,8 @@ def auto_adjust_subplotpars(
         fig, renderer, nrows_ncols, num1num2_list, subplot_list,
         ax_bbox_list=None, pad=1.08, h_pad=None, w_pad=None, rect=None):
     """
-    Return a dict of subplot parameters to adjust spacing between subplots.
+    Return a dict of subplot parameters to adjust spacing between subplots
+    or ``None`` if resulting axes would have zero height or width.
 
     Note that this function ignores geometry information of subplot
     itself, but uses what is given by the *nrows_ncols* and *num1num2_list*

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -295,7 +295,7 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
     -------
     subplotspec or None
         subplotspec kwargs to be passed to `.Figure.subplots_adjust` or
-        None if tight_layout could not be accomplished.  
+        None if tight_layout could not be accomplished.
 
     """
 

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -172,15 +172,15 @@ def auto_adjust_subplotpars(
         margin_bottom += pad_inches / fig_height_inch
 
     if margin_left + margin_right >= 1:
-        margin_left = 0.4999
-        margin_right = 0.4999
-        warnings.warn('The left and right margins cannot be made large '
+        warnings.warn('Tight layout not applied. The left and right margins '
+                      'cannot be made large '
                       'enough to accommodate all axes decorations. ')
+        return None
     if margin_bottom + margin_top >= 1:
-        margin_bottom = 0.4999
-        margin_top = 0.4999
-        warnings.warn('The bottom and top margins cannot be made large '
+        warnings.warn('Tight layout not applied. '
+                      'The bottom and top margins cannot be made large '
                       'enough to accommodate all axes decorations. ')
+        return None
 
     kwargs = dict(left=margin_left,
                   right=1 - margin_right,
@@ -195,9 +195,10 @@ def auto_adjust_subplotpars(
         # axes widths:
         h_axes = (1 - margin_right - margin_left - hspace * (cols - 1)) / cols
         if h_axes < 0:
-            warnings.warn('tight_layout cannot make axes width small enough '
+            warnings.warn('Tight layout not applied. '
+                          'tight_layout cannot make axes width small enough '
                           'to accommodate all axes decorations')
-            kwargs["wspace"] = 0.5
+            return None
         else:
             kwargs["wspace"] = hspace / h_axes
 
@@ -206,9 +207,10 @@ def auto_adjust_subplotpars(
                   + vpad_inches / fig_height_inch)
         v_axes = (1 - margin_top - margin_bottom - vspace * (rows - 1)) / rows
         if v_axes < 0:
-            warnings.warn('tight_layout cannot make axes height small enough '
+            warnings.warn('Tight layout not applied. '
+                          'tight_layout cannot make axes height small enough '
                           'to accommodate all axes decorations')
-            kwargs["hspace"] = 0.5
+            return None
         else:
             kwargs["hspace"] = vspace / v_axes
 

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -290,6 +290,13 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
         (left, bottom, right, top) rectangle in normalized figure coordinates
         that the whole subplots area (including labels) will fit into.
         Defaults to using the entire figure.
+
+    Returns
+    -------
+    subplotspec or None
+        subplotspec kwargs to be passed to `.Figure.subplots_adjust` or
+        None if tight_layout could not be accomplished.  
+
     """
 
     subplot_list = []


### PR DESCRIPTION
## PR Summary

Partially addresses #12256

If tight_layout is called and there is an annotation or legend that is outside the axes, it can sometimes happen that the axes completely collapses.  There is currently a warning, but this PR also doesn't apply tight_layout if that happens, under the assumption its better to draw something rather than draw something that is completely broken.

Note however, it is still possible for the axes to get quite small.

The origin of these issues is that `axes.get_tightbbox` now includes all artists when computing the bounding box, whereas before 3.0 it only included the axes elements themselves, and *none* of the artists.  Now artists can be excluded by explictly setting `a.set_inlayout(False)`.  

NOTE: this is an API change in that `tight_layout.auto_adjust_subplotpars` now can return None if no good subplotpars were computed.  

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documentation is sphinx and numpydoc compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->