### PR TITLE
Make FigureManagerWx more consistent with other backends.

### DIFF
--- a/doc/api/next_api_changes/deprecations/13153-AL.rst
+++ b/doc/api/next_api_changes/deprecations/13153-AL.rst
@@ -1,0 +1,13 @@
+Changes to the wx backend
+`````````````````````````
+
+- ``FigureFrameWx`` no longer attaches a ``FigureManagerWx``
+  to the figure.  Instead, the ``FigureManagerWx`` is
+  now created by ``backend_wx.new_figure_manager`` or
+  ``backend_wx.new_figure_manager_given_figure``, consistently with the
+  other backends.  Accordingly, the ``FigureFrameWx.figmgr`` attribute
+  and ``FigureFrameWx.get_figure_manager`` method are deprecated (use the
+  cross-backend ``figure.canvas.manager`` instead).
+- The *frame* argument and attribute of ``FigureManagerWx`` are deprecated, for
+  consistency with other backends.  The ``FigureManagerWx.window``
+  attribute is now always set to the canvas' parent.


### PR DESCRIPTION
## PR Summary

~~Builds on top of #13146 to avoid a rebase.~~
Note that unlike in https://github.com/matplotlib/matplotlib/pull/10606, FigureManagerWx is a pure-python class, not a wx Widget, so there's no problems with wxness of the constructor there.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
