### PR TITLE
ENH: add colorbar method to axes

### DIFF
--- a/doc/users/next_whats_new/2018-09-28-JMK.rst
+++ b/doc/users/next_whats_new/2018-09-28-JMK.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+New `.axes.Axes.colorbar` method for attaching colorbar to single axes
+``````````````````````````````````````````````````````````````````````
+
+A simple wrapper for `.Figure.colorbar` that allows the user to omit the
+``ax`` kwarg. The new ``ax.colorbar(mappable)`` is equivalent to
+``fig.colorbar(mappable, ax=ax)``.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -418,6 +418,21 @@ class Axes(_AxesBase):
     def _remove_legend(self, legend):
         self.legend_ = None
 
+    @docstring.dedent_interpd
+    def colorbar(self, mappable, cax=None, use_gridspec=True, **kw):
+        """
+        Create a colorbar for a ScalarMappable instance, *mappable*, with the
+        axes as the parent.
+
+        Documentation for the pyplot thin wrapper:
+        %(colorbar_doc)s
+        """
+        ax = kw.pop('ax', None)
+        if ax is not None:
+            warnings.warn('Supplied ax argument ignored')
+        self.figure.colorbar(mappable,  ax=self, cax=cax,
+                             use_gridspec=use_gridspec, **kw)
+
     def inset_axes(self, bounds, *, transform=None, zorder=5,
             **kwargs):
         """

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -396,3 +396,19 @@ def test_colorbar_axes_kw():
     plt.imshow(([[1, 2], [3, 4]]))
     plt.colorbar(orientation='horizontal', fraction=0.2, pad=0.2, shrink=0.5,
                  aspect=10, anchor=(0., 0.), panchor=(0., 1.))
+
+
+def test_colorbar_axes():
+    fig, ax = plt.subplots()
+    pcm = ax.pcolormesh(np.random.random((32, 32)))
+    # smoketest that this works:
+    ax.colorbar(pcm)
+    with pytest.warns(UserWarning) as record:
+        ax.colorbar(pcm, ax=ax)
+        assert len(record) == 1
+
+    fig, ax = plt.subplots()
+    pcm = ax.pcolormesh(np.random.random((32, 32)))
+    # smoketest that this works:
+    ax.colorbar(pcm, orientation='horizontal', fraction=0.2, pad=0.2, shrink=0.5,
+                 aspect=10, anchor=(0., 0.), panchor=(0., 1.))

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -109,7 +109,8 @@ arguments:
     the :class:`~matplotlib.image.Image`,
     :class:`~matplotlib.contour.ContourSet`, etc. to
     which the colorbar applies; this argument is mandatory for the
-    :meth:`~matplotlib.figure.Figure.colorbar` method but optional for the
+    :meth:`~matplotlib.figure.Figure.colorbar`
+    and :meth:`~matplotlib.axes.Axes.colorbar` methods but optional for the
     :func:`~matplotlib.pyplot.colorbar` function, which sets the
     default to the current image.
 
@@ -119,7 +120,7 @@ keyword arguments:
     None | axes object into which the colorbar will be drawn
   *ax*
     None | parent axes object from which space for a new
-    colorbar axes will be stolen
+    colorbar axes will be stolen (ignored for `.axes.Axes.colorbar`)
 
 
 Additional keyword arguments are of two kinds:


### PR DESCRIPTION
## PR Summary

It has always struck me as strange that if we want to add a colorbar to an axes we have to call if from `figure`.  This change just lets you do `ax.colorbar(mappable)`.  

Note that `ax.colorbar(mappable, ax=axother)` will just ignore the `ax` argument.  


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
