### PR TITLE
Qt5 reset signals after non-interactive plotting

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -1124,6 +1124,11 @@ class _BackendQT5(_Backend):
 
     @staticmethod
     def mainloop():
-        # allow KeyboardInterrupt exceptions to close the plot window.
+        old_signal = signal.getsignal(signal.SIGINT)
+        # allow SIGINT exceptions to close the plot window.
         signal.signal(signal.SIGINT, signal.SIG_DFL)
-        qApp.exec_()
+        try:
+            qApp.exec_()
+        finally:
+            # reset the SIGINT exception handler
+            signal.signal(signal.SIGINT, old_signal)

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -114,6 +114,53 @@ def test_fig_close(backend):
     assert init_figs == Gcf.figs
 
 
+@pytest.mark.backend('Qt5Agg')
+def test_fig_signals(qt_module):
+    # Create a figure
+    fig = plt.figure()
+
+    # Access QtCore
+    QtCore = qt_module[0]
+
+    # Access signals
+    import signal
+    event_loop_signal = None
+
+    # Callback to fire during event loop: save SIGINT handler, then exit
+    def fire_signal_and_quit():
+        # Save event loop signal
+        nonlocal event_loop_signal
+        event_loop_signal = signal.getsignal(signal.SIGINT)
+
+        # Request event loop exit
+        QtCore.QCoreApplication.exit()
+
+    # Timer to exit event loop
+    QtCore.QTimer.singleShot(0, fire_signal_and_quit)
+
+    # Save original SIGINT handler
+    original_signal = signal.getsignal(signal.SIGINT)
+
+    # Use our own SIGINT handler to be 100% sure this is working
+    def CustomHandler(signum, frame):
+        pass
+
+    signal.signal(signal.SIGINT, CustomHandler)
+
+    # mainloop() sets SIGINT, starts Qt event loop (which trigers timer and
+    # exits) and then mainloop() resets SIGINT
+    matplotlib.backends.backend_qt5._BackendQT5.mainloop()
+
+    # Assert: signal handler during loop execution is signal.SIG_DFL
+    assert event_loop_signal == signal.SIG_DFL
+
+    # Assert: current signal handler is the same as the one we set before
+    assert CustomHandler == signal.getsignal(signal.SIGINT)
+
+    # Reset SIGINT handler to what it was before the test
+    signal.signal(signal.SIGINT, original_signal)
+
+
 @pytest.mark.parametrize(
     'qt_key, qt_mods, answer',
     [


### PR DESCRIPTION
## PR Summary

Non-interactive plots change the signal handler after they have been closed. They should reset it instead

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant