### PR TITLE
Remove logic for optionally building Agg and TkAgg.

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -1,5 +1,4 @@
-# Rename this file to setup.cfg to modify Matplotlib's
-# build options.
+# Rename this file to setup.cfg to modify Matplotlib's build options.
 
 [egg_info]
 
@@ -18,25 +17,10 @@
 #sample_data = True
 
 [gui_support]
-# Matplotlib supports multiple GUI toolkits, including
-# GTK3, MacOSX, Qt4, Qt5, Tk, and WX. Support for many of
-# these toolkits requires AGG, the Anti-Grain Geometry library,
-# which is provided by Matplotlib and built by default.
-#
-# Some backends are written in pure Python, and others require
-# extension code to be compiled. By default, Matplotlib checks for
-# these GUI toolkits during installation and, if present, compiles the
-# required extensions to support the toolkit.
-#
-# - Tk support requires Tk development headers and Tkinter.
-# - Mac OSX backend requires the Cocoa headers included with XCode.
-#
-# The other GUI toolkits do not require any extension code, and can be
-# used as long as the libraries are installed on your system --
-# therefore they are installed unconditionally.
-#
-# You can uncomment any the following lines to change this
-# behavior. Acceptable values are:
+# Matplotlib supports multiple GUI toolkits, known as backends.
+# The Mac OSX backend requires the Cocoa headers included with XCode.
+# You can select whether to build it by uncommenting the following line.
+# Acceptable values are:
 #
 #     True: build the extension. Exits with a warning if the
 #           required dependencies are not available
@@ -45,9 +29,7 @@
 #           otherwise skip silently. This is the default
 #           behavior
 #
-#agg = auto
 #macosx = auto
-#tkagg = auto
 
 [rc_options]
 # User-configurable options
@@ -55,8 +37,8 @@
 # Default backend, one of: Agg, Cairo, GTK3Agg, GTK3Cairo, MacOSX, Pdf, Ps,
 # Qt4Agg, Qt5Agg, SVG, TkAgg, WX, WXAgg.
 #
-# The Agg, Ps, Pdf and SVG backends do not require external dependencies. Do
-# not choose MacOSX, or TkAgg if you have disabled the relevant extension
-# modules.  The default is determined by fallback.
+# The Agg, Ps, Pdf and SVG backends do not require external dependencies.  Do
+# not choose MacOSX if you have disabled the relevant extension modules.  The
+# default is determined by fallback.
 #
 #backend = Agg

--- a/setupext.py
+++ b/setupext.py
@@ -302,7 +302,6 @@ class SetupPackage:
 
 class OptionalPackage(SetupPackage):
     optional = True
-    force = False
     config_category = "packages"
     default_config = "auto"
 
@@ -328,26 +327,13 @@ class OptionalPackage(SetupPackage):
 
         May be overridden by subclasses for additional checks.
         """
-        # Check configuration file
-        conf = self.get_config()
-        # Default "auto" state or install forced by user
-        if conf in [True, 'auto']:
-            # Set non-optional if user sets `True` in config
-            if conf is True:
+        conf = self.get_config()  # Check configuration file
+        if conf in [True, 'auto']:  # Default "auto", or install forced by user
+            if conf is True:  # Set non-optional if user sets `True` in config
                 self.optional = False
             return "installing"
-        # Configuration opt-out by user
-        else:
-            # Some backend extensions (e.g. Agg) need to be built for certain
-            # other GUI backends (e.g. TkAgg) even when manually disabled
-            if self.force is True:
-                return "installing forced (config override)"
-            else:
-                raise CheckFailed("skipping due to configuration")
-
-
-class OptionalBackendPackage(OptionalPackage):
-    config_category = "gui_support"
+        else:  # Configuration opt-out by user
+            raise CheckFailed("skipping due to configuration")
 
 
 class Platform(SetupPackage):
@@ -707,9 +693,8 @@ class Tri(SetupPackage):
         return ext
 
 
-class BackendAgg(OptionalBackendPackage):
+class BackendAgg(SetupPackage):
     name = "agg"
-    force = True
 
     def get_extension(self):
         sources = [
@@ -725,9 +710,8 @@ class BackendAgg(OptionalBackendPackage):
         return ext
 
 
-class BackendTkAgg(OptionalBackendPackage):
+class BackendTkAgg(SetupPackage):
     name = "tkagg"
-    force = True
 
     def check(self):
         return "installing; run-time loading from Python Tcl/Tk"
@@ -755,7 +739,8 @@ class BackendTkAgg(OptionalBackendPackage):
             ext.libraries.extend(['dl'])
 
 
-class BackendMacOSX(OptionalBackendPackage):
+class BackendMacOSX(OptionalPackage):
+    config_category = 'gui_support'
     name = 'macosx'
 
     def check(self):


### PR DESCRIPTION
## PR Summary

They are actually not optional (that's the `force = True` setting which
overrides the OptionalBackendPackage logic), so just make them
SetupPackages and remove the corresponding (outdated) comments in
setup.cfg.template.

Builds on top of https://github.com/matplotlib/matplotlib/pull/13074 as the prose in setup.cfg.template is only true if we also remove windowing from there. [edit: that PR has been merged]

(The OptionalBackendPackage logic was also previously useful back when the default backend was selected at build time, but that's no longer the case.)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
