### PR TITLE
MAINT: numpy deprecates asscalar in 1.16

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -107,7 +107,7 @@ def _sanitize_extrema(ex):
     if ex is None:
         return ex
     try:
-        ret = np.ndarray.item(ex)
+        ret = ex.item()
     except AttributeError:
         ret = float(ex)
     return ret

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -107,7 +107,7 @@ def _sanitize_extrema(ex):
     if ex is None:
         return ex
     try:
-        ret = np.asscalar(ex)
+        ret = np.ndarray.item(ex)
     except AttributeError:
         ret = float(ex)
     return ret

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -411,9 +411,9 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
                 A_scaled -= a_min
                 # a_min and a_max might be ndarray subclasses so use
-                # asscalar to avoid errors
-                a_min = np.asscalar(a_min.astype(scaled_dtype))
-                a_max = np.asscalar(a_max.astype(scaled_dtype))
+                # item to avoid errors
+                a_min = np.ndarray.item(a_min.astype(scaled_dtype))
+                a_max = np.ndarray.item(a_max.astype(scaled_dtype))
 
                 if a_min != a_max:
                     A_scaled /= ((a_max - a_min) / 0.8)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -412,8 +412,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 A_scaled -= a_min
                 # a_min and a_max might be ndarray subclasses so use
                 # item to avoid errors
-                a_min = np.ndarray.item(a_min.astype(scaled_dtype))
-                a_max = np.ndarray.item(a_max.astype(scaled_dtype))
+                a_min = a_min.astype(scaled_dtype).item()
+                a_max = a_max.astype(scaled_dtype).item()
 
                 if a_min != a_max:
                     A_scaled /= ((a_max - a_min) / 0.8)


### PR DESCRIPTION
## PR Summary

Small clean up to avoid deprecation warnings. See numpy/numpy#12123

## PR Checklist

- [x] Has Pytest style unit tests (No change)
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related (No change)
- [x] Documentation is sphinx and numpydoc compliant (N/A)
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there) (N/A)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way (N/A)


