### PR TITLE
Adjust the widths of the messages during the build.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -165,18 +165,18 @@ def is_min_version(found, minversion):
 # Define the display functions only if display_status is True.
 if options['display_status']:
     def print_line(char='='):
-        print(char * 76)
+        print(char * 79)
 
     def print_status(package, status):
-        initial_indent = "%22s: " % package
+        initial_indent = "%18s: " % package
         indent = ' ' * 24
-        print(textwrap.fill(str(status), width=76,
+        print(textwrap.fill(str(status), width=79,
                             initial_indent=initial_indent,
                             subsequent_indent=indent))
 
     def print_message(message):
         indent = ' ' * 24 + "* "
-        print(textwrap.fill(str(message), width=76,
+        print(textwrap.fill(str(message), width=79,
                             initial_indent=indent,
                             subsequent_indent=indent))
 
@@ -1231,7 +1231,7 @@ class BackendTkAgg(OptionalBackendPackage):
     force = True
 
     def check(self):
-        return "installing; run-time loading from Python Tcl / Tk"
+        return "installing; run-time loading from Python Tcl/Tk"
 
     def get_extension(self):
         sources = [
@@ -1246,7 +1246,7 @@ class BackendTkAgg(OptionalBackendPackage):
     def add_flags(self, ext):
         ext.include_dirs.insert(0, 'src')
         if sys.platform == 'win32':
-            # PSAPI library needed for finding Tcl / Tk at run time
+            # PSAPI library needed for finding Tcl/Tk at run time
             ext.libraries.extend(['psapi'])
         elif sys.platform == 'linux':
             ext.libraries.extend(['dl'])


### PR DESCRIPTION
This makes them fit in a single line (usually).

Before:
```
============================================================================
Edit setup.cfg to change the build options

BUILDING MATPLOTLIB
            matplotlib: yes [3.0.0rc1+644.gaa1e5cfce]
                python: yes [3.7.0 (default, Jun 28 2018, 13:15:42)  [GCC
                        7.2.0]]
              platform: yes [linux]

REQUIRED DEPENDENCIES AND EXTENSIONS
      install_requires: yes [handled by setuptools]
              freetype: yes [version 2.8.0]
                   png: yes [version 1.6.34]

OPTIONAL SUBPACKAGES
           sample_data: yes [installing]
                 tests: yes [using pytest version 3.8.2]

OPTIONAL BACKEND EXTENSIONS
                   agg: yes [installing]
                 tkagg: yes [installing; run-time loading from Python Tcl /
                        Tk]
                macosx: no  [Mac OS-X only]
             windowing: no  [Microsoft Windows only]

OPTIONAL PACKAGE DATA
                  dlls: no  [skipping due to configuration]
```

After
```
===============================================================================
Edit setup.cfg to change the build options

BUILDING MATPLOTLIB
        matplotlib: yes [3.0.0rc1+644.gaa1e5cfce.dirty]
            python: yes [3.7.0 (default, Jun 28 2018, 13:15:42)  [GCC 7.2.0]]
          platform: yes [linux]

REQUIRED DEPENDENCIES AND EXTENSIONS
  install_requires: yes [handled by setuptools]
          freetype: yes [version 2.8.0]
               png: yes [version 1.6.34]

OPTIONAL SUBPACKAGES
       sample_data: yes [installing]
             tests: yes [using pytest version 3.8.2]

OPTIONAL BACKEND EXTENSIONS
               agg: yes [installing]
             tkagg: yes [installing; run-time loading from Python Tcl/Tk]
            macosx: no  [Mac OS-X only]
         windowing: no  [Microsoft Windows only]

OPTIONAL PACKAGE DATA
              dlls: no  [skipping due to configuration]
```

I'll assume 79 characters is not too wide for python development :p

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
