### PR TITLE
Improve margins in formlayout

### DIFF
--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -209,11 +209,30 @@ def is_edit_valid(edit):
 class FormWidget(QtWidgets.QWidget):
     update_buttons = QtCore.Signal()
 
-    def __init__(self, data, comment="", parent=None):
+    def __init__(self, data, comment="", with_margin=False, parent=None):
+        """
+        Parameters
+        ----------
+        data : list of (label, value) pairs
+            The data to be edited in the form.
+        comment : str, optional
+
+        with_margin : bool, optional, default: False
+            If False, the form elements reach to the border of the widget.
+            This is the desired behavior if the FormWidget is used as a widget
+            alongside with other widgets such as a QComboBox, which also do
+            not have a margin around them.
+            However, a margin can be desired if the FormWidget is the only
+            widget within a container, e.g. a tab in a QTabWidget.
+        parent : QWidget or None
+            The parent widget.
+        """
         QtWidgets.QWidget.__init__(self, parent)
         self.data = copy.deepcopy(data)
         self.widgets = []
         self.formlayout = QtWidgets.QFormLayout(self)
+        if not with_margin:
+            self.formlayout.setContentsMargins(0, 0, 0, 0)
         if comment:
             self.formlayout.addRow(QtWidgets.QLabel(comment))
             self.formlayout.addRow(QtWidgets.QLabel(" "))
@@ -370,13 +389,15 @@ class FormTabWidget(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout()
         self.tabwidget = QtWidgets.QTabWidget()
         layout.addWidget(self.tabwidget)
+        layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
         self.widgetlist = []
         for data, title, comment in datalist:
             if len(data[0]) == 3:
                 widget = FormComboWidget(data, comment=comment, parent=self)
             else:
-                widget = FormWidget(data, comment=comment, parent=self)
+                widget = FormWidget(data, with_margin=True, comment=comment,
+                                    parent=self)
             index = self.tabwidget.addTab(widget, title)
             self.tabwidget.setTabToolTip(index, comment)
             self.widgetlist.append(widget)


### PR DESCRIPTION
## PR Summary

The formlayout has some extra margins in some places. This happens when nesting widgets into a container widget with a layout, which by default has a margin. If you then layout the (transparent) container together with regular widgets. The margin of the container widget insets its content compared to other widgets in the outer layout. This results in extra large margins and edges not being aligned.

This PR removes the extra margins to give a more homogeneous look:

before:
![grafik](https://user-images.githubusercontent.com/2836374/48982658-c3536680-f0e5-11e8-8d39-baac40567e6a.png)

after:
![grafik](https://user-images.githubusercontent.com/2836374/48982640-7f606180-f0e5-11e8-9d02-a7d7f0814c93.png)
