### PR TITLE
Allow "real" LaTeX code for pgf.preamble in matplotlibrc

### DIFF
--- a/doc/api/next_api_changes/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
+++ b/doc/api/next_api_changes/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
@@ -1,0 +1,12 @@
+Allow "real" LaTeX code for ``pgf.preamble`` in matplotlib rc file
+``````````````````````````````````````````````````````````````````
+
+Previously, the rc file key ``pgf.preamble`` was parsed using commmas as
+separators. This would break valid LaTeX code, such as::
+
+\usepackage[protrusion=true, expansion=false]{microtype}
+
+The parsing has been modified to pass the complete line to the LaTeX system,
+keeping all commas.
+
+Passing a list of strings from within a Python script still works as it used to.

--- a/doc/api/next_api_changes/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
+++ b/doc/api/next_api_changes/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
@@ -1,8 +1,7 @@
-Allow "real" LaTeX code for ``pgf.preamble`` in matplotlib rc file
-``````````````````````````````````````````````````````````````````
+Allow "real" LaTeX code for ``pgf.preamble`` and ``text.latex.preamble`` in matplotlib rc file
+``````````````````````````````````````````````````````````````````````````````````````````````
 
-Previously, the rc file key ``pgf.preamble`` was parsed using commmas as
-separators. This would break valid LaTeX code, such as::
+Previously, the rc file keys ``pgf.preamble`` and ``text.latex.preamble`` were parsed using commmas as separators. This would break valid LaTeX code, such as::
 
 \usepackage[protrusion=true, expansion=false]{microtype}
 

--- a/doc/users/next_whats_new/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
+++ b/doc/users/next_whats_new/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
@@ -1,0 +1,11 @@
+Allow "real" LaTeX code for ``pgf.preamble`` and ``text.latex.preamble`` in matplotlib rc file
+``````````````````````````````````````````````````````````````````````````````````````````````
+
+Previously, the rc file keys ``pgf.preamble`` and ``text.latex.preamble`` were parsed using commmas as separators. This would break valid LaTeX code, such as::
+
+\usepackage[protrusion=true, expansion=false]{microtype}
+
+The parsing has been modified to pass the complete line to the LaTeX system,
+keeping all commas.
+
+Passing a list of strings from within a Python script still works as it used to.

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -59,7 +59,7 @@ def get_fontspec():
 
 def get_preamble():
     """Get LaTeX preamble from rc."""
-    return "\n".join(rcParams["pgf.preamble"])
+    return rcParams["pgf.preamble"]
 
 ###############################################################################
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -174,6 +174,20 @@ def validate_string_or_None(s):
     except ValueError:
         raise ValueError('Could not convert "%s" to string' % s)
 
+def validate_stringlist_or_string(s):
+    """convert s to string or raise"""
+    if s is None or s == 'None':
+        return str()
+    try:
+        if isinstance(s, six.text_type):
+            return s
+        elif isinstance(s, list):
+            return "".join([six.text_type(i) for i in s])
+        else:
+            raise ValueError()
+    except ValueError:
+        raise ValueError('Could not convert "%s" to string' % s)
+
 
 def validate_axisbelow(s):
     try:
