### PR TITLE
Fix xtick.minor.visible only acting on the xaxis

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -69,7 +69,8 @@ class LinearScale(ScaleBase):
         axis.set_major_formatter(ScalarFormatter())
         axis.set_minor_formatter(NullFormatter())
         # update the minor locator for x and y axis based on rcParams
-        if rcParams['xtick.minor.visible']:
+        if (axis.axis_name == 'x' and rcParams['xtick.minor.visible']
+            or axis.axis_name == 'y' and rcParams['ytick.minor.visible']):
             axis.set_minor_locator(AutoMinorLocator())
         else:
             axis.set_minor_locator(NullLocator())

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -851,3 +851,21 @@ def test_minlocator_type():
     fig, ax = plt.subplots()
     with pytest.raises(TypeError):
         ax.xaxis.set_minor_locator(matplotlib.ticker.LogFormatter())
+
+
+def test_minorticks_rc():
+    fig = plt.figure()
+
+    def minorticksubplot(xminor, yminor, i):
+        rc = {'xtick.minor.visible': xminor,
+              'ytick.minor.visible': yminor}
+        with plt.rc_context(rc=rc):
+            ax = fig.add_subplot(2, 2, i)
+
+        assert (len(ax.xaxis.get_minor_ticks()) > 0) == xminor
+        assert (len(ax.yaxis.get_minor_ticks()) > 0) == yminor
+
+    minorticksubplot(False, False, 1)
+    minorticksubplot(True, False, 2)
+    minorticksubplot(False, True, 3)
+    minorticksubplot(True, True, 4)


### PR DESCRIPTION
## PR Summary

#10193 introduced a bug, that when the rc param `xtick.minor.visible` is set to `True`, also the y-axis would get minor ticks.

```
import matplotlib.pyplot as plt
plt.rcParams["xtick.minor.visible"] =  True

plt.plot([1,2])
plt.show()
```

![minorticks_bug](https://user-images.githubusercontent.com/23121882/49555328-caf1e700-f8ff-11e8-8558-e63c41fc9104.png)

This PR fixes this. 
**with this PR**

![minorticks_fixed](https://user-images.githubusercontent.com/23121882/49555371-e9f07900-f8ff-11e8-88ef-946f9121a7a7.png)

Interestingly though,  `plt.rcParams["ytick.minor.visible"] =  True` always worked fine. So in that sense I'm not sure if the `Scale` would even need to set the locator the way it does.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
