### PR TITLE
Warn in colorbar() when mappable.axes != figure.gca().

### DIFF
--- a/doc/api/next_api_changes/deprecations/12443-AL.rst
+++ b/doc/api/next_api_changes/deprecations/12443-AL.rst
@@ -1,0 +1,8 @@
+Figure.colorbar now warns when the mappable's axes is different from the current axes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, `.Figure.colorbar` steals space by default from the current axes
+to place the colorbar.  In a future version, it will steal space from the
+mappable's axes instead.  In preparation for this change, `.Figure.colorbar`
+now emits a warning when the current axes is not the same as the mappable's
+axes.

--- a/doc/api/next_api_changes/deprecations/12443-AL.rst
+++ b/doc/api/next_api_changes/deprecations/12443-AL.rst
@@ -1,8 +1,8 @@
-Figure.colorbar now warns when the mappable's axes is different from the current axes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``colorbar`` now warns when the mappable's axes is different from the current axes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Currently, `.Figure.colorbar` steals space by default from the current axes
-to place the colorbar.  In a future version, it will steal space from the
-mappable's axes instead.  In preparation for this change, `.Figure.colorbar`
-now emits a warning when the current axes is not the same as the mappable's
-axes.
+Currently, `.Figure.colorbar` and `.pyplot.colorbar` steal space by default
+from the current axes to place the colorbar.  In a future version, they will
+steal space from the mappable's axes instead.  In preparation for this change,
+`.Figure.colorbar` and `.pyplot.colorbar` now emits a warning when the current
+axes is not the same as the mappable's axes.

--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -277,7 +277,7 @@ class BlockingContourLabeler(BlockingMouseInput):
 
     def __init__(self, cs):
         self.cs = cs
-        BlockingMouseInput.__init__(self, fig=cs.ax.figure)
+        BlockingMouseInput.__init__(self, fig=cs.axes.figure)
 
     def add_click(self, event):
         self.button1(event)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2318,13 +2318,21 @@ default: 'top'
         """%(colorbar_doc)s"""
         if ax is None:
             ax = self.gca()
+            if (hasattr(mappable, "axes") and ax is not mappable.axes
+                    and cax is None):
+                cbook.warn_deprecated(
+                    "3.4", message="Starting from Matplotlib 3.6, colorbar() "
+                    "will steal space from the mappable's axes, rather than "
+                    "from the current axes, to place the colorbar.  To "
+                    "silence this warning, explicitly pass the 'ax' argument "
+                    "to colorbar().")
 
         # Store the value of gca so that we can set it back later on.
         current_ax = self.gca()
 
         if cax is None:
-            if use_gridspec and isinstance(ax, SubplotBase)  \
-                     and (not self.get_constrained_layout()):
+            if (use_gridspec and isinstance(ax, SubplotBase)
+                    and not self.get_constrained_layout()):
                 cax, kw = cbar.make_axes_gridspec(ax, **kw)
             else:
                 cax, kw = cbar.make_axes(ax, **kw)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2181,8 +2181,6 @@ def colorbar(mappable=None, cax=None, ax=None, **kw):
                                'creation. First define a mappable such as '
                                'an image (with imshow) or a contour set ('
                                'with contourf).')
-    if ax is None:
-        ax = gca()
     ret = gcf().colorbar(mappable, cax=cax, ax=ax, **kw)
     return ret
 


### PR DESCRIPTION
## PR Summary

See discussion at https://github.com/matplotlib/matplotlib/pull/12333#issuecomment-425660082.  Already :+1:'d by @tacaswell :)

Edit: also closes https://github.com/matplotlib/matplotlib/issues/15986 indirectly.

Edit: will be rebased over https://github.com/matplotlib/matplotlib/pull/16058 once that goes in.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
