### PR TITLE
Replace axes_grid by axes_grid1 in test

### DIFF
--- a/lib/mpl_toolkits/axes_grid/__init__.py
+++ b/lib/mpl_toolkits/axes_grid/__init__.py
@@ -7,6 +7,6 @@ from matplotlib.cbook import warn_deprecated
 warn_deprecated(since='2.1',
                 name='mpl_toolkits.axes_grid',
                 alternative='mpl_toolkits.axes_grid1 and'
-                            ' mpl_toolkits.axisartist provies the same'
-                            ' functionality',
+                            ' mpl_toolkits.axisartist, which provide'
+                            ' the same functionality',
                 obj_type='module')

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -7,8 +7,8 @@ from matplotlib.projections import PolarAxes
 from matplotlib.transforms import Affine2D, Transform
 from matplotlib.testing.decorators import image_comparison
 
-from mpl_toolkits.axes_grid.parasite_axes import ParasiteAxesAuxTrans, \
-    SubplotHost
+from mpl_toolkits.axes_grid1.parasite_axes import ParasiteAxesAuxTrans
+from mpl_toolkits.axisartist import SubplotHost
 from mpl_toolkits.axes_grid1.parasite_axes import host_subplot_class_factory
 from mpl_toolkits.axisartist import angle_helper
 from mpl_toolkits.axisartist.axislines import Axes


### PR DESCRIPTION
## PR Summary

Replace axes_grid by axes_grid1 in test to suppress warning 

```
/home/travis/build/matplotlib/matplotlib/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py:10: MatplotlibDeprecationWarning: 
The mpl_toolkits.axes_grid module was deprecated in Matplotlib 2.1 and will be removed two minor releases later. Use mpl_toolkits.axes_grid1 and mpl_toolkits.axisartist provies the same functionality instead.
  from mpl_toolkits.axes_grid.parasite_axes import ParasiteAxesAuxTrans, \
```

The change in the warning message may look a bit strange, this is because the  `alternative` argument gets embedded into `"Use " + alternative + `" instead."`. So the new message now reads 
> The mpl_toolkits.axes_grid module was deprecated in Matplotlib 2.1 and will be removed two minor releases later. Use mpl_toolkits.axes_grid1 and mpl_toolkits.axisartist, which provide the same functionality instead.

## PR Checklist

- [x] Is Pytest style unit test
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
