### PR TITLE
Add unobtrusive depreaction note to the first line of the docstring.

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -247,7 +247,7 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
         old_doc = inspect.cleandoc(old_doc or '').strip('\n')
 
         message = message.strip()
-        new_doc = ('{old_doc}\n'
+        new_doc = ('[*Deprecated*] {old_doc}\n'
                    '\n'
                    '.. deprecated:: {since}\n'
                    '   {message}'


### PR DESCRIPTION
## PR Summary

As suggested in https://github.com/matplotlib/matplotlib/pull/12736#pullrequestreview-171367317, this PR adds an unobtrusive "Deprecated." to the beginning of the docstring.

This is intended particularly for the summary.

![grafik](https://user-images.githubusercontent.com/2836374/47967845-40993780-e062-11e8-9ecb-53f40256bd5a.png)

A maybe slightly unwanted side-effect is that this is of course also present in the docstring, which is a duplication with the more verbose deprecation note.

![grafik](https://user-images.githubusercontent.com/2836374/47967855-67f00480-e062-11e8-9f09-5e400fa42006.png)


However, every other way of adding such a not to the summary is far more complicated. It would have to happen within `autosummary`, which has to be patched or extended for that functionality. Also for a universal extension of `autosummary`, there would be the problem of detecting a deprecated method. So overall, the solution presented here is preferable due to its simplicity.