### PR TITLE
Scatter color: moving #10809 forward

### DIFF
--- a/doc/api/next_api_changes/2018-11-14-AL-scatter.rst
+++ b/doc/api/next_api_changes/2018-11-14-AL-scatter.rst
@@ -9,6 +9,6 @@ by `PathCollection.get_array`)
 
 Such points are now included, but masked out by returning a masked array.
 
-If the *plotinvalid* kwarg to `~.Axes.scatter` is set, then points with
+If the *plotnonfinite* kwarg to `~.Axes.scatter` is set, then points with
 nonfinite values are plotted using the bad color of the `PathCollection`\ 's
 colormap (as set by `Colormap.set_bad`).

--- a/doc/api/next_api_changes/2018-11-14-AL-scatter.rst
+++ b/doc/api/next_api_changes/2018-11-14-AL-scatter.rst
@@ -1,0 +1,14 @@
+PathCollections created with `~.Axes.scatter` now keep track of invalid points
+``````````````````````````````````````````````````````````````````````````````
+
+Previously, points with nonfinite (infinite or nan) coordinates would not be
+included in the offsets (as returned by `PathCollection.get_offsets`) of a
+`PathCollection` created by `~.Axes.scatter`, and points with nonfinite values
+(as specified by the *c* kwarg) would not be included in the array (as returned
+by `PathCollection.get_array`)
+
+Such points are now included, but masked out by returning a masked array.
+
+If the *plotinvalid* kwarg to `~.Axes.scatter` is set, then points with
+nonfinite values are plotted using the bad color of the `PathCollection`\ 's
+colormap (as set by `Colormap.set_bad`).

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -348,9 +348,9 @@ class BasicUnitConverter(units.ConversionInterface):
         if units.ConversionInterface.is_numlike(val):
             return val
         if np.iterable(val):
-            if np.ma.isMaskedArray(val):
+            if isinstance(val, np.ma.MaskedArray):
                 val = val.astype(float).filled(np.nan)
-            out = np.empty((len(val),),  dtype=float)
+            out = np.empty(len(val))
             for i, thisval in enumerate(val):
                 if np.ma.is_masked(thisval):
                     out[i] = np.nan

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -174,7 +174,10 @@ class TaggedValue(metaclass=TaggedValueMeta):
     def convert_to(self, unit):
         if unit == self.unit or not unit:
             return self
-        new_value = self.unit.convert_value_to(self.value, unit)
+        try:
+            new_value = self.unit.convert_value_to(self.value, unit)
+        except AttributeError:
+            new_value = self
         return TaggedValue(new_value, unit)
 
     def get_value(self):
@@ -345,7 +348,20 @@ class BasicUnitConverter(units.ConversionInterface):
         if units.ConversionInterface.is_numlike(val):
             return val
         if np.iterable(val):
-            return [thisval.convert_to(unit).get_value() for thisval in val]
+            if np.ma.isMaskedArray(val):
+                val = val.astype(float).filled(np.nan)
+            out = np.empty((len(val),),  dtype=float)
+            for i, thisval in enumerate(val):
+                if np.ma.is_masked(thisval):
+                    out[i] = np.nan
+                else:
+                    try:
+                        out[i] = thisval.convert_to(unit).get_value()
+                    except AttributeError:
+                        out[i] = thisval
+            return out
+        if np.ma.is_masked(val):
+            return np.nan
         else:
             return val.convert_to(unit).get_value()
 

--- a/examples/units/units_scatter.py
+++ b/examples/units/units_scatter.py
@@ -27,9 +27,8 @@ ax1.axis([0, 10, 0, 10])
 ax2.scatter(xsecs, xsecs, yunits=hertz)
 ax2.axis([0, 10, 0, 1])
 
