### PR TITLE
Add ishistogammed option to the hist plotting method

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6256,6 +6256,7 @@ class Axes(_AxesBase):
              cumulative=False, bottom=None, histtype='bar', align='mid',
              orientation='vertical', rwidth=None, log=False,
              color=None, label=None, stacked=False, normed=None,
+             ishistogrammed=False,
              **kwargs):
         """
         Plot a histogram.
@@ -6430,6 +6431,13 @@ class Axes(_AxesBase):
         normed : bool, optional
             Deprecated; use the density keyword argument instead.
 
+        ishistogrammed : bool, optional
+            If ``True``, interpret the input data ``x`` as already histogrammed
+            data, preventing this method from preforming the histogramming. If
+            ``True``, the argument ``bins`` must also be provided.
+
+            Default is ``False``
+
         Returns
         -------
         n : array or list of arrays
@@ -6496,6 +6504,10 @@ class Axes(_AxesBase):
         if normed is not None:
             cbook.warn_deprecated("2.1", name="'normed'", obj_type="kwarg",
                                   alternative="'density'", removal="3.1")
+
+        if ishistogrammed and bins is None:
+            raise ValueError("'bins' must be passed if 'ishistogrammed' is "
+                             "True.")
 
         # basic input validation
         input_empty = np.size(x) == 0
@@ -6565,7 +6577,10 @@ class Axes(_AxesBase):
         for i in range(nx):
             # this will automatically overwrite bins,
             # so that each histogram uses the same bins
-            m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)
+            if ishistogrammed:
+                m, bins = x[i], bins
+            else:
+                m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)
             m = m.astype(float)  # causes problems later if it's an int
             if mlast is None:
                 mlast = np.zeros(len(bins)-1, m.dtype)


### PR DESCRIPTION
## PR Summary

The option `ishistogrammed` to the `hist` plotting method, e.g.

```
plt.hist(x, bins=bins, ishistogrammed=True)
```

This is used if `x` is already histogrammed through the `np.histogram` function (or similar).

Use case:
* If the non-histogrammed `x` is too large to pass to `plt.hist` in one go then the user can histogram in chunks themselves and then pass the summed histograms to do the plotting.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
