### PR TITLE
Avoid 1-tick or 0-tick log-scaled axis.

### DIFF
--- a/doc/api/next_api_changes/2018-11-23-AL.rst
+++ b/doc/api/next_api_changes/2018-11-23-AL.rst
@@ -1,0 +1,6 @@
+Log-scaled axes avoid having zero or only one tick
+``````````````````````````````````````````````````
+
+When the default `LogLocator` would generate no ticks for an axis (e.g., an
+axis with limits from 0.31 to 0.39) or only a single tick, it now instead falls
+back on the linear `AutoLocator` to pick reasonable tick positions.

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,7 +1,7 @@
 import warnings
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
 import matplotlib
@@ -178,6 +178,11 @@ class TestLogLocator(object):
         loc = mticker.LogLocator(base=2)
         test_value = np.array([0.5, 1., 2., 4., 8., 16., 32., 64., 128., 256.])
         assert_almost_equal(loc.tick_values(1, 100), test_value)
+
+    def test_switch_to_autolocator(self):
+        loc = mticker.LogLocator(subs="all")
+        assert_array_equal(loc.tick_values(0.45, 0.55),
+                           [0.44, 0.46, 0.48, 0.5, 0.52, 0.54, 0.56])
 
     def test_set_params(self):
         """

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2165,13 +2165,13 @@ class LogLocator(Locator):
                     "log-scaled.")
 
         _log.debug('vmin %s vmax %s', vmin, vmax)
-        vmin = math.log(vmin) / math.log(b)
-        vmax = math.log(vmax) / math.log(b)
 
         if vmax < vmin:
             vmin, vmax = vmax, vmin
+        log_vmin = math.log(vmin) / math.log(b)
+        log_vmax = math.log(vmax) / math.log(b)
 
-        numdec = math.floor(vmax) - math.ceil(vmin)
+        numdec = math.floor(log_vmax) - math.ceil(log_vmin)
 
         if isinstance(self._subs, str):
             _first = 2.0 if self._subs == 'auto' else 1.0
@@ -2195,11 +2195,12 @@ class LogLocator(Locator):
             while numdec // stride + 1 > numticks:
                 stride += 1
 
-        # Does subs include anything other than 1?
+        # Does subs include anything other than 1?  Essentially a hack to know
+        # whether we're a major or a minor locator.
         have_subs = len(subs) > 1 or (len(subs) == 1 and subs[0] != 1.0)
 
-        decades = np.arange(math.floor(vmin) - stride,
-                            math.ceil(vmax) + 2 * stride, stride)
+        decades = np.arange(math.floor(log_vmin) - stride,
+                            math.ceil(log_vmax) + 2 * stride, stride)
 
         if hasattr(self, '_transform'):
             ticklocs = self._transform.inverted().transform(decades)
@@ -2207,20 +2208,27 @@ class LogLocator(Locator):
                 if stride == 1:
                     ticklocs = np.ravel(np.outer(subs, ticklocs))
                 else:
-                    # no ticklocs if we have more than one decade
-                    # between major ticks.
-                    ticklocs = []
+                    # No ticklocs if we have >1 decade between major ticks.
+                    ticklocs = np.array([])
         else:
             if have_subs:
-                ticklocs = []
                 if stride == 1:
-                    for decadeStart in b ** decades:
-                        ticklocs.extend(subs * decadeStart)
+                    ticklocs = np.concatenate(
+                        [subs * decade_start for decade_start in b ** decades])
+                else:
+                    ticklocs = np.array([])
             else:
                 ticklocs = b ** decades
 
         _log.debug('ticklocs %r', ticklocs)
-        return self.raise_if_exceeds(np.asarray(ticklocs))
+        if (len(subs) > 1
+                and stride == 1
+                and ((vmin <= ticklocs) & (ticklocs <= vmax)).sum() <= 1):
+            # If we're a minor locator *that expects at least two ticks per
+            # decade* and the major locator stride is 1 and there's no more
+            # than one minor tick, switch to AutoLocator.
+            return AutoLocator().tick_values(vmin, vmax)
+        return self.raise_if_exceeds(ticklocs)
 
     def view_limits(self, vmin, vmax):
         'Try to choose the view limits intelligently'


### PR DESCRIPTION
... by switching to AutoLocator when the minor LogLocator would produce
no more than one tick.

The examples below come from #8768, which this fixes.

```
fig, axs = subplots(2)
axs[0].loglog([.53, .41], [.53, .41])
axs[1].loglog([0.45, 0.46], [0.45, 0.46])
```
![test](https://user-images.githubusercontent.com/1322974/48915237-41adcf80-ee7e-11e8-94ea-2318f8d23c28.png)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
