### PR TITLE
Fix numpydoc parameter formatting

### DIFF
--- a/examples/specialty_plots/leftventricle_bulleye.py
+++ b/examples/specialty_plots/leftventricle_bulleye.py
@@ -21,7 +21,7 @@ def bullseye_plot(ax, data, segBold=None, cmap=None, norm=None):
     ax : axes
     data : list of int and float
         The intensity values for each of the 17 segments
-    segBold: list of int, optional
+    segBold : list of int, optional
         A list with the segments to highlight
     cmap : ColorMap or None, optional
         Optional argument to set the desired colormap

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1192,7 +1192,7 @@ def rcdefaults():
 
     See Also
     --------
-    rc_file_defaults :
+    rc_file_defaults
         Restore the rc params from the rc file originally loaded by Matplotlib.
     matplotlib.style.use :
         Use a specific style file.  Call ``style.use('default')`` to restore

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -89,10 +89,10 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
     ----------
 
 
-    fig: Figure
+    fig : Figure
       is the ``figure`` instance to do the layout in.
 
-    renderer: Renderer
+    renderer : Renderer
       the renderer to use.
 
      h_pad, w_pad : float

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -195,11 +195,11 @@ class AbstractMovieWriter(abc.ABC):
 
         Parameters
         ----------
-        fig: `matplotlib.figure.Figure` instance
+        fig : `matplotlib.figure.Figure` instance
             The figure object that contains the information for frames
-        outfile: string
+        outfile : string
             The filename of the resulting movie file
