### PR TITLE
Drop compat code for outdated MSVC.

### DIFF
--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -5,11 +5,7 @@
 #ifndef MPLUTILS_H
 #define MPLUTILS_H
 
-#if defined(_MSC_VER) && _MSC_VER <= 1600
-typedef unsigned __int8   uint8_t;
-#else
 #include <stdint.h>
-#endif
 
 #ifdef _POSIX_C_SOURCE
 #    undef _POSIX_C_SOURCE
@@ -55,11 +51,5 @@ enum {
 const size_t NUM_VERTICES[] = { 1, 1, 1, 2, 3, 1 };
 
 extern "C" int add_dict_int(PyObject *dict, const char *key, long val);
-
-#if defined(_MSC_VER) && (_MSC_VER < 1800)
-namespace std {
-  inline bool isfinite(double num) { return _finite(num) != 0; }
-}
-#endif
 
 #endif


### PR DESCRIPTION
Per
https://wiki.python.org/moin/WindowsCompilers#Which_Microsoft_Visual_C.2B-.2B-_compiler_to_use_with_a_specific_Python_version_.3F
https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B

Py>=3.5+ requires VC++>=14, which corresponds to _MSV_VER>=1900, so drop
the now irrelevant #ifdef blocks.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
