### PR TITLE
Delayed C# color evaluation for plot()

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -101,7 +101,7 @@ def _process_plot_format(fmt):
             i += 1
         elif c == 'C' and i < len(fmt) - 1:
             color_cycle_number = int(fmt[i + 1])
-            color = mcolors.to_rgba("C{}".format(color_cycle_number))
+            color = "C{}".format(color_cycle_number)
             i += 2
         else:
             raise ValueError(


### PR DESCRIPTION
## PR Summary

One way of fixing #12967 by delaying the color evaluation in `plt.plot([1, 2], "C0")`.

It's not clear to me if this is the right way to go; and that may need a discussion. This is rather for documenting how to change the code *if* we want delayed evaluation.