### PR TITLE
Simplify use of Path._fast_from_codes_and_verts.

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1552,9 +1552,7 @@ class Transform(TransformNode):
         ``transform_path_affine(transform_path_non_affine(values))``.
         """
         x = self.transform_non_affine(path.vertices)
-        return Path._fast_from_codes_and_verts(x, path.codes,
-                {'interpolation_steps': path._interpolation_steps,
-                 'should_simplify': path.should_simplify})
+        return Path._fast_from_codes_and_verts(x, path.codes, path)
 
     def transform_angles(self, angles, pts, radians=False, pushoff=1e-5):
         """
@@ -2762,9 +2760,7 @@ class TransformedPath(TransformNode):
             self._transformed_points = \
                 Path._fast_from_codes_and_verts(
                     self._transform.transform_non_affine(self._path.vertices),
-                    None,
-                    {'interpolation_steps': self._path._interpolation_steps,
-                     'should_simplify': self._path.should_simplify})
+                    None, self._path)
         self._invalid = 0
 
     def get_transformed_points_and_affine(self):
@@ -2832,9 +2828,7 @@ class TransformedPatchPath(TransformedPath):
             self._transformed_points = \
                 Path._fast_from_codes_and_verts(
                     self._transform.transform_non_affine(patch_path.vertices),
-                    None,
-                    {'interpolation_steps': patch_path._interpolation_steps,
-                     'should_simplify': patch_path.should_simplify})
+                    None, patch_path)
         self._invalid = 0
 
 


### PR DESCRIPTION
## PR Summary

All uses of Path._fast_from_codes_and_verts create the internals dict by
copying the attribute from another Path.  Instead of having the caller
create that dict, just let him pass a Path from which to copy the
attributes.

Note that this means that the copying will now also use the
simplify_threshold from the previous Path; however I think it is clear
that the previous behavior of not copying it was an oversight
(compounded by the fact that simplify_threshold is rarely, if ever,
overwritten on a per-Path basis).

Builds on top of #12846, which removes one of these attributes (has_nonfinite, now a deprecated property).
Preparatory work towards #12850.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
