### PR TITLE
MNT: add a logging call if a categorical string array is all convertible

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -14,12 +14,16 @@ class:`.UnitData` that creates and stores the string-to-integer mapping.
 from collections import OrderedDict
 import dateutil.parser
 import itertools
+import logging
 
 import numpy as np
 
 import matplotlib.cbook as cbook
 import matplotlib.units as units
 import matplotlib.ticker as ticker
+
+
+_log = logging.getLogger(__name__)
 
 
 class StrCategoryConverter(units.ConversionInterface):
@@ -216,10 +220,10 @@ class UnitData(object):
                 self._mapping[val] = next(self._counter)
         # check if we can convert all strings to number or date...
         if self._strs_are_convertible(data):
-            cbook._warn_external('using category units to plot a list of '
-                          'strings that is a;; floats or parsable as dates. '
-                          'If you do not mean these to be categories, cast '
-                          'to the approriate data type before plotting.')
+            _log.info('using category units to plot a list of '
+                      'strings that is a;; floats or parsable as dates. '
+                      'If you do not mean these to be categories, cast '
+                      'to the approriate data type before plotting.')
 
 
 # Register the converter with Matplotlib's unit framework

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -222,7 +222,7 @@ class UnitData(object):
             if val not in self._mapping:
                 self._mapping[val] = next(self._counter)
         if convertable:
