### PR TITLE
Fix test_non_gui_warning for Azure (and mplcairo).

### DIFF
--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -58,10 +58,10 @@ def test_get_default_filename(tmpdir):
 
 
 @pytest.mark.backend('pdf')
-@pytest.mark.skipif('SYSTEM_TEAMFOUNDATIONCOLLECTIONURI' in os.environ,
-                    reason="this test fails an azure for unknown reasons")
-def test_non_gui_warning():
+def test_non_gui_warning(monkeypatch):
     plt.subplots()
+
+    monkeypatch.setitem(os.environ, "DISPLAY", ":999")
 
     with pytest.warns(UserWarning) as rec:
         plt.show()


### PR DESCRIPTION
If on Linux and $DISPLAY is not set, then the non-gui warning is not
emitted.

We didn't notice that on Travis as $DISPLAY was indeed always set; but
it's not on Azure.

Milestoned as 3.0.x as it goes together with #12267, which was merged as part of #12322.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
