### PR TITLE
DOC: nudges legend position in tutorial to be within graph area

### DIFF
--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -219,7 +219,7 @@ fig, axs = plt.subplots(2, 2, constrained_layout=True)
 for ax in axs.flatten()[:-1]:
     ax.plot(np.arange(10))
 axs[1, 1].plot(np.arange(10), label='This is a plot')
-leg = axs[1, 1].legend(loc='center left', bbox_to_anchor=(0.8, 0.5))
+leg = axs[1, 1].legend(loc='center left', bbox_to_anchor=(0.4, 0.3))
 leg.set_in_layout(False)
 wanttoprint = False
 if wanttoprint:
@@ -236,7 +236,7 @@ for ax in axs.flatten()[:-1]:
 lines = axs[1, 1].plot(np.arange(10), label='This is a plot')
 labels = [l.get_label() for l in lines]
 leg = fig.legend(lines, labels, loc='center left',
-                 bbox_to_anchor=(0.8, 0.5), bbox_transform=axs[1, 1].transAxes)
+                 bbox_to_anchor=(0.4, 0.3), bbox_transform=axs[1, 1].transAxes)
 
 ###############################################################################
 # Padding and Spacing


### PR DESCRIPTION
## PR Summary

The tutorial on constrained layout has an example showing the (recommended) approach of placing a legend on the figure object to avoid shrinking a bunch of other stuff. However, the legend runs off the edge of the plot figure, which seems a bit undesirable. This commit bumps the anchor point a bit so everything fits.

#### Before

<img width="456" alt="screenshot 2018-10-03 02 35 27" src="https://user-images.githubusercontent.com/6868396/46397336-996a5e80-c6b7-11e8-9125-9a48af54c72e.png">

#### After

<img width="752" alt="screenshot 2018-10-03 02 41 19" src="https://user-images.githubusercontent.com/6868396/46397340-9ec7a900-c6b7-11e8-8071-7e1b7debcd1d.png">

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
