### PR TITLE
Add boxplot.flierprops.markeredgewidth rcParam

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3769,6 +3769,7 @@ class Axes(_AxesBase):
             marker=rcParams['boxplot.flierprops.marker'],
             markerfacecolor=rcParams['boxplot.flierprops.markerfacecolor'],
             markeredgecolor=rcParams['boxplot.flierprops.markeredgecolor'],
+            markeredgewidth=rcParams['boxplot.flierprops.markeredgewidth'],
             markersize=rcParams['boxplot.flierprops.markersize'],
         )
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1067,6 +1067,7 @@ defaultParams = {
     'boxplot.flierprops.marker': ['o', validate_string],
     'boxplot.flierprops.markerfacecolor': ['none', validate_color_or_auto],
     'boxplot.flierprops.markeredgecolor': ['black', validate_color],
+    'boxplot.flierprops.markeredgewidth': [1.0, validate_float],
     'boxplot.flierprops.markersize': [6, validate_float],
     'boxplot.flierprops.linestyle': ['none', _validate_linestyle],
     'boxplot.flierprops.linewidth': [1.0, validate_float],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -128,6 +128,7 @@
 #boxplot.flierprops.marker          : o
 #boxplot.flierprops.markerfacecolor : none
 #boxplot.flierprops.markeredgecolor : black
+#boxplot.flierprops.markeredgewidth : 1.0
 #boxplot.flierprops.markersize      : 6
 #boxplot.flierprops.linestyle       : none
 #boxplot.flierprops.linewidth       : 1.0


### PR DESCRIPTION
## PR Summary

Fixes #13022.

The edgewidth of fliers was not configurable and inherited the value from `lines.markeredgewidth` causing unfilled flier markers to disappear in boxplots.