### PR TITLE
DOC: constrained layout guide (fix: Spacing with colorbars)

### DIFF
--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -300,15 +300,17 @@ fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,
 # Spacing with colorbars
 # -----------------------
 #
-# Colorbars still respect the ``w_pad`` and ``h_pad`` values. However they will
-# be ``wspace`` and ``hsapce`` apart from other subplots.  Note the use of a
-# ``pad`` kwarg here in the ``colorbar`` call.  It defaults to 0.02 of the size
+# Colorbars will be placed ``wspace`` and ``hsapce`` apart from other
+# subplots. The padding between the colorbar and the axis it is
+# attached to will never be less than ``w_pad`` (for a vertical colorbar)
+# or ``h_pad`` (for a horizontal colorbar). Note the use of the ``pad`` kwarg
+# here in the ``colorbar`` call.  It defaults to 0.02 of the size
 # of the axis it is attached to.
 
 fig, axs = plt.subplots(2, 2, constrained_layout=True)
 for ax in axs.flatten():
     pc = ax.pcolormesh(arr, **pc_kwargs)
-    fig.colorbar(im, ax=ax, shrink=0.6, pad=0)
+    fig.colorbar(pc, ax=ax, shrink=0.6, pad=0)
     ax.set_xticklabels('')
     ax.set_yticklabels('')
 fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,


### PR DESCRIPTION
## PR Summary
Fixed a line in the 'constrained layout guide' that appeared to be slightly misleading. The guide says 
"Colorbars still RESPECT the w_pad and h_pad values" and then goes on to show in the next block that `w_pad`, `h_pad` can be overridden by setting a non-zero value for the pad kwarg when calling `fig.colorbar`.

Also fixed an incorrect mappable being passed to `fig.colorbar`.
## PR Checklist

- ~[ ] Has Pytest style unit tests~
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- ~[ ] New features are documented, with examples if plot related~
- [x] Documentation is sphinx and numpydoc compliant
- ~[ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~
- ~[ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
