### PR TITLE
Add hist.histtype rcParam.

### DIFF
--- a/doc/users/next_whats_new/2018-10-11-AL.rst
+++ b/doc/users/next_whats_new/2018-10-11-AL.rst
@@ -1,0 +1,7 @@
+Introduction of :rc:`hist.histtype`
+```````````````````````````````````
+
+The default value of the ``histtype`` argument to `Axes.hist()` can now be
+controlled using :rc:`hist.histtype`.  For large numbers of bins, setting
+this value to 'step' or 'stepfilled' can result in significant performance
+improvements over 'bar', the current default.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6319,7 +6319,7 @@ class Axes(_AxesBase):
             is based on the specified bin range instead of the
             range of x.
 
-            Default is ``None``
+            Default is ``None``.
 
         density : bool, optional
             If ``True``, the first element of the return tuple will
@@ -6343,7 +6343,7 @@ class Axes(_AxesBase):
             the weights are normalized, so that the integral of the density
             over the range remains 1.
 
-            Default is ``None``
+            Default is ``None``.
 
         cumulative : bool, optional
             If ``True``, then a histogram is computed where each bin gives the
@@ -6355,7 +6355,7 @@ class Axes(_AxesBase):
             In this case, if *normed* and/or *density* is also ``True``, then
             the histogram is normalized such that the first bin equals 1.
 
-            Default is ``False``
+            Default is ``False``.
 
         bottom : array_like, scalar, or None
             Location of the bottom baseline of each bin.  If a scalar,
@@ -6363,35 +6363,28 @@ class Axes(_AxesBase):
             If an array, each bin is shifted independently and the length
             of bottom must match the number of bins.  If None, defaults to 0.
 
-            Default is ``None``
+            Default is ``None``.
 
         histtype : {'bar', 'barstacked', 'step',  'stepfilled'}, optional
             The type of histogram to draw.
 
-            - 'bar' is a traditional bar-type histogram.  If multiple data
-              are given the bars are arranged side by side.
+            - 'bar' is a traditional bar-type histogram.  If multiple data are
+              given the bars are arranged side by side.
+            - 'barstacked' is a bar-type histogram where multiple data are
+              stacked on top of each other.
+            - 'step' generates a lineplot that is by default unfilled.
+            - 'stepfilled' generates a lineplot that is by default filled.
 
-            - 'barstacked' is a bar-type histogram where multiple
-              data are stacked on top of each other.
-
-            - 'step' generates a lineplot that is by default
-              unfilled.
-
-            - 'stepfilled' generates a lineplot that is by default
-              filled.
-
-            Default is 'bar'
+            Default is 'bar'.
 
         align : {'left', 'mid', 'right'}, optional
             Controls how the histogram is plotted.
 
-                - 'left': bars are centered on the left bin edges.
+            - 'left': bars are centered on the left bin edges.
+            - 'mid': bars are centered between the bin edges.
+            - 'right': bars are centered on the right bin edges.
 
-                - 'mid': bars are centered between the bin edges.
-
-                - 'right': bars are centered on the right bin edges.
-
-            Default is 'mid'
+            Default is 'mid'.
 
         orientation : {'horizontal', 'vertical'}, optional
             If 'horizontal', `~matplotlib.pyplot.barh` will be used for
@@ -6403,7 +6396,7 @@ class Axes(_AxesBase):
 
             Ignored if *histtype* is 'step' or 'stepfilled'.
 
-            Default is ``None``
+            Default is ``None``.
 
         log : bool, optional
             If ``True``, the histogram axis will be set to a log scale. If
@@ -6411,27 +6404,27 @@ class Axes(_AxesBase):
             filtered out and only the non-empty ``(n, bins, patches)``
             will be returned.
 
-            Default is ``False``
+            Default is ``False``.
 
         color : color or array_like of colors or None, optional
             Color spec or sequence of color specs, one per dataset.  Default
             (``None``) uses the standard line color sequence.
 
-            Default is ``None``
+            Default is ``None``.
 
         label : str or None, optional
             String, or sequence of strings to match multiple datasets.  Bar
             charts yield multiple patches per dataset, but only the first gets
             the label, so that the legend command will work as expected.
 
-            default is ``None``
+            Default is ``None``.
 
         stacked : bool, optional
-            If ``True``, multiple data are stacked on top of each other If
+            If ``True``, multiple data are stacked on top of each other. If
             ``False`` multiple data are arranged side by side if histtype is
             'bar' or on top of each other if histtype is 'step'
 
-            Default is ``False``
+            Default is ``False``.
 
         normed : bool, optional
             Deprecated; use the density keyword argument instead.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6259,7 +6259,7 @@ class Axes(_AxesBase):
 
     @_preprocess_data(replace_names=["x", 'weights'], label_namer="x")
     def hist(self, x, bins=None, range=None, density=None, weights=None,
-             cumulative=False, bottom=None, histtype='bar', align='mid',
+             cumulative=False, bottom=None, histtype=None, align='mid',
              orientation='vertical', rwidth=None, log=False,
              color=None, label=None, stacked=False, normed=None,
              **kwargs):
@@ -6375,7 +6375,10 @@ class Axes(_AxesBase):
             - 'step' generates a lineplot that is by default unfilled.
             - 'stepfilled' generates a lineplot that is by default filled.
 
-            Default is 'bar'.
+            For large numbers of bins, 'step' and 'stepfilled' can be
+            significantly faster than 'bar' and 'barstacked'.
+
+            Default is taken from :rc:`hist.histtype`.
 
         align : {'left', 'mid', 'right'}, optional
             Controls how the histogram is plotted.
@@ -6471,6 +6474,8 @@ class Axes(_AxesBase):
 
         if bins is None:
             bins = rcParams['hist.bins']
+        if histtype is None:
+            histtype = rcParams['hist.histtype']
 
         # Validate string inputs here so we don't have to clutter
         # subsequent code.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2625,7 +2625,7 @@ def hexbin(
 @docstring.copy_dedent(Axes.hist)
 def hist(
         x, bins=None, range=None, density=None, weights=None,
-        cumulative=False, bottom=None, histtype='bar', align='mid',
+        cumulative=False, bottom=None, histtype=None, align='mid',
         orientation='vertical', rwidth=None, log=False, color=None,
         label=None, stacked=False, normed=None, *, data=None,
         **kwargs):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1034,6 +1034,10 @@ defaultParams = {
 
     ## Histogram properties
     'hist.bins': [10, validate_hist_bins],
+    'hist.histtype': [
+        'bar',
+        ValidateInStrings(
+            'histtype', ['bar', 'barstacked', 'step', 'stepfilled'])],
 
     ## Boxplot properties
     'boxplot.notch': [False, validate_bool],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -481,6 +481,7 @@
 #hist.bins : 10                   ## The default number of histogram bins.
                                   ## If Numpy 1.11 or later is
                                   ## installed, may also be `auto`
+#hist.histtype : bar              ## The default histtype.
 
 #### SCATTER PLOTS
 #scatter.marker : o               ## The default marker type for scatter plots.


### PR DESCRIPTION
## PR Summary

histtype='stepfilled' is significantly faster than the current default
('bar') for large numbers of bins, but changing the default would cause
backcompat problems.

The 'hist.histtype' rcParam is introduced with the explicit intent of
preparing this transition (later making 'stepfilled' (or perhaps 'step')
the default and then deprecating the rcParam, to avoid neverending
growth of the rcParam list).

(The first commit is just docstring reformatting, the interesting part is the second commit.)
See discussion in #7121.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
