### PR TITLE
Fix TypeError when calculating tick_values

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2193,7 +2193,7 @@ class LogLocator(Locator):
                 stride += 1
 
         # Does subs include anything other than 1?
-        have_subs = len(subs) > 1 or (len(subs == 1) and subs[0] != 1.0)
+        have_subs = len(subs) > 1 or (len(subs) == 1 and subs[0] != 1.0)
 
         decades = np.arange(math.floor(vmin) - stride,
                             math.ceil(vmax) + 2 * stride, stride)


### PR DESCRIPTION
## PR Summary

Fixes #12806.

This was caused by a misplaced parentheses. Introduced in https://github.com/matplotlib/matplotlib/commit/54d6f08de99acf97c3e00309a9ef2adf911d5f80 (attn. @efiring).
