### PR TITLE
When linking against libpng/zlib on Windows, use upstream lib names.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -77,8 +77,8 @@ install:
   # Let the install prefer the static builds of the libs
   - set LIBRARY_LIB=%CONDA_PREFIX%\Library\lib
   - mkdir lib || cmd /c "exit /b 0"
-  - copy /y %LIBRARY_LIB%\zlibstatic.lib lib\z.lib
-  - copy /y %LIBRARY_LIB%\libpng_static.lib lib\png.lib
+  - copy /y %LIBRARY_LIB%\zlibstatic.lib lib\zlib.lib
+  - copy /y %LIBRARY_LIB%\libpng16_static.lib lib\libpng16.lib
   # These z.lib / png.lib are not static versions but files which end up as
   # dependencies to the dll file. This is fine for the conda build, but not here
   # and for the wheels

--- a/build_alllocal.cmd
+++ b/build_alllocal.cmd
@@ -20,8 +20,8 @@ IF NOT DEFINED CONDA_PREFIX (
 :: copy the libs which have "wrong" names
 set LIBRARY_LIB=%CONDA_PREFIX%\Library\lib
 mkdir lib || cmd /c "exit /b 0"
-copy %LIBRARY_LIB%\zlibstatic.lib lib\z.lib
-copy %LIBRARY_LIB%\libpng_static.lib lib\png.lib
+copy %LIBRARY_LIB%\zlibstatic.lib lib\zlib.lib
+copy %LIBRARY_LIB%\libpng16_static.lib lib\libpng16.lib
 
 :: build the target
 python setup.py %TARGET%

--- a/doc/api/next_api_changes/2019-01-02-AL.rst
+++ b/doc/api/next_api_changes/2019-01-02-AL.rst
@@ -1,0 +1,19 @@
+Changes to the Windows build
+````````````````````````````
+
+Previously, when building the :mod:`matplotlib._png` extension, the build
+script would add "png" and "z" to the extensions ``.libraries`` attribute (if
+pkg-config information is not available, which is in particular the case on
+Windows).
+
+In particular, this implies that the Windows build would look up files named
+``png.lib`` and ``z.lib``; but neither libpng upstream nor zlib upstream
+provides these files by default.  (On Linux, this would look up ``libpng.so``
+and ``libz.so``, which are indeed standard names.)
+
+Instead, on Windows, we now look up ``libpng16.lib`` and ``zlib.lib``, which
+*are* the upstream names for the shared libraries (as of libpng 1.6.x).
+
+For a statically-linked build, the upstream names are ``libpng16_static.lib``
+and ``zlibstatic.lib``; one still needs to manually rename them if such a build
+is desired.

--- a/setupext.py
+++ b/setupext.py
@@ -645,7 +645,13 @@ class Png(SetupPackage):
             ext, 'libpng',
             atleast_version='1.2',
             alt_exec=['libpng-config', '--ldflags'],
-            default_libraries=['png', 'z'])
+            default_libraries=(
+                ['png', 'z'] if os.name == 'posix' else
+                # libpng upstream names their lib libpng16.lib, not png.lib.
+                # zlib upstream names their lib zlib.lib, not z.lib.
+                ['libpng16', 'zlib'] if os.name == 'nt' else
+                []
+            ))
         add_numpy_flags(ext)
         return ext
 


### PR DESCRIPTION
See changelog for details.

Should fix the symptoms (failure to link png.lib) of #13016 (@rth, can you confirm?).

Implements part of #9693; the static/dynamic switch proposed there could be added later.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
