### PR TITLE
Restore special casing of grayscale images in PostScript backend.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -2,7 +2,6 @@
 A PostScript backend, which can produce both PostScript .ps and .eps.
 """
 
-import binascii
 import datetime
 import glob
 from io import StringIO, TextIOWrapper
@@ -13,6 +12,7 @@ import re
 import shutil
 import subprocess
 from tempfile import TemporaryDirectory
+import textwrap
 import time
 
 import numpy as np
@@ -392,26 +392,8 @@ class RendererPS(RendererBase):
         font.set_size(size, 72.0)
         return font
 
-    def _rgb(self, rgba):
-        h, w = rgba.shape[:2]
-        rgb = rgba[::-1, :, :3]
-        return h, w, rgb.tostring()
-
-    def _hex_lines(self, s, chars_per_line=128):
-        s = binascii.b2a_hex(s)
-        nhex = len(s)
-        lines = []
-        for i in range(0, nhex, chars_per_line):
-            limit = min(i+chars_per_line, nhex)
-            lines.append(s[i:limit])
-        return lines
-
     def get_image_magnification(self):
-        """
-        Get the factor by which to magnify images passed to draw_image.
-        Allows a backend to have images at a different resolution to other
-        artists.
-        """
+        # docstring inherited
         return self.image_magnification
 
     def option_scale_image(self):
@@ -422,17 +404,22 @@ class RendererPS(RendererBase):
         # docstring inherited
         return not rcParams['image.composite_image']
 
-    def _get_image_h_w_bits_command(self, im):
-        h, w, bits = self._rgb(im)
-        imagecmd = "false 3 colorimage"
-
-        return h, w, bits, imagecmd
-
     def draw_image(self, gc, x, y, im, transform=None):
         # docstring inherited
 
-        h, w, bits, imagecmd = self._get_image_h_w_bits_command(im)
-        hexlines = b'\n'.join(self._hex_lines(bits)).decode('ascii')
+        h, w = im.shape[:2]
+        if ((im[..., 3] == 255).all()
+                and (im[..., 0] == im[..., 1]).all()
+                and (im[..., 0] == im[..., 2]).all()):
+            data = im[::-1, ..., 0]
+            imagecmd = "image"
+        else:
+            data = im[::-1, :, :3]
+            imagecmd = "false 3 colorimage"
+
+        # data.tobytes().hex() has no spaces, so can be linewrapped by relying
+        # on textwrap.fill breaking long words.
+        hexlines = textwrap.fill(data.tobytes().hex(), 128)
 
         if transform is None:
             matrix = "1 0 0 1 0 0"


### PR DESCRIPTION
This divides the filesize by ~3 by not storing three identical channels
(e.g. compare the size of
```
imshow(np.random.rand(255, 255), cmap="gray")
gca().set_axis_off()
savefig("test.ps")
```
before and after the patch).

Looks like some kind of similar functionality was present before mpl2.0, though with some weird magic factors (https://github.com/matplotlib/matplotlib/pull/5718/files#diff-b465967f537465fec4960b152fa49cffL415), and I stumbled on some vestigial leftovers of it (https://github.com/matplotlib/matplotlib/pull/5718/files#diff-b465967f537465fec4960b152fa49cffL457 where the "image" command comes from)...

No hard numbers but I don't think the performance cost (on non-grayscale images) really matters as we're going to iterate through the array just after to serialize it anyways.

Probably the same thing can be done for the pdf backend -- see `grayscale` parameter of `_writeImg`.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
