### PR TITLE
Simplify Text.get_usetex.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1204,16 +1204,8 @@ class Text(Artist):
         self.stale = True
 
     def get_usetex(self):
-        """
-        Return whether this `Text` object uses TeX for rendering.
-
-        If the user has not manually set this value, it defaults to
-        :rc:`text.usetex`.
-        """
-        if self._usetex is None:
-            return rcParams['text.usetex']
-        else:
-            return self._usetex
+        """Return whether this `Text` object uses TeX for rendering."""
+        return self._usetex
 
     def set_fontname(self, fontname):
         """


### PR DESCRIPTION
- <del>Make the module-level _wrap_text a text method instead, and don't make
  it yield anything as it is modifying the text object in-place anyways.
  (This avoids having to wonder where other textobj attributes come
  from.)</del>  Removed this as I realized there's an even simpler way to handle
  it, but would be better on top of #12951.
- `text._usetex` is never None because `set_usetex` already replaces
  None by the rc value, so we don't need to additionally validate in the
  getter.

Preliminary work towards fixing https://github.com/matplotlib/matplotlib/issues/13139#issuecomment-453460563 (#12951 would be needed too to avoid a rebase).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
