### PR TITLE
Fix formatting of docstring

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2764,10 +2764,10 @@ class _AxesBase(martist.Artist):
           *scilimits*      (m, n), pair of integers; if *style*
                            is 'sci', scientific notation will
                            be used for numbers outside the range
-                           10`m`:sup: to 10`n`:sup:.
+                           10\ :sup:`m`\  to 10\ :sup:`n`\ .
                            Use (0,0) to include all numbers.
                            Use (m,m) where m <> 0 to fix the order
-                           of magnitude to 10`m`:sup:.
+                           of magnitude to 10\ :sup:`m`:\ .
           *useOffset*      [ bool | offset ]; if True,
                            the offset will be calculated as needed;
                            if False, no offset will be used; if a

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2764,10 +2764,10 @@ class _AxesBase(martist.Artist):
           *scilimits*      (m, n), pair of integers; if *style*
                            is 'sci', scientific notation will
                            be used for numbers outside the range
-                           10\ :sup:`m`\  to 10\ :sup:`n`\ .
+                           10\ :sup:`m` to 10\ :sup:`n`.
                            Use (0,0) to include all numbers.
                            Use (m,m) where m <> 0 to fix the order
-                           of magnitude to 10\ :sup:`m`:\ .
+                           of magnitude to 10\ :sup:`m`.
           *useOffset*      [ bool | offset ]; if True,
                            the offset will be calculated as needed;
                            if False, no offset will be used; if a


### PR DESCRIPTION
I cannot really test, but according to http://docutils.sourceforge.net/docs/ref/rst/roles.html#subscript this should correct the display on https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.ticklabel_format.html

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
