### PR TITLE
Properly enable forward/backward buttons on Qt

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -856,6 +856,12 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                     self, "Error saving file", str(e),
                     QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.NoButton)
 
+    def set_history_buttons(self):
+        can_backward = self._nav_stack._pos > 0
+        can_forward = self._nav_stack._pos < len(self._nav_stack._elements) - 1
+        self._actions['back'].setEnabled(can_backward)
+        self._actions['forward'].setEnabled(can_forward)
+
 
 class SubplotToolQt(UiSubplotTool):
     def __init__(self, targetfig, parent):


### PR DESCRIPTION
## PR Summary

The forward/backward buttons were always enabled when using Qt.

This PR implements `set_history_buttons` as requested by `NavigationToolbar2` and thus provides deactivation of the buttons if they would have no effect.