### PR TITLE
Check for sphinx_copybutton when building the docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,13 +51,16 @@ extensions = [
 exclude_patterns = ['api/api_changes/*', 'users/whats_new/*']
 
 
-def _check_deps():
-    names = {"colorspacious": 'colorspacious',
-             "IPython.sphinxext.ipython_console_highlighting": 'ipython',
-             "matplotlib": 'matplotlib',
-             "numpydoc": 'numpydoc',
-             "PIL.Image": 'pillow',
-             "sphinx_gallery": 'sphinx_gallery'}
+def _check_dependencies():
+    names = {
+        "colorspacious": 'colorspacious',
+        "IPython.sphinxext.ipython_console_highlighting": 'ipython',
+        "matplotlib": 'matplotlib',
+        "numpydoc": 'numpydoc',
+        "PIL.Image": 'pillow',
+        "sphinx_copybutton": 'sphinx_copybutton',
+        "sphinx_gallery": 'sphinx_gallery',
+    }
     missing = []
     for name in names:
         try:
@@ -69,7 +72,8 @@ def _check_deps():
             "The following dependencies are missing to build the "
             "documentation: {}".format(", ".join(missing)))
 
-_check_deps()
+_check_dependencies()
+
 
 # Import only after checking for dependencies.
 # gallery_order.py from the sphinxext folder provides the classes that


### PR DESCRIPTION
## PR Summary

#12997 added the extension sphinx_copybutton as a dependency for the docs.

This adds it to the list of checked dependencies when building the docs.