### PR TITLE
CI: Don't run AppVeyor/Travis for doc backport branches.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@
 branches:
   except:
     - /auto-backport-.*/
+    - /^v\d+\.\d+\.[\dx]+-doc$/
 
 clone_depth: 50
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 branches:
   except:
   - /^auto-backport-of-pr-\d*/
+  - /^v\d+\.\d+\.[\dx]+-doc$/
 
 cache:
   pip: true


### PR DESCRIPTION
These branches are only supposed to contain changes to documentation, so not running Linux or Windows CI will reduce some load (on CI and wrt requiring extra backports to keep it working). CircleCI, which builds docs, will of course continue to be run on these branches.

Since these feed into the micro-release/bugfix branches, it should be enough to run CI there only.