### PR TITLE
Throw ValueError when irregularly gridded data is passed to streamplot.

### DIFF
--- a/doc/api/api_changes/2018-10-10-AL.rst
+++ b/doc/api/api_changes/2018-10-10-AL.rst
@@ -1,0 +1,9 @@
+`Axes.streamplot` now raises ValueError when an irregular grid is passed in
+```````````````````````````````````````````````````````````````````````````
+
+`Axes.streamplot` does not support irregularly gridded ``x`` and ``y`` values.
+So far, it used to silently plot an incorrect result.  This has been changed to
+raise a ValueError instead.
+
+The `.streamplot.Grid` class, which is internally used by streamplot code, also
+throws a ValueError when irregularly gridded values are passed in.

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -335,6 +335,11 @@ class Grid(object):
         self.width = x[-1] - x[0]
         self.height = y[-1] - y[0]
 
+        if not np.allclose(np.diff(x), self.width / (self.nx - 1)):
+            raise ValueError("'x' values must be equally spaced")
+        if not np.allclose(np.diff(y), self.height / (self.ny - 1)):
+            raise ValueError("'y' values must be equally spaced")
+
     @property
     def shape(self):
         return self.ny, self.nx


### PR DESCRIPTION
... instead of silently generating an incorrect streamplot.

Temporary fix for https://github.com/matplotlib/matplotlib/issues/12025#issuecomment-418755950 (until someone implements streamplot for irregularly gridded data).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
