### PR TITLE
Don't silence TypeErrors in fmt_{x,y}data.

### DIFF
--- a/doc/api/next_api_changes/2018-10-27-AL.rst
+++ b/doc/api/next_api_changes/2018-10-27-AL.rst
@@ -1,0 +1,7 @@
+``Axes.fmt_xdata`` and ``Axes.fmt_ydata`` no longer ignore TypeErrors raised by a user-provided formatter
+`````````````````````````````````````````````````````````````````````````````````````````````````````````
+
+Previously, if the user provided a ``fmt_xdata`` or ``fmt_ydata`` function that
+raised a TypeError (or set them to a non-callable), the exception would be
+silently ignored and the default formatter be used instead.  This is no longer
+the case; the exception is now propagated out.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3700,32 +3700,26 @@ class _AxesBase(martist.Artist):
 
     def format_xdata(self, x):
         """
-        Return *x* string formatted.  This function will use the attribute
-        self.fmt_xdata if it is callable, else will fall back on the xaxis
-        major formatter
+        Return *x* formatted as an x-value.
+
+        This function will use the `.fmt_xdata` attribute if it is not None,
+        else will fall back on the xaxis major formatter.
         """
-        try:
-            return self.fmt_xdata(x)
-        except TypeError:
-            func = self.xaxis.get_major_formatter().format_data_short
-            val = func(x)
-            return val
+        return (self.fmt_xdata if self.fmt_xdata is not None
+                else self.xaxis.get_major_formatter().format_data_short)(x)
 
     def format_ydata(self, y):
         """
-        Return y string formatted.  This function will use the
-        :attr:`fmt_ydata` attribute if it is callable, else will fall
-        back on the yaxis major formatter
+        Return *y* formatted as an y-value.
+
+        This function will use the `.fmt_ydata` attribute if it is not None,
+        else will fall back on the yaxis major formatter.
         """
-        try:
-            return self.fmt_ydata(y)
-        except TypeError:
-            func = self.yaxis.get_major_formatter().format_data_short
-            val = func(y)
-            return val
+        return (self.fmt_ydata if self.fmt_ydata is not None
+                else self.yaxis.get_major_formatter().format_data_short)(y)
 
     def format_coord(self, x, y):
-        """Return a format string formatting the *x*, *y* coord"""
+        """Return a format string formatting the *x*, *y* coordinates."""
         if x is None:
             xs = '???'
         else:

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -1,3 +1,5 @@
+import re
+
 from matplotlib.backend_bases import (
     FigureCanvasBase, LocationEvent, RendererBase)
 import matplotlib.pyplot as plt
@@ -71,22 +73,26 @@ def test_non_gui_warning():
                 in str(rec[0].message))
 
 
-def test_location_event_position():
-    # LocationEvent should cast its x and y arguments
-    # to int unless it is None
-    fig = plt.figure()
+@pytest.mark.parametrize(
+    "x, y", [(42, 24), (None, 42), (None, None), (200, 100.01), (205.75, 2.0)])
+def test_location_event_position(x, y):
+    # LocationEvent should cast its x and y arguments to int unless it is None.
+    fig, ax = plt.subplots()
     canvas = FigureCanvasBase(fig)
-    test_positions = [(42, 24), (None, 42), (None, None),
-                      (200, 100.01), (205.75, 2.0)]
-    for x, y in test_positions:
-        event = LocationEvent("test_event", canvas, x, y)
-        if x is None:
-            assert event.x is None
-        else:
-            assert event.x == int(x)
-            assert isinstance(event.x, int)
-        if y is None:
-            assert event.y is None
-        else:
-            assert event.y == int(y)
-            assert isinstance(event.y, int)
+    event = LocationEvent("test_event", canvas, x, y)
+    if x is None:
+        assert event.x is None
+    else:
+        assert event.x == int(x)
+        assert isinstance(event.x, int)
+    if y is None:
+        assert event.y is None
+    else:
+        assert event.y == int(y)
+        assert isinstance(event.y, int)
+    if x is not None and y is not None:
+        assert re.match(
+            "x={} +y={}".format(ax.format_xdata(x), ax.format_ydata(y)),
+            ax.format_coord(x, y))
+        ax.fmt_xdata = ax.fmt_ydata = lambda x: "foo"
+        assert re.match("x=foo +y=foo", ax.format_coord(x, y))


### PR DESCRIPTION
Still in the "fewer ways to shoot oneself in the foot" spirit.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
