### PR TITLE
Fix vertical alignment of text

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -349,6 +349,19 @@ def test_get_rotation_mod360():
         assert_almost_equal(text.get_rotation(i), j)
 
 
+@pytest.mark.parametrize("ha", ["center", "right", "left"])
+@pytest.mark.parametrize("va", ["center", "top", "bottom",
+                                "baseline", "center_baseline"])
+def test_null_rotation_with_rotation_mode(ha, va):
+    fig, ax = plt.subplots()
+    kw = dict(rotation=0, va=va, ha=ha)
+    t0 = ax.text(.5, .5, 'test', rotation_mode='anchor', **kw)
+    t1 = ax.text(.5, .5, 'test', rotation_mode='default', **kw)
+    fig.canvas.draw()
+    assert_almost_equal(t0.get_window_extent(fig.canvas.renderer).get_points(),
+                        t1.get_window_extent(fig.canvas.renderer).get_points())
+
+
 @image_comparison(baseline_images=['text_bboxclip'])
 def test_bbox_clipping():
     plt.text(0.9, 0.2, 'Is bbox clipped?', backgroundcolor='r', clip_on=True)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -403,7 +403,7 @@ class Text(Artist):
             elif valign == 'baseline':
                 offsety = ymax1 - baseline
             elif valign == 'center_baseline':
-                offsety = (ymin1 + ymax1 - baseline) / 2.0
+                offsety = ymax1 - baseline / 2.0
             else:
                 offsety = ymin1
 


### PR DESCRIPTION

## PR Summary

This solves #13028: when ``rotation_mode='anchor'`` and ``"verticalaligment="center_baseline"``, the vertical alignment is wrong even if ``rotation=0``. The vertical position of text was badly computed in this configuration, and the PR solves the problem.

## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
