### PR TITLE
Warn when "best" loc of legend is used with lots of data

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1117,7 +1117,7 @@ class Legend(Artist):
         verts, bboxes, lines, offsets = self._auto_legend_data()
         if self._loc_used_default and verts.shape[0] > 200000:
             # this size results in a 3+ second render time on a good machine
-            warnings.warn(
+            cbook._warn_external(
                 'Creating legend with loc="best" can be slow with large'
                 ' amounts of data.'
             )

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1119,7 +1119,7 @@ class Legend(Artist):
             # this size results in a 3+ second render time on a good machine
             cbook._warn_external(
                 'Creating legend with loc="best" can be slow with large '
-                ' amounts of data.'
+                'amounts of data.'
             )
 
         bbox = Bbox.from_bounds(0, 0, width, height)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1118,7 +1118,7 @@ class Legend(Artist):
         if self._loc_used_default and verts.shape[0] > 200000:
             # this size results in a 3+ second render time on a good machine
             cbook._warn_external(
-                'Creating legend with loc="best" can be slow with large'
+                'Creating legend with loc="best" can be slow with large '
                 ' amounts of data.'
             )
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -484,13 +484,11 @@ class Legend(Artist):
             raise TypeError("Legend needs either Axes or Figure as parent")
         self.parent = parent
 
+        self._loc_used_default = loc is None
         if loc is None:
-            self._loc_used_default = True
             loc = rcParams["legend.loc"]
             if not self.isaxes and loc in [0, 'best']:
                 loc = 'upper right'
-        else:
-            self._loc_used_default = False
         if isinstance(loc, str):
             if loc not in self.codes:
                 if self.isaxes:
@@ -571,7 +569,9 @@ class Legend(Artist):
         else:
             self.get_frame().set_alpha(framealpha)
 
-        self._set_loc(loc, is_initial_setting=True)
+        tmp = self._loc_used_default
+        self._set_loc(loc)
+        self._loc_used_default = tmp  # ignore changes done by _set_loc
 
         # figure out title fontsize:
         if title_fontsize is None:
@@ -592,13 +592,11 @@ class Legend(Artist):
 
         a.set_transform(self.get_transform())
 
-    def _set_loc(self, loc, is_initial_setting=False):
+    def _set_loc(self, loc):
         # find_offset function will be provided to _legend_box and
         # _legend_box will draw itself at the location of the return
         # value of the find_offset.
-        if not is_initial_setting:
-            # User manually changed self._loc
-            self._loc_used_default = False
+        self._loc_used_default = False
         self._loc_real = loc
         self.stale = True
         self._legend_box.set_offset(self._findoffset)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1108,6 +1108,11 @@ class Legend(Artist):
         assert self.isaxes
 
         verts, bboxes, lines, offsets = self._auto_legend_data()
+        if len(verts) + len(bboxes) + len(lines) + len(offsets) > 10000:
+            warnings.warn(
+                'Creating legend with loc="best" can be slow with large'
+                ' amounts of data.'
+            )
 
         bbox = Bbox.from_bounds(0, 0, width, height)
         if consider is None:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1108,7 +1108,7 @@ class Legend(Artist):
         assert self.isaxes
 
         verts, bboxes, lines, offsets = self._auto_legend_data()
-        if len(verts) + len(bboxes) + len(lines) + len(offsets) > 10000:
+        if len(verts) + len(bboxes) + len(lines) + len(offsets) > 500000:
             warnings.warn(
                 'Creating legend with loc="best" can be slow with large'
                 ' amounts of data.'

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -581,3 +581,14 @@ def test_warn_big_data_best_loc():
         assert str(record.message) == (
             'Creating legend with loc="best" can be slow with large'
             ' amounts of data.')
+
+
+def test_no_warn_big_data_when_loc_specified():
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(200001), label='Is this big data?')
+    with pytest.warns(None) as records:
+        l = ax.legend('best')
+        fig.canvas.draw()
+    # The _find_best_position method of Legend is called twice, duplicating
+    # the warning message.
+    assert len(records) == 0

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -567,10 +567,13 @@ def test_alpha_handles():
 
 def test_warn_big_data_best_loc():
     fig, ax = plt.subplots()
-    ax.plot(np.arange(500001), label='Is this big data?')
+    ax.plot(np.arange(200001), label='Is this big data?')
     with pytest.warns(UserWarning) as records:
-        l = ax.legend(loc='best')
-        l.draw(fig.canvas.get_renderer())
+        l = ax.legend()
+        # We need to call an internal set method tricking it into thinking
+        # 'best' location was default.
+        l._set_loc(l.codes['best'], is_initial_setting=True)
+        fig.canvas.draw()
     # The _find_best_position method of Legend is called twice, duplicating
     # the warning message.
     assert len(records) == 2

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -589,6 +589,4 @@ def test_no_warn_big_data_when_loc_specified():
     with pytest.warns(None) as records:
         l = ax.legend('best')
         fig.canvas.draw()
-    # The _find_best_position method of Legend is called twice, duplicating
-    # the warning message.
     assert len(records) == 0

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -567,7 +567,7 @@ def test_alpha_handles():
 
 def test_warn_big_data_best_loc():
     fig, ax = plt.subplots()
-    ax.plot(np.arange(10001), label='Is this big data?')
+    ax.plot(np.arange(500001), label='Is this big data?')
     with pytest.warns(UserWarning) as records:
         l = ax.legend(loc='best')
         l.draw(fig.canvas.get_renderer())

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -563,3 +563,18 @@ def test_alpha_handles():
         lh.set_alpha(1.0)
     assert lh.get_facecolor()[:-1] == hh[1].get_facecolor()[:-1]
     assert lh.get_edgecolor()[:-1] == hh[1].get_edgecolor()[:-1]
+
+
+def test_warn_big_data_best_loc():
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10001), label='Is this big data?')
+    with pytest.warns(UserWarning) as records:
+        l = ax.legend(loc='best')
+        l.draw(fig.canvas.get_renderer())
+    # The _find_best_position method of Legend is called twice, duplicating
+    # the warning message.
+    assert len(records) == 2
+    for record in records:
+        assert str(record.message) == (
+            'Creating legend with loc="best" can be slow with large'
+            ' amounts of data.')

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -13,6 +13,7 @@ import matplotlib.collections as mcollections
 from matplotlib.legend_handler import HandlerTuple
 import matplotlib.legend as mlegend
 from matplotlib.cbook.deprecation import MatplotlibDeprecationWarning
+from matplotlib import rc_context
 
 
 def test_legend_ordereddict():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -569,10 +569,8 @@ def test_warn_big_data_best_loc():
     fig, ax = plt.subplots()
     ax.plot(np.arange(200001), label='Is this big data?')
     with pytest.warns(UserWarning) as records:
-        l = ax.legend()
-        # We need to call an internal set method tricking it into thinking
-        # 'best' location was default.
-        l._set_loc(l.codes['best'], is_initial_setting=True)
+        with rc_context({'legend.loc': 'best'}):
+            l = ax.legend()
         fig.canvas.draw()
     # The _find_best_position method of Legend is called twice, duplicating
     # the warning message.


### PR DESCRIPTION
## PR Summary

Warn when "best" loc of legend is used with lots of data, as it can be quite slow.

Ref #12120 and #12203

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] N/A New features are documented, with examples if plot related
- [x] N/A Documentation is sphinx and numpydoc compliant
- [x] N/A Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] N/A Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
