### PR TITLE
Simplify callable(self._contains) checks

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -383,7 +383,7 @@ class Artist(object):
         --------
         set_contains, get_contains
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
         _log.warning("%r needs 'contains' method", self.__class__.__name__)
         return False, {}
@@ -411,6 +411,8 @@ class Artist(object):
               implementation of the respective artist, but may provide
               additional information.
         """
+        if not callable(picker):
+            raise TypeError("picker is not a callable")
         self._contains = picker
 
     def get_contains(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4229,7 +4229,7 @@ class _AxesBase(martist.Artist):
 
     def contains(self, mouseevent):
         # docstring inherited.
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
         return self.patch.contains(mouseevent)
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -246,7 +246,7 @@ class Tick(martist.Artist):
         This function always returns false.  It is more useful to test if the
         axis as a whole contains the mouse rather than the set of tick marks.
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
         return False, {}
 
@@ -1858,7 +1858,7 @@ class XAxis(Axis):
     def contains(self, mouseevent):
         """Test whether the mouse event occurred in the x axis.
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
 
         x, y = mouseevent.x, mouseevent.y
@@ -2202,7 +2202,7 @@ class YAxis(Axis):
 
         Returns *True* | *False*
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
 
         x, y = mouseevent.x, mouseevent.y

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -352,7 +352,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         Returns ``bool, dict(ind=itemlist)``, where every item in itemlist
         contains the event.
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
 
         if not self.get_visible():

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -656,7 +656,7 @@ class Figure(Artist):
         -------
             bool, {}
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
         inside = self.bbox.contains(mouseevent.x, mouseevent.y)
         return inside, {}

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -613,7 +613,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         """
         Test whether the mouse event occurred within the image.
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
         # TODO: make sure this is consistent with patch and patch
         # collection on nonlinear transformed coordinates.
@@ -1310,7 +1310,7 @@ class BboxImage(_ImageBase):
 
     def contains(self, mouseevent):
         """Test whether the mouse event occurred within the image."""
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
 
         if not self.get_visible():  # or self.get_figure()._renderer is None:

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -127,7 +127,7 @@ class Patch(artist.Artist):
 
         Returns T/F, {}
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
         radius = self._process_radius(radius)
         inside = self.get_path().contains_point(

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -438,7 +438,7 @@ class Table(Artist):
 
     def contains(self, mouseevent):
         # docstring inherited
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
 
         # TODO: Return index of the cell containing the cursor so that the user

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -193,7 +193,7 @@ class Text(Artist):
         -------
         bool : bool
         """
-        if callable(self._contains):
+        if self._contains is not None:
             return self._contains(self, mouseevent)
 
         if not self.get_visible() or self._renderer is None:


### PR DESCRIPTION
Artist._contains can either be None (not-set) or a callable (see
docstring of Artist.set_contains). Therefore, the
callable(self._contains) checks can be simplified to
bool(self._contains).

## PR Summary

I had a look at the traitlets PR (#4762, still has unresolved merge conflicts) and noticed some parts that could be moved to its own PR. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
