### PR TITLE
Slightly tighten the Bbox/Transform API.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -409,3 +409,9 @@ The *add_all* parameter of `.axes_grid1.axes_grid.Grid`,
 `.axes_grid1.axes_grid.ImageGrid`, `.axes_grid1.axes_rgb.make_rgb_axes` and
 `.axes_grid1.axes_rgb.RGBAxes` is deprecated.  Axes are now always added to the
 parent figure, though they can be later removed with ``ax.remove()``.
+
+``BboxBase.inverse_transformed``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``.BboxBase.inverse_transformed`` is deprecated (call `.BboxBase.transformed`
+on the `~.Transform.inverted()` transform instead).

--- a/examples/pyplots/auto_subplots_adjust.py
+++ b/examples/pyplots/auto_subplots_adjust.py
@@ -26,7 +26,7 @@ def on_draw(event):
         bbox = label.get_window_extent()
         # the figure transform goes from relative coords->pixels and we
         # want the inverse of that
-        bboxi = bbox.inverse_transformed(fig.transFigure)
+        bboxi = bbox.transformed(fig.transFigure.inverted())
         bboxes.append(bboxi)
 
         # this is the bbox that bounds all the bboxes, again in relative
@@ -54,8 +54,9 @@ plt.show()
 import matplotlib
 matplotlib.artist.Artist.get_window_extent
 matplotlib.transforms.Bbox
-matplotlib.transforms.Bbox.inverse_transformed
+matplotlib.transforms.Bbox.transformed
 matplotlib.transforms.Bbox.union
+matplotlib.transforms.Transform.inverted
 matplotlib.figure.Figure.subplots_adjust
 matplotlib.figure.SubplotParams
 matplotlib.backend_bases.FigureCanvasBase.mpl_connect

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -227,7 +227,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 result = mpath.get_path_collection_extents(
                     transform.get_affine(), paths, self.get_transforms(),
                     offsets, transOffset.get_affine().frozen())
-                return result.inverse_transformed(transData)
+                return result.transformed(transData.inverted())
             if not self._offsetsNone:
                 # this is for collections that have their paths (shapes)
                 # in physical, axes-relative, or figure-relative units

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -157,9 +157,9 @@ class Cell(Rectangle):
         """
         Return the text bounds as *(x, y, width, height)* in table coordinates.
         """
-        bbox = self._text.get_window_extent(renderer)
-        bboxa = bbox.inverse_transformed(self.get_data_transform())
-        return bboxa.bounds
+        return (self._text.get_window_extent(renderer)
+                .transformed(self.get_data_transform().inverted())
+                .bounds)
 
     def get_required_width(self, renderer):
         """Return the minimal required width for the cell."""
@@ -431,7 +431,7 @@ class Table(Artist):
                  for (row, col), cell in self._cells.items()
                  if row >= 0 and col >= 0]
         bbox = Bbox.union(boxes)
-        return bbox.inverse_transformed(self.get_transform())
+        return bbox.transformed(self.get_transform().inverted())
 
     def contains(self, mouseevent):
         # docstring inherited

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -143,11 +143,12 @@ def test_multiline2():
     renderer = fig.canvas.get_renderer()
 
     def draw_box(ax, tt):
-        bb = tt.get_window_extent(renderer)
-        bbt = bb.inverse_transformed(ax.transAxes)
         r = mpatches.Rectangle((0, 0), 1, 1, clip_on=False,
                                transform=ax.transAxes)
-        r.set_bounds(bbt.bounds)
+        r.set_bounds(
+            tt.get_window_extent(renderer)
+            .transformed(ax.transAxes.inverted())
+            .bounds)
         ax.add_patch(r)
 
     horal = 'left'

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -473,6 +473,7 @@ class BboxBase(TransformNode):
             [pts[0], [pts[0, 0], pts[1, 1]], [pts[1, 0], pts[0, 1]]]))
         return Bbox([ll, [lr[0], ul[1]]])
 
+    @cbook.deprecated("3.3", alternative="transformed(transform.inverted())")
     def inverse_transformed(self, transform):
         """
         Construct a `Bbox` by statically transforming this one by the inverse


### PR DESCRIPTION
At least it's explicit that Bbox.inverse_transformed() follows the
Bbox.transformed() semantics, not those of Transform.transform_bbox() or
of TransformedBbox (#12059) (sounds obvious, but you never know...).

Also one less thing to implement for a possible future C implementation of the transform stack.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
