### PR TITLE
Add Azure Pipelines build badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,11 @@
-|Travis|_ |AppVeyor|_ |Codecov|_ |LGTM|_ |PyPi|_ |Gitter|_ |NUMFocus|_ |GitTutorial|_
+|Travis|_ |AzurePipelines|_ |AppVeyor|_ |Codecov|_ |LGTM|_ |PyPi|_ |Gitter|_ |NUMFocus|_ |GitTutorial|_
 
 
 .. |Travis| image:: https://travis-ci.org/matplotlib/matplotlib.svg?branch=master
 .. _Travis: https://travis-ci.org/matplotlib/matplotlib
+
+.. |AzurePipelines| image:: https://dev.azure.com/matplotlib/matplotlib/_apis/build/status/matplotlib.matplotlib?branchName=master
+.. _AzurePipelines: https://dev.azure.com/matplotlib/matplotlib/_build/latest?definitionId=1&branchName=master
 
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/matplotlib/matplotlib?branch=master&svg=true
 .. _AppVeyor: https://ci.appveyor.com/project/matplotlib/matplotlib


### PR DESCRIPTION
Add a build badge for Azure Pipelines. The badge is scoped to reporting the status of the `master` branch.