### PR TITLE
make Axes._parse_scatter_color_args static

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4013,7 +4013,9 @@ class Axes(_AxesBase):
         return dict(whiskers=whiskers, caps=caps, boxes=boxes,
                     medians=medians, fliers=fliers, means=means)
 
-    def _parse_scatter_color_args(self, c, edgecolors, kwargs, xshape, yshape):
+    @staticmethod
+    def _parse_scatter_color_args(c, edgecolors, kwargs, xshape, yshape,
+                                  get_next_color_func):
         """
         Helper function to process color related arguments of `.Axes.scatter`.
 
@@ -4023,7 +4025,7 @@ class Axes(_AxesBase):
         - kwargs['facecolors']
         - kwargs['facecolor']
         - kwargs['color'] (==kwcolor)
-        - 'b' if in classic mode else next color from color cycle
+        - 'b' if in classic mode else the result of ``get_next_color_func()``
 
         Argument precedence for edgecolors:
 
@@ -4044,6 +4046,16 @@ class Axes(_AxesBase):
             Note: The dict is modified by this function.
         xshape, yshape : tuple of int
             The shape of the x and y arrays passed to `.Axes.scatter`.
+        get_next_color_func : callable
+            A callable that returns a color. This color is used as facecolor
+            if no other color is provided.
+
+            Note, that this is a function rather than a fixed color value to
+            support conditional evaluation of the next color.  As of the
+            current implementation obtaining the next color from the
+            property cycle advances the cycle. This must only happen if we
+            actually use the color, which will only be decided within this
+            method.
 
         Returns
         -------
@@ -4090,7 +4102,7 @@ class Axes(_AxesBase):
         if c is None:
             c = (facecolors if facecolors is not None
                  else "b" if rcParams['_internal.classic_mode']
-                 else self._get_patches_for_fill.get_next_color())
+                 else get_next_color_func())
 
         # After this block, c_array will be None unless
         # c is an array for mapping.  The potential ambiguity
@@ -4289,8 +4301,9 @@ class Axes(_AxesBase):
         s = np.ma.ravel(s)  # This doesn't have to match x, y in size.
 
         c, colors, edgecolors = \
-            self._parse_scatter_color_args(c, edgecolors, kwargs,
-                                           xshape, yshape)
+            self._parse_scatter_color_args(
+                c, edgecolors, kwargs, xshape, yshape,
+                get_next_color_func=self._get_patches_for_fill.get_next_color)
 
         # `delete_masked_points` only modifies arguments of the same length as
         # `x`.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1793,19 +1793,30 @@ class TestScatter(object):
 
     @pytest.mark.parametrize('c_case, re_key', params_test_scatter_c)
     def test_scatter_c(self, c_case, re_key):
+        def get_next_color():
+            return 'blue'  # currently unused
+
+        from matplotlib.axes import Axes
+
+        xshape = yshape = (4,)
+
         # Additional checking of *c* (introduced in #11383).
         REGEXP = {
             "shape": "^'c' argument has [0-9]+ elements",  # shape mismatch
             "conversion": "^'c' argument must be a mpl color",  # bad vals
             }
-        x = y = [0, 1, 2, 3]
-        fig, ax = plt.subplots()
 
         if re_key is None:
-            ax.scatter(x, y, c=c_case, edgecolors="black")
+            Axes._parse_scatter_color_args(
+                c=c_case, edgecolors="black", kwargs={},
+                xshape=xshape, yshape=yshape,
+                get_next_color_func=get_next_color)
         else:
             with pytest.raises(ValueError, match=REGEXP[re_key]):
-                ax.scatter(x, y, c=c_case, edgecolors="black")
+                Axes._parse_scatter_color_args(
+                    c=c_case, edgecolors="black", kwargs={},
+                    xshape=xshape, yshape=yshape,
+                    get_next_color_func=get_next_color)
 
 
 def _params(c=None, xshape=(2,), yshape=(2,), **kwargs):
@@ -1829,11 +1840,12 @@ _result = namedtuple('_result', 'c, colors')
       _result(c=['b', 'g'], colors=np.array([[0, 0, 1, 1], [0, .5, 0, 1]]))),
      ])
 def test_parse_scatter_color_args(params, expected_result):
+    def get_next_color():
+        return 'blue'  # currently unused
+
     from matplotlib.axes import Axes
-    dummyself = 'UNUSED'  # self is only used in one case, which we do not
-                          # test. Therefore we can get away without costly
-                          # creating an Axes instance.
-    c, colors, _edgecolors = Axes._parse_scatter_color_args(dummyself, *params)
+    c, colors, _edgecolors = Axes._parse_scatter_color_args(
+        *params, get_next_color_func=get_next_color)
     assert c == expected_result.c
     assert_allclose(colors, expected_result.colors)
 
@@ -1855,15 +1867,16 @@ del _result
      (dict(color='r', edgecolor='g'), 'g'),
      ])
 def test_parse_scatter_color_args_edgecolors(kwargs, expected_edgecolors):
+    def get_next_color():
+        return 'blue'  # currently unused
+
     from matplotlib.axes import Axes
-    dummyself = 'UNUSED'  # self is only used in one case, which we do not
-                          # test. Therefore we can get away without costly
-                          # creating an Axes instance.
     c = kwargs.pop('c', None)
     edgecolors = kwargs.pop('edgecolors', None)
     _, _, result_edgecolors = \
-        Axes._parse_scatter_color_args(dummyself, c, edgecolors, kwargs,
-                                       xshape=(2,), yshape=(2,))
+        Axes._parse_scatter_color_args(c, edgecolors, kwargs,
+                                       xshape=(2,), yshape=(2,),
+                                       get_next_color_func=get_next_color)
     assert result_edgecolors == expected_edgecolors
 
 


### PR DESCRIPTION
## PR Summary

Continuation of #11663. In particular point 2. from https://github.com/matplotlib/matplotlib/pull/11663#discussion_r230591482

This refactors ` Axes._parse_scatter_color_args` to be static by extracting the sole remaining `Axes` dependency to a color-getter function, which is passed as an argument.

This allows to explicitly test the parser logic without the need to generate a full figure for each test.

The existing test `test_scatter_c()` is rewritten accordingly. It's currently still limited to the original defaults (4 elements) and does still only do pass/fail testing. But that's to be expanded upon in future PRs.


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documentation is sphinx and numpydoc compliant
