### PR TITLE
Backport PR #12277: FIX: datetime64 now recognized if in a list

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -410,18 +410,19 @@ def date2num(d):
     Gregorian calendar is assumed; this is not universal practice.
     For details see the module docstring.
     """
-
     if hasattr(d, "values"):
         # this unpacks pandas series or dataframes...
         d = d.values
-
-    if ((isinstance(d, np.ndarray) and np.issubdtype(d.dtype, np.datetime64))
-            or isinstance(d, np.datetime64)):
-        return _dt64_to_ordinalf(d)
-    if not cbook.iterable(d):
+    if not np.iterable(d):
+        if (isinstance(d, np.datetime64) or (isinstance(d, np.ndarray) and
+                np.issubdtype(d.dtype, np.datetime64))):
+            return _dt64_to_ordinalf(d)
         return _to_ordinalf(d)
+
     else:
         d = np.asarray(d)
+        if np.issubdtype(d.dtype, np.datetime64):
+            return _dt64_to_ordinalf(d)
         if not d.size:
             return d
         return _to_ordinalf_np_vectorized(d)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -641,3 +641,9 @@ def test_tz_utc():
 def test_num2timedelta(x, tdelta):
     dt = mdates.num2timedelta(x)
     assert dt == tdelta
+
+
+def test_datetime64_in_list():
+    dt = [np.datetime64('2000-01-01'), np.datetime64('2001-01-01')]
+    dn = mdates.date2num(dt)
+    assert np.array_equal(dn, [730120.,  730486.])


### PR DESCRIPTION
Backport PR #12277: FIX: datetime64 now recognized if in a list