### PR TITLE
Pin pytest to <3.8 (for 3.0.x)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,8 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest>=3.4" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest>=3.4,<3.8" "pytest-cov>=2.3.1" pytest-rerunfailures
+    pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -8,7 +8,8 @@ pillow
 pyparsing
 # pytest-timeout master depends on pytest>=3.6. Testing with pytest 3.4 is
 # still supported; this is tested by the first travis python 3.5 build
-pytest>=3.6
+# pytest>=3.8 throws RemovedInPytest4Warning (github #12825)
+pytest>=3.6,<3.8
 pytest-cov
 pytest-faulthandler
 pytest-rerunfailures


### PR DESCRIPTION
## PR Summary

Fixes #12825 for 3.0.x (CI failure due to pytest warnings).

2.2.x must be handled separately.