### PR TITLE
Update AutoDateFormatter with locator

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1567,6 +1567,8 @@ class Axis(martist.Artist):
                             "matplotlib.ticker.Formatter")
         self.isDefault_minfmt = False
         self.minor.formatter = formatter
+        if hasattr(self.minor.formatter, "_ismajor"):
+            self.minor.formatter._ismajor = False
         formatter.set_axis(self)
         self.stale = True
 
@@ -1583,9 +1585,6 @@ class Axis(martist.Artist):
                             "matplotlib.ticker.Locator")
         self.isDefault_majloc = False
         self.major.locator = locator
-        if (hasattr(self.get_major_formatter(), "_locator") and
-            hasattr(self.get_major_formatter(), "_tz")):
-            self.get_major_formatter()._locator = locator
         locator.set_axis(self)
         self.stale = True
 
@@ -1602,9 +1601,6 @@ class Axis(martist.Artist):
                             "matplotlib.ticker.Locator")
         self.isDefault_minloc = False
         self.minor.locator = locator
-        if (hasattr(self.get_minor_formatter(), "_locator") and
-            hasattr(self.get_minor_formatter(), "_tz")):
-            self.get_minor_formatter()._locator = locator
         locator.set_axis(self)
         self.stale = True
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1579,10 +1579,13 @@ class Axis(martist.Artist):
         locator : ~matplotlib.ticker.Locator
         """
         if not isinstance(locator, mticker.Locator):
-            raise TypeError("formatter argument should be instance of "
+            raise TypeError("locator argument should be instance of "
                             "matplotlib.ticker.Locator")
         self.isDefault_majloc = False
         self.major.locator = locator
+        if (hasattr(self.get_major_formatter(), "_locator") and
+            hasattr(self.get_major_formatter(), "_tz")):
+            self.get_major_formatter()._locator = locator
         locator.set_axis(self)
         self.stale = True
 
@@ -1595,10 +1598,13 @@ class Axis(martist.Artist):
         locator : ~matplotlib.ticker.Locator
         """
         if not isinstance(locator, mticker.Locator):
-            raise TypeError("formatter argument should be instance of "
+            raise TypeError("locator argument should be instance of "
                             "matplotlib.ticker.Locator")
         self.isDefault_minloc = False
         self.minor.locator = locator
+        if (hasattr(self.get_minor_formatter(), "_locator") and
+            hasattr(self.get_minor_formatter(), "_tz")):
+            self.get_minor_formatter()._locator = locator
         locator.set_axis(self)
         self.stale = True
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1567,8 +1567,6 @@ class Axis(martist.Artist):
                             "matplotlib.ticker.Formatter")
         self.isDefault_minfmt = False
         self.minor.formatter = formatter
-        if hasattr(self.minor.formatter, "_ismajor"):
-            self.minor.formatter._ismajor = False
         formatter.set_axis(self)
         self.stale = True
 
@@ -1585,6 +1583,8 @@ class Axis(martist.Artist):
                             "matplotlib.ticker.Locator")
         self.isDefault_majloc = False
         self.major.locator = locator
+        if self.major.formatter:
+            self.major.formatter._set_locator(locator)
         locator.set_axis(self)
         self.stale = True
 
@@ -1601,6 +1601,8 @@ class Axis(martist.Artist):
                             "matplotlib.ticker.Locator")
         self.isDefault_minloc = False
         self.minor.locator = locator
+        if self.minor.formatter:
+            self.minor.formatter._set_locator(locator)
         locator.set_axis(self)
         self.stale = True
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -806,7 +806,6 @@ class AutoDateFormatter(ticker.Formatter):
         returned by ``locator._get_unit()``.
         """
         self._locator = locator
-        self._ismajor = True
         self._tz = tz
         self.defaultfmt = defaultfmt
         self._formatter = DateFormatter(self.defaultfmt, tz)
@@ -821,13 +820,10 @@ class AutoDateFormatter(ticker.Formatter):
                        1. / (MUSECONDS_PER_DAY):
                            rcParams['date.autoformatter.microsecond']}
 
+    def _set_locator(self, locator):
+        self._locator = locator
+
     def __call__(self, x, pos=None):
-        # Check if locator is still the one from the axis to format
-        if hasattr(self.axis, "get_major_locator"):
-            pot_locator = self.axis.get_major_locator() if self._ismajor \
-                          else self.axis.get_minor_locator()
-            if self._locator is not pot_locator:
-                self._locator = pot_locator
         try:
             locator_unit_scale = float(self._locator._get_unit())
         except AttributeError:

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -806,6 +806,7 @@ class AutoDateFormatter(ticker.Formatter):
         returned by ``locator._get_unit()``.
         """
         self._locator = locator
+        self._ismajor = True
         self._tz = tz
         self.defaultfmt = defaultfmt
         self._formatter = DateFormatter(self.defaultfmt, tz)
