### PR TITLE
Improve error messages for unit conversion

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1486,8 +1486,11 @@ class Axis(martist.Artist):
 
         if self.converter is None:
             return x
-
-        ret = self.converter.convert(x, self.units, self)
+        try:
+            ret = self.converter.convert(x, self.units, self)
+        except Exception as e:
+            raise munits.ConversionError('Failed to convert value(s) to axis '
+                                         f'units: {x!r}') from e
         return ret
 
     def set_units(self, u):

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -23,24 +23,30 @@ import matplotlib.ticker as ticker
 class StrCategoryConverter(units.ConversionInterface):
     @staticmethod
     def convert(value, unit, axis):
-        """Converts strings in value to floats using
+        """Convert strings in value to floats using
         mapping information store in the unit object.
 
         Parameters
         ----------
         value : string or iterable
-            value or list of values to be converted
-        unit : :class:`.UnitData`
-           object string unit information for value
-        axis : :class:`~matplotlib.Axis.axis`
-            axis on which the converted value is plotted
+            Value or list of values to be converted.
+        unit : `.UnitData`
+            An object mapping strings to integers.
+        axis : `~matplotlib.axis.Axis`
+            axis on which the converted value is plotted.
+
+            .. note:: *axis* is unused.
 
         Returns
         -------
-        mapped_ value : float or ndarray[float]
-
-        .. note:: axis is not used in this function
+        mapped_value : float or ndarray[float]
         """
+        if unit is None:
+            raise ValueError(
+                'Missing category information for StrCategoryConverter; '
+                'this might be caused by unintendedly mixing categorical and '
+                'numeric data')
+
         # dtype = object preserves numerical pass throughs
         values = np.atleast_1d(np.array(value, dtype=object))
 
@@ -190,7 +196,7 @@ class UnitData(object):
                 self._mapping[val] = next(self._counter)
 
 
-# Connects the convertor to matplotlib
+# Register the converter with Matplotlib's unit framework
 units.registry[str] = StrCategoryConverter()
 units.registry[np.str_] = StrCategoryConverter()
 units.registry[bytes] = StrCategoryConverter()

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -49,6 +49,10 @@ import numpy as np
 from matplotlib import cbook
 
 
+class ConversionError(TypeError):
+    pass
+
+
 class AxisInfo(object):
     """
     Information to support default axis labeling, tick labeling, and


### PR DESCRIPTION
## PR Summary

Fixes #12990. The call stack is a bit lengthy, but that's because the error happens several levels down and at least the reason gets clear.


#### Assigning categoricals to floats.

~~~
from matplotlib import pyplot as plt
xs = [1, 2, 3]
ys = [50, 10, 20]
ticks = ['banana', 'apple', 'pear']
plt.bar(xs, ys)
plt.xticks(ticks)
~~~

results in
~~~
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/dev/matplotlib/lib/matplotlib/axis.py in convert_units(self, x)
   1489         try:
-> 1490             ret = self.converter.convert(x, self.units, self)
   1491         except Exception as e:

~/dev/matplotlib/lib/matplotlib/category.py in convert(value, unit, axis)
     45             raise ValueError(
---> 46                 'Missing unit for StrCategoryConverter. This might be caused'
     47                 'by unintendedly mixing categorical and numeric data.')

ValueError: Missing unit for StrCategoryConverter. This might be causedby unintendedly mixing categorical and numeric data.

The above exception was the direct cause of the following exception:

ConversionError                           Traceback (most recent call last)
<ipython-input-2-8d8628e715b5> in <module>()
      4 ticks = ['banana', 'apple', 'pear']
      5 plt.bar(xs, ys)
----> 6 plt.xticks(ticks)

~/dev/matplotlib/lib/matplotlib/pyplot.py in xticks(ticks, labels, **kwargs)
   1518         labels = ax.get_xticklabels()
   1519     elif labels is None:
-> 1520         locs = ax.set_xticks(ticks)
   1521         labels = ax.get_xticklabels()
   1522     else:

~/dev/matplotlib/lib/matplotlib/axes/_base.py in set_xticks(self, ticks, minor)
   3303             Default is ``False``.
   3304         """
-> 3305         ret = self.xaxis.set_ticks(ticks, minor=minor)
   3306         self.stale = True
   3307         return ret

~/dev/matplotlib/lib/matplotlib/axis.py in set_ticks(self, ticks, minor)
   1689         """
   1690         # XXX if the user changes units, the information will be lost here
-> 1691         ticks = self.convert_units(ticks)
   1692         if len(ticks) > 1:
   1693             xleft, xright = self.get_view_interval()

~/dev/matplotlib/lib/matplotlib/axis.py in convert_units(self, x)
   1491         except Exception as e:
   1492             raise munits.ConversionError('Failed to convert value(s) to axis '
-> 1493                                          'units: %r' % x) from e
   1494         return ret
   1495 

ConversionError: Failed to convert value(s) to axis units: ['banana', 'apple', 'pear']
~~~


#### Assigning categoricals to dates.

~~~
from matplotlib import pyplot as plt
xs = [datetime(2015, 1, 1), datetime(2016, 1, 1), datetime(2017, 1, 1)]
ys = [50, 10, 20]
ticks = ['banana', 'apple', 'pear']
plt.bar(xs, ys)
plt.xticks(ticks)
~~~
results in
~~~
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/dev/matplotlib/lib/matplotlib/axis.py in convert_units(self, x)
   1489         try:
-> 1490             ret = self.converter.convert(x, self.units, self)
   1491         except Exception as e:

~/dev/matplotlib/lib/matplotlib/dates.py in convert(value, unit, axis)
   1805         """
-> 1806         return date2num(value)
   1807 

~/dev/matplotlib/lib/matplotlib/dates.py in date2num(d)
    421             return d
--> 422         return _to_ordinalf_np_vectorized(d)
    423 

~/miniconda3/envs/mpl/lib/python3.6/site-packages/numpy/lib/function_base.py in __call__(self, *args, **kwargs)
   2754 
-> 2755         return self._vectorize_call(func=func, args=vargs)
   2756 

~/miniconda3/envs/mpl/lib/python3.6/site-packages/numpy/lib/function_base.py in _vectorize_call(self, func, args)
   2824         else:
-> 2825             ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)
   2826 

~/miniconda3/envs/mpl/lib/python3.6/site-packages/numpy/lib/function_base.py in _get_ufunc_and_otypes(self, func, args)
   2784             inputs = [arg.flat[0] for arg in args]
-> 2785             outputs = func(*inputs)
   2786 

~/dev/matplotlib/lib/matplotlib/dates.py in _to_ordinalf(dt)
    225 
--> 226     base = float(dt.toordinal())
    227 

AttributeError: 'numpy.str_' object has no attribute 'toordinal'

The above exception was the direct cause of the following exception:

ConversionError                           Traceback (most recent call last)
<ipython-input-3-e7444cbe73e7> in <module>()
      4 ticks = ['banana', 'apple', 'pear']
      5 plt.bar(xs, ys)
----> 6 plt.xticks(ticks)

~/dev/matplotlib/lib/matplotlib/pyplot.py in xticks(ticks, labels, **kwargs)
   1518         labels = ax.get_xticklabels()
   1519     elif labels is None:
-> 1520         locs = ax.set_xticks(ticks)
   1521         labels = ax.get_xticklabels()
   1522     else:

~/dev/matplotlib/lib/matplotlib/axes/_base.py in set_xticks(self, ticks, minor)
   3303             Default is ``False``.
   3304         """
-> 3305         ret = self.xaxis.set_ticks(ticks, minor=minor)
   3306         self.stale = True
   3307         return ret

~/dev/matplotlib/lib/matplotlib/axis.py in set_ticks(self, ticks, minor)
   1689         """
   1690         # XXX if the user changes units, the information will be lost here
-> 1691         ticks = self.convert_units(ticks)
   1692         if len(ticks) > 1:
   1693             xleft, xright = self.get_view_interval()

~/dev/matplotlib/lib/matplotlib/axis.py in convert_units(self, x)
   1491         except Exception as e:
   1492             raise munits.ConversionError('Failed to convert value(s) to axis '
-> 1493                                          'units: %r' % x) from e
   1494         return ret
   1495 

ConversionError: Failed to convert value(s) to axis units: ['banana', 'apple', 'pear']
~~~