-ax3.scatter(xsecs, xsecs, yunits=hertz)
-ax3.yaxis.set_units(minutes)
-ax3.axis([0, 10, 0, 1])
+ax3.scatter(xsecs, xsecs, yunits=minutes)
+ax3.axis([0, 10, 0, 0.2])
 
 fig.tight_layout()
 plt.show()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4180,7 +4180,7 @@ class Axes(_AxesBase):
                       label_namer="y")
     def scatter(self, x, y, s=None, c=None, marker=None, cmap=None, norm=None,
                 vmin=None, vmax=None, alpha=None, linewidths=None,
-                verts=None, edgecolors=None,
+                verts=None, edgecolors=None, masked=False,
                 **kwargs):
         """
         A scatter plot of *y* vs *x* with varying marker size and/or color.
@@ -4257,6 +4257,10 @@ class Axes(_AxesBase):
             For non-filled markers, the *edgecolors* kwarg is ignored and
             forced to 'face' internally.
 
+        masked : boolean, optional, default: False
+            Set to plot valid points with invalid color, in conjunction with
+            `~matplotlib.colors.Colormap.set_bad`.
+
         Returns
         -------
         paths : `~matplotlib.collections.PathCollection`
@@ -4310,11 +4314,12 @@ class Axes(_AxesBase):
                 c, edgecolors, kwargs, xshape, yshape,
                 get_next_color_func=self._get_patches_for_fill.get_next_color)
 
-        # `delete_masked_points` only modifies arguments of the same length as
-        # `x`.
-        x, y, s, c, colors, edgecolors, linewidths =\
-            cbook.delete_masked_points(
-                x, y, s, c, colors, edgecolors, linewidths)
+        if masked is False:
+            # `delete_masked_points` only modifies arguments of the same length
+            #  as `x`.
+            x, y, s, c, colors, edgecolors, linewidths =\
+               cbook.delete_masked_points(
+                   x, y, s, c, colors, edgecolors, linewidths)
 
         scales = s   # Renamed for readability below.
 
@@ -4358,7 +4363,12 @@ class Axes(_AxesBase):
             if norm is not None and not isinstance(norm, mcolors.Normalize):
                 raise ValueError(
                     "'norm' must be an instance of 'mcolors.Normalize'")
-            collection.set_array(np.asarray(c))
+
+            if masked is False:
+                collection.set_array(c)
+            else:
+                collection.set_array(ma.masked_invalid(c))
+
             collection.set_cmap(cmap)
             collection.set_norm(norm)
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4180,7 +4180,7 @@ class Axes(_AxesBase):
                       label_namer="y")
     def scatter(self, x, y, s=None, c=None, marker=None, cmap=None, norm=None,
                 vmin=None, vmax=None, alpha=None, linewidths=None,
-                verts=None, edgecolors=None, plotinvalid=False,
+                verts=None, edgecolors=None, *, plotinvalid=False,
                 **kwargs):
         """
         A scatter plot of *y* vs *x* with varying marker size and/or color.
@@ -4314,25 +4314,14 @@ class Axes(_AxesBase):
                 c, edgecolors, kwargs, xshape, yshape,
                 get_next_color_func=self._get_patches_for_fill.get_next_color)
 
-        # if plotinvalid and colors == None:
-        #     # Do full color mapping; don't remove invalid c entries.
-        #     ind = np.arange(len(c))
-        #     x, y, s, ind, colors, edgecolors, linewidths =\
-        #        cbook.delete_masked_points(
-        #            x, y, s, ind, colors, edgecolors, linewidths)
-        #     c = np.ma.masked_invalid(c[ind])
-        # else:
-        #     x, y, s, c, colors, edgecolors, linewidths =\
-        #        cbook.delete_masked_points(
-        #            x, y, s, c, colors, edgecolors, linewidths)
-
-        if plotinvalid and colors == None:
+        if plotinvalid and colors is None:
             c = np.ma.masked_invalid(c)
-            x, y, s, colors, edgecolors, linewidths =\
-                cbook.combine_masks(x, y, s, colors, edgecolors, linewidths)
+            x, y, s, colors, edgecolors, linewidths = \
+                cbook._combine_masks(x, y, s, colors, edgecolors, linewidths)
         else:
