### PR TITLE
ENH: LogLocator: check for correct dimension of subs added

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1260,3 +1260,12 @@ def test_remove_overlap(remove_overlapping_locs, expected_num):
     assert len(ax.xaxis.get_minor_ticks()) == expected_num
     assert len(ax.xaxis.get_minorticklabels()) == expected_num
     assert len(ax.xaxis.get_minorticklines()) == expected_num*2
+
+
+@pytest.mark.parametrize('sub', [
+    ['hi', 'aardvark'],
+    np.zeros((2, 2))])
+def test_bad_locator_subs(sub):
+    ll = mticker.LogLocator()
+    with pytest.raises(ValueError):
+        ll.subs(sub)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2382,7 +2382,16 @@ class LogLocator(Locator):
             cbook._check_in_list(('all', 'auto'), subs=subs)
             self._subs = subs
         else:
-            self._subs = np.asarray(subs, dtype=float)
+            try:
+                self._subs = np.asarray(subs, dtype=float)
+            except ValueError as e:
+                raise ValueError("If subs is not None and not a string, "
+                                 "it must be a sequence of float.") from e
+            if self._subs.ndim != 1:
+                raise ValueError("If subs is not None and not a string, it "
+                                 "must be a sequence of float. Hence subs "
+                                 "should have 1 dimension but it has {} "
+                                 "dimensions.".format(self._subs.ndim))
 
     def __call__(self):
         'Return the locations of the ticks'

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2385,13 +2385,13 @@ class LogLocator(Locator):
             try:
                 self._subs = np.asarray(subs, dtype=float)
             except ValueError as e:
-                raise ValueError("If subs is not None and not a string, "
-                                 "it must be a sequence of float.") from e
+                raise ValueError("subs must be None, 'all', 'auto' or "
+                                 "a sequence of floats, not "
+                                 "{}.".format(subs)) from e
             if self._subs.ndim != 1:
-                raise ValueError("If subs is not None and not a string, it "
-                                 "must be a sequence of float. Hence subs "
-                                 "should have 1 dimension but it has {} "
-                                 "dimensions.".format(self._subs.ndim))
+                raise ValueError("A sequence passed to subs must be "
+                                 "1-dimensional, not "
+                                 "{}-dimensional.".format(self._subs.ndim))
 
     def __call__(self):
         'Return the locations of the ticks'


### PR DESCRIPTION
Some checks with explanatory error messages are added to the `subs` method of the `LogLocator`.