### PR TITLE
BUG: fix CubicTriInterpolator when masked triangulation is used

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -948,6 +948,32 @@ def test_trirefine():
     assert_array_almost_equal(xyz_data[0], xyz_data[1])
 
 
+def test_cubic_trirefine_masked():
+    np.random.seed(19680801)
+    x = np.zeros(1000)
+    for i in range(10):
+        x[500+i] = np.random.rand()
+    y = np.repeat(np.arange(100), 10)
+    z = np.random.rand(1000)
+    tri = mtri.Triangulation(x, y)
+    refiner = mtri.UniformTriRefiner(tri)
+    cinterp = mtri.CubicTriInterpolator(tri, z)
+    refiner.refine_field(z, triinterpolator=cinterp, subdiv=2)
+
+
+def test_linear_trirefine_masked():
+    np.random.seed(19680801)
+    x = np.zeros(1000)
+    for i in range(10):
+        x[500+i] = np.random.rand()
+    y = np.repeat(np.arange(100), 10)
+    z = np.random.rand(1000)
+    tri = mtri.Triangulation(x, y)
+    refiner = mtri.UniformTriRefiner(tri)
+    linterp = mtri.LinearTriInterpolator(tri, z)
+    refiner.refine_field(z, triinterpolator=linterp, subdiv=2)
+
+
 def meshgrid_triangles(n):
     """
     Utility function.

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -408,8 +408,8 @@ class CubicTriInterpolator(TriInterpolator):
         self._tri_renum = tri_renum
         # Taking into account the node renumbering in self._z:
         node_mask = (node_renum == -1)
-        self._z[node_renum[~node_mask]] = self._z
         self._z = self._z[~node_mask]
+        self._z[node_renum[~node_mask]] = self._z
 
         # Computing scale factors
         self._unit_x = np.ptp(compressed_x)


### PR DESCRIPTION
## PR Summary

If triangulation is masked, there is an assignment of arrays of different shapes in CubicTriInterpolator. It comes down to a typo, i.e., the mask is applied after the assignment.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
