### PR TITLE
Add sphinx-copybutton to docs

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for building docs
-# You will first need a matching matplotlib installed
+# You will first need a matching matplotlib installation
 # e.g (from the matplotlib root directory)
 #     pip install -e .
 #

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -13,3 +13,4 @@ ipywidgets
 numpydoc>=0.8
 pillow>=3.4
 sphinx-gallery>=0.2
+sphinx-copybutton

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,8 +25,8 @@ sys.path.append('.')
 # General configuration
 # ---------------------
 
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
@@ -45,6 +45,7 @@ extensions = [
     'sphinxext.math_symbol_table',
     'sphinxext.mock_gui_toolkits',
     'sphinxext.skip_deprecated',
+    'sphinx_copybutton',
 ]
 
 exclude_patterns = ['api/api_changes/*', 'users/whats_new/*']

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -47,15 +47,10 @@ Installing dependencies
 The documentation for Matplotlib is generated from reStructuredText (ReST_)
 using the Sphinx_ documentation generation tool. There are several extra
 requirements that are needed to build the documentation. They are listed in
-:file:`doc-requirements.txt` and listed below:
+:file:`doc-requirements.txt`, which is shown below:
 
-* Sphinx>=1.3, !=1.5.0, !=1.6.4, !=1.7.3
-* colorspacious
-* IPython
-* numpydoc>=0.8
-* Pillow>=3.4
-* sphinx-gallery>=0.2
-* graphviz
+.. include:: ../../doc-requirements.txt
+   :literal:
 
 .. note::
 


### PR DESCRIPTION
See #12745 for details; essentially this just adds a little button next to code snippets that lets the reader copy the code. Fixes #12745.