### PR TITLE
fix typo in docstring in `axis_artist.py`

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -929,8 +929,8 @@ class AxisArtist(martist.Artist):
          comma-separated attributes. Alternatively, the attrs can
          be provided as keywords.
 
-         set_arrowstyle("->,size=1.5")
-         set_arrowstyle("->", size=1.5)
+         set_axisline_style("->,size=1.5")
+         set_axisline_style("->", size=1.5)
 
         Old attrs simply are forgotten.
 


### PR DESCRIPTION
## PR Summary
fix typo in docstring in `axis_artist.py`

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

