### PR TITLE
Improve selection of inset indicator connectors.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -580,16 +580,14 @@ class Axes(_AxesBase):
             bboxins = pos.transformed(self.figure.transFigure)
             rectbbox = mtransforms.Bbox.from_bounds(
                         *bounds).transformed(transform)
-            if rectbbox.x0 < bboxins.x0:
-                sig = 1
-            else:
-                sig = -1
-            if sig*rectbbox.y0 < sig*bboxins.y0:
-                connects[0].set_visible(False)
-                connects[3].set_visible(False)
-            else:
-                connects[1].set_visible(False)
-                connects[2].set_visible(False)
+            x0 = rectbbox.x0 < bboxins.x0
+            x1 = rectbbox.x1 < bboxins.x1
+            y0 = rectbbox.y0 < bboxins.y0
+            y1 = rectbbox.y1 < bboxins.y1
+            connects[0].set_visible(x0 ^ y0)
+            connects[1].set_visible(x0 == y1)
+            connects[2].set_visible(x1 == y0)
+            connects[3].set_visible(x1 ^ y1)
 
         return rectpatch, connects
 


### PR DESCRIPTION
## PR Summary

Instead of selecting just one pair of corners, determine whether each connector is visible individually based on relative position of the bbox corners that each one connects.
It took me a couple of false starts, but ended up relatively simple in the end.

Fixes #12323.

Since it's marked experimental, I'll leave it to @jklymak to determine milestoning, and then write up the changelog accordingly, and maybe update the test too.

### On master
![master](https://user-images.githubusercontent.com/302469/46241940-21d2c180-c38f-11e8-8f6a-2188c8fd151f.gif)
### This PR
![fix](https://user-images.githubusercontent.com/302469/46241941-27300c00-c38f-11e8-9f41-f4683a1d41cd.gif)

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way