### PR TITLE
Fix travis OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install: |
     export PATH=/usr/lib/ccache:$PATH
   else
     ci/silence brew update
-    brew uninstall numpy
+    brew uninstall numpy gdal postgis
     brew upgrade python
     brew install ffmpeg imagemagick mplayer ccache
     hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ before_install: |
     ci/silence brew update
     brew upgrade python
     brew install ffmpeg imagemagick mplayer ccache
+    brew reinstall numpy
     hash -r
     which python
     python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,9 +103,9 @@ before_install: |
     export PATH=/usr/lib/ccache:$PATH
   else
     ci/silence brew update
+    brew uninstall numpy
     brew upgrade python
     brew install ffmpeg imagemagick mplayer ccache
-    brew reinstall numpy
     hash -r
     which python
     python --version


### PR DESCRIPTION
The homebrew numpy seems to be broken, so this just uninstalls it which then lets pip install its own version later in the build. fixes #12578