### PR TITLE
Fix the docs build.

### DIFF
--- a/doc/api/backend_wxagg_api.rst
+++ b/doc/api/backend_wxagg_api.rst
@@ -2,7 +2,9 @@
 :mod:`matplotlib.backends.backend_wxagg`
 ========================================
 
-.. automodule:: matplotlib.backends.backend_wxagg
-   :members:
-   :undoc-members:
-   :show-inheritance:
+**NOTE** Not included, to avoid adding a dependency to building the docs.
+
+.. .. automodule:: matplotlib.backends.backend_wxagg
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:

--- a/doc/sphinxext/mock_gui_toolkits.py
+++ b/doc/sphinxext/mock_gui_toolkits.py
@@ -6,23 +6,8 @@ class MyCairoCffi(MagicMock):
     __name__ = "cairocffi"
 
 
-class MyWX(MagicMock):
-    class Panel(object):
-        pass
-
-    class ToolBar(object):
-        pass
-
-    class Frame(object):
-        pass
-
-    class StatusBar(object):
-        pass
-
-
 def setup(app):
     sys.modules.update(
         cairocffi=MyCairoCffi(),
-        wx=MyWX(),
     )
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -18,7 +18,7 @@ import warnings
 import numpy as np
 
 from matplotlib import rcParams
-from matplotlib import docstring
+from matplotlib import backends, docstring
 from matplotlib import __version__ as _mpl_version
 from matplotlib import get_backend
 
@@ -415,12 +415,8 @@ class Figure(Artist):
         Parameters
         ----------
         warn : bool
-            If ``True``, issue warning when called on a non-GUI backend
-
-        Notes
-        -----
-        For non-GUI backends, this does nothing, in which case a warning will
-        be issued if *warn* is ``True`` (default).
+            If ``True`` and we are not running headless (i.e. on Linux with an
+            unset DISPLAY), issue warning when called on a non-GUI backend.
         """
         try:
             manager = getattr(self.canvas, 'manager')
@@ -436,7 +432,8 @@ class Figure(Artist):
                 return
             except NonGuiException:
                 pass
-        if warn:
+        if (backends._get_running_interactive_framework() != "headless"
+                and warn):
             warnings.warn('Matplotlib is currently using %s, which is a '
                           'non-GUI backend, so cannot show the figure.'
                           % get_backend())


### PR DESCRIPTION
## PR Summary

Don't mock wx in docs build.

Otherwise, wx.GetApp() returns a truthy value and the backend switching
machinery believes that a wx event loop is running, leading to warnings
about show() not doing anything with agg.

Builds on top of #12267.  Will self-merge if passes.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
