### PR TITLE
Fix issue with PyPy on macOS

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1270,6 +1270,8 @@ class BackendMacOSX(OptionalBackendPackage):
 
         ext = make_extension('matplotlib.backends._macosx', sources)
         ext.extra_link_args.extend(['-framework', 'Cocoa'])
+        if platform.python_implementation().lower() == 'pypy':
+            ext.extra_compile_args.append('-DPYPY=1')
         return ext
 
 

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -277,7 +277,9 @@ static void lazy_init(void) {
 
     NSApp = [NSApplication sharedApplication];
 
+#ifndef PYPY
     PyOS_InputHook = wait_for_stdin;
+#endif
 
     NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
     WindowServerConnectionManager* connectionManager = [WindowServerConnectionManager sharedManager];

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -3,8 +3,10 @@
 #include <sys/socket.h>
 #include <Python.h>
 
+#ifndef PYPY
 /* Remove this once Python is fixed: https://bugs.python.org/issue23237 */
 #define PYOSINPUTHOOK_REPETITIVE 1
+#endif
 
 /* Proper way to check for the OS X version we are compiling for, from
    http://developer.apple.com/documentation/DeveloperTools/Conceptual/cross_development */


### PR DESCRIPTION
This PR fixes the issue with `PyOS_InputHook` variable that is not defined in PyPy implementation:

```
src/_macosx.m:280:5: error: use of undeclared identifier 'PyOS_InputHook'
PyOS_InputHook = wait_for_stdin;
^
```

p.s.
The corresponding issue in PyPy bug tracking is https://bitbucket.org/pypy/pypy/issues/2327