### PR TITLE
Improved exception handling on animation failure

### DIFF
--- a/doc/api/next_api_changes/2018-10-02-AL-animation.rst
+++ b/doc/api/next_api_changes/2018-10-02-AL-animation.rst
@@ -1,0 +1,7 @@
+Exception on failing animations changed
+```````````````````````````````````````
+
+Previously, subprocess failures in the animation framework would raise either
+in a `RuntimeError` or a `ValueError` depending on when the error occurred.
+They now raise a `subprocess.CalledProcessError` with attributes set as
+documented by the exception class.


### PR DESCRIPTION
## PR Summary

Previously, if an animation-generating subprocess (e.g. ffmpeg)
failed while data was piped in, we'd get a ValueError because we'd
communicate() with the subprocess once in grab_frame(), to generate a
first error, and again at cleanup time, in the finally: clause, but that
second time, the subprocess' stdout and stderr had already been closed.

Instead, don't do anything in grab_frame() and let the finally: clause
handle the errors.

Also replace the nondescript RuntimeError by a CalledProcessError, which
is more descriptive, generates a proper error message by itself
("Command 'foo' returned non-zero exit status 42") and is more easily
introspectable (it includes stdout, stderr as attributes).  Given that
we would previously sometimes throw a ValueError instead of the intended
RuntimeError, I think the API change is worth it.

Un-xfail a test.

Builds on top of #12368.  Closes the second half of #9205.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