-            x, y, s, c, colors, edgecolors, linewidths =\
-                cbook.combine_masks(x, y, s, c, colors, edgecolors, linewidths)
+            x, y, s, c, colors, edgecolors, linewidths = \
+                cbook._combine_masks(
+                    x, y, s, c, colors, edgecolors, linewidths)
 
         scales = s   # Renamed for readability below.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4316,8 +4316,8 @@ class Axes(_AxesBase):
 
         if plotnonfinite and colors is None:
             c = np.ma.masked_invalid(c)
-            x, y, s, colors, edgecolors, linewidths = \
-                cbook._combine_masks(x, y, s, colors, edgecolors, linewidths)
+            x, y, s, edgecolors, linewidths = \
+                cbook._combine_masks(x, y, s, edgecolors, linewidths)
         else:
             x, y, s, c, colors, edgecolors, linewidths = \
                 cbook._combine_masks(

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4314,9 +4314,14 @@ class Axes(_AxesBase):
                 c, edgecolors, kwargs, xshape, yshape,
                 get_next_color_func=self._get_patches_for_fill.get_next_color)
 
-        if plotinvalid is False:
-            # `delete_masked_points` only modifies arguments of the same length
-            #  as `x`.
+        if plotinvalid and colors == None:
+            # Do full color mapping; don't remove invalid c entries.
+            ind = np.arange(len(c))
+            x, y, s, ind, colors, edgecolors, linewidths =\
+               cbook.delete_masked_points(
+                   x, y, s, ind, colors, edgecolors, linewidths)
+            c = np.ma.masked_invalid(c[ind])
+        else:
             x, y, s, c, colors, edgecolors, linewidths =\
                cbook.delete_masked_points(
                    x, y, s, c, colors, edgecolors, linewidths)
@@ -4363,12 +4368,7 @@ class Axes(_AxesBase):
             if norm is not None and not isinstance(norm, mcolors.Normalize):
                 raise ValueError(
                     "'norm' must be an instance of 'mcolors.Normalize'")
-
-            if plotinvalid is False:
-                collection.set_array(c)
-            else:
-                collection.set_array(ma.masked_invalid(c))
-
+            collection.set_array(c)
             collection.set_cmap(cmap)
             collection.set_norm(norm)
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4180,7 +4180,7 @@ class Axes(_AxesBase):
                       label_namer="y")
     def scatter(self, x, y, s=None, c=None, marker=None, cmap=None, norm=None,
                 vmin=None, vmax=None, alpha=None, linewidths=None,
-                verts=None, edgecolors=None, masked=False,
+                verts=None, edgecolors=None, plotinvalid=False,
                 **kwargs):
         """
         A scatter plot of *y* vs *x* with varying marker size and/or color.
@@ -4257,7 +4257,7 @@ class Axes(_AxesBase):
             For non-filled markers, the *edgecolors* kwarg is ignored and
             forced to 'face' internally.
 
-        masked : boolean, optional, default: False
+        plotinvalid : boolean, optional, default: False
             Set to plot valid points with invalid color, in conjunction with
             `~matplotlib.colors.Colormap.set_bad`.
 
@@ -4314,7 +4314,7 @@ class Axes(_AxesBase):
                 c, edgecolors, kwargs, xshape, yshape,
                 get_next_color_func=self._get_patches_for_fill.get_next_color)
 
-        if masked is False:
+        if plotinvalid is False:
             # `delete_masked_points` only modifies arguments of the same length
             #  as `x`.
             x, y, s, c, colors, edgecolors, linewidths =\
@@ -4364,7 +4364,7 @@ class Axes(_AxesBase):
                 raise ValueError(
                     "'norm' must be an instance of 'mcolors.Normalize'")
 
-            if masked is False:
+            if plotinvalid is False:
                 collection.set_array(c)
             else:
                 collection.set_array(ma.masked_invalid(c))

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4347,7 +4347,7 @@ class Axes(_AxesBase):
             edgecolors = 'face'
             linewidths = rcParams['lines.linewidth']
 
-        offsets = np.column_stack([x, y])
+        offsets = np.ma.column_stack([x, y])
 
         collection = mcoll.PathCollection(
                 (path,), scales,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4314,17 +4314,25 @@ class Axes(_AxesBase):
                 c, edgecolors, kwargs, xshape, yshape,
                 get_next_color_func=self._get_patches_for_fill.get_next_color)
 
+        # if plotinvalid and colors == None:
+        #     # Do full color mapping; don't remove invalid c entries.
+        #     ind = np.arange(len(c))
+        #     x, y, s, ind, colors, edgecolors, linewidths =\
+        #        cbook.delete_masked_points(
+        #            x, y, s, ind, colors, edgecolors, linewidths)
+        #     c = np.ma.masked_invalid(c[ind])
+        # else:
+        #     x, y, s, c, colors, edgecolors, linewidths =\
+        #        cbook.delete_masked_points(
+        #            x, y, s, c, colors, edgecolors, linewidths)
+
         if plotinvalid and colors == None:
-            # Do full color mapping; don't remove invalid c entries.
-            ind = np.arange(len(c))
-            x, y, s, ind, colors, edgecolors, linewidths =\
-               cbook.delete_masked_points(
-                   x, y, s, ind, colors, edgecolors, linewidths)
-            c = np.ma.masked_invalid(c[ind])
+            c = np.ma.masked_invalid(c)
+            x, y, s, colors, edgecolors, linewidths =\
+                cbook.combine_masks(x, y, s, colors, edgecolors, linewidths)
         else:
             x, y, s, c, colors, edgecolors, linewidths =\
-               cbook.delete_masked_points(
-                   x, y, s, c, colors, edgecolors, linewidths)
+                cbook.combine_masks(x, y, s, c, colors, edgecolors, linewidths)
 
         scales = s   # Renamed for readability below.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4180,7 +4180,7 @@ class Axes(_AxesBase):
                       label_namer="y")
     def scatter(self, x, y, s=None, c=None, marker=None, cmap=None, norm=None,
                 vmin=None, vmax=None, alpha=None, linewidths=None,
-                verts=None, edgecolors=None, *, plotinvalid=False,
+                verts=None, edgecolors=None, *, plotnonfinite=False,
                 **kwargs):
         """
         A scatter plot of *y* vs *x* with varying marker size and/or color.