@@ -821,7 +822,16 @@ class AutoDateFormatter(ticker.Formatter):
                            rcParams['date.autoformatter.microsecond']}
 
     def __call__(self, x, pos=None):
-        locator_unit_scale = float(self._locator._get_unit())
+        # Check if locator is still the one from the axis to format
+        if hasattr(self.axis, "get_major_locator"):
+            pot_locator = self.axis.get_major_locator() if self._ismajor \
+                          else self.axis.get_minor_locator()
+            if self._locator is not pot_locator:
+                self._locator = pot_locator
+        try:
+            locator_unit_scale = float(self._locator._get_unit())
+        except AttributeError:
+            locator_unit_scale = 1
         # Pick the first scale which is greater than the locator unit.
         fmt = next((fmt for scale, fmt in sorted(self.scaled.items())
                     if scale >= locator_unit_scale),

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -220,6 +220,27 @@ def test_DateFormatter():
     fig.autofmt_xdate()
 
 
+def test_locator_set_formatter():
+    """
+    Test if setting the locator only will update the formatter to use
+    the new locator.
+    """
+    plt.rcParams["date.autoformatter.minute"] = "%d %H:%M"
+    t = [datetime.datetime(2018, 9, 30, 8, 0),
+         datetime.datetime(2018, 9, 30, 8, 59),
+         datetime.datetime(2018, 9, 30, 10, 30)]
+    x = [2, 3, 1]
+
+    fig, ax = plt.subplots()
+    ax.plot(t, x)
+    ax.xaxis.set_major_locator(mdates.MinuteLocator((0, 30)))
+    fig.canvas.draw()
+    ticklabels = [tl.get_text() for tl in ax.get_xticklabels()]
+    expected = ['30 08:00', '30 08:30', '30 09:00',
+                '30 09:30', '30 10:00', '30 10:30']
+    assert ticklabels == expected
+
+
 def test_date_formatter_strftime():
     """
     Tests that DateFormatter matches datetime.strftime,

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -11,6 +11,7 @@ from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 
 
 def __has_pytz():
@@ -222,7 +223,7 @@ def test_DateFormatter():
 
 def test_locator_set_formatter():
     """
-    Test if setting the locator only will update the formatter to use
+    Test if setting the locator only will update the AutoDateFormatter to use
     the new locator.
     """
     plt.rcParams["date.autoformatter.minute"] = "%d %H:%M"
@@ -238,6 +239,17 @@ def test_locator_set_formatter():
     ticklabels = [tl.get_text() for tl in ax.get_xticklabels()]
     expected = ['30 08:00', '30 08:30', '30 09:00',
                 '30 09:30', '30 10:00', '30 10:30']
+    assert ticklabels == expected
+
+    ax.xaxis.set_major_locator(mticker.NullLocator())
+    ax.xaxis.set_minor_locator(mdates.MinuteLocator((5, 55)))
+    decoy_loc = mdates.MinuteLocator((12, 27))
+    ax.xaxis.set_minor_formatter(mdates.AutoDateFormatter(decoy_loc))
+
+    ax.xaxis.set_minor_locator(mdates.MinuteLocator((15, 45)))
+    fig.canvas.draw()
+    ticklabels = [tl.get_text() for tl in ax.get_xticklabels(which="minor")]
+    expected = ['30 08:15', '30 08:45', '30 09:15', '30 09:45', '30 10:15']
     assert ticklabels == expected
 
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -301,6 +301,10 @@ class Formatter(TickHelper):
         """
         return s
 
+    def _set_locator(self, locator):
+        """ Subclasses may want to override this to set a locator. """
+        pass
+
 
 class IndexFormatter(Formatter):
     """


### PR DESCRIPTION
## PR Summary

When setting a date locator without setting a new formatter, the ticklabels become mostly useless.
This PR checks inside of the formatter call if the current locator is still the same as the one active on the axis and if not, sets its `_locator` to the new locator. 

```
import matplotlib.pyplot as plt
import matplotlib.dates as mdates
from datetime import datetime

t = [datetime(2018,9,30,8,0), datetime(2018,9,30,8,59), datetime(2018,9,30,10,30)]
x = [2,3,1]

fig, ax = plt.subplots()
ax.plot(t,x)
ax.xaxis.set_major_locator(mdates.MinuteLocator((0,30)))
fig.autofmt_xdate()
```
**Previously**
![scatterml_3 0 0](https://user-images.githubusercontent.com/23121882/46708312-499f1080-cc3e-11e8-8620-e4c3340b1abf.png)

**With this PR**

![scatterml_3 0 0rc1 post620 g74e066586](https://user-images.githubusercontent.com/23121882/46708334-69cecf80-cc3e-11e8-8ad5-6e256a06db08.png)



## PR Checklist

- [x] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
