### PR TITLE
Cairo backend: Fix alpha render of collections

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -286,57 +286,6 @@ class RendererCairo(RendererBase):
             self._fill_and_stroke(
                 ctx, rgbFace, gc.get_alpha(), gc.get_forced_alpha())
 
-    def draw_path_collection(
-            self, gc, master_transform, paths, all_transforms, offsets,
-            offsetTrans, facecolors, edgecolors, linewidths, linestyles,
-            antialiaseds, urls, offset_position):
-
-        path_ids = [
-            (path, Affine2D(transform))
-            for path, transform in self._iter_collection_raw_paths(
-                    master_transform, paths, all_transforms)]
-
-        reuse_key = None
-        grouped_draw = []
-
-        def _draw_paths():
-            if not grouped_draw:
-                return
-            gc_vars, rgb_fc = reuse_key
-            gc = copy.copy(gc0)
-            # We actually need to call the setters to reset the internal state.
-            vars(gc).update(gc_vars)
-            for k, v in gc_vars.items():
-                if k == "_linestyle":  # Deprecated, no effect.
-                    continue
-                try:
-                    getattr(gc, "set" + k)(v)
-                except (AttributeError, TypeError) as e:
-                    pass
-            gc.ctx.new_path()
-            paths, transforms = zip(*grouped_draw)
-            grouped_draw.clear()
-            _append_paths(gc.ctx, paths, transforms)
-            self._fill_and_stroke(
-                gc.ctx, rgb_fc, gc.get_alpha(), gc.get_forced_alpha())
-
-        for xo, yo, path_id, gc0, rgb_fc in self._iter_collection(
-                gc, master_transform, all_transforms, path_ids, offsets,
-                offsetTrans, facecolors, edgecolors, linewidths, linestyles,
-                antialiaseds, urls, offset_position):
-            path, transform = path_id
-            transform = (Affine2D(transform.get_matrix())
-                         .translate(xo, yo - self.height).scale(1, -1))
-            # rgb_fc could be a ndarray, for which equality is elementwise.
-            new_key = vars(gc0), tuple(rgb_fc) if rgb_fc is not None else None
-            if new_key == reuse_key:
-                grouped_draw.append((path, transform))
-            else:
-                _draw_paths()
-                grouped_draw.append((path, transform))
-                reuse_key = new_key
-        _draw_paths()
-
     def draw_image(self, gc, x, y, im):
         im = cbook._unmultiplied_rgba8888_to_premultiplied_argb32(im[::-1])
         surface = cairo.ImageSurface.create_for_data(

--- a/lib/matplotlib/tests/test_backend_cairo.py
+++ b/lib/matplotlib/tests/test_backend_cairo.py
@@ -1,0 +1,55 @@
+import numpy as np
+from io import BytesIO
+import os
+import tempfile
+import warnings
+import xml.parsers.expat
+
+import pytest
+
+import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import check_figures_equal
+import matplotlib
+from matplotlib import (
+    collections as mcollections, patches as mpatches, path as mpath)
+
+
+@pytest.mark.backend('cairo')
+@check_figures_equal(extensions=["png"])
+def test_patch_alpha_coloring(fig_test, fig_ref):
+    """
+    Test checks that the patch and collection are rendered with the specified
+    alpha values in their facecolor and edgecolor.
+    """
+    star = mpath.Path.unit_regular_star(6)
+    circle = mpath.Path.unit_circle()
+    # concatenate the star with an internal cutout of the circle
+    verts = np.concatenate([circle.vertices, star.vertices[::-1]])
+    codes = np.concatenate([circle.codes, star.codes])
+    cut_star1 = mpath.Path(verts, codes)
+    cut_star2 = mpath.Path(verts + 1, codes)
+
+    # Reference: two separate patches
+    ax = fig_ref.subplots()
+    ax.set_xlim([-1, 2])
+    ax.set_ylim([-1, 2])
+    patch = mpatches.PathPatch(cut_star1,
+                               linewidth=5, linestyle='dashdot',
+                               facecolor=(1, 0, 0, 0.5),
+                               edgecolor=(0, 0, 1, 0.75))
+    ax.add_patch(patch)
+    patch = mpatches.PathPatch(cut_star2,
+                               linewidth=5, linestyle='dashdot',
+                               facecolor=(1, 0, 0, 0.5),
+                               edgecolor=(0, 0, 1, 0.75))
+    ax.add_patch(patch)
+
+    # Test: path collection
+    ax = fig_test.subplots()
+    ax.set_xlim([-1, 2])
+    ax.set_ylim([-1, 2])
+    col = mcollections.PathCollection([cut_star1, cut_star2],
+                                      linewidth=5, linestyles='dashdot',
+                                      facecolor=(1, 0, 0, 0.5),
+                                      edgecolor=(0, 0, 1, 0.75))
+    ax.add_collection(col)


### PR DESCRIPTION
Fix for #12773

## PR Summary
RendererCairo.draw_path_collection() had two issues related to alpha channels.

First, the call to gc.set_alpha in line 310 would also inadvertently set gc._forced_alpha = True. This is fixed by moving the line which updates the gc from gc_vars below the loop.

Second, the code has an optimization where artists with identical properties would be grouped and then rendered in one go. This strategy doesn't work if the artists overlap and have alpha value < 1.0 in which case alpha blending is necessary. So the second fix disables the grouping optimization if any of the artists have alpha < 1.0 or the whole collection has alpha < 1.0.

## PR Checklist

- [ ] Has Pytest style unit tests
Not yet, but I'll try to write one if necessary.
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
