### PR TITLE
Fix Travis 3.6 builds

### DIFF
--- a/requirements/testing/travis36.txt
+++ b/requirements/testing/travis36.txt
@@ -2,6 +2,7 @@
 
 flake8
 flake8-per-file-ignores
-jupyter
+ipykernel
+nbconvert[execute]
 pandas
 pytz


### PR DESCRIPTION
## PR Summary

We do not need the whole Jupyter stack, and it currently installs packages that do not work with each other. Installing just ipykernel & nbconvert is lighter and avoids the conflict.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way