### PR TITLE
Cleanup dviread.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -530,8 +530,10 @@ class DviFont(object):
         if not isinstance(texname, bytes):
             raise ValueError("texname must be a bytestring, got %s"
                              % type(texname))
-        self._scale, self._tfm, self.texname, self._vf = \
-            scale, tfm, texname, vf
+        self._scale = scale
+        self._tfm = tfm
+        self.texname = texname
+        self._vf = vf
         self.size = scale * (72.0 / (72.27 * 2**16))
         try:
             nchars = max(tfm.width) + 1
@@ -541,17 +543,17 @@ class DviFont(object):
                        for char in range(nchars)]
 
     def __eq__(self, other):
-        return self.__class__ == other.__class__ and \
-            self.texname == other.texname and self.size == other.size
+        return (type(self) == type(other)
+                and self.texname == other.texname and self.size == other.size)
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def _width_of(self, char):
-        """
-        Width of char in dvi units. For internal use by dviread.py.
-        """
+    def __repr__(self):
+        return "<{}: {}>".format(type(self).__name__, self.texname)
 
+    def _width_of(self, char):
+        """Width of char in dvi units."""
         width = self._tfm.width.get(char, None)
         if width is not None:
             return _mul2012(width, self._scale)
@@ -559,10 +561,7 @@ class DviFont(object):
         return 0
 
     def _height_depth_of(self, char):
-        """
-        Height and depth of char in dvi units. For internal use by dviread.py.
-        """
-
+        """Height and depth of char in dvi units."""
         result = []
         for metric, name in ((self._tfm.height, "height"),
                              (self._tfm.depth, "depth")):
@@ -577,8 +576,8 @@ class DviFont(object):
 
 
 class Vf(Dvi):
-    """
-    A virtual font (\\*.vf file) containing subroutines for dvi files.
+    r"""
+    A virtual font (\*.vf file) containing subroutines for dvi files.
 
     Usage::
 
@@ -588,12 +587,10 @@ class Vf(Dvi):
 
     Parameters
     ----------
-
     filename : string or bytestring
 
     Notes
     -----
-
     The virtual font format is a derivative of dvi:
     http://mirrors.ctan.org/info/knuth/virtual-fonts
     This class reuses some of the machinery of `Dvi`
@@ -689,9 +686,7 @@ class Vf(Dvi):
 
 
 def _fix2comp(num):
-    """
-    Convert from two's complement to negative.
-    """
+    """Convert from two's complement to negative."""
     assert 0 <= num < 2**32
     if num & 2**31:
         return num - 2**32
@@ -700,9 +695,7 @@ def _fix2comp(num):
 
 
 def _mul2012(num1, num2):
-    """
-    Multiply two numbers in 20.12 fixed point format.
-    """
+    """Multiply two numbers in 20.12 fixed point format."""
     # Separated into a function because >> has surprising precedence
     return (num1*num2) >> 20
 
@@ -931,8 +924,8 @@ class PsfontsMap(object):
 
 
 class Encoding(object):
-    """
-    Parses a \\*.enc file referenced from a psfonts.map style file.
+    r"""
+    Parses a \*.enc file referenced from a psfonts.map style file.
     The format this class understands is a very limited subset of
     PostScript.
 
@@ -1045,21 +1038,25 @@ _vffile = partial(_fontfile, Vf, ".vf")
 
 
 if __name__ == '__main__':
+    from argparse import ArgumentParser
+    import itertools
     import sys
-    fname = sys.argv[1]
-    try:
-        dpi = float(sys.argv[2])
-    except IndexError:
-        dpi = None
-    with Dvi(fname, dpi) as dvi:
+
+    parser = ArgumentParser()
+    parser.add_argument("filename")
+    parser.add_argument("dpi", nargs="?", type=float, default=None)
+    args = parser.parse_args()
+    with Dvi(args.filename, args.dpi) as dvi:
         fontmap = PsfontsMap(find_tex_file('pdftex.map'))
         for page in dvi:
             print('=== new page ===')
-            fPrev = None
-            for x, y, f, c, w in page.text:
-                if f != fPrev:
-                    print('font', f.texname, 'scaled', f._scale/pow(2.0, 20))
-                    fPrev = f
-                print(x, y, c, 32 <= c < 128 and chr(c) or '.', w)
+            for font, group in itertools.groupby(
+                    page.text, lambda text: text.font):
+                print('font', font.texname, 'scaled', font._scale / 2 ** 20)
+                for text in group:
+                    print(text.x, text.y, text.glyph,
+                          chr(text.glyph) if chr(text.glyph).isprintable()
+                          else ".",
+                          text.width)
             for x, y, w, h in page.boxes:
                 print(x, y, 'BOX', w, h)


### PR DESCRIPTION
In the repr of DviFont, we don't include the tfm anf vf fields, as they
are actually always directly derived from texname anyways.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
