### PR TITLE
documenting dtype of hist counts

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6508,7 +6508,9 @@ class Axes(_AxesBase):
             *nbins*. If input is a sequence of arrays
             ``[data1, data2,..]``, then this is a list of arrays with
             the values of the histograms for each of the arrays in the
-            same order.
+            same order. The dtype of the elements of the array *n*
+            (or of its element arrays) will always be float even if no
+            weighting or normalization is used.
 
         bins : array
             The edges of the bins. Length nbins + 1 (nbins left edges and right


### PR DESCRIPTION
## PR Summary
closes #12784
Updating the documentation for ``hist`` to clarify that the dtype of values of histogram i.e. counts being returned will always be float (even when no weighting or normalization is used).

Reviewers -- 
(1) please let me know if the explanation for this behavior needs to be added in the documentation (since this is a "side-effect" of accommodating numpy.histogram's inconsistent behavior, I am not sure how much detail should go in the docstring).
~~(2) Please have a look at #12802 for an alternative solution~~

~~I am not sure which approach should be preferred.~~

## PR Checklist

- ~~[ ] Has Pytest style unit tests~~
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- ~~[ ] New features are documented, with examples if plot related~~
- [x] Documentation is sphinx and numpydoc compliant
- ~~[ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- ~~[ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
