### PR TITLE
Run flake8 before pytest on travis

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+# fail immediately if one of the following commands fails
+
+if [[ $RUN_FLAKE8 == 1 ]]; then
+    flake8 --statistics && echo "Flake8 passed without any issues!"
+fi
+
+echo "Calling pytest with the following arguments: $PYTEST_ADDOPTS"
+python -mpytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,16 +158,7 @@ before_script: |
   fi
 
 script:
-  # each script we want to run need to go in it's own section and the program you want
-  # to fail travis need to be the last thing called
-  - |
-    echo "Calling pytest with the following arguments: $PYTEST_ADDOPTS"
-    python -mpytest
-  - |
-    if [[ $RUN_FLAKE8 == 1 ]]; then
-      flake8 --statistics && echo "Flake8 passed without any issues!"
-    fi
-
+  ./.travis-script.sh
 
 before_cache: |
   rm -rf $HOME/.cache/matplotlib/tex.cache

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6228,6 +6228,8 @@ class Axes(_AxesBase):
         return CS.clabel(*args, **kwargs)
     clabel.__doc__ = mcontour.ContourSet.clabel.__doc__
 
+
+
     @docstring.dedent_interpd
     def table(self, **kwargs):
         """


### PR DESCRIPTION
## PR Summary

flake8 is significantly faster than running the tests. Let's first check if the code is formally correct. It doesn't make much sense to do a lengthy test run just to fail later because flake8 is not satisfied.