### PR TITLE
Add category module to docs

### DIFF
--- a/doc/api/category_api.rst
+++ b/doc/api/category_api.rst
@@ -1,0 +1,8 @@
+***********************
+``matplotlib.category``
+***********************
+
+.. automodule:: matplotlib.category
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -28,6 +28,7 @@ Modules
    backend_tools_api.rst
    index_backend_api.rst
    blocking_input_api.rst
+   category_api.rst
    cbook_api.rst
    cm_api.rst
    collections_api.rst

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -63,15 +63,15 @@ class StrCategoryConverter(units.ConversionInterface):
         """Sets the default axis ticks and labels
 
         Parameters
-        ---------
-        unit : :class:`.UnitData`
+        ----------
+        unit : `.UnitData`
             object string unit information for value
-        axis : :class:`~matplotlib.Axis.axis`
+        axis : `~matplotlib.Axis.axis`
             axis for which information is being set
 
         Returns
         -------
-        :class:~matplotlib.units.AxisInfo~
+        axisinfo : `~matplotlib.units.AxisInfo`
             Information to support default tick labeling
 
         .. note: axis is not used


### PR DESCRIPTION
## PR Summary

This adds the category module to the docs (was simply missing).
