### PR TITLE
add explanations and examples to the docstring of violinplot

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7811,9 +7811,7 @@ class Axes(_AxesBase):
         Make a violin plot.
 
         Make a violin plot for each column of *dataset* or each vector in
-        sequence *dataset*. 
-
-        Each filled area extends to represent the entire data range, with optional lines at the mean, the median,
+        sequence *dataset*. Each filled area extends to represent the entire data range, with optional lines at the mean, the median,
         the minimum, and the maximum.
 
         Parameters

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7811,14 +7811,19 @@ class Axes(_AxesBase):
         Make a violin plot.
 
         Make a violin plot for each column of *dataset* or each vector in
-        sequence *dataset*.  Each filled area extends to represent the
-        entire data range, with optional lines at the mean, the median,
+        sequence *dataset*.  To illustrate, if passing an 2D array/matrix, 
+        the function will treat each column as data. However, if passing a list of vectors
+        (i.e. sequence *dataset*), the function will treat each vector as data.
+
+        Each filled area extends to represent the entire data range, with optional lines at the mean, the median,
         the minimum, and the maximum.
 
         Parameters
         ----------
-        dataset : Array or a sequence of vectors.
-          The input data.
+        dataset : 2D Array/Matrix or a sequence of vectors.
+          The input data. 
+          If passing a 2D Array/Matrix, such as *np.array([[1,2,3], [4,5,6]])*, it will plot (1,4), (2,5), and (3,6)
+          If passing a sequence of vectors such as *list([[1,2,3], [4,5,6]])*, it will plot (1,2,3), (4,5,6)
 
         positions : array-like, default = [1, 2, ..., n]
           Sets the positions of the violins. The ticks and limits are

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7811,9 +7811,7 @@ class Axes(_AxesBase):
         Make a violin plot.
 
         Make a violin plot for each column of *dataset* or each vector in
-        sequence *dataset*.  To illustrate, if passing an 2D array/matrix, 
-        the function will treat each column as data. However, if passing a list of vectors
-        (i.e. sequence *dataset*), the function will treat each vector as data.
+        sequence *dataset*. 
 
         Each filled area extends to represent the entire data range, with optional lines at the mean, the median,
         the minimum, and the maximum.


### PR DESCRIPTION
Add explanations and examples to the docstring of violinplot to explain how violinplot handles differently w.r.t. sequence of vectors and 2D array. 
Closes #12178

## PR Summary

## PR Checklist

- [V] Has Pytest style unit tests
- [V] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [V] New features are documented, with examples if plot related
- [V] Documentation is sphinx and numpydoc compliant
- [V] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [V] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
