### PR TITLE
fixed minor spelling error in docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1508,7 +1508,7 @@ class Axes(_AxesBase):
 
         See Also
         --------
-        scatter : XY scatter plot with markers of variing size and/or color (
+        scatter : XY scatter plot with markers of varying size and/or color (
             sometimes also called bubble chart).
 
 


### PR DESCRIPTION
## PR Summary

Fixed minor spelling error in `plot(...)` docstring. "Varying" was spelled "variing"--now fixed.

## PR Checklist

- [ unchanged ] Has Pytest style unit tests
- [ unchanged ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ NA ] New features are documented, with examples if plot related
- [ unchanged ] Documentation is sphinx and numpydoc compliant
- [ NA ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ NA ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

