### PR TITLE
Extend sphinx Makefile to cleanup completely

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,6 +14,16 @@ help:
 
 .PHONY: help Makefile
 
+# workaround because sphinx does not completely clean up (#11139)
+clean:
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	rm -rf "$(SOURCEDIR)/build"
+	rm -rf "$(SOURCEDIR)/api/_as_gen"
+	rm -rf "$(SOURCEDIR)/gallery"
+	rm -rf "$(SOURCEDIR)/tutorials"
+	rm -rf "$(SOURCEDIR)/savefig"
+	rm -rf "$(SOURCEDIR)/sphinxext/__pycache__"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile


### PR DESCRIPTION
## PR Summary

Fixes #11139. That PR references an upstream fix, which hasn't made any progress so far.

For the time being, we can work around this by using a hand-crafted clean target.