### PR TITLE
Explicit plotorder

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -20,6 +20,12 @@ from matplotlib.patches import Patch
 from . import proj3d
 
 
+class Object3D(object):
+    """A base class for any 3D object"""
+    def __init__(self):
+        self._sort_zpos = -np.inf  # defaults to background (plotted first)
+
+
 def norm_angle(a):
     """Return the given angle normalized to -180 < *a* <= 180 degrees."""
     a = (a + 360) % 360
@@ -71,7 +77,7 @@ def get_dir_vector(zdir):
         raise ValueError("'x', 'y', 'z', None or vector of length 3 expected")
 
 
-class Text3D(mtext.Text):
+class Text3D(mtext.Text, Object3D):
     """
     Text object with 3D position and direction.
 
@@ -93,6 +99,7 @@ class Text3D(mtext.Text):
 
     def __init__(self, x=0, y=0, z=0, text='', zdir='z', **kwargs):
         mtext.Text.__init__(self, x, y, text, **kwargs)
+        Object3D.__init__(self)
         self.set_3d_properties(z, zdir)
 
     def set_3d_properties(self, z=0, zdir='z'):
@@ -120,7 +127,7 @@ def text_2d_to_3d(obj, z=0, zdir='z'):
     obj.set_3d_properties(z, zdir)
 
 
-class Line3D(lines.Line2D):
+class Line3D(lines.Line2D, Object3D):
     """
     3D line object.
     """
@@ -130,6 +137,7 @@ class Line3D(lines.Line2D):
         Keyword arguments are passed onto :func:`~matplotlib.lines.Line2D`.
         """
         lines.Line2D.__init__(self, [], [], *args, **kwargs)
+        Object3D.__init__(self)
         self._verts3d = xs, ys, zs
 
     def set_3d_properties(self, zs=0, zdir='z'):
@@ -209,10 +217,14 @@ def paths_to_3d_segments_with_codes(paths, zs=0, zdir='z'):
     return segments, codes_list
 
 
-class Line3DCollection(LineCollection):
+class Line3DCollection(LineCollection, Object3D):
     """
     A collection of 3D lines.
     """
+
+    def __init__(self, *args, **kwargs):
+        LineCollection.__init__(self, *args, **kwargs)
+        Object3D.__init__(self)
 
     def set_sort_zpos(self, val):
         """Set the position to use for z-sorting."""
@@ -256,13 +268,14 @@ def line_collection_2d_to_3d(col, zs=0, zdir='z'):
     col.set_segments(segments3d)
 
 
-class Patch3D(Patch):
+class Patch3D(Patch, Object3D):
     """
     3D patch object.
     """
 
     def __init__(self, *args, zs=(), zdir='z', **kwargs):
         Patch.__init__(self, *args, **kwargs)
+        Object3D.__init__(self)
         self.set_3d_properties(zs, zdir)
 
     def set_3d_properties(self, verts, zs=0, zdir='z'):
@@ -287,13 +300,14 @@ class Patch3D(Patch):
         return min(vzs)
 
 
-class PathPatch3D(Patch3D):
+class PathPatch3D(Patch3D, Object3D):
     """
     3D PathPatch object.
     """
 
     def __init__(self, path, *, zs=(), zdir='z', **kwargs):
         Patch.__init__(self, **kwargs)
+        Object3D.__init__(self)
         self.set_3d_properties(path, zs, zdir)
 
     def set_3d_properties(self, path, zs=0, zdir='z'):
@@ -338,7 +352,7 @@ def pathpatch_2d_to_3d(pathpatch, z=0, zdir='z'):
     pathpatch.set_3d_properties(mpath, z, zdir)
 
 
-class Patch3DCollection(PatchCollection):
+class Patch3DCollection(PatchCollection, Object3D):
     """
     A collection of 3D patches.
     """
@@ -360,7 +374,8 @@ class Patch3DCollection(PatchCollection):
         This is typically desired in scatter plots.
         """
         self._depthshade = depthshade
-        super().__init__(*args, **kwargs)
+        PatchCollection.__init__(self, *args, **kwargs)
+        Object3D.__init__(self)
         self.set_3d_properties(zs, zdir)
 
     def set_sort_zpos(self, val):
@@ -404,7 +419,7 @@ class Patch3DCollection(PatchCollection):
             return np.nan
 
 
-class Path3DCollection(PathCollection):
+class Path3DCollection(PathCollection, Object3D):
     """
     A collection of 3D paths.
     """
@@ -426,7 +441,8 @@ class Path3DCollection(PathCollection):
         This is typically desired in scatter plots.
         """
         self._depthshade = depthshade
