### PR TITLE
Deprecate add_subplot(<no positional args>) silently doing nothing.

### DIFF
--- a/doc/api/next_api_changes/2018-01-09-AL.rst
+++ b/doc/api/next_api_changes/2018-01-09-AL.rst
@@ -1,0 +1,5 @@
+Behavior changes
+````````````````
+
+Calling `.Figure.add_subplot()` with no positional arguments used to do
+nothing; this now is equivalent to calling ``add_subplot(111)`` instead.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1311,14 +1311,14 @@ default: 'top'
         --------
         ::
 
-            fig=plt.figure()
+            fig = plt.figure()
             fig.add_subplot(221)
 
             # equivalent but more general
-            ax1=fig.add_subplot(2, 2, 1)
+            ax1 = fig.add_subplot(2, 2, 1)
 
             # add a subplot with no frame
-            ax2=fig.add_subplot(222, frameon=False)
+            ax2 = fig.add_subplot(222, frameon=False)
 
             # add a polar subplot
             fig.add_subplot(223, projection='polar')
@@ -1333,7 +1333,7 @@ default: 'top'
             fig.add_subplot(ax2)
         """
         if not len(args):
-            return
+            args = (1, 1, 1)
 
         if len(args) == 1 and isinstance(args[0], Integral):
             if not 100 <= args[0] <= 999:

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -116,7 +116,7 @@ def test_clf_keyword():
 def test_figure():
     # named figure support
     fig = plt.figure('today')
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot()
     ax.set_title(fig.get_label())
     ax.plot(np.arange(5))
     # plot red line in a different figure.


### PR DESCRIPTION
To avoid head-scratching when `add_subplot(projection="3d")` does
nothing (the correct call is `add_subplot(111, projection="3d")`).

Also a poll: after the deprecation period, should `add_subplot(<no positional args>)`
- raise an exception?
- behave as `add_subplot(111, **kwargs)` (see the mplot3d case above for a reasonable use case)?

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
