### PR TITLE
Disable sticky edge accumulation if no autoscaling.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2403,7 +2403,9 @@ class _AxesBase(martist.Artist):
         if tight is not None:
             self._tight = bool(tight)
 
-        if self.use_sticky_edges and (self._xmargin or self._ymargin):
+        if self.use_sticky_edges and (
+                (self._xmargin and scalex and self._autoscaleXon) or
+                (self._ymargin and scaley and self._autoscaleYon)):
             stickies = [artist.sticky_edges for artist in self.get_children()]
             x_stickies = sum([sticky.x for sticky in stickies], [])
             y_stickies = sum([sticky.y for sticky in stickies], [])


### PR DESCRIPTION
## PR Summary

If there's no margin to be added, we don't need sticky edges, but if autoscaling is off, we _also_ don't need the sticky edges. This saves a lot of time when plotting many artists, like in #12542.

Note this doesn't fix the problem in #12542, it just helps if you've already disabled autoscale as in https://github.com/matplotlib/matplotlib/issues/12542#issuecomment-430560836 in that you don't need to disable sticky edges yourself as well.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way