### PR TITLE
Building docs has issues with ipython version 7.0.0. Created a condition in the docs-requirements.txt to not allow installing the specific version.

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -8,7 +8,7 @@
 #
 sphinx>=1.3,!=1.5.0,!=1.6.4,!=1.7.3,!=1.8.0
 colorspacious
-ipython
+ipython!=7.0.0
 ipywidgets
 numpydoc>=0.4
 pillow

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -8,7 +8,7 @@
 #
 sphinx>=1.3,!=1.5.0,!=1.6.4,!=1.7.3,!=1.8.0
 colorspacious
-ipython!=7.0.0
+ipython!=7.0.0,!=7.0.1
 ipywidgets
 numpydoc>=0.4
 pillow


### PR DESCRIPTION
I have included a condition to not install ipython version 7.0.0 in the docs-requirement.txt file. This is because Ipython version 7.0.0  wasn't allowing the make html command to build the doc files.