@@ -1391,7 +1405,7 @@ defaultParams = {
     # use matplotlib rc settings for font configuration
     'pgf.rcfonts':   [True, validate_bool],
     # provide a custom preamble for the latex process
-    'pgf.preamble':  [[], validate_stringlist],
+    'pgf.preamble':  ['', validate_stringlist_or_string],
 
     # write raster image data directly into the svg file
     'svg.image_inline':     [True, validate_bool],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -174,6 +174,7 @@ def validate_string_or_None(s):
     except ValueError:
         raise ValueError('Could not convert "%s" to string' % s)
 
+
 def validate_stringlist_or_string(s):
     """convert s to string or raise"""
     if s is None or s == 'None':

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -179,10 +179,10 @@ def validate_stringlist_or_string(s):
     if s is None or s == 'None':
         return str()
     try:
-        if isinstance(s, six.text_type):
+        if isinstance(s, str):
             return s
         elif isinstance(s, list):
-            return "".join([six.text_type(i) for i in s])
+            return "".join([str(i) for i in s])
         else:
             raise ValueError()
     except ValueError:

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -183,7 +183,7 @@ def _validate_stringlist_or_string(s):
         if isinstance(s, str):
             return s
         if isinstance(s, list):
-            return "".join([str(i) for i in s])
+            return '\n'.join([str(i) for i in s])
         raise ValueError()
     except ValueError:
         raise ValueError('Could not convert "%s" to string' % s)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -178,7 +178,7 @@ def validate_string_or_None(s):
 def validate_stringlist_or_string(s):
     """convert s to string or raise"""
     if s is None or s == 'None':
-        return str()
+        return ""
     try:
         if isinstance(s, str):
             return s

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -175,7 +175,7 @@ def validate_string_or_None(s):
         raise ValueError('Could not convert "%s" to string' % s)
 
 
-def validate_stringlist_or_string(s):
+def _validate_stringlist_or_string(s):
     """convert s to string or raise"""
     if s is None or s == 'None':
         return ""
@@ -1405,7 +1405,7 @@ defaultParams = {
     # use matplotlib rc settings for font configuration
     'pgf.rcfonts':   [True, validate_bool],
     # provide a custom preamble for the latex process
-    'pgf.preamble':  ['', validate_stringlist_or_string],
+    'pgf.preamble':  ['', _validate_stringlist_or_string],
 
     # write raster image data directly into the svg file
     'svg.image_inline':     [True, validate_bool],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -182,7 +182,7 @@ def _validate_stringlist_or_string(s):
     try:
         if isinstance(s, str):
             return s
-        if isinstance(s, list):
+        if isinstance(s, Iterable):
             return '\n'.join([str(i) for i in s])
         raise ValueError()
     except ValueError:

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1129,7 +1129,7 @@ defaultParams = {
     'text.color':          ['black', validate_color],
     'text.usetex':         [False, validate_bool],
     'text.latex.unicode':  [True, validate_bool],
-    'text.latex.preamble': [[], validate_stringlist],
+    'text.latex.preamble': ['', _validate_stringlist_or_string],
     'text.latex.preview':  [False, validate_bool],
     'text.dvipnghack':     [None, validate_bool_maybe_none],
     'text.hinting':        ['auto', validate_hinting],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -182,10 +182,9 @@ def validate_stringlist_or_string(s):
     try:
         if isinstance(s, str):
             return s
-        elif isinstance(s, list):
+        if isinstance(s, list):
             return "".join([str(i) for i in s])
-        else:
-            raise ValueError()
+        raise ValueError()
     except ValueError:
         raise ValueError('Could not convert "%s" to string' % s)
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -229,14 +229,18 @@
 #text.latex.preamble :      ## IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
                             ## AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
                             ## IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.
-                            ## preamble is a comma separated list of LaTeX statements
-                            ## that are included in the LaTeX document preamble.
-                            ## An example:
-                            ## text.latex.preamble : \usepackage{bm},\usepackage{euler}
+                            ## text.latex.preamble is a single line of LaTeX code that
+                            ## will be passed on to the LaTeX system. It may contain
+                            ## any code that is valid for the LaTeX "preamble", i.e.
+                            ## between the "\documentclass" and "\begin{document}"
+                            ## statements.
+                            ## Note that it has to be put on a single line, which may
+                            ## become quite long.
                             ## The following packages are always loaded with usetex, so
                             ## beware of package collisions: color, geometry, graphicx,
-                            ## type1cm, textcomp. Adobe Postscript (PSSNFS) font packages
-                            ## may also be loaded, depending on your font settings
+                            ## type1cm, textcomp.
+                            ## Adobe Postscript (PSSNFS) font packages may also be
+                            ## loaded, depending on your font settings.
 #text.latex.preview : False
 
 #text.hinting : auto   ## May be one of the following:
@@ -567,7 +571,7 @@
                                ## instead of uuid4
 ### pgf parameter
 #pgf.rcfonts : True
-#pgf.preamble :
+#pgf.preamble :            ## see text.latex.preamble for documentation
 #pgf.texsystem : xelatex
 
 ### docstring params


### PR DESCRIPTION
This allows to use the rc key "pgf.preamble" to contain "real" LaTeX code. As of before this patch, commas are used as parser separators, causing the PGF backend call to latex to fail, for example at loading packages which contain options such as:
\usepackage[protrusion=true, expansion=false]{microtype}

Passing a list of strings from within a Python script works fine, and with this patch it stays this way.


Any feedback would be appreciated.