### PR TITLE
added property  usemathtext to EngFormatter

### DIFF
--- a/doc/users/next_whats_new/engformatter_usetex_usemathtext.rst
+++ b/doc/users/next_whats_new/engformatter_usetex_usemathtext.rst
@@ -1,11 +1,14 @@
 `EngFormatter` now accepts `usetex`, `useMathText` as keyword only arguments
-``````````````````````````````````````````````````````````````````````````````````````````````
+````````````````````````````````````````````````````````````````````````````
 
-A public API has been added to `EngFormatter` to control how the numbers in the ticklabels will be rendered.
-By default, `useMathText` evaluates to `rcParams['axes.formatter.use_mathtext']` and
-`usetex` evaluates to `rcParams['text.usetex']`.
+A public API has been added to `EngFormatter` to control how the numbers in the
+ ticklabels will be rendered. By default, ``useMathText`` evaluates to
+ ``rcParams['axes.formatter.use_mathtext']`` and ``usetex`` evaluates to
+ ``rcParams['text.usetex']``.
 
-If either is `True` then  the numbers will be encapsulated by `$` signs. When using `TeX` this implies
-that the numbers will be shown in TeX's math font. When using mathtext, the `$` signs around numbers will
-ensure unicode rendering (as implied by mathtext). This will make sure that the minus signs in the ticks
-are rendered as the unicode-minus (U+2212) when using mathtext (without relying on the `fix_minus` method).
+If either is ``True`` then  the numbers will be encapsulated by ``$`` signs.
+ When using ``TeX`` this implies that the numbers will be shown in TeX's math
+ font. When using mathtext, the ``$`` signs around numbers will ensure unicode
+ rendering (as implied by mathtext). This will make sure that the minus signs
+ in the ticks are rendered as the unicode-minus (U+2212) when using mathtext
+ (without relying on the ``fix_minus`` method).

--- a/doc/users/next_whats_new/engformatter_usetex_usemathtext.rst
+++ b/doc/users/next_whats_new/engformatter_usetex_usemathtext.rst
@@ -1,7 +1,7 @@
 `EngFormatter` now accepts `usetex`, `useMathText` as keyword only arguments
 ``````````````````````````````````````````````````````````````````````````````````````````````
 
-A public API has been added to `EngFormatter` control how the numbers in the ticklabels will be rendered.
+A public API has been added to `EngFormatter` to control how the numbers in the ticklabels will be rendered.
 By default, `useMathText` evaluates to `rcParams['axes.formatter.use_mathtext']` and
 `usetex` evaluates to `rcParams['text.usetex']`.
 

--- a/doc/users/next_whats_new/engformatter_usetex_usemathtext.rst
+++ b/doc/users/next_whats_new/engformatter_usetex_usemathtext.rst
@@ -1,0 +1,11 @@
+`EngFormatter` now accepts `usetex`, `useMathText` as keyword only arguments
+``````````````````````````````````````````````````````````````````````````````````````````````
+
+A public API has been added to `EngFormatter` control how the numbers in the ticklabels will be rendered.
+By default, `useMathText` evaluates to `rcParams['axes.formatter.use_mathtext']` and
+`usetex` evaluates to `rcParams['text.usetex']`.
+
+If either is `True` then  the numbers will be encapsulated by `$` signs. When using `TeX` this implies
+that the numbers will be shown in TeX's math font. When using mathtext, the `$` signs around numbers will
+ensure unicode rendering (as implied by mathtext). This will make sure that the minus signs in the ticks
+are rendered as the unicode-minus (U+2212) when using mathtext (without relying on the `fix_minus` method).

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -788,17 +788,18 @@ class TestEngFormatter(object):
                 assert _formatter(input) == _exp_output
 
 
-def test_engformatter_mathtext():
+def test_engformatter_usetex_useMathText():
     fig, ax = plt.subplots()
     ax.plot([0, 500, 1000], [0, 500, 1000])
     ax.set_xticks([0, 500, 1000])
