### PR TITLE
Deprecate redundant log-scale transform classes.

### DIFF
--- a/doc/api/next_api_changes/2018-11-18-AL.rst
+++ b/doc/api/next_api_changes/2018-11-18-AL.rst
@@ -1,0 +1,10 @@
+Deprecations
+````````````
+
+- The ``LogTransformBase``, ``Log10Transform``, ``Log2Transform``,
+  ``NaturalLogTransformLog``, ``InvertedLogTransformBase``,
+  ``InvertedLog10Transform``, ``InvertedLog2Transform``, and
+  ``InvertedNaturalLogTransform`` classes (all defined in
+  :mod:`matplotlib.scales`) are deprecated.  As a replacement, use the general
+  `LogTransform` and `InvertedLogTransform` classes, whose constructors take a
+  *base* argument.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5282,8 +5282,7 @@ def test_title_location_roundtrip():
 
 
 @image_comparison(baseline_images=["loglog"], remove_text=True,
-                  extensions=['png'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  extensions=['png'], tol=0.02)
 def test_loglog():
     fig, ax = plt.subplots()
     x = np.arange(1, 11)

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -105,8 +105,7 @@ def test_logscale_transform_repr():
 
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'], style='mpl20')
+                  extensions=['png'], tol=0.02, style='mpl20')
 def test_logscale_nonpos_values():
     np.random.seed(19680801)
     xs = np.random.normal(size=int(1e3))


### PR DESCRIPTION
## PR Summary

Having a bunch of separate log Transform classes is mentioned as an optimization, but that optimization wasn't even there anymore.  Restore it, while keeping everything in a single log Transform class.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