-        super().__init__(*args, **kwargs)
+        PathCollection.__init__(self, *args, **kwargs)
+        Object3D.__init__(self)
         self.set_3d_properties(zs, zdir)
 
     def set_sort_zpos(self, val):
@@ -493,7 +509,7 @@ def patch_collection_2d_to_3d(col, zs=0, zdir='z', depthshade=True):
     col.set_3d_properties(zs, zdir)
 
 
-class Poly3DCollection(PolyCollection):
+class Poly3DCollection(PolyCollection, Object3D):
     """
     A collection of 3D polygons.
     """
@@ -510,7 +526,8 @@ class Poly3DCollection(PolyCollection):
         Note that this class does a bit of magic with the _facecolors
         and _edgecolors properties.
         """
-        super().__init__(verts, *args, **kwargs)
+        PolyCollection.__init__(self, verts, *args, **kwargs)
+        Object3D.__init__(self)
         self.set_zsort(zsort)
         self._codes3d = None
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -140,6 +140,11 @@ class Line3D(lines.Line2D, Object3D):
         Object3D.__init__(self)
         self._verts3d = xs, ys, zs
 
+    def set_sort_zpos(self, val):
+        """Set the position to use for z-sorting."""
+        self._sort_zpos = val
+        self.stale = True
+
     def set_3d_properties(self, zs=0, zdir='z'):
         xs = self.get_xdata()
         ys = self.get_ydata()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -281,16 +281,23 @@ class Axes3D(Axes):
         # Make sure they are drawn above the grids.
         zorder_offset = max(axis.get_zorder()
                             for axis in self._get_axis_list()) + 1
-        for i, col in enumerate(
-                sorted(self.collections,
-                       key=lambda col: col.do_3d_projection(renderer),
-                       reverse=True)):
-            col.zorder = zorder_offset + i
-        for i, patch in enumerate(
-                sorted(self.patches,
-                       key=lambda patch: patch.do_3d_projection(renderer),
-                       reverse=True)):
-            patch.zorder = zorder_offset + i
+
+        # Group of objects to be dynamically reordered
+        select_children = list()
+        select_children.extend(self.collections)
+        select_children.extend(self.patches)
+        select_children.extend(self.lines)
+        select_children.extend(self.texts)
+        for i, h in enumerate(
+                sorted(
+                    select_children,
+                    key=lambda h: (
+                        h._sort_zpos if hasattr(h, '_sort_zpos') else np.inf,
+                        -h.do_3d_projection(renderer) if hasattr(h, 'do_3d_projection') else -np.inf
+                    )
+                )
+        ):
+            h.zorder = zorder_offset + i
 
         if self._axis3don:
             # Draw panes first


### PR DESCRIPTION
## PR Summary
Artifacts are common in mplot3d when overlaying several 3D objects
This is stated in the [official FAQ](https://matplotlib.org/mpl_toolkits/mplot3d/faq.html#my-3d-plot-doesn-t-look-right-at-certain-viewing-angles),
and there exist some related issues(e.g. [this one](https://github.com/matplotlib/matplotlib/issues/7684/)) as well as [SO questions](https://stackoverflow.com/q/37611023).

The official answer is that mplot3d is not powerful enough to deal with a realistic z-order behavior, so switch to a more powerful framework instead.
In some use cases, we don't need super-realistic z-ordering, yet some control of which objects are plot over which others is important to get a nice look.
For example: My personal (current) use case was plotting some points and lines over a surface in 3D (to represent the evolution of optimization over a surface in a nice 3D figure).

The current behavior of mplot3d is to order collections and patches (set their zorder value) in terms of the minimum z as seen in the current perspective, which gives aweful results in some common scenarios (e.g. when plotting a point on top of the surface, it will often appear behind the surface rather than in front of it).
Worse yet, art3d objects silently accept a 'zorder' argument but then ignore that value in favor of the behavior explained above.
I think it should be possible to provide user-given zorder values to ensure certain objects are in front of others, and then order also in terms of the computed zmin value for the object.

I have created a quick solution that works for me, leveraging an already existing method `set_sort_zpos` (which by the way I couldn't see used in any other place, so I kind of assumed it had this purpose). The commits should be more-or-less self-explanatory.
There are some aspects to refine yet, e.g.
- Catch the 'zorder' kw-argument in mplot3d objects and set the internal parameter and use it to set `_sort_zpos` instead. This way the zorder option would behave in a more expectable way for the user.
- Complete PR Checklist

However, before refining those details I wanted to present the case and get some feedback on this!

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
