### PR TITLE
ENH: add a user-friendly verbose interface

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -448,6 +448,11 @@ Then they will receive messages like::
   matplotlib.yourmodulename: 347 - INFO - Here is some information
   matplotlib.yourmodulename: 348 - DEBUG - Here is some more detailed information
 
+More straight forward helper methods are available to end-users as well::
+
+  import matplotlib.pyplot as plt
+  plt.set_loglevel(level='info')  # or plt.set_loglevel(level='debug')
+
 Which logging level to use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/faq/troubleshooting_faq.rst
+++ b/doc/faq/troubleshooting_faq.rst
@@ -120,10 +120,16 @@ provide the following information in your e-mail to the `mailing list
 
      python -c "from logging import *; basicConfig(level=DEBUG); from pylab import *; plot(); show()"
 
+  If you want to trigger logging in a script, it can be done with helper
+  functions::
 
-  If you want to put the debugging hooks in your own code, then the
-  most simple way to do so is to insert the following *before* any calls
-  to ``import matplotlib``::
+    import matplotlib.pyplot as plt
+    plt.set_loglevel(level='info')  # or plt.set_loglevel(level='debug')
+
+
+  If you want to put full debugging hooks in your own code, including
+  debug information when matplotlib starts up, then the way to do so is to
+  insert the following *before* any calls to ``import matplotlib``::
 
     import logging
     logging.basicConfig(level=logging.DEBUG)

--- a/doc/users/next_whats_new/pyplot_verbose.rst
+++ b/doc/users/next_whats_new/pyplot_verbose.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+New methods for verbose logging
+-------------------------------
+
+If more debugging information is required, the user can call
+the `.pyplot.set_loglevel` method.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -207,14 +207,35 @@ if not hasattr(sys, 'argv'):  # for modpython
     sys.argv = ['modpython']
 
 
-_verbose_msg = """\
-matplotlib.verbose is deprecated;
-Command line argument --verbose-LEVEL is deprecated.
-This functionality is now provided by the standard
-python logging library.  To get more (or less) logging output:
-    import logging
-    logger = logging.getLogger('matplotlib')
-    logger.set_level(logging.INFO)"""
+def set_loglevel(level='info'):
+    """
+    Shortcut to set the logging level of the logging module.
+
+    Parameters
+    ----------
+    level : str or bool
+        If True set logging level to "INFO" for matplotlib module.
+        If FALSE set logging level to "WARNING" for matplotlib module (this
+        is the default level if ``set_loglevel`` is not called). If a string,
+        must be one of ['warning', 'info', 'debug'], in order of increasing
+        verbosity.
+
+    Notes
+    -----
+    This is the same as the standard python `logging` module::
+
+        import logging
+
+        _log = logging.getLogger(__name__)
+        _log.setLevel(logging.INFO)  # or logging.WARNING, logging.INFO
+
+    """
+
+    if level is True:
+        level = 'info'
+    if level is False:
+        level = 'warning'
+    _set_logger_verbose_level(level_str=level.lower())
 
 
 def _set_logger_verbose_level(level_str='silent', file_str='sys.stdout'):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1997,6 +1997,32 @@ def colormaps():
     return sorted(cm.cmap_d)
 
 
+def set_loglevel(level='info'):
+    """
+    Shortcut to set the debugging level of the logging module.
+
+    Parameters
+    ----------
+    level : str or bool (optional)
+        If *True* (default) set logging level to "INFO" for matplotlib module.
+        If *False* set logging level to "WARNING" for matplotlib module (this
+        is the default level if ``verbose`` is not called). If a string, must
+        be one of ['warning', 'info', 'debug'], in order of increasing
+        verbosity.
+
+    Notes
+    -----
+    This is the same as the standard python `logging` module::
+
+        import logging
+
+        _log = logging.getLogger(__name__)
+        _log.setLevel(logging.DEBUG)  # or logging.WARNING, logging.INFO
+
+    """
+    matplotlib.set_loglevel(level=level)
+
+
 def _setup_pyplot_info_docstrings():
     """
     Generates the plotting docstring.


### PR DESCRIPTION
EDIT: updated to change default ot INFO

## PR Summary
A simple verbose interface that turns on the logging module for matplotlib:

```python
import matplotlib.pyplot as plt
plt.verbose()  # or plt.verbose('info') or plt.verbose(True)
```

Now all `_log.info()` and more urgent messages will be printed.

```python
import matplotlib.pyplot as plt
plt.debug()  # or plt.verbose('debug') 
```
for more info.  

and 

```python
import matplotlib.pyplot as plt
plt.verbose('warning')  # or plt.verbose(False)
```

to get back to standard logging level.    


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->