### PR TITLE
Fix dependencies for travis build with python 3.5

### DIFF
--- a/requirements/testing/travis35.txt
+++ b/requirements/testing/travis35.txt
@@ -9,4 +9,5 @@ pytest==3.4
 pytest-cov==2.3.1
 pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest 3.4.
 pytest-rerunfailures<5  # newer versions require pytest3.6
+pytest-xdist==1.24.0  # newer versions require pytest3.6
 sphinx==1.3


### PR DESCRIPTION
## PR Summary

This unbreaks travis py3.5 builds.

Pinning pytest-xdist because pytest>=1.25.0 requires pytest3.6, which conficts with pytest 3.4 used for the travis py3.5 build.

