### PR TITLE
Update HTML animation as slider is dragged

### DIFF
--- a/lib/matplotlib/_animation_data.py
+++ b/lib/matplotlib/_animation_data.py
@@ -4,6 +4,12 @@ JS_INCLUDE = """
 href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/
 css/font-awesome.min.css">
 <script language="javascript">
+  function isInternetExplorer() {
+    ua = navigator.userAgent;
+    /* MSIE used to detect old browsers and Trident used to newer ones*/
+    return ua.indexOf("MSIE ") > -1 || ua.indexOf("Trident/") > -1;
+  }
+
   /* Define the Animation class */
   function Animation(frames, img_id, slider_id, interval, loop_select_id){
     this.img_id = img_id;
@@ -20,7 +26,15 @@ css/font-awesome.min.css">
      this.frames[i] = new Image();
      this.frames[i].src = frames[i];
     }
-    document.getElementById(this.slider_id).max = this.frames.length - 1;
+    var slider = document.getElementById(this.slider_id);
+    slider.max = this.frames.length - 1;
+    if (isInternetExplorer()) {
+        // switch from oninput to onchange because IE <= 11 does not conform
+        // with W3C specification. It ignores oninput and onchange behaves
+        // like oninput. In contrast, Mircosoft Edge behaves correctly.
+        slider.setAttribute('onchange', slider.getAttribute('oninput'));
+        slider.setAttribute('oninput', null);
+    }
     this.set_frame(this.current_frame);
   }
 
@@ -183,7 +197,7 @@ DISPLAY_TEMPLATE = """
   <div class="anim-controls">
     <input id="_anim_slider{id}" type="range" class="anim-slider"
            name="points" min="0" max="1" step="1" value="0"
-           onchange="anim{id}.set_frame(parseInt(this.value));"></input>
+           oninput="anim{id}.set_frame(parseInt(this.value));"></input>
     <div class="anim-buttons">
       <button onclick="anim{id}.slower()"><i class="fa fa-minus"></i></button>
       <button onclick="anim{id}.first_frame()"><i class="fa fa-fast-backward">


### PR DESCRIPTION
## PR Summary

Currently, HTML animations do not update while the slider is dragged. The update occurs only when the slider is released. This is because we are using the `onchange` event. This PR switches to using `oninput` so that we get continuous updates.

Special handling of Internet Explorer <= 11 is done because it does not understand `oninput` and its `onchange` works like the W3C specifcation of `oninput`.

For details see https://www.impressivewebs.com/onchange-vs-oninput-for-range-sliders/

If someone wants to test the effect, here is some example code to create an animation. To test on different browsers you can simply open a [binder instance](https://mybinder.org/v2/gh/ipython/ipython-in-depth/master?filepath=binder/Index.ipynb) and change between `oninput` and `onchange` using the developer tools of the browser.

~~~
import numpy as np
import matplotlib.pyplot as plt
import matplotlib.animation as animation
from IPython.display import display, HTML

fig, ax = plt.subplots()

x = np.arange(0, 2*np.pi, 0.01)
line, = ax.plot(x, np.sin(x))

def init():  # only required for blitting to give a clean slate.
    line.set_ydata([np.nan] * len(x))
    return line,

def animate(i):
    line.set_ydata(np.sin(x + i / 100))  # update the data.
    return line,

ani = animation.FuncAnimation(
    fig, animate, init_func=init, interval=2, blit=True, save_count=50)

display(HTML(ani.to_jshtml(default_mode='reflect')))
~~~
