### PR TITLE
Fix duplicate condition in pathpatch3d example

### DIFF
--- a/examples/mplot3d/pathpatch3d.py
+++ b/examples/mplot3d/pathpatch3d.py
@@ -29,7 +29,7 @@ def text3d(ax, xyz, s, zdir="z", size=None, angle=0, usetex=False, **kwargs):
     x, y, z = xyz
     if zdir == "y":
         xy1, z1 = (x, z), y
-    elif zdir == "y":
+    elif zdir == "x":
         xy1, z1 = (y, z), x
     else:
         xy1, z1 = (x, y), z


### PR DESCRIPTION
## PR Summary

The conditional tests are the same for:

```python
    if zdir == "y":
        xy1, z1 = (x, z), y
    elif zdir == "y":
        xy1, z1 = (y, z), x
```

My guess is the second test is supposed to be `"x"`, based on the body `xy1, z1 = (y, z), x`
