### PR TITLE
FIX: don't import macosx to check if eventloop running

### DIFF
--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -47,12 +47,7 @@ def _get_running_interactive_framework():
                 if frame.f_code == tkinter.mainloop.__code__:
                     return "tk"
                 frame = frame.f_back
-    try:
-        from matplotlib.backends import _macosx
-    except ImportError:
-        pass
-    else:
-        if _macosx.event_loop_is_running():
+    if ('_macosx' in sys.modules) and (_macosx.event_loop_is_running()):
             return "macosx"
     if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
         return "headless"

--- a/lib/matplotlib/backends/__init__.py
+++ b/lib/matplotlib/backends/__init__.py
@@ -47,7 +47,8 @@ def _get_running_interactive_framework():
                 if frame.f_code == tkinter.mainloop.__code__:
                     return "tk"
                 frame = frame.f_back
-    if ('_macosx' in sys.modules) and (_macosx.event_loop_is_running()):
+    if 'matplotlib.backends._macosx' in sys.modules:
+        if sys.modules["matplotlib.backends._macosx"].event_loop_is_running():
             return "macosx"
     if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
         return "headless"

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2580,9 +2580,21 @@ static bool verify_framework(void)
     ProcessSerialNumber psn;
     /* These methods are deprecated, but they don't require the app to
        have started  */
+#ifdef COMPILING_FOR_10_6
+         NSApp = [NSApplication sharedApplication];
+         NSApplicationActivationPolicy activationPolicy = [NSApp activationPolicy];
+         switch (activationPolicy) {
+             case NSApplicationActivationPolicyRegular:
+             case NSApplicationActivationPolicyAccessory:
+                 return true;
+             case NSApplicationActivationPolicyProhibited:
+                 break;
+         }
+#else
     if (CGMainDisplayID()!=0
      && GetCurrentProcess(&psn)==noErr
      && SetFrontProcess(&psn)==noErr) return true;
+#endif
     PyErr_SetString(PyExc_ImportError,
         "Python is not installed as a framework. The Mac OS X backend will "
         "not be able to function correctly if Python is not installed as a "


### PR DESCRIPTION
## PR Summary
Alternative to #12557

Crossref #11850, 

@anntzer, isn't this right?  If the user has started the macosx event loop, they must have already imported macosx?  

OTOH I am not sure how to make a Mac GUI to test that this test now does the right thing if the user has made a GUI. If someone has a easy GUI to test, that'd help...


### Framework build:

From python prompt:

```
import matplotlib.pyplot as plt
```

Goes to MacOSX backend, bounces dock icon, but keeps focus on terminal

```
import matplotlib; matplotlib.use('qt5agg'); import matplotlib.pyplot as plt
```

No icon until a draw command is given.  (Goes to QT5)

### non-Framework

```
import matplotlib.pyplot as plt
```

falls back to qt5AGG

```
import matplotlib; matplotlib.use('macosx'); import matplotlib.pyplot as plt
```

Gives import error.  

So....  I think this all works as expected.  The windows connection gets made earlier than we'd like (`    NSApp = [NSApplication sharedApplication];` in `verify_framework()`), but there is no way around that.  

This also no longer uses the deprecated code.  



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->