### PR TITLE
correctly format ticklabels when EngFormatter is used with usetex = True

### DIFF
--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -5,6 +5,7 @@ import pytest
 import matplotlib
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
+from matplotlib.ticker import EngFormatter
 
 
 with warnings.catch_warnings():
@@ -31,3 +32,18 @@ def test_usetex():
             fontsize=24)
     ax.set_xticks([])
     ax.set_yticks([])
+
+
+@needs_usetex
+def test_usetex_engformatter():
+    matplotlib.rcParams['text.usetex'] = True
+    fig, ax = plt.subplots()
+    ax.plot([0, 500, 1000], [0, 500, 1000])
+    ax.set_xticks([0, 500, 1000])
+    formatter = EngFormatter()
+    ax.xaxis.set_major_formatter(formatter)
+    fig.canvas.draw()
+    x_tick_label_text = [label.get_text() for label in ax.get_xticklabels()]
+    # Checking if the dollar `$` signs have been inserted around numbers
+    # in tick label text.
+    assert x_tick_label_text == ['$0$', '$500$', '$1$ k']

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1283,9 +1283,12 @@ class EngFormatter(Formatter):
             pow10 += 3
 
         prefix = self.ENG_PREFIXES[int(pow10)]
-
-        formatted = "{mant:{fmt}}{sep}{prefix}".format(
-            mant=mant, sep=self.sep, prefix=prefix, fmt=fmt)
+        if rcParams['text.usetex']:
+            formatted = "${mant:{fmt}}${sep}{prefix}".format(
+                mant=mant, sep=self.sep, prefix=prefix, fmt=fmt)
+        else:
+            formatted = "{mant:{fmt}}{sep}{prefix}".format(
+                mant=mant, sep=self.sep, prefix=prefix, fmt=fmt)
 
         return formatted
 


### PR DESCRIPTION
## PR Summary

`ScalarFormatter` correctly formats the numbers in ticklabels using `$` signs when used with `usetex=True` but `EngFormatter` doesn't do so (hence the numbers show up in "text font" instead of "math font"). This results in inconsistent fonts if one of the axes uses `EngFormatter` but the other one doesn't (see the example below). This PR fixes that by correctly formatting the numbers in ticklabels when `EngFormatter` is used.

One workaround (as suggested in a related issue https://github.com/matplotlib/matplotlib/issues/11586#issuecomment-406786746) is to turn off `usetex` for the axis that uses `ScalarFormatter` so that both the axes show ticklables in "text font" (For example -- `ax.yaxis.get_major_formatter()._usetex = False`).

I think the solution suggested in this PR is much better since it results in consistent (and expected) behavior across different Formatters without having to use the non-public attribute `._usetex`.

```python
import matplotlib.pyplot as plt
from matplotlib.ticker import EngFormatter
import numpy as np
plt.rc('text', usetex=True)
plt.rc('font', size=14)

fig, ax = plt.subplots(figsize=(3.0, 2), constrained_layout=True)
ax.plot(np.arange(2000))
ax.set_xticks([0, 500, 1000, 1500, 2000])
ax.set_yticks([0, 500, 1000, 1500, 2000])
formatter = EngFormatter(sep=r'\,')
ax.xaxis.set_major_formatter(formatter)
fig.savefig('test.png', dpi=200)
```

### **Before the PR:**
![old](https://user-images.githubusercontent.com/15175620/48756025-8874ad00-ec65-11e8-9068-b642f6cb519a.png)

### **After the PR:**
![new](https://user-images.githubusercontent.com/15175620/48756096-b823b500-ec65-11e8-823a-01a21e5fef68.png)

## PR Checklist

- ~~[ ] Has Pytest style unit tests~~
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- ~~[ ] New features are documented, with examples if plot related~~
- ~~[ ] Documentation is sphinx and numpydoc compliant~~
- ~~[ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- ~~[ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
