### PR TITLE
Deprecate NavigationToolbar2GTK3.ctx.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -373,6 +373,10 @@ These attributes are deprecated.  In order to access the parent window, use
 also be accessible as ``toolbar.parent()``.  The base directory to the icons
 is ``os.path.join(mpl.get_data_path(), "images")``.
 
+NavigationToolbar2QT.ctx
+~~~~~~~~~~~~~~~~~~~~~~~~
+This attribute is deprecated.
+
 Path helpers in :mod:`.bezier`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -452,7 +452,11 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         self.win = window
         GObject.GObject.__init__(self)
         NavigationToolbar2.__init__(self, canvas)
-        self.ctx = None
+
+    @cbook.deprecated("3.3")
+    @property
+    def ctx(self):
+        return self.canvas.get_property("window").cairo_create()
 
     def set_message(self, s):
         self.message.set_label(s)
@@ -464,7 +468,7 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
     def draw_rubberband(self, event, x0, y0, x1, y1):
         # adapted from
         # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/189744
-        self.ctx = self.canvas.get_property("window").cairo_create()
+        ctx = self.canvas.get_property("window").cairo_create()
 
         # todo: instead of redrawing the entire figure, copy the part of
         # the figure that was covered by the previous rubberband rectangle
@@ -477,11 +481,11 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         h = abs(y1 - y0)
         rect = [int(val) for val in (min(x0, x1), min(y0, y1), w, h)]
 
-        self.ctx.new_path()
-        self.ctx.set_line_width(0.5)
-        self.ctx.rectangle(rect[0], rect[1], rect[2], rect[3])
-        self.ctx.set_source_rgb(0, 0, 0)
-        self.ctx.stroke()
+        ctx.new_path()
+        ctx.set_line_width(0.5)
+        ctx.rectangle(*rect)
+        ctx.set_source_rgb(0, 0, 0)
+        ctx.stroke()
 
     def _init_toolbar(self):
         self.set_style(Gtk.ToolbarStyle.ICONS)


### PR DESCRIPTION
No alternative documented: messing with the window cairo context is
quite low level; if you're doing that, creating the context should not
be that hard.

Intentionally not changing it on RubberbandGTK3 as that's handled by #12760.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
