### PR TITLE
Create a hidden colorbar on-the-fly to format imshow cursor data if no colorbar exists yet.

### DIFF
--- a/doc/users/next_whats_new/2018-10-10-AL.rst
+++ b/doc/users/next_whats_new/2018-10-10-AL.rst
@@ -1,0 +1,8 @@
+Improved formatting of image values under cursor when a colorbar is present
+```````````````````````````````````````````````````````````````````````````
+
+To format image values under the mouse cursor into the status bar, we now
+use the image's colorbar formatter (creating a hidden colorbar on-the-fly if
+necessary).  For example, for an image displaying the values 10,000 and 10,001,
+the statusbar will now (using default settings) display the values as ``10000``
+and ``10001``), whereas both values were previously displayed as ``1e+04``.

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -936,14 +936,19 @@ class AxesImage(_ImageBase):
             return arr[i, j]
 
     def format_cursor_data(self, data):
-        if np.ndim(data) == 0 and self.colorbar:
-            return (
-                "["
+        if np.ndim(data):
+            return super().format_cursor_data(data)
+        if not self.colorbar:
+            from matplotlib.figure import Figure
+            fig = Figure()
+            ax = fig.subplots()
+            self.colorbar = fig.colorbar(self, cax=ax)
+            # This will call the locator and call set_locs() on the formatter.
+            ax.yaxis._update_ticks()
+        return ("["
                 + cbook.strip_math(
                     self.colorbar.formatter.format_data_short(data)).strip()
                 + "]")
-        else:
-            return super().format_cursor_data(data)
 
 
 class NonUniformImage(AxesImage):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -288,11 +288,11 @@ def test_cursor_data():
 
 
 @pytest.mark.parametrize(
-    "data, text_without_colorbar, text_with_colorbar", [
-        ([[10001, 10000]], "[1e+04]", "[10001]"),
-        ([[.123, .987]], "[0.123]", "[0.123]"),
+    "data, text", [
+        ([[10001, 10000]], "[10001]"),
+        ([[.123, .987]], "[0.123]"),
 ])
-def test_format_cursor_data(data, text_without_colorbar, text_with_colorbar):
+def test_format_cursor_data(data, text):
     from matplotlib.backend_bases import MouseEvent
 
     fig, ax = plt.subplots()
@@ -302,14 +302,7 @@ def test_format_cursor_data(data, text_without_colorbar, text_with_colorbar):
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) == data[0][0]
     assert im.format_cursor_data(im.get_cursor_data(event)) \
-        == text_without_colorbar
-
-    fig.colorbar(im)
-    fig.canvas.draw()  # This is necessary to set up the colorbar formatter.
-
-    assert im.get_cursor_data(event) == data[0][0]
-    assert im.format_cursor_data(im.get_cursor_data(event)) \
-        == text_with_colorbar
+        == text
 
 
 @image_comparison(baseline_images=['image_clip'], style='mpl20')


### PR DESCRIPTION
## PR Summary

Followup to #12459, which also works when no colorbar exists.  Adds a second commit on top of #12459.

Made as a separate PR as it's a bit an ugly hack (optimally we'd factor out the formatter selection) but still proposing it as I think the behavior is quite nice.

I don't think it'd be a performance issue as we don't actually draw() the hidden figure -- it doesn't even have a renderer attached to it.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
