### PR TITLE
Allow unit input to FancyArrowPatch

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -571,6 +571,14 @@ class Patch(artist.Artist):
     def get_window_extent(self, renderer=None):
         return self.get_path().get_extents(self.get_transform())
 
+    def _convert_xy_units(self, xy):
+        """
+        Convert x and y units for a tuple (x, y)
+        """
+        x = self.convert_xunits(xy[0])
+        y = self.convert_yunits(xy[1])
+        return (x, y)
+
 
 patchdoc = artist.kwdoc(Patch)
 for k in ('Rectangle', 'Circle', 'RegularPolygon', 'Polygon', 'Wedge', 'Arrow',
@@ -4253,8 +4261,10 @@ class FancyArrowPatch(Patch):
         dpi_cor = self.get_dpi_cor()
 
         if self._posA_posB is not None:
-            posA = self.get_transform().transform_point(self._posA_posB[0])
-            posB = self.get_transform().transform_point(self._posA_posB[1])
+            posA = self._convert_xy_units(self._posA_posB[0])
+            posB = self._convert_xy_units(self._posA_posB[1])
+            posA = self.get_transform().transform_point(posA)
+            posB = self.get_transform().transform_point(posB)
             _path = self.get_connectionstyle()(posA, posB,
                                                patchA=self.patchA,
                                                patchB=self.patchB,

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
 from matplotlib.cbook import MatplotlibDeprecationWarning
-from matplotlib.patches import Polygon, Rectangle
+from matplotlib.patches import Polygon, Rectangle, FancyArrowPatch
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 import matplotlib.pyplot as plt
 from matplotlib import (
@@ -468,3 +468,12 @@ def test_shadow(fig_test, fig_ref):
         alpha=.5)
     a2.add_patch(shadow)
     a2.add_patch(rect)
+
+
+def test_fancyarrow_units():
+    from datetime import datetime
+    # Smoke test to check that FancyArrowPatch works with units
+    dtime = datetime(2000, 1, 1)
+    fig, ax = plt.subplots()
+    arrow = FancyArrowPatch((0, dtime), (0.01, dtime))
+    ax.add_patch(arrow)


### PR DESCRIPTION
Fixes #12591. I added `_convert_xy_units` to the `Patch` base class, as I figure it's probably useful for other `Patch` subclasses too.