### PR TITLE
Canonicalize weights extracted for AFM fonts.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -398,7 +398,6 @@ def afmFontProperty(fontpath, font):
     -------
     `FontEntry`
         The extracted font properties.
-
     """
 
     name = font.get_familyname()
@@ -422,6 +421,8 @@ def afmFontProperty(fontpath, font):
         variant = 'normal'
 
     weight = font.get_weight().lower()
+    if weight not in weight_dict:
+        weight = 'normal'
 
     #  Stretch can be absolute and relative
     #  Absolute stretches are: ultra-condensed, extra-condensed, condensed,
@@ -935,7 +936,7 @@ class FontManager(object):
     # Increment this version number whenever the font cache data
     # format or behavior has changed and requires a existing font
     # cache files to be rebuilt.
-    __version__ = 300
+    __version__ = 310
 
     def __init__(self, size=None, weight='normal'):
         self._version = self.__version__

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
-import matplotlib.afm as afm
+from matplotlib import afm
+from matplotlib import font_manager as fm
 
 
 AFM_TEST_DATA = b"""StartFontMetrics 2.0
@@ -75,6 +76,12 @@ def test_parse_char_metrics():
 
 def test_get_familyname_guessed():
     fh = BytesIO(AFM_TEST_DATA)
-    fm = afm.AFM(fh)
-    del fm._header[b'FamilyName']  # remove FamilyName, so we have to guess
-    assert fm.get_familyname() == 'My Font'
+    font = afm.AFM(fh)
+    del font._header[b'FamilyName']  # remove FamilyName, so we have to guess
+    assert font.get_familyname() == 'My Font'
+
+
+def test_font_manager_weight_normalization():
+    font = afm.AFM(BytesIO(
+        AFM_TEST_DATA.replace(b"Weight Bold\n", b"Weight Custom\n")))
+    assert fm.afmFontProperty("", font).weight == "normal"


### PR DESCRIPTION
## PR Summary

Fixes the part of #12987 that I broke...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
