### PR TITLE
Fix tk error when closing first pyplot figure

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -1037,4 +1037,6 @@ class _BackendTk(_Backend):
 
     @staticmethod
     def mainloop():
-        Tk.mainloop()
+        managers = Gcf.get_all_fig_managers()
+        if managers:
+            managers[0].window.mainloop()


### PR DESCRIPTION
## PR Summary

Fixes #12703, where closing the first pyplot figure before `show` results in a tk error.

This PR implements [the solution](https://github.com/matplotlib/matplotlib/issues/12703#issuecomment-435141494) proposed by @anntzer.

I wouldn't currently know how to test the interactive backend, but I'm happy to find out if someone thinks this needs to be tested.

I milestoned for *v3.0.x*, despite being no regression, because it fixes an ugly bug.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
