### PR TITLE
Rename tkinter import from Tk to tk.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -2,7 +2,7 @@ import math
 import logging
 import os.path
 import sys
-import tkinter as Tk
+import tkinter as tk
 from tkinter.simpledialog import SimpleDialog
 import tkinter.filedialog
 import tkinter.messagebox
@@ -41,7 +41,7 @@ else:
 
 _log = logging.getLogger(__name__)
 
-backend_version = Tk.TkVersion
+backend_version = tk.TkVersion
 
 # the true dots per inch on the screen; should be display dependent
 # see http://groups.google.com/groups?q=screen+dpi+x11&hl=en&lr=&ie=UTF-8&oe=UTF-8&safe=off&selm=7077.26e81ad5%40swift.cs.tcd.ie&rnum=5 for some info about screen dpi
@@ -208,10 +208,10 @@ class FigureCanvasTk(FigureCanvasBase):
         self._idle_callback = None
         t1, t2, w, h = self.figure.bbox.bounds
         w, h = int(w), int(h)
-        self._tkcanvas = Tk.Canvas(
+        self._tkcanvas = tk.Canvas(
             master=master, background="white",
             width=w, height=h, borderwidth=0, highlightthickness=0)
-        self._tkphoto = Tk.PhotoImage(
+        self._tkphoto = tk.PhotoImage(
             master=self._tkcanvas, width=w, height=h)
         self._tkcanvas.create_image(w//2, h//2, image=self._tkphoto)
         self._resize_callback = resize_callback
@@ -261,7 +261,7 @@ class FigureCanvasTk(FigureCanvasBase):
         self.figure.set_size_inches(winch, hinch, forward=False)
 
         self._tkcanvas.delete(self._tkphoto)
-        self._tkphoto = Tk.PhotoImage(
+        self._tkphoto = tk.PhotoImage(
             master=self._tkcanvas, width=int(width), height=int(height))
         self._tkcanvas.create_image(
             int(width / 2), int(height / 2), image=self._tkphoto)
@@ -521,7 +521,7 @@ class FigureManagerTk(FigureManagerBase):
         # packing toolbar first, because if space is getting low, last packed
         # widget is getting shrunk first (-> the canvas)
         self.toolbar = self._get_toolbar()
-        self.canvas._tkcanvas.pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
+        self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=1)
         self._num = num
 
         self.statusbar = None
@@ -597,7 +597,7 @@ class FigureManagerTk(FigureManagerBase):
         self.window.attributes('-fullscreen', not is_fullscreen)
 
 
-class NavigationToolbar2Tk(NavigationToolbar2, Tk.Frame):
+class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
     """
     Attributes
     ----------
@@ -614,7 +614,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, Tk.Frame):
 
     def destroy(self, *args):
         del self.message
-        Tk.Frame.destroy(self, *args)
+        tk.Frame.destroy(self, *args)
 
     def set_message(self, s):
         self.message.set(s)
@@ -641,24 +641,24 @@ class NavigationToolbar2Tk(NavigationToolbar2, Tk.Frame):
     def _Button(self, text, file, command, extension='.gif'):
         img_file = os.path.join(
             rcParams['datapath'], 'images', file + extension)
-        im = Tk.PhotoImage(master=self, file=img_file)
-        b = Tk.Button(
+        im = tk.PhotoImage(master=self, file=img_file)
+        b = tk.Button(
             master=self, text=text, padx=2, pady=2, image=im, command=command)
         b._ntimage = im
-        b.pack(side=Tk.LEFT)
+        b.pack(side=tk.LEFT)
         return b
 
     def _Spacer(self):
         # Buttons are 30px high. Make this 26px tall +2px padding to center it.
-        s = Tk.Frame(
-            master=self, height=26, relief=Tk.RIDGE, pady=2, bg="DarkGray")
-        s.pack(side=Tk.LEFT, padx=5)
+        s = tk.Frame(
+            master=self, height=26, relief=tk.RIDGE, pady=2, bg="DarkGray")
+        s.pack(side=tk.LEFT, padx=5)
         return s
 
     def _init_toolbar(self):
         xmin, xmax = self.canvas.figure.bbox.intervalx
         height, width = 50, xmax-xmin
-        Tk.Frame.__init__(self, master=self.window,
+        tk.Frame.__init__(self, master=self.window,
                           width=int(width), height=int(height),
                           borderwidth=2)
 
@@ -674,19 +674,19 @@ class NavigationToolbar2Tk(NavigationToolbar2, Tk.Frame):
                 if tooltip_text is not None:
                     ToolTip.createToolTip(button, tooltip_text)
 
-        self.message = Tk.StringVar(master=self)
-        self._message_label = Tk.Label(master=self, textvariable=self.message)
-        self._message_label.pack(side=Tk.RIGHT)
-        self.pack(side=Tk.BOTTOM, fill=Tk.X)
+        self.message = tk.StringVar(master=self)
+        self._message_label = tk.Label(master=self, textvariable=self.message)
+        self._message_label.pack(side=tk.RIGHT)
+        self.pack(side=tk.BOTTOM, fill=tk.X)
 
     def configure_subplots(self):
         toolfig = Figure(figsize=(6, 3))
-        window = Tk.Toplevel()
+        window = tk.Toplevel()
         canvas = type(self.canvas)(toolfig, master=window)
         toolfig.subplots_adjust(top=0.9)
         canvas.tool = SubplotTool(self.canvas.figure, toolfig)
         canvas.draw()
-        canvas.get_tk_widget().pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
+        canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=1)
         window.grab_set()
 
     def save_figure(self, *args):
@@ -768,7 +768,7 @@ class ToolTip(object):
         x, y, _, _ = self.widget.bbox("insert")
         x = x + self.widget.winfo_rootx() + 27
         y = y + self.widget.winfo_rooty()
-        self.tipwindow = tw = Tk.Toplevel(self.widget)
+        self.tipwindow = tw = tk.Toplevel(self.widget)
         tw.wm_overrideredirect(1)
         tw.wm_geometry("+%d+%d" % (x, y))
         try:
@@ -776,10 +776,10 @@ class ToolTip(object):
             tw.tk.call("::tk::unsupported::MacWindowStyle",
                        "style", tw._w,
                        "help", "noActivates")
-        except Tk.TclError:
+        except tk.TclError:
             pass
-        label = Tk.Label(tw, text=self.text, justify=Tk.LEFT,
-                         background="#ffffe0", relief=Tk.SOLID, borderwidth=1)
+        label = tk.Label(tw, text=self.text, justify=tk.LEFT,
+                         background="#ffffe0", relief=tk.SOLID, borderwidth=1)
         label.pack(ipadx=1)
 
     def hidetip(self):
@@ -813,18 +813,18 @@ class SetCursorTk(backend_tools.SetCursorBase):
         self.figure.canvas.manager.window.configure(cursor=cursord[cursor])
 
 
-class ToolbarTk(ToolContainerBase, Tk.Frame):
+class ToolbarTk(ToolContainerBase, tk.Frame):
     _icon_extension = '.gif'
 
     def __init__(self, toolmanager, window):
         ToolContainerBase.__init__(self, toolmanager)
         xmin, xmax = self.toolmanager.canvas.figure.bbox.intervalx
         height, width = 50, xmax - xmin
-        Tk.Frame.__init__(self, master=window,
+        tk.Frame.__init__(self, master=window,
                           width=int(width), height=int(height),
                           borderwidth=2)
         self._toolitems = {}
-        self.pack(side=Tk.TOP, fill=Tk.X)
+        self.pack(side=tk.TOP, fill=tk.X)
         self._groups = {}
 
     def add_toolitem(
@@ -840,23 +840,23 @@ class ToolbarTk(ToolContainerBase, Tk.Frame):
         if group not in self._groups:
             if self._groups:
                 self._add_separator()
-            frame = Tk.Frame(master=self, borderwidth=0)
-            frame.pack(side=Tk.LEFT, fill=Tk.Y)
+            frame = tk.Frame(master=self, borderwidth=0)
+            frame.pack(side=tk.LEFT, fill=tk.Y)
             self._groups[group] = frame
         return self._groups[group]
 
     def _add_separator(self):
-        separator = Tk.Frame(master=self, bd=5, width=1, bg='black')
-        separator.pack(side=Tk.LEFT, fill=Tk.Y, padx=2)
+        separator = tk.Frame(master=self, bd=5, width=1, bg='black')
+        separator.pack(side=tk.LEFT, fill=tk.Y, padx=2)
 
     def _Button(self, text, image_file, toggle, frame):
         if image_file is not None:
-            im = Tk.PhotoImage(master=self, file=image_file)
+            im = tk.PhotoImage(master=self, file=image_file)
         else:
             im = None
 
         if not toggle:
-            b = Tk.Button(master=frame, text=text, padx=2, pady=2, image=im,
+            b = tk.Button(master=frame, text=text, padx=2, pady=2, image=im,
                           command=lambda: self._button_click(text))
         else:
             # There is a bug in tkinter included in some python 3.6 versions
@@ -864,13 +864,13 @@ class ToolbarTk(ToolContainerBase, Tk.Frame):
             # other near checkbuttons
             # https://bugs.python.org/issue29402
             # https://bugs.python.org/issue25684
-            var = Tk.IntVar()
-            b = Tk.Checkbutton(master=frame, text=text, padx=2, pady=2,
+            var = tk.IntVar()
+            b = tk.Checkbutton(master=frame, text=text, padx=2, pady=2,
                                image=im, indicatoron=False,
                                command=lambda: self._button_click(text),
                                variable=var)
         b._ntimage = im
-        b.pack(side=Tk.LEFT)
+        b.pack(side=tk.LEFT)
         return b
 
     def _button_click(self, name):
@@ -891,18 +891,18 @@ class ToolbarTk(ToolContainerBase, Tk.Frame):
         del self._toolitems[name]
 
 
-class StatusbarTk(StatusbarBase, Tk.Frame):
+class StatusbarTk(StatusbarBase, tk.Frame):
     def __init__(self, window, *args, **kwargs):
         StatusbarBase.__init__(self, *args, **kwargs)
         xmin, xmax = self.toolmanager.canvas.figure.bbox.intervalx
         height, width = 50, xmax - xmin
-        Tk.Frame.__init__(self, master=window,
+        tk.Frame.__init__(self, master=window,
                           width=int(width), height=int(height),
                           borderwidth=2)
-        self._message = Tk.StringVar(master=self)
-        self._message_label = Tk.Label(master=self, textvariable=self._message)
-        self._message_label.pack(side=Tk.RIGHT)
-        self.pack(side=Tk.TOP, fill=Tk.X)
+        self._message = tk.StringVar(master=self)
+        self._message_label = tk.Label(master=self, textvariable=self._message)
+        self._message_label.pack(side=tk.RIGHT)
+        self.pack(side=tk.TOP, fill=tk.X)
 
     def set_message(self, s):
         self._message.set(s)
@@ -967,13 +967,13 @@ class ConfigureSubplotsTk(backend_tools.ConfigureSubplotsBase):
             return
 
         toolfig = Figure(figsize=(6, 3))
-        self.window = Tk.Tk()
+        self.window = tk.Tk()
 
         canvas = type(self.canvas)(toolfig, master=self.window)
         toolfig.subplots_adjust(top=0.9)
         _tool = SubplotTool(self.figure, toolfig)
         canvas.draw()
-        canvas.get_tk_widget().pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
+        canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=1)
         self.window.protocol("WM_DELETE_WINDOW", self.destroy)
 
     def destroy(self, *args, **kwargs):
@@ -1008,7 +1008,7 @@ class _BackendTk(_Backend):
         Create a new figure manager instance for the given figure.
         """
         with _restore_foreground_window_at_end():
-            window = Tk.Tk(className="matplotlib")
+            window = tk.Tk(className="matplotlib")
             window.withdraw()
 
             # Put a mpl icon on the window rather than the default tk icon.
@@ -1017,7 +1017,7 @@ class _BackendTk(_Backend):
             # http://mail.python.org/pipermail/tkinter-discuss/2006-November/000954.html
             icon_fname = os.path.join(
                 rcParams['datapath'], 'images', 'matplotlib.ppm')
-            icon_img = Tk.PhotoImage(file=icon_fname, master=window)
+            icon_img = tk.PhotoImage(file=icon_fname, master=window)
             try:
                 window.iconphoto(False, icon_img)
             except Exception as exc:

--- a/lib/matplotlib/backends/tkagg.py
+++ b/lib/matplotlib/backends/tkagg.py
@@ -1,4 +1,4 @@
-import tkinter as Tk
+import tkinter as tk
 
 import numpy as np
 
@@ -25,7 +25,7 @@ def blit(photoimage, aggimage, bbox=None, colormode=1):
         tk.call(
             "PyAggImagePhoto", photoimage,
             dataptr, colormode, bboxptr)
-    except Tk.TclError:
+    except tk.TclError:
         if hasattr(tk, 'interpaddr'):
             _tkagg.tkinit(tk.interpaddr(), 1)
         else:
@@ -36,10 +36,10 @@ def blit(photoimage, aggimage, bbox=None, colormode=1):
 
 
 def test(aggimage):
-    r = Tk.Tk()
-    c = Tk.Canvas(r, width=aggimage.width, height=aggimage.height)
+    r = tk.Tk()
+    c = tk.Canvas(r, width=aggimage.width, height=aggimage.height)
     c.pack()
-    p = Tk.PhotoImage(width=aggimage.width, height=aggimage.height)
+    p = tk.PhotoImage(width=aggimage.width, height=aggimage.height)
     blit(p, aggimage)
     c.create_image(aggimage.width, aggimage.height, image=p)
     blit(p, aggimage)


### PR DESCRIPTION
Currently we `import tkinter as Tk`, which is a bit confusing as there
is also a `tkinter.Tk` class (for example, both `tkinter.mainloop` --
currently aliased as `Tk.mainloop` -- and `tkinter.Tk.mainloop` exist).
Instead, `import tkinter as tk`; this shorthand is also consistent with
the tkinter docs (https://docs.python.org/3/library/tkinter.html).

Noted while investigating #12703.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
