### PR TITLE
Various TextPath cleanups.

### DIFF
--- a/doc/api/next_api_changes/2019-01-13-AL.rst
+++ b/doc/api/next_api_changes/2019-01-13-AL.rst
@@ -2,3 +2,19 @@ Deprecations
 ````````````
 
 ``Text.is_math_text`` is deprecated.
+
+``TextPath.is_math_text`` and ``TextPath.text_get_vertices_codes`` are
+deprecated.  As an alternative to the latter, construct a new ``TextPath``
+object.
+
+The ``usetex`` parameter of ``TextToPath.get_text_path`` is deprecated and
+folded into the ``ismath`` parameter, which can now take the values False,
+True, and "TeX", consistently with other low-level text processing functions.
+
+Behavior changes
+````````````````
+
+Previously, if :rc:`text.usetex` was True, then constructing a `TextPath` on
+a non-mathtext string with ``usetex=False`` would rely on the mathtext parser
+(but not on usetex support!) to parse the string.  The mathtext parser is not
+invoked anymore, which may cause slight changes in glyph positioning.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -556,8 +556,6 @@ class RendererBase(object):
             The font property.
         s : str
             The text to be converted.
-        usetex : bool
-            Whether to use matplotlib usetex mode.
         ismath : bool or "TeX"
             If True, use mathtext parser. If "TeX", use *usetex* mode.
         """


### PR DESCRIPTION
## PR Summary

In TextToPath.get_text_path, deprecate the usetex parameter in favor of
a tristate ismath={False, True, "TeX"}, which is consistent with all
other low-level text handling APIs (at the renderer level).  (TextToPath
methods should be considered as low-level APIs; the main high-level API
is TextPath.)

Deprecate `TextPath.text_get_vertices_codes` and `TextPath.is_math_text`
which are clearly helper functions for the main constructor.
Moreover, previously, if TextPath was called with `usetex=False` and
`rcParams["text.usetex"]` == True, then `TextPath.is_math_text` would
return "TeX" as the ismath flag, which would then be interpreted as a
True ismath value (but not a True usetex value(!)) by
TextToPath.get_text_path.  The new implementation avoids that problem.

Remove a nonexistent parameter from the docs of
RendererBase._get_text_path_transform.

Goes on top of https://github.com/matplotlib/matplotlib/pull/13173 (because of the use of the _delete_parameter decorator); so you may want to just review the last commit.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
