### PR TITLE
Be a bit more stringent on invalid inputs.

### DIFF
--- a/doc/api/next_api_changes/2018-10-25-AL.rst
+++ b/doc/api/next_api_changes/2018-10-25-AL.rst
@@ -1,0 +1,13 @@
+Invalid inputs
+``````````````
+
+Passing invalid locations to `legend` and `table` used to fallback on a default
+location.  This behavior is deprecated and will throw an exception in a future
+version.
+
+`offsetbox.AnchoredText` is unable to handle the ``horizontalalignment`` or
+``verticalalignment`` kwargs, and used to ignore them with a warning.  This
+behavior is deprecated and will throw an exception in a future version.
+
+Passing steps less than 1 or greater than 10 to `MaxNLocator` used to result in
+undefined behavior.  It now throws a ValueError.

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -8,7 +8,6 @@ This backend depends on cairocffi or pycairo.
 
 import copy
 import gzip
-import warnings
 
 import numpy as np
 
@@ -602,8 +601,7 @@ class FigureCanvasCairo(FigureCanvasBase):
                     fo = gzip.GzipFile(None, 'wb', fileobj=fo)
             surface = cairo.SVGSurface(fo, width_in_points, height_in_points)
         else:
-            warnings.warn("unknown format: %s" % fmt, stacklevel=2)
-            return
+            raise ValueError("Unknown format: {!r}".format(fmt))
 
         # surface.set_dpi() can be used
         renderer = RendererCairo(self.figure.dpi)

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -24,7 +24,7 @@ def _generate_deprecation_message(
         obj_type='attribute', addendum='', *, removal=''):
 
     if removal == "":
