### PR TITLE
Added rc parameters for tight_layout

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1349,6 +1349,11 @@ defaultParams = {
     'figure.constrained_layout.h_pad': [0.04167, validate_float],
     'figure.constrained_layout.w_pad': [0.04167, validate_float],
 
+    ##Figure tight_layout
+    'figure.tight_layout.pad': [1.08, validate_float],
+    'figure.tight_layout.h_pad': [None, validate_float],
+    'figure.tight_layout.w_pad': [None, validate_float],
+
     ## Saving figure's properties
     'savefig.dpi':         ['figure', validate_dpi],  # DPI
     'savefig.facecolor':   ['white', validate_color],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1351,8 +1351,8 @@ defaultParams = {
 
     ##Figure tight_layout
     'figure.tight_layout.pad': [1.08, validate_float],
-    'figure.tight_layout.h_pad': [None, validate_float],
-    'figure.tight_layout.w_pad': [None, validate_float],
+    'figure.tight_layout.h_pad': [None, validate_float_or_None],
+    'figure.tight_layout.w_pad': [None, validate_float_or_None],
 
     ## Saving figure's properties
     'savefig.dpi':         ['figure', validate_dpi],  # DPI

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -36,7 +36,7 @@ def _get_top(tight_bbox, axes_bbox):
 
 def auto_adjust_subplotpars(
         fig, renderer, nrows_ncols, num1num2_list, subplot_list,
-        ax_bbox_list=None, pad=1.08, h_pad=None, w_pad=None, rect=None):
+        ax_bbox_list=None, pad=rcParams['figure.tight_layout.pad'], h_pad=rcParams['figure.tight_layout.h_pad'], w_pad=rcParams['figure.tight_layout.wpad'], rect=None):
     """
     Return a dict of subplot parameters to adjust spacing between subplots.
 

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -37,7 +37,7 @@ def _get_top(tight_bbox, axes_bbox):
 def auto_adjust_subplotpars(
         fig, renderer, nrows_ncols, num1num2_list, subplot_list,
         ax_bbox_list=None, pad=rcParams['figure.tight_layout.pad'],
-        h_pad=rcParams['figure.tight_layout.h_pad'], w_pad=rcParams['figure.tight_layout.wpad'], rect=None):
+        h_pad=rcParams['figure.tight_layout.h_pad'], w_pad=rcParams['figure.tight_layout.w_pad'], rect=None):
     """
     Return a dict of subplot parameters to adjust spacing between subplots.
 
@@ -268,7 +268,7 @@ def get_subplotspec_list(axes_list, grid_spec=None):
 
 def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
                             pad=rcParams['figure.tight_layout.pad'], h_pad=rcParams['figure.tight_layout.h_pad'],
-                            w_pad=rcParams['figure.tight_layout.wpad'], rect=None):
+                            w_pad=rcParams['figure.tight_layout.w_pad'], rect=None):
     """
     Return subplot parameters for tight-layouted-figure with specified padding.
 

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -36,7 +36,8 @@ def _get_top(tight_bbox, axes_bbox):
 
 def auto_adjust_subplotpars(
         fig, renderer, nrows_ncols, num1num2_list, subplot_list,
-        ax_bbox_list=None, pad=rcParams['figure.tight_layout.pad'], h_pad=rcParams['figure.tight_layout.h_pad'], w_pad=rcParams['figure.tight_layout.wpad'], rect=None):
+        ax_bbox_list=None, pad=rcParams['figure.tight_layout.pad'],
+        h_pad=rcParams['figure.tight_layout.h_pad'], w_pad=rcParams['figure.tight_layout.wpad'], rect=None):
     """
     Return a dict of subplot parameters to adjust spacing between subplots.
 
@@ -266,7 +267,8 @@ def get_subplotspec_list(axes_list, grid_spec=None):
 
 
 def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
-                            pad=1.08, h_pad=None, w_pad=None, rect=None):
+                            pad=rcParams['figure.tight_layout.pad'], h_pad=rcParams['figure.tight_layout.h_pad'],
+                            w_pad=rcParams['figure.tight_layout.wpad'], rect=None):
     """
     Return subplot parameters for tight-layouted-figure with specified padding.
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -450,6 +450,9 @@
 #figure.autolayout : False     ## When True, automatically adjust subplot
                                ## parameters to make the plot fit the figure
                                ## using `tight_layout`
+#figure.tight_layout.pad : 1.08 ## padding between the figure edge and subplots
+#figure.tight_layout.h_pad : None ## padding height between edges of subplots
+#figure.tight_layout.w_pad : None ## padding width between edges of subplots
 #figure.constrained_layout.use: False ## When True, automatically make plot
                                       ## elements fit on the figure. (Not compatible
                                       ## with `autolayout`, above).


### PR DESCRIPTION
added rc parameters for tight_layout padding

## PR Summary
Fixes #5266. 
-added properties in matplotlibrc and rcsetup
-replaced hardcoded values in tight_layout.py with the new rc properties
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
