### PR TITLE
cairo backend: default to pycairo

### DIFF
--- a/doc/users/next_whats_new/2019-01-06-pycairo-default.rst
+++ b/doc/users/next_whats_new/2019-01-06-pycairo-default.rst
@@ -1,0 +1,5 @@
+The cairo backend now defaults to pycairo instead of cairocffi
+``````````````````````````````````````````````````````````````
+
+This leads to faster import/runtime performance in some cases. The backend
+will fall back to cairocffi in case pycairo isn't available.

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -10,21 +10,18 @@ import gzip
 
 import numpy as np
 
-# cairocffi is more widely compatible than pycairo so try it first.
 try:
-    import cairocffi as cairo
+    import cairo
+    if cairo.version_info < (1, 11, 0):
+        # Introduced create_for_data for Py3.
+        raise ImportError
 except ImportError:
     try:
-        import cairo
+        import cairocffi as cairo
     except ImportError:
-        raise ImportError("cairo backend requires that cairocffi or pycairo "
-                          "is installed")
-    else:
-        if cairo.version_info < (1, 11, 0):
-            # Introduced create_for_data for Py3.
-            raise ImportError(
-                "cairo {} is installed; cairo>=1.11.0 is required"
-                .format(cairo.version))
+        raise ImportError(
+            "cairo backend requires that pycairo>=1.11.0 or cairocffi"
+            "is installed")
 
 backend_version = cairo.version
 


### PR DESCRIPTION
## PR Summary

As seen in #13042 it's a bit faster than cairocffi and it also takes 50 ms less
time to import here. Also the GTK3Cairo backend requires pycairo, so there is a
good chance it's already loaded anyway for that case.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
