### PR TITLE
FIX: (broken)bar(h) math before units

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2048,7 +2048,7 @@ class Axes(_AxesBase):
             try:
                 x = xconv[0]
             except (TypeError, IndexError, KeyError):
-                x =  xconv
+                x = xconv
 
             delist = False
             if not np.iterable(dx):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2012,20 +2012,51 @@ class Axes(_AxesBase):
         return self.plot(x, y, *args, data=data, **kwargs)
 
     @staticmethod
-    def _convert_dx(dx, x0, x, convert):
+    def _convert_dx(dx, x0, xconv, convert):
         """
         Small helper to do logic of width conversion flexibly.
 
-        *dx* and *x0* have units, but *x* has already been converted
-        to unitless.  This allows the *dx* to have units that are
-        different from *x0*, but are still accepted by the  ``__add__``
-        operator of *x0*.
+        *dx* and *x0* have units, but *xconv* has already been converted
+        to unitless (and is an ndarray).  This allows the *dx* to have units
+        that are different from *x0*, but are still accepted by the
+        ``__add__`` operator of *x0*.
         """
+
+        # x should be an array...
+        assert type(xconv) is np.ndarray
+
+        if xconv.size == 0:
+            # xconv has already been converted, but maybe empty...
+            return convert(dx)
+
         try:
             # attempt to add the width to x0; this works for
             # datetime+timedelta, for instance
-            dx = convert(x0 + dx) - x
-        except (TypeError, AttributeError):
+
+            # only use the first element of x and x0.  This saves
+            # having to be sure addition works across the whole
+            # vector.  This is particularly an issue if
+            # x0 and dx are lists so x0 + dx just concatenates the lists.
+            # We can't just cast x0 and dx to numpy arrays because that
+            # removes the units from unit packages like `pint`.
+            try:
+                x0 = x0[0]
+            except (TypeError, IndexError, KeyError):
+                x0 = x0
+
+            try:
+                x = xconv[0]
+            except (TypeError, IndexError, KeyError):
+                x =  xconv
+
+            delist = False
+            if not np.iterable(dx):
+                dx = [dx]
+                delist = True
+            dx = [convert(x0 + ddx) - x for ddx in dx]
+            if delist:
+                dx = dx[0]
+        except (TypeError, AttributeError) as e:
             # but doesn't work for 'string' + float, so just
             # see if the converter works on the float.
             dx = convert(dx)
@@ -2192,25 +2223,26 @@ class Axes(_AxesBase):
         else:
             raise ValueError('invalid orientation: %s' % orientation)
 
-        x, height, width, y, linewidth = np.broadcast_arrays(
-            # Make args iterable too.
-            np.atleast_1d(x), height, width, y, linewidth)
 
         # lets do some conversions now since some types cannot be
         # subtracted uniformly
         if self.xaxis is not None:
             x0 = x
-            x = self.convert_xunits(x)
+            x = np.asarray(self.convert_xunits(x))
             width = self._convert_dx(width, x0, x, self.convert_xunits)
             if xerr is not None:
                 xerr = self._convert_dx(xerr, x0, x, self.convert_xunits)
-
         if self.yaxis is not None:
             y0 = y
-            y = self.convert_yunits(y)
+            y = np.asarray(self.convert_yunits(y))
             height = self._convert_dx(height, y0, y, self.convert_yunits)
             if yerr is not None:
                 yerr = self._convert_dx(yerr, y0, y, self.convert_yunits)
+
+        x, height, width, y, linewidth = np.broadcast_arrays(
+            # Make args iterable too.
+            np.atleast_1d(x), height, width, y, linewidth)
+
 
         # Now that units have been converted, set the tick locations.
         if orientation == 'vertical':
@@ -2493,7 +2525,7 @@ class Axes(_AxesBase):
                 raise ValueError('each range in xrange must be a sequence '
                                  'with two elements (i.e. an Nx2 array)')
             # convert the absolute values, not the x and dx...
-            x_conv = self.convert_xunits(xr[0])
+            x_conv = np.asarray(self.convert_xunits(xr[0]))
             x1 = self._convert_dx(xr[1], xr[0], x_conv, self.convert_xunits)
             xranges_conv.append((x_conv, x1))
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2224,7 +2224,6 @@ class Axes(_AxesBase):
         else:
             raise ValueError('invalid orientation: %s' % orientation)
 
-
         # lets do some conversions now since some types cannot be
         # subtracted uniformly
         if self.xaxis is not None:
