### PR TITLE
Deprecate TextToPath.glyph_to_path.

### DIFF
--- a/doc/api/next_api_changes/2018-01-07-AL.rst
+++ b/doc/api/next_api_changes/2018-01-07-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+￼
+``TextToPath.glyph_to_path`` is deprecated (call ``font.get_path()`` and
+manually transform the path instead).

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -67,6 +67,9 @@ class TextToPath(object):
         char_id = urllib.parse.quote('%s-%d' % (ps_name, ccode))
         return char_id
 
+    @cbook.deprecated(
+        "3.1",
+        alternative="font.get_path() and manual translation of the vertices")
     def glyph_to_path(self, font, currx=0.):
         """
         convert the ft2font glyph to vertices and codes.
@@ -215,7 +218,7 @@ class TextToPath(object):
 
             char_id = self._get_char_id(font, ccode)
             if char_id not in glyph_map:
-                glyph_map_new[char_id] = self.glyph_to_path(font)
+                glyph_map_new[char_id] = font.get_path()
 
             currx += kern / 64
 
@@ -266,7 +269,7 @@ class TextToPath(object):
                 font.clear()
                 font.set_size(self.FONT_SCALE, self.DPI)
                 glyph = font.load_char(ccode, flags=LOAD_NO_HINTING)
-                glyph_map_new[char_id] = self.glyph_to_path(font)
+                glyph_map_new[char_id] = font.get_path()
 
             xpositions.append(ox)
             ypositions.append(oy)
@@ -343,7 +346,7 @@ class TextToPath(object):
 
                     glyph0 = font.load_char(glyph, flags=ft2font_flag)
 
-                glyph_map_new[char_id] = self.glyph_to_path(font)
+                glyph_map_new[char_id] = font.get_path()
 
             glyph_ids.append(char_id)
             xpositions.append(x1)


### PR DESCRIPTION
The currx argument is unused, and realistic uses of glyph_to_path that
may need currx (to generate the path for layouting multiple glyphs)
would likely cache the path for performance anyways (as TextToPath
does).

If we deprecate currx, then we may as well deprecate glyph_to_path which
becomes synonym to `font.get_path()`.

Split out of #13108.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
