### PR TITLE
retaining dtype of hist bins as int when data is int and no weighting is used

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6635,7 +6635,6 @@ class Axes(_AxesBase):
             # this will automatically overwrite bins,
             # so that each histogram uses the same bins
             m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)
-            m = m.astype(float)  # causes problems later if it's an int
             if mlast is None:
                 mlast = np.zeros(len(bins)-1, m.dtype)
             if stacked:
@@ -6647,6 +6646,9 @@ class Axes(_AxesBase):
         # histograms together is 1
         if stacked and density:
             db = np.diff(bins)
+            # casting as float to avoid issues with division result being
+            # stored in the same numpy array (in case the dtype is int).
+            tops = [m.astype(float) for m in tops]
             for m in tops:
                 m[:] = (m / db) / tops[-1].sum()
         if cumulative:


### PR DESCRIPTION
## PR Summary
When calling the histogram plotting method/function, if the input data has dtype ``int`` and no weighting/nomralization is used then the returned histogram values should be returned with dtype ``int`` (as is the behavior of ``numpy.histogram``). The current implementation tries to avoid incosistency in return type of numpy.histogram (int if no weighting, float if weighting used) by always casting the input data as float.

This PR is an attempt to address #12784  by postponing the casting step in the ``ax.hist`` code. The data is casted to float if either ``stacked`` or ``density`` kwarg is True.

(alternative is to just document the behavior as attempted in #12800).

## PR Checklist

- ~~[ ] Has Pytest style unit tests~~
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- ~~[ ] New features are documented, with examples if plot related~~
- [x] Documentation is sphinx and numpydoc compliant
- ~~[ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
-~~ [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
