### PR TITLE
Enable local doc building without git installation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,7 @@
 
 import os
 import shutil
+import subprocess
 import sys
 
 import matplotlib
@@ -141,8 +142,13 @@ source_encoding = "utf-8"
 master_doc = 'contents'
 
 # General substitutions.
-from subprocess import check_output
-SHA = check_output(['git', 'describe', '--dirty']).decode('utf-8').strip()
+try:
+    SHA = subprocess.check_output(
+        ['git', 'describe', '--dirty']).decode('utf-8').strip()
+# Catch the case where git is not installed locally, and use the versioneer
+# version number instead
+except subprocess.CalledProcessError:
+    SHA = matplotlib.__version__
 
 html_context = {'sha': SHA}
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -147,7 +147,7 @@ try:
         ['git', 'describe', '--dirty']).decode('utf-8').strip()
 # Catch the case where git is not installed locally, and use the versioneer
 # version number instead
-except subprocess.CalledProcessError:
+except (subprocess.CalledProcessError, FileNotFoundError):
     SHA = matplotlib.__version__
 
 html_context = {'sha': SHA}


### PR DESCRIPTION
This just uses the version that `versioneer` gives Matplotlib. This should be a 1:1 mapping between commits and version numbers (my local build gives ` Doc version 3.0.2.post1037.dev0+g0fec7f1c3.`).

Fixes #13013 