### PR TITLE
Fix `set_ylim` unit handling

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3480,6 +3480,7 @@ class _AxesBase(martist.Artist):
                 raise TypeError('Cannot pass both `ymax` and `top`')
             top = ymax
 
+        self._process_unit_info(ydata=(bottom, top))
         bottom = self._validate_converted_limits(bottom, self.convert_yunits)
         top = self._validate_converted_limits(top, self.convert_yunits)
 


### PR DESCRIPTION
## PR Summary
Code is missing a call to `_process_unit_info`  (which **is** present in `set_xlim`). Without it, trying to call `set_ylim` on a blank plot using unit values results in the unit converter machinery being called to convert a value of `None`.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant