### PR TITLE
Backport PR #12673 to v3.0.x

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4199,8 +4199,9 @@ class Axes(_AxesBase):
         if (c_none or
                 co is not None or
                 isinstance(c, str) or
-                (isinstance(c, collections.abc.Iterable) and
-                    isinstance(c[0], str))):
+                (isinstance(c, collections.Iterable) and
+                    len(c) > 0 and
+                    isinstance(cbook.safe_first_element(c), str))):
             c_array = None
         else:
             try:  # First, does 'c' look suitable for value-mapping?

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5820,7 +5820,7 @@ def test_spines_properbbox_after_zoom():
     bb = ax.spines['bottom'].get_window_extent(fig.canvas.get_renderer())
     # this is what zoom calls:
     ax._set_view_from_bbox((320, 320, 500, 500), 'in',
-                      None, False, False)
+                           None, False, False)
     bb2 = ax.spines['bottom'].get_window_extent(fig.canvas.get_renderer())
     np.testing.assert_allclose(bb.get_points(), bb2.get_points(), rtol=1e-6)
 
@@ -5848,3 +5848,18 @@ def test_gettightbbox_ignoreNaN():
     t = ax.text(np.NaN, 1, 'Boo')
     renderer = fig.canvas.get_renderer()
     np.testing.assert_allclose(ax.get_tightbbox(renderer).width, 532.444444)
+
+
+def test_scatter_series_non_zero_index(pd):
+    # create non-zero index
+    ids = range(10, 18)
+    x = pd.Series(np.random.uniform(size=8), index=ids)
+    y = pd.Series(np.random.uniform(size=8), index=ids)
+    c = pd.Series([1, 1, 1, 1, 1, 0, 0, 0], index=ids)
+    plt.scatter(x, y, c)
+
+
+def test_scatter_empty_data():
+    # making sure this does not raise an exception
+    plt.scatter([], [])
+    plt.scatter([], [], s=[], c=[])

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -484,50 +484,6 @@ def test_flatiter():
     assert 1 == next(it)
 
 
-def test_reshape2d():
-    class dummy():
-        pass
-    x = [dummy() for j in range(5)]
-    xnew = cbook._reshape_2D(x, 'x')
-    assert np.shape(xnew) == (1, 5)
-
-    x = np.arange(5)
-    xnew = cbook._reshape_2D(x, 'x')
-    assert np.shape(xnew) == (1, 5)
-
-    x = [[dummy() for j in range(5)] for i in range(3)]
-    xnew = cbook._reshape_2D(x, 'x')
-    assert np.shape(xnew) == (3, 5)
-
-    # this is strange behaviour, but...
-    x = np.random.rand(3, 5)
-    xnew = cbook._reshape_2D(x, 'x')
-    assert np.shape(xnew) == (5, 3)
-
-
-def test_contiguous_regions():
-    a, b, c = 3, 4, 5
-    # Starts and ends with True
-    mask = [True]*a + [False]*b + [True]*c
-    expected = [(0, a), (a+b, a+b+c)]
-    assert cbook.contiguous_regions(mask) == expected
-    d, e = 6, 7
-    # Starts with True ends with False
-    mask = mask + [False]*e
-    assert cbook.contiguous_regions(mask) == expected
-    # Starts with False ends with True
-    mask = [False]*d + mask[:-e]
-    expected = [(d, d+a), (d+a+b, d+a+b+c)]
-    assert cbook.contiguous_regions(mask) == expected
-    # Starts and ends with False
-    mask = mask + [False]*e
-    assert cbook.contiguous_regions(mask) == expected
-    # No True in mask
-    assert cbook.contiguous_regions([False]*5) == []
-    # Empty mask
-    assert cbook.contiguous_regions([]) == []
-
-
 def test_safe_first_element_pandas_series(pd):
     # delibrately create a pandas series with index not starting from 0
     s = pd.Series(range(5), index=range(10, 15))

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -482,3 +482,54 @@ def test_flatiter():
 
     assert 0 == next(it)
     assert 1 == next(it)
+
+
+def test_reshape2d():
+    class dummy():
+        pass
+    x = [dummy() for j in range(5)]
+    xnew = cbook._reshape_2D(x, 'x')
+    assert np.shape(xnew) == (1, 5)
+
+    x = np.arange(5)
+    xnew = cbook._reshape_2D(x, 'x')
+    assert np.shape(xnew) == (1, 5)
+
+    x = [[dummy() for j in range(5)] for i in range(3)]
+    xnew = cbook._reshape_2D(x, 'x')
+    assert np.shape(xnew) == (3, 5)
+
+    # this is strange behaviour, but...
+    x = np.random.rand(3, 5)
+    xnew = cbook._reshape_2D(x, 'x')
+    assert np.shape(xnew) == (5, 3)
+
+
+def test_contiguous_regions():
+    a, b, c = 3, 4, 5
+    # Starts and ends with True
+    mask = [True]*a + [False]*b + [True]*c
+    expected = [(0, a), (a+b, a+b+c)]
+    assert cbook.contiguous_regions(mask) == expected
+    d, e = 6, 7
+    # Starts with True ends with False
+    mask = mask + [False]*e
+    assert cbook.contiguous_regions(mask) == expected
+    # Starts with False ends with True
+    mask = [False]*d + mask[:-e]
+    expected = [(d, d+a), (d+a+b, d+a+b+c)]
+    assert cbook.contiguous_regions(mask) == expected
+    # Starts and ends with False
+    mask = mask + [False]*e
+    assert cbook.contiguous_regions(mask) == expected
+    # No True in mask
+    assert cbook.contiguous_regions([False]*5) == []
+    # Empty mask
+    assert cbook.contiguous_regions([]) == []
+
+
+def test_safe_first_element_pandas_series(pd):
+    # delibrately create a pandas series with index not starting from 0
+    s = pd.Series(range(5), index=range(10, 15))
+    actual = cbook.safe_first_element(s)
+    assert actual == 0


### PR DESCRIPTION
Fix for _axes.scatter() array index out of bound error 

Manual backport of #12673

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
