### PR TITLE
Fix macosx verify later

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -123,6 +123,8 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
     Wrap everything up into a window for the pylab interface
     """
     def __init__(self, canvas, num):
+        _macosx.verify_framework()
+
         FigureManagerBase.__init__(self, canvas, num)
         title = "Figure %d" % num
         _macosx.FigureManager.__init__(self, canvas, title)

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -123,7 +123,18 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
     Wrap everything up into a window for the pylab interface
     """
     def __init__(self, canvas, num):
-        _macosx.verify_framework()
+
+        if not _macosx.verify_framework():
+            raise ImportError(
+            "Python is not installed as a framework. The Mac OS X backend "
+            "will not be able to function correctly if Python is not  "
+            "installed as a framework. See the Python documentation for more  "
+            "information on installing Python as a framework on Mac OS X. "
+            "Please either reinstall Python as a framework, or try one of "
+            "the other backends. If you are using (Ana)Conda please install "
+            "python.app and replace the use of 'python' with 'pythonw'. See "
+            "'Working with Matplotlib on OSX' in the Matplotlib FAQ for "
+            "more information.")
 
         FigureManagerBase.__init__(self, canvas, num)
         title = "Figure %d" % num

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2619,7 +2619,12 @@ static struct PyMethodDef methods[] = {
     METH_VARARGS,
     "Sets the active cursor."
    },
-   {NULL, NULL, 0, NULL} /* sentinel */
+   {"verify_framework",
+    (PyCFunction)verify_framework,
+    METH_NOARGS,
+    "Verifies that the framework build is being used."
+   },
+   {NULL, NULL, 0, NULL, NULL} /* sentinel */
 };
 
 static struct PyModuleDef moduledef = {
@@ -2644,8 +2649,6 @@ PyObject* PyInit__macosx(void)
      || PyType_Ready(&TimerType) < 0)
         return NULL;
 
-    if (!verify_framework())
-        return NULL;
 
     module = PyModule_Create(&moduledef);
     if (!module)

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2575,24 +2575,16 @@ static PyTypeObject TimerType = {
     Timer_new,                 /* tp_new */
 };
 
-static bool verify_framework(void)
+PyObject*
+verify_framework(void)
 {
     ProcessSerialNumber psn;
     /* These methods are deprecated, but they don't require the app to
        have started  */
     if (CGMainDisplayID()!=0
      && GetCurrentProcess(&psn)==noErr
-     && SetFrontProcess(&psn)==noErr) return true;
-    PyErr_SetString(PyExc_ImportError,
-        "Python is not installed as a framework. The Mac OS X backend will "
-        "not be able to function correctly if Python is not installed as a "
-        "framework. See the Python documentation for more information on "
-        "installing Python as a framework on Mac OS X. Please either reinstall "
-        "Python as a framework, or try one of the other backends. If you are "
-        "using (Ana)Conda please install python.app and replace the use of "
-        "'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the "
-        "Matplotlib FAQ for more information.");
-    return false;
+     && SetFrontProcess(&psn)==noErr) return Py_True;
+    return Py_False;
 }
 
 static struct PyMethodDef methods[] = {


### PR DESCRIPTION
## PR Summary

This moves the verification of the framework build out of `import _macosx`, allowing us to 
call that more often, and into the creation of the figure manager...

Closes #12188

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->