### PR TITLE
MAINT Use np.full when possible

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4000,7 +4000,7 @@ class Axes(_AxesBase):
             # maybe draw the fliers
             if showfliers:
                 # fliers coords
-                flier_x = np.ones(len(stats['fliers'])) * pos
+                flier_x = np.full(len(stats['fliers']), pos)
                 flier_y = stats['fliers']
 
                 fliers.extend(doplot(

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4000,7 +4000,7 @@ class Axes(_AxesBase):
             # maybe draw the fliers
             if showfliers:
                 # fliers coords
-                flier_x = np.full(len(stats['fliers']), pos)
+                flier_x = np.full(len(stats['fliers']), pos, dtype='float64')
                 flier_y = stats['fliers']
 
                 fliers.extend(doplot(

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4000,7 +4000,7 @@ class Axes(_AxesBase):
             # maybe draw the fliers
             if showfliers:
                 # fliers coords
-                flier_x = np.full(len(stats['fliers']), pos, dtype='float64')
+                flier_x = np.full(len(stats['fliers']), pos, dtype=np.float64)
                 flier_y = stats['fliers']
 
                 fliers.extend(doplot(

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -169,7 +169,7 @@ class Stars(Shapes):
         self.num_rows = (hatch.count('*')) * density
         path = Path.unit_regular_star(5)
         self.shape_vertices = path.vertices
-        self.shape_codes = np.ones(len(self.shape_vertices)) * Path.LINETO
+        self.shape_codes = np.full(len(self.shape_vertices), Path.LINETO)
         self.shape_codes[0] = Path.MOVETO
         Shapes.__init__(self, hatch, density)
 

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -170,7 +170,7 @@ class Stars(Shapes):
         path = Path.unit_regular_star(5)
         self.shape_vertices = path.vertices
         self.shape_codes = np.full(len(self.shape_vertices), Path.LINETO,
-                                   dtype='float64')
+                                   dtype='int32')
         self.shape_codes[0] = Path.MOVETO
         Shapes.__init__(self, hatch, density)
 

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -170,7 +170,7 @@ class Stars(Shapes):
         path = Path.unit_regular_star(5)
         self.shape_vertices = path.vertices
         self.shape_codes = np.full(len(self.shape_vertices), Path.LINETO,
-                                   dtype=np.int32)
+                                   dtype=Path.code_type)
         self.shape_codes[0] = Path.MOVETO
         Shapes.__init__(self, hatch, density)
 

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -170,7 +170,7 @@ class Stars(Shapes):
         path = Path.unit_regular_star(5)
         self.shape_vertices = path.vertices
         self.shape_codes = np.full(len(self.shape_vertices), Path.LINETO,
-                                   dtype='int32')
+                                   dtype=np.int32)
         self.shape_codes[0] = Path.MOVETO
         Shapes.__init__(self, hatch, density)
 

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -169,7 +169,8 @@ class Stars(Shapes):
         self.num_rows = (hatch.count('*')) * density
         path = Path.unit_regular_star(5)
         self.shape_vertices = path.vertices
-        self.shape_codes = np.full(len(self.shape_vertices), Path.LINETO)
+        self.shape_codes = np.full(len(self.shape_vertices), Path.LINETO,
+                                   dtype='float64')
         self.shape_codes[0] = Path.MOVETO
         Shapes.__init__(self, hatch, density)
 

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -231,7 +231,7 @@ class HandlerLine2D(HandlerNpoints):
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
-        ydata = np.full(xdata.shape, ((height - ydescent) / 2), float)
+        ydata = np.full_like(xdata, ((height - ydescent) / 2))
         legline = Line2D(xdata, ydata)
 
         self.update_prop(legline, orig_handle, legend)

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -231,7 +231,7 @@ class HandlerLine2D(HandlerNpoints):
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
-        ydata = ((height - ydescent) / 2.) * np.ones(xdata.shape, float)
+        ydata = np.full(xdata.shape, ((height - ydescent) / 2.), float)
         legline = Line2D(xdata, ydata)
 
         self.update_prop(legline, orig_handle, legend)

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -231,7 +231,7 @@ class HandlerLine2D(HandlerNpoints):
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
-        ydata = np.full(xdata.shape, ((height - ydescent) / 2.), float)
+        ydata = np.full(xdata.shape, ((height - ydescent) / 2), float)
         legline = Line2D(xdata, ydata)
 
         self.update_prop(legline, orig_handle, legend)

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -312,7 +312,7 @@ class Path(object):
         stride = numsides + 1
         nverts = numpolys * stride
         verts = np.zeros((nverts, 2))
-        codes = np.ones(nverts, int) * cls.LINETO
+        codes = np.full(nverts, cls.LINETO, dtype=int)
         codes[0::stride] = cls.MOVETO
         codes[numsides::stride] = cls.CLOSEPOLY
         for i in range(numsides):
@@ -552,7 +552,7 @@ class Path(object):
         vertices = simple_linear_interpolation(self.vertices, steps)
         codes = self.codes
         if codes is not None:
-            new_codes = Path.LINETO * np.ones(((len(codes) - 1) * steps + 1, ))
+            new_codes = np.full(((len(codes) - 1) * steps + 1, ), Path.LINETO)
             new_codes[0::steps] = codes
         else:
             new_codes = None
@@ -802,7 +802,7 @@ class Path(object):
 
                 float)
 
-            codes = cls.CURVE4 * np.ones(14)
+            codes = np.full(14, cls.CURVE4)
             codes[0] = cls.MOVETO
             codes[-1] = cls.CLOSEPOLY
 
@@ -864,7 +864,7 @@ class Path(object):
         if is_wedge:
             length = n * 3 + 4
             vertices = np.zeros((length, 2), float)
-            codes = cls.CURVE4 * np.ones((length, ), cls.code_type)
+            codes = np.full((length, ), cls.CURVE4, dtype=cls.code_type)
             vertices[1] = [xA[0], yA[0]]
             codes[0:2] = [cls.MOVETO, cls.LINETO]
             codes[-2:] = [cls.LINETO, cls.CLOSEPOLY]
@@ -873,7 +873,7 @@ class Path(object):
         else:
             length = n * 3 + 1
             vertices = np.empty((length, 2), float)
-            codes = cls.CURVE4 * np.ones((length, ), cls.code_type)
+            codes = np.full((length, ), cls.CURVE4, dtype=cls.code_type)
             vertices[0] = [xA[0], yA[0]]
             codes[0] = cls.MOVETO
             vertex_offset = 1

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -312,7 +312,7 @@ class Path(object):
         stride = numsides + 1
         nverts = numpolys * stride
         verts = np.zeros((nverts, 2))
-        codes = np.full(nverts, cls.LINETO, dtype=int)
+        codes = np.full(nverts, cls.LINETO, dtype=cls.code_type)
         codes[0::stride] = cls.MOVETO
         codes[numsides::stride] = cls.CLOSEPOLY
         for i in range(numsides):
@@ -553,7 +553,7 @@ class Path(object):
         codes = self.codes
         if codes is not None:
             new_codes = np.full(((len(codes) - 1) * steps + 1, ), Path.LINETO,
-                                dtype='float64')
+                                dtype=self.code_type)
             new_codes[0::steps] = codes
         else:
             new_codes = None
@@ -803,7 +803,7 @@ class Path(object):
 
                 float)
 
