### PR TITLE
Slightly rework animation logging.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -387,12 +387,14 @@ class MovieWriter(AbstractMovieWriter):
         # Use the encoding/errors that universal_newlines would use.
         out = TextIOWrapper(BytesIO(out)).read()
         err = TextIOWrapper(BytesIO(err)).read()
-        _log.log(
-            logging.WARNING if self._proc.returncode else logging.DEBUG,
-            "MovieWriter stdout:\n%s", out)
-        _log.log(
-            logging.WARNING if self._proc.returncode else logging.DEBUG,
-            "MovieWriter stderr:\n%s", err)
+        if out:
+            _log.log(
+                logging.WARNING if self._proc.returncode else logging.DEBUG,
+                "MovieWriter stdout:\n%s", out)
+        if err:
+            _log.log(
+                logging.WARNING if self._proc.returncode else logging.DEBUG,
+                "MovieWriter stderr:\n%s", err)
         if self._proc.returncode:
             raise subprocess.CalledProcessError(
                 self._proc.returncode, self._proc.args, out, err)
@@ -1085,14 +1087,14 @@ class Animation(object):
                                          extra_args=extra_args,
                                          metadata=metadata)
             else:
-                _log.warning("MovieWriter {} unavailable. Trying to use {} "
-                             "instead.".format(writer, writers.list()[0]))
-
-                try:
-                    writer = writers[writers.list()[0]](fps, codec, bitrate,
-                                                        extra_args=extra_args,
-                                                        metadata=metadata)
-                except IndexError:
+                if writers.list():
+                    alt_writer = writers[writers.list()[0]]
+                    _log.warning("MovieWriter %s unavailable; trying to use "
+                                 "%s instead.", writer, alt_writer)
+                    writer = alt_writer(
+                        fps, codec, bitrate,
+                        extra_args=extra_args, metadata=metadata)
+                else:
                     raise ValueError("Cannot save animation: no writers are "
                                      "available. Please install ffmpeg to "
                                      "save animations.")


### PR DESCRIPTION
- Only log ffmpeg stdout/stderr if it outputted something on that
  stream.  This avoids a spurious empty stdout log when the entire
  interesting part is on stderr.  (#13155 for an example use case.)
- Improve the writer-fallback logic (right now the IndexError clause is
  never going to be executed as the IndexError is first raised (if
  writers.list() is empty) in the log.warning call, before the try:
  ...).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
