### PR TITLE
Fix extension building on Xcode 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,8 @@ class BuildExtraLibraries(BuildExtCommand):
         return super().build_extensions()
 
     def _xcode_gte_10(self):
+        if sys.platform != "darwin":
+            return False
         # Returns True if compiler is from Xcode version >= 10
         compiler_version = str(subprocess.check_output(
             self.compiler.compiler + ['--version'], universal_newlines=True))

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ Make sure you have pip >= 9.0.1.
 """
     sys.exit(error)
 
+import subprocess
 # The setuptools version of sdist adds a setup.cfg file to the tree.
 # We don't want that, so we simply remove it, and it will fall back to
 # vanilla distutils.
@@ -105,9 +106,24 @@ class BuildExtraLibraries(BuildExtCommand):
             self.compiler.compiler_so.remove('-Wstrict-prototypes')
         except (ValueError, AttributeError):
             pass
+        if self._xcode_gte_10():
+            # If compiling using Xcode >= 10, need to manually specify the
+            # -stdlib flag because libstdc++ is no longer available
+            for mod in self.distribution.ext_modules:
+                mod.extra_compile_args = ['-stdlib=libc++']
+                mod.extra_link_args = ['-stdlib=libc++']
         for package in good_packages:
             package.do_custom_build()
         return super().build_extensions()
+
+    def _xcode_gte_10(self):
+        # Returns True if compiler is from Xcode version >= 10
+        compiler_version = str(subprocess.check_output(
+            self.compiler.compiler + ['--version'], universal_newlines=True))
+        compiler_version = compiler_version.split(' ')
+        return ((compiler_version[0] == 'Apple') and
+                (compiler_version[1] == 'LLVM') and
+                (int(compiler_version[3].split('.')[0]) >= 10))
 
 
 cmdclass = versioneer.get_cmdclass()


### PR DESCRIPTION
Xcode 10 removed the `libstdc++` libraries, but for some reason just warns and doesn't automatically switch to and find the `libc++` libraries. This PR fixes that by checking for the system version and then adding the extra compile and link arguments needed to build extensions.