### PR TITLE
undef _XOPEN_SOURCE breaks the build in AIX

### DIFF
--- a/extern/ttconv/pprdrv_tt.cpp
+++ b/extern/ttconv/pprdrv_tt.cpp
@@ -34,8 +34,10 @@
 #ifdef _POSIX_C_SOURCE
 #    undef _POSIX_C_SOURCE
 #endif
+#ifndef _AIX
 #ifdef _XOPEN_SOURCE
 #    undef _XOPEN_SOURCE
+#endif
 #endif
 #include <Python.h>
 

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -16,8 +16,10 @@ extern "C" {
 #   ifdef _POSIX_C_SOURCE
 #       undef _POSIX_C_SOURCE
 #   endif
+#   ifndef _AIX
 #   ifdef _XOPEN_SOURCE
 #       undef _XOPEN_SOURCE
+#   endif
 #   endif
 }
 

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -14,8 +14,10 @@ typedef unsigned __int8   uint8_t;
 #ifdef _POSIX_C_SOURCE
 #    undef _POSIX_C_SOURCE
 #endif
+#ifndef _AIX
 #ifdef _XOPEN_SOURCE
 #    undef _XOPEN_SOURCE
+#endif
 #endif
 
 // Prevent multiple conflicting definitions of swab from stdlib.h and unistd.h

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -21,8 +21,10 @@
 #ifdef _POSIX_C_SOURCE
 #    undef _POSIX_C_SOURCE
 #endif
+#ifndef _AIX
 #ifdef _XOPEN_SOURCE
 #    undef _XOPEN_SOURCE
+#endif
 #endif
 
 // Prevent multiple conflicting definitions of swab from stdlib.h and unistd.h


### PR DESCRIPTION
## PR Summary
This PR addresses the issue #12535
 Some of the function declarations in AIX header files are based on the _XOPEN_SOURCE value. So undefining it breaks the build. 
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
