### PR TITLE
Don't use deprecated wx.NewId().

### DIFF
--- a/examples/user_interfaces/embedding_in_wx4_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx4_sgskip.py
@@ -17,19 +17,16 @@ import wx
 
 
 class MyNavigationToolbar(NavigationToolbar):
-    """
-    Extend the default wx toolbar with your own event handlers
-    """
-    ON_CUSTOM = wx.NewId()
+    """Extend the default wx toolbar with your own event handlers."""
 
     def __init__(self, canvas, cankill):
         NavigationToolbar.__init__(self, canvas)
 
         # for simplicity I'm going to reuse a bitmap from wx, you'll
         # probably want to add your own.
-        self.AddTool(self.ON_CUSTOM, 'Click me', _load_bitmap('back.png'),
-                     'Activate custom contol')
-        self.Bind(wx.EVT_TOOL, self._on_custom, id=self.ON_CUSTOM)
+        tool = self.AddTool(wx.ID_ANY, 'Click me', _load_bitmap('back.png'),
+                            'Activate custom contol')
+        self.Bind(wx.EVT_TOOL, self._on_custom, id=tool.GetId())
 
     def _on_custom(self, evt):
         # add some text to the axes in a random location in axes (0,1)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -713,11 +713,10 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         """
         if hasattr(self, '_event_loop'):
             raise RuntimeError("Event loop already running")
-        id = wx.NewId()
-        timer = wx.Timer(self, id=id)
+        timer = wx.Timer(self, id=wx.ID_ANY)
         if timeout > 0:
             timer.Start(timeout * 1000, oneShot=True)
-            self.Bind(wx.EVT_TIMER, self.stop_event_loop, id=id)
+            self.Bind(wx.EVT_TIMER, self.stop_event_loop, id=timer.GetId())
 
         # Event loop handler for start/stop event loop
         self._event_loop = wx.GUIEventLoop()
@@ -1293,26 +1292,6 @@ class FigureManagerWx(FigureManagerBase):
         self.canvas.SetInitialSize(wx.Size(width, height))
         self.window.GetSizer().Fit(self.window)
 
-# Identifiers for toolbar controls - images_wx contains bitmaps for the images
-# used in the controls. wxWindows does not provide any stock images, so I've
-# 'stolen' those from GTK2, and transformed them into the appropriate format.
-# import images_wx
-
-
-_NTB_AXISMENU = wx.NewId()
-_NTB_AXISMENU_BUTTON = wx.NewId()
-_NTB_X_PAN_LEFT = wx.NewId()
-_NTB_X_PAN_RIGHT = wx.NewId()
-_NTB_X_ZOOMIN = wx.NewId()
-_NTB_X_ZOOMOUT = wx.NewId()
-_NTB_Y_PAN_UP = wx.NewId()
-_NTB_Y_PAN_DOWN = wx.NewId()
-_NTB_Y_ZOOMIN = wx.NewId()
-_NTB_Y_ZOOMOUT = wx.NewId()
-# _NTB_SUBPLOT            =wx.NewId()
-_NTB_SAVE = wx.NewId()
-_NTB_CLOSE = wx.NewId()
-
 
 def _load_bitmap(filename):
     """
@@ -1356,7 +1335,7 @@ class MenuButtonWx(wx.Button):
 
     def __init__(self, parent):
 
-        wx.Button.__init__(self, parent, _NTB_AXISMENU_BUTTON, "Axes:        ",
+        wx.Button.__init__(self, parent, wx.ID_ANY, "Axes:        ",
                            style=wx.BU_EXACTFIT)
         self._toolbar = parent
         self._menu = wx.Menu()
@@ -1369,7 +1348,7 @@ class MenuButtonWx(wx.Button):
                           False)
         self._menu.AppendSeparator()
 
-        self.Bind(wx.EVT_BUTTON, self._onMenuButton, id=_NTB_AXISMENU_BUTTON)
+        self.Bind(wx.EVT_BUTTON, self._onMenuButton, id=self.GetId())
         self.Bind(wx.EVT_MENU, self._handleSelectAllAxes, id=self._allId)
         self.Bind(wx.EVT_MENU, self._handleInvertAxesSelected,
                   id=self._invertId)


### PR DESCRIPTION
There are some uses left in MenuButton but that class also needs to be
deprecated anyways (#10209).

Closes #12859.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
