### PR TITLE
BUG: Fix typo in view_limits() for MultipleLocator

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -59,6 +59,23 @@ class TestMultipleLocator(object):
                                9.441, 12.588])
         assert_almost_equal(loc.tick_values(-7, 10), test_value)
 
+    def test_view_limits(self):
+        """
+        Test basic behavior of view limits.
+        """
+        with matplotlib.rc_context({'axes.autolimit_mode': 'data'}):
+            loc = mticker.MultipleLocator(base=3.147)
+            assert_almost_equal(loc.view_limits(-5, 5), (-5, 5))
+
+    def test_view_limits_round_numbers(self):
+        """
+        Test that everything works properly with 'round_numbers' for auto
+        limit.
+        """
+        with matplotlib.rc_context({'axes.autolimit_mode': 'round_numbers'}):
+            loc = mticker.MultipleLocator(base=3.147)
+            assert_almost_equal(loc.view_limits(-4, 4), (-6.294, 6.294))
+
     def test_set_params(self):
         """
         Create multiple locator with 0.7 base, and change it to something else.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1750,7 +1750,7 @@ class MultipleLocator(Locator):
         """
         if rcParams['axes.autolimit_mode'] == 'round_numbers':
             vmin = self._edge.le(dmin) * self._edge.step
-            vmax = self._base.ge(dmax) * self._edge.step
+            vmax = self._edge.ge(dmax) * self._edge.step
             if vmin == vmax:
                 vmin -= 1
                 vmax += 1


### PR DESCRIPTION
## PR Summary
Fixes (what looks to be) a copy/paste error in `MultipleLocator`. Apparently, we had no tests for this code path. Before this fix, calling `view_limits()` on an instance of `MultipleLocator` (when using `'round_numbers'` for `axes.autolimit_mode`) would give:
```pytb
../../../virtualenv/python3.6.3/lib/python3.6/site-packages/matplotlib/__init__.py:1785: in inner
    return func(ax, *args, **kwargs)
../../../virtualenv/python3.6.3/lib/python3.6/site-packages/matplotlib/axes/_axes.py:4876: in barbs
    self.autoscale_view()
../../../virtualenv/python3.6.3/lib/python3.6/site-packages/matplotlib/axes/_base.py:2478: in autoscale_view
    'minposx', self.xaxis, self._xmargin, x_stickies, self.set_xbound)
../../../virtualenv/python3.6.3/lib/python3.6/site-packages/matplotlib/axes/_base.py:2472: in handle_single_axis
    x0, x1 = locator.view_limits(x0, x1)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <matplotlib.ticker.MultipleLocator object at 0x7f98ab3c47f0>
dmin = -20.0, dmax = 21.89385499011344
    def view_limits(self, dmin, dmax):
        """
            Set the view limits to the nearest multiples of base that
            contain the data.
            """
        if rcParams['axes.autolimit_mode'] == 'round_numbers':
            vmin = self._edge.le(dmin) * self._edge.step
>           vmax = self._base.ge(dmax) * self._edge.step
E           AttributeError: 'MultipleLocator' object has no attribute '_base'
../../../virtualenv/python3.6.3/lib/python3.6/site-packages/matplotlib/ticker.py:1745: AttributeError
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
