### PR TITLE
DOC: better argcheck bar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2267,10 +2267,20 @@ class Axes(_AxesBase):
         # left, bottom, width, height vectors
         if align == 'center':
             if orientation == 'vertical':
-                left = x - width / 2
+                try:
+                    left = x - width / 2
+                except TypeError as e:
+                    raise TypeError(f'the dtypes of parameters x ({x.dtype}) '
+                                    f'and width ({width.dtype}) '
+                                    f'are incompatible') from e
                 bottom = y
             elif orientation == 'horizontal':
-                bottom = y - height / 2
+                try:
+                    bottom = y - height / 2
+                except TypeError as e:
+                    raise TypeError(f'the dtypes of parameters y ({y.dtype}) '
+                                    f'and height ({height.dtype}) '
+                                    f'are incompatible') from e
                 left = x
         elif align == 'edge':
             left = x


### PR DESCRIPTION
## PR Summary

Closes #13142

This checks that `x` and `width` in bar can be subtracted and emits a more useful message than before.

The underlying issue is that width=0.8, which has no units, and in this case x has datetime64 units.

### Code

```python
import pandas as pd
import matplotlib.pyplot as plt
from datetime import datetime

def timestamp_to_datetime(raw):
    return datetime.fromtimestamp(raw/1000)

df = pd.DataFrame([{
    'timestamp': 1500854400000,
    'activity': 5},
{
    'timestamp': 1500940800000,
    'activity': 6
}])
df['date'] = df['timestamp'].apply(timestamp_to_datetime)

plt.figure(figsize=(20,10))
plt.bar(df['date'], df['activity'])
plt.show();
```
### Before:

```
Traceback (most recent call last):
  File "testBarDT.py", line 24, in <module>
    plt.bar(df['date'], df['activity'])
  File "/Users/jklymak/matplotlib/lib/matplotlib/pyplot.py", line 2438, in bar
    **({"data": data} if data is not None else {}), **kwargs)
  File "/Users/jklymak/matplotlib/lib/matplotlib/__init__.py", line 1778, in inner
    return func(ax, *args, **kwargs)
  File "/Users/jklymak/matplotlib/lib/matplotlib/axes/_axes.py", line 2277, in bar
    left = x - width / 2
TypeError: ufunc subtract cannot use operands with types dtype('<M8[ns]') and dtype('float64')
```


### After

```
Traceback (most recent call last):
  File "/Users/jklymak/matplotlib/lib/matplotlib/axes/_axes.py", line 2278, in bar
    left = x - width / 2
TypeError: ufunc subtract cannot use operands with types dtype('<M8[ns]') and dtype('float64')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "testBarDT.py", line 18, in <module>
    plt.bar(df['date'], df['activity'])
  File "/Users/jklymak/matplotlib/lib/matplotlib/pyplot.py", line 2438, in bar
    **({"data": data} if data is not None else {}), **kwargs)
  File "/Users/jklymak/matplotlib/lib/matplotlib/__init__.py", line 1778, in inner
    return func(ax, *args, **kwargs)
  File "/Users/jklymak/matplotlib/lib/matplotlib/axes/_axes.py", line 2282, in bar
    f'({width.dtype}) are incompatible') from e
ValueError: the dtypes of parameters x (datetime64[ns]) and width (float64) are incompatible
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->