### PR TITLE
Correctly get weight & style hints from certain newer Microsoft fonts

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -321,9 +321,13 @@ def ttfFontProperty(font):
     sfnt = font.get_sfnt()
     # These tables are actually mac_roman-encoded, but mac_roman support may be
     # missing in some alternative Python implementations and we are only going
-    # to look for ASCII substrings, where any ASCII-compatible encoding works.
-    sfnt2 = sfnt.get((1, 0, 0, 2), b'').decode('latin-1').lower()
-    sfnt4 = sfnt.get((1, 0, 0, 4), b'').decode('latin-1').lower()
+    # to look for ASCII substrings, where any ASCII-compatible encoding works
+    # - or big-endian UTF-16, since important Microsoft fonts use that.
+    sfnt2 = (sfnt.get((1, 0,      0, 2), b'').decode('latin-1').lower() or
+             sfnt.get((3, 1, 0x0409, 2), b'').decode('utf_16_be').lower())
+    sfnt4 = (sfnt.get((1, 0,      0, 4), b'').decode('latin-1').lower() or
+             sfnt.get((3, 1, 0x0409, 4), b'').decode('utf_16_be').lower())
+
     if sfnt4.find('oblique') >= 0:
         style = 'oblique'
     elif sfnt4.find('italic') >= 0:

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import shutil
+import sys
 import warnings
 
 import numpy as np
@@ -87,3 +88,20 @@ def test_hinting_factor(factor):
     # Check that hinting only changes text layout by a small (10%) amount.
     np.testing.assert_allclose(hinted_font.get_width_height(), expected,
                                rtol=0.1)
+
+
+@pytest.mark.skipif(sys.platform != "win32",
+                   reason="Need Windows font to test against")
+def test_utf16m_sfnt():
+    segoe_ui_semibold = None
+    for f in fontManager.ttflist:
+        # seguisbi = Microsoft Segoe UI Semibold
+        if f.fname[-12:] == "seguisbi.ttf":
+            segoe_ui_semibold = f
+            break
+    else:
+        pytest.xfail(reason="Couldn't find font to test against.")
+
+    # Check that we successfully read the "semibold" from the font's
+    # sfnt table and set its weight accordingly
+    assert segoe_ui_semibold.weight == "semibold"


### PR DESCRIPTION
## PR Summary

We've been having some internationalization issues caused by MPL not loading our international font, Microsoft YaHei. Part of the problem is that YaHei got turned in to a .TTC by a Windows update, which we rectified by overlaying [this PR](https://github.com/matplotlib/matplotlib/pull/9787). But we still weren't getting what we wanted because matplotlib was displaying using YaHei Light instead of regular YaHei, and it looked really bad.

We tracked the issue down to the fact that the font manager wasn't identifying the light and regular versions as having different weights, making them appear identical and leading to plots using whichever one was higher up in the list.

We rectified this issue by giving `font_manager.ttfFontProperty` the ability to read Microsoft's SFNT tables. This allows matplotlib to correctly interpret the properties of a bunch of Windows default fonts including the one we were specifically interested in.

We just did this:
```
    sfnt2 = sfnt.get((1, 0, 0, 2), b'').decode('latin-1').lower() or \
            sfnt.get((3, 1, 0x0409, 2), b'').decode('utf_16_be').lower()
    sfnt4 = sfnt.get((1, 0, 0, 4), b'').decode('latin-1').lower() or \
            sfnt.get((3, 1, 0x0409, 4), b'').decode('utf_16_be').lower()
```

and it started working (the utf_16_be lines are the new ones.)

I haven't written a test for this yet since, honestly, we're just wondering if there's some obvious reason that this is a bad idea and hasn't been done already. If the community think it's a worthwhile addition I can finish it up as a proper PR though.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
