### PR TITLE
BUG: mplot3d: Don't crash if azim or elev are non-integral

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1169,7 +1169,8 @@ class Axes3D(Axes):
             return ''
 
         if self.button_pressed in self._rotate_btn:
-            return 'azimuth=%d deg, elevation=%d deg ' % (self.azim, self.elev)
+            return 'azimuth={:.0f} deg, elevation={:.0f} deg '.format(
+                self.azim, self.elev)
             # ignore xd and yd and display angles instead
 
         # nearest edge


### PR DESCRIPTION
Formatting these via a format string causes 'inf' or 'nan' to be displayed in the status bar, which is much better than crashing because the user tried to rotate.

Extracted from https://github.com/matplotlib/matplotlib/pull/8896#discussion_r155960126, since that PR is a can of worms, but this small fix is not.

No unit tests, because testing mouse interaction sounds super hard.