### PR TITLE
Added a test to default the value of Fs to 2 for Axes.specgram and ml…

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7513,7 +7513,7 @@ class Axes(_AxesBase):
 
     @_preprocess_data(replace_names=["x"], label_namer=None)
     @docstring.dedent_interpd
-    def specgram(x, NFFT=None, Fs=None, Fc=None, detrend=None,
+    def specgram(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
                  window=None, noverlap=None,
                  cmap=None, xextent=None, pad_to=None, sides=None,
                  scale_by_freq=None, mode=None, scale=None,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7513,7 +7513,7 @@ class Axes(_AxesBase):
 
     @_preprocess_data(replace_names=["x"], label_namer=None)
     @docstring.dedent_interpd
-    def specgram(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
+    def specgram(x, NFFT=None, Fs=None, Fc=None, detrend=None,
                  window=None, noverlap=None,
                  cmap=None, xextent=None, pad_to=None, sides=None,
                  scale_by_freq=None, mode=None, scale=None,
@@ -7629,6 +7629,8 @@ class Axes(_AxesBase):
             Fc = 0  # same default as in mlab._spectral_helper()
         if noverlap is None:
             noverlap = 128  # same default as in mlab.specgram()
+        if Fs is None:
+            Fs = 2  # same default as in mlab.specgram()
 
         if mode == 'complex':
             raise ValueError('Cannot plot a complex specgram')

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1113,6 +1113,8 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
         noverlap = 128  # default in _spectral_helper() is noverlap = 0
     if NFFT is None:
         NFFT = 256  # same default as in _spectral_helper()
+    if Fs is None:
+        Fs = 2 # same default as in _spectral_helper()
     if len(x) <= NFFT:
         cbook._warn_external("Only one segment is calculated since parameter "
                              "NFFT (=%d) >= signal length (=%d)." %


### PR DESCRIPTION
…ab.specgram to match docstring and mlab._spectral_helper() default value.
Addresses issue #9100

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