@@ -2243,7 +2242,6 @@ class Axes(_AxesBase):
         x, height, width, y, linewidth = np.broadcast_arrays(
             # Make args iterable too.
             np.atleast_1d(x), height, width, y, linewidth)
-
 
         # Now that units have been converted, set the tick locations.
         if orientation == 'vertical':

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2038,7 +2038,8 @@ class Axes(_AxesBase):
             # vector.  This is particularly an issue if
             # x0 and dx are lists so x0 + dx just concatenates the lists.
             # We can't just cast x0 and dx to numpy arrays because that
-            # removes the units from unit packages like `pint`.
+            # removes the units from unit packages like `pint` that
+            # wrap numpy arrays.
             try:
                 x0 = x0[0]
             except (TypeError, IndexError, KeyError):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1498,6 +1498,32 @@ def test_barh_tick_label():
             align='center')
 
 
+def test_bar_timedelta():
+    """smoketest that bar can handle width and height in delta units"""
+    fig, ax = plt.subplots()
+    ax.bar(datetime.datetime(2018, 1, 1), 1.,
+           width=datetime.timedelta(hours=3))
+    ax.bar(datetime.datetime(2018, 1, 1), 1.,
+           xerr=datetime.timedelta(hours=2),
+           width=datetime.timedelta(hours=3))
+    fig, ax = plt.subplots()
+    ax.barh(datetime.datetime(2018, 1, 1), 1,
+            height=datetime.timedelta(hours=3))
+    ax.barh(datetime.datetime(2018, 1, 1), 1,
+            height=datetime.timedelta(hours=3),
+            yerr=datetime.timedelta(hours=2))
+    fig, ax = plt.subplots()
+    ax.barh([datetime.datetime(2018, 1, 1), datetime.datetime(2018, 1, 1)],
+            np.array([1, 1.5]),
+            height=datetime.timedelta(hours=3))
+    ax.barh([datetime.datetime(2018, 1, 1), datetime.datetime(2018, 1, 1)],
+            np.array([1, 1.5]),
+            height=[datetime.timedelta(hours=t) for t in [1, 2]])
+    ax.broken_barh([(datetime.datetime(2018, 1, 1),
+                     datetime.timedelta(hours=1))],
+                   (10, 20))
+
+
 @image_comparison(baseline_images=['hist_log'],
                   remove_text=True)
 def test_hist_log():
@@ -5431,6 +5457,15 @@ def test_auto_numticks_log():
 def test_broken_barh_empty():
     fig, ax = plt.subplots()
     ax.broken_barh([], (.1, .5))
+
+
+def test_broken_barh_timedelta():
+    """Check that timedelta works as x, dx pair for this method """
+    fig, ax = plt.subplots()
+    pp = ax.broken_barh([(datetime.datetime(2018, 11, 9, 0, 0, 0),
+                          datetime.timedelta(hours=1))], [1, 2])
+    assert pp.get_paths()[0].vertices[0, 0] == 737007.0
+    assert pp.get_paths()[0].vertices[2, 0] == 737007.0 + 1 / 24
 
 
 def test_pandas_pcolormesh(pd):


### PR DESCRIPTION
## PR Summary

OK, this works w/ `bar`, `barh`, and `broken_barh`, and I think it even passes the tests....

~EDIT: now works w/ bar, but see issue below with the pdf (and pgf) determinism tests...~

EDIT:  OK, this may not work:   i.e. consider `ax.bar(['a', 'b'], ['c', 'd'])`.  Width defaults to 0.8, so we can't add 0.8 to 'a'.  It works fine for `datetime` and `timedelta` because they have addition defined, but you can't add a float to a string.  

So, we may have to go back to something like `delta = convert_units_delta(x, delta)` and then assume that the converter can do the math.  

Closes #12862

Also closes #11290, though it doesn't address the call for a timedelta formatter, but at least it doesn't crash!  Now time deltas work for both `bar` and `barh`.  

```python
import matplotlib.pyplot as plt
from datetime import datetime, timedelta

lo = datetime(2018, 11, 9, 20, 0, 0)
hi = datetime(2018, 11, 9, 22, 0, 0)

fig, ax = plt.subplots()

ax.set_xlim(lo-timedelta(hours=1), hi)
ax.set_ylim(0, 30)

ax.broken_barh([(lo, timedelta(hours=1))], (10, 20))
plt.show()

```

fails on master.  Now works by making sure that the timedelta math is done before the unit conversion is done.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->