### PR TITLE
Deprecate Path.has_nonfinite.

### DIFF
--- a/doc/api/next_api_changes/2018-11-20-AL.rst
+++ b/doc/api/next_api_changes/2018-11-20-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The ``Path.has_nonfinite`` attribute is deprecated (use ``not
+np.isfinite(path.vertices).all()`` instead).

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -14,7 +14,7 @@ from weakref import WeakValueDictionary
 
 import numpy as np
 
-from . import _path, rcParams
+from . import _path, cbook, rcParams
 from .cbook import _to_unmasked_float_array, simple_linear_interpolation
 
 
@@ -166,9 +166,8 @@ class Path(object):
         verts : numpy array
         codes : numpy array
         internals : dict or None
-            The attributes that the resulting path should have.
-            Allowed keys are ``readonly``, ``should_simplify``,
-            ``simplify_threshold``, ``has_nonfinite`` and
+            The attributes that the resulting path should have.  Allowed keys
+            are ``readonly``, ``should_simplify``, ``simplify_threshold``, and
             ``interpolation_steps``.
 
         """
@@ -182,7 +181,6 @@ class Path(object):
             internals.pop('simplify_threshold',
                           rcParams['path.simplify_threshold'])
         )
-        pth._has_nonfinite = internals.pop('has_nonfinite', False)
         pth._interpolation_steps = internals.pop('interpolation_steps', 1)
         if internals:
             raise ValueError('Unexpected internals provided to '
@@ -198,7 +196,6 @@ class Path(object):
             len(self._vertices) >= 128 and
             (self._codes is None or np.all(self._codes <= Path.LINETO))
         )
-        self._has_nonfinite = not np.isfinite(self._vertices).all()
 
     @property
     def vertices(self):
@@ -245,12 +242,14 @@ class Path(object):
     def simplify_threshold(self, threshold):
         self._simplify_threshold = threshold
 
+    @cbook.deprecated(
+        "3.1", alternative="not np.isfinite(self.vertices).all()")
     @property
     def has_nonfinite(self):
         """
         `True` if the vertices array has nonfinite values.
         """
-        return self._has_nonfinite
+        return not np.isfinite(self._vertices).all()
 
     @property
     def should_simplify(self):
@@ -448,7 +447,6 @@ class Path(object):
                                              snap, stroke_width,
                                              simplify, curves, sketch)
         internals = {'should_simplify': self.should_simplify and not simplify,
-                     'has_nonfinite': self.has_nonfinite and not remove_nans,
                      'simplify_threshold': self.simplify_threshold,
                      'interpolation_steps': self._interpolation_steps}
         return Path._fast_from_codes_and_verts(vertices, codes, internals)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -480,7 +480,6 @@ class TextPath(Path):
 
         self._should_simplify = False
         self._simplify_threshold = rcParams['path.simplify_threshold']
-        self._has_nonfinite = False
         self._interpolation_steps = _interpolation_steps
 
     def set_size(self, size):


### PR DESCRIPTION
The attribute was introduced in c7837e4 (Oct. 2008) for optimization
pruposes, but it is internally unused since 0ad0ee4 (Jan. 2009) when
the path nan-handling moved to C++.  Since then it's only been touched
by additional commits to make sure it is correctly updated by APIs like
`cleaned`, but it has far outlived its utility (plus, directly checking
the vertices is just as good if you really care -- don't make everyone
else pay for it when instantiating Paths).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
