### PR TITLE
Fix RcParams.__len__

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -887,6 +887,9 @@ class RcParams(MutableMapping, dict):
         """Yield sorted list of keys."""
         yield from sorted(dict.__iter__(self))
 
+    def __len__(self):
+        return dict.__len__(self)
+
     def find_all(self, pattern):
         """
         Return the subset of this RcParams dictionary whose keys match,


### PR DESCRIPTION
## PR Summary

Addresses the `RcParams.__len__ == 0` issue from #12576.