-        dpi: int, optional
+        dpi : int, optional
             The DPI (or resolution) for the file.  This controls the size
             in pixels of the resulting movie file. Default is ``fig.dpi``.
         '''
@@ -254,22 +254,22 @@ class MovieWriter(AbstractMovieWriter):
 
         Parameters
         ----------
-        fps: int
+        fps : int
             Framerate for movie.
-        codec: string or None, optional
+        codec : string or None, optional
             The codec to use. If ``None`` (the default) the ``animation.codec``
             rcParam is used.
-        bitrate: int or None, optional
+        bitrate : int or None, optional
             The bitrate for the saved movie file, which is one way to control
             the output file size and quality. The default value is ``None``,
             which uses the ``animation.bitrate`` rcParam.  A value of -1
             implies that the bitrate should be determined automatically by the
             underlying utility.
-        extra_args: list of strings or None, optional
+        extra_args : list of strings or None, optional
             A list of extra string arguments to be passed to the underlying
             movie utility. The default is ``None``, which passes the additional
             arguments in the ``animation.extra_args`` rcParam.
-        metadata: Dict[str, str] or None
+        metadata : Dict[str, str] or None
             A dictionary of keys and values for metadata to include in the
             output file. Some keys that may be of use include:
             title, artist, genre, subject, copyright, srcform, comment.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -537,10 +537,10 @@ class Axes(_AxesBase):
         Returns
         -------
 
-        rectangle_patch: `.Patches.Rectangle`
+        rectangle_patch : `.Patches.Rectangle`
              Rectangle artist.
 
-        connector_lines: 4-tuple of `.Patches.ConnectionPatch`
+        connector_lines : 4-tuple of `.Patches.ConnectionPatch`
             One for each of four connector lines.  Two are set with visibility
             to *False*,  but the user can set the visibility to True if the
             automatic choice is not deemed correct.
@@ -616,10 +616,10 @@ class Axes(_AxesBase):
         Returns
         -------
 
-        rectangle_patch: `.Patches.Rectangle`
+        rectangle_patch : `.Patches.Rectangle`
              Rectangle artist.
 
-        connector_lines: 4-tuple of `.Patches.ConnectionPatch`
+        connector_lines : 4-tuple of `.Patches.ConnectionPatch`
             One for each of four connector lines.  Two are set with visibility
             to *False*,  but the user can set the visibility to True if the
             automatic choice is not deemed correct.
@@ -753,7 +753,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
             with the exception of 'transform':
 
@@ -823,7 +823,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Valid kwargs are :class:`~matplotlib.lines.Line2D` properties,
             with the exception of 'transform':
 
@@ -2998,7 +2998,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             All other keyword arguments are passed on to the plot
             command for the markers. For example, this code makes big red
             squares with thick green edges::
@@ -5657,7 +5657,7 @@ class Axes(_AxesBase):
             Stroking the edges may be preferred if *alpha* is 1, but will
             cause artifacts otherwise.
 
-        **kwargs :
+        **kwargs
             Additionally, the following arguments are allowed. They are passed
             along to the `~matplotlib.collections.PolyCollection` constructor:
 
@@ -6942,7 +6942,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
@@ -7067,7 +7067,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
@@ -7165,7 +7165,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
@@ -7262,7 +7262,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
@@ -7344,7 +7344,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
@@ -7423,7 +7423,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        **kwargs :
+        **kwargs
             Keyword arguments control the :class:`~matplotlib.lines.Line2D`
             properties:
 
@@ -7505,7 +7505,7 @@ class Axes(_AxesBase):
             when a signal is acquired and then filtered and downsampled to
             baseband.
 
-        cmap :
+        cmap
             A :class:`matplotlib.colors.Colormap` instance; if *None*, use
             default determined by rc
 
@@ -7515,7 +7515,7 @@ class Axes(_AxesBase):
             right border of the last bin. Note that for *noverlap>0* the width
             of the bins is smaller than those of the segments.
 
-        **kwargs :
+        **kwargs
             Additional kwargs are passed on to imshow which makes the
             specgram image.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2000,7 +2000,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        tab: `matplotlib.table.Table`
+        tab : `matplotlib.table.Table`
             Table instance
 
         Returns
@@ -2350,7 +2350,7 @@ class _AxesBase(martist.Artist):
         axis : {'both', 'x', 'y'}, optional
             which axis to operate on; default is 'both'
 
-        tight: bool or None, optional
+        tight : bool or None, optional
             If True, set view limits to data limits;
             if False, let the locator and margins expand the view limits;
             if None, use tight scaling if the only artist is an image,
@@ -2848,7 +2848,7 @@ class _AxesBase(martist.Artist):
 
         Other Parameters
         ----------------
-        **kw :
+        **kw
             Remaining keyword arguments are passed to directly to the
             :meth:`~matplotlib.ticker.MaxNLocator.set_params` method.
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1527,7 +1527,7 @@ class Axis(martist.Artist):
             Text string.
         fontdict : dict
             Text properties.
-        **kwargs :
+        **kwargs
             Merged into fontdict.
         """
         self.isDefault_label = False

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3089,7 +3089,7 @@ class ToolContainerBase(object):
 
         Parameters
         ----------
-        name : String
+        name : string
             Name (id) of the tool triggered from within the container
         """
         self.toolmanager.trigger_tool(name, sender=self)

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -46,10 +46,10 @@ class ToolManager(object):
 
     Attributes
     ----------
-    figure: `Figure`
-    keypresslock: `widgets.LockDraw`
+    figure : `Figure`
+    keypresslock : `widgets.LockDraw`
         `LockDraw` object to know if the `canvas` key_press_event is locked
-    messagelock: `widgets.LockDraw`
+    messagelock : `widgets.LockDraw`
         `LockDraw` object to know if the message is available to write
     """
 
@@ -299,8 +299,8 @@ class ToolManager(object):
 
         Parameters
         ----------
-        tool: Tool object
-        sender: object
+        tool : Tool object
+        sender : object
             Object that wishes to trigger the tool
         canvasevent : Event
             Original Canvas event or None
@@ -363,7 +363,7 @@ class ToolManager(object):
         ----------
         name : string
             Name of the tool
-        sender: object
+        sender : object
             Object that wishes to trigger the tool
         canvasevent : Event
             Original Canvas event or None

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -41,11 +41,11 @@ class ToolBase(object):
 
     Attributes
     ----------
-    toolmanager: `matplotlib.backend_managers.ToolManager`
+    toolmanager : `matplotlib.backend_managers.ToolManager`
         ToolManager that controls this Tool
-    figure: `FigureCanvas`
+    figure : `FigureCanvas`
         Figure instance that is affected by this Tool
-    name: String
+    name : string
         Used as **Id** of the tool, has to be unique among tools of the same
         ToolManager
     """
@@ -106,7 +106,7 @@ class ToolBase(object):
 
         Parameters
         ----------
-        figure: `Figure`
+        figure : `Figure`
         """
         self._figure = figure
 
@@ -119,11 +119,11 @@ class ToolBase(object):
 
         Parameters
         ----------
-        event: `Event`
+        event : `Event`
             The Canvas event that caused this tool to be called
-        sender: object
+        sender : object
             Object that requested the tool to be triggered
-        data: object
+        data : object
             Extra data
         """
 
@@ -1106,7 +1106,7 @@ def add_tools_to_manager(toolmanager, tools=default_tools):
 
     Parameters
     ----------
-    toolmanager: ToolManager
+    toolmanager : ToolManager
         `backend_managers.ToolManager` object that will get the tools added
     tools : {str: class_like}, optional
         The tools to add in a {name: tool} dict, see `add_tool` for more
@@ -1123,7 +1123,7 @@ def add_tools_to_container(container, tools=default_toolbar_tools):
 
     Parameters
     ----------
-    container: Container
+    container : Container
         `backend_bases.ToolContainerBase` object that will get the tools added
     tools : list, optional
         List in the form

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -89,12 +89,12 @@ class StrCategoryConverter(units.ConversionInterface):
         Parameters
         ----------
         data : string or iterable of strings
-        axis : :class:`~matplotlib.Axis.axis`
+        axis : `~matplotlib.Axis.axis`
             axis on which the data is plotted
 
         Returns
         -------
-        class:~.UnitData~
+        class : `.UnitData`
             object storing string to integer mapping
         """
         # the conversion call stack is supposed to be
@@ -160,8 +160,8 @@ class UnitData(object):
 
         Parameters
         ----------
-        data: iterable
-              sequence of string values
+        data : iterable
+            sequence of string values
         """
         self._mapping = OrderedDict()
         self._counter = itertools.count()
@@ -173,8 +173,8 @@ class UnitData(object):
 
         Parameters
         ----------
-        data: iterable
-              sequence of string values
+        data : iterable
+            sequence of string values
 
         Raises
         ------

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -267,19 +267,19 @@ def local_over_kwdict(local_var, kwargs, *keys):
 
     Parameters
     ----------
-        local_var: any object
+        local_var : any object
             The local variable (highest priority)
 
-        kwargs: dict
+        kwargs : dict
             Dictionary of keyword arguments; modified in place
 
-        keys: str(s)
+        keys : str(s)
             Name(s) of keyword arguments to process, in descending order of
             priority
 
     Returns
     -------
-        out: any object
+        out : any object
             Either local_var or one of kwargs[key] for key in keys
 
     Raises

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1133,7 +1133,7 @@ class LineCollection(Collection):
         """
         Parameters
         ----------
-        segments :
+        segments
             A sequence of (*line0*, *line1*, *line2*), where::
 
                 linen = (x0, y0), (x1, y1), ... (xm, ym)
@@ -1280,7 +1280,7 @@ class LineCollection(Collection):
 
         Parameters
         ----------
-        c :
+        c : color or list of colors
             Matplotlib color argument (all patches have same color), or a
             sequence or rgba tuples; if it is a sequence the patches will
             cycle through the sequence.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -140,7 +140,7 @@ but the first are also method signatures for the
 
 Parameters
 ----------
-mappable :
+mappable
     The :class:`~matplotlib.image.Image`,
     :class:`~matplotlib.contour.ContourSet`, etc. to
     which the colorbar applies; this argument is mandatory for the Figure

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1798,7 +1798,7 @@ class LightSource(object):
         hsv_max_val : number, optional
             The maximum value ("v" in "hsv") that the *intensity* map can shift
             the output image to. Defaults to 1.
-        hsv_min_val: number, optional
+        hsv_min_val : number, optional
             The minimum value ("v" in "hsv") that the *intensity* map can shift
             the output image to. Defaults to 0.
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -702,8 +702,10 @@ def _is_closed_polygon(X):
 
 def _find_closest_point_on_path(lc, point):
     """
-    lc: coordinates of vertices
-    point: coordinates of test point
+    Parameters
+    ----------
+    lc : coordinates of vertices
+    point : coordinates of test point
     """
 
     # find index of closest vertex for this segment
@@ -770,22 +772,22 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         particular contour level are grouped together so that
         ``level0segs = [polygon0]`` and ``level0kinds = [polygon0kinds]``.
 
-    kwargs :
+    **kwargs
         Keyword arguments are as described in the docstring of
         `~.axes.Axes.contour`.
 
     Attributes
     ----------
-    ax:
+    ax
         The axes object in which the contours are drawn.
 
-    collections:
+    collections
         A silent_list of LineCollections or PolyCollections.
 
-    levels:
+    levels
         Contour levels.
 
-    layers:
+    layers
         Same as levels for line contours; half-way between
         levels for filled contours.  See :meth:`_process_colors`.
     """
@@ -806,7 +808,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
 
         Parameters
         ----------
-        ax :
+        ax : `~.axes.Axes`
             The `~.axes.Axes` object to draw on.
 
         levels : [level0, level1, ..., leveln]
@@ -1452,16 +1454,16 @@ class QuadContourSet(ContourSet):
 
     Attributes
     ----------
-    ax:
+    ax
         The axes object in which the contours are drawn.
 
-    collections:
+    collections
         A silent_list of LineCollections or PolyCollections.
 
-    levels:
+    levels
         Contour levels.
 
-    layers:
+    layers
         Same as levels for line contours; half-way between
         levels for filled contours. See :meth:`_process_colors` method.
     """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -547,11 +547,11 @@ class Figure(Artist):
         h_pad : scalar
             Height padding in inches. Defaults to 3 pts.
 
-        wspace: scalar
+        wspace : scalar
             Width padding between subplots, expressed as a fraction of the
             subplot width.  The total padding ends up being w_pad + wspace.
 
-        hspace: scalar
+        hspace : scalar
             Height padding between subplots, expressed as a fraction of the
             subplot width. The total padding ends up being h_pad + hspace.
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -554,7 +554,7 @@ class Line2D(Artist):
 
         Parameters
         ----------
-        every: None or int or (int, int) or slice or List[int] or float or \
+        every : None or int or (int, int) or slice or List[int] or float or \
 (float, float)
             Which markers to plot.
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1161,7 +1161,7 @@ class Arrow(Patch):
         width : scalar, optional (default: 1)
             Scale factor for the width of the arrow. With a default value of
             1, the tail width is 0.2 and head width is 0.6.
-        **kwargs :
+        **kwargs
             Keyword arguments control the :class:`~matplotlib.patches.Patch`
             properties:
 
@@ -3977,7 +3977,7 @@ class FancyArrowPatch(Patch):
 
             %(AvailableArrowstyles)s
 
-        arrow_transmuter :
+        arrow_transmuter
             Ignored
 
         connectionstyle : str, ConnectionStyle, or None, optional
@@ -3989,7 +3989,7 @@ class FancyArrowPatch(Patch):
 
             %(AvailableConnectorstyles)s
 
-        connector :
+        connector
             Ignored
 
         patchA, patchB : None, Patch, optional (default: None)

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -368,7 +368,7 @@ class PathPatchEffect(AbstractPathEffect):
         ----------
         offset : pair of floats
             The offset to apply to the path, in points.
-        **kwargs :
+        **kwargs
             All keyword arguments are passed through to the
             :class:`~matplotlib.patches.PathPatch` constructor. The
             properties which cannot be overridden are "path", "clip_box"

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -437,11 +437,11 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
         resolution of the figure. If not provided, defaults to
         :rc:`figure.dpi` = ``100``.
 
-    facecolor :
+    facecolor : color spec
         the background color. If not provided, defaults to
         :rc:`figure.facecolor` = ``'w'``.
 
-    edgecolor :
+    edgecolor : color spec
         the border color. If not provided, defaults to
         :rc:`figure.edgecolor` = ``'w'``.
 
@@ -1119,7 +1119,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         Dict with keywords passed to the `~matplotlib.gridspec.GridSpec`
         constructor used to create the grid the subplots are placed on.
 
-    **fig_kw :
+    **fig_kw
         All additional keyword arguments are passed to the
         `.pyplot.figure` call.
 

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -47,7 +47,7 @@ def stackplot(axes, x, *args,
         A list or tuple of colors. These will be cycled through and used to
         colour the stacked areas.
 
-    **kwargs :
+    **kwargs
         All other keyword arguments are passed to `Axes.fill_between()`.
 
 

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -562,7 +562,7 @@ class BboxBase(TransformNode):
 
         Parameters
         ----------
-        c :
+        c : (float, float) or str
             May be either:
 
             * A sequence (*cx*, *cy*) where *cx* and *cy* range from 0

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -461,10 +461,10 @@ class CubicTriInterpolator(TriInterpolator):
 
         Parameters
         ----------
-        kind: {'min_E', 'geom', 'user'}
+        kind : {'min_E', 'geom', 'user'}
             Choice of the _DOF_estimator subclass to perform the gradient
             estimation.
-        dz: tuple of array_likes (dzdx, dzdy), optional
+        dz : tuple of array_likes (dzdx, dzdy), optional
             Used only if *kind*=user; in this case passed to the
             :class:`_DOF_estimator_user`.
 

--- a/lib/matplotlib/tri/trirefine.py
+++ b/lib/matplotlib/tri/trirefine.py
@@ -18,7 +18,7 @@ class TriRefiner(object):
 
         - ``refine_triangulation(return_tri_index=False, **kwargs)`` , where
           the optional keyword arguments *kwargs* are defined in each
-          TriRefiner concrete implementation, and which returns :
+          TriRefiner concrete implementation, and which returns:
 
               - a refined triangulation
               - optionally (depending on *return_tri_index*), for each

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -140,13 +140,13 @@ class Button(AxesWidget):
 
     Attributes
     ----------
-    ax :
+    ax
         The :class:`matplotlib.axes.Axes` the button renders into.
-    label :
+    label
         A :class:`matplotlib.text.Text` instance.
-    color :
+    color
         The color of the button when not hovering.
-    hovercolor :
+    hovercolor
         The color of the button when hovering.
     """
 

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -57,7 +57,7 @@ class AnchoredDrawingArea(AnchoredOffsetbox):
         frameon : bool, optional
             If True, draw a box around this artists. Defaults to True.
 
-        **kwargs :
+        **kwargs
             Keyworded arguments to pass to
             :class:`matplotlib.offsetbox.AnchoredOffsetbox`.
 
@@ -131,7 +131,7 @@ class AnchoredAuxTransformBox(AnchoredOffsetbox):
         frameon : bool, optional
             If True, draw a box around this artists. Defaults to True.
 
-        **kwargs :
+        **kwargs
             Keyworded arguments to pass to
             :class:`matplotlib.offsetbox.AnchoredOffsetbox`.
 
@@ -206,7 +206,7 @@ class AnchoredEllipse(AnchoredOffsetbox):
         prop : `matplotlib.font_manager.FontProperties`, optional
             Font property used as a reference for paddings.
 
-        **kwargs :
+        **kwargs
             Keyworded arguments to pass to
             :class:`matplotlib.offsetbox.AnchoredOffsetbox`.
 
@@ -299,7 +299,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
             Defaults to True if `size_vertical` is greater than
             zero and False otherwise.
 
-        **kwargs :
+        **kwargs
             Keyworded arguments to pass to
             :class:`matplotlib.offsetbox.AnchoredOffsetbox`.
 
@@ -477,7 +477,7 @@ class AnchoredDirectionArrows(AnchoredOffsetbox):
             :class:`matplotlib.text.TextPath` and
             `matplotlib.patches.FancyArrowPatch`
 
-        **kwargs :
+        **kwargs
             Keyworded arguments to pass to
             :class:`matplotlib.offsetbox.AnchoredOffsetbox`.
 

--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -106,9 +106,9 @@ class RGBAxesBase(object):
             defaults to True.
         axes_class : matplotlib.axes.Axes
 
-        kl :
+        *args
             Unpacked into axes_class() init for RGB
-        kwargs :
+        **kwargs
             Unpacked into axes_class() init for RGB, R, G, B axes
         """
         try:

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -366,7 +366,7 @@ def host_axes(*args, axes_class=None, figure=None, **kwargs):
         Figure to which the axes will be added. Defaults to the current figure
         `pyplot.gcf()`.
 
-    *args, **kwargs :
+    *args, **kwargs
         Will be passed on to the underlying ``Axes`` object creation.
     """
     import matplotlib.pyplot as plt
@@ -389,7 +389,7 @@ def host_subplot(*args, axes_class=None, figure=None, **kwargs):
         Figure to which the subplot will be added. Defaults to the current
         figure `pyplot.gcf()`.
 
-    *args, **kwargs :
+    *args, **kwargs
         Will be passed on to the underlying ``Axes`` object creation.
     """
     import matplotlib.pyplot as plt

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1603,7 +1603,7 @@ class Axes3D(Axes):
         lightsource : `~matplotlib.colors.LightSource`
             The lightsource to use when `shade` is True.
 
-        **kwargs :
+        **kwargs
             Other arguments are forwarded to `.Poly3DCollection`.
         """
 
@@ -1796,7 +1796,7 @@ class Axes3D(Axes):
             'classic' mode uses a default of ``rstride = cstride = 1`` instead
             of the new default of ``rcount = ccount = 50``.
 
-        **kwargs :
+        **kwargs
             Other arguments are forwarded to `.Line3DCollection`.
         """
 


### PR DESCRIPTION
## PR Summary

This PR aligns the docs with the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes) requirements for Paramters:

> The colon must be preceded by a space, or omitted if the type is absent.

