### PR TITLE
fooImage -> foo_image in testing/compare.py

### DIFF
--- a/doc/api/next_api_changes/2018-11-24-AL.rst
+++ b/doc/api/next_api_changes/2018-11-24-AL.rst
@@ -1,0 +1,10 @@
+API changes
+```````````
+The arguments of `matplotlib.testing.compare.calculate_rms` have been renamed
+from ``expectedImage, actualImage``, to ``expected_image, actual_image``.
+
+Deprecations
+````````````
+The ``matplotlib.testing.decorators.switch_backend`` decorator is deprecated.
+Test functions should use ``pytest.mark.backend(...)``, and the mark will be
+picked up by the ``matplotlib.testing.conftest.mpl_test_settings`` fixture.

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -352,14 +352,14 @@ def crop_to_same(actual_path, actual_image, expected_path, expected_image):
     return actual_image, expected_image
 
 
-def calculate_rms(expectedImage, actualImage):
+def calculate_rms(expected_image, actual_image):
     "Calculate the per-pixel errors, then compute the root mean square error."
-    if expectedImage.shape != actualImage.shape:
+    if expected_image.shape != actual_image.shape:
         raise ImageComparisonFailure(
             "Image sizes do not match expected size: {} "
-            "actual size {}".format(expectedImage.shape, actualImage.shape))
+            "actual size {}".format(expected_image.shape, actual_image.shape))
     # Convert to float to avoid overflowing finite integer types.
-    return np.sqrt(((expectedImage - actualImage).astype(float) ** 2).mean())
+    return np.sqrt(((expected_image - actual_image).astype(float) ** 2).mean())
 
 
 def compare_images(expected, actual, tol, in_decorator=False):
@@ -428,26 +428,26 @@ def compare_images(expected, actual, tol, in_decorator=False):
         expected = convert(expected, True)
 
     # open the image files and remove the alpha channel (if it exists)
-    expectedImage = _png.read_png_int(expected)
-    actualImage = _png.read_png_int(actual)
-    expectedImage = expectedImage[:, :, :3]
-    actualImage = actualImage[:, :, :3]
+    expected_image = _png.read_png_int(expected)
+    actual_image = _png.read_png_int(actual)
+    expected_image = expected_image[:, :, :3]
+    actual_image = actual_image[:, :, :3]
 
-    actualImage, expectedImage = crop_to_same(
-        actual, actualImage, expected, expectedImage)
+    actual_image, expected_image = crop_to_same(
+        actual, actual_image, expected, expected_image)
 
     diff_image = make_test_filename(actual, 'failed-diff')
 
     if tol <= 0:
-        if np.array_equal(expectedImage, actualImage):
+        if np.array_equal(expected_image, actual_image):
             return None
 
     # convert to signed integers, so that the images can be subtracted without
     # overflow
-    expectedImage = expectedImage.astype(np.int16)
-    actualImage = actualImage.astype(np.int16)
+    expected_image = expected_image.astype(np.int16)
+    actual_image = actual_image.astype(np.int16)
 
-    rms = calculate_rms(expectedImage, actualImage)
+    rms = calculate_rms(expected_image, actual_image)
 
     if rms <= tol:
         return None
@@ -481,21 +481,21 @@ def save_diff_image(expected, actual, output):
         File path to save difference image to.
     '''
     # Drop alpha channels, similarly to compare_images.
-    expectedImage = _png.read_png(expected)[..., :3]
-    actualImage = _png.read_png(actual)[..., :3]
-    actualImage, expectedImage = crop_to_same(
-        actual, actualImage, expected, expectedImage)
-    expectedImage = np.array(expectedImage).astype(float)
-    actualImage = np.array(actualImage).astype(float)
-    if expectedImage.shape != actualImage.shape:
+    expected_image = _png.read_png(expected)[..., :3]
+    actual_image = _png.read_png(actual)[..., :3]
+    actual_image, expected_image = crop_to_same(
+        actual, actual_image, expected, expected_image)
+    expected_image = np.array(expected_image).astype(float)
+    actual_image = np.array(actual_image).astype(float)
+    if expected_image.shape != actual_image.shape:
         raise ImageComparisonFailure(
             "Image sizes do not match expected size: {} "
-            "actual size {}".format(expectedImage.shape, actualImage.shape))
-    absDiffImage = np.abs(expectedImage - actualImage)
+            "actual size {}".format(expected_image.shape, actual_image.shape))
+    abs_diff_image = np.abs(expected_image - actual_image)
 
     # expand differences in luminance domain
-    absDiffImage *= 255 * 10
-    save_image_np = np.clip(absDiffImage, 0, 255).astype(np.uint8)
+    abs_diff_image *= 255 * 10
+    save_image_np = np.clip(abs_diff_image, 0, 255).astype(np.uint8)
     height, width, depth = save_image_np.shape
 
     # The PDF renderer doesn't produce an alpha channel, but the

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -487,6 +487,7 @@ def _image_directories(func):
     return str(baseline_dir), str(result_dir)
 
 
+@cbook.deprecated("3.1", alternative="pytest.mark.backend")
 def switch_backend(backend):
 
     def switch_backend_decorator(func):


### PR DESCRIPTION
Just to not make me cringe every time I read that file.

Also deprecate the unused decorators.switch_backend decorator (now
replaced by the backend pytest mark).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
