### PR TITLE
API: Use class-based directive in sphinxext

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -42,7 +42,6 @@ per-file-ignores =
     matplotlib/projections/geo.py: E203, E221, E502
     matplotlib/pylab.py: E501
     matplotlib/rcsetup.py: E501
-    matplotlib/sphinxext/plot_directive.py: E402
     matplotlib/tests/test_mathtext.py: E501
     matplotlib/transforms.py: E201, E202, E203, E501
     matplotlib/tri/triinterpolate.py: E201, E221

--- a/doc/api/next_api_changes/2019-01-09-deprecations.rst
+++ b/doc/api/next_api_changes/2019-01-09-deprecations.rst
@@ -1,0 +1,8 @@
+Deprecations
+````````````
+
+The ``matplotlib.sphinxext.plot_directive`` interface has changed from
+the (Sphinx-)deprecated function-based interface to a class-based interface.
+This should not affect end users, but the
+``matplotlib.sphinxext.plot_directive.plot_directive`` function is now
+deprecated.


### PR DESCRIPTION
## PR Summary

Changes `matplotlib.sphinxext.plot_directive` to use class-based mechanics instead of the deprecated function interface. I have verified building the SciPy doc looks the same before and after this change, and that having an error in the code emits the same warning/error in both cases. But I guess we'll see how the `matplotlib` doc builds (assuming it's built by CI)!

I also added a `version` to the `.. plot::` config settings, and set to `0.2` (previously was unset, so I assumed it to be `0.1`).

Closes #13132. 

## PR Checklist

- [x] Has Pytest style unit tests (implicitly any existing tests have been updated)
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

One question -- I put the API changes stuff in a new file because I assume it's going in the next release rather than 3.0.1. Should `.github/PULL_REQUEST_TEMPLATE.md` be updated to mention `doc/api/next_api_changes/` instead of `doc/api/api_changes.rst`? If so I can add it here or make a new PR.