### PR TITLE
Pin pytest to <3.8 (for 2.2.x)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,8 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest!=3.3.0,>=3.2.0" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest!=3.3.0,>=3.2.0,<3.8" "pytest-cov>=2.3.1"
+    pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,9 @@ env:
     - PYPARSING=pyparsing
     # pytest-timeout master depends on pytest>=3.6.  Testing with pytest 3.1 is
     # still supported; this is tested by the first matrix entry.
-    - PYTEST='pytest>=3.6'
+    - PYTEST='pytest>=3.6,<3.8'
     - PYTEST_COV=pytest-cov
+    - PYTEST_RERUNFAILURES=pytest-rerunfailures
     - PYTEST_PEP8=
     - PYTEST_TIMEOUT=pytest-timeout
     - SPHINX=sphinx
@@ -82,6 +83,7 @@ matrix:
         - PYTEST=pytest==3.1.0
         - PYTEST_COV=pytest-cov==2.3.1
         - PYTEST_TIMEOUT=pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest <3.4.
+        - PYTEST_RERUNFAILURES='pytest-rerunfailures<5'  # 5 needs pytest>=3.6
         - SPHINX=sphinx==1.3
     - python: 3.4
       env: PYTHON_ARGS=-OO
@@ -177,7 +179,7 @@ install:
         $PYTEST_COV \
         pytest-faulthandler \
         $PYTEST_PEP8 \
-        pytest-rerunfailures \
+        $PYTEST_RERUNFAILURES \
         $PYTEST_TIMEOUT \
         pytest-xdist
 


### PR DESCRIPTION
## PR Summary

Fixes #12825 for 2.2.x (CI failure due to pytest warnings).

3.0.x is handled separately in #12878.

This limits

- `pytest<3.8` because 3.8 starts issueing warnings that we do not want to fix in the 2.2.x code.
- `pytest-rerunfailures<5` for the py27 build because that build uses `pytest==3.1` and the new `pytest-rerunfailures==5` requires `pytest>=3.6`.