### PR TITLE
ENH: replace deprecated numpy header

### DIFF
--- a/src/qhull_wrap.c
+++ b/src/qhull_wrap.c
@@ -6,7 +6,7 @@
  * class without specifying a triangles array.
  */
 #include "Python.h"
-#include "numpy/noprefix.h"
+#include "numpy/ndarrayobject.h"
 #include "libqhull/qhull_a.h"
 #include <stdio.h>
 


### PR DESCRIPTION
Exchange an old (should be deprecated) header with the modern alternative

xref numpy/numpy#12475, numpy/numpy#12402