### PR TITLE
Improve plot() docstring.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1335,7 +1335,7 @@ class Axes(_AxesBase):
 
         Call signatures::
 
-            plot([x], y, [fmt], data=None, **kwargs)
+            plot([x], y, [fmt], *, data=None, **kwargs)
             plot([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
 
         The coordinates of the points or line nodes are given by *x*, *y*.
@@ -1358,6 +1358,7 @@ class Axes(_AxesBase):
         ...      linewidth=2, markersize=12)
 
         When conflicting with *fmt*, keyword arguments take precedence.
+
 
         **Plotting labelled data**
 
@@ -1406,19 +1407,19 @@ class Axes(_AxesBase):
         Alternatively, you can also change the style cycle using the
         'axes.prop_cycle' rcParam.
 
+
         Parameters
         ----------
         x, y : array-like or scalar
             The horizontal / vertical coordinates of the data points.
-            *x* values are optional. If not given, they default to
-            ``[0, ..., N-1]``.
+            *x* values are optional and default to `range(len(y))`.
 
-            Commonly, these parameters are arrays of length N. However,
-            scalars are supported as well (equivalent to an array with
-            constant value).
+            Commonly, these parameters are 1D arrays.
 
-            The parameters can also be 2-dimensional. Then, the columns
-            represent separate data sets.
+            They can also be scalars, or two-dimensional (in that case, the
+            columns represent separate data sets).
+
+            These arguments cannot be passed as keywords.
 
         fmt : str, optional
             A format string, e.g. 'ro' for red circles. See the *Notes*
@@ -1427,6 +1428,8 @@ class Axes(_AxesBase):
             Format strings are just an abbreviation for quickly setting
             basic line properties. All of these and more can also be
             controlled by keyword arguments.
+
+            This argument cannot be passed as keyword.
 
         data : indexable object, optional
             An object with labelled data. If given, provide the label names to


### PR DESCRIPTION
- Mark `x`, `y`, `fmt` as positional-only.
- Scalar values are not broadcasted against non-scalar values, despite
  what the docstring claims.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
