### PR TITLE
Make FooConverter inherit from ConversionInterface in examples

### DIFF
--- a/examples/units/evans_test.py
+++ b/examples/units/evans_test.py
@@ -27,7 +27,7 @@ class Foo(object):
         return self._val / unit
 
 
-class FooConverter(object):
+class FooConverter(units.ConversionInterface):
     @staticmethod
     def axisinfo(unit, axis):
         'return the Foo AxisInfo'


### PR DESCRIPTION
Adds the correct inheritance for `FooConverter`.