### PR TITLE
Simplify stride calculations in loglocator.

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2182,15 +2182,10 @@ class LogLocator(Locator):
         else:
             subs = self._subs
 
-        # get decades between major ticks.
-        stride = 1
-        if rcParams['_internal.classic_mode']:
-            # Leave the bug left over from the PY2-PY3 transition.
-            while numdec / stride + 1 > numticks:
-                stride += 1
-        else:
-            while numdec // stride + 1 > numticks:
-                stride += 1
+        # Get decades between major ticks.
+        stride = (max(math.ceil(numdec / (numticks - 1)), 1)
+                  if rcParams['_internal.classic_mode'] else
+                  (numdec + 1) // numticks + 1)
 
         # Does subs include anything other than 1?
         have_subs = len(subs) > 1 or (len(subs) == 1 and subs[0] != 1.0)


### PR DESCRIPTION
These are just algebraic manipulations:

In classic mode, we want the smallest stride so that

    numdec/stride+1 <= numticks

i.e.

    stride >= numdec/(numticks-1)

so stride is the ceil() of the RHS (and at least 1, to handle the case
vmin==vmax).

In nonclassic mode, we want the smallest stride so that

    numdec//stride+1 <= numticks, i.e. numdec//stride < numticks

(everything is integer), i.e.

    numdec < numticks*stride- 1

i.e.

    stride > (numdec+1)/numticks

so stride is 1 + the floor() of the LHS.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
