### PR TITLE
Try to eagerly install pip dependencies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ install:
     python -mpip install --upgrade pip setuptools wheel
   - |
     # Install dependencies from PyPI.
-    python -mpip install --upgrade $PRE -r requirements/testing/travis_all.txt $EXTRAREQS $PINNEDVERS
+    python -mpip install --upgrade --upgrade-strategy eager $PRE -r requirements/testing/travis_all.txt $EXTRAREQS $PINNEDVERS
     # GUI toolkits are pip-installable only for some versions of Python so
     # don't fail if we can't install them.  Make it easier to check whether the
     # install was successful by trying to import the toolkit (sometimes, the


### PR DESCRIPTION
Might fix #12578 by forcing pip to install a pip version of numpy instead of a brew version (that seems to be broken)