### PR TITLE
Fix item check for pandas Series

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -49,9 +49,12 @@ def _has_item(data, name):
     availability) and with numpy.arrays.
     """
     try:
-        return data.dtype.names is not None and name in data.dtype.names
-    except AttributeError:  # not a numpy array
-        return name in data
+        if not type(data).__name__ == 'Series':
+            # numpy array
+            return data.dtype.names is not None and name in data.dtype.names
+    except AttributeError:
+        pass
+    return name in data
 
 
 def _plot_args_replacer(args, data):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -26,11 +26,33 @@ from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
 from matplotlib.cbook import (
     IgnoredKeywordWarning, MatplotlibDeprecationWarning)
+from matplotlib.axes._axes import _has_item
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have
 #       different baseline images to prevent race conditions when pytest runs
 #       the tests with multiple threads.
+
+
+def test_has_item():
+    d = {'a': 1, 'b': 2}
+    assert _has_item(d, 'a')
+    assert not _has_item(d, 'c')
+    d = np.array([(1, 11), (2, 22)], dtype=[('a', float), ('b', float)])
+    assert _has_item(d, 'a')
+    assert not _has_item(d, 'c')
+    d = np.array([1, 2])
+    assert not _has_item(d, 'a')
+
+
+def test_has_item_pandas(pd):
+    s = pd.Series([1, 2], index=['a', 'b'])
+    assert _has_item(s, 'a')
+    assert not _has_item(s, 'c')
+    df = pd.DataFrame([[1, 2], [3, 4]], index=['A', 'B'], columns=['a', 'b'])
+    assert _has_item(df, 'a')
+    assert not _has_item(df, 'A')
+    assert not _has_item(df, 'c')
 
 
 def test_get_labels():


### PR DESCRIPTION
## PR Summary

Fixes #12971.

This was a problem specific to pandas Series, which has a None `data.dtype.names` but still is index-accessible and can use `in`. Note that numpy arrays cannot use `in` and therefore must check for `data.dtype.names`.

## PR Checklist

- [x] Has Pytest style unit tests
