### PR TITLE
Simplify generation of error messages for missing libpng/freetype.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,10 +166,6 @@ if __name__ == '__main__':
             print_line()
             print_message("The following required packages can not be built: "
                           "%s" % ", ".join(x.name for x in required_failed))
-            for pkg in required_failed:
-                msg = pkg.install_help_msg()
-                if msg:
-                    print_message(msg)
             sys.exit(1)
 
         # Now collect all of the information we need to build all of the

--- a/setupext.py
+++ b/setupext.py
@@ -338,14 +338,6 @@ class CheckFailed(Exception):
 
 class SetupPackage(object):
     optional = False
-    pkg_names = {
-        "apt-get": None,
-        "yum": None,
-        "dnf": None,
-        "brew": None,
-        "port": None,
-        "windows_url": None
-        }
 
     def check(self):
         """
@@ -460,56 +452,6 @@ class SetupPackage(object):
         override this method.
         """
         pass
-
-    def install_help_msg(self):
-        """
-        Do not override this method !
-
-        Generate the help message to show if the package is not installed.
-        To use this in subclasses, simply add the dictionary `pkg_names` as
-        a class variable:
-
-        pkg_names = {
-            "apt-get": <Name of the apt-get package>,
-            "yum": <Name of the yum package>,
-            "dnf": <Name of the dnf package>,
-            "brew": <Name of the brew package>,
-            "port": <Name of the port package>,
-            "windows_url": <The url which has installation instructions>
-            }
-
-        All the dictionary keys are optional. If a key is not present or has
-        the value `None` no message is provided for that platform.
-        """
-        def _try_managers(*managers):
-            for manager in managers:
-                pkg_name = self.pkg_names.get(manager, None)
-                if pkg_name:
-                    if shutil.which(manager) is not None:
-                        if manager == 'port':
-                            pkgconfig = 'pkgconfig'
-                        else:
-                            pkgconfig = 'pkg-config'
-                        return ('Try installing {0} with `{1} install {2}` '
-                                'and pkg-config with `{1} install {3}`'
-                                .format(self.name, manager, pkg_name,
-                                        pkgconfig))
-
-        message = None
-        if sys.platform == "win32":
-            url = self.pkg_names.get("windows_url", None)
-            if url:
-                message = ('Please check {0} for instructions to install {1}'
-                           .format(url, self.name))
-        elif sys.platform == "darwin":
-            message = _try_managers("brew", "port")
-        elif sys.platform == "linux":
-            release = platform.linux_distribution()[0].lower()
-            if release in ('debian', 'ubuntu'):
-                message = _try_managers('apt-get')
-            elif release in ('centos', 'redhat', 'fedora'):
-                message = _try_managers('dnf', 'yum')
-        return message
 
 
 class OptionalPackage(SetupPackage):
@@ -823,14 +765,6 @@ class LibAgg(SetupPackage):
 
 class FreeType(SetupPackage):
     name = "freetype"
-    pkg_names = {
-        "apt-get": "libfreetype6-dev",
-        "yum": "freetype-devel",
-        "dnf": "freetype-devel",
-        "brew": "freetype",
-        "port": "freetype",
-        "windows_url": "http://gnuwin32.sourceforge.net/packages/freetype.htm"
-        }
 
     def add_flags(self, ext):
         ext.sources.insert(0, 'src/checkdep_freetype2.c')
@@ -1005,14 +939,6 @@ class FT2Font(SetupPackage):
 
 class Png(SetupPackage):
     name = "png"
-    pkg_names = {
-        "apt-get": "libpng12-dev",
-        "yum": "libpng-devel",
-        "dnf": "libpng-devel",
-        "brew": "libpng",
-        "port": "libpng",
-        "windows_url": "http://gnuwin32.sourceforge.net/packages/libpng.htm"
-        }
 
     def get_extension(self):
         sources = [

--- a/src/checkdep_freetype2.c
+++ b/src/checkdep_freetype2.c
@@ -1,13 +1,23 @@
-#include <ft2build.h>
-#include FT_FREETYPE_H
+#if defined __has_include && ! __has_include(<ft2build.h>)
 
-#define XSTR(x) STR(x)
-#define STR(x) #x
+  #error "FreeType version 2.3 or higher is required. \
+You may set the MPLLOCALFREETYPE environment variable to 1 to let \
+Matplotlib download it."
 
-#pragma message("Compiling with FreeType version " \
-  XSTR(FREETYPE_MAJOR) "." XSTR(FREETYPE_MINOR) "." XSTR(FREETYPE_PATCH) ".")
-#if FREETYPE_MAJOR << 16 + FREETYPE_MINOR << 8 + FREETYPE_PATCH < 0x020300
-    #error "FreeType version 2.3 or higher is required." \
-      "Consider setting the MPLLOCALFREETYPE environment variable to 1."
-  #error
+#else
+
+  #include <ft2build.h>
+  #include FT_FREETYPE_H
+
+  #define XSTR(x) STR(x)
+  #define STR(x) #x
+
+  #pragma message("Compiling with FreeType version " \
+    XSTR(FREETYPE_MAJOR) "." XSTR(FREETYPE_MINOR) "." XSTR(FREETYPE_PATCH) ".")
+  #if FREETYPE_MAJOR << 16 + FREETYPE_MINOR << 8 + FREETYPE_PATCH < 0x020300
+    #error "FreeType version 2.3 or higher is required. \
+You may set the MPLLOCALFREETYPE environment variable to 1 to let \
+Matplotlib download it."
+  #endif
+
 #endif

--- a/src/checkdep_libpng.c
+++ b/src/checkdep_libpng.c
@@ -1,5 +1,19 @@
-#include <png.h>
-#pragma message("Compiling with libpng version " PNG_LIBPNG_VER_STRING ".")
-#if PNG_LIBPNG_VER < 10200
-  #error "libpng version 1.2 or higher is required."
+#if defined __has_include && ! __has_include(<png.h>)
+
+  #error "libpng version 1.2 or higher is required. \
+Consider installing it with e.g. 'conda install libpng', \
+'apt install libpng12-dev', 'dnf install libpng-devel', or \
+'brew install libpng'."
+
+#else
+
+  #include <png.h>
+  #pragma message("Compiling with libpng version " PNG_LIBPNG_VER_STRING ".")
+  #if PNG_LIBPNG_VER < 10200
+    #error "libpng version 1.2 or higher is required. \
+Consider installing it with e.g. 'conda install libpng', \
+'apt install libpng12-dev', 'dnf install libpng-devel', or \
+'brew install libpng'."
+  #endif
+
 #endif


### PR DESCRIPTION
Since we don't manually check anymore for the presence of the headers,
we'll never detect in setup.py/setupext.py that freetype or libpng are
missing, so the message generation using install_help_msg() will never
be used.  Delete the relevant chunk of code.

However, when using recent enough compilers (e.g. gcc 5 / VS2017 15.3),
we can generate similar error messages on the compiler's side using
`__has_include` (which is technically part of C++17, but always enabled
by the compiler as an extension --
https://www.gnu.org/software/gcc/gcc-5/changes.html
https://blogs.msdn.microsoft.com/vcblog/2017/05/10/c17-features-in-vs-2017-3/
).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
