### PR TITLE
Remove deprecation warnings in tests

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import functools
 import itertools
 import logging
@@ -4187,7 +4187,7 @@ class Axes(_AxesBase):
         if (c_none or
                 co is not None or
                 isinstance(c, str) or
-                (isinstance(c, collections.Iterable) and
+                (isinstance(c, collections.abc.Iterable) and
                     isinstance(c[0], str))):
             c_array = None
         else:


### PR DESCRIPTION
Removes
```python
lib/matplotlib/axes/_axes.py:4190
  /home/travis/build/matplotlib/matplotlib/lib/matplotlib/axes/_axes.py:4190:
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```