### PR TITLE
FIX: skip gtk backend if gobject but not pygtk is installed

### DIFF
--- a/lib/matplotlib/backends/_gtk3_compat.py
+++ b/lib/matplotlib/backends/_gtk3_compat.py
@@ -40,7 +40,15 @@ if gi.__name__ == "pgi" and cairo.__name__ == "cairo":
 
 if gi.__name__ == "pgi" and gi.version_info < (0, 0, 11, 2):
     raise ImportError("The GTK3 backends are incompatible with pgi<0.0.11.2")
-gi.require_version("Gtk", "3.0")
+try:
+    # :raises ValueError: If module/version is already loaded, already
+    # required, or unavailable.
+    gi.require_version("Gtk", "3.0")
+except ValueError as e:
+    # in this case we want to re-raise as ImportError so the
+    # auto-backend selection logic correctly skips.
+    raise ImportError from e
+
 globals().update(
     {name:
      importlib.import_module("{}.repository.{}".format(gi.__name__, name))


### PR DESCRIPTION
It is possible to install gobject (which provides `gi`) but not
pygtk (which provide the `GTK` bindings).  This try-except converts
the ValueError that gi raises to an ImportError so our machinery works
correctly.




- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->