### PR TITLE
Fix the title of testing_api

### DIFF
--- a/doc/api/testing_api.rst
+++ b/doc/api/testing_api.rst
@@ -1,6 +1,6 @@
-*******
-testing
-*******
+**********************
+``matplotlib.testing``
+**********************
 
 
 :mod:`matplotlib.testing`


### PR DESCRIPTION
## PR Summary

`testing_api.rst` still has a different title format compared to all other api docs:

![image](https://user-images.githubusercontent.com/2836374/49607478-561dbc00-f996-11e8-8259-4d5ef080ece7.png)

This PR fixes this.
