### PR TITLE
Suppress deprecation warning when testing drawstyle conflict

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5484,8 +5484,14 @@ def test_none_kwargs():
 
 
 def test_ls_ds_conflict():
-    with pytest.raises(ValueError):
-        plt.plot(range(32), linestyle='steps-pre:', drawstyle='steps-post')
+    with warnings.catch_warnings():
+        # Passing the drawstyle with the linestyle is deprecated since 3.1.
+        # We still need to test this until it's removed from the code.
+        # But we don't want to see the deprecation warning in the test.
+        warnings.filterwarnings('ignore',
+                                category=MatplotlibDeprecationWarning)
+        with pytest.raises(ValueError):
+            plt.plot(range(32), linestyle='steps-pre:', drawstyle='steps-post')
 
 
 def test_bar_uint8():


### PR DESCRIPTION
## PR Summary

The comment in the code says it all:

~~~
        # Passing the drawstyle with the linestyle is deprecated since 3.1.
        # We still need to test this until it's removed from the code.
        # But we don't want to see the deprecation warning in the test.
~~~
