### PR TITLE
Fix Bezier degree elevation formula in backend_cairo.

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -97,10 +97,10 @@ def _append_paths_slow(ctx, paths, transforms, clip=None):
             elif code == Path.LINETO:
                 ctx.line_to(*points)
             elif code == Path.CURVE3:
-                cur = ctx.get_current_point()
-                ctx.curve_to(
-                    *np.concatenate([cur / 3 + points[:2] * 2 / 3,
-                                     points[:2] * 2 / 3 + points[-2:] / 3]))
+                cur = np.asarray(ctx.get_current_point())
+                a = points[:2]
+                b = points[-2:]
+                ctx.curve_to(*(cur / 3 + a * 2 / 3), *(a * 2 / 3 + b / 3), *b)
             elif code == Path.CURVE4:
                 ctx.curve_to(*points)
 


### PR DESCRIPTION
The quad_bezier example would previously fail under the cairo backend;
this patch fixes it.

Closes #12794.

The broken implementation went in in 3.0 so milestoning as 3.0.x.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
