### PR TITLE
ENH: allow matplotlib.use after getbackend

### DIFF
--- a/doc/api/next_api_changes/2018-10-24-JMK.rst
+++ b/doc/api/next_api_changes/2018-10-24-JMK.rst
@@ -1,0 +1,7 @@
+Matplotlib.use now has an ImportError for interactive backend
+-------------------------------------------------------------
+
+Switching backends via `matplotlib.use` is now allowed by default,
+regardless of whether `matplotlib.pyplot` has been imported. If the user
+tries to switch from an already-started interactive backend to a different
+interactive backend, an ImportError will be raised.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1292,7 +1292,7 @@ class rc_context:
         self.__fallback()
 
 
-def use(arg, warn=True, force=False):
+def use(arg, warn=False, force=True):
     """
     Set the matplotlib backend to one of the known backends.
 
@@ -1318,11 +1318,11 @@ def use(arg, warn=True, force=False):
         If True, warn if this is called after pyplot has been imported
         and a backend is set up.
 
-        defaults to True
+        defaults to False
 
     force : bool, optional
         If True, attempt to switch the backend.  This defaults to
-        False.
+        True.
 
     See Also
     --------

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1318,11 +1318,12 @@ def use(arg, warn=False, force=True):
         If True, warn if this is called after pyplot has been imported
         and a backend is set up.
 
-        defaults to False
+        defaults to False.
 
     force : bool, optional
-        If True, attempt to switch the backend.  This defaults to
-        True.
+        If True, attempt to switch the backend.   An ImportError is raised if
+        an interactive backend is selected, but another interactive
+        backend has already started.  This defaults to True.
 
     See Also
     --------


### PR DESCRIPTION
## PR Summary

Closes the long-desired ability to just call `matplotlib.use` so long as another GUI backend hasn't been started:

Closes #12362 (for example)

```python
import matplotlib
import matplotlib.pyplot as plt

matplotlib.use('Qt5Agg')
print('backend:', matplotlib.get_backend())
if not matplotlib.get_backend() == 'MacOSX':
    matplotlib.use('MacOSX')
print('backend:', matplotlib.get_backend())

plt.plot(range(10))
plt.show()
matplotlib.use('Qt5Agg')
```

### With this PR:

```
$ pythonw testgetbackend.py
backend: Qt5Agg
backend: MacOSX
Traceback (most recent call last):
  File "testgetbackend.py", line 11, in <module>
    matplotlib.use('Qt5Agg')
  File "/Users/jklymak/matplotlib/lib/matplotlib/__init__.py", line 1355, in use
    switch_backend(name)
  File "/Users/jklymak/matplotlib/lib/matplotlib/pyplot.py", line 222, in switch_backend
    newbackend, required_framework, current_framework))
ImportError: Cannot load backend 'Qt5Agg' which requires the 'qt5' interactive framework, as 'macosx' is currently running
```

### Before:

```
$ pythonw testgetbackend.py
testgetbackend.py:3: UserWarning: matplotlib.pyplot as already been imported, this call will have no effect.
  matplotlib.use('Qt5Agg')
backend: MacOSX
backend: MacOSX
testgetbackend.py:11: UserWarning: matplotlib.pyplot as already been imported, this call will have no effect.
  matplotlib.use('Qt5Agg')
```
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->