### PR TITLE
Add note to errorbar function about sign of errors

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2950,6 +2950,8 @@ class Axes(_AxesBase):
                 upper errors.
             - *None*: No errorbar.
 
+            Note that all error arrays should have *positive* values.
+
             See :doc:`/gallery/statistics/errorbar_features`
             for an example on the usage of ``xerr`` and ``yerr``.
 


### PR DESCRIPTION
This is purely a docstring change.

I was tripped up by the sign the errors need to have. Both lower and upper bounds are always positive numbers, so it would be useful to note this in the documentation.