### PR TITLE
cairo: speed up the cairo append_path() slow path

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -90,6 +90,8 @@ def _append_paths_slow(ctx, paths, transforms, clip=None):
     for path, transform in zip(paths, transforms):
         for points, code in path.iter_segments(
                 transform, remove_nans=True, clip=clip):
+            # int is a lot faster than uint8 when comparing
+            code = int(code)
             if code == Path.MOVETO:
                 ctx.move_to(*points)
             elif code == Path.CLOSEPOLY:


### PR DESCRIPTION
## PR Summary

Using the Gtk3Cairo backend with wire3d_animation_sgskip.py:

Before: 9.15 fps
After: 10.93 fps

Converting the code to int makes the comparisons faster.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way