### PR TITLE
Fix scatter() with empty data and c argument

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4187,7 +4187,7 @@ class Axes(_AxesBase):
         if (c_none or
                 co is not None or
                 isinstance(c, str) or
-                (isinstance(c, collections.Iterable) and
+                (isinstance(c, collections.Iterable) and len(c) > 0 and
                     isinstance(c[0], str))):
             c_array = None
         else:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1741,6 +1741,11 @@ class TestScatter(object):
         with pytest.raises(ValueError):
             plt.scatter([1, 2, 3], [1, 2, 3], color=[1, 2, 3])
 
+    def test_scatter_empty(self):
+        # just making sure this does not raise an exception
+        plt.scatter([], [])
+        plt.scatter([], [], s=[], c=[])
+
     # Parameters for *test_scatter_c*. NB: assuming that the
     # scatter plot will have 4 elements. The tuple scheme is:
     # (*c* parameter case, exception regexp key or None if no exception)


### PR DESCRIPTION
## PR Summary

Fixes #12641. The issue is that `c[0]` is accessed for an empty array (the 3d code drops invalid points and thus passes an empty array in case of the MWE https://github.com/matplotlib/matplotlib/issues/12641#issuecomment-434056462).

*Note:* While the canonical way of checking emptiness is `if c`, I feel it's more clear to use `len(c) > 0` here.


## PR Checklist

- [x] Has Pytest style unit tests