### PR TITLE
Deprecate to-days converters in matplotlib dates

### DIFF
--- a/doc/api/next_api_changes/2018-10-04-TH-deprecations.rst
+++ b/doc/api/next_api_changes/2018-10-04-TH-deprecations.rst
@@ -1,0 +1,7 @@
+API deprecations
+````````````````
+
+The following API elements are deprecated:
+
+- ``dates.seconds()``, ``dates.minutes()``, ``dates.hours()``,
+  ``dates.weeks()``

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1728,6 +1728,7 @@ def date_ticker_factory(span, tz=None, numticks=5):
     return locator, formatter
 
 
+@cbook.deprecated("3.1")
 def seconds(s):
     """
     Return seconds as days.
@@ -1735,6 +1736,7 @@ def seconds(s):
     return s / SEC_PER_DAY
 
 
+@cbook.deprecated("3.1")
 def minutes(m):
     """
     Return minutes as days.
@@ -1742,6 +1744,7 @@ def minutes(m):
     return m / MINUTES_PER_DAY
 
 
+@cbook.deprecated("3.1")
 def hours(h):
     """
     Return hours as days.
@@ -1749,6 +1752,7 @@ def hours(h):
     return h / HOURS_PER_DAY
 
 
+@cbook.deprecated("3.1")
 def weeks(w):
     """
     Return weeks as days.


### PR DESCRIPTION
## PR Summary

The functions `seconds()`, `minutes()`, `hours()` and `weeks()` in `matplotlib.dates` are unused. Additionally their name is quite ambiguous.

I don't see that they are needed and therefore deprecate them. If however, they serve some purpose for the user, they should be replaced by a single function`to_days(/, weeks=0, hours=0, minutes=0, seconds=0)`.



## PR Checklist

- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
