### PR TITLE
Don't insert spurious newlines by joining tex.preamble.

### DIFF
--- a/doc/api/next_api_changes/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
+++ b/doc/api/next_api_changes/2018-10-30-rcparams-pgf.preamble-full-LaTeX-support.rst
@@ -9,3 +9,5 @@ The parsing has been modified to pass the complete line to the LaTeX system,
 keeping all commas.
 
 Passing a list of strings from within a Python script still works as it used to.
+
+Passing a list containing non-strings now fails, instead of coercing the results to strings.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -175,17 +175,17 @@ def validate_string_or_None(s):
         raise ValueError('Could not convert "%s" to string' % s)
 
 
-def _validate_stringlist_or_string(s):
-    """convert s to string or raise"""
+def _validate_tex_preamble(s):
     if s is None or s == 'None':
         return ""
     try:
         if isinstance(s, str):
             return s
-        if isinstance(s, Iterable):
-            return '\n'.join([str(i) for i in s])
-        raise ValueError()
-    except ValueError:
+        elif isinstance(s, Iterable):
+            return '\n'.join(s)
+        else:
+            raise TypeError
+    except TypeError:
         raise ValueError('Could not convert "%s" to string' % s)
 
 
@@ -412,7 +412,7 @@ validate_colorlist.__doc__ = 'return a list of colorspecs'
 
 
 def validate_string(s):
-    if isinstance(s, (str, str)):
+    if isinstance(s, str):
         # Always leave str as str and unicode as unicode
         return s
     else:
@@ -1129,7 +1129,7 @@ defaultParams = {
     'text.color':          ['black', validate_color],
     'text.usetex':         [False, validate_bool],
     'text.latex.unicode':  [True, validate_bool],
-    'text.latex.preamble': ['', _validate_stringlist_or_string],
+    'text.latex.preamble': ['', _validate_tex_preamble],
     'text.latex.preview':  [False, validate_bool],
     'text.dvipnghack':     [None, validate_bool_maybe_none],
     'text.hinting':        ['auto', validate_hinting],
@@ -1405,7 +1405,7 @@ defaultParams = {
     # use matplotlib rc settings for font configuration
     'pgf.rcfonts':   [True, validate_bool],
     # provide a custom preamble for the latex process
-    'pgf.preamble':  ['', _validate_stringlist_or_string],
+    'pgf.preamble':  ['', _validate_tex_preamble],
 
     # write raster image data directly into the svg file
     'svg.image_inline':     [True, validate_bool],

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -181,7 +181,7 @@ class TexManager(object):
 
     def get_custom_preamble(self):
         """Return a string containing user additions to the tex preamble."""
-        return '\n'.join(rcParams['text.latex.preamble'])
+        return rcParams['text.latex.preamble']
 
     def make_tex(self, tex, fontsize):
         """


### PR DESCRIPTION
The rc validator already makes it a single string.

Also reject non-strings in the validator, as there isn't much use to
them anyways in this context.

Closes #12804, I think.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