@@ -4257,8 +4257,8 @@ class Axes(_AxesBase):
             For non-filled markers, the *edgecolors* kwarg is ignored and
             forced to 'face' internally.
 
-        plotinvalid : boolean, optional, default: False
-            Set to plot valid points with invalid color, in conjunction with
+        plotnonfinite : boolean, optional, default: False
+            Set to plot points with nonfinite *c*, in conjunction with
             `~matplotlib.colors.Colormap.set_bad`.
 
         Returns
@@ -4314,7 +4314,7 @@ class Axes(_AxesBase):
                 c, edgecolors, kwargs, xshape, yshape,
                 get_next_color_func=self._get_patches_for_fill.get_next_color)
 
-        if plotinvalid and colors is None:
+        if plotnonfinite and colors is None:
             c = np.ma.masked_invalid(c)
             x, y, s, colors, edgecolors, linewidths = \
                 cbook._combine_masks(x, y, s, colors, edgecolors, linewidths)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1117,21 +1117,22 @@ def _combine_masks(*args):
     if is_scalar_or_string(args[0]):
         raise ValueError("First argument must be a sequence")
     nrecs = len(args[0])
-    margs = []
-    seqlist = [False] * len(args)
-    masks = []    # list of masks that are True where bad
+    margs = []  # Output args; some may be modified.
+    seqlist = [False] * len(args)  # Flags: True if output will be masked.
+    masks = []    # List of masks.
     for i, x in enumerate(args):
-        if not isinstance(x, str) and np.iterable(x) and len(x) == nrecs:
-            if isinstance(x, np.ma.MaskedArray):
-                if x.ndim > 1:
-                    raise ValueError("Masked arrays must be 1-D")
+        if is_scalar_or_string(x) or len(x) != nrecs:
+            margs.append(x)  # Leave it unmodified.
+        else:
+            if isinstance(x, np.ma.MaskedArray) and x.ndim > 1:
+                raise ValueError("Masked arrays must be 1-D")
             x = np.asanyarray(x)
             if x.ndim == 1:
                 x = safe_masked_invalid(x)
                 seqlist[i] = True
                 if np.ma.is_masked(x):
                     masks.append(np.ma.getmaskarray(x))
