### PR TITLE
5 minor divisions when major ticks are 2.5 units apart

### DIFF
--- a/doc/users/next_whats_new/2019-01-25-AH-modify-minor-tick-spacing.rst
+++ b/doc/users/next_whats_new/2019-01-25-AH-modify-minor-tick-spacing.rst
@@ -1,0 +1,5 @@
+Adjust default minor tick spacing
+`````````````````````````````````
+
+Default minor tick spacing was changed from 0.625 to 0.5 for major ticks spaced
+2.5 units apart.

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -99,9 +99,7 @@ class TestAutoMinorLocator(object):
     # NB: the following values are assuming that *xlim* is [0, 5]
     params = [
         (0, 0),  # no major tick => no minor tick either
-        (1, 0),  # a single major tick => no minor tick
-        (2, 4),  # 1 "nice" major step => 1*5 minor **divisions**
-        (3, 6)   # 2 "not nice" major steps => 2*4 minor **divisions**
+        (1, 0)   # a single major tick => no minor tick
     ]
 
     @pytest.mark.parametrize('nb_majorticks, expected_nb_minorticks', params)
@@ -115,6 +113,32 @@ class TestAutoMinorLocator(object):
         ax.minorticks_on()
         ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
         assert len(ax.xaxis.get_minorticklocs()) == expected_nb_minorticks
+
+    majorstep_minordivisions = [(1, 5),
+                                (2, 4),
+                                (2.5, 5),
+                                (5, 5),
+                                (10, 5)]
+
+    # This test is meant to verify the parameterization for
+    # test_number_of_minor_ticks
+    def test_using_all_default_major_steps(self):
+        with matplotlib.rc_context({'_internal.classic_mode': False}):
+            majorsteps = [x[0] for x in self.majorstep_minordivisions]
+            assert np.allclose(majorsteps, mticker.AutoLocator()._steps)
+
+    @pytest.mark.parametrize('major_step, expected_nb_minordivisions',
+                             majorstep_minordivisions)
+    def test_number_of_minor_ticks(
+            self, major_step, expected_nb_minordivisions):
+        fig, ax = plt.subplots()
+        xlims = (0, major_step)
+        ax.set_xlim(*xlims)
+        ax.set_xticks(xlims)
+        ax.minorticks_on()
+        ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
+        nb_minor_divisions = len(ax.xaxis.get_minorticklocs()) + 1
+        assert nb_minor_divisions == expected_nb_minordivisions
 
     limits = [(0, 1.39), (0, 0.139),
               (0, 0.11e-19), (0, 0.112e-12),

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2620,8 +2620,10 @@ class AutoMinorLocator(Locator):
             return []
 
         if self.ndivs is None:
-            x = int(np.round(10 ** (np.log10(majorstep) % 1)))
-            if x in [1, 5, 10]:
+
+            majorstep_no_exponent = 10 ** (np.log10(majorstep) % 1)
+
+            if np.isclose(majorstep_no_exponent, [1.0, 2.5, 5.0, 10.0]).any():
                 ndivs = 5
             else:
                 ndivs = 4


### PR DESCRIPTION
## PR Summary

Currently when the major ticks are spaced 2.5 units apart there are 3 minor ticks spaced 0.625 units apart. 
This PR increases the number of minor ticks to 4, spaced 0.5 units apart. To me, this is a much more natural spacing.



**Before**:
![before](https://user-images.githubusercontent.com/25623375/50554729-108e9f00-0c75-11e9-9736-9f34cc6a74a0.png)

**After**:
![after](https://user-images.githubusercontent.com/25623375/50554728-108e9f00-0c75-11e9-86f7-ef7680786aba.png)



```
from matplotlib import pyplot as plt
import matplotlib as mpl

fix, ax = plt.subplots()

ax.set_xlim(0, 5)
ax.set_xticks([0, 2.5, 5])
ax.minorticks_on()

ax.tick_params(which='major', length=7)

ax.yaxis.set_major_locator(mpl.ticker.NullLocator())
```

## PR Checklist

- [x ] Has Pytest style unit tests
- [x ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