-            _log.info('Using categrocical units to plot a list of strings '
+            _log.info('Using categorical units to plot a list of strings '
                       'that are all parsable as floats or dates. If these '
                       'strings should be plotted as numbers, cast to the '
                       'approriate data type before plotting.')

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -181,20 +181,18 @@ class UnitData(object):
             self.update(data)
 
     @staticmethod
-    def _strs_are_convertible(vals):
+    def _str_is_convertible(val):
         """
-        Helper method to see if list of strings can all be cast to float or
+        Helper method to see if a string can be cast to float or
         parsed as date.
         """
-
-        for val in vals:
+        try:
+            float(val)
+        except ValueError:
             try:
-                float(val)
+                dateutil.parser.parse(val)
             except ValueError:
-                try:
-                    dateutil.parser.parse(val)
-                except ValueError:
-                    return False
+                return False
         return True
 
     def update(self, data):
@@ -212,18 +210,22 @@ class UnitData(object):
         """
         data = np.atleast_1d(np.array(data, dtype=object))
 
+        # check if convertable to number:
+        convertable = True
         for val in OrderedDict.fromkeys(data):
             # OrderedDict just iterates over unique values in data.
             if not isinstance(val, (str, bytes)):
                 raise TypeError("{val!r} is not a string".format(val=val))
+            if convertable:
+                # this will only be called so long as convertable is True.
+                convertable = self._str_is_convertible(val)
             if val not in self._mapping:
                 self._mapping[val] = next(self._counter)
-        # check if we can convert all strings to number or date...
-        if self._strs_are_convertible(data):
-            _log.info('using category units to plot a list of '
-                      'strings that is a;; floats or parsable as dates. '
-                      'If you do not mean these to be categories, cast '
-                      'to the approriate data type before plotting.')
+        if convertable:
+            _log.info('Using categrocical units to plot a list of strings '
+                      'that are all parsable as floats or dates. If these '
+                      'strings should be plotted as numbers, cast to the '
+                      'approriate data type before plotting.')
 
 
 # Register the converter with Matplotlib's unit framework

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -177,17 +177,20 @@ class UnitData(object):
             self.update(data)
 
     @staticmethod
-    def _str_is_convertable(val):
+    def _strs_are_convertible(vals):
         """
-        Helper method to see if string can be cast to float or parsed as date.
+        Helper method to see if list of strings can all be cast to float or
+        parsed as date.
         """
-        try:
-            float(val)
-        except ValueError:
+
+        for val in vals:
             try:
-                dateutil.parser.parse(val)
+                float(val)
             except ValueError:
-                return False
+                try:
+                    dateutil.parser.parse(val)
+                except ValueError:
+                    return False
         return True
 
     def update(self, data):
@@ -205,16 +208,14 @@ class UnitData(object):
         """
         data = np.atleast_1d(np.array(data, dtype=object))
 
-        convertable = True
         for val in OrderedDict.fromkeys(data):
             # OrderedDict just iterates over unique values in data.
             if not isinstance(val, (str, bytes)):
                 raise TypeError("{val!r} is not a string".format(val=val))
-            # check if we can convert string to number or date...
-            convertable = (convertable and self._str_is_convertable(val))
             if val not in self._mapping:
                 self._mapping[val] = next(self._counter)
-        if convertable:
+        # check if we can convert all strings to number or date...
+        if self._strs_are_convertible(data):
             cbook._warn_external('using category units to plot a list of '
                           'strings that is a;; floats or parsable as dates. '
                           'If you do not mean these to be categories, cast '

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -203,8 +203,7 @@ class TestPlotNumlike(object):
     @pytest.mark.parametrize("ndata", numlike_data, ids=numlike_ids)
     def test_plot_numlike(self, ax, plotter, ndata):
         counts = np.array([4, 6, 5])
-        with pytest.warns(UserWarning, match='using category units to plot'):
-            plotter(ax, ndata, counts)
+        plotter(ax, ndata, counts)
         axis_test(ax.xaxis, ndata)
 
 
@@ -262,14 +261,12 @@ class TestPlotTypes(object):
 
     PLOT_BROKEN_IDS = ["scatter", "plot", "bar"]
 
-    @pytest.mark.filterwarnings('ignore::UserWarning')
     @pytest.mark.parametrize("plotter", PLOT_BROKEN_LIST, ids=PLOT_BROKEN_IDS)
     @pytest.mark.parametrize("xdata", fvalues, ids=fids)
     def test_mixed_type_exception(self, ax, plotter, xdata):
         with pytest.raises(TypeError):
             plotter(ax, xdata, [1, 2])
 
-    @pytest.mark.filterwarnings('ignore::UserWarning')
     @pytest.mark.parametrize("plotter", PLOT_BROKEN_LIST, ids=PLOT_BROKEN_IDS)
     @pytest.mark.parametrize("xdata", fvalues, ids=fids)
     def test_mixed_type_update_exception(self, ax, plotter, xdata):

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -203,7 +203,8 @@ class TestPlotNumlike(object):
     @pytest.mark.parametrize("ndata", numlike_data, ids=numlike_ids)
     def test_plot_numlike(self, ax, plotter, ndata):
         counts = np.array([4, 6, 5])
-        plotter(ax, ndata, counts)
+        with pytest.warns(UserWarning, match='using category units to plot'):
+            plotter(ax, ndata, counts)
         axis_test(ax.xaxis, ndata)
 
 
@@ -261,12 +262,14 @@ class TestPlotTypes(object):
 
     PLOT_BROKEN_IDS = ["scatter", "plot", "bar"]
 
+    @pytest.mark.filterwarnings('ignore::UserWarning')
     @pytest.mark.parametrize("plotter", PLOT_BROKEN_LIST, ids=PLOT_BROKEN_IDS)
     @pytest.mark.parametrize("xdata", fvalues, ids=fids)
     def test_mixed_type_exception(self, ax, plotter, xdata):
         with pytest.raises(TypeError):
             plotter(ax, xdata, [1, 2])
 
+    @pytest.mark.filterwarnings('ignore::UserWarning')
     @pytest.mark.parametrize("plotter", PLOT_BROKEN_LIST, ids=PLOT_BROKEN_IDS)
     @pytest.mark.parametrize("xdata", fvalues, ids=fids)
     def test_mixed_type_update_exception(self, ax, plotter, xdata):


### PR DESCRIPTION
Users somertimes do:

```
plt.plot(['1', '3', '2'])

```

and are surprised when they get a plot that looks like:

![figure_1](https://user-images.githubusercontent.com/1562854/50266661-4d3ada80-03d9-11e9-9c60-b80ffc4b0ecf.png)

This now emits (if `logging.basicConfig(level=logging.INFO)`):

```
INFO:matplotlib.category:using category units to plot a list of strings that is all floats or parsable as dates. If you do not mean these to be categories, cast to the approriate data type before plotting.
```

```
plt.plot(['10/20/10'])
```

emits the same info message, 

but 

```
plt.plot(['1', 'a', '2'])
```

does not.

Note that we decided to use logging as less intrusive to knowledgable users.  See #13129 for more user-friendly way to activate matplotlib logging.  

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->