### PR TITLE
Do not rely on external stack frame to exist

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1990,6 +1990,8 @@ def _warn_external(message, category=None):
     """
     frame = sys._getframe()
     for stacklevel in itertools.count(1):  # lgtm[py/unused-loop-variable]
+        if frame is None:
+            break
         if not re.match(r"\A(matplotlib|mpl_toolkits)(\Z|\.)",
                         # Work around sphinx-gallery not setting __name__.
                         frame.f_globals.get("__name__", "")):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1991,6 +1991,7 @@ def _warn_external(message, category=None):
     frame = sys._getframe()
     for stacklevel in itertools.count(1):  # lgtm[py/unused-loop-variable]
         if frame is None:
+            # when called in embedded context may hit frame is None
             break
         if not re.match(r"\A(matplotlib|mpl_toolkits)(\Z|\.)",
                         # Work around sphinx-gallery not setting __name__.

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -2,6 +2,7 @@ import itertools
 import pickle
 from weakref import ref
 import warnings
+from unittest.mock import patch, Mock
 
 from datetime import datetime
 
@@ -348,6 +349,15 @@ def test_normalize_kwargs_pass(inp, expected, kwargs_to_norm):
         warnings.simplefilter("always")
         assert expected == cbook.normalize_kwargs(inp, **kwargs_to_norm)
         assert len(w) == 0
+
+
+def test_warn_external_frame_embedded_python():
+    with patch.object(cbook, "sys") as mock_sys:
+        mock_sys._getframe = Mock(return_value=None)
+        with warnings.catch_warnings(record=True) as w:
+            cbook._warn_external("dummy")
+    assert len(w) == 1
+    assert str(w[0].message) == "dummy"
 
 
 def test_to_prestep():


### PR DESCRIPTION
## PR Summary

When using matplotlib in an embedded Python interpreter (such as in Julia package PyCall.jl), stack frame may not exist outside matplotlib.  Therefore, it is better to not assume `frame.f_back` to be an existing call frame.

See: https://github.com/JuliaPy/PyPlot.jl/issues/409

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
