### PR TITLE
DOC: Add explanatory comment for colorbar with axes divider example

### DIFF
--- a/examples/axes_grid1/demo_colorbar_with_axes_divider.py
+++ b/examples/axes_grid1/demo_colorbar_with_axes_divider.py
@@ -3,6 +3,12 @@
 Demo Colorbar with Axes Divider
 ===============================
 
+The make_axes_locatable function (part of the axes_divider module) takes an
+existing axes, creates a divider for it and returns an instance of the
+AxesLocator class. The append_axes method of this AxesLocator can then be used
+to create a new axes on a given side ("top", "right", "bottom", or "left") of
+the original axes. This example uses Axes Divider to add colorbars next to
+axes.
 """
 
 import matplotlib.pyplot as plt
@@ -14,13 +20,17 @@ fig.subplots_adjust(wspace=0.5)
 
 im1 = ax1.imshow([[1, 2], [3, 4]])
 ax1_divider = make_axes_locatable(ax1)
+# add an axes to the right of the main axes.
 cax1 = ax1_divider.append_axes("right", size="7%", pad="2%")
 cb1 = colorbar(im1, cax=cax1)
 
 im2 = ax2.imshow([[1, 2], [3, 4]])
 ax2_divider = make_axes_locatable(ax2)
+# add an axes above the main axes.
 cax2 = ax2_divider.append_axes("top", size="7%", pad="2%")
 cb2 = colorbar(im2, cax=cax2, orientation="horizontal")
+# change tick position to top. Tick position defaults to bottom and overlaps
+# the image.
 cax2.xaxis.set_ticks_position("top")
 
 plt.show()


### PR DESCRIPTION
##  PR Summary

This pull request adds explanatory text to the Demo Colorbar with Axes Divider gallery example in response to issue #11654.

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
