### PR TITLE
MAINT: Correctly handle empty lists in zip unpacking in mplot3d.art3d

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -191,8 +191,12 @@ def path_to_3d_segment_with_codes(path, zs=0, zdir='z'):
     zs = np.broadcast_to(zs, len(path))
     pathsegs = path.iter_segments(simplify=False, curves=False)
     seg_codes = [((x, y, z), code) for ((x, y), code), z in zip(pathsegs, zs)]
-    seg, codes = zip(*seg_codes)
-    seg3d = [juggle_axes(x, y, z, zdir) for (x, y, z) in seg]
+    if seg_codes:
+        seg, codes = zip(*seg_codes)
+        seg3d = [juggle_axes(x, y, z, zdir) for (x, y, z) in seg]
+    else:
+        seg3d = []
+        codes = []
     return seg3d, list(codes)
 
 
@@ -204,7 +208,10 @@ def paths_to_3d_segments_with_codes(paths, zs=0, zdir='z'):
     zs = np.broadcast_to(zs, len(paths))
     segments_codes = [path_to_3d_segment_with_codes(path, pathz, zdir)
                       for path, pathz in zip(paths, zs)]
-    segments, codes = zip(*segments_codes)
+    if segments_codes:
+        segments, codes = zip(*segments_codes)
+    else:
+        segments, codes = [], []
     return list(segments), list(codes)
 
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -3,7 +3,7 @@ import pytest
 from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d, art3d
 from matplotlib import cm
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
-from matplotlib.collections import LineCollection
+from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import Circle
 import matplotlib.pyplot as plt
 import numpy as np
@@ -438,6 +438,13 @@ def test_poly3dcollection_closed():
                                 facecolor=(1, 0.5, 0.5, 0.5), closed=False)
     ax.add_collection3d(c1)
     ax.add_collection3d(c2)
+
+
+def test_poly_collection_2d_to_3d_empty():
+    poly = PolyCollection([])
+    art3d.poly_collection_2d_to_3d(poly)
+    assert isinstance(poly, art3d.Poly3DCollection)
+    assert poly.get_paths() == []
 
 
 @image_comparison(baseline_images=['axes3d_labelpad'], extensions=['png'])


### PR DESCRIPTION
This fixes a possible bug introduced in my earlier PR https://github.com/matplotlib/matplotlib/pull/12883, detected by @WeatherGod in https://github.com/matplotlib/matplotlib/pull/12883#pullrequestreview-178396664, where zip unpacking didn't correctly handle the case of empty lists.

It makes sense to add this specialized path in this case (with respect to the previous version), as zip unpacking is much faster, and those are performance sensitive parts of the code, as identified in https://github.com/matplotlib/matplotlib/pull/11577