### PR TITLE
Do not warn-depreacted when iterating over rcParams

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -885,7 +885,9 @@ class RcParams(MutableMapping, dict):
 
     def __iter__(self):
         """Yield sorted list of keys."""
-        yield from sorted(dict.__iter__(self))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', MatplotlibDeprecationWarning)
+            yield from sorted(dict.__iter__(self))
 
     def __len__(self):
         return dict.__len__(self)
@@ -907,8 +909,7 @@ class RcParams(MutableMapping, dict):
                         if pattern_re.search(key))
 
     def copy(self):
-        return {k: dict.__getitem__(self, k)
-                for k in self}
+        return {k: dict.__getitem__(self, k) for k in self}
 
 
 def rc_params(fail_on_error=False):


### PR DESCRIPTION
## PR Summary

Closes #12649. 

This is an alternative approach to #12652. In contrast to #12652 we still return the deprecated rcParams