### PR TITLE
np.fromstring -> np.frombuffer.

### DIFF
--- a/examples/images_contours_and_fields/image_demo.py
+++ b/examples/images_contours_and_fields/image_demo.py
@@ -8,7 +8,6 @@ Many ways to plot images in Matplotlib.
 The most common way to plot images in Matplotlib is with
 :meth:`~.axes.Axes.imshow`. The following examples demonstrate much of the
 functionality of imshow and the many images you can create.
-
 """
 
 import numpy as np
@@ -54,7 +53,7 @@ w, h = 512, 512
 
 with cbook.get_sample_data('ct.raw.gz', asfileobj=True) as datafile:
     s = datafile.read()
-A = np.fromstring(s, np.uint16).astype(float).reshape((w, h))
+A = np.frombuffer(s, np.uint16).astype(float).reshape((w, h))
 A /= A.max()
 
 fig, ax = plt.subplots()

--- a/examples/misc/agg_buffer.py
+++ b/examples/misc/agg_buffer.py
@@ -21,7 +21,7 @@ agg.draw()
 s, (width, height) = agg.print_to_buffer()
 
 # Convert to a NumPy array.
-X = np.fromstring(s, np.uint8).reshape((height, width, 4))
+X = np.frombuffer(s, np.uint8).reshape((height, width, 4))
 
 # Pass off to PIL.
 from PIL import Image

--- a/examples/specialty_plots/mri_demo.py
+++ b/examples/specialty_plots/mri_demo.py
@@ -3,24 +3,21 @@
 MRI
 ===
 
-
 This example illustrates how to read an image (of an MRI) into a NumPy
 array, and display it in greyscale using `imshow`.
-
 """
 
 import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
-import matplotlib.cm as cm
 import numpy as np
 
 
-# Data are 256x256 16 bit integers
+# Data are 256x256 16 bit integers.
 with cbook.get_sample_data('s1045.ima.gz') as dfile:
-    im = np.fromstring(dfile.read(), np.uint16).reshape((256, 256))
+    im = np.frombuffer(dfile.read(), np.uint16).reshape((256, 256))
 
 fig, ax = plt.subplots(num="MRI_demo")
-ax.imshow(im, cmap=cm.gray)
+ax.imshow(im, cmap="gray")
 ax.axis('off')
 
 plt.show()

--- a/examples/specialty_plots/mri_with_eeg.py
+++ b/examples/specialty_plots/mri_with_eeg.py
@@ -7,7 +7,6 @@ Displays a set of subplots with an MRI image, its intensity
 histogram and some EEG traces.
 """
 
-
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
@@ -20,7 +19,7 @@ fig = plt.figure("MRI_with_EEG")
 
 # Load the MRI data (256x256 16 bit integers)
 with cbook.get_sample_data('s1045.ima.gz') as dfile:
-    im = np.fromstring(dfile.read(), np.uint16).reshape((256, 256))
+    im = np.frombuffer(dfile.read(), np.uint16).reshape((256, 256))
 
 # Plot the MRI image
 ax0 = fig.add_subplot(2, 2, 1)

--- a/examples/user_interfaces/canvasagg.py
+++ b/examples/user_interfaces/canvasagg.py
@@ -42,7 +42,7 @@ canvas.draw()
 s, (width, height) = canvas.print_to_buffer()
 
 # Option 2a: Convert to a NumPy array.
-X = np.fromstring(s, np.uint8).reshape((height, width, 4))
+X = np.frombuffer(s, np.uint8).reshape((height, width, 4))
 
 # Option 2b: Pass off to PIL.
 from PIL import Image


### PR DESCRIPTION
Use of fromstring on binary data is deprecated since numpy 1.14.
(https://github.com/numpy/numpy/pull/9487)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
