### PR TITLE
Adding rcParams[‘scatter.edgecolors’] defaulting to ‘face’

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4247,12 +4247,13 @@ class Axes(_AxesBase):
             is 'face'. You may want to change this as well.
             If *None*, defaults to rcParams ``lines.linewidth``.
 
-        edgecolors : {'face', 'none', *None*} or color, optional
+        edgecolors : {'face', 'none', *None*} or color or sequence of color, \
+                optional.
             The edge color of the marker. Possible values:
 
             - 'face': The edge color will always be the same as the face color.
             - 'none': No patch boundary will be drawn.
-            - A matplotib color.
+            - A matplotib color or sequence of color.
 
             Defaults to ``None``, in which case it takes the value of
             :rc:`scatter.edgecolors` = 'face'.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4248,7 +4248,7 @@ class Axes(_AxesBase):
             If *None*, defaults to rcParams ``lines.linewidth``.
 
         edgecolors : {'face', 'none', *None*} or color or sequence of color, \
-                optional.
+optional.
             The edge color of the marker. Possible values:
 
             - 'face': The edge color will always be the same as the face color.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4101,7 +4101,7 @@ class Axes(_AxesBase):
                 facecolors = kwcolor
 
         if edgecolors is None and not rcParams['_internal.classic_mode']:
-            edgecolors = 'face'
+            edgecolors = rcParams['scatter.edgecolors']
 
         c_was_none = c is None
         if c is None:
@@ -4247,12 +4247,15 @@ class Axes(_AxesBase):
             is 'face'. You may want to change this as well.
             If *None*, defaults to rcParams ``lines.linewidth``.
 
-        edgecolors : color or sequence of color, optional, default: 'face'
+        edgecolors : {'face', 'none', *None*} or color, optional
             The edge color of the marker. Possible values:
 
             - 'face': The edge color will always be the same as the face color.
             - 'none': No patch boundary will be drawn.
             - A matplotib color.
+
+            Defaults to ``None``, in which case it takes the value of
+            :rc:`scatter.edgecolors` = 'face'.
 
             For non-filled markers, the *edgecolors* kwarg is ignored and
             forced to 'face' internally.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1230,6 +1230,7 @@ defaultParams = {
 
     # scatter props
     'scatter.marker': ['o', validate_string],
+    'scatter.edgecolors': ['face', validate_string],
 
     # TODO validate that these are valid datetime format strings
     'date.autoformatter.year': ['%Y', validate_string],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -418,7 +418,7 @@
 #legend.scatterpoints : 1        ## number of scatter points
 #legend.markerscale   : 1.0      ## the relative size of legend markers vs. original
 #legend.fontsize      : medium
-#legend.title_fontsize    : None ## None sets to the same as the default axes.  
+#legend.title_fontsize    : None ## None sets to the same as the default axes.
 ## Dimensions as fraction of fontsize:
 #legend.borderpad     : 0.4      ## border whitespace
 #legend.labelspacing  : 0.5      ## the vertical space between the legend entries
@@ -488,6 +488,7 @@
 
 #### SCATTER PLOTS
 #scatter.marker : o               ## The default marker type for scatter plots.
+#scatter.edgecolors : face        ## The default edgecolors for scatter plots.
 
 #### Agg rendering
 #### Warning: experimental, 2008/10/10


### PR DESCRIPTION
## PR Summary

This PR attempts to add `scatter.edgecolors` to the rcParams as per a recent discussion on gitter.

I would like to set edgecolors for scatter plots centrally so my plots will be more consistent without adding the kwarg to each of them (the original plots relied on the old style having a default edgecolor that is different from facecolor). 
I couldn't find an rcParam that set it and was suggested to use `_internal.classic_mode` as a workaround.

I haven't yet figured out where the default list is generated for testing, and thought it better ask for help there. Also, please advise whether this needs more docs beyond the change in the docstring. Also, if needed, I can go though the other functions to find use cases for the new rcParam, e.g. I suppose hexbin could also use it.


## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