-    formatter = mticker.EngFormatter(useMathText=True)
-    ax.xaxis.set_major_formatter(formatter)
-    fig.canvas.draw()
-    x_tick_label_text = [label.get_text() for label in ax.get_xticklabels()]
-    # Checking if the dollar `$` signs have been inserted around numbers
-    # in tick label text.
-    assert x_tick_label_text == ['$0$', '$500$', '$1$ k']
+    for formatter in (mticker.EngFormatter(usetex=True),
+                      mticker.EngFormatter(useMathText=True)):
+        ax.xaxis.set_major_formatter(formatter)
+        fig.canvas.draw()
+        x_tick_label_text = [labl.get_text() for labl in ax.get_xticklabels()]
+        # Checking if the dollar `$` signs have been inserted around numbers
+        # in tick labels.
+        assert x_tick_label_text == ['$0$', '$500$', '$1$ k']
 
 
 class TestPercentFormatter(object):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -788,6 +788,19 @@ class TestEngFormatter(object):
                 assert _formatter(input) == _exp_output
 
 
+def test_engformatter_mathtext():
+    fig, ax = plt.subplots()
+    ax.plot([0, 500, 1000], [0, 500, 1000])
+    ax.set_xticks([0, 500, 1000])
+    formatter = mticker.EngFormatter(useMathText=True)
+    ax.xaxis.set_major_formatter(formatter)
+    fig.canvas.draw()
+    x_tick_label_text = [label.get_text() for label in ax.get_xticklabels()]
+    # Checking if the dollar `$` signs have been inserted around numbers
+    # in tick label text.
+    assert x_tick_label_text == ['$0$', '$500$', '$1$ k']
+
+
 class TestPercentFormatter(object):
     percent_data = [
         # Check explicitly set decimals over different intervals and values

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -32,18 +32,3 @@ def test_usetex():
             fontsize=24)
     ax.set_xticks([])
     ax.set_yticks([])
-
-
-@needs_usetex
-def test_usetex_engformatter():
-    matplotlib.rcParams['text.usetex'] = True
-    fig, ax = plt.subplots()
-    ax.plot([0, 500, 1000], [0, 500, 1000])
-    ax.set_xticks([0, 500, 1000])
-    formatter = EngFormatter()
-    ax.xaxis.set_major_formatter(formatter)
-    fig.canvas.draw()
-    x_tick_label_text = [label.get_text() for label in ax.get_xticklabels()]
-    # Checking if the dollar `$` signs have been inserted around numbers
-    # in tick label text.
-    assert x_tick_label_text == ['$0$', '$500$', '$1$ k']

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1200,7 +1200,7 @@ class EngFormatter(Formatter):
          24: "Y"
     }
 
-    def __init__(self, unit="", places=None, sep=" "):
+    def __init__(self, unit="", places=None, sep=" ", useMathText=None):
         """
         Parameters
         ----------
@@ -1230,7 +1230,20 @@ class EngFormatter(Formatter):
         self.unit = unit
         self.places = places
         self.sep = sep
-        self._usetex = rcParams['text.usetex']
+        if useMathText is None:
+            useMathText = rcParams['axes.formatter.use_mathtext']
+        self.set_useMathText(useMathText)
+
+    def get_useMathText(self):
+        return self._useMathText
+
+    def set_useMathText(self, val):
+        if val is None:
+            self._useMathText = rcParams['axes.formatter.use_mathtext']
+        else:
+            self._useMathText = val
+
+    useMathText = property(fget=get_useMathText, fset=set_useMathText)
 
     def __call__(self, x, pos=None):
         s = "%s%s" % (self.format_eng(x), self.unit)
@@ -1282,7 +1295,7 @@ class EngFormatter(Formatter):
             pow10 += 3
 
         prefix = self.ENG_PREFIXES[int(pow10)]
-        if self._usetex:
+        if self._useMathText:
             formatted = "${mant:{fmt}}${sep}{prefix}".format(
                 mant=mant, sep=self.sep, prefix=prefix, fmt=fmt)
         else:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1200,7 +1200,8 @@ class EngFormatter(Formatter):
          24: "Y"
     }
 
-    def __init__(self, unit="", places=None, sep=" ", useMathText=None):
+    def __init__(self, unit="", places=None, sep=" ", usetex=None,
+                 useMathText=None):
         """
         Parameters
         ----------
