### PR TITLE
Search also for user fonts on Windows (#12954)

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -240,11 +240,11 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
     items = set()
 
     # System fonts
-    items.update(win32RegistryFonts(winreg.HKEY_LOCAL_MACHINE, directory))
+    items.update(_win32RegistryFonts(winreg.HKEY_LOCAL_MACHINE, directory))
 
     # User fonts
     for userdir in MSUserFontDirectories:
-        items.update(win32RegistryFonts(winreg.HKEY_CURRENT_USER, userdir))
+        items.update(_win32RegistryFonts(winreg.HKEY_CURRENT_USER, userdir))
 
     # Keep only paths with matching file extension.
     return [str(path) for path in items if path.suffix.lower() in fontext]
@@ -301,7 +301,7 @@ def findSystemFonts(fontpaths=None, fontext='ttf'):
         if sys.platform == 'win32':
             fontpaths = MSUserFontDirectories + [win32FontDirectory()]
             # now get all installed fonts directly...
-            fontfiles.update(_win32InstalledFonts(fontext=fontext))
+            fontfiles.update(win32InstalledFonts(fontext=fontext))
         else:
             fontpaths = X11FontDirectories
             if sys.platform == 'darwin':

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -177,10 +177,10 @@ def win32RegistryFonts(reg_domain, base_dir):
 
     Parameters
     ----------
-    reg_domain : `int`
+    reg_domain : int
         The top level registry domain (e.g. HKEY_LOCAL_MACHINE).
 
-    base_dir : `string`
+    base_dir : str
         The path to the folder where the font files are usually located (e.g.
         C:\Windows\Fonts). If only the filename of the font is stored in the
         registry, the absolute path is built relative to this base directory.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -171,7 +171,7 @@ def win32FontDirectory():
         return os.path.join(os.environ['WINDIR'], 'Fonts')
 
 
-def win32RegistryFonts(reg_domain, base_dir):
+def _win32RegistryFonts(reg_domain, base_dir):
     r"""
     Searches for fonts in the Windows registry.
 
@@ -223,7 +223,7 @@ def win32RegistryFonts(reg_domain, base_dir):
     return items
 
 
-def _win32InstalledFonts(directory=None, fontext='ttf'):
+def win32InstalledFonts(directory=None, fontext='ttf'):
     """
     Search for fonts in the specified font directory, or use the
     system directories if none given. Additionally, it is searched for user

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -223,7 +223,7 @@ def win32RegistryFonts(reg_domain, base_dir):
     return items
 
 
-def win32InstalledFonts(directory=None, fontext='ttf'):
+def _win32InstalledFonts(directory=None, fontext='ttf'):
     """
     Search for fonts in the specified font directory, or use the
     system directories if none given. Additionally, it is searched for user
@@ -301,7 +301,7 @@ def findSystemFonts(fontpaths=None, fontext='ttf'):
         if sys.platform == 'win32':
             fontpaths = MSUserFontDirectories + [win32FontDirectory()]
             # now get all installed fonts directly...
-            fontfiles.update(win32InstalledFonts(fontext=fontext))
+            fontfiles.update(_win32InstalledFonts(fontext=fontext))
         else:
             fontpaths = X11FontDirectories
             if sys.platform == 'darwin':

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -9,8 +9,9 @@ import numpy as np
 import pytest
 
 from matplotlib.font_manager import (
-    findfont, FontProperties, fontManager, json_dump, json_load, get_font,
-    get_fontconfig_fonts, is_opentype_cff_font)
+    findfont, findSystemFonts, FontProperties, fontManager, json_dump,
+    json_load, get_font, get_fontconfig_fonts, is_opentype_cff_font,
+    MSUserFontDirectories)
 from matplotlib import pyplot as plt, rc_context
 
 has_fclist = shutil.which('fc-list') is not None
@@ -124,3 +125,29 @@ def test_find_ttc():
         fig.savefig(BytesIO(), format="pdf")
     with pytest.raises(RuntimeError):
         fig.savefig(BytesIO(), format="ps")
+
+
+def test_user_fonts():
+    if not os.environ.get('APPVEYOR', False):
+        pytest.xfail('This test does only work on appveyor since user fonts '
+                     'are Windows specific')
+
+    font_test_file = 'mpltest.ttf'
+
+    # Precondition: the test font should not be available
+    fonts = findSystemFonts()
+    assert not any(font_test_file in font for font in fonts)
+
+    user_fonts_dir = MSUserFontDirectories[0]
+
+    # Make sure that the user font directory exists (this is probably not the
+    # case on Windows versions < 1809)
+    os.makedirs(user_fonts_dir)
+
+    # Copy the test font to the user font directory
+    shutil.copyfile(os.path.join(os.path.dirname(__file__), font_test_file),
+                    os.path.join(user_fonts_dir, font_test_file))
+
+    # Now, the font should be available
+    fonts = findSystemFonts()
+    assert any(font_test_file in font for font in fonts)

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -130,7 +130,8 @@ def test_find_ttc():
 def test_user_fonts():
     if not os.environ.get('APPVEYOR', False):
         pytest.xfail('This test does only work on appveyor since user fonts '
-                     'are Windows specific')
+                     'are Windows specific and the developer\'s font '
+                     'directory should remain unchanged')
 
     font_test_file = 'mpltest.ttf'
 


### PR DESCRIPTION
## PR Summary
This PR fixes #12954, i.e. the fonts installed to the user directory are now also found by matplotlib.
