### PR TITLE
Added support for MacOSX backend for PyPy

### DIFF
--- a/doc/users/next_whats_new/2018-10-26-DM.rst
+++ b/doc/users/next_whats_new/2018-10-26-DM.rst
@@ -1,0 +1,5 @@
+Added support for MacOSX backend for PyPy
+-----------------------------------------
+
+Fixed issue with MacOSX backend for PyPy and also for non-framework Python
+installations.

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -278,8 +278,11 @@ static void lazy_init(void) {
     backend_inited = true;
 
     NSApp = [NSApplication sharedApplication];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 
 #ifndef PYPY
+    /* TODO: remove ifndef after the new PyPy with the PyOS_InputHook implementation
+    get released: https://bitbucket.org/pypy/pypy/commits/caaf91a */
     PyOS_InputHook = wait_for_stdin;
 #endif
 
@@ -2579,27 +2582,13 @@ static PyTypeObject TimerType = {
     Timer_new,                 /* tp_new */
 };
 
+#ifndef COMPILING_FOR_10_6
 static bool verify_framework(void)
 {
     ProcessSerialNumber psn;
-    /* These methods are deprecated, but they don't require the app to
-       have started  */
-#ifdef COMPILING_FOR_10_6
-         NSApp = [NSApplication sharedApplication];
-        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-         NSApplicationActivationPolicy activationPolicy = [NSApp activationPolicy];
-         switch (activationPolicy) {
-             case NSApplicationActivationPolicyRegular:
-             case NSApplicationActivationPolicyAccessory:
-                 return true;
-             case NSApplicationActivationPolicyProhibited:
-                 break;
-         }
-#else
     if (CGMainDisplayID()!=0
      && GetCurrentProcess(&psn)==noErr
      && SetFrontProcess(&psn)==noErr) return true;
-#endif
     PyErr_SetString(PyExc_ImportError,
         "Python is not installed as a framework. The Mac OS X backend will "
         "not be able to function correctly if Python is not installed as a "
@@ -2611,6 +2600,7 @@ static bool verify_framework(void)
         "Matplotlib FAQ for more information.");
     return false;
 }
+#endif
 
 static struct PyMethodDef methods[] = {
    {"event_loop_is_running",
@@ -2661,8 +2651,11 @@ PyObject* PyInit__macosx(void)
      || PyType_Ready(&TimerType) < 0)
         return NULL;
 
+#ifndef COMPILING_FOR_10_6
+    /* if >=10.6 invoke setActivationPolicy in lazy_init */
     if (!verify_framework())
         return NULL;
+#endif
 
     module = PyModule_Create(&moduledef);
     if (!module)

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2586,6 +2586,7 @@ static bool verify_framework(void)
        have started  */
 #ifdef COMPILING_FOR_10_6
          NSApp = [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
          NSApplicationActivationPolicy activationPolicy = [NSApp activationPolicy];
          switch (activationPolicy) {
              case NSApplicationActivationPolicyRegular:


### PR DESCRIPTION
This PR adds support for `MacOSX` backend for __PyPy__ and fixes an issue with the buggy/inactive/background/hidden windows in non-framework Python setups.

### PR Checklist
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