-        removal = {"2.2": "in 3.1", "3.0": "in 3.2"}.get(
+        removal = {"2.2": "in 3.1", "3.0": "in 3.2", "3.1": "in 3.3"}.get(
             since, "two minor releases later")
     elif removal:
         if pending:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -27,7 +27,7 @@ import warnings
 import numpy as np
 
 from matplotlib import rcParams
-from matplotlib import docstring
+from matplotlib import cbook, docstring
 from matplotlib.artist import Artist, allow_rasterization
 from matplotlib.cbook import silent_list, is_hashable, warn_deprecated
 from matplotlib.font_manager import FontProperties
@@ -491,22 +491,26 @@ class Legend(Artist):
         if isinstance(loc, str):
             if loc not in self.codes:
                 if self.isaxes:
-                    warnings.warn('Unrecognized location "%s". Falling back '
-                                  'on "best"; valid locations are\n\t%s\n'
-                                  % (loc, '\n\t'.join(self.codes)))
+                    cbook.warn_deprecated(
+                        "3.1", message="Unrecognized location {!r}. Falling "
+                        "back on 'best'; valid locations are\n\t{}\n"
+                        "This will raise an exception %(removal)s."
+                        .format(loc, '\n\t'.join(self.codes)))
                     loc = 0
                 else:
-                    warnings.warn('Unrecognized location "%s". Falling back '
-                                  'on "upper right"; '
-                                  'valid locations are\n\t%s\n'
-                                  % (loc, '\n\t'.join(self.codes)))
+                    cbook.warn_deprecated(
+                        "3.1", message="Unrecognized location {!r}. Falling "
+                        "back on 'upper right'; valid locations are\n\t{}\n'"
+                        "This will raise an exception %(removal)s."
+                        .format(loc, '\n\t'.join(self.codes)))
                     loc = 1
             else:
                 loc = self.codes[loc]
         if not self.isaxes and loc == 0:
-            warnings.warn('Automatic legend placement (loc="best") not '
-                          'implemented for figure legend. '
-                          'Falling back on "upper right".')
+            cbook.warn_deprecated(
+                "3.1", message="Automatic legend placement (loc='best') not "
+                "implemented for figure legend. Falling back on 'upper "
+                "right'. This will raise an exception %(removal)s.")
             loc = 1
 
         self._mode = mode

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -18,22 +18,17 @@ import warnings
 
 import numpy as np
 
-import matplotlib.transforms as mtransforms
+from matplotlib import cbook, docstring, rcParams
 import matplotlib.artist as martist
-import matplotlib.text as mtext
 import matplotlib.path as mpath
-from matplotlib.transforms import Bbox, BboxBase, TransformedBbox
-
+import matplotlib.text as mtext
+import matplotlib.transforms as mtransforms
 from matplotlib.font_manager import FontProperties
-from matplotlib.patches import FancyBboxPatch, FancyArrowPatch
-from matplotlib import rcParams
-
-from matplotlib import docstring
-
 from matplotlib.image import BboxImage
-
-from matplotlib.patches import bbox_artist as mbbox_artist
+from matplotlib.patches import (
+    FancyBboxPatch, FancyArrowPatch, bbox_artist as mbbox_artist)
 from matplotlib.text import _AnnotationBase
+from matplotlib.transforms import Bbox, BboxBase, TransformedBbox
 
 
 DEBUG = False
@@ -1249,8 +1244,10 @@ class AnchoredText(AnchoredOffsetbox):
             prop = {}
         badkwargs = {'ha', 'horizontalalignment', 'va', 'verticalalignment'}
         if badkwargs & set(prop):
-            warnings.warn("Mixing horizontalalignment or verticalalignment "
-                          "with AnchoredText is not supported.")
+            cbook.warn_deprecated(
+                "3.1", "Mixing horizontalalignment or verticalalignment with "
+                "AnchoredText is not supported, deprecated since %(version)s, "
+                "and will raise an exception %(removal)s.")
 
         self.txt = TextArea(s, textprops=prop, minimumdescent=False)
         fp = self.txt._text.get_fontproperties()

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -17,9 +17,7 @@ ways of positioning more interesting grids.
 Author    : John Gill <jng@europe.renre.com>
 Copyright : 2004 John Gill and John Hunter
 License   : matplotlib license
-
 """
-import warnings
 
 from . import artist, cbook, docstring
 from .artist import Artist, allow_rasterization
@@ -243,9 +241,11 @@ class Table(Artist):
 
         if isinstance(loc, str):
             if loc not in self.codes:
-                warnings.warn('Unrecognized location %s. Falling back on '
-                              'bottom; valid locations are\n%s\t' %
-                              (loc, '\n\t'.join(self.codes)))
+                cbook.warn_deprecated(
+                    "3.1", message="Unrecognized location {!r}. Falling back "
+                    "on 'bottom'; valid locations are\n\t{}\n"
+                    "This will raise an exception %(removal)s."
+                    .format(loc, '\n\t'.join(self.codes)))
                 loc = 'bottom'
             loc = self.codes[loc]
         self.set_figure(ax.figure)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1878,16 +1878,12 @@ class MaxNLocator(Locator):
     @staticmethod
     def _validate_steps(steps):
         if not np.iterable(steps):
-            raise ValueError('steps argument must be a sequence of numbers '
-                             'from 1 to 10')
+            raise ValueError('steps argument must be an increasing sequence '
+                             'of numbers between 1 and 10 inclusive')
         steps = np.asarray(steps)
-        if np.any(np.diff(steps) <= 0):
-            raise ValueError('steps argument must be uniformly increasing')
-        if steps[-1] > 10 or steps[0] < 1:
-            warnings.warn('Steps argument should be a sequence of numbers\n'
-                          'increasing from 1 to 10, inclusive. Behavior with\n'
-                          'values outside this range is undefined, and will\n'
-                          'raise a ValueError in future versions of mpl.')
+        if np.any(np.diff(steps) <= 0) or steps[-1] > 10 or steps[0] < 1:
+            raise ValueError('steps argument must be an increasing sequence '
+                             'of numbers between 1 and 10 inclusive')
         if steps[0] != 1:
             steps = np.hstack((1, steps))
         if steps[-1] != 10:


### PR DESCRIPTION
and give the user fewer ways to shoot themselves in the foot.

The change in backend_cairo is on private API; _save is only ever called
by the various print_foo methods, with a valid fmt.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
