### PR TITLE
FIX: always eraseRect in Qt widget

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -240,7 +240,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         self._dpi_ratio_prev = None
 
         self._draw_pending = False
-        self._erase_before_paint = False
         self._is_drawing = False
         self._draw_rect_callback = lambda painter: None
 
@@ -491,7 +490,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             return
         with cbook._setattr_cm(self, _is_drawing=True):
             super().draw()
-        self._erase_before_paint = True
         self.update()
 
     def draw_idle(self):

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -38,10 +38,6 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
         painter = QtGui.QPainter(self)
 
-        if self._erase_before_paint:
-            painter.eraseRect(self.rect())
-            self._erase_before_paint = False
-
         rect = event.rect()
         left = rect.left()
         top = rect.top()
@@ -55,6 +51,10 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         reg = self.copy_from_bbox(bbox)
         buf = cbook._unmultiplied_rgba8888_to_premultiplied_argb32(
             memoryview(reg))
+
+        # clear the widget canvas
+        painter.eraseRect(rect)
+
         qimage = QtGui.QImage(buf, buf.shape[1], buf.shape[0],
                               QtGui.QImage.Format_ARGB32_Premultiplied)
         if hasattr(qimage, 'setDevicePixelRatio'):

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -37,9 +37,7 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
             # Not available on Qt4 or some older Qt5.
             qimage.setDevicePixelRatio(dpi_ratio)
         painter = QtGui.QPainter(self)
-        if self._erase_before_paint:
-            painter.eraseRect(self.rect())
-            self._erase_before_paint = False
+        painter.eraseRect(event.rect())
         painter.drawImage(0, 0, qimage)
         self._draw_rect_callback(painter)
         painter.end()


### PR DESCRIPTION
Re-focusing the figure window will call the draw method.  If the
facecolor of the figure and axes are transparent and we do not
erase the widget we are effectively compositing the figure on to its
self which results in artifacts anywhere there is alpha or
anti-aliasing.

Closes #13012