### PR TITLE
Ghostscript 9.0 requirement revisited

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -170,8 +170,8 @@ etc., you can install the following:
   animated gifs;
 * `Pillow <https://pillow.readthedocs.io/en/latest/>`_ (>= 3.4): for a larger
   selection of image file formats: JPEG, BMP, and TIFF image files;
-* `LaTeX <https://miktex.org/>`_ and `GhostScript
-  <https://ghostscript.com/download/>`_ (for rendering text with LaTeX).
+* `LaTeX <https://miktex.org/>`_ and `GhostScript (>=9.0)
+  <https://ghostscript.com/download/>`_ : for rendering text with LaTeX.
 
 .. note::
 

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -26,7 +26,7 @@ local FreeType build.
 The following software is required to run the tests:
 
 - pytest_ (>=3.6)
-- Ghostscript_ (to render PDF files)
+- Ghostscript_ (>= 9.0, to render PDF files)
 - Inkscape_ (to render SVG files)
 
 Optionally you can install:

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -516,7 +516,7 @@ def checkdep_usetex(s):
     if not s:
         return False
 
-    gs_req = '8.60'
+    gs_req = '9.00'
     dvipng_req = '1.6'
     flag = True
 

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -21,7 +21,7 @@ to use the same fonts in your figures as in the main document.
 
 Matplotlib's LaTeX support requires a working LaTeX_ installation, dvipng_
 (which may be included with your LaTeX installation), and Ghostscript_
-(GPL Ghostscript 8.60 or later is recommended). The executables for these
+(GPL Ghostscript 9.0 or later is required). The executables for these
 external dependencies must all be located on your :envvar:`PATH`.
 
 There are a couple of options to mention, which can be changed using


### PR DESCRIPTION
## PR Summary

In #11989 the required version of ghostscript was changed to be >= 9.0.  
This is currently not reflected in parts of the code and the docs. 

This PR updates the code and docs where appropriate to make this requirement visible.

It thereby provides an answer to [the question](https://github.com/matplotlib/matplotlib/pull/9639#issuecomment-340842784) raised a year ago

> Is the minimal gs version in the docs anyplace that also needs to be update?



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
