### PR TITLE
Don't confuse uintptr_t and Py_ssize_t.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1235,11 +1235,13 @@ class BackendTkAgg(OptionalBackendPackage):
 
     def get_extension(self):
         sources = [
-            'src/_tkagg.cpp'
+            'src/_tkagg.cpp',
+            'src/py_converters.cpp',
             ]
 
         ext = make_extension('matplotlib.backends._tkagg', sources)
         self.add_flags(ext)
+        Numpy().add_flags(ext)
         LibAgg().add_flags(ext, add_sources=False)
         return ext
 

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -18,6 +18,8 @@
 // Include our own excerpts from the Tcl / Tk headers
 #include "_tkmini.h"
 
+#include "py_converters.h"
+
 #if defined(_MSC_VER)
 #  define IMG_FORMAT "%d %d %Iu"
 #else
@@ -213,9 +215,9 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
     int x1, x2, y1, y2;
     Tk_PhotoHandle photo;
     Tk_PhotoImageBlock block;
-    if (!PyArg_ParseTuple(args, "ns(iin)(iiii)(iiii):blit",
-                          &interp, &photo_name,
-                          &height, &width, &data_ptr,
+    if (!PyArg_ParseTuple(args, "O&s(iiO&)(iiii)(iiii):blit",
+                          convert_voidptr, &interp, &photo_name,
+                          &height, &width, convert_voidptr, &data_ptr,
                           &o0, &o1, &o2, &o3,
                           &x1, &x2, &y1, &y2)) {
         goto exit;

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -94,6 +94,13 @@ int convert_from_attr(PyObject *obj, const char *name, converter func, void *p)
     return 1;
 }
 
+int convert_voidptr(PyObject *obj, void *p)
+{
+    void **val = (void **)p;
+    *val = PyLong_AsVoidPtr(obj);
+    return *val != NULL ? 1 : !PyErr_Occurred();
+}
+
 int convert_double(PyObject *obj, void *p)
 {
     double *val = (double *)p;

--- a/src/py_converters.h
+++ b/src/py_converters.h
@@ -23,6 +23,7 @@ typedef int (*converter)(PyObject *, void *);
 int convert_from_attr(PyObject *obj, const char *name, converter func, void *p);
 int convert_from_method(PyObject *obj, const char *name, converter func, void *p);
 
+int convert_voidptr(PyObject *obj, void *p);
 int convert_double(PyObject *obj, void *p);
 int convert_bool(PyObject *obj, void *p);
 int convert_cap(PyObject *capobj, void *capp);


### PR DESCRIPTION
## PR Summary

Should hopefully close #12567.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