-        margs.append(x)
+            margs.append(x)  # Possibly modified.
     if len(masks):
         mask = np.logical_or.reduce(masks)
         for i, x in enumerate(margs):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1081,7 +1081,7 @@ def delete_masked_points(*args):
     return margs
 
 
-def combine_masks(*args):
+def _combine_masks(*args):
     """
     Find all masked and/or non-finite points in a set of arguments,
     and return the arguments as masked arrays with a common mask.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1123,8 +1123,8 @@ def _combine_masks(*args):
                 if x.ndim > 1:
                     raise ValueError("Masked arrays must be 1-D")
             x = np.asanyarray(x)
-            if x.ndim == 1 and x.dtype.kind == 'f':
-                x = np.ma.masked_invalid(x)
+            if x.ndim == 1:
+                x = safe_masked_invalid(x)
                 seqlist[i] = True
         margs.append(x)
     masks = []    # list of masks that are True where bad

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2835,7 +2835,7 @@ def quiverkey(Q, X, Y, U, label, **kw):
 def scatter(
         x, y, s=None, c=None, marker=None, cmap=None, norm=None,
         vmin=None, vmax=None, alpha=None, linewidths=None, verts=None,
-        edgecolors=None, plotinvalid=False, *, data=None, **kwargs):
+        edgecolors=None, *, plotinvalid=False, data=None, **kwargs):
     __ret = gca().scatter(
         x, y, s=s, c=c, marker=marker, cmap=cmap, norm=norm,
         vmin=vmin, vmax=vmax, alpha=alpha, linewidths=linewidths,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2835,12 +2835,13 @@ def quiverkey(Q, X, Y, U, label, **kw):
 def scatter(
         x, y, s=None, c=None, marker=None, cmap=None, norm=None,
         vmin=None, vmax=None, alpha=None, linewidths=None, verts=None,
-        edgecolors=None, *, plotinvalid=False, data=None, **kwargs):
+        edgecolors=None, *, plotnonfinite=False, data=None, **kwargs):
     __ret = gca().scatter(
         x, y, s=s, c=c, marker=marker, cmap=cmap, norm=norm,
         vmin=vmin, vmax=vmax, alpha=alpha, linewidths=linewidths,
-        verts=verts, edgecolors=edgecolors, plotinvalid=plotinvalid,
-        **({"data": data} if data is not None else {}), **kwargs)
+        verts=verts, edgecolors=edgecolors,
+        plotnonfinite=plotnonfinite, **({"data": data} if data is not
+        None else {}), **kwargs)
     sci(__ret)
     return __ret
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2835,12 +2835,12 @@ def quiverkey(Q, X, Y, U, label, **kw):
 def scatter(
         x, y, s=None, c=None, marker=None, cmap=None, norm=None,
         vmin=None, vmax=None, alpha=None, linewidths=None, verts=None,
-        edgecolors=None, *, data=None, **kwargs):
+        edgecolors=None, plotinvalid=False, *, data=None, **kwargs):
     __ret = gca().scatter(
         x, y, s=s, c=c, marker=marker, cmap=cmap, norm=norm,
         vmin=vmin, vmax=vmax, alpha=alpha, linewidths=linewidths,
-        verts=verts, edgecolors=edgecolors, **({"data": data} if data
-        is not None else {}), **kwargs)
+        verts=verts, edgecolors=edgecolors, plotinvalid=plotinvalid,
+        **({"data": data} if data is not None else {}), **kwargs)
     sci(__ret)
     return __ret
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -452,19 +452,37 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
 
         _, result_dir = map(Path, _image_directories(func))
 
-        @pytest.mark.parametrize("ext", extensions)
-        def wrapper(ext):
-            fig_test = plt.figure("test")
-            fig_ref = plt.figure("reference")
-            func(fig_test, fig_ref)
-            test_image_path = str(
-                result_dir / (func.__name__ + "." + ext))
-            ref_image_path = str(
-                result_dir / (func.__name__ + "-expected." + ext))
-            fig_test.savefig(test_image_path)
-            fig_ref.savefig(ref_image_path)
-            _raise_on_image_difference(
-                ref_image_path, test_image_path, tol=tol)
+        if len(inspect.signature(func).parameters) == 2:
+            # Free-standing function.
+            @pytest.mark.parametrize("ext", extensions)
+            def wrapper(ext):
+                fig_test = plt.figure("test")
+                fig_ref = plt.figure("reference")
+                func(fig_test, fig_ref)
+                test_image_path = str(
+                    result_dir / (func.__name__ + "." + ext))
+                ref_image_path = str(
+                    result_dir / (func.__name__ + "-expected." + ext))
+                fig_test.savefig(test_image_path)
+                fig_ref.savefig(ref_image_path)
+                _raise_on_image_difference(
+                    ref_image_path, test_image_path, tol=tol)
+
+        elif len(inspect.signature(func).parameters) == 3:
+            # Method.
+            @pytest.mark.parametrize("ext", extensions)
+            def wrapper(self, ext):
+                fig_test = plt.figure("test")
+                fig_ref = plt.figure("reference")
+                func(self, fig_test, fig_ref)
+                test_image_path = str(
+                    result_dir / (func.__name__ + "." + ext))
+                ref_image_path = str(
+                    result_dir / (func.__name__ + "-expected." + ext))
+                fig_test.savefig(test_image_path)
+                fig_ref.savefig(ref_image_path)
+                _raise_on_image_difference(
+                    ref_image_path, test_image_path, tol=tol)
 
         return wrapper
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1759,7 +1759,7 @@ class TestScatter(object):
         # stamping fast path, which would result in slightly offset markers.
         ax.scatter(range(4), range(4),
                    c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
-                   cmap=cmap, plotinvalid=True)
+                   cmap=cmap, plotnonfinite=True)
         ax = fig_ref.subplots()
         cmap = plt.get_cmap("viridis", 16)
         ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1759,7 +1759,7 @@ class TestScatter(object):
         # stamping fast path, which would result in slightly offset markers.
         ax.scatter(range(4), range(4),
                    c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
-                   cmap=cmap, masked=True)
+                   cmap=cmap, plotinvalid=True)
         ax = fig_ref.subplots()
         cmap = plt.get_cmap("viridis", 16)
         ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5759,19 +5759,20 @@ def test_color_length_mismatch():
     ax.scatter(x, y, c=[c_rgb] * N)
 
 
-def test_scatter_color_masking():
-    x = np.array([1, 2, 3])
-    y = np.array([1, np.nan, 3])
-    colors = np.array(['k', 'w', 'k'])
-    linewidths = np.array([1, 2, 3])
-    s = plt.scatter(x, y, color=colors, linewidths=linewidths)
-
-    facecolors = s.get_facecolors()
-    linecolors = s.get_edgecolors()
-    linewidths = s.get_linewidths()
-    assert_array_equal(facecolors[1], np.array([0, 0, 0, 1]))
-    assert_array_equal(linecolors[1], np.array([0, 0, 0, 1]))
-    assert linewidths[1] == 3
+# The following test is based on the old behavior of deleting bad points.
+# def test_scatter_color_masking():
+#     x = np.array([1, 2, 3])
+#     y = np.array([1, np.nan, 3])
+#     colors = np.array(['k', 'w', 'k'])
+#     linewidths = np.array([1, 2, 3])
+#     s = plt.scatter(x, y, color=colors, linewidths=linewidths)
+#
+#     facecolors = s.get_facecolors()
+#     linecolors = s.get_edgecolors()
+#     linewidths = s.get_linewidths()
+#     assert_array_equal(facecolors[1], np.array([0, 0, 0, 1]))
+#     assert_array_equal(linecolors[1], np.array([0, 0, 0, 1]))
+#     assert linewidths[1] == 3
 
 
 def test_eventplot_legend():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1749,6 +1749,22 @@ class TestScatter(object):
         with pytest.raises(ValueError):
             plt.scatter([1, 2, 3], [1, 2, 3], color=[1, 2, 3])
 
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_invalid_color(self, fig_test, fig_ref):
+        ax = fig_test.subplots()
+        cmap = plt.get_cmap("viridis", 16)
+        cmap.set_bad("k", 1)
+        # Set a nonuniform size to prevent the last call to `scatter` (plotting
+        # the invalid points separately in fig_ref) from using the marker
+        # stamping fast path, which would result in slightly offset markers.
+        ax.scatter(range(4), range(4),
+                   c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
+                   cmap=cmap, masked=True)
+        ax = fig_ref.subplots()
+        cmap = plt.get_cmap("viridis", 16)
+        ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
+        ax.scatter([1, 3], [1, 3], s=[2, 4], color="k")
+
     # Parameters for *test_scatter_c*. NB: assuming that the
     # scatter plot will have 4 elements. The tuple scheme is:
     # (*c* parameter case, exception regexp key or None if no exception)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1765,6 +1765,18 @@ class TestScatter(object):
         ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
         ax.scatter([1, 3], [1, 3], s=[2, 4], color="k")
 
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_no_invalid_color(self, fig_test, fig_ref):
+        # With plotninfinite=False we plot only 2 points.
+        ax = fig_test.subplots()
+        cmap = plt.get_cmap("viridis", 16)
+        cmap.set_bad("k", 1)
+        ax.scatter(range(4), range(4),
+                   c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
+                   cmap=cmap, plotnonfinite=False)
+        ax = fig_ref.subplots()
+        ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
+
     # Parameters for *test_scatter_c*. NB: assuming that the
     # scatter plot will have 4 elements. The tuple scheme is:
     # (*c* parameter case, exception regexp key or None if no exception)
@@ -5757,22 +5769,6 @@ def test_color_length_mismatch():
     c_rgb = (0.5, 0.5, 0.5)
     ax.scatter(x, y, c=c_rgb)
     ax.scatter(x, y, c=[c_rgb] * N)
-
-
-# The following test is based on the old behavior of deleting bad points.
-# def test_scatter_color_masking():
-#     x = np.array([1, 2, 3])
-#     y = np.array([1, np.nan, 3])
-#     colors = np.array(['k', 'w', 'k'])
-#     linewidths = np.array([1, 2, 3])
-#     s = plt.scatter(x, y, color=colors, linewidths=linewidths)
-#
-#     facecolors = s.get_facecolors()
-#     linecolors = s.get_edgecolors()
-#     linewidths = s.get_linewidths()
-#     assert_array_equal(facecolors[1], np.array([0, 0, 0, 1]))
-#     assert_array_equal(linecolors[1], np.array([0, 0, 0, 1]))
-#     assert linewidths[1] == 3
 
 
 def test_eventplot_legend():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -197,9 +197,8 @@ def test_colorbar_single_scatter():
     # the norm scaling within the colorbar must ensure a
     # finite range, otherwise a zero denominator will occur in _locate.
     plt.figure()
-    x = np.arange(4)
-    y = x.copy()
-    z = np.ma.masked_greater(np.arange(50, 54), 50)
+    x =  y = [0]
+    z = [50]
     cmap = plt.get_cmap('jet', 16)
     cs = plt.scatter(x, y, z, c=z, cmap=cmap)
     plt.colorbar(cs)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -197,7 +197,7 @@ def test_colorbar_single_scatter():
     # the norm scaling within the colorbar must ensure a
     # finite range, otherwise a zero denominator will occur in _locate.
     plt.figure()
-    x =  y = [0]
+    x = y = [0]
     z = [50]
     cmap = plt.get_cmap('jet', 16)
     cs = plt.scatter(x, y, z, c=z, cmap=cmap)


### PR DESCRIPTION
## PR Summary
This is a minimal update plus fixup for #10809, followed by a changeset to address #10381.
Along the way, it turned out that examples/units/units_scatter.py was doubly broken. It purported to show masked array support by basic_units.py, but didn't, because the support didn't exist; and it's third panel labeled the y-axis as Minutes but showed the values in Hz.  Both of these problems are fixed in this PR.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
