### PR TITLE
Fix for _axes.scatter() array index out of bound error

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4188,7 +4188,8 @@ class Axes(_AxesBase):
                 co is not None or
                 isinstance(c, str) or
                 (isinstance(c, collections.Iterable) and
-                    isinstance(c[0], str))):
+                    len(c) > 0 and
+                    isinstance(cbook.safe_first_element(c), str))):
             c_array = None
         else:
             try:  # First, does 'c' look suitable for value-mapping?

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -526,3 +526,10 @@ def test_contiguous_regions():
     assert cbook.contiguous_regions([False]*5) == []
     # Empty mask
     assert cbook.contiguous_regions([]) == []
+
+
+def test_safe_first_element_pandas_series(pd):
+    # delibrately create a pandas series with index not starting from 0
+    s = pd.Series(range(5), index=range(10, 15))
+    actual = cbook.safe_first_element(s)
+    assert actual == 0


### PR DESCRIPTION
## PR Summary

This is to issue #12641, fixing the index out of bound error for accessing first element of an Iterable. Solution uses `cbook.safe_first_element()`. 

Added test case for `cbook.safe_first_element()` for `pandas.Series` object.
