### PR TITLE
Tell IPython the correct GUI event loop to use for all backends.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1597,6 +1597,11 @@ class FigureCanvasBase(object):
         if not ip:
             return
         from IPython.core import pylabtools as pt
+        if (not hasattr(pt, "backend2gui")
+                or not hasattr(ip, "enable_matplotlib")):
+            # In case we ever move the patch to IPython and remove these APIs,
+            # don't break on our side.
+            return
         backend_mod = sys.modules[cls.__module__]
         rif = getattr(backend_mod, "required_interactive_framework", None)
         backend2gui_rif = {"qt5": "qt", "qt4": "qt", "gtk3": "gtk3",


### PR DESCRIPTION
IPython currently uses a hard-coded table
(IPython.core.pylabtools.backend2gui) to know which event loop to use
for which backend.  This approach fails for both the new builtin
cairo-based backends (which do not appear in the table), and for
third-party backends (e.g. mplcairo).

mplcairo has used some custom code to patch that table for a while;
reuse it to more generally use the new "required_interactive_framework"
attribute.

Note that this PR suggests that there should be a better way to go back
from the canvas class to the backend module (rather than looking for
`sys.modules[cls.__module__].required_interactive_framework`, which is a
bit hacky and could in theory fail if the canvas class is actually
defined in another submodule).

(Edits:
Actually the "hack" above "sort-of" fails for Qt4 in the sense that `backend_qt4agg.FigureCanvas` is actually the *same* class as `backend_qt5agg.FigureCanvas`, so trying to reach the required_interactive_framework that way will point to "qt5".  But fortunately ipython maps both "qt4" and "qt5" to "qt", so we're fine...

Perhaps we can just mandate that the `__module__` attribute of FigureCanvas subclasses must point to their actual backend module name.  It's not as if requiring that the backend module name be stored in *another* attribute really helps.)

Fixes #10763.
attn @Carreau 

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
