### PR TITLE
Fix mathtext tutorial for build with Sphinx 1.8.

### DIFF
--- a/doc/sphinxext/math_symbol_table.py
+++ b/doc/sphinxext/math_symbol_table.py
@@ -1,3 +1,6 @@
+from matplotlib import mathtext
+
+
 symbols = [
     ["Lower-case Greek",
      6,
@@ -112,9 +115,19 @@ def run(state_machine):
         header = "    " + (('=' * max_width) + ' ') * columns
         lines.append(header)
         for part in get_n(columns, syms):
-            line = "    " + " ".join(
-                ":math:`{0}` ``{0}``".format(sym).rjust(max_width)
-                for sym in part)
+            line = (
+                "    " +
+                " ".join(
+                    "{} ``{}``".format(
+                        sym
+                        if not sym.startswith("\\")
+                        else sym[1:]
+                        if (sym[1:] in mathtext.Parser._overunder_functions
+                            or sym[1:] in mathtext.Parser._function_names)
+                        else chr(mathtext.tex2uni[sym[1:]]),
+                        sym)
+                    .rjust(max_width)
+                    for sym in part))
             lines.append(line)
         lines.append(header)
         lines.append('')

--- a/tutorials/text/mathtext.py
+++ b/tutorials/text/mathtext.py
@@ -179,9 +179,13 @@ command to add a little whitespace between them::
 
     r's(t) = \mathcal{A}\/\sin(2 \omega t)'
 
+.. Here we cheat a bit: for HTML math rendering, Sphinx relies on MathJax which
+   doesn't actually support the italic correction (\/); instead, use a thin
+   space (\,) which is supported.
+
 .. math::
 
-    s(t) = \mathcal{A}\/\sin(2 \omega t)
+    s(t) = \mathcal{A}\,\sin(2 \omega t)
 
 The choices available with all fonts are:
 


### PR DESCRIPTION
Sphinx 1.8 relies on MathJax for HTML math rendering, but a lot of
symbols provided by Matplotlib's mathtext come from somewhat obscure
packages that MathJax does not support.

Instead of trying to patch MathJax, just display the symbols as unicode.

Closes #12532.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
