### PR TITLE
Replace 1-tuples by scalars where possible.

### DIFF
--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -36,11 +36,8 @@ Z = (Z1 - Z2) * 2
 
 class nf(float):
     def __repr__(self):
-        str = '%.1f' % (self.__float__(),)
-        if str[-1] == '0':
-            return '%.0f' % self.__float__()
-        else:
-            return '%.1f' % self.__float__()
+        s = f'{self:.1f}'
+        return f'{self:.0f}' if s[-1] == '0' else s
 
 
 # Basic contour plot

--- a/examples/misc/transoffset.py
+++ b/examples/misc/transoffset.py
@@ -38,7 +38,7 @@ trans_offset = mtransforms.offset_copy(ax.transData, fig=fig,
                                        x=0.05, y=0.10, units='inches')
 
 for x, y in zip(xs, ys):
-    plt.plot((x,), (y,), 'ro')
+    plt.plot(x, y, 'ro')
     plt.text(x, y, '%d, %d' % (int(x), int(y)), transform=trans_offset)
 
 
@@ -49,7 +49,7 @@ trans_offset = mtransforms.offset_copy(ax.transData, fig=fig,
                                        y=6, units='dots')
 
 for x, y in zip(xs, ys):
-    plt.polar((x,), (y,), 'ro')
+    plt.polar(x, y, 'ro')
     plt.text(x, y, '%d, %d' % (int(x), int(y)),
              transform=trans_offset,
              horizontalalignment='center',

--- a/examples/mplot3d/lorenz_attractor.py
+++ b/examples/mplot3d/lorenz_attractor.py
@@ -38,9 +38,9 @@ dt = 0.01
 num_steps = 10000
 
 # Need one more for the initial values
-xs = np.empty((num_steps + 1,))
-ys = np.empty((num_steps + 1,))
-zs = np.empty((num_steps + 1,))
+xs = np.empty(num_steps + 1)
+ys = np.empty(num_steps + 1)
+zs = np.empty(num_steps + 1)
 
 # Set initial values
 xs[0], ys[0], zs[0] = (0., 1., 1.05)

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -790,7 +790,7 @@ class ColorbarBase(cm.ScalarMappable):
         if self.values is not None:
             self._values = np.array(self.values)
             if self.boundaries is None:
-                b = np.zeros(len(self.values) + 1, 'd')
+                b = np.zeros(len(self.values) + 1)
                 b[1:-1] = 0.5 * (self._values[:-1] - self._values[1:])
                 b[0] = 2.0 * b[1] - b[2]
                 b[-1] = 2.0 * b[-2] - b[-3]
@@ -802,7 +802,7 @@ class ColorbarBase(cm.ScalarMappable):
         # make reasonable ones based on cmap and norm.
         if isinstance(self.norm, colors.NoNorm):
             b = self._uniform_y(self.cmap.N + 1) * self.cmap.N - 0.5
-            v = np.zeros((len(b) - 1,), dtype=np.int16)
+            v = np.zeros(len(b) - 1, dtype=np.int16)
             v[self._inside] = np.arange(self.cmap.N, dtype=np.int16)
             if self._extend_lower():
                 v[0] = -1
@@ -818,7 +818,7 @@ class ColorbarBase(cm.ScalarMappable):
             if self._extend_upper():
                 b = b + [b[-1] + 1]
             b = np.array(b)
-            v = np.zeros((len(b) - 1,), dtype=float)
+            v = np.zeros(len(b) - 1)
             bi = self.norm.boundaries
             v[self._inside] = 0.5 * (bi[:-1] + bi[1:])
             if self._extend_lower():

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -412,14 +412,15 @@ def makeMappingArray(N, data, gamma=1.0):
         raise ValueError("data mapping points must have x in increasing order")
     # begin generation of lookup table
     x = x * (N - 1)
-    lut = np.zeros((N,), float)
     xind = (N - 1) * np.linspace(0, 1, N) ** gamma
     ind = np.searchsorted(x, xind)[1:-1]
 
     distance = (xind[1:-1] - x[ind - 1]) / (x[ind] - x[ind - 1])
-    lut[1:-1] = distance * (y0[ind] - y1[ind - 1]) + y1[ind - 1]
-    lut[0] = y1[0]
-    lut[-1] = y0[-1]
+    lut = np.concatenate([
+        [y1[0]],
+        distance * (y0[ind] - y1[ind - 1]) + y1[ind - 1],
+        [y0[-1]],
+    ])
     # ensure that the lut is confined to values between 0 and 1 by clipping it
     return np.clip(lut, 0.0, 1.0)
 
@@ -543,8 +544,7 @@ class Colormap(object):
                 # If the bad value is set to have a color, then we
                 # override its alpha just as for any other value.
 
-        rgba = np.empty(shape=xa.shape + (4,), dtype=lut.dtype)
-        lut.take(xa, axis=0, mode='clip', out=rgba)
+        rgba = lut.take(xa, axis=0, mode='clip')
         if vtype == 'scalar':
             rgba = tuple(rgba[0, :])
         return rgba

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -201,7 +201,7 @@ def get_path(hatchpattern, density=6):
         return Path(np.empty((0, 2)))
 
     vertices = np.empty((num_vertices, 2))
-    codes = np.empty((num_vertices,), np.uint8)
+    codes = np.empty(num_vertices, Path.code_type)
 
     cursor = 0
     for pattern in patterns:

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -516,12 +516,12 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
     # zero pad x and y up to NFFT if they are shorter than NFFT
     if len(x) < NFFT:
         n = len(x)
-        x = np.resize(x, (NFFT,))
+        x = np.resize(x, NFFT)
         x[n:] = 0
 
     if not same_data and len(y) < NFFT:
         n = len(y)
-        y = np.resize(y, (NFFT,))
+        y = np.resize(y, NFFT)
         y[n:] = 0
 
     if pad_to is None:
@@ -1598,7 +1598,7 @@ class GaussianKDE(object):
             raise ValueError("points have dimension {}, dataset has dimension "
                              "{}".format(dim, self.dim))
 
-        result = np.zeros((num_m,), dtype=float)
+        result = np.zeros(num_m)
 
         if num_m >= self.num_dp:
             # there are more points than data, so loop over data

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1123,12 +1123,10 @@ class PolarAxes(Axes):
            Theta increases in the counterclockwise direction
         """
         mtx = self._direction.get_matrix()
-        if direction in ('clockwise',):
+        if direction in ('clockwise', -1):
             mtx[0, 0] = -1
-        elif direction in ('counterclockwise', 'anticlockwise'):
+        elif direction in ('counterclockwise', 'anticlockwise', 1):
             mtx[0, 0] = 1
-        elif direction in (1, -1):
-            mtx[0, 0] = direction
         else:
             raise ValueError(
                 "direction must be 1, -1, clockwise or counterclockwise")

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -306,9 +306,8 @@ class QuiverKey(martist.Artist):
             # Hack: save and restore the Umask
             _mask = self.Q.Umask
             self.Q.Umask = ma.nomask
-            self.verts = self.Q._make_verts(np.array([self.U]),
-                                            np.zeros((1,)),
-                                            self.angle)
+            self.verts = self.Q._make_verts(
+                np.array([self.U]), np.zeros(1), self.angle)
             self.Q.Umask = _mask
             self.Q.pivot = _pivot
             kw = self.Q.polykw

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -630,13 +630,13 @@ def test_const_xy():
     fig = plt.figure()
 
     plt.subplot(311)
-    plt.plot(np.arange(10), np.ones((10,)))
+    plt.plot(np.arange(10), np.ones(10))
 
     plt.subplot(312)
-    plt.plot(np.ones((10,)), np.arange(10))
+    plt.plot(np.ones(10), np.arange(10))
 
     plt.subplot(313)
-    plt.plot(np.ones((10,)), np.ones((10,)), 'o')
+    plt.plot(np.ones(10), np.ones(10), 'o')
 
 
 @image_comparison(baseline_images=['polar_wrap_180', 'polar_wrap_360'],
@@ -5198,7 +5198,7 @@ def test_violin_point_mass():
 
 
 def generate_errorbar_inputs():
-    base_xy = cycler('x', [np.arange(5)]) + cycler('y', [np.ones((5, ))])
+    base_xy = cycler('x', [np.arange(5)]) + cycler('y', [np.ones(5)])
     err_cycler = cycler('err', [1,
                                 [1, 1, 1, 1, 1],
                                 [[1, 1, 1, 1, 1],

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -210,7 +210,7 @@ class TestWindow(object):
         if np.iterable(window):
             windowVals = window
         else:
-            windowVals = window(np.ones((NFFT,), x.dtype))
+            windowVals = window(np.ones(NFFT, x.dtype))
 
         # do the ffts of the slices
         for i in range(n):

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -49,7 +49,7 @@ def test_diamond():
 
 def test_noise():
     np.random.seed(0)
-    x = np.random.uniform(size=(50000,)) * 50
+    x = np.random.uniform(size=50000) * 50
 
     fig, ax = plt.subplots()
     p1 = ax.plot(x, solid_joinstyle='round', linewidth=2.0)
@@ -190,7 +190,7 @@ def test_angled_antiparallel(angle, offset):
 def test_sine_plus_noise():
     np.random.seed(0)
     x = (np.sin(np.linspace(0, np.pi * 2.0, 50000)) +
-         np.random.uniform(size=(50000,)) * 0.01)
+         np.random.uniform(size=50000) * 0.01)
 
     fig, ax = plt.subplots()
     p1 = ax.plot(x, solid_joinstyle='round', linewidth=2.0)

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -596,8 +596,8 @@ class ColorbarBase(cm.ScalarMappable):
         if b is not None:
             self._boundaries = np.asarray(b, dtype=float)
             if self.values is None:
-                self._values = 0.5*(self._boundaries[:-1]
-                                        + self._boundaries[1:])
+                self._values = (self._boundaries[:-1]
+                                + self._boundaries[1:]) / 2
                 if isinstance(self.norm, colors.NoNorm):
                     self._values = (self._values + 0.00001).astype(np.int16)
                 return
@@ -606,7 +606,7 @@ class ColorbarBase(cm.ScalarMappable):
         if self.values is not None:
             self._values = np.array(self.values)
             if self.boundaries is None:
-                b = np.zeros(len(self.values)+1, 'd')
+                b = np.zeros(len(self.values) + 1)
                 b[1:-1] = 0.5*(self._values[:-1] - self._values[1:])
                 b[0] = 2.0*b[1] - b[2]
                 b[-1] = 2.0*b[-2] - b[-3]
@@ -617,22 +617,16 @@ class ColorbarBase(cm.ScalarMappable):
         # Neither boundaries nor values are specified;
         # make reasonable ones based on cmap and norm.
         if isinstance(self.norm, colors.NoNorm):
-            b = self._uniform_y(self.cmap.N+1) * self.cmap.N - 0.5
-            v = np.zeros((len(b)-1,), dtype=np.int16)
-            v = np.arange(self.cmap.N, dtype=np.int16)
-            self._boundaries = b
-            self._values = v
+            self._boundaries = (
+                self._uniform_y(self.cmap.N + 1) * self.cmap.N - 0.5)
+            self._values = np.arange(self.cmap.N, dtype=np.int16)
             return
         elif isinstance(self.norm, colors.BoundaryNorm):
-            b = np.array(self.norm.boundaries)
-            v = np.zeros((len(b)-1,), dtype=float)
-            bi = self.norm.boundaries
-            v = 0.5*(bi[:-1] + bi[1:])
-            self._boundaries = b
-            self._values = v
+            self._boundaries = np.array(self.norm.boundaries)
+            self._values = (self._boundaries[:-1] + self._boundaries[1:]) / 2
             return
         else:
-            b = self._uniform_y(self.cmap.N+1)
+            b = self._uniform_y(self.cmap.N + 1)
 
         self._process_values(b)
 

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -18,12 +18,12 @@ def run_memleak_test(bench, iterations, report):
     starti = min(50, iterations // 2)
     endi = iterations
 
-    malloc_arr = np.empty((endi,), dtype=np.int64)
-    rss_arr = np.empty((endi,), dtype=np.int64)
-    rss_peaks = np.empty((endi,), dtype=np.int64)
-    nobjs_arr = np.empty((endi,), dtype=np.int64)
-    garbage_arr = np.empty((endi,), dtype=np.int64)
-    open_files_arr = np.empty((endi,), dtype=np.int64)
+    malloc_arr = np.empty(endi, dtype=np.int64)
+    rss_arr = np.empty(endi, dtype=np.int64)
+    rss_peaks = np.empty(endi, dtype=np.int64)
+    nobjs_arr = np.empty(endi, dtype=np.int64)
+    garbage_arr = np.empty(endi, dtype=np.int64)
+    open_files_arr = np.empty(endi, dtype=np.int64)
     rss_peak = 0
 
     p = psutil.Process()


### PR DESCRIPTION
`(x,)` is a bit unsightly when `x` would work as well...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
