### PR TITLE
Move doc-requirements from root folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ deps-run: &deps-install
   name: Install Python dependencies
   command: |
     python -mpip install --user numpy${NUMPY_VERSION} codecov coverage
-    python -mpip install --user -r doc-requirements.txt
+    python -mpip install --user -r requirements/doc/doc-requirements.txt
 
 mpl-run: &mpl-install
   name: Install Matplotlib

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -49,7 +49,7 @@ using the Sphinx_ documentation generation tool. There are several extra
 requirements that are needed to build the documentation. They are listed in
 :file:`doc-requirements.txt`, which is shown below:
 
-.. include:: ../../doc-requirements.txt
+.. include:: ../../requirements/doc/doc-requirements.txt
    :literal:
 
 .. note::

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -209,7 +209,7 @@ To build the documentation you must have the tagged version installed, but
 build the docs from the ``ver-doc`` branch.  An easy way to arrange this is::
 
   pip install matplotlib
-  pip install -r doc-requirements.txt
+  pip install -r requirements/doc/doc-requirements.txt
   git checkout v2.0.0-doc
   git clean -xfd
   cd doc

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -1,10 +1,11 @@
 # Requirements for building docs
-# You will first need a matching matplotlib installation
-# e.g (from the matplotlib root directory)
+#
+# You will first need a matching Matplotlib installation
+# e.g (from the Matplotlib root directory)
 #     pip install -e .
 #
 # Install the documentation requirements with:
-#     pip install -r doc-requirements.txt
+#     pip install -r requirements/doc/doc-requirements.txt
 #
 sphinx>=1.3,!=1.5.0,!=1.6.4,!=1.7.3,!=1.8.0
 colorspacious


### PR DESCRIPTION
Cleans up the root folder (a little bit!), and puts the documentation requirements in a more sensible place.