### PR TITLE
Simplify color conversion backcompat shim.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -305,60 +305,15 @@ hex2color = to_rgb
 
 class ColorConverter(object):
     """
-    Provides methods for converting color specifications to *RGB* or *RGBA*
+    This class is only kept for backwards compatibility.
 
-    Caching is used for more efficient conversion upon repeated calls
-    with the same argument.
-
-    Ordinarily only the single instance instantiated in this module,
-    *colorConverter*, is needed.
+    Its functionality is entirely provided by module-level functions.
     """
-
     colors = _colors_full_map
     cache = _colors_full_map.cache
-
-    @staticmethod
-    def to_rgb(arg):
-        """
-        Returns an *RGB* tuple of three floats from 0-1.
-
-        *arg* can be an *RGB* or *RGBA* sequence or a string in any of
-        several forms:
-
-            1) a letter from the set 'rgbcmykw'
-            2) a hex color string, like '#00FFFF'
-            3) a standard name, like 'aqua'
-            4) a string representation of a float, like '0.4',
-               indicating gray on a 0-1 scale
-
-        if *arg* is *RGBA*, the *A* will simply be discarded.
-        """
-        return to_rgb(arg)
-
-    @staticmethod
-    def to_rgba(arg, alpha=None):
-        """
-        Returns an *RGBA* tuple of four floats from 0-1.
-
-        For acceptable values of *arg*, see :meth:`to_rgb`.
-        In addition, if *arg* is "none" (case-insensitive),
-        then (0,0,0,0) will be returned.
-        If *arg* is an *RGBA* sequence and *alpha* is not *None*,
-        *alpha* will replace the original *A*.
-        """
-        return to_rgba(arg, alpha)
-
-    @staticmethod
-    def to_rgba_array(arg, alpha=None):
-        """
-        Returns a numpy array of *RGBA* tuples.
-
-        Accepts a single mpl color spec or a sequence of specs.
-
-        Special case to handle "no color": if *c* is "none" (case-insensitive),
-        then an empty array will be returned.  Same for an empty list.
-        """
-        return to_rgba_array(arg, alpha)
+    to_rgb = staticmethod(to_rgb)
+    to_rgba = staticmethod(to_rgba)
+    to_rgba_array = staticmethod(to_rgba_array)
 
 
 colorConverter = ColorConverter()


### PR DESCRIPTION
One doesn't need to have separate docstrings for the old and the new
method; the new implementation will just reuse the "new" docstrings in
the backcompat layer.

At least half of the docstring of the ColorConverter class is outdated
(even the single colorConverter instance is unneeded now) so just
rewrite the whole thing.

(@tacaswell argued against deprecating ColorConverter in https://github.com/matplotlib/matplotlib/pull/6382#issuecomment-217910498; I don't really care either way.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
