### PR TITLE
Decorator for deleting a parameter with a deprecation period.

### DIFF
--- a/doc/api/next_api_changes/2018-01-10-AL.rst
+++ b/doc/api/next_api_changes/2018-01-10-AL.rst
@@ -16,6 +16,11 @@ In each case, the old parameter name remains supported (it cannot be used
 simultaneously with the new name), but suppport for it will be dropped in
 Matplotlib 3.3.
 
+- The unused ``shape`` and ``imlim`` parameters to `Axes.imshow` are
+  deprecated.  To avoid triggering the deprecation warning, the ``filternorm``,
+  ``filterrad``, ``resample``, and ``url`` arguments should be passed by
+  keyword.
+
 Deprecations
 ````````````
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5395,6 +5395,8 @@ optional.
 
     #### plotting z(x,y): imshow, pcolor and relatives, contour
     @_preprocess_data()
+    @cbook._delete_parameter("3.1", "shape")
+    @cbook._delete_parameter("3.1", "imlim")
     def imshow(self, X, cmap=None, norm=None, aspect=None,
                interpolation=None, alpha=None, vmin=None, vmax=None,
                origin=None, extent=None, shape=None, filternorm=1,
@@ -5507,9 +5509,6 @@ optional.
 
             See the example :doc:`/tutorials/intermediate/imshow_extent` for a
             more detailed description.
-
-        shape : scalars (columns, rows), optional, default: None
-            For raw buffer images.
 
         filternorm : bool, optional, default: True
             A parameter for the antigrain image resize filter (see the

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -32,7 +32,7 @@ import numpy as np
 
 import matplotlib
 from .deprecation import (
-    deprecated, warn_deprecated, _rename_parameter,
+    deprecated, warn_deprecated, _rename_parameter, _delete_parameter,
     _suppress_matplotlib_deprecation_warning,
     MatplotlibDeprecationWarning, mplDeprecation)
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2644,7 +2644,8 @@ def hlines(
 def imshow(
         X, cmap=None, norm=None, aspect=None, interpolation=None,
         alpha=None, vmin=None, vmax=None, origin=None, extent=None,
-        shape=None, filternorm=1, filterrad=4.0, imlim=None,
+        shape=cbook.deprecation._deprecated_parameter, filternorm=1,
+        filterrad=4.0, imlim=cbook.deprecation._deprecated_parameter,
         resample=None, url=None, *, data=None, **kwargs):
     __ret = gca().imshow(
         X, cmap=cmap, norm=norm, aspect=aspect,

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -15,6 +15,7 @@ from numpy.testing import assert_array_equal
 from matplotlib import (
     colors, image as mimage, patches, pyplot as plt,
     rc_context, rcParams)
+from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
 from matplotlib.testing.decorators import image_comparison
@@ -944,3 +945,17 @@ def test_relim():
     ax.relim()
     ax.autoscale()
     assert ax.get_xlim() == ax.get_ylim() == (0, 1)
+
+
+def test_deprecation():
+    data = [[1, 2], [3, 4]]
+    ax = plt.figure().subplots()
+    for obj in [ax, plt]:
+        with pytest.warns(None) as record:
+            obj.imshow(data)
+            assert len(record) == 0
+        with pytest.warns(MatplotlibDeprecationWarning):
+            obj.imshow(data, shape=None)
+        with pytest.warns(MatplotlibDeprecationWarning):
+            # Enough arguments to pass "shape" positionally.
+            obj.imshow(data, *[None] * 10)

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -20,7 +20,7 @@ import textwrap
 
 # This line imports the installed copy of matplotlib, and not the local copy.
 import numpy as np
-from matplotlib import mlab
+from matplotlib import cbook, mlab
 from matplotlib.axes import Axes
 
 
@@ -175,6 +175,8 @@ def boilerplate_gen():
                 self._repr = "mlab.window_hanning"
             elif value is np.mean:
                 self._repr = "np.mean"
+            elif value is cbook.deprecation._deprecated_parameter:
+                self._repr = "cbook.deprecation._deprecated_parameter"
             else:
                 self._repr = repr(value)
 


### PR DESCRIPTION
## PR Summary

As an example application, deprecate the unused shape and imlim args to
imshow() (unused since around 4d1107c (2006)).

Goes on top of #13128 to avoid a rebase.  [edit: it has been merged]

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
