### PR TITLE
textpath encoding

### DIFF
--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -184,3 +184,24 @@ def test_missing_psfont(monkeypatch):
     ax.text(0.5, 0.5, 'hello')
     with tempfile.TemporaryFile() as tmpfile, pytest.raises(ValueError):
         fig.savefig(tmpfile, format='svg')
+
+
+@needs_tex
+def test_unicode_won():
+    from pylab import rcParams, plot, ylabel, savefig
+    rcParams.update({'text.usetex': True, 'text.latex.unicode': True})
+
+    plot(1, 1)
+    ylabel(r'\textwon')
+
+    fd = BytesIO()
+    savefig(fd, format='svg')
+    fd.seek(0)
+    buf = fd.read().decode()
+    fd.close()
+
+    won_id = 'Computer_Modern_Sans_Serif-142'
+    def_regex = re.compile(r'<path d=(.|\s)*?id="{0}"/>'.format(won_id))
+    use_regex = re.compile(r'<use[^/>]*? xlink:href="#{0}"/>'.format(won_id))
+    assertTrue(bool(def_regex.search(buf)))
+    assertTrue(bool(use_regex.search(buf)))

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -1,22 +1,24 @@
 import numpy as np
 from io import BytesIO
 import os
+import re
 import tempfile
 import warnings
 import xml.parsers.expat
 
 import pytest
 
+import matplotlib as mpl
+from matplotlib import dviread
+from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
-import matplotlib
-from matplotlib import dviread
 
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
     needs_usetex = pytest.mark.skipif(
-        not matplotlib.checkdep_usetex(True),
+        not mpl.checkdep_usetex(True),
         reason="This test needs a TeX installation")
 
 
@@ -107,15 +109,10 @@ def test_bold_font_output_with_none_fonttype():
 
 def _test_determinism_save(filename, usetex):
     # This function is mostly copy&paste from "def test_visibility"
-    # To require no GUI, we use Figure and FigureCanvasSVG
-    # instead of plt.figure and fig.savefig
-    from matplotlib.figure import Figure
-    from matplotlib.backends.backend_svg import FigureCanvasSVG
-    from matplotlib import rc
-    rc('svg', hashsalt='asdf')
-    rc('text', usetex=usetex)
+    mpl.rc('svg', hashsalt='asdf')
+    mpl.rc('text', usetex=usetex)
 
-    fig = Figure()
+    fig = Figure()  # Require no GUI.
     ax = fig.add_subplot(111)
 
     x = np.linspace(0, 4 * np.pi, 50)
@@ -129,7 +126,7 @@ def _test_determinism_save(filename, usetex):
     ax.set_xlabel('A string $1+2+\\sigma$')
     ax.set_ylabel('A string $1+2+\\sigma$')
 
-    FigureCanvasSVG(fig).print_svg(filename)
+    fig.savefig(filename, format="svg")
 
 
 @pytest.mark.parametrize(
@@ -172,36 +169,30 @@ def test_determinism(filename, usetex):
 @needs_usetex
 def test_missing_psfont(monkeypatch):
     """An error is raised if a TeX font lacks a Type-1 equivalent"""
-    from matplotlib import rc
 
     def psfont(*args, **kwargs):
         return dviread.PsFont(texname='texfont', psname='Some Font',
                               effects=None, encoding=None, filename=None)
 
     monkeypatch.setattr(dviread.PsfontsMap, '__getitem__', psfont)
-    rc('text', usetex=True)
+    mpl.rc('text', usetex=True)
     fig, ax = plt.subplots()
     ax.text(0.5, 0.5, 'hello')
     with tempfile.TemporaryFile() as tmpfile, pytest.raises(ValueError):
         fig.savefig(tmpfile, format='svg')
 
 
-@needs_tex
+# Use Computer Modern Sans Serif, not Helvetica (which has no \textwon).
+@pytest.mark.style('default')
+@needs_usetex
 def test_unicode_won():
-    from pylab import rcParams, plot, ylabel, savefig
-    rcParams.update({'text.usetex': True, 'text.latex.unicode': True})
+    fig = Figure()
+    fig.text(.5, .5, r'\textwon', usetex=True)
 
-    plot(1, 1)
-    ylabel(r'\textwon')
-
-    fd = BytesIO()
-    savefig(fd, format='svg')
-    fd.seek(0)
-    buf = fd.read().decode()
-    fd.close()
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg')
+        buf = fd.getvalue().decode('ascii')
 
     won_id = 'Computer_Modern_Sans_Serif-142'
-    def_regex = re.compile(r'<path d=(.|\s)*?id="{0}"/>'.format(won_id))
-    use_regex = re.compile(r'<use[^/>]*? xlink:href="#{0}"/>'.format(won_id))
-    assertTrue(bool(def_regex.search(buf)))
-    assertTrue(bool(use_regex.search(buf)))
+    assert re.search(r'<path d=(.|\s)*?id="{0}"/>'.format(won_id), buf)
+    assert re.search(r'<use[^/>]*? xlink:href="#{0}"/>'.format(won_id), buf)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -312,8 +312,15 @@ class TextToPath(object):
                 font.set_size(self.FONT_SCALE, self.DPI)
                 # See comments in _get_ps_font_and_encoding.
                 if enc is not None:
-                    index = font.get_name_index(enc[glyph])
-                    font.load_glyph(index, flags=LOAD_TARGET_LIGHT)
+                    if glyph not in enc:
+                        _log.warning(
+                            "The glyph %d of font %s cannot be converted with "
+                            "the encoding; glyph may be wrong.",
+                            glyph, font.fname)
+                        font.load_char(glyph, flags=LOAD_TARGET_LIGHT)
+                    else:
+                        index = font.get_name_index(enc[glyph])
+                        font.load_glyph(index, flags=LOAD_TARGET_LIGHT)
                 else:
                     index = glyph
                     font.load_char(index, flags=LOAD_TARGET_LIGHT)


### PR DESCRIPTION
## PR Summary


Consider the following example.

    import matplotlib.pyplot as plt
    plt.rcParams['text.usetex'] = True
    plt.rcParams['text.latex.preamble'] = r'\usepackage{siunitx}'
    plt.rcParams['text.hinting_factor'] = 1
    plt.text(.5, .5, r'$\si{\degree}$')
    plt.text(.5, .4, r'ff\textwon')
    plt.gca().set_axis_off()
    plt.savefig('/tmp/plot.svg')
    plt.savefig('/tmp/plot.pdf')
    plt.savefig('/tmp/plot.png')
    plt.show()

In the svg output, one sees that the \degree and \textwon characters
(which come from a different font that the ff ligature) are now
correctly loaded, *but* at a too small size -- this still needs to be
fixedn but is already better than not loading the glyphs at all.
(pdf and png output are unaffected.)
![screenshot_20181203_174540](https://user-images.githubusercontent.com/1322974/49387965-53676080-f723-11e8-8882-aeff5df6f10f.png)

Supersedes #8286, #8415 (from which a test is taken).
Fixes part of #8068, #8280 (the glyph-loading part; the sizing issue is a bug this PR newly exposes).

Likely the bad font sizing has something to do with the use, in textpath.py of `self.FONT_SCALE` rather than `prop.get_size_in_points()`/`dvifont.size`...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
