### PR TITLE
Fix stripping of CRLF on Windows.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1017,16 +1017,16 @@ def find_tex_file(filename, format=None):
     if format is not None:
         cmd += ['--format=' + format]
     cmd += [filename]
-    try:  # Below: strip final newline.
-        result = cbook._check_and_log_subprocess(cmd, _log)[:-1]
+    try:
+        result = cbook._check_and_log_subprocess(cmd, _log)
     except RuntimeError:
         return ''
     if os.name == 'nt':
         # On Windows only, kpathsea appears to use utf-8 output(?); see
         # __win32_fputs in the kpathsea sources and mpl issue #11848.
-        return result.decode('utf-8')
+        return result.decode('utf-8').rstrip('\r\n')
     else:
-        return os.fsdecode(result)
+        return os.fsdecode(result).rstrip('\n')
 
 
 @lru_cache()


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/12308,
Closes https://github.com/matplotlib/matplotlib/issues/12352 (patch proposed there).

I actually don't think the original PR (https://github.com/matplotlib/matplotlib/pull/12253) needed to be milestoned to 3.0.x, but now that it has been, this fix needs to go in too.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