@@ -1226,13 +1227,31 @@ class EngFormatter(Formatter):
             * ``sep="\\N{THIN SPACE}"`` (``U+2009``);
             * ``sep="\\N{NARROW NO-BREAK SPACE}"`` (``U+202F``);
             * ``sep="\\N{NO-BREAK SPACE}"`` (``U+00A0``).
+                `
+        usetex : bool (default: None)
+            To enable/disable the use of TeX's math mode for rendering the
+            numbers in the formatter.
+
+        useMathText : bool (default: None)
+            To enable/disable the use mathtext for rendering the numbers in
+            the formatter.
         """
         self.unit = unit
         self.places = places
         self.sep = sep
-        if useMathText is None:
-            useMathText = rcParams['axes.formatter.use_mathtext']
+        self.set_usetex(usetex)
         self.set_useMathText(useMathText)
+
+    def get_usetex(self):
+        return self._usetex
+
+    def set_usetex(self, val):
+        if val is None:
+            self._usetex = rcParams['text.usetex']
+        else:
+            self._usetex = val
+
+    usetex = property(fget=get_usetex, fset=set_usetex)
 
     def get_useMathText(self):
         return self._useMathText
@@ -1295,7 +1314,7 @@ class EngFormatter(Formatter):
             pow10 += 3
 
         prefix = self.ENG_PREFIXES[int(pow10)]
-        if self._useMathText:
+        if self._usetex or self._useMathText:
             formatted = "${mant:{fmt}}${sep}{prefix}".format(
                 mant=mant, sep=self.sep, prefix=prefix, fmt=fmt)
         else:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1227,7 +1227,7 @@ class EngFormatter(Formatter):
             * ``sep="\\N{THIN SPACE}"`` (``U+2009``);
             * ``sep="\\N{NARROW NO-BREAK SPACE}"`` (``U+202F``);
             * ``sep="\\N{NO-BREAK SPACE}"`` (``U+00A0``).
-                `
+
         usetex : bool (default: None)
             To enable/disable the use of TeX's math mode for rendering the
             numbers in the formatter.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1230,6 +1230,7 @@ class EngFormatter(Formatter):
         self.unit = unit
         self.places = places
         self.sep = sep
+        self._usetex = rcParams['text.usetex']
 
     def __call__(self, x, pos=None):
         s = "%s%s" % (self.format_eng(x), self.unit)
@@ -1281,7 +1282,7 @@ class EngFormatter(Formatter):
             pow10 += 3
 
         prefix = self.ENG_PREFIXES[int(pow10)]
-        if rcParams['text.usetex']:
+        if self._usetex:
             formatted = "${mant:{fmt}}${sep}{prefix}".format(
                 mant=mant, sep=self.sep, prefix=prefix, fmt=fmt)
         else:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1200,7 +1200,7 @@ class EngFormatter(Formatter):
          24: "Y"
     }
 
-    def __init__(self, unit="", places=None, sep=" ", usetex=None,
+    def __init__(self, unit="", places=None, sep=" ", *, usetex=None,
                  useMathText=None):
         """
         Parameters


### PR DESCRIPTION
## PR Summary
Based on https://github.com/matplotlib/matplotlib/pull/12847#issuecomment-440497607

~~Adding `._usetex` as an attribute for EngFormatter so as to allow the user to set it to `False` (resulting in numbers being displayed using text font instead of math font). This will be consistent with what `ScalarFormatter` allows.~~
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
