### PR TITLE
Init MaxNLocator params only once

### DIFF
--- a/doc/api/next_api_changes/2018-12-16-TH-deprecations.rst
+++ b/doc/api/next_api_changes/2018-12-16-TH-deprecations.rst
@@ -1,0 +1,10 @@
+Deprecations
+````````````
+
+The class variable ``matplotlib.ticker.MaxNLocator.default_params`` is
+deprecated and will be removed in a future version. The defaults are not
+supposed to be user-configurable.
+
+``matplotlib.ticker.MaxNLocator`` and its ``set_params`` method will issue
+a warning on unknown keyword arguments instead of silently ignoring them.
+Future versions will raise an error.


### PR DESCRIPTION
## PR Summary

This makes creating `MaxNLocator` a bit faster (~3ms -> ~2ms) by calling `set_params` only once.

**Edit:**

Original PR was just: `self.set_params(**{**self._default_params, **kwargs})`.

Additionally, I've introduced preparatory steps to make the signature explicit, which needs a lot of deprecation logic. It's still easiest to make the signature only explicit after the deprecation period is over.