### PR TITLE
Globally cache single TexManager instances.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -29,6 +29,7 @@ To enable tex rendering of all text in your matplotlib figure, set
 """
 
 import copy
+import functools
 import glob
 import hashlib
 import logging
@@ -48,6 +49,8 @@ _log = logging.getLogger(__name__)
 class TexManager(object):
     """
     Convert strings to dvi files using TeX, caching the results to a directory.
+
+    Repeated calls to this constructor always return the same instance.
     """
 
     cachedir = mpl.get_cachedir()
@@ -95,8 +98,13 @@ class TexManager(object):
         ('text.latex.preamble', 'text.latex.unicode', 'text.latex.preview',
          'font.family') + tuple('font.' + n for n in font_families))
 
-    def __init__(self):
+    @functools.lru_cache()  # Always return the same instance.
+    def __new__(cls):
+        self = object.__new__(cls)
+        self._reinit()
+        return self
 
+    def _reinit(self):
         if self.texcache is None:
             raise RuntimeError('Cannot create TexManager, as there is no '
                                'cache directory available')
@@ -169,7 +177,7 @@ class TexManager(object):
                 # deepcopy may not be necessary, but feels more future-proof
                 self._rc_cache[k] = copy.deepcopy(rcParams[k])
             _log.debug('RE-INIT\nold fontconfig: %s', self._fontconfig)
-            self.__init__()
+            self._reinit()
         _log.debug('fontconfig: %s', self._fontconfig)
         return self._fontconfig
 

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -24,9 +24,7 @@ def _get_adobe_standard_encoding():
 
 
 class TextToPath(object):
-    """
-    A class that convert a given text to a path using ttf fonts.
-    """
+    """A class that converts strings to paths."""
 
     FONT_SCALE = 100.
     DPI = 72


### PR DESCRIPTION
This allows sharing its caches across renderer instances.

(If it was up to me this classes would be replaced by module-level
functions and a module-level cache, but heh.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
