### PR TITLE
Deprecate setting the same property under two different aliases.

### DIFF
--- a/doc/api/next_api_changes/2018-12-09-AL.rst
+++ b/doc/api/next_api_changes/2018-12-09-AL.rst
@@ -1,0 +1,19 @@
+Setting the same artist property multiple time via aliases is deprecated
+````````````````````````````````````````````````````````````````````````
+
+Previously, code such as ``plt.plot([0, 1], c="red", color="blue")`` would
+emit a warning indicating that ``c`` and ``color`` are aliases of one another,
+and only keep the ``color`` kwarg.  This behavior is deprecated; in a future
+version, this will raise a TypeError, similarly to Python's behavior when a
+keyword argument is passed twice (``plt.plot([0, 1], c="red", c="blue")``).
+
+This warning is raised by `~.cbook.normalize_kwargs`.
+
+Artist.set now normalizes keywords before sorting them
+``````````````````````````````````````````````````````
+
+`Artist.set` currently sorts its keyword arguments in reverse alphabetical
+order (with a special-case to put ``color`` at the end) before applying them.
+
+It now normalizes aliases (and, as above, emits a warning on duplicate
+properties) before doing the sorting (so ``c`` goes to the end too).

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1063,12 +1063,12 @@ class Artist(object):
         return ArtistInspector(self).properties()
 
     def set(self, **kwargs):
-        """A property batch setter. Pass *kwargs* to set properties.
-        """
+        """A property batch setter.  Pass *kwargs* to set properties."""
+        kwargs = cbook.normalize_kwargs(
+            kwargs, getattr(type(self), "_alias_map", {}))
         props = OrderedDict(
             sorted(kwargs.items(), reverse=True,
                    key=lambda x: (self._prop_order.get(x[0], 0), x[0])))
-
         return self.update(props)
 
     def findobj(self, match=None, include_self=True):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1725,9 +1725,11 @@ def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
         if tmp:
             ret[canonical] = tmp[-1]
             if len(tmp) > 1:
-                _warn_external("Saw kwargs {seen!r} which are all aliases for "
-                               "{canon!r}.  Kept value from {used!r}".format(
-                               seen=seen, canon=canonical, used=seen[-1]))
+                warn_deprecated(
+                    "3.1", message=f"Saw kwargs {seen!r} which are all "
+                    f"aliases for {canonical!r}.  Kept value from "
+                    f"{seen[-1]!r}.  Passing multiple aliases for the same "
+                    f"property will raise a TypeError %(removal)s.")
 
     # at this point we know that all keys which are aliased are removed, update
     # the return dictionary from the cleaned local copy of the input


### PR DESCRIPTION
This will allow getting rid of the notion of alias priority, and is
consistent with Python's behavior (as explained in the changelog entry).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
