### PR TITLE
Prepare for ipython 7.1 stricter ipython directive.

### DIFF
--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -37,6 +37,7 @@ The upshot of this is that for interactive backends (including
 ``%matplotlib notebook``) in interactive mode (with ``plt.ion()``)
 
 .. ipython :: python
+   :okwarning:
 
    import matplotlib.pyplot as plt
 


### PR DESCRIPTION
In 7.1 the IPython directive will be stricter about unexpected
error/warnings _by default_ and will stop the build.

This can be disabled globally with ipython_warn_is_error,
or on a per-block basis by setting the appropriate `:okwarning:`/`:okexcept:`

I was only able to go that far as other things were preventing me from
finishing the build (some document not included in any toctree),
but at least this is one less error.

Also this should give you a heads up, that IPython 7.1 should be released soon-ish (I hope end of week as it introduce some fixes and compatibility with Python 3.7.1, that if all build breaks it will likely not be your fault. 

