### PR TITLE
FIX: allow non bbox_extra_artists calls

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2296,9 +2296,16 @@ default: 'top'
             if bbox is not None and (bbox.width != 0 or bbox.height != 0):
                 bb.append(bbox)
 
-        bb.extend(
-            ax.get_tightbbox(renderer, bbox_extra_artists=bbox_extra_artists)
-            for ax in self.axes if ax.get_visible())
+        for ax in self.axes:
+            if ax.get_visible():
+                # some axes don't take the bbox_extra_artists kwarg so we
+                # need this conditional....
+                try:
+                    bbox = ax.get_tightbbox(renderer,
+                            bbox_extra_artists=bbox_extra_artists)
+                except TypeError:
+                    bbox = ax.get_tightbbox(renderer)
+                bb.append(bbox)
 
         if len(bb) == 0:
             return self.bbox_inches

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -326,11 +326,13 @@ class HostAxesBase:
 
         return ax2
 
-    def get_tightbbox(self, renderer, call_axes_locator=True):
+    def get_tightbbox(self, renderer, call_axes_locator=True,
+                      bbox_extra_artists=None):
         bbs = [ax.get_tightbbox(renderer, call_axes_locator=call_axes_locator)
                for ax in self.parasites]
         bbs.append(super().get_tightbbox(renderer,
-                                         call_axes_locator=call_axes_locator))
+                call_axes_locator=call_axes_locator,
+                bbox_extra_artists=bbox_extra_artists))
         return Bbox.union([b for b in bbs if b.width != 0 or b.height != 0])
 
 

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -406,3 +406,18 @@ def test_image_grid():
     for i in range(4):
         grid[i].imshow(im)
         grid[i].set_title('test {0}{0}'.format(i))
+
+
+def test_gettightbbox():
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+
+    l, = ax.plot([1, 2, 3], [0, 1, 0])
+
+    ax_zoom = zoomed_inset_axes(ax, 4)
+    ax_zoom.plot([1, 2, 3], [0, 1, 0])
+
+    mark_inset(ax, ax_zoom, loc1=1, loc2=3, fc="none", ec='0.3')
+    bbox = fig.get_tightbbox(fig.canvas.get_renderer())
+    np.testing.assert_array_almost_equal(bbox.extents,
+            [-18.022743, -14.118056,   7.332813,   5.4625])


### PR DESCRIPTION
## PR Summary

Closes #12634

Apparently some axes don't allow accept `bbox_extra_artists` kwarg.  I could not track down how to get the parasite axes' `get_tightbbox` to accept this kwarg, but this fix seems to work fine. 

The offending PR was #12363 where I introduced the `bbox_extra_artists` as a kwarg. That was probably a mistake because some axes subclasses out there may not impliment this kwarg.  

This PR makes that kwarg optional - if `axsubclass.get_tightbbox(renderer, bbox_extra_artists=artists)` gives a TypeError, then we just call it w/o this kwarg.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->