### PR TITLE
TST: mark test_constrainedlayout.py::test_colorbar_location as flaky

### DIFF
--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -380,6 +380,11 @@ def test_constrained_layout23():
         fig.suptitle("Suptitle{}".format(i))
 
 
+# This test occasionally fails the image comparison tests, so we mark as
+# flaky.  Apparently the constraint solver occasionally doesn't fully
+# optimize.  Would be nice if this were more deterministic...
+@pytest.mark.timeout(30)
+@pytest.mark.flaky(reruns=3)
 @image_comparison(baseline_images=['test_colorbar_location'],
         extensions=['png'], remove_text=True, style='mpl20')
 def test_colorbar_location():


### PR DESCRIPTION
## PR Summary

Closes #12433

`test_constrainedlayout.py::test_colorbar_location` is sometimes flaky; i.e. the constraint solver sometimes seems tochoose the wrong constraint.  The flakiness is rare, but occasionally causes CI to not pass. 

Also added a `@pytest.mark.timeout(30)` because I saw one instance where the CI timed out because of this test.  I don't see that we do this elsewhere in the CI suite, so please feel free to tell me if this is incorrect.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->