### PR TITLE
Use sudo:true for nightly builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ matrix:
     - python: 3.7
       sudo: true
     - python: "nightly"
+      sudo: true
       env: PRE=--pre
     - os: osx
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312


### PR DESCRIPTION
~Trusty~ Container builds are limited to 3.7.0a4 due to outdated OpenSSL.

I'm not sure if this will fix it or whether we will have to use `3.8-dev` too.