### PR TITLE
Pin pytest<4.1 to unbreak CI tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest>=3.4" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest>=3.4,<4.1" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -6,7 +6,7 @@ cycler
 numpy
 pillow
 pyparsing
-pytest
+pytest<4.1
 pytest-cov
 pytest-faulthandler
 pytest-rerunfailures


### PR DESCRIPTION
## PR Summary

Temporary fix for #13121.

This can be undone once a new pytest-cov release is out.

