### PR TITLE
Make get_scale_docs() internal

### DIFF
--- a/doc/api/next_api_changes/2018-11-02-TH-deprecations.rst
+++ b/doc/api/next_api_changes/2018-11-02-TH-deprecations.rst
@@ -1,0 +1,6 @@
+Deprecations
+````````````
+
+The function ``matplotlib.scale.get_scale_docs()`` and its alias
+``matplotlib.pyplot.get_scale_docs()`` are considered internal and will be
+removed from the public API in a future version.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -579,7 +579,17 @@ def register_scale(scale_class):
     _scale_mapping[scale_class.name] = scale_class
 
 
+@cbook.deprecated(
+    '3.1', message='get_scale_docs() is considered private API since '
+                   '3.1 and will be removed from the public API in 3.3.')
 def get_scale_docs():
+    """
+    Helper function for generating docstrings related to scales.
+    """
+    return _get_scale_docs()
+
+
+def _get_scale_docs():
     """
     Helper function for generating docstrings related to scales.
     """
@@ -598,5 +608,5 @@ def get_scale_docs():
 
 docstring.interpd.update(
     scale=' | '.join([repr(x) for x in get_scale_names()]),
-    scale_docs=get_scale_docs().rstrip(),
+    scale_docs=_get_scale_docs().rstrip(),
     )


### PR DESCRIPTION
## PR Summary

The functions `matplotlib.scale.get_scale_docs()` and its alias `matplotlib.pyplot.get_scale_docs()` are internal and should not be part of the public API.

Probably nobody is using these anyway. However, I've introduced a deprecation first to be on the safe side.

A similar issue is `get_scale_names()`, which is not addressed by the PR so far. `get_scale_names()` might actually have a value for the user, so it may be worth keeping and documenting. However, I would then at least remove it from `pyplot`.