-            codes = np.full(14, cls.CURVE4, dtype='float64')
+            codes = np.full(14, cls.CURVE4, dtype=cls.code_type)
             codes[0] = cls.MOVETO
             codes[-1] = cls.CLOSEPOLY
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -552,7 +552,8 @@ class Path(object):
         vertices = simple_linear_interpolation(self.vertices, steps)
         codes = self.codes
         if codes is not None:
-            new_codes = np.full(((len(codes) - 1) * steps + 1, ), Path.LINETO)
+            new_codes = np.full(((len(codes) - 1) * steps + 1, ), Path.LINETO,
+                                dtype='float64')
             new_codes[0::steps] = codes
         else:
             new_codes = None
@@ -802,7 +803,7 @@ class Path(object):
 
                 float)
 
-            codes = np.full(14, cls.CURVE4)
+            codes = np.full(14, cls.CURVE4, dtype='float64')
             codes[0] = cls.MOVETO
             codes[-1] = cls.CLOSEPOLY
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -552,7 +552,7 @@ class Path(object):
         vertices = simple_linear_interpolation(self.vertices, steps)
         codes = self.codes
         if codes is not None:
-            new_codes = np.full(((len(codes) - 1) * steps + 1, ), Path.LINETO,
+            new_codes = np.full((len(codes) - 1) * steps + 1, Path.LINETO,
                                 dtype=self.code_type)
             new_codes[0::steps] = codes
         else:
@@ -865,7 +865,7 @@ class Path(object):
         if is_wedge:
             length = n * 3 + 4
             vertices = np.zeros((length, 2), float)
-            codes = np.full((length, ), cls.CURVE4, dtype=cls.code_type)
+            codes = np.full(length, cls.CURVE4, dtype=cls.code_type)
             vertices[1] = [xA[0], yA[0]]
             codes[0:2] = [cls.MOVETO, cls.LINETO]
             codes[-2:] = [cls.LINETO, cls.CLOSEPOLY]
@@ -874,7 +874,7 @@ class Path(object):
         else:
             length = n * 3 + 1
             vertices = np.empty((length, 2), float)
-            codes = np.full((length, ), cls.CURVE4, dtype=cls.code_type)
+            codes = np.full(length, cls.CURVE4, dtype=cls.code_type)
             vertices[0] = [xA[0], yA[0]]
             codes[0] = cls.MOVETO
             vertex_offset = 1

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -959,7 +959,7 @@ class _ReducedHCT_Element():
         """
         ntri = np.size(ecc, 0)
         vec_range = np.arange(ntri, dtype=np.int32)
-        c_indices = -np.ones(ntri, dtype=np.int32)  # for unused dofs, -1
+        c_indices = np.full(ntri, -1, dtype=np.int32)  # for unused dofs, -1
         f_dof = [1, 2, 4, 5, 7, 8]
         c_dof = [0, 3, 6]
 

--- a/lib/matplotlib/tri/trirefine.py
+++ b/lib/matplotlib/tri/trirefine.py
@@ -238,12 +238,8 @@ class UniformTriRefiner(TriRefiner):
         # (can be -1 if border edge)
         # For slave and master we will identify the apex pointing to the edge
         # start
-        edge_elems = np.ravel(np.vstack([np.arange(ntri, dtype=np.int32),
-                                         np.arange(ntri, dtype=np.int32),
-                                         np.arange(ntri, dtype=np.int32)]))
-        edge_apexes = np.ravel(np.vstack([np.zeros(ntri, dtype=np.int32),
-                                          np.ones(ntri, dtype=np.int32),
-                                          np.full(ntri, 2, dtype=np.int32)]))
+        edge_elems = np.tile(np.arange(3, dtype=np.int32), ntri)
+        edge_apexes = np.repeat(np.arange(3, dtype=np.int32), ntri)
         edge_neighbors = neighbors[edge_elems, edge_apexes]
         mask_masters = (edge_elems > edge_neighbors)
 

--- a/lib/matplotlib/tri/trirefine.py
+++ b/lib/matplotlib/tri/trirefine.py
@@ -111,7 +111,7 @@ class UniformTriRefiner(TriRefiner):
             # We have to initialize found_index with -1 because some nodes
             # may very well belong to no triangle at all, e.g., in case of
             # Delaunay Triangulation with DuplicatePointWarning.
-            found_index = - np.ones(refi_npts, dtype=np.int32)
+            found_index = np.full(refi_npts, -1, dtype=np.int32)
             tri_mask = self._triangulation.mask
             if tri_mask is None:
                 found_index[refi_triangles] = np.repeat(ancestors,
@@ -243,7 +243,7 @@ class UniformTriRefiner(TriRefiner):
                                          np.arange(ntri, dtype=np.int32)]))
         edge_apexes = np.ravel(np.vstack([np.zeros(ntri, dtype=np.int32),
                                           np.ones(ntri, dtype=np.int32),
-                                          np.ones(ntri, dtype=np.int32)*2]))
+                                          np.full(ntri, 2, dtype=np.int32)]))
         edge_neighbors = neighbors[edge_elems, edge_apexes]
         mask_masters = (edge_elems > edge_neighbors)
 

--- a/lib/matplotlib/tri/trirefine.py
+++ b/lib/matplotlib/tri/trirefine.py
@@ -238,7 +238,7 @@ class UniformTriRefiner(TriRefiner):
         # (can be -1 if border edge)
         # For slave and master we will identify the apex pointing to the edge
         # start
-        edge_elems = np.tile(np.arange(3, dtype=np.int32), ntri)
+        edge_elems = np.tile(np.arange(ntri, dtype=np.int32), 3)
         edge_apexes = np.repeat(np.arange(3, dtype=np.int32), ntri)
         edge_neighbors = neighbors[edge_elems, edge_apexes]
         mask_masters = (edge_elems > edge_neighbors)

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -292,7 +292,7 @@ class TriAnalyzer(object):
         if n is None:
             n = np.size(mask)
         if mask is not None:
-            renum = -np.ones(n, dtype=np.int32)  # Default num is -1
+            renum = np.full(n, -1, dtype=np.int32)  # Default num is -1
             valid = np.arange(n, dtype=np.int32).compress(~mask, axis=0)
             renum[valid] = np.arange(np.size(valid, 0), dtype=np.int32)
             return renum


### PR DESCRIPTION
This uses `np.full` in a few places instead of `cst*np.ones` which avoids a memory copy and should be ~2x faster. 
