### PR TITLE
Typos on subplot comments and example

### DIFF
--- a/doc/api/prev_api_changes/api_changes_2.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.0.0.rst
@@ -168,7 +168,7 @@ call the function with ::
 where "ax" is an ``Axes3d`` object created with something like ::
 
    import mpl_toolkits.mplot3d.axes3d
-   ax = plt.sublot(111, projection='3d')
+   ax = plt.subplot(111, projection='3d')
 
 
 Stale figure behavior

--- a/examples/subplots_axes_and_figures/subplot_toolbar.py
+++ b/examples/subplots_axes_and_figures/subplot_toolbar.py
@@ -3,7 +3,7 @@
 Subplot Toolbar
 ===============
 
-Matplotlib has a toolbar available for adjusting suplot spacing.
+Matplotlib has a toolbar available for adjusting subplot spacing.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -424,7 +424,7 @@ class Axes(_AxesBase):
         This example makes two inset axes, the first is in axes-relative
         coordinates, and the second in data-coordinates::
 
-            fig, ax = plt.suplots()
+            fig, ax = plt.subplots()
             ax.plot(range(10))
             axin1 = ax.inset_axes([0.8, 0.1, 0.15, 0.15])
             axin2 = ax.inset_axes(

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1290,7 +1290,7 @@ default: 'top'
         *kwargs*) then it will simply make that subplot current and
         return it.  This behavior is deprecated. Meanwhile, if you do
         not want this behavior (i.e., you want to force the creation of a
-        new suplot), you must use a unique set of args and kwargs.  The axes
+        new subplot), you must use a unique set of args and kwargs.  The axes
         *label* attribute has been exposed for this purpose: if you want
         two subplots that are otherwise identical to be added to the figure,
         make sure you give them unique labels.

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -63,7 +63,7 @@ class GridSpecBase(object):
 
     def new_subplotspec(self, loc, rowspan=1, colspan=1):
         """
-        create and return a SuplotSpec instance.
+        create and return a SubplotSpec instance.
         """
         loc1, loc2 = loc
         subplotspec = self[loc1:loc1+rowspan, loc2:loc2+colspan]
@@ -142,7 +142,7 @@ class GridSpecBase(object):
         return fig_bottoms, fig_tops, fig_lefts, fig_rights
 
     def __getitem__(self, key):
-        """Create and return a SuplotSpec instance.
+        """Create and return a SubplotSpec instance.
         """
         nrows, ncols = self.get_geometry()
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -984,7 +984,7 @@ def subplot(*args, **kwargs):
     *kwargs*) then it will simply make that subplot current and
     return it.  This behavior is deprecated. Meanwhile, if you do
     not want this behavior (i.e., you want to force the creation of a
-    new suplot), you must use a unique set of args and kwargs.  The axes
+    new subplot), you must use a unique set of args and kwargs.  The axes
     *label* attribute has been exposed for this purpose: if you want
     two subplots that are otherwise identical to be added to the figure,
     make sure you give them unique labels.

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -154,7 +154,7 @@ def test_tight_layout8():
 
 @image_comparison(baseline_images=['tight_layout9'])
 def test_tight_layout9():
-    # Test tight_layout for non-visible suplots
+    # Test tight_layout for non-visible subplots
     # GH 8244
     f, axarr = plt.subplots(2, 2)
     axarr[1][1].set_visible(False)

--- a/tutorials/toolkits/axes_grid.py
+++ b/tutorials/toolkits/axes_grid.py
@@ -259,7 +259,7 @@ the host axes and then drawn according to their zorder.  The host and
 parasite axes modifies some of the axes behavior. For example, color
 cycle for plot lines are shared between host and parasites. Also, the
 legend command in host, creates a legend that includes lines in the
-parasite axes.  To create a host axes, you may use *host_suplot* or
+parasite axes.  To create a host axes, you may use *host_subplot* or
 *host_axes* command.
 
 


### PR DESCRIPTION
## PR Summary

Corrected a typo on the example provided for inset_axes + further omittances of "b" in subplot.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
