### PR TITLE
Lazy import of private modules

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -46,6 +46,20 @@ subplotparams will collapse axes to zero width or height.  This prevents
 ``tight_layout`` from being executed.  Similarly
 `.tight_layout.get_tight_layout_figure` will return None.
 
+To improve import (startup) time, private modules are now imported lazily.
+These modules are no longer available at these locations:
+
+  - `matplotlib.backends.backend_agg._png`
+  - `matplotlib.contour._contour`
+  - `matplotlib.image._png`
+  - `matplotlib.mathtext._png`
+  - `matplotlib.testing.compare._png`
+  - `matplotlib.texmanager._png`
+  - `matplotlib.tri.triangulation._tri`
+  - `matplotlib.tri.triangulation._qhull`
+  - `matplotlib.tri.tricontour._tri`
+  - `matplotlib.tri.trifinder._tri`
+
 API Changes for 3.0.0
 =====================
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -132,7 +132,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-import urllib.request
 
 # cbook must import matplotlib only within function
 # definitions, so it is safe to import from it here.
@@ -874,6 +873,7 @@ def is_url(filename):
 @contextlib.contextmanager
 def _open_file_or_url(fname):
     if is_url(fname):
+        import urllib.request
         with urllib.request.urlopen(fname) as f:
             yield (line.decode('utf-8') for line in f)
     else:

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -38,7 +38,6 @@ from matplotlib.transforms import Bbox, BboxBase
 from matplotlib import colors as mcolors
 
 from matplotlib.backends._backend_agg import RendererAgg as _RendererAgg
-from matplotlib import _png
 
 from matplotlib.backend_bases import _has_pil
 
@@ -499,6 +498,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             If the 'pnginfo' key is present, it completely overrides
             *metadata*, including the default 'Software' key.
         """
+        from matplotlib import _png
 
         if metadata is None:
             metadata = {}

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy import ma
 
 import matplotlib as mpl
-import matplotlib._contour as _contour
 import matplotlib.path as mpath
 import matplotlib.ticker as ticker
 import matplotlib.cm as cm
@@ -1451,6 +1450,8 @@ class QuadContourSet(ContourSet):
             self._mins = args[0]._mins
             self._maxs = args[0]._maxs
         else:
+            import matplotlib._contour as _contour
+
             self._corner_mask = kwargs.pop('corner_mask', None)
             if self._corner_mask is None:
                 self._corner_mask = mpl.rcParams['contour.corner_mask']

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -22,7 +22,6 @@ import matplotlib.cbook as cbook
 
 # For clarity, names from _image are given explicitly in this module:
 import matplotlib._image as _image
-import matplotlib._png as _png
 
 # For user convenience, the names from _image are also imported into
 # the image namespace:
@@ -635,6 +634,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def write_png(self, fname):
         """Write the image to png file with fname"""
+        from matplotlib import _png
         im = self.to_rgba(self._A[::-1] if self.origin == 'lower' else self._A,
                           bytes=True, norm=True)
         _png.write_png(im, fname)
@@ -1359,7 +1359,11 @@ def imread(fname, format=None):
     .. _Pillow documentation: http://pillow.readthedocs.io/en/latest/
     """
 
-    handlers = {'png': _png.read_png, }
+    def read_png(*args, **kwargs):
+        from matplotlib import _png
+        return _png.read_png(*args, **kwargs)
+
+    handlers = {'png': read_png, }
     if format is None:
         if isinstance(fname, str):
             parsed = urllib.parse.urlparse(fname)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -9,7 +9,6 @@ import os
 import logging
 from pathlib import Path
 import urllib.parse
-import urllib.request
 
 import numpy as np
 
@@ -1400,6 +1399,7 @@ def imread(fname, format=None):
         parsed = urllib.parse.urlparse(fname)
         # If fname is a URL, download the data
         if len(parsed.scheme) > 1:
+            import urllib.request
             fd = BytesIO(urllib.request.urlopen(fname).read())
             return handler(fd)
         else:

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1399,8 +1399,8 @@ def imread(fname, format=None):
         parsed = urllib.parse.urlparse(fname)
         # If fname is a URL, download the data
         if len(parsed.scheme) > 1:
-            import urllib.request
-            fd = BytesIO(urllib.request.urlopen(fname).read())
+            from urllib import request
+            fd = BytesIO(request.urlopen(fname).read())
             return handler(fd)
         else:
             with open(fname, 'rb') as fd:

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1445,6 +1445,7 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
         resolution of the output image.
     """
     from matplotlib.figure import Figure
+    from matplotlib import _png
     if isinstance(fname, os.PathLike):
         fname = os.fspath(fname)
     if format is None:

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -32,7 +32,7 @@ from pyparsing import (
 
 ParserElement.enablePackrat()
 
-from matplotlib import _png, cbook, colors as mcolors, get_data_path, rcParams
+from matplotlib import cbook, colors as mcolors, get_data_path, rcParams
 from matplotlib.afm import AFM
 from matplotlib.cbook import get_realpath_and_stat
 from matplotlib.ft2font import FT2Image, KERNING_DEFAULT, LOAD_NO_HINTING
@@ -3450,6 +3450,7 @@ class MathTextParser(object):
         Returns the offset of the baseline from the bottom of the
         image in pixels.
         """
+        from matplotlib import _png
         rgba, depth = self.to_rgba(
             texstr, color=color, dpi=dpi, fontsize=fontsize)
         _png.write_png(rgba, filename)

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import matplotlib as mpl
 from matplotlib.testing.exceptions import ImageComparisonFailure
-from matplotlib import _png, cbook
+from matplotlib import cbook
 
 __all__ = ['compare_float', 'compare_images', 'comparable_formats']
 
