### PR TITLE
Allow all valid hist.bins strings to be set in the rcparams

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6380,7 +6380,7 @@ class Axes(_AxesBase):
 
             With Numpy 1.11 or newer, you can alternatively provide a string
             describing a binning strategy, such as 'auto', 'sturges', 'fd',
-            'doane', 'scott', 'rice', 'sturges' or 'sqrt', see
+            'doane', 'scott', 'rice' or 'sqrt', see
             `numpy.histogram`.
 
             The default is taken from :rc:`hist.bins`.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -914,7 +914,8 @@ def validate_cycler(s):
 
 
 def validate_hist_bins(s):
-    if cbook._str_equal(s, "auto"):
+    valid_strs = ["auto", "sturges", "fd", "doane", "scott", "rice", "sqrt"]
+    if isinstance(s, str) and s in valid_strs:
         return s
     try:
         return int(s)
@@ -924,8 +925,8 @@ def validate_hist_bins(s):
         return validate_floatlist(s)
     except ValueError:
         pass
-    raise ValueError("'hist.bins' must be 'auto', an int or " +
-                     "a sequence of floats")
+    raise ValueError("'hist.bins' must be one of {}, an int or"
+                     " a sequence of floats".format(valid_strs))
 
 
 def validate_animation_writer_path(p):

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -321,6 +321,7 @@ def generate_validator_testcases(valid):
         },
         {'validator': validate_hist_bins,
          'success': (('auto', 'auto'),
+                     ('fd', 'fd'),
                      ('10', 10),
                      ('1, 2, 3', [1, 2, 3]),
                      ([1, 2, 3], [1, 2, 3]),


### PR DESCRIPTION
## PR Summary
Currently the one string that can be set in the rcParams is "auto". However there are a number of other strings that can be passed to the `bins` argument of `hist`. I think those should also be allowed to be set in the rcParams.

Also note in the docs one of the allowed strings `'sturges'` was repeated. I've removed the repeat.

Apologies if I have made any process mistakes - this is my first PR to matplotlib. I also didn't get tests running locally but if they fail here I will do that and fix any issues.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
