### PR TITLE
Improve formatting of imshow() cursor data when a colorbar exists.

### DIFF
--- a/doc/users/next_whats_new/2018-10-10-AL.rst
+++ b/doc/users/next_whats_new/2018-10-10-AL.rst
@@ -1,0 +1,9 @@
+Improved formatting of image values under cursor when a colorbar is present
+```````````````````````````````````````````````````````````````````````````
+
+When a colorbar is present, its formatter is now used to format the image
+values under the mouse cursor in the status bar.  For example, for an image
+displaying the values 10,000 and 10,001, the statusbar will now (using default
+settings) display the values as ``0.0+1e4`` and ``1.0+1e4`` (or ``10000.0``
+and ``10001.0`` if the offset-text is disabled on the colorbar), whereas both
+values were previously displayed as ``1e+04``.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -2,6 +2,7 @@ from collections import OrderedDict, namedtuple
 from functools import wraps
 import inspect
 import logging
+from numbers import Number
 import re
 import warnings
 
@@ -1167,8 +1168,8 @@ class Artist(object):
             data[0]
         except (TypeError, IndexError):
             data = [data]
-        data_str = ', '.join('{:0.3g}'.format(item) for item in data if
-                   isinstance(item, (np.floating, np.integer, int, float)))
+        data_str = ', '.join('{:0.3g}'.format(item) for item in data
+                             if isinstance(item, Number))
         return "[" + data_str + "]"
 
     @property

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -309,10 +309,18 @@ def strip_math(s):
     """
     if len(s) >= 2 and s[0] == s[-1] == "$":
         s = s[1:-1]
-        remove = [
-            r'\mathdefault', r'\rm', r'\cal', r'\tt', r'\it', '\\', '{', '}']
-        for r in remove:
-            s = s.replace(r, '')
+        for tex, plain in [
+                (r"\times", "x"),  # Specifically for Formatter support.
+                (r"\mathdefault", ""),
+                (r"\rm", ""),
+                (r"\cal", ""),
+                (r"\tt", ""),
+                (r"\it", ""),
+                ("\\", ""),
+                ("{", ""),
+                ("}", ""),
+        ]:
+            s = s.replace(tex, plain)
     return s
 
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -302,11 +302,17 @@ def local_over_kwdict(local_var, kwargs, *keys):
 
 
 def strip_math(s):
-    """remove latex formatting from mathtext"""
-    remove = (r'\mathdefault', r'\rm', r'\cal', r'\tt', r'\it', '\\', '{', '}')
-    s = s[1:-1]
-    for r in remove:
-        s = s.replace(r, '')
+    """
+    Remove latex formatting from mathtext.
+
+    Only handles fully math and fully non-math strings.
+    """
+    if len(s) >= 2 and s[0] == s[-1] == "$":
+        s = s[1:-1]
+        remove = [
+            r'\mathdefault', r'\rm', r'\cal', r'\tt', r'\it', '\\', '{', '}']
+        for r in remove:
+            s = s.replace(r, '')
     return s
 
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -906,6 +906,15 @@ class AxesImage(_ImageBase):
         else:
             return arr[i, j]
 
+    def format_cursor_data(self, data):
+        if self.colorbar:
+            return ("["
+                    + cbook.strip_math(self.colorbar.formatter(data))
+                    + cbook.strip_math(self.colorbar.formatter.get_offset())
+                    + "]")
+        else:
+            return super().format_cursor_data(data)
+
 
 class NonUniformImage(AxesImage):
     def __init__(self, ax, *, interpolation='nearest', **kwargs):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -262,6 +262,24 @@ def test_cursor_data():
     assert im.get_cursor_data(event) is None
 
 
+def test_format_cursor_data():
+    from matplotlib.backend_bases import MouseEvent
+
+    fig, ax = plt.subplots()
+    im = ax.imshow([[10000, 10001]])
+
+    xdisp, ydisp = ax.transData.transform_point([0, 0])
+    event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
+    assert im.get_cursor_data(event) == 10000
+    assert im.format_cursor_data(im.get_cursor_data(event)) == "[1e+04]"
+
+    fig.colorbar(im)
+    fig.canvas.draw()  # This is necessary to set up the colorbar formatter.
+
+    assert im.get_cursor_data(event) == 10000
+    assert im.format_cursor_data(im.get_cursor_data(event)) == "[0.0+1e4]"
+
+
 @image_comparison(baseline_images=['image_clip'], style='mpl20')
 def test_image_clip():
     d = [[1, 2], [3, 4]]


### PR DESCRIPTION
When a colorbar exists, use its formatter to format cursor data.
For example, after
```
imshow([[10000, 10001]]); colorbar()
```
currently the cursor data on either pixel is rendered as 1e4, but after
this patch it becomes 0.0+1e4 / 1.0+1e4, or 10000.0 / 10001.0 if
`rcParams["axes.formatter.useoffset"]` is set to False.  (Even though
the version with the offset text may not be the most esthetic, it's
clearly more informative than the current behavior...)

It would be nice if this worked even for ScalarMappables that don't
have a colorbar; this may include extracting the Formatter selection
code out of the colorbar code into something generally applicable to
ScalarMappables, or just generating a hidden colorbar "on-the-fly" if
needed just for the purpose of getting its Formatter.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