@@ -418,6 +418,8 @@ def compare_images(expected, actual, tol, in_decorator=False):
         compare_images(img1, img2, 0.001)
 
     """
+    from matplotlib import _png
+
     if not os.path.exists(actual):
         raise Exception("Output image %s does not exist." % actual)
 
@@ -488,6 +490,7 @@ def save_diff_image(expected, actual, output):
         File path to save difference image to.
     '''
     # Drop alpha channels, similarly to compare_images.
+    from matplotlib import _png
     expected_image = _png.read_png(expected)[..., :3]
     actual_image = _png.read_png(actual)[..., :3]
     actual_image, expected_image = crop_to_same(

--- a/lib/matplotlib/testing/disable_internet.py
+++ b/lib/matplotlib/testing/disable_internet.py
@@ -3,7 +3,6 @@
 
 import contextlib
 import socket
-import urllib.request
 
 # save original socket method for restoration
 # These are global so that re-calling the turn_off_internet function doesn't
@@ -76,6 +75,7 @@ def turn_off_internet(verbose=False):
     using some other means of accessing the internet, but all default python
     modules (urllib, requests, etc.) use socket [citation needed].
     """
+    import urllib.request
 
     global INTERNET_OFF
     global _orig_opener
@@ -108,6 +108,7 @@ def turn_on_internet(verbose=False):
     """
     Restore internet access.  Not used, but kept in case it is needed.
     """
+    import urllib.request
 
     global INTERNET_OFF
     global _orig_opener

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -47,6 +47,7 @@ def test_lazy_imports():
     assert 'matplotlib._tri' not in sys.modules
     assert 'matplotlib._qhull' not in sys.modules
     assert 'matplotlib._contour' not in sys.modules
+    assert 'urllib.request' not in sys.modules
     """)
 
     subprocess.check_call([

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -1,6 +1,9 @@
 import builtins
+import subprocess
+import sys
 
 import matplotlib
+from matplotlib.cbook import dedent
 
 
 def test_simple():
@@ -30,3 +33,24 @@ def test_override_builtins():
                 overridden = True
 
     assert not overridden
+
+
+def test_lazy_imports():
+    source = dedent("""
+    import sys
+
+    import matplotlib.figure
+    import matplotlib.backend_bases
+    import matplotlib.pyplot
+
+    assert 'matplotlib._png' not in sys.modules
+    assert 'matplotlib._tri' not in sys.modules
+    assert 'matplotlib._qhull' not in sys.modules
+    assert 'matplotlib._contour' not in sys.modules
+    """)
+
+    subprocess.check_call([
+        sys.executable,
+        '-c',
+        source
+    ])

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -41,7 +41,7 @@ import subprocess
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _png, cbook, dviread, rcParams
+from matplotlib import cbook, dviread, rcParams
 
 _log = logging.getLogger(__name__)
 
@@ -397,6 +397,7 @@ class TexManager(object):
 
     def get_grey(self, tex, fontsize=None, dpi=None):
         """Return the alpha channel."""
+        from matplotlib import _png
         key = tex, self.get_font_config(), fontsize, dpi
         alpha = self.grey_arrayd.get(key)
         if alpha is None:

--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -1,8 +1,5 @@
 import numpy as np
 
-import matplotlib._tri as _tri
-import matplotlib._qhull as _qhull
-
 
 class Triangulation(object):
     """
@@ -39,6 +36,8 @@ class Triangulation(object):
     triangles formed from colinear points, or overlapping triangles.
     """
     def __init__(self, x, y, triangles=None, mask=None):
+        from matplotlib import _qhull
+
         self.x = np.asarray(x, dtype=np.float64)
         self.y = np.asarray(y, dtype=np.float64)
         if self.x.shape != self.y.shape or self.x.ndim != 1:
@@ -106,6 +105,7 @@ class Triangulation(object):
         Return the underlying C++ Triangulation object, creating it
         if necessary.
         """
+        from matplotlib import _tri
         if self._cpp_triangulation is None:
             self._cpp_triangulation = _tri.Triangulation(
                 self.x, self.y, self.triangles, self.mask, self._edges,

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from matplotlib.contour import ContourSet
 from matplotlib.tri.triangulation import Triangulation
-import matplotlib._tri as _tri
 
 
 class TriContourSet(ContourSet):
@@ -44,6 +43,7 @@ class TriContourSet(ContourSet):
             if self.levels is None:
                 self.levels = args[0].levels
         else:
+            from matplotlib import _tri
             tri, z = self._contour_args(args, kwargs)
             C = _tri.TriContourGenerator(tri.get_cpp_triangulation(), z)
             self._mins = [tri.x.min(), tri.y.min()]

--- a/lib/matplotlib/tri/trifinder.py
+++ b/lib/matplotlib/tri/trifinder.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from matplotlib.tri import Triangulation
-import matplotlib._tri as _tri
 
 
 class TriFinder(object):
@@ -35,6 +34,7 @@ class TrapezoidMapTriFinder(TriFinder):
     this should not be relied upon.
     """
     def __init__(self, triangulation):
+        from matplotlib import _tri
         TriFinder.__init__(self, triangulation)
         self._cpp_trifinder = _tri.TrapezoidMapTriFinder(
             triangulation.get_cpp_triangulation())


### PR DESCRIPTION
## PR Summary

Not all platforms have blazing fast dynamic linkers, therefore a lot of import (startup) time can be saved by not importing extension modules that we don't have to.

There are some more aggressive uses of lazy loading that are possible, but this is just the stuff that's already declared private and thus users who are importing these things at this path have had "fair warning".  If acceptable, I can provide a follow-on PR that deprecates and then removes additional things.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
