### PR TITLE
Move deprecation note to end of docstring

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -245,11 +245,12 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
             return func(*args, **kwargs)
 
         old_doc = inspect.cleandoc(old_doc or '').strip('\n')
+
         message = message.strip()
-        new_doc = ('.. deprecated:: {since}\n'
-                   '   {message}\n'
+        new_doc = ('{old_doc}\n'
                    '\n'
-                   '{old_doc}'
+                   '.. deprecated:: {since}\n'
+                   '   {message}'
                    .format(since=since, message=message, old_doc=old_doc))
         if not old_doc:
             # This is to prevent a spurious 'unexected unindent' warning from


### PR DESCRIPTION
## PR Summary

This PR moves the deprecation note, that is generated by `@deprecated` from the top of the docstring to the bottom.

The issue with the top position is that the first line should contain a description of the function. This place is currently taken over by the deprecation note. Tools that extract a summary sentence with thus pick up the note, e.g. autosummary:

![grafik](https://user-images.githubusercontent.com/2836374/47965999-d1b1e380-e04d-11e8-8c48-8bcb6b8a0ecf.png)

All deprecated elements that I've checked have quite a short docstring so that there's no significant change in visibility of the deprecation note in the rendered HTML docs.

Before:
![grafik](https://user-images.githubusercontent.com/2836374/47966075-9c59c580-e04e-11e8-9153-84d818c504fb.png)

After:
![grafik](https://user-images.githubusercontent.com/2836374/47966083-a8de1e00-e04e-11e8-926d-0f84c4f9038c.png)

