### PR TITLE
Don't warn when accessing deprecated properties from the class.

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -201,18 +201,21 @@ def deprecated(since, message='', name='', alternative='', pending=False,
 
             class _deprecated_property(property):
                 def __get__(self, instance, owner):
-                    from . import _warn_external
-                    _warn_external(message, category)
+                    if instance is not None:
+                        from . import _warn_external
+                        _warn_external(message, category)
                     return super().__get__(instance, owner)
 
                 def __set__(self, instance, value):
-                    from . import _warn_external
-                    _warn_external(message, category)
+                    if instance is not None:
+                        from . import _warn_external
+                        _warn_external(message, category)
                     return super().__set__(instance, value)
 
                 def __delete__(self, instance):
-                    from . import _warn_external
-                    _warn_external(message, category)
+                    if instance is not None:
+                        from . import _warn_external
+                        _warn_external(message, category)
                     return super().__delete__(instance)
 
             def finalize(_, new_doc):


### PR DESCRIPTION
Otherwise, we get a lot of spurious warnings from inspection tools such
as pydoc.

Partially reverts #12247.  Closes half of #12650 (the other half is handled by #12652).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
