### PR TITLE
Workaround Text3D breaking tight_layout()

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -118,6 +118,7 @@ class Text3D(mtext.Text):
         # For now, just return None to exclude from layout calculation.
         return None
 
+    
 def text_2d_to_3d(obj, z=0, zdir='z'):
     """Convert a Text to a Text3D object."""
     obj.__class__ = Text3D

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -118,7 +118,7 @@ class Text3D(mtext.Text):
         # For now, just return None to exclude from layout calculation.
         return None
 
-    
+
 def text_2d_to_3d(obj, z=0, zdir='z'):
     """Convert a Text to a Text3D object."""
     obj.__class__ = Text3D

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -113,6 +113,10 @@ class Text3D(mtext.Text):
         mtext.Text.draw(self, renderer)
         self.stale = False
 
+    def get_tightbbox(self, renderer):
+        # Overwriting the 2d Text behavior which is not valid for 3d.
+        # For now, just return None to exclude from layout calculation.
+        return None
 
 def text_2d_to_3d(obj, z=0, zdir='z'):
     """Convert a Text to a Text3D object."""

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -2,7 +2,7 @@ import pytest
 
 from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d, art3d
 from matplotlib import cm
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.collections import LineCollection
 from matplotlib.patches import Circle
 import matplotlib.pyplot as plt
@@ -161,6 +161,19 @@ def test_mixedsubplots():
                            linewidth=0, antialiased=False)
 
     ax.set_zlim3d(-1, 1)
+
+
+@check_figures_equal(extensions=['png'])
+def test_tight_layout_text(fig_test, fig_ref):
+    # text is currently ignored in tight layout. So the order of text() and
+    # tight_layout() calls should not influence the result.
+    ax1 = fig_test.gca(projection='3d')
+    ax1.text(.5, .5, .5, s='some string')
+    fig_test.tight_layout()
+
+    ax2 = fig_ref.gca(projection='3d')
+    fig_ref.tight_layout()
+    ax2.text(.5, .5, .5, s='some string')
 
 
 @image_comparison(baseline_images=['scatter3d'], remove_text=True)


### PR DESCRIPTION
## PR Summary

Closes #12687.

`Text3D` used the `get_tightbbox()` calculation of `Text`, which is not valid for 3D. This patch reimplements `get_tightbbox()` for `Text3D`.

For now, we just exclude the text from the layout. This is better than breaking the layout. In the long run, it would be good to get the transform right so that the text is included in the layout calculation.

*Note:* `Axis3D` currently does the same. https://github.com/matplotlib/matplotlib/blob/ec6a45ad6489319b245d6777c975cf96f9be2ec8/lib/mpl_toolkits/mplot3d/axis3d.py#L460