### PR TITLE
[WIP] Remove some pytest parameterising warnings

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -229,7 +229,8 @@ def test_embed_limit(method_name, caplog, tmpdir):
 @pytest.mark.parametrize(
     "method_name",
     ["to_html5_video",
-     pytest.mark.xfail("to_jshtml")])  # Needs to be fixed.
+     pytest.param("to_jshtml",
+                  marks=pytest.mark.xfail)])
 def test_cleanup_temporaries(method_name, tmpdir):
     with tmpdir.as_cwd():
         getattr(make_animation(frames=1), method_name)()

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -26,14 +26,14 @@ needs_usetex = pytest.mark.skipif(
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('format, use_log, rcParams', [
     ('ps', False, {}),
-    needs_ghostscript(
-        ('ps', False, {'ps.usedistiller': 'ghostscript'})),
-    needs_usetex(needs_ghostscript(
-        ('ps', False, {'text.usetex': True}))),
+    pytest.param('ps', False, {'ps.usedistiller': 'ghostscript'},
+                 marks=needs_ghostscript),
+    pytest.param('ps', False, {'text.usetex': True},
+                 marks=[needs_ghostscript, needs_usetex]),
     ('eps', False, {}),
     ('eps', True, {'ps.useafm': True}),
-    needs_usetex(needs_ghostscript(
-        ('eps', False, {'text.usetex': True}))),
+    pytest.param('eps', False, {'text.usetex': True},
+                 marks=[needs_ghostscript, needs_usetex]),
 ], ids=[
     'ps',
     'ps with distiller',

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -126,7 +126,7 @@ def _test_determinism_save(filename, usetex):
     "filename, usetex",
     # unique filenames to allow for parallel testing
     [("determinism_notex.svg", False),
-     needs_usetex(("determinism_tex.svg", True))])
+     pytest.param("determinism_tex.svg", True, marks=needs_usetex)])
 def test_determinism(filename, usetex):
     import sys
     from subprocess import check_output, STDOUT, CalledProcessError

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -32,8 +32,10 @@ def _get_testable_interactive_backends():
             reason = "No $DISPLAY"
         elif any(importlib.util.find_spec(dep) is None for dep in deps):
             reason = "Missing dependency"
-        backends.append(pytest.mark.skip(reason=reason)(backend) if reason
-                        else backend)
+        if reason:
+            backend = pytest.param(
+                backend, marks=pytest.mark.skip(reason=reason))
+        backends.append(backend)
     return backends
 
 


### PR DESCRIPTION
Removes a bunch of warnings that look like
```
lib/mpl_toolkits/tests/test_mplot3d.py:129: RemovedInPytest4Warning: Applying marks directly to parameters is deprecated, please use pytest.param(..., marks=...) instead.
For more details, see: https://docs.pytest.org/en/latest/parametrize.html
  @image_comparison(baseline_images=['mixedsubplot'], remove_text=True,
```
There's still a few to fix.