### PR TITLE
Deprecate public use of Formatter.pprint_val.

### DIFF
--- a/doc/api/next_api_changes/2018-12-03-AL.rst
+++ b/doc/api/next_api_changes/2018-12-03-AL.rst
@@ -1,0 +1,3 @@
+``OldScalarFormatter.pprint_val``, ``ScalarFormatter.pprint_val``, and ``LogFormatter.pprint_val`` are deprecated
+`````````````````````````````````````````````````````````````````````````````````````````````````````````````````
+They are helper methods that do not even have a consistent signatures across formatter classes.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -428,22 +428,23 @@ class OldScalarFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         """
-        Return the format for tick val `x` based on the width of the
-        axis.
+        Return the format for tick val `x` based on the width of the axis.
 
         The position `pos` is ignored.
         """
         xmin, xmax = self.axis.get_view_interval()
         d = abs(xmax - xmin)
+        return self._pprint_val(x, d)
 
-        return self.pprint_val(x, d)
+    @cbook.deprecated("3.1")
+    def pprint_val(self, *args, **kwargs):
+        return self._pprint_val(*args, **kwargs)
 
-    def pprint_val(self, x, d):
+    def _pprint_val(self, x, d):
         """
         Formats the value `x` based on the size of the axis range `d`.
         """
-        #if the number is not too big and it's an int, format it as an
-        #int
+        # If the number is not too big and it's an int, format it as an int.
         if abs(x) < 1e4 and x == int(x):
             return '%d' % x
 
@@ -555,7 +556,7 @@ class ScalarFormatter(Formatter):
         if len(self.locs) == 0:
             return ''
         else:
-            s = self.pprint_val(x)
+            s = self._pprint_val(x)
             return self.fix_minus(s)
 
     def set_scientific(self, b):
@@ -766,7 +767,11 @@ class ScalarFormatter(Formatter):
         elif self._useMathText:
             self.format = '$%s$' % _mathdefault(self.format)
 
-    def pprint_val(self, x):
+    @cbook.deprecated("3.1")
+    def pprint_val(self, *args, **kwargs):
+        return self._pprint_val(*args, **kwargs)
+
+    def _pprint_val(self, x):
         xp = (x - self.offset) / (10. ** self.orderOfMagnitude)
         if np.abs(xp) < 1e-8:
             xp = 0
@@ -966,7 +971,7 @@ class LogFormatter(Formatter):
         elif x < 1:
             s = '%1.0e' % x
         else:
-            s = self.pprint_val(x, vmax - vmin)
+            s = self._pprint_val(x, vmax - vmin)
         return s
 
     def __call__(self, x, pos=None):
@@ -1007,9 +1012,12 @@ class LogFormatter(Formatter):
         """
         return '%-12g' % value
 
-    def pprint_val(self, x, d):
-        #if the number is not too big and it's an int, format it as an
-        #int
+    @cbook.deprecated("3.1")
+    def pprint_val(self, *args, **kwargs):
+        return self._pprint_val(*args, **kwargs)
+
+    def _pprint_val(self, x, d):
+        # If the number is not too big and it's an int, format it as an int.
         if abs(x) < 1e4 and x == int(x):
             return '%d' % x
 
@@ -1052,7 +1060,7 @@ class LogFormatterExponent(LogFormatter):
             s = '%1.0g' % fx
         else:
             fd = math.log(vmax - vmin) / math.log(self._base)
-            s = self.pprint_val(fx, fd)
+            s = self._pprint_val(fx, fd)
         return s
 
 


### PR DESCRIPTION
It's really a helper method.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
