### PR TITLE
Change ipython block to code-block

### DIFF
--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -36,16 +36,12 @@ that the draw command is deferred and only called once.
 The upshot of this is that for interactive backends (including
 ``%matplotlib notebook``) in interactive mode (with ``plt.ion()``)
 
-.. ipython :: python
+.. code-block :: python
 
    import matplotlib.pyplot as plt
-
    fig, ax = plt.subplots()
-
    ln, = ax.plot([0, 1, 4, 9, 16])
-
    plt.show()
-
    ln.set_color('g')
 
 


### PR DESCRIPTION
Alternative to #12587. This stops the code block being executed when the docs are built, which avoids us having to maintain code that was written for Matplotlib 1.5.