### PR TITLE
FIX: get_backend return None if no backend set

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1361,14 +1361,29 @@ if os.environ.get('MPLBACKEND'):
     rcParams['backend'] = os.environ.get('MPLBACKEND')
 
 
-def get_backend():
+def get_backend(fallback=False):
     """
     Return the name of the current backend.
+
+    Parameters
+    ----------
+    fallback : bool
+        Search and set a valid backend before returning the backend's name.
+        Default is False.
+
+    Returns
+    -------
+    backend : str
+        Return the backend's name.  The string "None" means the backend has
+        not been set yet.
 
     See Also
     --------
     matplotlib.use
     """
+    val = dict.__getitem__(rcParams, 'backend')
+    if val is rcsetup._auto_backend_sentinel:
+        return "None"
     return rcParams['backend']
 
 


### PR DESCRIPTION
## PR Summary

Closes #12362

Allows the following to run if rcParams['backend'] is not already set.  

```python
import matplotlib
print('pre-backend', matplotlib.get_backend())
if not matplotlib.get_backend() == 'WXAgg':
    matplotlib.use('WXAgg')
print('backend:', matplotlib.get_backend())
```

### Before

```
pre-backend MacOSX
testit.py:4: UserWarning: matplotlib.pyplot as already been imported, this call will have no effect.
  matplotlib.use('WXAgg')
backend: MacOSX
```

### After


```
pre-backend None
backend: WXAgg
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->