### PR TITLE
Deprecate RendererBase.strip_math.

### DIFF
--- a/doc/api/api_changes/2018-10-09-AL-deprecations.rst
+++ b/doc/api/api_changes/2018-10-09-AL-deprecations.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The ``backend_bases.RendererBase.strip_math`` method is deprecated.  Use
+`.cbook.strip_math` instead.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -695,6 +695,7 @@ class RendererBase(object):
         """
         return points
 
+    @cbook.deprecated("3.1", alternative="cbook.strip_math")
     def strip_math(self, s):
         return cbook.strip_math(s)
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -21,7 +21,6 @@ from matplotlib.backend_bases import (
 from matplotlib.backend_bases import _has_pil
 
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.cbook import is_writable_file_like, warn_deprecated
 from matplotlib.figure import Figure
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
@@ -196,15 +195,11 @@ class RendererWx(RendererBase):
     }
 
     def __init__(self, bitmap, dpi):
-        """
-        Initialise a wxWindows renderer instance.
-        """
-        warn_deprecated('2.0', message="The WX backend is "
-                        "deprecated. It's untested "
-                        "and will be removed in Matplotlib 3.0. "
-                        "Use the WXAgg backend instead. "
-                        "See Matplotlib usage FAQ for more info on backends.",
-                        alternative='WXAgg')
+        """Initialise a wxWindows renderer instance."""
+        cbook.warn_deprecated(
+            "2.0", name="wx", obj_type="backend", removal="the future",
+            alternative="wxagg", addendum="See the Matplotlib usage FAQ for "
+            "more info on backends.")
         RendererBase.__init__(self)
         DEBUG_MSG("__init__()", 1, self)
         self.width = bitmap.GetWidth()
@@ -225,9 +220,8 @@ class RendererWx(RendererBase):
         get the width and height in display coords of the string s
         with FontPropertry prop
         """
-        # return 1, 1
         if ismath:
-            s = self.strip_math(s)
+            s = cbook.strip_math(s)
 
         if self.gc is None:
             gc = self.new_gc()
@@ -307,7 +301,7 @@ class RendererWx(RendererBase):
 
     def draw_text(self, gc, x, y, s, prop, angle, ismath=False, mtext=None):
         if ismath:
-            s = self.strip_math(s)
+            s = cbook.strip_math(s)
         DEBUG_MSG("draw_text()", 1, self)
         gc.select()
         self.handle_clip_rectangle(gc)
@@ -1107,7 +1101,7 @@ class FigureCanvasWx(_FigureCanvasWxBase):
                 raise RuntimeError(
                     'Could not save figure to %s\n' %
                     (filename))
-        elif is_writable_file_like(filename):
+        elif cbook.is_writable_file_like(filename):
             if not isinstance(image, wx.Image):
                 image = image.ConvertToImage()
             if not image.SaveStream(filename, filetype):


### PR DESCRIPTION
This function exists as cbook.strip_math and has no reason to be a
Renderer (static) method.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
